### PR TITLE
Remove setting from Input

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -185,6 +185,7 @@ MixFlakeOptions::MixFlakeOptions()
                     }
 
                     overrideRegistry(
+                        fetchSettings,
                         fetchers::Input::fromAttrs(fetchSettings, {{"type", "indirect"}, {"id", inputName}}),
                         input3->lockedRef.input,
                         extraAttrs);

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -738,7 +738,7 @@ void NixRepl::loadFlake(const std::string & flakeRefS)
     }
 
     auto flakeRef = parseFlakeRef(fetchSettings, flakeRefS, cwd.string(), true);
-    if (evalSettings.pureEval && !flakeRef.input.isLocked())
+    if (evalSettings.pureEval && !flakeRef.input.isLocked(fetchSettings))
         throw Error("cannot use ':load-flake' on locked flake reference '%s' (use --impure to override)", flakeRefS);
 
     Value v;

--- a/src/libexpr/primops/fetchMercurial.cc
+++ b/src/libexpr/primops/fetchMercurial.cc
@@ -81,7 +81,7 @@ static void prim_fetchMercurial(EvalState & state, const PosIdx pos, Value ** ar
         attrs.insert_or_assign("rev", rev->gitRev());
     auto input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
 
-    auto [storePath, input2] = input.fetchToStore(state.store);
+    auto [storePath, input2] = input.fetchToStore(state.fetchSettings, state.store);
 
     auto attrs2 = state.buildBindings(8);
     state.mkStorePathString(storePath, attrs2.alloc(state.s.outPath));

--- a/src/libfetchers-tests/git.cc
+++ b/src/libfetchers-tests/git.cc
@@ -196,7 +196,7 @@ TEST_F(GitTest, submodulePeriodSupport)
             {"ref", "main"},
         });
 
-    auto [accessor, i] = input.getAccessor(store);
+    auto [accessor, i] = input.getAccessor(settings, store);
 
     ASSERT_EQ(accessor->readFile(CanonPath("deps/sub/lib.txt")), "hello from submodule\n");
 }

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -89,7 +89,7 @@ Input Input::fromAttrs(const Settings & settings, Attrs && attrs)
         // but not all of them. Doing this is to support those other
         // operations which are supposed to be robust on
         // unknown/uninterpretable inputs.
-        Input input{settings};
+        Input input;
         input.attrs = attrs;
         fixupInput(input);
         return input;
@@ -159,9 +159,9 @@ bool Input::isDirect() const
     return !scheme || scheme->isDirect(*this);
 }
 
-bool Input::isLocked() const
+bool Input::isLocked(const Settings & settings) const
 {
-    return scheme && scheme->isLocked(*this);
+    return scheme && scheme->isLocked(settings, *this);
 }
 
 bool Input::isFinal() const
@@ -198,17 +198,17 @@ bool Input::contains(const Input & other) const
 }
 
 // FIXME: remove
-std::pair<StorePath, Input> Input::fetchToStore(ref<Store> store) const
+std::pair<StorePath, Input> Input::fetchToStore(const Settings & settings, ref<Store> store) const
 {
     if (!scheme)
         throw Error("cannot fetch unsupported input '%s'", attrsToJSON(toAttrs()));
 
     auto [storePath, input] = [&]() -> std::pair<StorePath, Input> {
         try {
-            auto [accessor, result] = getAccessorUnchecked(store);
+            auto [accessor, result] = getAccessorUnchecked(settings, store);
 
             auto storePath =
-                nix::fetchToStore(*settings, *store, SourcePath(accessor), FetchMode::Copy, result.getName());
+                nix::fetchToStore(settings, *store, SourcePath(accessor), FetchMode::Copy, result.getName());
 
             auto narHash = store->queryPathInfo(storePath)->narHash;
             result.attrs.insert_or_assign("narHash", narHash.to_string(HashFormat::SRI, true));
@@ -297,10 +297,10 @@ void Input::checkLocks(Input specified, Input & result)
     }
 }
 
-std::pair<ref<SourceAccessor>, Input> Input::getAccessor(ref<Store> store) const
+std::pair<ref<SourceAccessor>, Input> Input::getAccessor(const Settings & settings, ref<Store> store) const
 {
     try {
-        auto [accessor, result] = getAccessorUnchecked(store);
+        auto [accessor, result] = getAccessorUnchecked(settings, store);
 
         result.attrs.insert_or_assign("__final", Explicit<bool>(true));
 
@@ -313,7 +313,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessor(ref<Store> store) const
     }
 }
 
-std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> store) const
+std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings & settings, ref<Store> store) const
 {
     // FIXME: cache the accessor
 
@@ -349,7 +349,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
             if (accessor->fingerprint) {
                 ContentAddressMethod method = ContentAddressMethod::Raw::NixArchive;
                 auto cacheKey = makeFetchToStoreCacheKey(getName(), *accessor->fingerprint, method, "/");
-                settings->getCache()->upsert(cacheKey, *store, {}, storePath);
+                settings.getCache()->upsert(cacheKey, *store, {}, storePath);
             }
 
             accessor->setPathDisplay("«" + to_string() + "»");
@@ -360,7 +360,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
         }
     }
 
