### PR TITLE
Fix macOS IPC cleanup in builder

### DIFF
--- a/src/libstore/unix/build/darwin-derivation-builder.cc
+++ b/src/libstore/unix/build/darwin-derivation-builder.cc
@@ -227,6 +227,15 @@ struct DarwinDerivationBuilder : DerivationBuilderImpl
             NULL, drv.builder.c_str(), NULL, &attrp, stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
     }
 
+    /**
+     * Cleans up all System V IPC objects owned by the specified user.
+     *
+     * On Darwin, IPC objects (shared memory segments, message queues, and semaphore)
+     * can persist after the build user's processes are killed, since there are no IPC namespaces
+     * like on Linux. This can exhaust kernel IPC limits over time.
+     *
+     * Uses sysctl to enumerate and remove all IPC objects owned by the given UID.
+     */
     void cleanupSysVIPCForUser(uid_t uid)
     {
         struct IpcsCommand ic;


### PR DESCRIPTION
In Linux, IPC objects are automatically cleaned up when the IPC namespace is destroyed. On Darwin, since there are no IPC namespaces, IPC objects may persist after the build user's processes are killed, leading to resource leaks.

This PR modifies the builder cleanup logic to enumerate and remove leftover IPC objects associated with the build user using Darwin's sysctl interface (`kern.sysv.ipcs.shm`), following the pattern from Apple's ipcs.c implementation.

**Changes in this PR:**
- Add `cleanupSysVIPCForUser()` function that uses Darwin's sysctl API to enumerate and remove IPC objects owned by the build user
- Call cleanup in `killSandbox()` after processes are terminated

Closes: #12548
References:
- https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sysctl.3.html
- https://github.com/apple/darwin-xnu/blob/main/bsd/sys/ipcs.h
- https://github.com/apple-open-source/macos/blob/f60c49b581c54dfc3367b3ebc5b7904fd7d5db7b/file_cmds/ipcs/ipcs.c