### PR TITLE
Fix warning in kaitai spec

### DIFF
--- a/doc/manual/source/protocols/nix-archive/nar.ksy
+++ b/doc/manual/source/protocols/nix-archive/nar.ksy
@@ -29,7 +29,7 @@ types:
       - id: body
         type: str
         size: len_str
-        encoding: 'ascii'
+        encoding: 'ASCII'
       - id: padding
         size: (8 - (len_str % 8)) % 8
 


### PR DESCRIPTION
Warning:
```
[39/483] Generating src/kaitai-struct-checks/kaitai-generated-sources with a custom command
../src/kaitai-struct-checks/nar.ksy: /types/padded_str/seq/1/encoding:
        warning: use canonical encoding name `ASCII` instead of `ascii` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
```


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
