### PR TITLE
JSON for `Hash` now has to be `Base16`

### DIFF
--- a/doc/manual/rl-next/json-format-changes.md
+++ b/doc/manual/rl-next/json-format-changes.md
@@ -19,7 +19,7 @@ The store path info JSON format has been updated from version 1 to version 2:
   Content address is now a structured JSON object instead of a string:
 
   - Old: `"ca": "fixed:r:sha256:1abc..."`
-  - New: `"ca": {"method": "nar", "hash": {"algorithm": "sha256", "format": "base64", "hash": "EMIJ+giQ..."}}`
+  - New: `"ca": {"method": "nar", "hash": {"algorithm": "sha256", "format": "base16", "hash": "10c209fa..."}}`
   - Still `null` values for input-addressed store objects
 
 - **Structured hash fields**:
@@ -27,8 +27,9 @@ The store path info JSON format has been updated from version 1 to version 2:
   Hash values (`narHash` and `downloadHash`) are now structured JSON objects instead of strings:
 
   - Old: `"narHash": "sha256:FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="`
-  - New: `"narHash": {"algorithm": "sha256", "format": "base64", "hash": "FePFYIlM..."}`
+  - New: `"narHash": {"algorithm": "sha256", "format": "base16", "hash": "15e3c5608946..."}`
   - Same structure applies to `downloadHash` in NAR info contexts
+  - The `format` field is always `"base16"` (hexadecimal)
 
 Nix currently only produces, and doesn't consume this format.
 
@@ -48,8 +49,8 @@ The derivation JSON format has been updated from version 3 to version 4:
 - **Consistent content addresses**:
 
   Floating content-addressed outputs now use structured JSON format.
-  This is the same format as `ca` in in store path info (after the new version).
+  This is the same format as `ca` in store path info (after the new version).
 
 Version 3 and earlier formats are *not* accepted when reading.
 
-**Affected command**: `nix derivation`, namely it's `show` and `add` sub-commands.
+**Affected command**: `nix derivation`, namely its `show` and `add` sub-commands.

--- a/doc/manual/source/protocols/json/hash.md
+++ b/doc/manual/source/protocols/json/hash.md
@@ -2,28 +2,16 @@
 
 ## Examples
 
-### SHA-256 with Base64 encoding
-
-```json
-{{#include schema/hash-v1/sha256-base64.json}}
-```
-
-### SHA-256 with Base16 (hexadecimal) encoding
+### SHA-256
 
 ```json
 {{#include schema/hash-v1/sha256-base16.json}}
 ```
 
-### SHA-256 with Nix32 encoding
+### BLAKE3
 
 ```json
-{{#include schema/hash-v1/sha256-nix32.json}}
-```
-
-### BLAKE3 with Base64 encoding
-
-```json
-{{#include schema/hash-v1/blake3-base64.json}}
+{{#include schema/hash-v1/blake3-base16.json}}
 ```
 
 <!-- need to convert YAML to JSON first

--- a/doc/manual/source/protocols/json/schema/hash-v1.yaml
+++ b/doc/manual/source/protocols/json/schema/hash-v1.yaml
@@ -12,18 +12,14 @@ properties:
   format:
     type: string
     enum:
-    - base64
-    - nix32
     - base16
-    - sri
     title: Hash format
     description: |
       The encoding format of the hash value.
 
