### PR TITLE
Parse deriving paths in `DerivationOptions`

### DIFF
--- a/src/libstore-tests/data/derivation/ca/all_set.json
+++ b/src/libstore-tests/data/derivation/ca/all_set.json
@@ -4,10 +4,13 @@
   "allowSubstitutes": false,
   "exportReferencesGraph": {
     "refs1": [
-      "/164j69y6zir9z0339n8pjigg3rckinlr77bxsavzizdaaljb7nh9"
+      {
+        "drvPath": "j56sf12rxpcv5swr14vsjn5cwm6bj03h-foo.drv",
+        "output": "out"
+      }
     ],
     "refs2": [
-      "/nix/store/qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv"
+      "qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv"
     ]
   },
   "impureEnvVars": [
@@ -20,18 +23,36 @@
   "outputChecks": {
     "forAllOutputs": {
       "allowedReferences": [
-        "/164j69y6zir9z0339n8pjigg3rckinlr77bxsavzizdaaljb7nh9"
+        {
+          "drvPath": "j56sf12rxpcv5swr14vsjn5cwm6bj03h-foo.drv",
+          "output": "out"
+        }
       ],
       "allowedRequisites": [
-        "/0nr45p69vn6izw9446wsh9bng9nndhvn19kpsm4n96a5mycw0s4z",
-        "bin"
+        {
+          "drvPath": "self",
+          "output": "bin"
+        },
+        {
+          "drvPath": "j56sf12rxpcv5swr14vsjn5cwm6bj03h-foo.drv",
+          "output": "dev"
+        }
       ],
       "disallowedReferences": [
-        "/0nyw57wm2iicnm9rglvjmbci3ikmcp823czdqdzdcgsnnwqps71g",
-        "dev"
+        {
+          "drvPath": "self",
+          "output": "dev"
+        },
+        {
+          "drvPath": "qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv",
+          "output": "out"
+        }
       ],
       "disallowedRequisites": [
-        "/07f301yqyz8c6wf6bbbavb2q39j4n8kmcly1s09xadyhgy6x2wr8"
+        {
+          "drvPath": "qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv",
+          "output": "dev"
+        }
       ],
       "ignoreSelfRefs": true,
       "maxClosureSize": null,

--- a/src/libstore-tests/data/derivation/ca/structuredAttrs_all_set.json
+++ b/src/libstore-tests/data/derivation/ca/structuredAttrs_all_set.json
@@ -4,10 +4,13 @@
   "allowSubstitutes": false,
   "exportReferencesGraph": {
     "refs1": [
-      "/164j69y6zir9z0339n8pjigg3rckinlr77bxsavzizdaaljb7nh9"
+      {
+        "drvPath": "j56sf12rxpcv5swr14vsjn5cwm6bj03h-foo.drv",
+        "output": "out"
+      }
     ],
     "refs2": [
-      "/nix/store/qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv"
+      "qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv"
     ]
   },
   "impureEnvVars": [
@@ -23,11 +26,20 @@
         "allowedReferences": null,
         "allowedRequisites": null,
         "disallowedReferences": [
-          "/0nyw57wm2iicnm9rglvjmbci3ikmcp823czdqdzdcgsnnwqps71g",
-          "dev"
+          {
+            "drvPath": "self",
+            "output": "dev"
+          },
+          {
+            "drvPath": "qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv",
+            "output": "out"
+          }
         ],
         "disallowedRequisites": [
-          "/07f301yqyz8c6wf6bbbavb2q39j4n8kmcly1s09xadyhgy6x2wr8"
+          {
+            "drvPath": "qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv",
+            "output": "dev"
+          }
         ],
         "ignoreSelfRefs": false,
         "maxClosureSize": null,
@@ -44,11 +56,20 @@
       },
       "out": {
         "allowedReferences": [
-          "/164j69y6zir9z0339n8pjigg3rckinlr77bxsavzizdaaljb7nh9"
+          {
+            "drvPath": "j56sf12rxpcv5swr14vsjn5cwm6bj03h-foo.drv",
+            "output": "out"
+          }
         ],
         "allowedRequisites": [
-          "/0nr45p69vn6izw9446wsh9bng9nndhvn19kpsm4n96a5mycw0s4z",
-          "bin"
+          {
+            "drvPath": "self",
+            "output": "bin"
+          },
+          {
+            "drvPath": "j56sf12rxpcv5swr14vsjn5cwm6bj03h-foo.drv",
+            "output": "dev"
+          }
         ],
         "disallowedReferences": [],
         "disallowedRequisites": [],

--- a/src/libstore-tests/data/derivation/ia/all_set.json
+++ b/src/libstore-tests/data/derivation/ia/all_set.json
@@ -4,10 +4,10 @@
   "allowSubstitutes": false,
   "exportReferencesGraph": {
     "refs1": [
-      "/nix/store/p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
+      "p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
     ],
     "refs2": [
-      "/nix/store/vj2i49jm2868j2fmqvxm70vlzmzvgv14-bar.drv"
+      "vj2i49jm2868j2fmqvxm70vlzmzvgv14-bar.drv"
     ]
   },
   "impureEnvVars": [
@@ -20,18 +20,24 @@
   "outputChecks": {
     "forAllOutputs": {
       "allowedReferences": [
-        "/nix/store/p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
+        "p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
       ],
       "allowedRequisites": [
-        "/nix/store/z0rjzy29v9k5qa4nqpykrbzirj7sd43v-foo-dev",
-        "bin"
+        {
+          "drvPath": "self",
+          "output": "bin"
+        },
+        "z0rjzy29v9k5qa4nqpykrbzirj7sd43v-foo-dev"
       ],
       "disallowedReferences": [
-        "/nix/store/r5cff30838majxk5mp3ip2diffi8vpaj-bar",
-        "dev"
+        {
+          "drvPath": "self",
+          "output": "dev"
+        },
+        "r5cff30838majxk5mp3ip2diffi8vpaj-bar"
       ],
       "disallowedRequisites": [
-        "/nix/store/9b61w26b4avv870dw0ymb6rw4r1hzpws-bar-dev"
+        "9b61w26b4avv870dw0ymb6rw4r1hzpws-bar-dev"
       ],
       "ignoreSelfRefs": true,
       "maxClosureSize": null,

--- a/src/libstore-tests/data/derivation/ia/structuredAttrs_all_set.json
+++ b/src/libstore-tests/data/derivation/ia/structuredAttrs_all_set.json
@@ -4,10 +4,10 @@
   "allowSubstitutes": false,
   "exportReferencesGraph": {
     "refs1": [
-      "/nix/store/p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
+      "p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
     ],
     "refs2": [
-      "/nix/store/vj2i49jm2868j2fmqvxm70vlzmzvgv14-bar.drv"
+      "vj2i49jm2868j2fmqvxm70vlzmzvgv14-bar.drv"
     ]
   },
   "impureEnvVars": [
@@ -23,11 +23,14 @@
         "allowedReferences": null,
         "allowedRequisites": null,
         "disallowedReferences": [
-          "/nix/store/r5cff30838majxk5mp3ip2diffi8vpaj-bar",
-          "dev"
+          {
+            "drvPath": "self",
+            "output": "dev"
+          },
+          "r5cff30838majxk5mp3ip2diffi8vpaj-bar"
         ],
         "disallowedRequisites": [
-          "/nix/store/9b61w26b4avv870dw0ymb6rw4r1hzpws-bar-dev"
+          "9b61w26b4avv870dw0ymb6rw4r1hzpws-bar-dev"
         ],
         "ignoreSelfRefs": false,
         "maxClosureSize": null,
@@ -44,11 +47,14 @@
       },
       "out": {
         "allowedReferences": [
-          "/nix/store/p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
+          "p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"
         ],
         "allowedRequisites": [
-          "/nix/store/z0rjzy29v9k5qa4nqpykrbzirj7sd43v-foo-dev",
-          "bin"
+          {
+            "drvPath": "self",
+            "output": "bin"
+          },
+          "z0rjzy29v9k5qa4nqpykrbzirj7sd43v-foo-dev"
         ],
         "disallowedReferences": [],
         "disallowedRequisites": [],

--- a/src/libstore-tests/derivation-advanced-attrs.cc
+++ b/src/libstore-tests/derivation-advanced-attrs.cc
@@ -3,7 +3,7 @@
 
 #include "nix/util/experimental-features.hh"
 #include "nix/store/derivations.hh"
-#include "nix/store/derivations.hh"
+#include "nix/store/derived-path.hh"
 #include "nix/store/derivation-options.hh"
 #include "nix/store/parsed-derivations.hh"
 #include "nix/util/types.hh"
@@ -17,7 +17,7 @@ namespace nix {
 using namespace nlohmann;
 
 class DerivationAdvancedAttrsTest : public JsonCharacterizationTest<Derivation>,
-                                    public JsonCharacterizationTest<DerivationOptions>,
+                                    public JsonCharacterizationTest<DerivationOptions<SingleDerivedPath>>,
                                     public LibStoreTest
 {
 protected:
@@ -42,7 +42,8 @@ public:
     {
         this->readTest(fileName, [&](auto encoded) {
             auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
-            DerivationOptions options = DerivationOptions::fromStructuredAttrs(got.env, got.structuredAttrs);
+            auto options = derivationOptionsFromStructuredAttrs(
+                *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
             EXPECT_EQ(options.getRequiredSystemFeatures(got), expectedFeatures);
         });
     }
@@ -51,11 +52,14 @@ public:
      * Helper function to test DerivationOptions parsing and comparison
      */
     void testDerivationOptions(
-        const std::string & fileName, const DerivationOptions & expected, const StringSet & expectedSystemFeatures)
+        const std::string & fileName,
+        const DerivationOptions<SingleDerivedPath> & expected,
+        const StringSet & expectedSystemFeatures)
     {
         this->readTest(fileName, [&](auto encoded) {
             auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
-            DerivationOptions options = DerivationOptions::fromStructuredAttrs(got.env, got.structuredAttrs);
+            auto options = derivationOptionsFromStructuredAttrs(
+                *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
 
             EXPECT_EQ(options, expected);
             EXPECT_EQ(options.getRequiredSystemFeatures(got), expectedSystemFeatures);
@@ -131,22 +135,38 @@ TEST_ATERM_JSON(advancedAttributes_structuredAttrs_defaults, "advanced-attribute
  * Since these are both repeated and sensative opaque values, it makes
  * sense to give them names in this file.
  */
-static std::string pathFoo = "/nix/store/p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo",
-                   pathFooDev = "/nix/store/z0rjzy29v9k5qa4nqpykrbzirj7sd43v-foo-dev",
-                   pathBar = "/nix/store/r5cff30838majxk5mp3ip2diffi8vpaj-bar",
-                   pathBarDev = "/nix/store/9b61w26b4avv870dw0ymb6rw4r1hzpws-bar-dev",
-                   pathBarDrvIA = "/nix/store/vj2i49jm2868j2fmqvxm70vlzmzvgv14-bar.drv",
-                   pathBarDrvCA = "/nix/store/qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv",
-                   placeholderFoo = "/164j69y6zir9z0339n8pjigg3rckinlr77bxsavzizdaaljb7nh9",
-                   placeholderFooDev = "/0nr45p69vn6izw9446wsh9bng9nndhvn19kpsm4n96a5mycw0s4z",
-                   placeholderBar = "/0nyw57wm2iicnm9rglvjmbci3ikmcp823czdqdzdcgsnnwqps71g",
-                   placeholderBarDev = "/07f301yqyz8c6wf6bbbavb2q39j4n8kmcly1s09xadyhgy6x2wr8";
+static SingleDerivedPath
+    pathFoo = SingleDerivedPath::Opaque{StorePath{"p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"}},
+    pathFooDev = SingleDerivedPath::Opaque{StorePath{"z0rjzy29v9k5qa4nqpykrbzirj7sd43v-foo-dev"}},
+    pathBar = SingleDerivedPath::Opaque{StorePath{"r5cff30838majxk5mp3ip2diffi8vpaj-bar"}},
+    pathBarDev = SingleDerivedPath::Opaque{StorePath{"9b61w26b4avv870dw0ymb6rw4r1hzpws-bar-dev"}},
+    pathBarDrvIA = SingleDerivedPath::Opaque{StorePath{"vj2i49jm2868j2fmqvxm70vlzmzvgv14-bar.drv"}},
+    pathBarDrvCA = SingleDerivedPath::Opaque{StorePath{"qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv"}},
+    placeholderFoo =
+        SingleDerivedPath::Built{
+            .drvPath = makeConstantStorePathRef(StorePath{"j56sf12rxpcv5swr14vsjn5cwm6bj03h-foo.drv"}),
+            .output = "out",
+        },
+    placeholderFooDev =
+        SingleDerivedPath::Built{
+            .drvPath = makeConstantStorePathRef(StorePath{"j56sf12rxpcv5swr14vsjn5cwm6bj03h-foo.drv"}),
+            .output = "dev",
+        },
+    placeholderBar =
+        SingleDerivedPath::Built{
+            .drvPath = makeConstantStorePathRef(StorePath{"qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv"}),
+            .output = "out",
+        },
+    placeholderBarDev = SingleDerivedPath::Built{
+        .drvPath = makeConstantStorePathRef(StorePath{"qnml92yh97a6fbrs2m5qg5cqlc8vni58-bar.drv"}),
+        .output = "dev",
+    };
 
-using ExportReferencesMap = decltype(DerivationOptions::exportReferencesGraph);
+using ExportReferencesMap = decltype(DerivationOptions<SingleDerivedPath>::exportReferencesGraph);
 
-static const DerivationOptions advancedAttributes_defaults = {
+static const DerivationOptions<SingleDerivedPath> advancedAttributes_defaults = {
     .outputChecks =
-        DerivationOptions::OutputChecks{
+        DerivationOptions<SingleDerivedPath>::OutputChecks{
             .ignoreSelfRefs = true,
         },
     .unsafeDiscardReferences = {},
@@ -167,7 +187,8 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_defaults)
     this->readTest("advanced-attributes-defaults.drv", [&](auto encoded) {
         auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
 
-        DerivationOptions options = DerivationOptions::fromStructuredAttrs(got.env, got.structuredAttrs);
+        auto options = derivationOptionsFromStructuredAttrs(
+            *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
 
         EXPECT_TRUE(!got.structuredAttrs);
 
@@ -192,9 +213,9 @@ TEST_F(CaDerivationAdvancedAttrsTest, advancedAttributes_defaults)
 
 TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes)
 {
-    DerivationOptions expected = {
+    DerivationOptions<SingleDerivedPath> expected = {
         .outputChecks =
-            DerivationOptions::OutputChecks{
+            DerivationOptions<SingleDerivedPath>::OutputChecks{
                 .ignoreSelfRefs = true,
             },
         .unsafeDiscardReferences = {},
@@ -212,12 +233,13 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes)
     this->readTest("advanced-attributes.drv", [&](auto encoded) {
         auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
 
-        DerivationOptions options = DerivationOptions::fromStructuredAttrs(got.env, got.structuredAttrs);
+        auto options = derivationOptionsFromStructuredAttrs(
+            *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
 
         EXPECT_TRUE(!got.structuredAttrs);
 
         // Reset fields that vary between test cases to enable whole-object comparison
-        options.outputChecks = DerivationOptions::OutputChecks{.ignoreSelfRefs = true};
+        options.outputChecks = DerivationOptions<SingleDerivedPath>::OutputChecks{.ignoreSelfRefs = true};
         options.exportReferencesGraph = {};
 
         EXPECT_EQ(options, expected);
@@ -227,14 +249,14 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes)
     });
 };
 
-DerivationOptions advancedAttributes_ia = {
+DerivationOptions<SingleDerivedPath> advancedAttributes_ia = {
     .outputChecks =
-        DerivationOptions::OutputChecks{
+        DerivationOptions<SingleDerivedPath>::OutputChecks{
             .ignoreSelfRefs = true,
-            .allowedReferences = StringSet{pathFoo},
-            .disallowedReferences = StringSet{pathBar, "dev"},
-            .allowedRequisites = StringSet{pathFooDev, "bin"},
-            .disallowedRequisites = StringSet{pathBarDev},
+            .allowedReferences = std::set<DrvRef<SingleDerivedPath>>{pathFoo},
+            .disallowedReferences = std::set<DrvRef<SingleDerivedPath>>{pathBar, OutputName{"dev"}},
+            .allowedRequisites = std::set<DrvRef<SingleDerivedPath>>{pathFooDev, OutputName{"bin"}},
+            .disallowedRequisites = std::set<DrvRef<SingleDerivedPath>>{pathBarDev},
         },
     .unsafeDiscardReferences = {},
     .passAsFile = {},
@@ -257,14 +279,14 @@ TEST_F(DerivationAdvancedAttrsTest, advancedAttributes_ia)
     testDerivationOptions("advanced-attributes.drv", advancedAttributes_ia, {"rainbow", "uid-range"});
 };
 
-DerivationOptions advancedAttributes_ca = {
+DerivationOptions<SingleDerivedPath> advancedAttributes_ca = {
     .outputChecks =
-        DerivationOptions::OutputChecks{
+        DerivationOptions<SingleDerivedPath>::OutputChecks{
             .ignoreSelfRefs = true,
-            .allowedReferences = StringSet{placeholderFoo},
-            .disallowedReferences = StringSet{placeholderBar, "dev"},
-            .allowedRequisites = StringSet{placeholderFooDev, "bin"},
-            .disallowedRequisites = StringSet{placeholderBarDev},
+            .allowedReferences = std::set<DrvRef<SingleDerivedPath>>{placeholderFoo},
+            .disallowedReferences = std::set<DrvRef<SingleDerivedPath>>{placeholderBar, OutputName{"dev"}},
+            .allowedRequisites = std::set<DrvRef<SingleDerivedPath>>{placeholderFooDev, OutputName{"bin"}},
+            .disallowedRequisites = std::set<DrvRef<SingleDerivedPath>>{placeholderBarDev},
         },
     .unsafeDiscardReferences = {},
     .passAsFile = {},
@@ -287,8 +309,8 @@ TEST_F(CaDerivationAdvancedAttrsTest, advancedAttributes)
     testDerivationOptions("advanced-attributes.drv", advancedAttributes_ca, {"rainbow", "uid-range", "ca-derivations"});
 };
 
-DerivationOptions advancedAttributes_structuredAttrs_defaults = {
-    .outputChecks = std::map<std::string, DerivationOptions::OutputChecks>{},
+DerivationOptions<SingleDerivedPath> advancedAttributes_structuredAttrs_defaults = {
+    .outputChecks = std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks>{},
     .unsafeDiscardReferences = {},
     .passAsFile = {},
     .exportReferencesGraph = {},
@@ -307,7 +329,8 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs_d
     this->readTest("advanced-attributes-structured-attrs-defaults.drv", [&](auto encoded) {
         auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
 
-        DerivationOptions options = DerivationOptions::fromStructuredAttrs(got.env, got.structuredAttrs);
+        auto options = derivationOptionsFromStructuredAttrs(
+            *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
 
         EXPECT_TRUE(got.structuredAttrs);
 
@@ -332,11 +355,11 @@ TEST_F(CaDerivationAdvancedAttrsTest, advancedAttributes_structuredAttrs_default
 
 TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs)
 {
-    DerivationOptions expected = {
+    DerivationOptions<SingleDerivedPath> expected = {
         .outputChecks =
-            std::map<std::string, DerivationOptions::OutputChecks>{
+            std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks>{
                 {"dev",
-                 DerivationOptions::OutputChecks{
+                 DerivationOptions<SingleDerivedPath>::OutputChecks{
                      .maxSize = 789,
                      .maxClosureSize = 5909,
                  }},
@@ -357,7 +380,8 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs)
     this->readTest("advanced-attributes-structured-attrs.drv", [&](auto encoded) {
         auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
 
-        DerivationOptions options = DerivationOptions::fromStructuredAttrs(got.env, got.structuredAttrs);
+        auto options = derivationOptionsFromStructuredAttrs(
+            *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
 
         EXPECT_TRUE(got.structuredAttrs);
 
@@ -365,7 +389,8 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs)
         {
             // Delete all keys but "dev" in options.outputChecks
             auto * outputChecksMapP =
-                std::get_if<std::map<std::string, DerivationOptions::OutputChecks>>(&options.outputChecks);
+                std::get_if<std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks>>(
+                    &options.outputChecks);
             ASSERT_TRUE(outputChecksMapP);
             auto & outputChecksMap = *outputChecksMapP;
             auto devEntry = outputChecksMap.find("dev");
@@ -385,21 +410,21 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs)
     });
 };
 
-DerivationOptions advancedAttributes_structuredAttrs_ia = {
+DerivationOptions<SingleDerivedPath> advancedAttributes_structuredAttrs_ia = {
     .outputChecks =
-        std::map<std::string, DerivationOptions::OutputChecks>{
+        std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks>{
             {"out",
-             DerivationOptions::OutputChecks{
-                 .allowedReferences = StringSet{pathFoo},
-                 .allowedRequisites = StringSet{pathFooDev, "bin"},
+             DerivationOptions<SingleDerivedPath>::OutputChecks{
+                 .allowedReferences = std::set<DrvRef<SingleDerivedPath>>{pathFoo},
+                 .allowedRequisites = std::set<DrvRef<SingleDerivedPath>>{pathFooDev, OutputName{"bin"}},
              }},
             {"bin",
-             DerivationOptions::OutputChecks{
-                 .disallowedReferences = StringSet{pathBar, "dev"},
-                 .disallowedRequisites = StringSet{pathBarDev},
+             DerivationOptions<SingleDerivedPath>::OutputChecks{
+                 .disallowedReferences = std::set<DrvRef<SingleDerivedPath>>{pathBar, OutputName{"dev"}},
+                 .disallowedRequisites = std::set<DrvRef<SingleDerivedPath>>{pathBarDev},
              }},
             {"dev",
-             DerivationOptions::OutputChecks{
+             DerivationOptions<SingleDerivedPath>::OutputChecks{
                  .maxSize = 789,
                  .maxClosureSize = 5909,
              }},
@@ -427,21 +452,21 @@ TEST_F(DerivationAdvancedAttrsTest, advancedAttributes_structuredAttrs)
         "advanced-attributes-structured-attrs.drv", advancedAttributes_structuredAttrs_ia, {"rainbow", "uid-range"});
 };
 
-DerivationOptions advancedAttributes_structuredAttrs_ca = {
+DerivationOptions<SingleDerivedPath> advancedAttributes_structuredAttrs_ca = {
     .outputChecks =
-        std::map<std::string, DerivationOptions::OutputChecks>{
+        std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks>{
             {"out",
-             DerivationOptions::OutputChecks{
-                 .allowedReferences = StringSet{placeholderFoo},
-                 .allowedRequisites = StringSet{placeholderFooDev, "bin"},
+             DerivationOptions<SingleDerivedPath>::OutputChecks{
+                 .allowedReferences = std::set<DrvRef<SingleDerivedPath>>{placeholderFoo},
+                 .allowedRequisites = std::set<DrvRef<SingleDerivedPath>>{placeholderFooDev, OutputName{"bin"}},
              }},
             {"bin",
-             DerivationOptions::OutputChecks{
-                 .disallowedReferences = StringSet{placeholderBar, "dev"},
-                 .disallowedRequisites = StringSet{placeholderBarDev},
+             DerivationOptions<SingleDerivedPath>::OutputChecks{
+                 .disallowedReferences = std::set<DrvRef<SingleDerivedPath>>{placeholderBar, OutputName{"dev"}},
+                 .disallowedRequisites = std::set<DrvRef<SingleDerivedPath>>{placeholderBarDev},
              }},
             {"dev",
-             DerivationOptions::OutputChecks{
+             DerivationOptions<SingleDerivedPath>::OutputChecks{
                  .maxSize = 789,
                  .maxClosureSize = 5909,
              }},
@@ -471,14 +496,16 @@ TEST_F(CaDerivationAdvancedAttrsTest, advancedAttributes_structuredAttrs)
         {"rainbow", "uid-range", "ca-derivations"});
 };
 
-#define TEST_JSON_OPTIONS(FIXUTURE, VAR, VAR2)                                                             \
-    TEST_F(FIXUTURE, DerivationOptions_##VAR##_from_json)                                                  \
-    {                                                                                                      \
-        this->JsonCharacterizationTest<DerivationOptions>::readJsonTest(#VAR, advancedAttributes_##VAR2);  \
-    }                                                                                                      \
-    TEST_F(FIXUTURE, DerivationOptions_##VAR##_to_json)                                                    \
-    {                                                                                                      \
-        this->JsonCharacterizationTest<DerivationOptions>::writeJsonTest(#VAR, advancedAttributes_##VAR2); \
+#define TEST_JSON_OPTIONS(FIXUTURE, VAR, VAR2)                                               \
+    TEST_F(FIXUTURE, DerivationOptions_##VAR##_from_json)                                    \
+    {                                                                                        \
+        this->JsonCharacterizationTest<DerivationOptions<SingleDerivedPath>>::readJsonTest(  \
+            #VAR, advancedAttributes_##VAR2);                                                \
+    }                                                                                        \
+    TEST_F(FIXUTURE, DerivationOptions_##VAR##_to_json)                                      \
+    {                                                                                        \
+        this->JsonCharacterizationTest<DerivationOptions<SingleDerivedPath>>::writeJsonTest( \
+            #VAR, advancedAttributes_##VAR2);                                                \
     }
 
 TEST_JSON_OPTIONS(DerivationAdvancedAttrsTest, defaults, defaults)

--- a/src/libstore/build/derivation-check.hh
+++ b/src/libstore/build/derivation-check.hh
@@ -21,7 +21,7 @@ void checkOutputs(
     Store & store,
     const StorePath & drvPath,
     const decltype(Derivation::outputs) & drvOutputs,
-    const decltype(DerivationOptions::outputChecks) & drvOptions,
+    const decltype(DerivationOptions<StorePath>::outputChecks) & drvOptions,
     const std::map<std::string, ValidPathInfo> & outputs);
 
 } // namespace nix

--- a/src/libstore/build/derivation-env-desugar.cc
+++ b/src/libstore/build/derivation-env-desugar.cc
@@ -18,7 +18,10 @@ std::string & DesugaredEnv::atFileEnvPair(std::string_view name, std::string fil
 }
 
 DesugaredEnv DesugaredEnv::create(
-    Store & store, const Derivation & drv, const DerivationOptions & drvOptions, const StorePathSet & inputPaths)
+    Store & store,
+    const Derivation & drv,
+    const DerivationOptions<StorePath> & drvOptions,
+    const StorePathSet & inputPaths)
 {
     DesugaredEnv res;
 
@@ -46,7 +49,7 @@ DesugaredEnv DesugaredEnv::create(
         }
 
         /* Handle exportReferencesGraph(), if set. */
-        for (auto & [fileName, storePaths] : drvOptions.getParsedExportReferencesGraph(store)) {
+        for (auto & [fileName, storePaths] : drvOptions.exportReferencesGraph) {
             /* Write closure info to <fileName>. */
             res.extraFiles.insert_or_assign(
                 fileName, store.makeValidityRegistration(store.exportReferences(storePaths, inputPaths), false, false));

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -64,9 +64,10 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
 {
     trace("have derivation");
 
-    auto drvOptions = [&]() -> DerivationOptions {
+    auto drvOptions = [&]() -> DerivationOptions<SingleDerivedPath> {
         try {
-            return DerivationOptions::fromStructuredAttrs(drv->env, drv->structuredAttrs);
+            return derivationOptionsFromStructuredAttrs(
+                worker.store, drv->inputDrvs, drv->env, get(drv->structuredAttrs));
         } catch (Error & e) {
             e.addTrace({}, "while parsing derivation '%s'", worker.store.printStorePath(drvPath));
             throw;

--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -2,15 +2,18 @@
 #include "nix/util/json-utils.hh"
 #include "nix/store/parsed-derivations.hh"
 #include "nix/store/derivations.hh"
+#include "nix/store/derived-path.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/types.hh"
 #include "nix/util/util.hh"
 #include "nix/store/globals.hh"
+#include "nix/util/variant-wrapper.hh"
 
 #include <optional>
 #include <string>
 #include <variant>
 #include <regex>
+#include <ranges>
 
 namespace nix {
 
@@ -90,14 +93,38 @@ getStringSetAttr(const StringMap & env, const StructuredAttrs * parsed, const st
     return ss ? (std::optional{StringSet{ss->begin(), ss->end()}}) : (std::optional<StringSet>{});
 }
 
-using OutputChecks = DerivationOptions::OutputChecks;
+template<typename Inputs>
+using OutputChecks = DerivationOptions<Inputs>::OutputChecks;
 
-using OutputChecksVariant = std::variant<OutputChecks, std::map<std::string, OutputChecks>>;
+template<typename Inputs>
+using OutputChecksVariant = std::variant<OutputChecks<Inputs>, std::map<std::string, OutputChecks<Inputs>>>;
 
-DerivationOptions DerivationOptions::fromStructuredAttrs(
-    const StringMap & env, const std::optional<StructuredAttrs> & parsed, bool shouldWarn)
+DerivationOptions<StorePath> derivationOptionsFromStructuredAttrs(
+    const StoreDirConfig & store,
+    const StringMap & env,
+    const StructuredAttrs * parsed,
+    bool shouldWarn,
+    const ExperimentalFeatureSettings & mockXpSettings)
 {
-    return fromStructuredAttrs(env, parsed ? &*parsed : nullptr);
+    /* Use the SingleDerivedPath version with empty inputDrvs, then
+       resolve. */
+    DerivedPathMap<StringSet> emptyInputDrvs{};
+    auto singleDerivedPathOptions =
+        derivationOptionsFromStructuredAttrs(store, emptyInputDrvs, env, parsed, shouldWarn, mockXpSettings);
+
+    /* "Resolve" all SingleDerivedPath inputs to StorePath. */
+    auto resolved = tryResolve(
+        singleDerivedPathOptions,
+        [&](ref<const SingleDerivedPath> drvPath, const std::string & outputName) -> std::optional<StorePath> {
+            // there should be nothing to resolve
+            assert(false);
+        });
+
+    /* Since we should never need to call the call back, there should be
+       no way it fails. */
+    assert(resolved);
+
+    return *resolved;
 }
 
 static void flatten(const nlohmann::json & value, StringSet & res)
@@ -111,10 +138,63 @@ static void flatten(const nlohmann::json & value, StringSet & res)
         throw Error("'exportReferencesGraph' value is not an array or a string");
 }
 
-DerivationOptions
-DerivationOptions::fromStructuredAttrs(const StringMap & env, const StructuredAttrs * parsed, bool shouldWarn)
+DerivationOptions<SingleDerivedPath> derivationOptionsFromStructuredAttrs(
+    const StoreDirConfig & store,
+    const DerivedPathMap<StringSet> & inputDrvs,
+    const StringMap & env,
+    const StructuredAttrs * parsed,
+    bool shouldWarn,
+    const ExperimentalFeatureSettings & mockXpSettings)
 {
-    DerivationOptions defaults = {};
+    DerivationOptions<SingleDerivedPath> defaults = {};
+
+    std::map<std::string, SingleDerivedPath::Built> placeholders;
+    if (mockXpSettings.isEnabled(Xp::CaDerivations)) {
+        /* Initialize placeholder map from inputDrvs */
+        auto initPlaceholders = [&](this const auto & initPlaceholders,
+                                    ref<const SingleDerivedPath> basePath,
+                                    const DerivedPathMap<StringSet>::ChildNode & node) -> void {
+            for (const auto & outputName : node.value) {
+                auto built = SingleDerivedPath::Built{
+                    .drvPath = basePath,
+                    .output = outputName,
+                };
+                placeholders.insert_or_assign(
+                    DownstreamPlaceholder::fromSingleDerivedPathBuilt(built, mockXpSettings).render(),
+                    std::move(built));
+            }
+
+            for (const auto & [outputName, childNode] : node.childMap) {
+                initPlaceholders(
+                    make_ref<const SingleDerivedPath>(SingleDerivedPath::Built{
+                        .drvPath = basePath,
+                        .output = outputName,
+                    }),
+                    childNode);
+            }
+        };
+
+        for (const auto & [drvPath, outputs] : inputDrvs.map) {
+            auto basePath = make_ref<const SingleDerivedPath>(SingleDerivedPath::Opaque{drvPath});
+            initPlaceholders(basePath, outputs);
+        }
+    }
+
+    auto parseSingleDerivedPath = [&](const std::string & pathS) -> SingleDerivedPath {
+        if (auto it = placeholders.find(pathS); it != placeholders.end())
+            return it->second;
+        else
+            return SingleDerivedPath::Opaque{store.toStorePath(pathS).first};
+    };
+
+    auto parseRef = [&](const std::string & pathS) -> DrvRef<SingleDerivedPath> {
+        if (auto it = placeholders.find(pathS); it != placeholders.end())
+            return it->second;
+        if (store.isStorePath(pathS))
+            return SingleDerivedPath::Opaque{store.toStorePath(pathS).first};
+        else
+            return pathS;
+    };
 
     if (shouldWarn && parsed) {
         auto & structuredAttrs = parsed->structuredAttrs;
@@ -146,14 +226,14 @@ DerivationOptions::fromStructuredAttrs(const StringMap & env, const StructuredAt
     }
 
     return {
-        .outputChecks = [&]() -> OutputChecksVariant {
+        .outputChecks = [&]() -> OutputChecksVariant<SingleDerivedPath> {
             if (parsed) {
                 auto & structuredAttrs = parsed->structuredAttrs;
 
-                std::map<std::string, OutputChecks> res;
+                std::map<std::string, OutputChecks<SingleDerivedPath>> res;
                 if (auto * outputChecks = get(structuredAttrs, "outputChecks")) {
                     for (auto & [outputName, output_] : getObject(*outputChecks)) {
-                        OutputChecks checks;
+                        OutputChecks<SingleDerivedPath> checks;
 
                         auto & output = getObject(output_);
 
@@ -163,13 +243,14 @@ DerivationOptions::fromStructuredAttrs(const StringMap & env, const StructuredAt
                         if (auto maxClosureSize = get(output, "maxClosureSize"))
                             checks.maxClosureSize = maxClosureSize->get<uint64_t>();
 
-                        auto get_ = [&output = output](const std::string & name) -> std::optional<StringSet> {
+                        auto get_ =
+                            [&](const std::string & name) -> std::optional<std::set<DrvRef<SingleDerivedPath>>> {
                             if (auto i = get(output, name)) {
-                                StringSet res;
+                                std::set<DrvRef<SingleDerivedPath>> res;
                                 for (auto j = i->begin(); j != i->end(); ++j) {
                                     if (!j->is_string())
                                         throw Error("attribute '%s' must be a list of strings", name);
-                                    res.insert(j->get<std::string>());
+                                    res.insert(parseRef(j->get<std::string>()));
                                 }
                                 return res;
                             }
@@ -178,7 +259,7 @@ DerivationOptions::fromStructuredAttrs(const StringMap & env, const StructuredAt
 
                         res.insert_or_assign(
                             outputName,
-                            OutputChecks{
+                            OutputChecks<SingleDerivedPath>{
                                 .maxSize = [&]() -> std::optional<uint64_t> {
                                     if (auto maxSize = get(output, "maxSize"))
                                         return maxSize->get<uint64_t>();
@@ -192,21 +273,32 @@ DerivationOptions::fromStructuredAttrs(const StringMap & env, const StructuredAt
                                         return std::nullopt;
                                 }(),
                                 .allowedReferences = get_("allowedReferences"),
-                                .disallowedReferences = get_("disallowedReferences").value_or(StringSet{}),
+                                .disallowedReferences =
+                                    get_("disallowedReferences").value_or(std::set<DrvRef<SingleDerivedPath>>{}),
                                 .allowedRequisites = get_("allowedRequisites"),
-                                .disallowedRequisites = get_("disallowedRequisites").value_or(StringSet{}),
+                                .disallowedRequisites =
+                                    get_("disallowedRequisites").value_or(std::set<DrvRef<SingleDerivedPath>>{}),
                             });
                     }
                 }
                 return res;
             } else {
-                return OutputChecks{
+                auto parseRefSet = [&](const std::optional<StringSet> optionalStringSet)
+                    -> std::optional<std::set<DrvRef<SingleDerivedPath>>> {
+                    if (!optionalStringSet)
+                        return std::nullopt;
+                    auto range = *optionalStringSet | std::views::transform(parseRef);
+                    return std::set<DrvRef<SingleDerivedPath>>(range.begin(), range.end());
+                };
+                return OutputChecks<SingleDerivedPath>{
                     // legacy non-structured-attributes case
                     .ignoreSelfRefs = true,
-                    .allowedReferences = getStringSetAttr(env, parsed, "allowedReferences"),
-                    .disallowedReferences = getStringSetAttr(env, parsed, "disallowedReferences").value_or(StringSet{}),
-                    .allowedRequisites = getStringSetAttr(env, parsed, "allowedRequisites"),
-                    .disallowedRequisites = getStringSetAttr(env, parsed, "disallowedRequisites").value_or(StringSet{}),
+                    .allowedReferences = parseRefSet(getStringSetAttr(env, parsed, "allowedReferences")),
+                    .disallowedReferences = parseRefSet(getStringSetAttr(env, parsed, "disallowedReferences"))
+                                                .value_or(std::set<DrvRef<SingleDerivedPath>>{}),
+                    .allowedRequisites = parseRefSet(getStringSetAttr(env, parsed, "allowedRequisites")),
+                    .disallowedRequisites = parseRefSet(getStringSetAttr(env, parsed, "disallowedRequisites"))
+                                                .value_or(std::set<DrvRef<SingleDerivedPath>>{}),
                 };
             }
         }(),
@@ -245,16 +337,19 @@ DerivationOptions::fromStructuredAttrs(const StringMap & env, const StructuredAt
             }(),
         .exportReferencesGraph =
             [&] {
-                std::map<std::string, StringSet> ret;
+                std::map<std::string, std::set<SingleDerivedPath>> ret;
 
                 if (parsed) {
                     auto * e = optionalValueAt(parsed->structuredAttrs, "exportReferencesGraph");
                     if (!e || !e->is_object())
                         return ret;
-                    for (auto & [key, value] : getObject(*e)) {
+                    for (auto & [key, storePathsJson] : getObject(*e)) {
                         StringSet ss;
-                        flatten(value, ss);
-                        ret.insert_or_assign(key, std::move(ss));
+                        flatten(storePathsJson, ss);
+                        std::set<SingleDerivedPath> storePaths;
+                        for (auto & s : ss)
+                            storePaths.insert(parseSingleDerivedPath(s));
+                        ret.insert_or_assign(key, std::move(storePaths));
                     }
                 } else {
                     auto s = getOr(env, "exportReferencesGraph", "");
@@ -268,7 +363,7 @@ DerivationOptions::fromStructuredAttrs(const StringMap & env, const StructuredAt
                             throw Error("invalid file name '%s' in 'exportReferencesGraph'", fileName);
 
                         auto & storePathS = *i++;
-                        ret.insert_or_assign(std::move(fileName), StringSet{storePathS});
+                        ret.insert_or_assign(std::move(fileName), std::set{parseSingleDerivedPath(storePathS)});
                     }
                 }
                 return ret;
@@ -286,28 +381,8 @@ DerivationOptions::fromStructuredAttrs(const StringMap & env, const StructuredAt
     };
 }
 
-std::map<std::string, StorePathSet>
-DerivationOptions::getParsedExportReferencesGraph(const StoreDirConfig & store) const
-{
-    std::map<std::string, StorePathSet> res;
-
-    for (auto & [fileName, ss] : exportReferencesGraph) {
-        StorePathSet storePaths;
-        for (auto & storePathS : ss) {
-            if (!store.isInStore(storePathS))
-                throw BuildError(
-                    BuildResult::Failure::InputRejected,
-                    "'exportReferencesGraph' contains a non-store path '%1%'",
-                    storePathS);
-            storePaths.insert(store.toStorePath(storePathS).first);
-        }
-        res.insert_or_assign(fileName, storePaths);
-    }
-
-    return res;
-}
-
-StringSet DerivationOptions::getRequiredSystemFeatures(const BasicDerivation & drv) const
+template<typename Input>
+StringSet DerivationOptions<Input>::getRequiredSystemFeatures(const BasicDerivation & drv) const
 {
     // FIXME: cache this?
     StringSet res;
@@ -318,7 +393,8 @@ StringSet DerivationOptions::getRequiredSystemFeatures(const BasicDerivation & d
     return res;
 }
 
-bool DerivationOptions::canBuildLocally(Store & localStore, const BasicDerivation & drv) const
+template<typename Input>
+bool DerivationOptions<Input>::canBuildLocally(Store & localStore, const BasicDerivation & drv) const
 {
     if (drv.platform != settings.thisSystem.get() && !settings.extraPlatforms.get().count(drv.platform)
         && !drv.isBuiltin())
@@ -334,20 +410,172 @@ bool DerivationOptions::canBuildLocally(Store & localStore, const BasicDerivatio
     return true;
 }
 
-bool DerivationOptions::willBuildLocally(Store & localStore, const BasicDerivation & drv) const
+template<typename Input>
+bool DerivationOptions<Input>::willBuildLocally(Store & localStore, const BasicDerivation & drv) const
 {
     return preferLocalBuild && canBuildLocally(localStore, drv);
 }
 
-bool DerivationOptions::substitutesAllowed() const
+template<typename Input>
+bool DerivationOptions<Input>::substitutesAllowed() const
 {
     return settings.alwaysAllowSubstitutes ? true : allowSubstitutes;
 }
 
-bool DerivationOptions::useUidRange(const BasicDerivation & drv) const
+template<typename Input>
+bool DerivationOptions<Input>::useUidRange(const BasicDerivation & drv) const
 {
     return getRequiredSystemFeatures(drv).count("uid-range");
 }
+
+std::optional<DerivationOptions<StorePath>> tryResolve(
+    const DerivationOptions<SingleDerivedPath> & drvOptions,
+    std::function<std::optional<StorePath>(ref<const SingleDerivedPath> drvPath, const std::string & outputName)>
+        queryResolutionChain)
+{
+    auto tryResolvePath = [&](const SingleDerivedPath & input) -> std::optional<StorePath> {
+        return std::visit(
+            overloaded{
+                [](const SingleDerivedPath::Opaque & p) -> std::optional<StorePath> { return p.path; },
+                [&](const SingleDerivedPath::Built & p) -> std::optional<StorePath> {
+                    return queryResolutionChain(p.drvPath, p.output);
+                }},
+            input.raw());
+    };
+
+    auto tryResolveRef = [&](const DrvRef<SingleDerivedPath> & ref) -> std::optional<DrvRef<StorePath>> {
+        return std::visit(
+            overloaded{
+                [](const OutputName & outputName) -> std::optional<DrvRef<StorePath>> { return outputName; },
+                [&](const SingleDerivedPath & input) -> std::optional<DrvRef<StorePath>> {
+                    return tryResolvePath(input);
+                }},
+            ref);
+    };
+
+    auto tryResolveRefSet =
+        [&](const std::set<DrvRef<SingleDerivedPath>> & refSet) -> std::optional<std::set<DrvRef<StorePath>>> {
+        std::set<DrvRef<StorePath>> resolvedSet;
+        for (const auto & ref : refSet) {
+            auto resolvedRef = tryResolveRef(ref);
+            if (!resolvedRef)
+                return std::nullopt;
+            resolvedSet.insert(*resolvedRef);
+        }
+        return resolvedSet;
+    };
+
+    // Helper function to try resolving OutputChecks using functional style
+    auto tryResolveOutputChecks = [&](const DerivationOptions<SingleDerivedPath>::OutputChecks & checks)
+        -> std::optional<DerivationOptions<StorePath>::OutputChecks> {
+        std::optional<std::set<DrvRef<StorePath>>> resolvedAllowedReferences;
+        if (checks.allowedReferences) {
+            resolvedAllowedReferences = tryResolveRefSet(*checks.allowedReferences);
+            if (!resolvedAllowedReferences)
+                return std::nullopt;
+        }
+
+        std::optional<std::set<DrvRef<StorePath>>> resolvedAllowedRequisites;
+        if (checks.allowedRequisites) {
+            resolvedAllowedRequisites = tryResolveRefSet(*checks.allowedRequisites);
+            if (!resolvedAllowedRequisites)
+                return std::nullopt;
+        }
+
+        auto resolvedDisallowedReferences = tryResolveRefSet(checks.disallowedReferences);
+        if (!resolvedDisallowedReferences)
+            return std::nullopt;
+
+        auto resolvedDisallowedRequisites = tryResolveRefSet(checks.disallowedRequisites);
+        if (!resolvedDisallowedRequisites)
+            return std::nullopt;
+
+        return DerivationOptions<StorePath>::OutputChecks{
+            .ignoreSelfRefs = checks.ignoreSelfRefs,
+            .maxSize = checks.maxSize,
+            .maxClosureSize = checks.maxClosureSize,
+            .allowedReferences = resolvedAllowedReferences,
+            .disallowedReferences = *resolvedDisallowedReferences,
+            .allowedRequisites = resolvedAllowedRequisites,
+            .disallowedRequisites = *resolvedDisallowedRequisites,
+        };
+    };
+
+    // Helper function to resolve exportReferencesGraph using functional style
+    auto tryResolveExportReferencesGraph = [&](const std::map<std::string, std::set<SingleDerivedPath>> & exportGraph)
+        -> std::optional<std::map<std::string, std::set<StorePath>>> {
+        std::map<std::string, std::set<StorePath>> resolved;
+        for (const auto & [name, inputPaths] : exportGraph) {
+            std::set<StorePath> resolvedPaths;
+            for (const auto & inputPath : inputPaths) {
+                auto resolvedPath = tryResolvePath(inputPath);
+                if (!resolvedPath)
+                    return std::nullopt;
+                resolvedPaths.insert(*resolvedPath);
+            }
+            resolved.emplace(name, std::move(resolvedPaths));
+        }
+        return resolved;
+    };
+
+    // Resolve outputChecks using functional style with std::visit
+    auto resolvedOutputChecks = std::visit(
+        overloaded{
+            [&](const DerivationOptions<SingleDerivedPath>::OutputChecks & checks)
+                -> std::optional<std::variant<
+                    DerivationOptions<StorePath>::OutputChecks,
+                    std::map<std::string, DerivationOptions<StorePath>::OutputChecks>>> {
+                auto resolved = tryResolveOutputChecks(checks);
+                if (!resolved)
+                    return std::nullopt;
+                return std::variant<
+                    DerivationOptions<StorePath>::OutputChecks,
+                    std::map<std::string, DerivationOptions<StorePath>::OutputChecks>>(*resolved);
+            },
+            [&](const std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks> & checksMap)
+                -> std::optional<std::variant<
+                    DerivationOptions<StorePath>::OutputChecks,
+                    std::map<std::string, DerivationOptions<StorePath>::OutputChecks>>> {
+                std::map<std::string, DerivationOptions<StorePath>::OutputChecks> resolvedMap;
+                for (const auto & [outputName, checks] : checksMap) {
+                    auto resolved = tryResolveOutputChecks(checks);
+                    if (!resolved)
+                        return std::nullopt;
+                    resolvedMap.emplace(outputName, *resolved);
+                }
+                return std::variant<
+                    DerivationOptions<StorePath>::OutputChecks,
+                    std::map<std::string, DerivationOptions<StorePath>::OutputChecks>>(resolvedMap);
+            }},
+        drvOptions.outputChecks);
+
+    if (!resolvedOutputChecks)
+        return std::nullopt;
+
+    // Resolve exportReferencesGraph
+    auto resolvedExportGraph = tryResolveExportReferencesGraph(drvOptions.exportReferencesGraph);
+    if (!resolvedExportGraph)
+        return std::nullopt;
+
+    // Return resolved DerivationOptions using designated initializers
+    return DerivationOptions<StorePath>{
+        .outputChecks = *resolvedOutputChecks,
+        .unsafeDiscardReferences = drvOptions.unsafeDiscardReferences,
+        .passAsFile = drvOptions.passAsFile,
+        .exportReferencesGraph = *resolvedExportGraph,
+        .additionalSandboxProfile = drvOptions.additionalSandboxProfile,
+        .noChroot = drvOptions.noChroot,
+        .impureHostDeps = drvOptions.impureHostDeps,
+        .impureEnvVars = drvOptions.impureEnvVars,
+        .allowLocalNetworking = drvOptions.allowLocalNetworking,
+        .requiredSystemFeatures = drvOptions.requiredSystemFeatures,
+        .preferLocalBuild = drvOptions.preferLocalBuild,
+        .allowSubstitutes = drvOptions.allowSubstitutes,
+    };
+}
+
+template struct DerivationOptions<StorePath>;
+template struct DerivationOptions<SingleDerivedPath>;
 
 } // namespace nix
 
@@ -355,21 +583,21 @@ namespace nlohmann {
 
 using namespace nix;
 
-DerivationOptions adl_serializer<DerivationOptions>::from_json(const json & json_)
+DerivationOptions<SingleDerivedPath> adl_serializer<DerivationOptions<SingleDerivedPath>>::from_json(const json & json_)
 {
     auto & json = getObject(json_);
 
     return {
-        .outputChecks = [&]() -> OutputChecksVariant {
+        .outputChecks = [&]() -> OutputChecksVariant<SingleDerivedPath> {
             auto outputChecks = getObject(valueAt(json, "outputChecks"));
 
             auto forAllOutputsOpt = optionalValueAt(outputChecks, "forAllOutputs");
             auto perOutputOpt = optionalValueAt(outputChecks, "perOutput");
 
             if (forAllOutputsOpt && !perOutputOpt) {
-                return static_cast<OutputChecks>(*forAllOutputsOpt);
+                return static_cast<OutputChecks<SingleDerivedPath>>(*forAllOutputsOpt);
             } else if (perOutputOpt && !forAllOutputsOpt) {
-                return static_cast<std::map<std::string, OutputChecks>>(*perOutputOpt);
+                return static_cast<std::map<std::string, OutputChecks<SingleDerivedPath>>>(*perOutputOpt);
             } else {
                 throw Error("Exactly one of 'perOutput' or 'forAllOutputs' is required");
             }
@@ -377,7 +605,7 @@ DerivationOptions adl_serializer<DerivationOptions>::from_json(const json & json
 
         .unsafeDiscardReferences = valueAt(json, "unsafeDiscardReferences"),
         .passAsFile = getStringSet(valueAt(json, "passAsFile")),
-        .exportReferencesGraph = getMap<StringSet>(getObject(valueAt(json, "exportReferencesGraph")), getStringSet),
+        .exportReferencesGraph = valueAt(json, "exportReferencesGraph"),
 
         .additionalSandboxProfile = getString(valueAt(json, "additionalSandboxProfile")),
         .noChroot = getBoolean(valueAt(json, "noChroot")),
@@ -391,16 +619,17 @@ DerivationOptions adl_serializer<DerivationOptions>::from_json(const json & json
     };
 }
 
-void adl_serializer<DerivationOptions>::to_json(json & json, const DerivationOptions & o)
+void adl_serializer<DerivationOptions<SingleDerivedPath>>::to_json(
+    json & json, const DerivationOptions<SingleDerivedPath> & o)
 {
     json["outputChecks"] = std::visit(
         overloaded{
-            [&](const OutputChecks & checks) {
+            [&](const OutputChecks<SingleDerivedPath> & checks) {
                 nlohmann::json outputChecks;
                 outputChecks["forAllOutputs"] = checks;
                 return outputChecks;
             },
-            [&](const std::map<std::string, OutputChecks> & checksPerOutput) {
+            [&](const std::map<std::string, OutputChecks<SingleDerivedPath>> & checksPerOutput) {
                 nlohmann::json outputChecks;
                 outputChecks["perOutput"] = checksPerOutput;
                 return outputChecks;
@@ -423,7 +652,7 @@ void adl_serializer<DerivationOptions>::to_json(json & json, const DerivationOpt
     json["allowSubstitutes"] = o.allowSubstitutes;
 }
 
-DerivationOptions::OutputChecks adl_serializer<DerivationOptions::OutputChecks>::from_json(const json & json_)
+OutputChecks<SingleDerivedPath> adl_serializer<OutputChecks<SingleDerivedPath>>::from_json(const json & json_)
 {
     auto & json = getObject(json_);
 
@@ -431,14 +660,16 @@ DerivationOptions::OutputChecks adl_serializer<DerivationOptions::OutputChecks>:
         .ignoreSelfRefs = getBoolean(valueAt(json, "ignoreSelfRefs")),
         .maxSize = ptrToOwned<uint64_t>(getNullable(valueAt(json, "maxSize"))),
         .maxClosureSize = ptrToOwned<uint64_t>(getNullable(valueAt(json, "maxClosureSize"))),
-        .allowedReferences = ptrToOwned<StringSet>(getNullable(valueAt(json, "allowedReferences"))),
-        .disallowedReferences = getStringSet(valueAt(json, "disallowedReferences")),
-        .allowedRequisites = ptrToOwned<StringSet>(getNullable(valueAt(json, "allowedRequisites"))),
-        .disallowedRequisites = getStringSet(valueAt(json, "disallowedRequisites")),
+        .allowedReferences =
+            ptrToOwned<std::set<DrvRef<SingleDerivedPath>>>(getNullable(valueAt(json, "allowedReferences"))),
+        .disallowedReferences = valueAt(json, "disallowedReferences"),
+        .allowedRequisites =
+            ptrToOwned<std::set<DrvRef<SingleDerivedPath>>>(getNullable(valueAt(json, "allowedRequisites"))),
+        .disallowedRequisites = valueAt(json, "disallowedRequisites"),
     };
 }
 
-void adl_serializer<DerivationOptions::OutputChecks>::to_json(json & json, const DerivationOptions::OutputChecks & c)
+void adl_serializer<OutputChecks<SingleDerivedPath>>::to_json(json & json, const OutputChecks<SingleDerivedPath> & c)
 {
     json["ignoreSelfRefs"] = c.ignoreSelfRefs;
     json["maxSize"] = c.maxSize;

--- a/src/libstore/downstream-placeholder.cc
+++ b/src/libstore/downstream-placeholder.cc
@@ -1,5 +1,6 @@
 #include "nix/store/downstream-placeholder.hh"
 #include "nix/store/derivations.hh"
+#include "nix/util/json-utils.hh"
 
 namespace nix {
 
@@ -49,3 +50,45 @@ DownstreamPlaceholder DownstreamPlaceholder::fromSingleDerivedPathBuilt(
 }
 
 } // namespace nix
+
+namespace nlohmann {
+
+using namespace nix;
+
+template<typename Item>
+DrvRef<Item> adl_serializer<DrvRef<Item>>::from_json(const json & json)
+{
+    // OutputName case: { "drvPath": "self", "output": <output> }
+    if (json.type() == nlohmann::json::value_t::object) {
+        auto & obj = getObject(json);
+        if (auto * drvPath_ = get(obj, "drvPath")) {
+            auto & drvPath = *drvPath_;
+            if (drvPath.type() == nlohmann::json::value_t::string && getString(drvPath) == "self") {
+                return getString(valueAt(obj, "output"));
+            }
+        }
+    }
+
+    // Input case
+    return adl_serializer<Item>::from_json(json);
+}
+
+template<typename Item>
+void adl_serializer<DrvRef<Item>>::to_json(json & json, const DrvRef<Item> & ref)
+{
+    std::visit(
+        overloaded{
+            [&](const OutputName & outputName) {
+                json = nlohmann::json::object();
+                json["drvPath"] = "self";
+                json["output"] = outputName;
+            },
+            [&](const Item & item) { json = item; },
+        },
+        ref);
+}
+
+template struct adl_serializer<nix::DrvRef<StorePath>>;
+template struct adl_serializer<nix::DrvRef<SingleDerivedPath>>;
+
+} // namespace nlohmann

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -69,7 +69,7 @@ struct DerivationBuilderParams
      *
      * @todo this should be part of `Derivation`.
      */
-    const DerivationOptions & drvOptions;
+    const DerivationOptions<StorePath> & drvOptions;
 
     // The remainder is state held during the build.
 

--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
@@ -52,8 +52,6 @@ private:
      */
     std::unique_ptr<Derivation> drv;
 
-    std::unique_ptr<DerivationOptions> drvOptions;
-
     /**
      * The remainder is state held during the build.
      */
@@ -115,7 +113,8 @@ private:
     /**
      * Is the build hook willing to perform the build?
      */
-    HookReply tryBuildHook(const std::map<std::string, InitialOutput> & initialOutputs);
+    HookReply tryBuildHook(
+        const std::map<std::string, InitialOutput> & initialOutputs, const DerivationOptions<StorePath> & drvOptions);
 
     /**
      * Open a log file and a pipe to it.

--- a/src/libstore/include/nix/store/build/derivation-env-desugar.hh
+++ b/src/libstore/include/nix/store/build/derivation-env-desugar.hh
@@ -8,6 +8,7 @@ namespace nix {
 
 class Store;
 struct Derivation;
+template<typename Input>
 struct DerivationOptions;
 
 /**
@@ -77,7 +78,10 @@ struct DesugaredEnv
      * just part of `Derivation`.
      */
     static DesugaredEnv create(
-        Store & store, const Derivation & drv, const DerivationOptions & drvOptions, const StorePathSet & inputPaths);
+        Store & store,
+        const Derivation & drv,
+        const DerivationOptions<StorePath> & drvOptions,
+        const StorePathSet & inputPaths);
 };
 
 } // namespace nix

--- a/src/libstore/include/nix/store/parsed-derivations.hh
+++ b/src/libstore/include/nix/store/parsed-derivations.hh
@@ -9,6 +9,7 @@
 namespace nix {
 
 class Store;
+template<typename Input>
 struct DerivationOptions;
 struct DerivationOutput;
 
@@ -47,7 +48,7 @@ struct StructuredAttrs
 
     nlohmann::json::object_t prepareStructuredAttrs(
         Store & store,
-        const DerivationOptions & drvOptions,
+        const DerivationOptions<StorePath> & drvOptions,
         const StorePathSet & inputPaths,
         const DerivationOutputs & outputs) const;
 

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -225,11 +225,12 @@ MissingPaths Store::queryMissing(const std::vector<DerivedPath> & targets)
                         return;
 
                     auto drv = make_ref<Derivation>(derivationFromPath(drvPath));
-                    DerivationOptions drvOptions;
+                    DerivationOptions<SingleDerivedPath> drvOptions;
                     try {
                         // FIXME: this is a lot of work just to get the value
                         // of `allowSubstitutes`.
-                        drvOptions = DerivationOptions::fromStructuredAttrs(drv->env, drv->structuredAttrs);
+                        drvOptions = derivationOptionsFromStructuredAttrs(
+                            *this, drv->inputDrvs, drv->env, get(drv->structuredAttrs));
                     } catch (Error & e) {
                         e.addTrace({}, "while parsing derivation '%s'", printStorePath(drvPath));
                         throw;

--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -100,7 +100,7 @@ static nlohmann::json pathInfoToJSON(Store & store, const StorePathSet & storePa
 
 nlohmann::json::object_t StructuredAttrs::prepareStructuredAttrs(
     Store & store,
-    const DerivationOptions & drvOptions,
+    const DerivationOptions<StorePath> & drvOptions,
     const StorePathSet & inputPaths,
     const DerivationOutputs & outputs) const
 {
@@ -114,8 +114,8 @@ nlohmann::json::object_t StructuredAttrs::prepareStructuredAttrs(
     json["outputs"] = std::move(outputsJson);
 
     /* Handle exportReferencesGraph. */
-    for (auto & [key, storePaths] : drvOptions.getParsedExportReferencesGraph(store)) {
-        json[key] = pathInfoToJSON(store, store.exportReferences(storePaths, storePaths));
+    for (auto & [key, storePaths] : drvOptions.exportReferencesGraph) {
+        json[key] = pathInfoToJSON(store, store.exportReferences(storePaths, inputPaths));
     }
 
     return json;

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -243,6 +243,28 @@ std::string stripIndentation(std::string_view s);
 std::pair<std::string_view, std::string_view> getLine(std::string_view s);
 
 /**
+ * Get a pointer to the contents of a `std::optional` if it is set, or a
+ * null pointer otherise.
+ *
+ * Const version.
+ */
+template<class T>
+const T * get(const std::optional<T> & opt)
+{
+    return opt ? &*opt : nullptr;
+}
+
+/**
+ * Non-const counterpart of `const T * get(const std::optional<T>)`.
+ * Takes a mutable reference, but returns a mutable pointer.
+ */
+template<class T>
+T * get(std::optional<T> & opt)
+{
+    return opt ? &*opt : nullptr;
+}
+
+/**
  * Get a value for the specified key from an associate container.
  */
 template<class T, typename K>

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -554,9 +554,9 @@ static void main_nix_build(int argc, char ** argv)
         env["NIX_STORE"] = store->storeDir;
         env["NIX_BUILD_CORES"] = fmt("%d", settings.buildCores ? settings.buildCores : settings.getDefaultCores());
 
-        DerivationOptions drvOptions;
+        DerivationOptions<StorePath> drvOptions;
         try {
-            drvOptions = DerivationOptions::fromStructuredAttrs(drv.env, drv.structuredAttrs);
+            drvOptions = derivationOptionsFromStructuredAttrs(*store, drv.env, get(drv.structuredAttrs));
         } catch (Error & e) {
             e.addTrace({}, "while parsing derivation '%s'", store->printStorePath(packageInfo.requireDrvPath()));
             throw;

--- a/tests/functional/check-refs.sh
+++ b/tests/functional/check-refs.sh
@@ -64,5 +64,13 @@ fi
 if isDaemonNewer "2.28pre20241225"; then
     # test12 should fail (syntactically invalid).
     expectStderr 1 nix-build -vvv -o "$RESULT" check-refs.nix -A test12 >"$TEST_ROOT/test12.stderr"
-    grepQuiet -F "output check for 'lib' contains an illegal reference specifier 'dev', expected store path or output name (one of [lib, out])" < "$TEST_ROOT/test12.stderr"
+    if isDaemonNewer "2.33pre20251110"; then
+        grepQuiet -F \
+            "output check for 'lib' contains output name 'dev', but this is not a valid output of this derivation. (Valid outputs are [lib, out].)" \
+            < "$TEST_ROOT/test12.stderr"
+    else
+        grepQuiet -F \
+            "output check for 'lib' contains an illegal reference specifier 'dev', expected store path or output name (one of [lib, out])" \
+            < "$TEST_ROOT/test12.stderr"
+    fi
 fi


### PR DESCRIPTION
## Motivation

This is an example of ["Parse, don't validate" principle](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/).

Before, we had a number of `StringSet`s in `DerivationOptions` that were not *actually* allowed to be arbitrary sets of strings. Instead, each set member had to be one of:

- a store path

- a CA "downstream placeholder"

- an output name

Only later, in the code that checks outputs, would these strings be further parsed to match these cases. (Actually, only 2 by that point, because the placeholders must be rewritten away by then.)

Now, we fully parse everything up front, and have an "honest" data type that reflects these invariants:

- store paths are parsed, stored as (opaque) deriving paths

- CA "downstream placeholders" are rewritten to the output deriving
  paths they denote

- output names are the only arbitrary strings left

Since the first two cases both become deriving paths, that leaves us with a `std::variant<SingleDerivedPath, String>` data type, which we use in our sets instead.

Getting rid of placeholders is especially nice because we are replacing them with something much more internally-structured / transparent.

## Context

Progress on #13570

Depends on #14505

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