-    auto [accessor, result] = scheme->getAccessor(store, *this);
+    auto [accessor, result] = scheme->getAccessor(settings, store, *this);
 
     if (!accessor->fingerprint)
         accessor->fingerprint = result.getFingerprint(store);
@@ -377,10 +377,10 @@ Input Input::applyOverrides(std::optional<std::string> ref, std::optional<Hash> 
     return scheme->applyOverrides(*this, ref, rev);
 }
 
-void Input::clone(const Path & destDir) const
+void Input::clone(const Settings & settings, const Path & destDir) const
 {
     assert(scheme);
-    scheme->clone(*this, destDir);
+    scheme->clone(settings, *this, destDir);
 }
 
 std::optional<std::filesystem::path> Input::getSourcePath() const
@@ -493,7 +493,7 @@ void InputScheme::putFile(
     throw Error("input '%s' does not support modifying file '%s'", input.to_string(), path);
 }
 
-void InputScheme::clone(const Input & input, const Path & destDir) const
+void InputScheme::clone(const Settings & settings, const Input & input, const Path & destDir) const
 {
     throw Error("do not know how to clone input '%s'", input.to_string());
 }

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -229,7 +229,7 @@ struct GitInputScheme : InputScheme
         if (auto ref = maybeGetStrAttr(attrs, "ref"); ref && !isLegalRefName(*ref))
             throw BadURL("invalid Git branch/tag name '%s'", *ref);
 
-        Input input{settings};
+        Input input{};
         input.attrs = attrs;
         input.attrs["url"] = fixGitURL(getStrAttr(attrs, "url")).to_string();
         getShallowAttr(input);
@@ -278,7 +278,7 @@ struct GitInputScheme : InputScheme
         return res;
     }
 
-    void clone(const Input & input, const Path & destDir) const override
+    void clone(const Settings & settings, const Input & input, const Path & destDir) const override
     {
         auto repoInfo = getRepoInfo(input);
 
@@ -623,7 +623,7 @@ struct GitInputScheme : InputScheme
     }
 
     std::pair<ref<SourceAccessor>, Input>
-    getAccessorFromCommit(ref<Store> store, RepoInfo & repoInfo, Input && input) const
+    getAccessorFromCommit(const Settings & settings, ref<Store> store, RepoInfo & repoInfo, Input && input) const
     {
         assert(!repoInfo.workdirInfo.isDirty);
 
@@ -733,10 +733,10 @@ struct GitInputScheme : InputScheme
 
         auto rev = *input.getRev();
 
-        input.attrs.insert_or_assign("lastModified", getLastModified(*input.settings, repoInfo, repoDir, rev));
+        input.attrs.insert_or_assign("lastModified", getLastModified(settings, repoInfo, repoDir, rev));
 
         if (!getShallowAttr(input))
-            input.attrs.insert_or_assign("revCount", getRevCount(*input.settings, repoInfo, repoDir, rev));
+            input.attrs.insert_or_assign("revCount", getRevCount(settings, repoInfo, repoDir, rev));
 
         printTalkative("using revision %s of repo '%s'", rev.gitRev(), repoInfo.locationToArg());
 
@@ -779,8 +779,8 @@ struct GitInputScheme : InputScheme
                 attrs.insert_or_assign("submodules", Explicit<bool>{true});
                 attrs.insert_or_assign("lfs", Explicit<bool>{smudgeLfs});
                 attrs.insert_or_assign("allRefs", Explicit<bool>{true});
-                auto submoduleInput = fetchers::Input::fromAttrs(*input.settings, std::move(attrs));
-                auto [submoduleAccessor, submoduleInput2] = submoduleInput.getAccessor(store);
+                auto submoduleInput = fetchers::Input::fromAttrs(settings, std::move(attrs));
+                auto [submoduleAccessor, submoduleInput2] = submoduleInput.getAccessor(settings, store);
                 submoduleAccessor->setPathDisplay("«" + submoduleInput.to_string() + "»");
                 mounts.insert_or_assign(submodule.path, submoduleAccessor);
             }
