### PR TITLE
Implement resource-management experimental feature

### DIFF
--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -4,6 +4,7 @@
 #include "nix/store/derivations.hh"
 #include "nix/store/derived-path.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/machines.hh"
 #include "nix/util/types.hh"
 #include "nix/util/util.hh"
 #include "nix/store/globals.hh"
@@ -407,9 +408,16 @@ bool DerivationOptions<Input>::canBuildLocally(Store & localStore, const BasicDe
     if (settings.maxBuildJobs.get() == 0 && !drv.isBuiltin())
         return false;
 
-    for (auto & feature : getRequiredSystemFeatures(drv))
-        if (!localStore.config.systemFeatures.get().count(feature))
-            return false;
+    auto features = getRequiredSystemFeatures(drv);
+    if (experimentalFeatureSettings.isEnabled(Xp::ResourceManagement)) {
+        auto featureCount = Machine::countFeatures(features);
+        for (auto & feature : featureCount)
+            if (!localStore.config.systemFeatures.get().count(feature.first))
+                return false;
+    } else
+        for (auto & feature : features)
+            if (!localStore.config.systemFeatures.get().count(feature))
+                return false;
 
     return true;
 }

--- a/src/libstore/include/nix/store/machines.hh
+++ b/src/libstore/include/nix/store/machines.hh
@@ -12,6 +12,8 @@ struct Machine;
 
 typedef std::vector<Machine> Machines;
 
+typedef std::map<std::string, unsigned long> FeatureCount;
+
 struct Machine
 {
 
@@ -21,7 +23,9 @@ struct Machine
     const unsigned int maxJobs;
     const float speedFactor;
     const StringSet supportedFeatures;
+    const FeatureCount supportedFeaturesCount;
     const StringSet mandatoryFeatures;
+    const FeatureCount mandatoryFeaturesCount;
     const std::string sshPublicHostKey;
     bool enabled = true;
 
@@ -77,6 +81,11 @@ struct Machine
      * the same format.
      */
     static Machines parseConfig(const StringSet & defaultSystems, const std::string & config);
+
+    /**
+     * Count the number of each feature specified in a feature string.
+     */
+    static FeatureCount countFeatures(const StringSet & features);
 };
 
 /**

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -25,7 +25,7 @@ struct ExperimentalFeatureDetails
  * feature, we either have no issue at all if few features are not added
  * at the end of the list, or a proper merge conflict if they are.
  */
-constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::BLAKE3Hashes);
+constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::ResourceManagement);
 
 constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails = {{
     {
@@ -321,6 +321,14 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         )",
         .trackingUrl = "",
     },
+    {
+        .tag = Xp::ResourceManagement,
+        .name = "resource-management",
+        .description = R"(
+            Enables support for resource management in remote build system features.
+        )",
+        .trackingUrl = "",
+    }
 }};
 
 static_assert(

--- a/src/libutil/include/nix/util/experimental-features.hh
+++ b/src/libutil/include/nix/util/experimental-features.hh
@@ -39,6 +39,7 @@ enum struct ExperimentalFeature {
     PipeOperators,
     ExternalBuilders,
     BLAKE3Hashes,
+    ResourceManagement,
 };
 
 /**

--- a/tests/functional/build-remote-resource-management-should-fail.sh
+++ b/tests/functional/build-remote-resource-management-should-fail.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+enableFeatures "resource-management"
+
+requireSandboxSupport
+[[ $busybox =~ busybox ]] || skipTest "no busybox"
+
+here=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+export NIX_USER_CONF_FILES=$here/config/nix-with-resource-management.conf
+
+expectStderr 1 nix build -Lvf resource-management.nix \
+  --arg busybox "$busybox" \
+  --out-link "$TEST_ROOT/result-from-remote" \
+  --store "$TEST_ROOT/local" \
+  --builders "ssh-ng://localhost?system-features=testf - - 4 1 testf:1" \
+| grepQuiet "Failed to find a machine for remote build!"

--- a/tests/functional/build-remote-resource-management.sh
+++ b/tests/functional/build-remote-resource-management.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+enableFeatures "resource-management"
+
+requireSandboxSupport
+[[ $busybox =~ busybox ]] || skipTest "no busybox"
+
+here=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+export NIX_USER_CONF_FILES=$here/config/nix-with-resource-management.conf
+
+nix build -Lvf resource-management.nix \
+  --arg busybox "$busybox" \
+  --out-link "$TEST_ROOT/result-from-remote" \
+  --store "$TEST_ROOT/local" \
+  --builders "ssh-ng://localhost?system-features=test - - 4 1 test:4"
+
+grepQuiet 'Hello World!' < "$TEST_ROOT/result-from-remote/hello"

--- a/tests/functional/config/nix-with-resource-management.conf
+++ b/tests/functional/config/nix-with-resource-management.conf
@@ -1,0 +1,2 @@
+experimental-features = resource-management nix-command
+system-features = test

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -109,6 +109,8 @@ suites = [
       'build-remote-trustless-should-pass-3.sh',
       'build-remote-trustless-should-fail-0.sh',
       'build-remote-with-mounted-ssh-ng.sh',
+      'build-remote-resource-management-should-fail.sh',
+      'build-remote-resource-management.sh',
       'nar-access.sh',
       'impure-eval.sh',
       'pure-eval.sh',

--- a/tests/functional/resource-management.nix
+++ b/tests/functional/resource-management.nix
@@ -1,0 +1,50 @@
+{ busybox }:
+
+with import ./config.nix;
+
+let
+  drv1 = mkDerivation {
+    name = "resource-management-1";
+    shell = busybox;
+    builder = ./simple.builder.sh;
+    PATH = "";
+    goodPath = path;
+    requiredSystemFeatures = ["test:2"];
+    meta.position = "${__curPos.file}:${toString __curPos.line}";
+  };
+  drv2 = mkDerivation {
+    name = "resource-management-2";
+    shell = busybox;
+    builder = ./simple.builder.sh;
+    PATH = "";
+    goodPath = path;
+    requiredSystemFeatures = ["test:2"];
+    meta.position = "${__curPos.file}:${toString __curPos.line}";
+  };
+  drv3 = mkDerivation {
+    name = "resource-management-3";
+    shell = busybox;
+    builder = ./simple.builder.sh;
+    PATH = "";
+    goodPath = path;
+    requiredSystemFeatures = ["test:2"];
+    meta.position = "${__curPos.file}:${toString __curPos.line}";
+  };
+  drv4 = mkDerivation {
+    name = "resource-management-4";
+    shell = busybox;
+    builder = ./simple.builder.sh;
+    PATH = "";
+    goodPath = path;
+    requiredSystemFeatures = ["test:2"];
+    meta.position = "${__curPos.file}:${toString __curPos.line}";
+  };
+in mkDerivation {
+  name = "resource-management";
+  shell = busybox;
+  builder = ./simple.builder.sh;
+  PATH = "";
+  goodPath = path;
+  DRVS = "${drv1}${drv2}${drv3}${drv4}";
+  meta.position = "${__curPos.file}:${toString __curPos.line}";
+}


### PR DESCRIPTION
Adds basic resource tracking to system features used by distributed builds, similar to resource management in job schedulers like Slurm.

Includes a positive and negative functional test and a documentation update to the distributed builds section.

Resolves #2307

There is a corresponding implementation for Hydra, but it is old and needs updating and rebasing. Interest has been expressed in having this feature both on the original Hydra PR https://github.com/NixOS/hydra/pull/588 and in the linked Nix issue.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Non-trivial derivations may consume various resources on remote machines, like memory or GPUs. Nix has no way to account for this beyond a one-dimensional "slots" measure per-machine. This can lead to over- or under-utilization of build machines, either needlessly limiting the number of slots to serve the most resource-intensive derivations, or running the risk of overrunning resource availability. 

## Context

#2307
https://github.com/NixOS/hydra/issues/585

File locks are used in build-remote.cc to keep track of resource usage on the dispatching end.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
