### PR TITLE
BuildResult: Add a "Cancelled" status

### DIFF
--- a/src/libstore/build-result.cc
+++ b/src/libstore/build-result.cc
@@ -40,7 +40,7 @@ static BuildResult::Success::Status successStatusFromString(std::string_view str
     throw Error("unknown built result success status '%s'", str);
 }
 
-static constexpr std::array<std::pair<BuildResult::Failure::Status, std::string_view>, 12> failureStatusStrings{{
+static constexpr std::array<std::pair<BuildResult::Failure::Status, std::string_view>, 13> failureStatusStrings{{
 #define ENUM_ENTRY(e) {BuildResult::Failure::e, #e}
     ENUM_ENTRY(PermanentFailure),
     ENUM_ENTRY(InputRejected),
@@ -54,6 +54,7 @@ static constexpr std::array<std::pair<BuildResult::Failure::Status, std::string_
     ENUM_ENTRY(NotDeterministic),
     ENUM_ENTRY(NoSubstituters),
     ENUM_ENTRY(HashMismatch),
+    ENUM_ENTRY(Cancelled),
 #undef ENUM_ENTRY
 }};
 

--- a/src/libstore/include/nix/store/build-result.hh
+++ b/src/libstore/include/nix/store/build-result.hh
@@ -74,6 +74,7 @@ struct BuildResult
             /// know about this one, so change it back to `OutputRejected`
             /// before serialization.
             HashMismatch = 15,
+            Cancelled = 16,
         } status = MiscFailure;
 
         /**

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -109,7 +109,7 @@ public:
     /**
      * Build result.
      */
-    BuildResult buildResult;
+    BuildResult buildResult = {.inner = BuildResult::Failure{.status = BuildResult::Failure::Cancelled}};
 
     /**
      * Suspend our goal and wait until we get `work`-ed again.


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This denotes the result of a build that didn't succeed or fail, but was cancelled because some other goal failed and `--keep-going` was not enabled.

Cherry-picked from https://github.com/DeterminateSystems/nix-src/pull/217, where I'm trying to make `nix flake check` output more informative by showing which flake outputs failed, succeeded or were cancelled because of another failure, for example:

[![asciicast](https://asciinema.org/a/oU3k9wBcueikLjZ1Q5P3icgs2.svg)](https://asciinema.org/a/oU3k9wBcueikLjZ1Q5P3icgs2)

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