-      - `base64` uses standard Base64 encoding [RFC 4648, section 4](https://datatracker.ietf.org/doc/html/rfc4648#section-4)
-      - `nix32` is Nix-specific base-32 encoding
-      - `base16` is lowercase hexadecimal
-      - `sri` is the [Subresource Integrity format](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).
+      `base16` (lowercase hexadecimal) is the only format that is currently supported for JSON serialization.
+      This field exists primarily to reduce ambiguity about what the hash means.
+      It would also help us support other formats in the future, but there are no concrete plans to do so at this.
   hash:
     type: string
     title: Hash

--- a/src/json-schema-checks/meson.build
+++ b/src/json-schema-checks/meson.build
@@ -32,10 +32,8 @@ schemas = [
     'stem' : 'hash',
     'schema' : schema_dir / 'hash-v1.yaml',
     'files' : [
-      'sha256-base64.json',
       'sha256-base16.json',
-      'sha256-nix32.json',
-      'blake3-base64.json',
+      'blake3-base16.json',
     ],
   },
   {

--- a/src/libstore-tests/data/common-protocol/content-address.json
+++ b/src/libstore-tests/data/common-protocol/content-address.json
@@ -2,24 +2,24 @@
   {
     "hash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "+Xc9Ll6mcPltwaewrk/BAQ56Y3G5T//wzhKUc0zrYu0="
+      "format": "base16",
+      "hash": "f9773d2e5ea670f96dc1a7b0ae4fc1010e7a6371b94ffff0ce1294734ceb62ed"
     },
     "method": "text"
   },
   {
     "hash": {
       "algorithm": "sha1",
-      "format": "base64",
-      "hash": "gGemBoenViNZM3hiwqns/Fgzqwo="
+      "format": "base16",
+      "hash": "8067a60687a7562359337862c2a9ecfc5833ab0a"
     },
     "method": "flat"
   },
   {
     "hash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "EMIJ+giQ/gLIWoxmPKjno3zHZrxbGymgzGGyZvZBIdM="
+      "format": "base16",
+      "hash": "10c209fa0890fe02c85a8c663ca8e7a37cc766bc5b1b29a0cc61b266f64121d3"
     },
     "method": "nar"
   }

--- a/src/libstore-tests/data/common-protocol/optional-content-address.json
+++ b/src/libstore-tests/data/common-protocol/optional-content-address.json
@@ -3,8 +3,8 @@
   {
     "hash": {
       "algorithm": "sha1",
-      "format": "base64",
-      "hash": "gGemBoenViNZM3hiwqns/Fgzqwo="
+      "format": "base16",
+      "hash": "8067a60687a7562359337862c2a9ecfc5833ab0a"
     },
     "method": "flat"
   }

--- a/src/libstore-tests/data/content-address/nar.json
+++ b/src/libstore-tests/data/content-address/nar.json
@@ -1,8 +1,8 @@
 {
   "hash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "9vLqj0XYoFfJVmoz+ZR02i5camYE1zYSFlDicwxvsKM="
+    "format": "base16",
+    "hash": "f6f2ea8f45d8a057c9566a33f99474da2e5c6a6604d736121650e2730c6fb0a3"
   },
   "method": "nar"
 }

--- a/src/libstore-tests/data/content-address/text.json
+++ b/src/libstore-tests/data/content-address/text.json
@@ -1,8 +1,8 @@
 {
   "hash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "8OTC92xYkW7CWPJGhRvqCR0U1CR6L8PhhpRGGxgW4Ts="
+    "format": "base16",
+    "hash": "f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b"
   },
   "method": "text"
 }

--- a/src/libstore-tests/data/derivation/output-caFixedFlat.json
+++ b/src/libstore-tests/data/derivation/output-caFixedFlat.json
@@ -1,8 +1,8 @@
 {
   "hash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="
+    "format": "base16",
+    "hash": "894517c9163c896ec31a2adbd33c0681fd5f45b2c0ef08a64c92a03fb97f390f"
   },
   "method": "flat"
 }

--- a/src/libstore-tests/data/derivation/output-caFixedNAR.json
+++ b/src/libstore-tests/data/derivation/output-caFixedNAR.json
@@ -1,8 +1,8 @@
 {
   "hash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="
+    "format": "base16",
+    "hash": "894517c9163c896ec31a2adbd33c0681fd5f45b2c0ef08a64c92a03fb97f390f"
   },
   "method": "nar"
 }

--- a/src/libstore-tests/data/derivation/output-caFixedText.json
+++ b/src/libstore-tests/data/derivation/output-caFixedText.json
@@ -1,8 +1,8 @@
 {
   "hash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="
+    "format": "base16",
+    "hash": "894517c9163c896ec31a2adbd33c0681fd5f45b2c0ef08a64c92a03fb97f390f"
   },
   "method": "text"
 }

