### PR TITLE
libexpr: shrink ExprWith by 8 bytes

### DIFF
--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -637,8 +637,8 @@ struct ExprLet : Expr
 struct ExprWith : Expr
 {
     PosIdx pos;
+    uint32_t prevWith;
     Expr *attrs, *body;
-    size_t prevWith;
     ExprWith * parentWith;
     ExprWith(const PosIdx & pos, Expr * attrs, Expr * body)
         : pos(pos)

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -523,6 +523,7 @@ void ExprWith::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> &
     prevWith = 0;
     for (curEnv = env.get(), level = 1; curEnv; curEnv = curEnv->up.get(), level++)
         if (curEnv->isWith) {
+            assert(level <= std::numeric_limits<uint32_t>::max());
             prevWith = level;
             break;
         }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Shrinks ExprWith by 8 bytes

- 4 bytes reducing size_t to uint32_t
- 4 bytes of padding

This doesn't make an appreciable difference in overall memory use, so not sure if it's worth it. But I'll leave that up to the team.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- loosely related to #14088. This doesn't move anything into the allocator, but I'm generally interested in shrinking datastructures in cppnix.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
