### PR TITLE
Remove static data from headers

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -2,6 +2,7 @@
 #include <nlohmann/json.hpp>
 
 #include "nix/cmd/command.hh"
+#include "nix/cmd/legacy.hh"
 #include "nix/cmd/markdown.hh"
 #include "nix/store/store-open.hh"
 #include "nix/store/local-fs-store.hh"
@@ -13,6 +14,18 @@
 #include "nix/util/environment-variables.hh"
 
 namespace nix {
+
+RegisterCommand::Commands & RegisterCommand::commands()
+{
+    static RegisterCommand::Commands commands;
+    return commands;
+}
+
+RegisterLegacyCommand::Commands & RegisterLegacyCommand::commands()
+{
+    static RegisterLegacyCommand::Commands commands;
+    return commands;
+}
 
 nix::Commands RegisterCommand::getCommandsFor(const std::vector<std::string> & prefix)
 {

--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -286,11 +286,7 @@ struct RegisterCommand
 {
     typedef std::map<std::vector<std::string>, std::function<ref<Command>()>> Commands;
 
-    static Commands & commands()
-    {
-        static Commands commands;
-        return commands;
-    }
+    static Commands & commands();
 
     RegisterCommand(std::vector<std::string> && name, std::function<ref<Command>()> command)
     {

--- a/src/libcmd/include/nix/cmd/legacy.hh
+++ b/src/libcmd/include/nix/cmd/legacy.hh
@@ -13,11 +13,7 @@ struct RegisterLegacyCommand
 {
     typedef std::map<std::string, MainFunction> Commands;
 
-    static Commands & commands()
-    {
-        static Commands commands;
-        return commands;
-    }
+    static Commands & commands();
 
     RegisterLegacyCommand(const std::string & name, MainFunction fun)
     {

--- a/src/libexpr/include/nix/expr/primops.hh
+++ b/src/libexpr/include/nix/expr/primops.hh
@@ -12,11 +12,7 @@ struct RegisterPrimOp
 {
     typedef std::vector<PrimOp> PrimOps;
 
-    static PrimOps & primOps()
-    {
-        static PrimOps primOps;
-        return primOps;
-    }
+    static PrimOps & primOps();
 
     /**
      * You can register a constant by passing an arity of 0. fun

--- a/src/libexpr/include/nix/expr/print-options.hh
+++ b/src/libexpr/include/nix/expr/print-options.hh
@@ -110,7 +110,7 @@ struct PrintOptions
  * `PrintOptions` for unknown and therefore potentially large values in error messages,
  * to avoid printing "too much" output.
  */
-static PrintOptions errorPrintOptions = PrintOptions{
+static constexpr PrintOptions errorPrintOptions = PrintOptions{
     .ansiColors = true,
     .maxDepth = 10,
     .maxAttrs = 10,

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -40,6 +40,12 @@
 
 namespace nix {
 
+RegisterPrimOp::PrimOps & RegisterPrimOp::primOps()
+{
+    static RegisterPrimOp::PrimOps primOps;
+    return primOps;
+}
+
 /*************************************************************
  * Miscellaneous
  *************************************************************/

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -10,6 +10,12 @@
 
 namespace nix {
 
+RegisterBuiltinBuilder::BuiltinBuilders & RegisterBuiltinBuilder::builtinBuilders()
+{
+    static RegisterBuiltinBuilder::BuiltinBuilders builders;
+    return builders;
+}
+
 namespace {
 
 struct State

--- a/src/libstore/include/nix/store/builtins.hh
+++ b/src/libstore/include/nix/store/builtins.hh
@@ -33,11 +33,7 @@ struct RegisterBuiltinBuilder
 {
     typedef std::map<std::string, BuiltinBuilder> BuiltinBuilders;
 
-    static BuiltinBuilders & builtinBuilders()
-    {
-        static BuiltinBuilders builders;
-        return builders;
-    }
+    static BuiltinBuilders & builtinBuilders();
 
     RegisterBuiltinBuilder(const std::string & name, BuiltinBuilder && fun)
     {

--- a/src/libutil/config-global.cc
+++ b/src/libutil/config-global.cc
@@ -4,6 +4,12 @@
 
 namespace nix {
 
+GlobalConfig::ConfigRegistrations & GlobalConfig::configRegistrations()
+{
+    static GlobalConfig::ConfigRegistrations configRegistrations;
+    return configRegistrations;
+}
+
 bool GlobalConfig::set(const std::string & name, const std::string & value)
 {
     for (auto & config : configRegistrations())

--- a/src/libutil/include/nix/util/config-global.hh
+++ b/src/libutil/include/nix/util/config-global.hh
@@ -9,11 +9,7 @@ struct GlobalConfig : public AbstractConfig
 {
     typedef std::vector<Config *> ConfigRegistrations;
 
-    static ConfigRegistrations & configRegistrations()
-    {
-        static ConfigRegistrations configRegistrations;
-        return configRegistrations;
-    }
+    static ConfigRegistrations & configRegistrations();
 
     bool set(const std::string & name, const std::string & value) override;
 


### PR DESCRIPTION
We don't want to duplicate any of these across libraries, which is what happens when the platform doesn't support unique symbols.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Nix on cygwin is broken because the RegisterCommand list is duplicated between nix and libcmd.  All subcommands appear to be missing.  This works on glibc because the linker uses unique symbols per-process.  LTO (which is disabled on cygwin) also has some impact.

## Context

See discussion on #13139

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
