### PR TITLE
doc: fix "Nix Archive (NAR) format" specification

### DIFF
--- a/doc/manual/source/protocols/nix-archive/index.md
+++ b/doc/manual/source/protocols/nix-archive/index.md
@@ -24,7 +24,7 @@ nar-obj-inner
   | str("type"), str("directory") directory
   ;
 
-regular = [ str("executable") ], str("contents"), str(contents);
+regular = [ str("executable"), str("") ], str("contents"), str(contents);
 
 symlink = str("target"), str(target);
 


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Fix the documentation of the NAR archive format.

## Context

For executable files in NAR archives, the `executable` tag is followed by an empty string, which was not indicated correctly in the specification.

Adding the empty string can be seen in [`src/libutil/archive.cc:62`](https://github.com/NixOS/nix/blob/af0ac14021a1de2302f89bcbb7aa3e0eb63631e0/src/libutil/archive.cc#L62).

Here is an example of a hexdump of a NAR archives where this empty string can be seen:

```
00000730  65 6e 74 72 79 00 00 00  01 00 00 00 00 00 00 00  |entry...........|
00000740  28 00 00 00 00 00 00 00  04 00 00 00 00 00 00 00  |(...............|
00000750  6e 61 6d 65 00 00 00 00  10 00 00 00 00 00 00 00  |name............|
00000760  6c 69 62 6d 70 66 72 2e  73 6f 2e 36 2e 32 2e 31  |libmpfr.so.6.2.1|
00000770  04 00 00 00 00 00 00 00  6e 6f 64 65 00 00 00 00  |........node....|
00000780  01 00 00 00 00 00 00 00  28 00 00 00 00 00 00 00  |........(.......|
00000790  04 00 00 00 00 00 00 00  74 79 70 65 00 00 00 00  |........type....|
000007a0  07 00 00 00 00 00 00 00  72 65 67 75 6c 61 72 00  |........regular.|
000007b0  0a 00 00 00 00 00 00 00  65 78 65 63 75 74 61 62  |........executab|
000007c0  6c 65 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |le..............|
000007d0  08 00 00 00 00 00 00 00  63 6f 6e 74 65 6e 74 73  |........contents|
000007e0  a0 16 0c 00 00 00 00 00  7f 45 4c 46 02 01 01 00  |.........ELF....|
000007f0  00 00 00 00 00 00 00 00  03 00 3e 00 01 00 00 00  |..........>.....|
00000800  00 00 00 00 00 00 00 00  40 00 00 00 00 00 00 00  |........@.......|
00000810  e0 0e 0c 00 00 00 00 00  00 00 00 00 40 00 38 00  |............@.8.|
00000820  0b 00 40 00 1f 00 1e 00  01 00 00 00 04 00 00 00  |..@.............|
00000830  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
```

(taken from `09zrxnn4j5hjxqj93xvxrl1dpmq4cyajas3yf7a7y0i7h81m6bd4.nar`, available on `cache.nixos.org`)

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