--- a/src/libstore-tests/data/dummy-store/one-flat-file.json
+++ b/src/libstore-tests/data/dummy-store/one-flat-file.json
@@ -14,16 +14,16 @@
         "ca": {
           "hash": {
             "algorithm": "sha256",
-            "format": "base64",
-            "hash": "f1eduuSIYC1BofXA1tycF79Ai2NSMJQtUErx5DxLYSU="
+            "format": "base16",
+            "hash": "7f579dbae488602d41a1f5c0d6dc9c17bf408b635230942d504af1e43c4b6125"
           },
           "method": "nar"
         },
         "deriver": null,
         "narHash": {
           "algorithm": "sha256",
-          "format": "base64",
-          "hash": "f1eduuSIYC1BofXA1tycF79Ai2NSMJQtUErx5DxLYSU="
+          "format": "base16",
+          "hash": "7f579dbae488602d41a1f5c0d6dc9c17bf408b635230942d504af1e43c4b6125"
         },
         "narSize": 120,
         "references": [],

--- a/src/libstore-tests/data/nar-info/impure.json
+++ b/src/libstore-tests/data/nar-info/impure.json
@@ -2,8 +2,8 @@
   "ca": {
     "hash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "EMIJ+giQ/gLIWoxmPKjno3zHZrxbGymgzGGyZvZBIdM="
+      "format": "base16",
+      "hash": "10c209fa0890fe02c85a8c663ca8e7a37cc766bc5b1b29a0cc61b266f64121d3"
     },
     "method": "nar"
   },
@@ -11,14 +11,14 @@
   "deriver": "/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
   "downloadHash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+    "format": "base16",
+    "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
   },
   "downloadSize": 4029176,
   "narHash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+    "format": "base16",
+    "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
   },
   "narSize": 34878,
   "references": [

--- a/src/libstore-tests/data/nar-info/pure.json
+++ b/src/libstore-tests/data/nar-info/pure.json
@@ -2,15 +2,15 @@
   "ca": {
     "hash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "EMIJ+giQ/gLIWoxmPKjno3zHZrxbGymgzGGyZvZBIdM="
+      "format": "base16",
+      "hash": "10c209fa0890fe02c85a8c663ca8e7a37cc766bc5b1b29a0cc61b266f64121d3"
     },
     "method": "nar"
   },
   "narHash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+    "format": "base16",
+    "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
   },
   "narSize": 34878,
   "references": [

--- a/src/libstore-tests/data/path-info/empty_impure.json
+++ b/src/libstore-tests/data/path-info/empty_impure.json
@@ -3,8 +3,8 @@
   "deriver": null,
   "narHash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+    "format": "base16",
+    "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
   },
   "narSize": 0,
   "references": [],

--- a/src/libstore-tests/data/path-info/empty_pure.json
+++ b/src/libstore-tests/data/path-info/empty_pure.json
@@ -2,8 +2,8 @@
   "ca": null,
   "narHash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+    "format": "base16",
+    "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
   },
   "narSize": 0,
   "references": [],

--- a/src/libstore-tests/data/path-info/impure.json
+++ b/src/libstore-tests/data/path-info/impure.json
@@ -2,16 +2,16 @@
   "ca": {
     "hash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "EMIJ+giQ/gLIWoxmPKjno3zHZrxbGymgzGGyZvZBIdM="
+      "format": "base16",
+      "hash": "10c209fa0890fe02c85a8c663ca8e7a37cc766bc5b1b29a0cc61b266f64121d3"
     },
     "method": "nar"
   },
   "deriver": "/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
   "narHash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+    "format": "base16",
+    "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
   },
   "narSize": 34878,
   "references": [

--- a/src/libstore-tests/data/path-info/pure.json
+++ b/src/libstore-tests/data/path-info/pure.json
@@ -2,15 +2,15 @@
   "ca": {
     "hash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "EMIJ+giQ/gLIWoxmPKjno3zHZrxbGymgzGGyZvZBIdM="
+      "format": "base16",
+      "hash": "10c209fa0890fe02c85a8c663ca8e7a37cc766bc5b1b29a0cc61b266f64121d3"
     },
     "method": "nar"
   },
   "narHash": {
     "algorithm": "sha256",
-    "format": "base64",
-    "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+    "format": "base16",
+    "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
   },
   "narSize": 34878,
   "references": [

--- a/src/libstore-tests/data/serve-protocol/content-address.json
+++ b/src/libstore-tests/data/serve-protocol/content-address.json
@@ -2,24 +2,24 @@
   {
     "hash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "+Xc9Ll6mcPltwaewrk/BAQ56Y3G5T//wzhKUc0zrYu0="
+      "format": "base16",
+      "hash": "f9773d2e5ea670f96dc1a7b0ae4fc1010e7a6371b94ffff0ce1294734ceb62ed"
     },
     "method": "text"
   },
   {
     "hash": {
       "algorithm": "sha1",
-      "format": "base64",
-      "hash": "gGemBoenViNZM3hiwqns/Fgzqwo="
+      "format": "base16",
+      "hash": "8067a60687a7562359337862c2a9ecfc5833ab0a"
     },
     "method": "flat"
   },
   {
     "hash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "EMIJ+giQ/gLIWoxmPKjno3zHZrxbGymgzGGyZvZBIdM="
+      "format": "base16",
+      "hash": "10c209fa0890fe02c85a8c663ca8e7a37cc766bc5b1b29a0cc61b266f64121d3"
     },
     "method": "nar"
   }

