### PR TITLE
Restore isAllowed check in ChrootLinuxDerivationBuilder

### DIFF
--- a/src/libstore/include/nix/store/restricted-store.hh
+++ b/src/libstore/include/nix/store/restricted-store.hh
@@ -52,7 +52,21 @@ struct RestrictionContext
      * Add 'path' to the set of paths that may be referenced by the
      * outputs, and make it appear in the sandbox.
      */
-    virtual void addDependency(const StorePath & path) = 0;
+    void addDependency(const StorePath & path)
+    {
+        if (isAllowed(path))
+            return;
+        addDependencyImpl(path);
+    }
+
+protected:
+
+    /**
+     * This is the underlying implementation to be defined. The caller
+     * will ensure that this is only called on newly added dependencies,
+     * and that idempotent calls are a no-op.
+     */
+    virtual void addDependencyImpl(const StorePath & path) = 0;
 };
 
 /**

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -334,7 +334,7 @@ private:
 
 protected:
 
-    void addDependency(const StorePath & path) override;
+    void addDependencyImpl(const StorePath & path) override;
 
     /**
      * Make a file owned by the builder.
@@ -1203,11 +1203,8 @@ void DerivationBuilderImpl::stopDaemon()
     daemonSocket.close();
 }
 
-void DerivationBuilderImpl::addDependency(const StorePath & path)
+void DerivationBuilderImpl::addDependencyImpl(const StorePath & path)
 {
-    if (isAllowed(path))
-        return;
-
     addedPaths.insert(path);
 }
 

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -709,8 +709,11 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
         DerivationBuilderImpl::killSandbox(getStats);
     }
 
-    void addDependency(const StorePath & path) override
+    void addDependencyImpl(const StorePath & path) override
     {
+        if (isAllowed(path))
+            return;
+
         auto [source, target] = ChrootDerivationBuilder::addDependencyPrep(path);
 
         /* Bind-mount the path into the sandbox. This requires


### PR DESCRIPTION
## Motivation

This early return was lost in d4ef822add1074483627c5dbbaa9077f15daf7bc.

By doing some https://en.wikipedia.org/wiki/Non-virtual_interface_pattern, we can ensure that we don't make this mistake again --- implementations are no longer responsible for implementing the caching/memoization mechanism.

## Context

https://github.com/NixOS/nix/commit/d4ef822add1074483627c5dbbaa9077f15daf7bc#diff-ac4d64db8e0fba7040c6a8bf9ab4a09e9408bdb9f2d8ddca8b3a773ef6113bf8L843-L844

Fixes ~~(probably)~~ https://github.com/NixOS/nix/issues/14529.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
