### PR TITLE
feat(tests/nixos/s3-binary-cache-store): exercise access with both s3:// and https:// URLs

### DIFF
--- a/src/libstore/s3-binary-cache-store.md
+++ b/src/libstore/s3-binary-cache-store.md
@@ -10,9 +10,28 @@ For S3 compatible binary caches, consult that cache's documentation.
 
 ### Anonymous reads to your S3-compatible binary cache
 
-> If your binary cache is publicly accessible and does not require authentication,
-> it is simplest to use the [HTTP Binary Cache Store] rather than S3 Binary Cache Store with
-> <https://example-nix-cache.s3.amazonaws.com> instead of <s3://example-nix-cache>.
+For publicly accessible binary caches that don't require authentication, you have two options:
+
+**Option 1: HTTP URLs (Recommended)**
+
+Use direct HTTPS URLs to avoid S3 credential lookup:
+
+```
+# AWS S3 (virtual-hosted style)
+https://bucket-name.s3.region.amazonaws.com
+
+# AWS S3 (path style)
+https://s3.region.amazonaws.com/bucket-name
+
+# S3-compatible services
+https://endpoint/bucket-name
+```
+
+This approach bypasses AWS credential lookup entirely, avoiding timeouts on non-AWS infrastructure.
+
+**Option 2: S3 URLs**
+
+You can still use `s3://bucket-name` URLs, though this may be slower due to credential lookup attempts before falling back to unauthenticated access.
 
 Your bucket will need a
 [bucket policy](https://docs.aws.amazon.com/AmazonS3/v1/userguide/bucket-policies.html)


### PR DESCRIPTION
## Motivation

When accessing public S3 buckets, users can use either:
1. Direct HTTPS URLs (recommended) - bypasses credential lookup entirely
2. s3:// URLs - works due to 403->404 special-casing in `HttpBinaryCacheStore`

This commit:
- Adds `parametrize_url_schemes` decorator for testing both URL types cleanly
- Adds tests to validate both approaches work for public buckets
- Updates documentation recommending HTTPS URLs for public access

## Context

Fixes: #4857

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
