### PR TITLE
feat(libstore): add S3 storage class support

### DIFF
--- a/doc/manual/rl-next/s3-storage-class.md
+++ b/doc/manual/rl-next/s3-storage-class.md
@@ -1,0 +1,21 @@
+---
+synopsis: "S3 binary cache stores now support storage class configuration"
+prs: [14464]
+issues: [7015]
+---
+
+S3 binary cache stores now support configuring the storage class for uploaded objects via the `storage-class` parameter. This allows users to optimize costs by selecting appropriate storage tiers based on access patterns.
+
+Example usage:
+
+```bash
+# Use Glacier storage for long-term archival
+nix copy --to 's3://my-bucket?storage-class=GLACIER' /nix/store/...
+
+# Use Intelligent Tiering for automatic cost optimization
+nix copy --to 's3://my-bucket?storage-class=INTELLIGENT_TIERING' /nix/store/...
+```
+
+The storage class applies to both regular uploads and multipart uploads. When not specified, objects use the bucket's default storage class.
+
+See the [S3 storage classes documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html) for available storage classes and their characteristics.

--- a/src/libstore-tests/s3-binary-cache-store.cc
+++ b/src/libstore-tests/s3-binary-cache-store.cc
@@ -122,4 +122,22 @@ TEST(S3BinaryCacheStore, parameterFiltering)
     EXPECT_EQ(ref.params["priority"], "10");
 }
 
+/**
+ * Test storage class configuration
+ */
+TEST(S3BinaryCacheStore, storageClassDefault)
+{
+    S3BinaryCacheStoreConfig config{"s3", "test-bucket", {}};
+    EXPECT_EQ(config.storageClass.get(), std::nullopt);
+}
+
+TEST(S3BinaryCacheStore, storageClassConfiguration)
+{
+    StringMap params;
+    params["storage-class"] = "GLACIER";
+
+    S3BinaryCacheStoreConfig config("s3", "test-bucket", params);
+    EXPECT_EQ(config.storageClass.get(), std::optional<std::string>("GLACIER"));
+}
+
 } // namespace nix

--- a/src/libstore/include/nix/store/s3-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/s3-binary-cache-store.hh
@@ -93,6 +93,26 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
           Default is 100 MiB. Only takes effect when multipart-upload is enabled.
         )"};
 
+    const Setting<std::optional<std::string>> storageClass{
+        this,
+        std::nullopt,
+        "storage-class",
+        R"(
+          The S3 storage class to use for uploaded objects. When not set (default),
+          uses the bucket's default storage class. Valid values include:
+          - STANDARD (default, frequently accessed data)
+          - REDUCED_REDUNDANCY (less frequently accessed data)
+          - STANDARD_IA (infrequent access)
+          - ONEZONE_IA (infrequent access, single AZ)
+          - INTELLIGENT_TIERING (automatic cost optimization)
+          - GLACIER (archival with retrieval times in minutes to hours)
+          - DEEP_ARCHIVE (long-term archival with 12-hour retrieval)
+          - GLACIER_IR (instant retrieval archival)
+
+          See AWS S3 documentation for detailed storage class descriptions and pricing:
+          https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html
+        )"};
+
     /**
      * Set of settings that are part of the S3 URI itself.
      * These are needed for region specification and other S3-specific settings.

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -134,10 +134,14 @@ void S3BinaryCacheStore::upsertFile(
     const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint)
 {
     auto doUpload = [&](RestartableSource & src, uint64_t size, std::optional<Headers> headers) {
+        Headers uploadHeaders = headers.value_or(Headers());
+        if (auto storageClass = s3Config->storageClass.get()) {
+            uploadHeaders.emplace_back("x-amz-storage-class", *storageClass);
+        }
         if (s3Config->multipartUpload && size > s3Config->multipartThreshold) {
-            uploadMultipart(path, src, size, mimeType, std::move(headers));
+            uploadMultipart(path, src, size, mimeType, std::move(uploadHeaders));
         } else {
-            upload(path, src, size, mimeType, std::move(headers));
+            upload(path, src, size, mimeType, std::move(uploadHeaders));
         }
     };
 


### PR DESCRIPTION
## Motivation

Add support for configuring S3 storage class via the storage-class
parameter for S3BinaryCacheStore. This allows users to optimize costs
by selecting appropriate storage tiers (STANDARD, GLACIER,
INTELLIGENT_TIERING, etc.) based on access patterns.

The storage class is applied via the x-amz-storage-class header for
both regular PUT uploads and multipart upload initiation.

## Context

Fixed: #7015

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
