### PR TITLE
build: Disable libstdc++ TBB backend to avoid unnecessary dependency

### DIFF
--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -42,6 +42,26 @@ if cxx.get_id() == 'clang'
   add_project_arguments('-fpch-instantiate-templates', language : 'cpp')
 endif
 
+# Detect if we're using libstdc++ (GCC's standard library)
+# libstdc++ uses Intel TBB as backend for C++17 parallel algorithms when <execution> is included.
+# boost::concurrent_flat_map includes <execution>, which would require linking against TBB.
+# Since we don't actually use parallel algorithms, disable the TBB backend to avoid the dependency.
+# TBB is a dependency of blake3 and leaking into our build environment.
+is_using_libstdcxx = cxx.compiles(
+  '''
+  #include <ciso646>
+  #ifndef __GLIBCXX__
+  #error "not libstdc++"
+  #endif
+  int main() { return 0; }
+''',
+  name : 'using libstdc++',
+)
+
+if is_using_libstdcxx
+  add_project_arguments('-D_GLIBCXX_USE_TBB_PAR_BACKEND=0', language : 'cpp')
+endif
+
 # Darwin ld doesn't like "X.Y.ZpreABCD+W"
 nix_soversion = meson.project_version().split('+')[0].split('pre')[0]
 


### PR DESCRIPTION
boost::concurrent_flat_map (used in libutil and libstore) includes the C++17 <execution> header. GCC's libstdc++ implements parallel algorithms using Intel TBB as the backend, which creates a link-time dependency on libtbb even though we don't actually use any parallel algorithms.

Disable the TBB backend for libstdc++ by setting
_GLIBCXX_USE_TBB_PAR_BACKEND=0. This makes parallel algorithms fall back to serial execution, which is acceptable since we don't use them anyway.

This only affects libstdc++ (GCC's standard library); other standard libraries like libc++ (LLVM) are unaffected.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