--- a/src/libstore-tests/data/serve-protocol/optional-content-address.json
+++ b/src/libstore-tests/data/serve-protocol/optional-content-address.json
@@ -3,8 +3,8 @@
   {
     "hash": {
       "algorithm": "sha1",
-      "format": "base64",
-      "hash": "gGemBoenViNZM3hiwqns/Fgzqwo="
+      "format": "base16",
+      "hash": "8067a60687a7562359337862c2a9ecfc5833ab0a"
     },
     "method": "flat"
   }

--- a/src/libstore-tests/data/serve-protocol/unkeyed-valid-path-info-2.3.json
+++ b/src/libstore-tests/data/serve-protocol/unkeyed-valid-path-info-2.3.json
@@ -4,8 +4,8 @@
     "deriver": null,
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      "format": "base16",
+      "hash": "0000000000000000000000000000000000000000000000000000000000000000"
     },
     "narSize": 34878,
     "references": [],
@@ -19,8 +19,8 @@
     "deriver": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      "format": "base16",
+      "hash": "0000000000000000000000000000000000000000000000000000000000000000"
     },
     "narSize": 34878,
     "references": [

--- a/src/libstore-tests/data/serve-protocol/unkeyed-valid-path-info-2.4.json
+++ b/src/libstore-tests/data/serve-protocol/unkeyed-valid-path-info-2.4.json
@@ -4,8 +4,8 @@
     "deriver": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+      "format": "base16",
+      "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
     },
     "narSize": 34878,
     "references": [
@@ -20,16 +20,16 @@
     "ca": {
       "hash": {
         "algorithm": "sha256",
-        "format": "base64",
-        "hash": "EMIJ+giQ/gLIWoxmPKjno3zHZrxbGymgzGGyZvZBIdM="
+        "format": "base16",
+        "hash": "10c209fa0890fe02c85a8c663ca8e7a37cc766bc5b1b29a0cc61b266f64121d3"
       },
       "method": "nar"
     },
     "deriver": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+      "format": "base16",
+      "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
     },
     "narSize": 34878,
     "references": [

--- a/src/libstore-tests/data/worker-protocol/content-address.json
+++ b/src/libstore-tests/data/worker-protocol/content-address.json
@@ -2,24 +2,24 @@
   {
     "hash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "+Xc9Ll6mcPltwaewrk/BAQ56Y3G5T//wzhKUc0zrYu0="
+      "format": "base16",
+      "hash": "f9773d2e5ea670f96dc1a7b0ae4fc1010e7a6371b94ffff0ce1294734ceb62ed"
     },
     "method": "text"
   },
   {
     "hash": {
       "algorithm": "sha1",
-      "format": "base64",
-      "hash": "gGemBoenViNZM3hiwqns/Fgzqwo="
+      "format": "base16",
+      "hash": "8067a60687a7562359337862c2a9ecfc5833ab0a"
     },
     "method": "flat"
   },
   {
     "hash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "EMIJ+giQ/gLIWoxmPKjno3zHZrxbGymgzGGyZvZBIdM="
+      "format": "base16",
+      "hash": "10c209fa0890fe02c85a8c663ca8e7a37cc766bc5b1b29a0cc61b266f64121d3"
     },
     "method": "nar"
   }

