### PR TITLE
libexpr: allocate the Exprs themselves in Exprs::alloc

### DIFF
--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -813,7 +813,7 @@ public:
     [[gnu::always_inline]]
     C * add(auto &&... args)
     {
-        return new C(std::forward<decltype(args)>(args)...);
+        return alloc.new_object<C>(std::forward<decltype(args)>(args)...);
     }
 
     // we define some calls to add explicitly so that the argument can be passed in as initializer lists
@@ -822,7 +822,7 @@ public:
     C * add(const PosIdx & pos, Expr * fun, std::vector<Expr *> && args)
         requires(std::same_as<C, ExprCall>)
     {
-        return new C(pos, fun, std::move(args));
+        return alloc.new_object<C>(pos, fun, std::move(args));
     }
 
     template<class C>
@@ -830,7 +830,7 @@ public:
     C * add(const PosIdx & pos, Expr * fun, std::vector<Expr *> && args, PosIdx && cursedOrEndPos)
         requires(std::same_as<C, ExprCall>)
     {
-        return new C(pos, fun, std::move(args), std::move(cursedOrEndPos));
+        return alloc.new_object<C>(pos, fun, std::move(args), std::move(cursedOrEndPos));
     }
 
     template<class C>


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

for big-picture motivation, see [the tracking issue](https://github.com/nixos/nix/issues/14088)

This PR moves the `Expr` objects into `Exprs::alloc`. In truth, eventually we want them to live outside of the allocator in vectors.

However, we're in a bit of a catch 22. Part of the reason we want to move the Exprs into vectors is so they don't get leaked so that we can do fuzz testing. But it's a big enough change that we're going to want to be able to fuzz-test it!

This is my way of snipping that loop. It gets rid of the leak so we can fuzz test the bigger changes.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- [tracking issue](https://github.com/nixos/nix/issues/14088)

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
