### PR TITLE
FIx `DerivationOptions` JSON and clean up unit tests

### DIFF
--- a/src/libstore-tests/data/derivation/ca/all_set.json
+++ b/src/libstore-tests/data/derivation/ca/all_set.json
@@ -1,0 +1,46 @@
+{
+  "additionalSandboxProfile": "sandcastle",
+  "allowLocalNetworking": true,
+  "allowSubstitutes": false,
+  "exportReferencesGraph": {
+    "refs1": [
+      "/164j69y6zir9z0339n8pjigg3rckinlr77bxsavzizdaaljb7nh9"
+    ],
+    "refs2": [
+      "/nix/store/qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv"
+    ]
+  },
+  "impureEnvVars": [
+    "UNICORN"
+  ],
+  "impureHostDeps": [
+    "/usr/bin/ditto"
+  ],
+  "noChroot": true,
+  "outputChecks": {
+    "forAllOutputs": {
+      "allowedReferences": [
+        "/164j69y6zir9z0339n8pjigg3rckinlr77bxsavzizdaaljb7nh9"
+      ],
+      "allowedRequisites": [
+        "/0nr45p69vn6izw9446wsh9bng9nndhvn19kpsm4n96a5mycw0s4z"
+      ],
+      "disallowedReferences": [
+        "/0nyw57wm2iicnm9rglvjmbci3ikmcp823czdqdzdcgsnnwqps71g"
+      ],
+      "disallowedRequisites": [
+        "/07f301yqyz8c6wf6bbbavb2q39j4n8kmcly1s09xadyhgy6x2wr8"
+      ],
+      "ignoreSelfRefs": true,
+      "maxClosureSize": null,
+      "maxSize": null
+    }
+  },
+  "passAsFile": [],
+  "preferLocalBuild": true,
+  "requiredSystemFeatures": [
+    "rainbow",
+    "uid-range"
+  ],
+  "unsafeDiscardReferences": {}
+}

--- a/src/libstore-tests/data/derivation/ca/structuredAttrs_all_set.json
+++ b/src/libstore-tests/data/derivation/ca/structuredAttrs_all_set.json
@@ -1,0 +1,66 @@
+{
+  "additionalSandboxProfile": "sandcastle",
+  "allowLocalNetworking": true,
+  "allowSubstitutes": false,
+  "exportReferencesGraph": {
+    "refs1": [
+      "/164j69y6zir9z0339n8pjigg3rckinlr77bxsavzizdaaljb7nh9"
+    ],
+    "refs2": [
+      "/nix/store/qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv"
+    ]
+  },
+  "impureEnvVars": [
+    "UNICORN"
+  ],
+  "impureHostDeps": [
+    "/usr/bin/ditto"
+  ],
+  "noChroot": true,
+  "outputChecks": {
+    "perOutput": {
+      "bin": {
+        "allowedReferences": null,
+        "allowedRequisites": null,
+        "disallowedReferences": [
+          "/0nyw57wm2iicnm9rglvjmbci3ikmcp823czdqdzdcgsnnwqps71g"
+        ],
+        "disallowedRequisites": [
+          "/07f301yqyz8c6wf6bbbavb2q39j4n8kmcly1s09xadyhgy6x2wr8"
+        ],
+        "ignoreSelfRefs": false,
+        "maxClosureSize": null,
+        "maxSize": null
+      },
+      "dev": {
+        "allowedReferences": null,
+        "allowedRequisites": null,
+        "disallowedReferences": [],
+        "disallowedRequisites": [],
+        "ignoreSelfRefs": false,
+        "maxClosureSize": 5909,
+        "maxSize": 789
+      },
+      "out": {
+        "allowedReferences": [
+          "/164j69y6zir9z0339n8pjigg3rckinlr77bxsavzizdaaljb7nh9"
+        ],
+        "allowedRequisites": [
+          "/0nr45p69vn6izw9446wsh9bng9nndhvn19kpsm4n96a5mycw0s4z"
+        ],
+        "disallowedReferences": [],
+        "disallowedRequisites": [],
+        "ignoreSelfRefs": false,
+        "maxClosureSize": null,
+        "maxSize": null
+      }
+    }
+  },
+  "passAsFile": [],
+  "preferLocalBuild": true,
+  "requiredSystemFeatures": [
+    "rainbow",
+    "uid-range"
+  ],
+  "unsafeDiscardReferences": {}
+}