--- a/src/libstore-tests/data/worker-protocol/optional-content-address.json
+++ b/src/libstore-tests/data/worker-protocol/optional-content-address.json
@@ -3,8 +3,8 @@
   {
     "hash": {
       "algorithm": "sha1",
-      "format": "base64",
-      "hash": "gGemBoenViNZM3hiwqns/Fgzqwo="
+      "format": "base16",
+      "hash": "8067a60687a7562359337862c2a9ecfc5833ab0a"
     },
     "method": "flat"
   }

--- a/src/libstore-tests/data/worker-protocol/unkeyed-valid-path-info-1.15.json
+++ b/src/libstore-tests/data/worker-protocol/unkeyed-valid-path-info-1.15.json
@@ -4,8 +4,8 @@
     "deriver": null,
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+      "format": "base16",
+      "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
     },
     "narSize": 34878,
     "references": [],
@@ -19,8 +19,8 @@
     "deriver": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+      "format": "base16",
+      "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
     },
     "narSize": 34878,
     "references": [

--- a/src/libstore-tests/data/worker-protocol/valid-path-info-1.15.json
+++ b/src/libstore-tests/data/worker-protocol/valid-path-info-1.15.json
@@ -4,8 +4,8 @@
     "deriver": null,
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+      "format": "base16",
+      "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
     },
     "narSize": 34878,
     "path": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar",
@@ -20,8 +20,8 @@
     "deriver": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+      "format": "base16",
+      "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
     },
     "narSize": 34878,
     "path": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar",

--- a/src/libstore-tests/data/worker-protocol/valid-path-info-1.16.json
+++ b/src/libstore-tests/data/worker-protocol/valid-path-info-1.16.json
@@ -4,8 +4,8 @@
     "deriver": null,
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+      "format": "base16",
+      "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
     },
     "narSize": 34878,
     "path": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar",
@@ -20,8 +20,8 @@
     "deriver": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+      "format": "base16",
+      "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
     },
     "narSize": 34878,
     "path": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar",
@@ -41,16 +41,16 @@
     "ca": {
       "hash": {
         "algorithm": "sha256",
-        "format": "base64",
-        "hash": "EMIJ+giQ/gLIWoxmPKjno3zHZrxbGymgzGGyZvZBIdM="
+        "format": "base16",
+        "hash": "10c209fa0890fe02c85a8c663ca8e7a37cc766bc5b1b29a0cc61b266f64121d3"
       },
       "method": "nar"
     },
     "deriver": null,
     "narHash": {
       "algorithm": "sha256",
-      "format": "base64",
-      "hash": "FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="
+      "format": "base16",
+      "hash": "15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
     },
     "narSize": 34878,
     "path": "n5wkd9frr45pa74if5gpz9j7mifg27fh-foo",

--- a/src/libutil-tests/data/hash/blake3-base16.json
+++ b/src/libutil-tests/data/hash/blake3-base16.json
@@ -1,0 +1,5 @@
+{
+  "algorithm": "blake3",
+  "format": "base16",
+  "hash": "9e70ee1449965fb62d049040a1ed06ec377430da6ec13173e7c4fffcd28be980"
+}

--- a/src/libutil-tests/data/hash/blake3-base64.json
+++ b/src/libutil-tests/data/hash/blake3-base64.json
@@ -1,5 +1,0 @@
-{
-  "algorithm": "blake3",
-  "format": "base64",
-  "hash": "nnDuFEmWX7YtBJBAoe0G7Dd0MNpuwTFz58T//NKL6YA="
-}

--- a/src/libutil-tests/data/hash/sha256-base16.json
+++ b/src/libutil-tests/data/hash/sha256-base16.json
@@ -1,5 +1,5 @@
 {
-    "algorithm": "sha256",
-    "format": "base16",
-    "hash": "f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b"
+  "algorithm": "sha256",
+  "format": "base16",
+  "hash": "f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b"
 }

