### PR TITLE
libmain/shared: Restore MiB units for printMissing

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -65,19 +65,25 @@ void printMissing(ref<Store> store, const MissingPaths & missing, Verbosity lvl)
     }
 
     if (!missing.willSubstitute.empty()) {
+        const float downloadSizeMiB = missing.downloadSize / (1024.f * 1024.f);
+        const float narSizeMiB = missing.narSize / (1024.f * 1024.f);
+        /* N.B these log messages are a de-facto stable interface for NOM [^]. This
+         * needs to be replaced with an alternative way that presents a structured view into
+         * list of paths to be substituted and their sizes.
+         *
+         * [^]:
+         * https://github.com/maralorn/nix-output-monitor/blob/07169b3894ab7cb1ee01d766145ab03bf2dc7a69/lib/NOM/Parser.hs#L76-L86
+         */
         if (missing.willSubstitute.size() == 1) {
             printMsg(
-                lvl,
-                "this path will be fetched (%s download, %s unpacked):",
-                renderSize(missing.downloadSize),
-                renderSize(missing.narSize));
+                lvl, "this path will be fetched (%.2f MiB download, %.2f MiB unpacked):", downloadSizeMiB, narSizeMiB);
         } else {
             printMsg(
                 lvl,
-                "these %d paths will be fetched (%s download, %s unpacked):",
+                "these %d paths will be fetched (%.2f MiB download, %.2f MiB unpacked):",
                 missing.willSubstitute.size(),
-                renderSize(missing.downloadSize),
-                renderSize(missing.narSize));
+                downloadSizeMiB,
+                narSizeMiB);
         }
         std::vector<const StorePath *> willSubstituteSorted = {};
         std::for_each(missing.willSubstitute.begin(), missing.willSubstitute.end(), [&](const StorePath & p) {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Partially reverts 584a8e8a0085e3597f79d1ac9cf9970f575de32a. See the code comment for details. Seems like reverting this change for now will have the least fallout.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
