### PR TITLE
JSON Schema for build trace entry

### DIFF
--- a/doc/manual/package.nix
+++ b/doc/manual/package.nix
@@ -37,6 +37,7 @@ mkMesonDerivation (finalAttrs: {
         ../../src/libutil-tests/data/hash
         ../../src/libstore-tests/data/content-address
         ../../src/libstore-tests/data/store-path
+        ../../src/libstore-tests/data/realisation
         ../../src/libstore-tests/data/derived-path
         ../../src/libstore-tests/data/path-info
         ../../src/libstore-tests/data/nar-info

--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -126,6 +126,7 @@
     - [Store Object Info](protocols/json/store-object-info.md)
     - [Derivation](protocols/json/derivation.md)
     - [Deriving Path](protocols/json/deriving-path.md)
+    - [Build Trace Entry](protocols/json/build-trace-entry.md)
   - [Serving Tarball Flakes](protocols/tarball-fetcher.md)
   - [Store Path Specification](protocols/store-path.md)
   - [Nix Archive (NAR) Format](protocols/nix-archive/index.md)

--- a/doc/manual/source/protocols/json/build-trace-entry.md
+++ b/doc/manual/source/protocols/json/build-trace-entry.md
@@ -1,0 +1,27 @@
+{{#include build-trace-entry-v1-fixed.md}}
+
+## Examples
+
+### Simple build trace entry
+
+```json
+{{#include schema/build-trace-entry-v1/simple.json}}
+```
+
+### Build trace entry with dependencies
+
+```json
+{{#include schema/build-trace-entry-v1/with-dependent-realisations.json}}
+```
+
+### Build trace entry with signature
+
+```json
+{{#include schema/build-trace-entry-v1/with-signature.json}}
+```
+
+<!--
+## Raw Schema
+
+[JSON Schema for Build Trace Entry v1](schema/build-trace-entry-v1.json)
+-->

--- a/doc/manual/source/protocols/json/meson.build
+++ b/doc/manual/source/protocols/json/meson.build
@@ -15,6 +15,7 @@ schemas = [
   'store-object-info-v1',
   'derivation-v3',
   'deriving-path-v1',
+  'build-trace-entry-v1',
 ]
 
 schema_files = files()

--- a/doc/manual/source/protocols/json/schema/build-trace-entry-v1
+++ b/doc/manual/source/protocols/json/schema/build-trace-entry-v1
@@ -1,0 +1,1 @@
+../../../../../../src/libstore-tests/data/realisation

--- a/doc/manual/source/protocols/json/schema/build-trace-entry-v1.yaml
+++ b/doc/manual/source/protocols/json/schema/build-trace-entry-v1.yaml
@@ -1,0 +1,74 @@
+"$schema": "http://json-schema.org/draft-04/schema"
+"$id": "https://nix.dev/manual/nix/latest/protocols/json/schema/build-trace-entry-v1.json"
+title: Build Trace Entry
+description: |
+  A record of a successful build outcome for a specific derivation output.
+
+  This schema describes the JSON representation of a [build trace entry](@docroot@/store/build-trace.md) entry.
+
+  > **Warning**
+  >
+  > This JSON format is currently
+  > [**experimental**](@docroot@/development/experimental-features.md#xp-feature-ca-derivations)
+  > and subject to change.
+
+type: object
+required:
+  - id
+  - outPath
+  - dependentRealisations
+  - signatures
+properties:
+  id:
+    type: string
+    title: Derivation Output ID
+    pattern: "^sha256:[0-9a-f]{64}![a-zA-Z_][a-zA-Z0-9_-]*$"
+    description: |
+      Unique identifier for the derivation output that was built.
+
+      Format: `{hash-quotient-drv}!{output-name}`
+
+      - **hash-quotient-drv**: SHA-256 [hash of the quotient derivation](@docroot@/store/derivation/outputs/input-address.md#hash-quotient-drv).
+        Begins with `sha256:`.
+
+      - **output-name**: Name of the specific output (e.g., "out", "dev", "doc")
+
+      Example: `"sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!foo"`
+
+  outPath:
+    "$ref": "store-path-v1.yaml"
+    title: Output Store Path
+    description: |
+      The path to the store object that resulted from building this derivation for the given output name.
+
+  dependentRealisations:
+    type: object
+    title: Underlying Base Build Trace
+    description: |
+      This is for [*derived*](@docroot@/store/build-trace.md#derived) build trace entries to ensure coherence.
+
+      Keys are derivation output IDs (same format as the main `id` field).
+      Values are the store paths that those dependencies resolved to.
+
+      As described in the linked section on derived build trace traces, derived build trace entries must be kept in addition and not instead of the underlying base build entries.
+      This is the set of base build trace entries that this derived build trace is derived from.
+      (The set is also a map since this miniature base build trace must be coherent, mapping each key to a single value.)
+
+    patternProperties:
+      "^sha256:[0-9a-f]{64}![a-zA-Z_][a-zA-Z0-9_-]*$":
+        $ref: "store-path-v1.yaml"
+        title: Dependent Store Path
+        description: Store path that this dependency resolved to during the build
+    additionalProperties: false
+
+  signatures:
+    type: array
+    title: Build Signatures
+    description: |
+      A set of cryptographic signatures attesting to the authenticity of this build trace entry.
+    items:
+      type: string
+      title: Signature
+      description: A single cryptographic signature
+
+additionalProperties: false

--- a/doc/manual/source/store/build-trace.md
+++ b/doc/manual/source/store/build-trace.md
@@ -29,7 +29,7 @@ And even in that case, a different result doesn't mean the original entry was a 
 As such, the decision of whether to trust a counterparty's build trace is a fundamentally subject policy choice.
 Build trace entries are typically *signed* in order to enable arbitrary public-key-based trust polices.
 
-## Derived build traces
+## Derived build traces {#derived}
 
 Implementations that wish to memoize the above may also keep additional *derived* build trace entries that do map unresolved derivations.
 But if they do so, they *must* also keep the underlying base entries with resolved derivation keys around.

--- a/src/json-schema-checks/build-trace-entry
+++ b/src/json-schema-checks/build-trace-entry
@@ -1,0 +1,1 @@
+../../src/libstore-tests/data/realisation

--- a/src/json-schema-checks/meson.build
+++ b/src/json-schema-checks/meson.build
@@ -54,6 +54,15 @@ schemas = [
       'single_built_built.json',
     ],
   },
+  {
+    'stem' : 'build-trace-entry',
+    'schema' : schema_dir / 'build-trace-entry-v1.yaml',
+    'files' : [
+      'simple.json',
+      'with-dependent-realisations.json',
+      'with-signature.json',
+    ],
+  },
 ]
 
 # Derivation and Derivation output

--- a/src/json-schema-checks/package.nix
+++ b/src/json-schema-checks/package.nix
@@ -23,6 +23,7 @@ mkMesonDerivation (finalAttrs: {
     ../../src/libutil-tests/data/hash
     ../../src/libstore-tests/data/content-address
     ../../src/libstore-tests/data/store-path
+    ../../src/libstore-tests/data/realisation
     ../../src/libstore-tests/data/derivation
     ../../src/libstore-tests/data/derived-path
     ../../src/libstore-tests/data/path-info


### PR DESCRIPTION
## Motivation

More JSON Schema completeness

## Context

Depends on #14408

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