--- a/src/libstore-tests/data/derivation/ia/all_set.json
+++ b/src/libstore-tests/data/derivation/ia/all_set.json
@@ -1,0 +1,46 @@
+{
+  "additionalSandboxProfile": "sandcastle",
+  "allowLocalNetworking": true,
+  "allowSubstitutes": false,
+  "exportReferencesGraph": {
+    "refs1": [
+      "/nix/store/p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
+    ],
+    "refs2": [
+      "/nix/store/vj2i49jm2868j2fmqvxm70vlzmzvgv14-bar.drv"
+    ]
+  },
+  "impureEnvVars": [
+    "UNICORN"
+  ],
+  "impureHostDeps": [
+    "/usr/bin/ditto"
+  ],
+  "noChroot": true,
+  "outputChecks": {
+    "forAllOutputs": {
+      "allowedReferences": [
+        "/nix/store/p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
+      ],
+      "allowedRequisites": [
+        "/nix/store/z0rjzy29v9k5qa4nqpykrbzirj7sd43v-foo-dev"
+      ],
+      "disallowedReferences": [
+        "/nix/store/r5cff30838majxk5mp3ip2diffi8vpaj-bar"
+      ],
+      "disallowedRequisites": [
+        "/nix/store/9b61w26b4avv870dw0ymb6rw4r1hzpws-bar-dev"
+      ],
+      "ignoreSelfRefs": true,
+      "maxClosureSize": null,
+      "maxSize": null
+    }
+  },
+  "passAsFile": [],
+  "preferLocalBuild": true,
+  "requiredSystemFeatures": [
+    "rainbow",
+    "uid-range"
+  ],
+  "unsafeDiscardReferences": {}
+}

--- a/src/libstore-tests/data/derivation/ia/defaults.json
+++ b/src/libstore-tests/data/derivation/ia/defaults.json
@@ -1,0 +1,24 @@
+{
+  "additionalSandboxProfile": "",
+  "allowLocalNetworking": false,
+  "allowSubstitutes": true,
+  "exportReferencesGraph": {},
+  "impureEnvVars": [],
+  "impureHostDeps": [],
+  "noChroot": false,
+  "outputChecks": {
+    "forAllOutputs": {
+      "allowedReferences": null,
+      "allowedRequisites": null,
+      "disallowedReferences": [],
+      "disallowedRequisites": [],
+      "ignoreSelfRefs": true,
+      "maxClosureSize": null,
+      "maxSize": null
+    }
+  },
+  "passAsFile": [],
+  "preferLocalBuild": false,
+  "requiredSystemFeatures": [],
+  "unsafeDiscardReferences": {}
+}

--- a/src/libstore-tests/data/derivation/ia/structuredAttrs_all_set.json
+++ b/src/libstore-tests/data/derivation/ia/structuredAttrs_all_set.json
@@ -1,0 +1,66 @@
+{
+  "additionalSandboxProfile": "sandcastle",
+  "allowLocalNetworking": true,
+  "allowSubstitutes": false,
+  "exportReferencesGraph": {
+    "refs1": [
+      "/nix/store/p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
+    ],
+    "refs2": [
+      "/nix/store/vj2i49jm2868j2fmqvxm70vlzmzvgv14-bar.drv"
+    ]
+  },
+  "impureEnvVars": [
+    "UNICORN"
+  ],
+  "impureHostDeps": [
+    "/usr/bin/ditto"
+  ],
+  "noChroot": true,
+  "outputChecks": {
+    "perOutput": {
+      "bin": {
+        "allowedReferences": null,
+        "allowedRequisites": null,
+        "disallowedReferences": [
+          "/nix/store/r5cff30838majxk5mp3ip2diffi8vpaj-bar"
+        ],
+        "disallowedRequisites": [
+          "/nix/store/9b61w26b4avv870dw0ymb6rw4r1hzpws-bar-dev"
+        ],
+        "ignoreSelfRefs": false,
+        "maxClosureSize": null,
+        "maxSize": null
+      },
+      "dev": {
+        "allowedReferences": null,
+        "allowedRequisites": null,
+        "disallowedReferences": [],
+        "disallowedRequisites": [],
+        "ignoreSelfRefs": false,
+        "maxClosureSize": 5909,
+        "maxSize": 789
+      },
+      "out": {
+        "allowedReferences": [
+          "/nix/store/p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
+        ],
+        "allowedRequisites": [
+          "/nix/store/z0rjzy29v9k5qa4nqpykrbzirj7sd43v-foo-dev"
+        ],
+        "disallowedReferences": [],
+        "disallowedRequisites": [],
+        "ignoreSelfRefs": false,
+        "maxClosureSize": null,
+        "maxSize": null
+      }
+    }
+  },
+  "passAsFile": [],
+  "preferLocalBuild": true,
+  "requiredSystemFeatures": [
+    "rainbow",
+    "uid-range"
+  ],
+  "unsafeDiscardReferences": {}
+}

--- a/src/libstore-tests/data/derivation/ia/structuredAttrs_defaults.json
+++ b/src/libstore-tests/data/derivation/ia/structuredAttrs_defaults.json
@@ -1,0 +1,16 @@
+{
+  "additionalSandboxProfile": "",
+  "allowLocalNetworking": false,
+  "allowSubstitutes": true,
+  "exportReferencesGraph": {},
+  "impureEnvVars": [],
+  "impureHostDeps": [],
+  "noChroot": false,
+  "outputChecks": {
+    "perOutput": {}
+  },
+  "passAsFile": [],
+  "preferLocalBuild": false,
+  "requiredSystemFeatures": [],
+  "unsafeDiscardReferences": {}
+}

