### PR TITLE
[Backport 2.31-maintenance] fix(libstore/build/derivation-goal): don't assert on partially valid outputs

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -182,8 +182,16 @@ Goal::Co DerivationGoal::haveDerivation()
             }
         }
 
-        if (buildResult.success())
-            assert(buildResult.builtOutputs.count(wantedOutput) > 0);
+        if (buildResult.success()) {
+            /* If the wanted output is not in builtOutputs (e.g., because it
+               was already valid and therefore not re-registered), we need to
+               add it ourselves to ensure we return the correct information. */
+            if (buildResult.builtOutputs.count(wantedOutput) == 0) {
+                debug(
+                    "BUG! wanted output '%s' not in builtOutputs, working around by adding it manually", wantedOutput);
+                buildResult.builtOutputs = {{wantedOutput, assertPathValidity()}};
+            }
+        }
     }
 
     co_return amDone(g->exitCode, g->ex);


### PR DESCRIPTION
Manual backport of #14137 to `2.31-maintenance`.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