--- a/src/libutil-tests/data/hash/simple.json
+++ b/src/libutil-tests/data/hash/simple.json
@@ -1,5 +1,5 @@
 {
   "algorithm": "sha256",
-  "format": "base64",
-  "hash": "8OTC92xYkW7CWPJGhRvqCR0U1CR6L8PhhpRGGxgW4Ts="
+  "format": "base16",
+  "hash": "f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b"
 }

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -508,7 +508,14 @@ Hash adl_serializer<Hash>::from_json(const json & json, const ExperimentalFeatur
 {
     auto & obj = getObject(json);
     auto algo = parseHashAlgo(getString(valueAt(obj, "algorithm")), xpSettings);
-    auto format = parseHashFormat(getString(valueAt(obj, "format")));
+    auto formatStr = getString(valueAt(obj, "format"));
+    auto format = parseHashFormat(formatStr);
+
+    // Only base16 format is supported for JSON serialization
+    if (format != HashFormat::Base16) {
+        throw Error("hash format '%s' is not supported in JSON; only 'base16' is currently supported", formatStr);
+    }
+
     auto & hashS = getString(valueAt(obj, "hash"));
     return Hash::parseExplicitFormatUnprefixed(hashS, algo, format, xpSettings);
 }
@@ -516,9 +523,9 @@ Hash adl_serializer<Hash>::from_json(const json & json, const ExperimentalFeatur
 void adl_serializer<Hash>::to_json(json & json, const Hash & hash)
 {
     json = {
-        {"format", printHashFormat(HashFormat::Base64)},
+        {"format", printHashFormat(HashFormat::Base16)},
         {"algorithm", printHashAlgo(hash.algo)},
-        {"hash", hash.to_string(HashFormat::Base64, false)},
+        {"hash", hash.to_string(HashFormat::Base16, false)},
     };
 }
 

--- a/tests/functional/fixed.sh
+++ b/tests/functional/fixed.sh
@@ -15,13 +15,12 @@ nix-build fixed.nix -A bad --no-out-link && fail "should fail"
 # a side-effect.
 [[ -e $path ]]
 nix path-info --json "$path" | jq -e \
-    --arg hash "$(nix hash convert --to base64 "md5:8ddd8be4b179a529afa5f2ffae4b9858")" \
     '.[].ca == {
         method: "flat",
         hash: {
             algorithm: "md5",
-            format: "base64",
-            hash: $hash
+            format: "base16",
+            hash: "8ddd8be4b179a529afa5f2ffae4b9858"
         },
     }'
 

--- a/tests/functional/git-hashing/simple-common.sh
+++ b/tests/functional/git-hashing/simple-common.sh
@@ -49,12 +49,12 @@ try2 () {
 
     nix path-info --json "$path" | jq -e \
         --arg algo "$hashAlgo" \
-        --arg hash "$(nix hash convert --to base64 "$hashAlgo:$hashFromGit")" \
+        --arg hash "$hashFromGit" \
         '.[].ca == {
             method: "git",
             hash: {
                 algorithm: $algo,
-                format: "base64",
+                format: "base16",
                 hash: $hash
             },
         }'

--- a/tests/functional/path-info.sh
+++ b/tests/functional/path-info.sh
@@ -19,13 +19,13 @@ diff --unified --color=always \
         {
           "$foo": {
             "algorithm": "sha256",
-            "format": "base64",
-            "hash": "QvtAMbUl/uvi+LCObmqOhvNOapHdA2raiI4xG5zI5pA="
+            "format": "base16",
+            "hash": "42fb4031b525feebe2f8b08e6e6a8e86f34e6a91dd036ada888e311b9cc8e690"
           },
           "$bar": {
             "algorithm": "sha256",
-            "format": "base64",
-            "hash": "9fhYGu9fqxcQC2Kc81qh2RMo1QcLBUBo8U+pPn+jthQ="
+            "format": "base16",
+            "hash": "f5f8581aef5fab17100b629cf35aa1d91328d5070b054068f14fa93e7fa3b614"
           },
           "$baz": null
         }


### PR DESCRIPTION
## Motivation

Fix https://github.com/NixOS/nix/issues/14532.

## Context

As discussed on the call today:

1. We'll stick with `format = "base16"` and `hash = "<hash>"`, not do `base16 = "<hash>"`, in order to be forward compatible with supporting more versioning formats.

   The motivation we discussed for someday *possibly* doing this is making it easier to write very slap-dash lang2nix tools that create (not consume) derivations with dynamic derivations.

2. We will remove support for non-base16 (and make that the default, not base64) in `Hash`, so this is strictly forward contingency, *not* yet something we support. (And also not something we have concrete plans to start supporting.)

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