--- a/src/libstore-tests/derivation-advanced-attrs.cc
+++ b/src/libstore-tests/derivation-advanced-attrs.cc
@@ -10,13 +10,15 @@
 #include "nix/util/json-utils.hh"
 
 #include "nix/store/tests/libstore.hh"
-#include "nix/util/tests/characterization.hh"
+#include "nix/util/tests/json-characterization.hh"
 
 namespace nix {
 
 using namespace nlohmann;
 
-class DerivationAdvancedAttrsTest : public CharacterizationTest, public LibStoreTest
+class DerivationAdvancedAttrsTest : public JsonCharacterizationTest<Derivation>,
+                                    public JsonCharacterizationTest<DerivationOptions>,
+                                    public LibStoreTest
 {
 protected:
     std::filesystem::path unitTestData = getUnitTestData() / "derivation" / "ia";
@@ -453,5 +455,24 @@ TEST_F(CaDerivationAdvancedAttrsTest, advancedAttributes_structuredAttrs)
         advancedAttributes_structuredAttrs_ca,
         {"rainbow", "uid-range", "ca-derivations"});
 };
+
+#define TEST_JSON_OPTIONS(FIXUTURE, VAR, VAR2)                                                             \
+    TEST_F(FIXUTURE, DerivationOptions_##VAR##_from_json)                                                  \
+    {                                                                                                      \
+        this->JsonCharacterizationTest<DerivationOptions>::readJsonTest(#VAR, advancedAttributes_##VAR2);  \
+    }                                                                                                      \
+    TEST_F(FIXUTURE, DerivationOptions_##VAR##_to_json)                                                    \
+    {                                                                                                      \
+        this->JsonCharacterizationTest<DerivationOptions>::writeJsonTest(#VAR, advancedAttributes_##VAR2); \
+    }
+
+TEST_JSON_OPTIONS(DerivationAdvancedAttrsTest, defaults, defaults)
+TEST_JSON_OPTIONS(DerivationAdvancedAttrsTest, all_set, ia)
+TEST_JSON_OPTIONS(CaDerivationAdvancedAttrsTest, all_set, ca)
+TEST_JSON_OPTIONS(DerivationAdvancedAttrsTest, structuredAttrs_defaults, structuredAttrs_defaults)
+TEST_JSON_OPTIONS(DerivationAdvancedAttrsTest, structuredAttrs_all_set, structuredAttrs_ia)
+TEST_JSON_OPTIONS(CaDerivationAdvancedAttrsTest, structuredAttrs_all_set, structuredAttrs_ca)
+
+#undef TEST_JSON_OPTIONS
 
 } // namespace nix

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -1404,7 +1404,7 @@ void adl_serializer<Derivation>::to_json(json & res, const Derivation & d)
 
     {
         auto & inputsList = res["inputSrcs"];
-        inputsList = nlohmann::json ::array();
+        inputsList = nlohmann::json::array();
         for (auto & input : d.inputSrcs)
             inputsList.emplace_back(input);
     }

--- a/src/libutil/include/nix/util/json-utils.hh
+++ b/src/libutil/include/nix/util/json-utils.hh
@@ -59,6 +59,17 @@ auto getInteger(const nlohmann::json & value) -> std::enable_if_t<std::is_signed
     throw Error("Out of range: JSON value '%s' cannot be casted to %d-bit integer", value.dump(), 8 * sizeof(T));
 }
 
+template<typename... Args>
+std::map<std::string, Args...> getMap(const nlohmann::json::object_t & jsonObject, auto && f)
+{
+    std::map<std::string, Args...> map;
+
+    for (const auto & [key, value] : jsonObject)
+        map.insert_or_assign(key, f(value));
+
+    return map;
+}
+
 const nlohmann::json::boolean_t & getBoolean(const nlohmann::json & value);
 Strings getStringList(const nlohmann::json & value);
 StringMap getStringMap(const nlohmann::json & value);

--- a/src/libutil/json-utils.cc
+++ b/src/libutil/json-utils.cc
@@ -91,14 +91,7 @@ Strings getStringList(const nlohmann::json & value)
 
 StringMap getStringMap(const nlohmann::json & value)
 {
-    auto & jsonObject = getObject(value);
-
-    StringMap stringMap;
-
-    for (const auto & [key, value] : jsonObject)
-        stringMap[getString(key)] = getString(value);
-
-    return stringMap;
+    return getMap<std::string, std::less<>>(getObject(value), getString);
 }
 
 StringSet getStringSet(const nlohmann::json & value)


### PR DESCRIPTION
## Motivation

Rest testing:

We now test equality on whole strucks much more often, which avoids
forgetting to test for specific fields.

## Context

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
