### PR TITLE
libstore: Improve store-reference back-compat with IPv6 ZoneId literals

### DIFF
--- a/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_4.txt
+++ b/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_4.txt
@@ -1,0 +1,1 @@
+ssh://userinfo@[fea5:23e1:3916:fc24:cb52:2837:2ecb:ea8e%eth0]?a=b&c=d

--- a/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_5.txt
+++ b/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_5.txt
@@ -1,0 +1,1 @@
+ssh://userinfo@[fea5:23e1:3916:fc24:cb52:2837:2ecb:ea8e%25eth0]?a=b&c=d

--- a/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_6.txt
+++ b/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_6.txt
@@ -1,0 +1,1 @@
+ssh://userinfo@fea5:23e1:3916:fc24:cb52:2837:2ecb:ea8e%25?a=b&c=d

--- a/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_7.txt
+++ b/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_7.txt
@@ -1,0 +1,1 @@
+ssh://userinfo@fea5:23e1:3916:fc24:cb52:2837:2ecb:ea8e%eth0?a=b&c=d

--- a/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_8.txt
+++ b/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_8.txt
@@ -1,0 +1,1 @@
+ssh://fea5:23e1:3916:fc24:cb52:2837:2ecb:ea8e%eth0?a=b&c=d

--- a/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_9.txt
+++ b/src/libstore-tests/data/store-reference/ssh_unbracketed_ipv6_9.txt
@@ -1,0 +1,1 @@
+ssh://fea5:23e1:3916:fc24:cb52:2837:2ecb:ea8e%eth0

--- a/src/libstore-tests/store-reference.cc
+++ b/src/libstore-tests/store-reference.cc
@@ -186,4 +186,64 @@ static StoreReference sshIPv6AuthorityWithUserinfoAndParams{
 
 URI_TEST_READ(ssh_unbracketed_ipv6_3, sshIPv6AuthorityWithUserinfoAndParams)
 
+static const StoreReference sshIPv6AuthorityWithUserinfoAndParamsAndZoneId{
+    .variant =
+        StoreReference::Specified{
+            .scheme = "ssh",
+            .authority = "userinfo@[fea5:23e1:3916:fc24:cb52:2837:2ecb:ea8e%25eth0]",
+        },
+    .params =
+        {
+            {"a", "b"},
+            {"c", "d"},
+        },
+};
+
+URI_TEST_READ(ssh_unbracketed_ipv6_4, sshIPv6AuthorityWithUserinfoAndParamsAndZoneId)
+URI_TEST_READ(ssh_unbracketed_ipv6_5, sshIPv6AuthorityWithUserinfoAndParamsAndZoneId)
+
+static const StoreReference sshIPv6AuthorityWithUserinfoAndParamsAndZoneIdTricky{
+    .variant =
+        StoreReference::Specified{
+            .scheme = "ssh",
+            .authority = "userinfo@[fea5:23e1:3916:fc24:cb52:2837:2ecb:ea8e%2525]",
+        },
+    .params =
+        {
+            {"a", "b"},
+            {"c", "d"},
+        },
+};
+
+// Non-standard syntax where the IPv6 literal appears without brackets. In
+// this case don't considering %25 to be a pct-encoded % and just take it as a
+// literal value. 25 is a perfectly legal ZoneId value in theory.
+URI_TEST_READ(ssh_unbracketed_ipv6_6, sshIPv6AuthorityWithUserinfoAndParamsAndZoneIdTricky)
+URI_TEST_READ(ssh_unbracketed_ipv6_7, sshIPv6AuthorityWithUserinfoAndParamsAndZoneId)
+
+static const StoreReference sshIPv6AuthorityWithParamsAndZoneId{
+    .variant =
+        StoreReference::Specified{
+            .scheme = "ssh",
+            .authority = "[fea5:23e1:3916:fc24:cb52:2837:2ecb:ea8e%25eth0]",
+        },
+    .params =
+        {
+            {"a", "b"},
+            {"c", "d"},
+        },
+};
+
+URI_TEST_READ(ssh_unbracketed_ipv6_8, sshIPv6AuthorityWithParamsAndZoneId)
+
+static const StoreReference sshIPv6AuthorityWithZoneId{
+    .variant =
+        StoreReference::Specified{
+            .scheme = "ssh",
+            .authority = "[fea5:23e1:3916:fc24:cb52:2837:2ecb:ea8e%25eth0]",
+        },
+};
+
+URI_TEST_READ(ssh_unbracketed_ipv6_9, sshIPv6AuthorityWithZoneId)
+
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This restores the pre-2.31 handling of ZoneID identifiers in store references. It's the only place we reasonably care about this back-compat.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Resolves https://github.com/NixOS/nix/issues/13937.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
