### PR TITLE
libstore: Include missing header to fix compile with libc++ 20

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -22,6 +22,7 @@
 #include <random>
 
 #include <climits>
+#include <thread>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/thread.html

src/libstore/gc.cc:121:39: error: no member named 'sleep_for' in namespace 'std::this_thread'
  121 |                     std::this_thread::sleep_for(std::chrono::milliseconds(100));
      |                     ~~~~~~~~~~~~~~~~~~^

(cherry picked from commit 140b08ae3e8a766fc04e70b7a281abb746f06241)

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I hit the same error compiling Nix for FreeBSD with latest nixpkgs source. But when I looked a bit deeper, the bug was already sorted.

In https://github.com/NixOS/nix/pull/14134 this issue was fixed against master branch. I noticed the automatic backporting had failed, so I resolved the conflict and raised a new PR.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
