### PR TITLE
nix-kaitai-struct: make it not longer part of the devshell

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,4 +61,3 @@ if get_option('unit-tests')
 endif
 subproject('nix-functional-tests')
 subproject('json-schema-checks')
-subproject('kaitai-struct-checks')

--- a/packaging/dev-shell.nix
+++ b/packaging/dev-shell.nix
@@ -109,7 +109,6 @@ pkgs.nixComponents2.nix-util.overrideAttrs (
           ++ pkgs.nixComponents2.nix-external-api-docs.nativeBuildInputs
           ++ pkgs.nixComponents2.nix-functional-tests.externalNativeBuildInputs
           ++ pkgs.nixComponents2.nix-json-schema-checks.externalNativeBuildInputs
-          ++ pkgs.nixComponents2.nix-kaitai-struct-checks.externalNativeBuildInputs
           ++ lib.optional (
             !buildCanExecuteHost
             # Hack around https://github.com/nixos/nixpkgs/commit/bf7ad8cfbfa102a90463433e2c5027573b462479
@@ -149,7 +148,6 @@ pkgs.nixComponents2.nix-util.overrideAttrs (
     ++ pkgs.nixComponents2.nix-expr.externalPropagatedBuildInputs
     ++ pkgs.nixComponents2.nix-cmd.buildInputs
     ++ lib.optionals havePerl pkgs.nixComponents2.nix-perl-bindings.externalBuildInputs
-    ++ lib.optional havePerl pkgs.perl
-    ++ pkgs.nixComponents2.nix-kaitai-struct-checks.externalBuildInputs;
+    ++ lib.optional havePerl pkgs.perl;
   }
 )

--- a/src/kaitai-struct-checks/package.nix
+++ b/src/kaitai-struct-checks/package.nix
@@ -1,4 +1,5 @@
 # Run with: nix build .#nix-kaitai-struct-checks
+# or: `nix develop .#nix-kaitai-struct-checks` to enter a dev shell
 {
   lib,
   mkMesonDerivation,


### PR DESCRIPTION
just now pulls in jdk in

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
