### PR TITLE
Make `ValidPathInfo`, `NarInfo` JSON instances, but don't yet use in the CLI

### DIFF
--- a/src/libstore-tests/nar-info.cc
+++ b/src/libstore-tests/nar-info.cc
@@ -65,7 +65,7 @@ static NarInfo makeNarInfo(const Store & store, bool includeImpureInfo)
         readTest(#STEM, [&](const auto & encoded_) {                                                  \
             auto encoded = json::parse(encoded_);                                                     \
             auto expected = makeNarInfo(*store, PURE);                                                \
-            NarInfo got = NarInfo::fromJSON(*store, expected.path, encoded);                          \
+            auto got = UnkeyedNarInfo::fromJSON(&*store, encoded);                                    \
             ASSERT_EQ(got, expected);                                                                 \
         });                                                                                           \
     }                                                                                                 \
@@ -74,7 +74,7 @@ static NarInfo makeNarInfo(const Store & store, bool includeImpureInfo)
     {                                                                                                 \
         writeTest(                                                                                    \
             #STEM,                                                                                    \
-            [&]() -> json { return makeNarInfo(*store, PURE).toJSON(*store, PURE); },                 \
+            [&]() -> json { return makeNarInfo(*store, PURE).toJSON(&*store, PURE); },                \
             [](const auto & file) { return json::parse(readFile(file)); },                            \
             [](const auto & file, const auto & got) { return writeFile(file, got.dump(2) + "\n"); }); \
     }

