### PR TITLE
Change channel URLs to channels.nixos.org subdomain

### DIFF
--- a/doc/manual/rl-next/channels-subdomain.md
+++ b/doc/manual/rl-next/channels-subdomain.md
@@ -1,0 +1,9 @@
+---
+synopsis: Channel URLs migrated to channels.nixos.org subdomain
+prs: [14518]
+issues: [14517]
+---
+
+Channel URLs have been updated from `https://nixos.org/channels/` to `https://channels.nixos.org/` throughout Nix.
+
+The subdomain provides better reliability with IPv6 support and improved CDN distribution. The old domain apex (`nixos.org/channels/`) currently redirects to the new location but may be deprecated in the future.

--- a/doc/manual/source/command-ref/nix-channel.md
+++ b/doc/manual/source/command-ref/nix-channel.md
@@ -11,7 +11,7 @@
 Channels are a mechanism for referencing remote Nix expressions and conveniently retrieving their latest version.
 
 The moving parts of channels are:
-- The official channels listed at <https://nixos.org/channels>
+- The official channels listed at <https://channels.nixos.org>
 - The user-specific list of [subscribed channels](#subscribed-channels)
 - The [downloaded channel contents](#channels)
 - The [Nix expression search path](@docroot@/command-ref/conf-file.md#conf-nix-path), set with the [`-I` option](#opt-I) or the [`NIX_PATH` environment variable](#env-NIX_PATH)
@@ -88,9 +88,9 @@ This command has the following operations:
 Subscribe to the Nixpkgs channel and run `hello` from the GNU Hello package:
 
 ```console
-$ nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+$ nix-channel --add https://channels.nixos.org/nixpkgs-unstable
 $ nix-channel --list
-nixpkgs https://nixos.org/channels/nixpkgs
+nixpkgs https://channels.nixos.org/nixpkgs
 $ nix-channel --update
 $ nix-shell -p hello --run hello
 hello

--- a/doc/manual/source/release-notes/rl-2.0.md
+++ b/doc/manual/source/release-notes/rl-2.0.md
@@ -358,7 +358,7 @@ This release has the following new features:
     they are needed for evaluation.
 
   - You can now use `channel:` as a short-hand for
-    <https://nixos.org/channels//nixexprs.tar.xz>. For example,
+    <https://nixos.org/channels//nixexprs.tar.xz> [now <https://channels.nixos.org//nixexprs.tar.xz>]. For example,
     `nix-build channel:nixos-15.09 -A hello` will build the GNU Hello
     package from the `nixos-15.09` channel. In the future, this may
     use Git to fetch updates more efficiently.

--- a/docker.nix
+++ b/docker.nix
@@ -10,7 +10,7 @@
   tag ? "latest",
   bundleNixpkgs ? true,
   channelName ? "nixpkgs",
-  channelURL ? "https://nixos.org/channels/nixpkgs-unstable",
+  channelURL ? "https://channels.nixos.org/nixpkgs-unstable",
   extraPkgs ? [ ],
   maxLayers ? 70,
   nixConf ? { },

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -714,7 +714,7 @@ EOF
 
 place_channel_configuration() {
     if [ -z "${NIX_INSTALLER_NO_CHANNEL_ADD:-}" ]; then
-        echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$SCRATCH/.nix-channels"
+        echo "https://channels.nixos.org/nixpkgs-unstable nixpkgs" > "$SCRATCH/.nix-channels"
         _sudo "to set up the default system channel (part 1)" \
             install -m 0644 "$SCRATCH/.nix-channels" "$ROOT_HOME/.nix-channels"
     fi

--- a/scripts/install-nix-from-tarball.sh
+++ b/scripts/install-nix-from-tarball.sh
@@ -213,7 +213,7 @@ fi
 # Subscribe the user to the Nixpkgs channel and fetch it.
 if [ -z "$NIX_INSTALLER_NO_CHANNEL_ADD" ]; then
     if ! "$nix/bin/nix-channel" --list | grep -q "^nixpkgs "; then
-        "$nix/bin/nix-channel" --add https://nixos.org/channels/nixpkgs-unstable
+        "$nix/bin/nix-channel" --add https://channels.nixos.org/nixpkgs-unstable
     fi
     if [ -z "$_NIX_INSTALLER_TEST" ]; then
         if ! "$nix/bin/nix-channel" --update nixpkgs; then

--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -92,7 +92,7 @@ bool EvalSettings::isPseudoUrl(std::string_view s)
 std::string EvalSettings::resolvePseudoUrl(std::string_view url)
 {
     if (hasPrefix(url, "channel:"))
-        return "https://nixos.org/channels/" + std::string(url.substr(8)) + "/nixexprs.tar.xz";
+        return "https://channels.nixos.org/" + std::string(url.substr(8)) + "/nixexprs.tar.xz";
     else
         return std::string(url);
 }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2234,7 +2234,7 @@ static RegisterPrimOp primop_findFile(
       > - ```
       >   {
       >     prefix = "nixpkgs";
-      >     path = "https://nixos.org/channels/nixos-unstable/nixexprs.tar.xz";
+      >     path = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
       >   }
       >   ```
 


### PR DESCRIPTION
Update all channel URLs from https://nixos.org/channels/ to https://channels.nixos.org/ to use the more reliable subdomain.

The nixos.org domain apex lacks IPv6 support due to DNS hoster limitations. Using the subdomain allows better CDN distribution and improved reliability.

Updated files:
- Installation scripts (multi-user and tarball installers)
- Channel URL resolution in eval-settings.cc
- Documentation and examples
- Docker image default channel URL
- Release notes (added note about URL change)

Fixes #14517

Tested:

```
$ ./result/bin/nix eval --impure --expr 'builtins.fetchTarball "channel:nixpkgs-unstable"'
unpacking 'https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz' into the Git cache...
"/nix/store/n9z9g10laiapycw47c3qgfyqmz7hp1mi-source"

$ ls /nix/store/n9z9g10laiapycw47c3qgfyqmz7hp1mi-source
ci  CONTRIBUTING.md  COPYING  default.nix  doc  flake.nix  lib  maintainers  modules  nixos  pkgs  README.md  shell.nix
```

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Fixes https://github.com/NixOS/nix/issues/14517
- https://github.com/NixOS/infra/issues/873
- https://github.com/NixOS/nixpkgs/pull/460057
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