@@ -797,7 +797,7 @@ struct GitInputScheme : InputScheme
     }
 
     std::pair<ref<SourceAccessor>, Input>
-    getAccessorFromWorkdir(ref<Store> store, RepoInfo & repoInfo, Input && input) const
+    getAccessorFromWorkdir(const Settings & settings, ref<Store> store, RepoInfo & repoInfo, Input && input) const
     {
         auto repoPath = repoInfo.getPath().value();
 
@@ -829,8 +829,8 @@ struct GitInputScheme : InputScheme
                 // TODO: fall back to getAccessorFromCommit-like fetch when submodules aren't checked out
                 // attrs.insert_or_assign("allRefs", Explicit<bool>{ true });
 
-                auto submoduleInput = fetchers::Input::fromAttrs(*input.settings, std::move(attrs));
-                auto [submoduleAccessor, submoduleInput2] = submoduleInput.getAccessor(store);
+                auto submoduleInput = fetchers::Input::fromAttrs(settings, std::move(attrs));
+                auto [submoduleAccessor, submoduleInput2] = submoduleInput.getAccessor(settings, store);
                 submoduleAccessor->setPathDisplay("«" + submoduleInput.to_string() + "»");
 
                 /* If the submodule is dirty, mark this repo dirty as
@@ -857,12 +857,12 @@ struct GitInputScheme : InputScheme
             input.attrs.insert_or_assign("rev", rev.gitRev());
             if (!getShallowAttr(input)) {
                 input.attrs.insert_or_assign(
-                    "revCount", rev == nullRev ? 0 : getRevCount(*input.settings, repoInfo, repoPath, rev));
+                    "revCount", rev == nullRev ? 0 : getRevCount(settings, repoInfo, repoPath, rev));
             }
 
             verifyCommit(input, repo);
         } else {
-            repoInfo.warnDirty(*input.settings);
+            repoInfo.warnDirty(settings);
 
             if (repoInfo.workdirInfo.headRev) {
                 input.attrs.insert_or_assign("dirtyRev", repoInfo.workdirInfo.headRev->gitRev() + "-dirty");
@@ -874,14 +874,14 @@ struct GitInputScheme : InputScheme
 
         input.attrs.insert_or_assign(
             "lastModified",
-            repoInfo.workdirInfo.headRev
-                ? getLastModified(*input.settings, repoInfo, repoPath, *repoInfo.workdirInfo.headRev)
-                : 0);
+            repoInfo.workdirInfo.headRev ? getLastModified(settings, repoInfo, repoPath, *repoInfo.workdirInfo.headRev)
+                                         : 0);
 
         return {accessor, std::move(input)};
     }
 
-    std::pair<ref<SourceAccessor>, Input> getAccessor(ref<Store> store, const Input & _input) const override
+    std::pair<ref<SourceAccessor>, Input>
+    getAccessor(const Settings & settings, ref<Store> store, const Input & _input) const override
     {
         Input input(_input);
 
@@ -897,8 +897,8 @@ struct GitInputScheme : InputScheme
         }
 
         auto [accessor, final] = input.getRef() || input.getRev() || !repoInfo.getPath()
-                                     ? getAccessorFromCommit(store, repoInfo, std::move(input))
-                                     : getAccessorFromWorkdir(store, repoInfo, std::move(input));
+                                     ? getAccessorFromCommit(settings, store, repoInfo, std::move(input))
+                                     : getAccessorFromWorkdir(settings, store, repoInfo, std::move(input));
 
         return {accessor, std::move(final)};
     }
@@ -934,7 +934,7 @@ struct GitInputScheme : InputScheme
         }
     }
 
-    bool isLocked(const Input & input) const override
+    bool isLocked(const Settings & settings, const Input & input) const override
     {
         auto rev = input.getRev();
         return rev && rev != nullRev;

--- a/src/libfetchers/include/nix/fetchers/input-cache.hh
+++ b/src/libfetchers/include/nix/fetchers/input-cache.hh
@@ -3,6 +3,7 @@
 namespace nix::fetchers {
 
 enum class UseRegistries : int;
+struct Settings;
 
 struct InputCache
 {
@@ -14,7 +15,8 @@ struct InputCache
         Attrs extraAttrs;
     };
 
-    CachedResult getAccessor(ref<Store> store, const Input & originalInput, UseRegistries useRegistries);
+    CachedResult
+    getAccessor(const Settings & settings, ref<Store> store, const Input & originalInput, UseRegistries useRegistries);
 
     struct CachedInput
     {

--- a/src/libfetchers/include/nix/fetchers/registry.hh
+++ b/src/libfetchers/include/nix/fetchers/registry.hh
@@ -59,7 +59,7 @@ Path getUserRegistryPath();
 
 Registries getRegistries(const Settings & settings, ref<Store> store);
 
-void overrideRegistry(const Input & from, const Input & to, const Attrs & extraAttrs);
+void overrideRegistry(const Settings & settings, const Input & from, const Input & to, const Attrs & extraAttrs);
 
 enum class UseRegistries : int {
     No,
@@ -71,6 +71,7 @@ enum class UseRegistries : int {
  * Rewrite a flakeref using the registries. If `filter` is set, only
  * use the registries for which the filter function returns true.
  */
-std::pair<Input, Attrs> lookupInRegistries(ref<Store> store, const Input & input, UseRegistries useRegistries);
+std::pair<Input, Attrs>
+lookupInRegistries(const Settings & settings, ref<Store> store, const Input & input, UseRegistries useRegistries);
 
 } // namespace nix::fetchers

