### PR TITLE
libexpr: move ExprConcatStrings data to Exprs::alloc

### DIFF
--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -760,11 +760,19 @@ struct ExprConcatStrings : Expr
 {
     PosIdx pos;
     bool forceString;
-    std::vector<std::pair<PosIdx, Expr *>> es;
-    ExprConcatStrings(const PosIdx & pos, bool forceString, std::vector<std::pair<PosIdx, Expr *>> && es)
+    std::span<std::pair<PosIdx, Expr *>> es;
+
+    ExprConcatStrings(
+        std::pmr::polymorphic_allocator<char> & alloc,
+        const PosIdx & pos,
+        bool forceString,
+        const std::vector<std::pair<PosIdx, Expr *>> & es)
         : pos(pos)
         , forceString(forceString)
-        , es(std::move(es)) {};
+        , es({alloc.allocate_object<std::pair<PosIdx, Expr *>>(es.size()), es.size()})
+    {
+        std::ranges::copy(es, this->es.begin());
+    };
 
     PosIdx getPos() const override
     {

--- a/src/libexpr/include/nix/expr/parser-state.hh
+++ b/src/libexpr/include/nix/expr/parser-state.hh
@@ -341,7 +341,7 @@ ParserState::stripIndentation(const PosIdx pos, std::vector<std::pair<PosIdx, st
         auto * const result = (es2)[0].second;
         return result;
     }
-    return new ExprConcatStrings(pos, true, std::move(es2));
+    return new ExprConcatStrings(alloc, pos, true, std::move(es2));
 }
 
 inline PosIdx LexerState::at(const ParserLocation & loc)

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -253,7 +253,7 @@ expr_op
   | expr_op UPDATE expr_op { $$ = new ExprOpUpdate(state->at(@2), $1, $3); }
   | expr_op '?' attrpath { $$ = new ExprOpHasAttr(state->alloc, $1, std::move($3)); }
   | expr_op '+' expr_op
-    { $$ = new ExprConcatStrings(state->at(@2), false, {{state->at(@1), $1}, {state->at(@3), $3}}); }
+    { $$ = new ExprConcatStrings(state->alloc, state->at(@2), false, {{state->at(@1), $1}, {state->at(@3), $3}}); }
   | expr_op '-' expr_op { $$ = new ExprCall(state->at(@2), new ExprVar(state->s.sub), {$1, $3}); }
   | expr_op '*' expr_op { $$ = new ExprCall(state->at(@2), new ExprVar(state->s.mul), {$1, $3}); }
   | expr_op '/' expr_op { $$ = new ExprCall(state->at(@2), new ExprVar(state->s.div), {$1, $3}); }
@@ -309,7 +309,7 @@ expr_simple
   | path_start PATH_END
   | path_start string_parts_interpolated PATH_END {
       $2.insert($2.begin(), {state->at(@1), $1});
-      $$ = new ExprConcatStrings(CUR_POS, false, std::move($2));
+      $$ = new ExprConcatStrings(state->alloc, CUR_POS, false, std::move($2));
   }
   | SPATH {
       std::string_view path($1.p + 1, $1.l - 2);
@@ -343,7 +343,7 @@ expr_simple
 
 string_parts
   : STR { $$ = $1; }
-  | string_parts_interpolated { $$ = new ExprConcatStrings(CUR_POS, true, std::move($1)); }
+  | string_parts_interpolated { $$ = new ExprConcatStrings(state->alloc, CUR_POS, true, std::move($1)); }
   | { $$ = std::string_view(); }
   ;
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

- see [the tracking issue](https://github.com/nixos/nix/issues/14088) for big-picture motivation

~~this PR moves ExprConcatStrings' data to Exprs::alloc, and saves 16 bytes per `ExprConcatStrings`~~

- ~~`std::vector` (24 bytes) -> `uint16_t` (fits in padding) + pointer (8 bytes)~~

UPDATE: saves 8 bytes.

- `std::vector` (24 bytes) -> 16 bytes (std::span)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
