### PR TITLE
libexpr: Clear PosTable contents in EvalState::resetFileCache

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1113,6 +1113,7 @@ void EvalState::resetFileCache()
     importResolutionCache->clear();
     fileEvalCache->clear();
     inputCache->clear();
+    positions.clear();
 }
 
 void EvalState::eval(Expr * e, Value & v)

--- a/src/libutil/include/nix/util/pos-table.hh
+++ b/src/libutil/include/nix/util/pos-table.hh
@@ -111,6 +111,16 @@ public:
             return o->origin;
         return std::monostate{};
     }
+
+    /**
+     * Remove all origins from the table.
+     */
+    void clear()
+    {
+        auto lines = linesCache.lock();
+        lines->clear();
+        origins.clear();
+    }
 };
 
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Otherwise `PosTable` grows indefinitely for each reload. Since the total input size is limited to 4GB (uint32_t for byte offset PosIdx) it can get exhausted pretty. This ensures that we don't waste memory on reloads as well.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
