### PR TITLE
libfetchers: Restore plain git inputs recognition

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -164,8 +164,7 @@ struct GitInputScheme : InputScheme
 {
     std::optional<Input> inputFromURL(const Settings & settings, const ParsedURL & url, bool requireTree) const override
     {
-        auto parsedScheme = parseUrlScheme(url.scheme);
-        if (parsedScheme.application != "git")
+        if (url.scheme != "git" && parseUrlScheme(url.scheme).application != "git")
             return {};
 
         auto url2(url);

--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -207,6 +207,28 @@ INSTANTIATE_TEST_SUITE_P(
             .expectedUrl = "flake:nixpkgs/branch/2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
         },
         InputFromURLTestCase{
+            .url = "git://somewhere/repo?ref=branch",
+            .attrs =
+                {
+                    {"type", Attr("git")},
+                    {"ref", Attr("branch")},
+                    {"url", Attr("git://somewhere/repo")},
+                },
+            .description = "plain_git_with_ref",
+            .expectedUrl = "git://somewhere/repo?ref=branch",
+        },
+        InputFromURLTestCase{
+            .url = "git+https://somewhere.aaaaaaa/repo?ref=branch",
+            .attrs =
+                {
+                    {"type", Attr("git")},
+                    {"ref", Attr("branch")},
+                    {"url", Attr("https://somewhere.aaaaaaa/repo")},
+                },
+            .description = "git_https_with_ref",
+            .expectedUrl = "git+https://somewhere.aaaaaaa/repo?ref=branch",
+        },
+        InputFromURLTestCase{
             // Note that this is different from above because the "flake id" shorthand
             // doesn't allow this.
             .url = "flake:/nixpkgs///branch////",


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Accidentally broken in dbc235cc62b0f26d459c1df7b4659ff15abdc718. Adds a bit of tests for this, even though this protocol is mostly deprecated everywhere.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