--- a/src/libfetchers/indirect.cc
+++ b/src/libfetchers/indirect.cc
@@ -44,7 +44,7 @@ struct IndirectInputScheme : InputScheme
 
         // FIXME: forbid query params?
 
-        Input input{settings};
+        Input input{};
         input.attrs.insert_or_assign("type", "indirect");
         input.attrs.insert_or_assign("id", id);
         if (rev)
@@ -76,7 +76,7 @@ struct IndirectInputScheme : InputScheme
         if (!std::regex_match(id, flakeRegex))
             throw BadURL("'%s' is not a valid flake ID", id);
 
-        Input input{settings};
+        Input input{};
         input.attrs = attrs;
         return input;
     }
@@ -106,7 +106,8 @@ struct IndirectInputScheme : InputScheme
         return input;
     }
 
-    std::pair<ref<SourceAccessor>, Input> getAccessor(ref<Store> store, const Input & input) const override
+    std::pair<ref<SourceAccessor>, Input>
+    getAccessor(const Settings & settings, ref<Store> store, const Input & input) const override
     {
         throw Error("indirect input '%s' cannot be fetched directly", input.to_string());
     }

--- a/src/libfetchers/input-cache.cc
+++ b/src/libfetchers/input-cache.cc
@@ -5,23 +5,23 @@
 
 namespace nix::fetchers {
 
-InputCache::CachedResult
-InputCache::getAccessor(ref<Store> store, const Input & originalInput, UseRegistries useRegistries)
+InputCache::CachedResult InputCache::getAccessor(
+    const Settings & settings, ref<Store> store, const Input & originalInput, UseRegistries useRegistries)
 {
     auto fetched = lookup(originalInput);
     Input resolvedInput = originalInput;
 
     if (!fetched) {
         if (originalInput.isDirect()) {
-            auto [accessor, lockedInput] = originalInput.getAccessor(store);
+            auto [accessor, lockedInput] = originalInput.getAccessor(settings, store);
             fetched.emplace(CachedInput{.lockedInput = lockedInput, .accessor = accessor});
         } else {
             if (useRegistries != UseRegistries::No) {
-                auto [res, extraAttrs] = lookupInRegistries(store, originalInput, useRegistries);
+                auto [res, extraAttrs] = lookupInRegistries(settings, store, originalInput, useRegistries);
                 resolvedInput = std::move(res);
                 fetched = lookup(resolvedInput);
                 if (!fetched) {
-                    auto [accessor, lockedInput] = resolvedInput.getAccessor(store);
+                    auto [accessor, lockedInput] = resolvedInput.getAccessor(settings, store);
                     fetched.emplace(
                         CachedInput{.lockedInput = lockedInput, .accessor = accessor, .extraAttrs = extraAttrs});
                 }

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -17,7 +17,7 @@ struct PathInputScheme : InputScheme
         if (url.authority && url.authority->host.size())
             throw Error("path URL '%s' should not have an authority ('%s')", url, *url.authority);
 
-        Input input{settings};
+        Input input{};
         input.attrs.insert_or_assign("type", "path");
         input.attrs.insert_or_assign("path", renderUrlPathEnsureLegal(url.path));
 
@@ -60,7 +60,7 @@ struct PathInputScheme : InputScheme
     {
         getStrAttr(attrs, "path");
 
-        Input input{settings};
+        Input input{};
         input.attrs = attrs;
         return input;
     }
@@ -101,7 +101,7 @@ struct PathInputScheme : InputScheme
             return path;
     }
 
-    bool isLocked(const Input & input) const override
+    bool isLocked(const Settings & settings, const Input & input) const override
     {
         return (bool) input.getNarHash();
     }
@@ -116,7 +116,8 @@ struct PathInputScheme : InputScheme
         throw Error("cannot fetch input '%s' because it uses a relative path", input.to_string());
     }
 
-    std::pair<ref<SourceAccessor>, Input> getAccessor(ref<Store> store, const Input & _input) const override
+    std::pair<ref<SourceAccessor>, Input>
+    getAccessor(const Settings & settings, ref<Store> store, const Input & _input) const override
     {
         Input input(_input);
         auto path = getStrAttr(input.attrs, "path");
@@ -145,7 +146,7 @@ struct PathInputScheme : InputScheme
         auto info = store->queryPathInfo(*storePath);
         accessor->fingerprint =
             fmt("path:%s", store->queryPathInfo(*storePath)->narHash.to_string(HashFormat::SRI, true));
-        input.settings->getCache()->upsert(
+        settings.getCache()->upsert(
             makeFetchToStoreCacheKey(
                 input.getName(), *accessor->fingerprint, ContentAddressMethod::Raw::NixArchive, "/"),
             *store,

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -131,9 +131,9 @@ std::shared_ptr<Registry> getFlagRegistry(const Settings & settings)
     return flagRegistry;
 }
 
-void overrideRegistry(const Input & from, const Input & to, const Attrs & extraAttrs)
+void overrideRegistry(const Settings & settings, const Input & from, const Input & to, const Attrs & extraAttrs)
 {
-    getFlagRegistry(*from.settings)->add(from, to, extraAttrs);
+    getFlagRegistry(settings)->add(from, to, extraAttrs);
 }
 
 static std::shared_ptr<Registry> getGlobalRegistry(const Settings & settings, ref<Store> store)
@@ -172,7 +172,8 @@ Registries getRegistries(const Settings & settings, ref<Store> store)
     return registries;
 }
 
-std::pair<Input, Attrs> lookupInRegistries(ref<Store> store, const Input & _input, UseRegistries useRegistries)
+std::pair<Input, Attrs>
+lookupInRegistries(const Settings & settings, ref<Store> store, const Input & _input, UseRegistries useRegistries)
 {
     Attrs extraAttrs;
     int n = 0;
@@ -187,7 +188,7 @@ restart:
     if (n > 100)
         throw Error("cycle detected in flake registry for '%s'", input.to_string());
 
-    for (auto & registry : getRegistries(*input.settings, store)) {
+    for (auto & registry : getRegistries(settings, store)) {
         if (useRegistries == UseRegistries::Limited
             && !(registry->type == fetchers::Registry::Flag || registry->type == fetchers::Registry::Global))
             continue;

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -224,7 +224,7 @@ ref<SourceAccessor> downloadTarball(ref<Store> store, const Settings & settings,
 
     auto input = Input::fromAttrs(settings, std::move(attrs));
 
-    return input.getAccessor(store).first;
+    return input.getAccessor(settings, store).first;
 }
 
 // An input scheme corresponding to a curl-downloadable resource.
@@ -252,7 +252,7 @@ struct CurlInputScheme : InputScheme
         if (!isValidURL(_url, requireTree))
             return std::nullopt;
 
-        Input input{settings};
+        Input input{};
 
         auto url = _url;
 
@@ -302,7 +302,7 @@ struct CurlInputScheme : InputScheme
 
     std::optional<Input> inputFromAttrs(const Settings & settings, const Attrs & attrs) const override
     {
-        Input input{settings};
+        Input input{};
         input.attrs = attrs;
 
         // input.locked = (bool) maybeGetStrAttr(input.attrs, "hash");
@@ -319,7 +319,7 @@ struct CurlInputScheme : InputScheme
         return url;
     }
 
-    bool isLocked(const Input & input) const override
+    bool isLocked(const Settings & settings, const Input & input) const override
     {
         return (bool) input.getNarHash();
     }
@@ -340,7 +340,8 @@ struct FileInputScheme : CurlInputScheme
                                                : (!requireTree && !hasTarballExtension(url)));
     }
 
-    std::pair<ref<SourceAccessor>, Input> getAccessor(ref<Store> store, const Input & _input) const override
+    std::pair<ref<SourceAccessor>, Input>
+    getAccessor(const Settings & settings, ref<Store> store, const Input & _input) const override
     {
         auto input(_input);
 
@@ -348,7 +349,7 @@ struct FileInputScheme : CurlInputScheme
            the Nix store directly, since there is little deduplication
            benefit in using the Git cache for single big files like
            tarballs. */
-        auto file = downloadFile(store, *input.settings, getStrAttr(input.attrs, "url"), input.getName());
+        auto file = downloadFile(store, settings, getStrAttr(input.attrs, "url"), input.getName());
 
         auto narHash = store->queryPathInfo(file.storePath)->narHash;
         input.attrs.insert_or_assign("narHash", narHash.to_string(HashFormat::SRI, true));
@@ -377,15 +378,15 @@ struct TarballInputScheme : CurlInputScheme
                                                : (requireTree || hasTarballExtension(url)));
     }
 
-    std::pair<ref<SourceAccessor>, Input> getAccessor(ref<Store> store, const Input & _input) const override
+    std::pair<ref<SourceAccessor>, Input>
+    getAccessor(const Settings & settings, ref<Store> store, const Input & _input) const override
     {
         auto input(_input);
 
-        auto result =
-            downloadTarball_(*input.settings, getStrAttr(input.attrs, "url"), {}, "«" + input.to_string() + "»");
+        auto result = downloadTarball_(settings, getStrAttr(input.attrs, "url"), {}, "«" + input.to_string() + "»");
 
         if (result.immutableUrl) {
-            auto immutableInput = Input::fromURL(*input.settings, *result.immutableUrl);
+            auto immutableInput = Input::fromURL(settings, *result.immutableUrl);
             // FIXME: would be nice to support arbitrary flakerefs
             // here, e.g. git flakes.
             if (immutableInput.getType() != "tarball")
@@ -398,9 +399,7 @@ struct TarballInputScheme : CurlInputScheme
 
         input.attrs.insert_or_assign(
             "narHash",
-            input.settings->getTarballCache()
-                ->treeHashToNarHash(*input.settings, result.treeHash)
-                .to_string(HashFormat::SRI, true));
+            settings.getTarballCache()->treeHashToNarHash(settings, result.treeHash).to_string(HashFormat::SRI, true));
 
         return {result.accessor, input};
     }

--- a/src/libflake/flake-primops.cc
+++ b/src/libflake/flake-primops.cc
@@ -38,7 +38,7 @@ PrimOp getFlake(const Settings & settings)
         std::string flakeRefS(
             state.forceStringNoCtx(*args[0], pos, "while evaluating the argument passed to builtins.getFlake"));
         auto flakeRef = nix::parseFlakeRef(state.fetchSettings, flakeRefS, {}, true);
-        if (state.settings.pureEval && !flakeRef.input.isLocked())
+        if (state.settings.pureEval && !flakeRef.input.isLocked(state.fetchSettings))
             throw Error(
                 "cannot call 'getFlake' on unlocked flake reference '%s', at %s (use --impure to override)",
                 flakeRefS,

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -372,7 +372,8 @@ static Flake getFlake(
     const InputAttrPath & lockRootAttrPath)
 {
     // Fetch a lazy tree first.
-    auto cachedInput = state.inputCache->getAccessor(state.store, originalRef.input, useRegistries);
+    auto cachedInput =
+        state.inputCache->getAccessor(state.fetchSettings, state.store, originalRef.input, useRegistries);
 
     auto subdir = fetchers::maybeGetStrAttr(cachedInput.extraAttrs, "dir").value_or(originalRef.subdir);
     auto resolvedRef = FlakeRef(std::move(cachedInput.resolvedInput), subdir);
@@ -388,7 +389,8 @@ static Flake getFlake(
         debug("refetching input '%s' due to self attribute", newLockedRef);
         // FIXME: need to remove attrs that are invalidated by the changed input attrs, such as 'narHash'.
         newLockedRef.input.attrs.erase("narHash");
-        auto cachedInput2 = state.inputCache->getAccessor(state.store, newLockedRef.input, fetchers::UseRegistries::No);
+        auto cachedInput2 = state.inputCache->getAccessor(
+            state.fetchSettings, state.store, newLockedRef.input, fetchers::UseRegistries::No);
         cachedInput.accessor = cachedInput2.accessor;
         lockedRef = FlakeRef(std::move(cachedInput2.lockedInput), newLockedRef.subdir);
     }
@@ -704,7 +706,8 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
                            this input. */
                         debug("creating new input '%s'", inputAttrPathS);
 
-                        if (!lockFlags.allowUnlocked && !input.ref->input.isLocked() && !input.ref->input.isRelative())
+                        if (!lockFlags.allowUnlocked && !input.ref->input.isLocked(state.fetchSettings)
+                            && !input.ref->input.isRelative())
                             throw Error("cannot update unlocked flake input '%s' in pure mode", inputAttrPathS);
 
                         /* Note: in case of an --override-input, we use
@@ -753,7 +756,7 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
                                     return {*resolvedPath, *input.ref};
                                 } else {
                                     auto cachedInput = state.inputCache->getAccessor(
-                                        state.store, input.ref->input, useRegistriesInputs);
+                                        state.fetchSettings, state.store, input.ref->input, useRegistriesInputs);
 
                                     auto lockedRef = FlakeRef(std::move(cachedInput.lockedInput), input.ref->subdir);
 

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -64,9 +64,10 @@ std::ostream & operator<<(std::ostream & str, const FlakeRef & flakeRef)
     return str;
 }
 
-FlakeRef FlakeRef::resolve(ref<Store> store, fetchers::UseRegistries useRegistries) const
+FlakeRef FlakeRef::resolve(
+    const fetchers::Settings & fetchSettings, ref<Store> store, fetchers::UseRegistries useRegistries) const
 {
-    auto [input2, extraAttrs] = lookupInRegistries(store, input, useRegistries);
+    auto [input2, extraAttrs] = lookupInRegistries(fetchSettings, store, input, useRegistries);
     return FlakeRef(std::move(input2), fetchers::maybeGetStrAttr(extraAttrs, "dir").value_or(subdir));
 }
 
@@ -287,9 +288,10 @@ FlakeRef FlakeRef::fromAttrs(const fetchers::Settings & fetchSettings, const fet
         fetchers::maybeGetStrAttr(attrs, "dir").value_or(""));
 }
 
-std::pair<ref<SourceAccessor>, FlakeRef> FlakeRef::lazyFetch(ref<Store> store) const
+std::pair<ref<SourceAccessor>, FlakeRef>
+FlakeRef::lazyFetch(const fetchers::Settings & fetchSettings, ref<Store> store) const
 {
-    auto [accessor, lockedInput] = input.getAccessor(store);
+    auto [accessor, lockedInput] = input.getAccessor(fetchSettings, store);
     return {accessor, FlakeRef(std::move(lockedInput), subdir)};
 }
 

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -71,11 +71,15 @@ struct FlakeRef
 
     fetchers::Attrs toAttrs() const;
 
-    FlakeRef resolve(ref<Store> store, fetchers::UseRegistries useRegistries = fetchers::UseRegistries::All) const;
+    FlakeRef resolve(
+        const fetchers::Settings & fetchSettings,
+        ref<Store> store,
+        fetchers::UseRegistries useRegistries = fetchers::UseRegistries::All) const;
 
     static FlakeRef fromAttrs(const fetchers::Settings & fetchSettings, const fetchers::Attrs & attrs);
 
-    std::pair<ref<SourceAccessor>, FlakeRef> lazyFetch(ref<Store> store) const;
+    std::pair<ref<SourceAccessor>, FlakeRef>
+    lazyFetch(const fetchers::Settings & fetchSettings, ref<Store> store) const;
 
     /**
      * Canonicalize a flakeref for the purpose of comparing "old" and

--- a/src/libflake/lockfile.cc
+++ b/src/libflake/lockfile.cc
@@ -74,7 +74,7 @@ LockedNode::LockedNode(const fetchers::Settings & fetchSettings, const nlohmann:
     , parentInputAttrPath(
           json.find("parent") != json.end() ? (std::optional<InputAttrPath>) json["parent"] : std::nullopt)
 {
-    if (!lockedRef.input.isLocked() && !lockedRef.input.isRelative()) {
+    if (!lockedRef.input.isLocked(fetchSettings) && !lockedRef.input.isRelative()) {
         if (lockedRef.input.getNarHash())
             warn(
                 "Lock file entry '%s' is unlocked (e.g. lacks a Git revision) but is checked by NAR hash. "
@@ -282,7 +282,7 @@ std::optional<FlakeRef> LockFile::isUnlocked(const fetchers::Settings & fetchSet
        latter case, we can verify the input but we may not be able to
        fetch it from anywhere. */
     auto isConsideredLocked = [&](const fetchers::Input & input) {
-        return input.isLocked() || (fetchSettings.allowDirtyLocks && input.getNarHash());
+        return input.isLocked(fetchSettings) || (fetchSettings.allowDirtyLocks && input.getNarHash());
     };
 
     for (auto & i : nodes) {

--- a/src/nix/flake-prefetch-inputs.cc
+++ b/src/nix/flake-prefetch-inputs.cc
@@ -45,7 +45,7 @@ struct CmdFlakePrefetchInputs : FlakeCommand
             if (auto lockedNode = dynamic_cast<const LockedNode *>(&node)) {
                 try {
                     Activity act(*logger, lvlInfo, actUnknown, fmt("fetching '%s'", lockedNode->lockedRef));
-                    auto accessor = lockedNode->lockedRef.input.getAccessor(store).first;
+                    auto accessor = lockedNode->lockedRef.input.getAccessor(fetchSettings, store).first;
                     fetchToStore(
                         fetchSettings, *store, accessor, FetchMode::Copy, lockedNode->lockedRef.input.getName());
                 } catch (Error & e) {

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -711,7 +711,7 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixDefaultProfile, MixProf
                     element.identifier());
                 continue;
             }
-            if (element.source->originalRef.input.isLocked()) {
+            if (element.source->originalRef.input.isLocked(getEvalState()->fetchSettings)) {
                 warn(
                     "Found package '%s', but it was added from a locked flake reference so it can't be upgraded!",
                     element.identifier());
@@ -740,7 +740,8 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixDefaultProfile, MixProf
             assert(infop);
             auto & info = *infop;
 
-            if (info.flake.lockedRef.input.isLocked() && element.source->lockedRef == info.flake.lockedRef)
+            if (info.flake.lockedRef.input.isLocked(getEvalState()->fetchSettings)
+                && element.source->lockedRef == info.flake.lockedRef)
                 continue;
 
             printInfo(

--- a/src/nix/registry.cc
+++ b/src/nix/registry.cc
@@ -190,8 +190,9 @@ struct CmdRegistryPin : RegistryCommand, EvalCommand
         auto ref = parseFlakeRef(fetchSettings, url);
         auto lockedRef = parseFlakeRef(fetchSettings, locked);
         registry->remove(ref.input);
-        auto resolved = lockedRef.resolve(store).input.getAccessor(store).second;
-        if (!resolved.isLocked())
+        auto resolvedInput = lockedRef.resolve(fetchSettings, store).input;
+        auto resolved = resolvedInput.getAccessor(fetchSettings, store).second;
+        if (!resolved.isLocked(fetchSettings))
             warn("flake '%s' is not locked", resolved.to_string());
         fetchers::Attrs extraAttrs;
         if (ref.subdir != "")


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I saw that this is not a large change as part of some experimental work, so I figured y'all could land this cleanup separately.
Surprisingly easy.

<!-- Briefly explain what the change is about and why it is desirable. -->
This is more straightforward and not subject to undocumented memory safety restrictions.
Also easier to test.

This would have saved me an hour or more on the rust bindings...

EDIT: now complete. It accurately represents that `isLocked()` depends on settings :tada: 

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
