### PR TITLE
WIP libstore: control parallel builds with gnu make jobserver protocol

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -50,6 +50,9 @@ Settings settings;
 
 static GlobalConfig::Register rSettings(&settings);
 
+// Global jobserver FIFO path (set by daemon, used by derivation-builder)
+std::string jobserverFifoPath;
+
 Settings::Settings()
     : nixPrefix(NIX_PREFIX)
     , nixStore(

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -207,6 +207,24 @@ public:
         )",
         {"build-cores"}};
 
+    Setting<bool> useJobserver{
+        this,
+        false,
+        "use-jobserver",
+        R"(
+          Enable the GNU Make jobserver protocol for coordinated parallelism across builds. This uses a token-based system to limit total parallelism.
+
+          When enabled, Nix creates a FIFO with a limited number of tokens. Build tools that support the jobserver protocol can coordinate parallelism through this shared resource.
+        )"};
+
+    Setting<unsigned int> jobserverTokens{
+        this,
+        0,
+        "jobserver-tokens",
+        R"(
+          Number of jobserver tokens to create. If set to 0 (default), uses the value of 'cores' or the number of available CPU cores.
+        )"};
+
     /**
      * Read-only mode.  Don't copy stuff to the store, don't change
      * the database.
@@ -1446,6 +1464,9 @@ public:
 
 // FIXME: don't use a global variable.
 extern Settings settings;
+
+// Global jobserver FIFO path (set by daemon, used by derivation-builder)
+extern std::string jobserverFifoPath;
 
 /**
  * Load the configuration (from `nix.conf`, `NIX_CONFIG`, etc.) into the

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -29,6 +29,8 @@
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
+#include <errno.h>
 
 #include "store-config-private.hh"
 
@@ -853,6 +855,15 @@ PathsInChroot DerivationBuilderImpl::getPathsInSandbox()
     }
     pathsInChroot[tmpDirInSandbox()] = {.source = tmpDir};
 
+    /* Add the jobserver FIFO to sandbox paths if jobserver is enabled */
+    if (settings.useJobserver && !jobserverFifoPath.empty()) {
+        struct stat st;
+        if (stat(jobserverFifoPath.c_str(), &st) == 0 && S_ISFIFO(st.st_mode)) {
+            pathsInChroot[jobserverFifoPath] = {.source = jobserverFifoPath};
+            printMsg(lvlDebug, "adding jobserver FIFO %s to sandbox paths", jobserverFifoPath);
+        }
+    }
+
     PathSet allowedPaths = settings.allowedImpureHostPrefixes;
 
     /* This works like the above, except on a per-derivation level */
@@ -1041,6 +1052,21 @@ void DerivationBuilderImpl::initEnv()
 
     /* The maximum number of cores to utilize for parallel building. */
     env["NIX_BUILD_CORES"] = fmt("%d", settings.buildCores ? settings.buildCores : settings.getDefaultCores());
+
+    /* GNU Make Jobserver Protocol Support
+     * Set MAKEFLAGS to enable jobserver for build processes. */
+    if (settings.useJobserver && !jobserverFifoPath.empty()) {
+        struct stat st;
+        if (stat(jobserverFifoPath.c_str(), &st) == 0 && S_ISFIFO(st.st_mode)) {
+            // Append to existing MAKEFLAGS (preserve any existing flags)
+            auto it = env.find("MAKEFLAGS");
+            std::string makeflags = (it != env.end() && !it->second.empty()) ? it->second + " " : "";
+            makeflags += fmt("--jobserver-auth=fifo:%s -j", jobserverFifoPath);
+            env["MAKEFLAGS"] = makeflags;
+
+            printMsg(lvlDebug, "jobserver: set MAKEFLAGS for build %s", store.printStorePath(drvPath));
+        }
+    }
 
     /* Write the final environment. Note that this is intentionally
        *not* `drv.env`, because we've desugared things like like


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
Another stab at the known issue involving parallel building on powerful machines with many cores.

This is a WIP draft implementation of the [GNU make jobserver protocol](https://www.gnu.org/software/make/manual/html_node/Job-Slots.html) I saw originally mentioned as a possible solution in #11143, although the load-limit setting from that pr may be a more generalized solution for this.

Another idea for this problem could involve some mechanism for resource allocation to the builder sandboxes themselves from the perspective of the system, starting minimal and ballooning resources as needed, and sleeping when they are not available. Ideally we can have some way to set a global hard cap on resource consumption.

 Hacking on this at https://github.com/Thaigersprint/thaigersprint-2025/issues/2

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context
Creates nix-daemon options `use-jobserver` and `jobserver-tokens`.

Places an impure FIFO populated with `jobserver-tokens` tokens when the nix-daemon is started if the `use-jobserver` option is enabled. Cleans up at termination.

The jobserver FIFO is added to sandbox paths for use by derivation builders with make.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
