### PR TITLE
docs: avoid secrets in the nix store

### DIFF
--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -29,6 +29,7 @@
   - [Build Trace](store/build-trace.md)
   - [Derivation Resolution](store/resolution.md)
   - [Building](store/building.md)
+  - [Secrets](store/secrets.md)
   - [Store Types](store/types/index.md)
 {{#include ./store/types/SUMMARY.md}}
   - [Appendix: Math notation](store/math-notation.md)

--- a/doc/manual/source/store/secrets.md
+++ b/doc/manual/source/store/secrets.md
@@ -1,0 +1,20 @@
+# Secrets
+
+The store is readable to all users on the system. For this reason, it
+is generally discouraged to allow secrets to make it into the store.
+
+Even on a single-user system, separate system users isolate services
+from each other and having secrets that all local users can read
+weakens that isolation. When using external store caches the secrets
+may end up there, and on multi-user systems the secrets will be
+available to all those users.
+
+Organize your derivations so that secrets are read from the filesystem
+(with appropriate access controls) at run time. Place the secrets on
+the filesystem manually or use a scheme that includes the secret in
+the store in encrypted form, and decrypts it adding the relevant
+access control on system activation.
+Several such schemes for NixOS can in the
+[comparison of secret managing schemes] on the wiki.
+
+[comparison of secret managing schemes]: https://wiki.nixos.org/wiki/Comparison_of_secret_managing_schemes


### PR DESCRIPTION
I think this is noncontroversial / common knowledge, but I didn't see it described anywhere authoratively yet.

## Motivation

It's helpful that it is clear that this is the 'official recommendation', explain why, and give (hopefully) actionable advice on how to achieve it.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
