### PR TITLE
POC add prim_trampoline

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -5057,6 +5057,56 @@ static RegisterPrimOp primop_splitVersion({
     .fun = prim_splitVersion,
 });
 
+
+static void prim_trampoline(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+{
+    state.forceFunction(*args[0], pos, "while evaluating the first argument passed to builtins.trampoline");
+
+    Value * vElem = state.allocValue();
+    *vElem = *args[1];
+
+    while (true) {
+        // Force to get the actual value, not a thunk
+        state.forceValue(*vElem, pos);
+
+        Value * res = state.allocValue();
+        res->mkApp(args[0], vElem);
+
+        state.forceList(*res, pos, "while evaluating the return value of pred");
+
+        auto len = res->listSize();
+        if (len != 2) {
+            throw Error("Wrong size :(");
+        }
+
+        auto recurse = res->listView()[0];
+        if (!state.forceBool(*recurse, pos, "while evaluating recurse")) {
+            // Assign the current result
+            v = *res->listView()[1];
+            state.forceValue(v, pos);
+            return;
+        }
+
+        vElem = res->listView()[1];
+    }
+}
+
+static RegisterPrimOp primop_trampoline({
+    .name = "trampoline",
+    .args = {"function", "value"},
+    .doc = R"(
+      Remove the attributes listed in *list* from *set*. The attributes
+      don’t have to exist in *set*. For instance,
+
+      ```nix
+      removeAttrs { x = 1; y = 2; z = 3; } [ "a" "x" "z" ]
+      ```
+
+      evaluates to `{ y = 2; }`.
+    )",
+    .fun = prim_trampoline,
+});
+
 /*************************************************************
  * Primop registration
  *************************************************************/


### PR DESCRIPTION
As first described here https://github.com/NixOS/nix/issues/8430

@adisbladis and me run a test where we reimplemented `lib.findFirstIndex` in terms of the new builtin.

```nix
  findFirstIndex =
    pred: default: list:
    let
      len = (length list);
      n = builtins.trampoline (
        idx:
        let
          found = pred (builtins.elemAt list idx);
        in
        [
          (if idx >= len then false else !found)
          (if idx >= len then -1 else if !found then idx + 1 else idx)
        ]
      ) 0;
    in
    if n == -1 then default else n;

```

## Motivation

The idea was that `findFirstIndex` is exhaustive, running more iterations than necessary.
Using a `trampoline` it would be turned into `O(n)` worst case, from `O(n)` generally.

## Observation

Running `nix-instantiate pkgs.jq` saved ~`100` thunks

Takeway this might NOT be worth it - for the sake of exhaustive iterations in nixpkgs.
Maybe somebody has better use-case for it? I.e. the mentioned tail-recursing, or on bigger lists?

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
