### PR TITLE
ci: test AWS OIDC for Nix releases

### DIFF
--- a/.github/workflows/test-release-oidc.yml
+++ b/.github/workflows/test-release-oidc.yml
@@ -1,0 +1,35 @@
+name: Test Release OIDC
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  oidc-check:
+    runs-on: ubuntu-latest
+    environment: releases
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "arn:aws:iam::080433136561:role/nix-release"
+          role-session-name: nix-release-oidc-test-${{ github.run_id }}
+          aws-region: eu-west-1
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Confirm access to release bucket
+        run: |
+          set -euo pipefail
+          KEY=$(aws s3api list-objects-v2 --bucket nix-releases --prefix nix/ --max-items 1 --query 'Contents[0].Key' --output text)
+          if [ "$KEY" = "None" ] || [ -z "$KEY" ]; then
+            echo "No objects found under nix/ prefix in nix-releases bucket" >&2
+            exit 1
+          fi
+          echo "Found object $KEY"
+          aws s3api head-object --bucket nix-releases --key "$KEY" --output json


### PR DESCRIPTION
DO NOT MERGE

This is a test run to check that the IAM role and OIDC setup on the AWS account is setup correctly.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Automate the Nix releases

## Context

https://github.com/NixOS/infra/pull/879 is the PR on the NixOS infra side.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