--- a/src/libstore-tests/path-info.cc
+++ b/src/libstore-tests/path-info.cc
@@ -70,7 +70,7 @@ static UnkeyedValidPathInfo makeFull(const Store & store, bool includeImpureInfo
     {                                                                                                 \
         readTest(#STEM, [&](const auto & encoded_) {                                                  \
             auto encoded = json::parse(encoded_);                                                     \
-            UnkeyedValidPathInfo got = UnkeyedValidPathInfo::fromJSON(*store, encoded);               \
+            UnkeyedValidPathInfo got = UnkeyedValidPathInfo::fromJSON(&*store, encoded);              \
             auto expected = OBJ;                                                                      \
             ASSERT_EQ(got, expected);                                                                 \
         });                                                                                           \
@@ -80,7 +80,7 @@ static UnkeyedValidPathInfo makeFull(const Store & store, bool includeImpureInfo
     {                                                                                                 \
         writeTest(                                                                                    \
             #STEM,                                                                                    \
-            [&]() -> json { return OBJ.toJSON(*store, PURE); },                                       \
+            [&]() -> json { return OBJ.toJSON(&*store, PURE); },                                      \
             [](const auto & file) { return json::parse(readFile(file)); },                            \
             [](const auto & file, const auto & got) { return writeFile(file, got.dump(2) + "\n"); }); \
     }

--- a/src/libstore/include/nix/store/nar-info.hh
+++ b/src/libstore/include/nix/store/nar-info.hh
@@ -9,17 +9,42 @@ namespace nix {
 
 struct StoreDirConfig;
 
-struct NarInfo : ValidPathInfo
+struct UnkeyedNarInfo : virtual UnkeyedValidPathInfo
 {
     std::string url;
     std::string compression;
     std::optional<Hash> fileHash;
     uint64_t fileSize = 0;
 
+    UnkeyedNarInfo(UnkeyedValidPathInfo info)
+        : UnkeyedValidPathInfo(std::move(info))
+    {
+    }
+
+    bool operator==(const UnkeyedNarInfo &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::optional::operator <=>`, can't do yet
+    // auto operator <=>(const NarInfo &) const = default;
+
+    nlohmann::json toJSON(const StoreDirConfig * store, bool includeImpureInfo) const override;
+    static UnkeyedNarInfo fromJSON(const StoreDirConfig * store, const nlohmann::json & json);
+};
+
+/**
+ * Key and the extra NAR fields
+ */
+struct NarInfo : ValidPathInfo, UnkeyedNarInfo
+{
     NarInfo() = delete;
 
     NarInfo(ValidPathInfo info)
-        : ValidPathInfo{std::move(info)}
+        : UnkeyedValidPathInfo{static_cast<UnkeyedValidPathInfo &&>(info)}
+        /* Later copies from `*this` are pointless. The argument is only
+           there so the constructors can also call
+           `UnkeyedValidPathInfo`, but this won't happen since the base
+           class is virtual. Only this counstructor (assuming it is most
+           derived) will initialize that virtual base class. */
+        , ValidPathInfo{info.path, static_cast<const UnkeyedValidPathInfo &>(*this)}
+        , UnkeyedNarInfo{static_cast<const UnkeyedValidPathInfo &>(*this)}
     {
     }
 
@@ -37,13 +62,10 @@ struct NarInfo : ValidPathInfo
     NarInfo(const StoreDirConfig & store, const std::string & s, const std::string & whence);
 
     bool operator==(const NarInfo &) const = default;
-    // TODO libc++ 16 (used by darwin) missing `std::optional::operator <=>`, can't do yet
-    // auto operator <=>(const NarInfo &) const = default;
 
     std::string to_string(const StoreDirConfig & store) const;
-
-    nlohmann::json toJSON(const StoreDirConfig & store, bool includeImpureInfo) const override;
-    static NarInfo fromJSON(const StoreDirConfig & store, const StorePath & path, const nlohmann::json & json);
 };
 
 } // namespace nix
+
+JSON_IMPL(nix::UnkeyedNarInfo)

--- a/src/libstore/include/nix/store/path-info.hh
+++ b/src/libstore/include/nix/store/path-info.hh
@@ -117,11 +117,11 @@ struct UnkeyedValidPathInfo
      * @param includeImpureInfo If true, variable elements such as the
      * registration time are included.
      */
-    virtual nlohmann::json toJSON(const StoreDirConfig & store, bool includeImpureInfo) const;
-    static UnkeyedValidPathInfo fromJSON(const StoreDirConfig & store, const nlohmann::json & json);
+    virtual nlohmann::json toJSON(const StoreDirConfig * store, bool includeImpureInfo) const;
+    static UnkeyedValidPathInfo fromJSON(const StoreDirConfig * store, const nlohmann::json & json);
 };
 
-struct ValidPathInfo : UnkeyedValidPathInfo
+struct ValidPathInfo : virtual UnkeyedValidPathInfo
 {
     StorePath path;
 
@@ -174,10 +174,14 @@ struct ValidPathInfo : UnkeyedValidPathInfo
 
     ValidPathInfo(StorePath && path, UnkeyedValidPathInfo info)
         : UnkeyedValidPathInfo(info)
-        , path(std::move(path)) {};
+        , path(std::move(path))
+    {
+    }
+
     ValidPathInfo(const StorePath & path, UnkeyedValidPathInfo info)
-        : UnkeyedValidPathInfo(info)
-        , path(path) {};
+        : ValidPathInfo(StorePath{path}, std::move(info))
+    {
+    }
 
     static ValidPathInfo
     makeFromCA(const StoreDirConfig & store, std::string_view name, ContentAddressWithReferences && ca, Hash narHash);
@@ -191,3 +195,5 @@ static_assert(std::is_move_constructible_v<ValidPathInfo>);
 using ValidPathInfos = std::map<StorePath, ValidPathInfo>;
 
 } // namespace nix
+
+JSON_IMPL(nix::UnkeyedValidPathInfo)

--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -51,7 +51,7 @@ static json pathInfoToJSON(Store & store, const StorePathSet & storePaths, bool 
             // know the name yet until we've read the NAR info.
             printedStorePath = store.printStorePath(info->path);
 
-            jsonObject = info->toJSON(store, true);
+            jsonObject = info->toJSON(&store, true);
 
             if (showClosureSize) {
                 StorePathSet closure;


### PR DESCRIPTION
## Motivation

Make instances for them that share code with `nix path-info`, but do a slightly different format without store paths containing store dirs (matching the other latest JSON formats).

Progress on https://github.com/NixOS/nix/issues/13570.

If we depend on the store dir, our JSON serializers/deserializers take extra arguements, and that interfaces with the likes of various frameworks for associating these with types (e.g. nlohmann in C++, Serde in Rust, and Aeson in Haskell).

## Context

For now, `nix path-info` still uses the previous format, with store dirs. We may yet decide to "rip of the band-aid", and just switch it over, but that is left as a future PR.

depends on #14502

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
