### PR TITLE
ThreadPool::enqueue(): Use move semantics

### DIFF
--- a/src/libutil/include/nix/util/thread-pool.hh
+++ b/src/libutil/include/nix/util/thread-pool.hh
@@ -36,7 +36,7 @@ public:
     /**
      * Enqueue a function to be executed by the thread pool.
      */
-    void enqueue(const work_t & t);
+    void enqueue(work_t t);
 
     /**
      * Execute work items until the queue is empty.

--- a/src/libutil/thread-pool.cc
+++ b/src/libutil/thread-pool.cc
@@ -41,12 +41,12 @@ void ThreadPool::shutdown()
         thr.join();
 }
 
-void ThreadPool::enqueue(const work_t & t)
+void ThreadPool::enqueue(work_t t)
 {
     auto state(state_.lock());
     if (quit)
         throw ThreadPoolShutDown("cannot enqueue a work item while the thread pool is shutting down");
-    state->pending.push(t);
+    state->pending.push(std::move(t));
     /* Note: process() also executes items, so count it as a worker. */
     if (state->pending.size() > state->workers.size() + 1 && state->workers.size() + 1 < maxThreads)
         state->workers.emplace_back(&ThreadPool::doWork, this, false);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This avoids a superfluous copy of the work item.

~~Also use C++23's `std::move_only_function`, as that allows (for instance) passing an `std::unique_ptr` to the work item.~~ (removed since this doesn't work on macOS yet)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
