### PR TITLE
`DerivationBuilderParams` have reference to `BasicDerivation`

### DIFF
--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -62,7 +62,7 @@ struct DerivationBuilderParams
     /**
      * The derivation stored at drvPath.
      */
-    const Derivation & drv;
+    const BasicDerivation & drv;
 
     /**
      * The derivation options of `drv`.


### PR DESCRIPTION
## Motivation

Have one to that instead of one to `Derivation`. `DerivationBuilder` doesn't need `inputDrvs`, so `BasicDerivation` suffices.

## Context

(In fact, it doesn't need `inputSrcs` either, but we don't yet hve a type to exclude that.)

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
