### PR TITLE
refactor(libstore): pass headers into upload methods

### DIFF
--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -103,18 +103,7 @@ protected:
         RestartableSource & source,
         uint64_t sizeHint,
         std::string_view mimeType,
-        std::optional<std::string_view> contentEncoding);
-
-    /**
-     * Uploads data to the binary cache (CompressedSource overload).
-     *
-     * This overload infers both the size and compression method from the CompressedSource.
-     *
-     * @param path The path in the binary cache to upload to
-     * @param source The compressed source (knows size and compression method)
-     * @param mimeType The MIME type of the content
-     */
-    void upload(std::string_view path, CompressedSource & source, std::string_view mimeType);
+        std::optional<Headers> headers);
 
     void getFile(const std::string & path, Sink & sink) override;
 


### PR DESCRIPTION
## Motivation

This will make it easier to attach additional headers (e.g. storage
class) on the s3 side of things and makes `Content-Encoding` less
special.

I also got rid of the override for CompressedSource, since I don't think it was helping much.

## Context

This should simplify #14464 a bit.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
