### PR TITLE
Short-circuit computeFSClosure when copying

### DIFF
--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -251,7 +251,7 @@ nix_err nix_store_copy_closure(nix_c_context * context, Store * srcStore, Store 
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        nix::RealisedPath::Set paths;
+        nix::StorePathSet paths;
         paths.insert(path->path);
         nix::copyClosure(*srcStore->ptr, *dstStore->ptr, paths);
     }

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -175,7 +175,8 @@ public:
         StorePathSet & out,
         bool flipDirection = false,
         bool includeOutputs = false,
-        bool includeDerivers = false) override;
+        bool includeDerivers = false,
+        std::function<bool(const StorePath & path)> pathCallback = nullptr) override;
 
     StorePathSet queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute = NoSubstitute) override;
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -802,13 +802,19 @@ public:
      * `storePath` is returned; that is, the closures under the
      * `referrers` relation instead of the `references` relation is
      * returned.
+     *
+     * @param onPathDiscovered A callback invoked on each discovered store
+     * path. Returning `false` from the callback will stop recursion on
+     * that path. Returning `true` will continue recursion. A `nullptr` is
+     * equivalent to a callback which always returns  `true`.
      */
     virtual void computeFSClosure(
         const StorePathSet & paths,
         StorePathSet & out,
         bool flipDirection = false,
         bool includeOutputs = false,
-        bool includeDerivers = false);
+        bool includeDerivers = false,
+        std::function<bool(const StorePath & path)> onPathDiscovered = nullptr);
 
     void computeFSClosure(
         const StorePath & path,

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -252,10 +252,15 @@ void LegacySSHStore::buildPaths(
 }
 
 void LegacySSHStore::computeFSClosure(
-    const StorePathSet & paths, StorePathSet & out, bool flipDirection, bool includeOutputs, bool includeDerivers)
+    const StorePathSet & paths,
+    StorePathSet & out,
+    bool flipDirection,
+    bool includeOutputs,
+    bool includeDerivers,
+    std::function<bool(const StorePath & path)> onPathDiscovered)
 {
-    if (flipDirection || includeDerivers) {
-        Store::computeFSClosure(paths, out, flipDirection, includeOutputs, includeDerivers);
+    if (flipDirection || includeDerivers || onPathDiscovered) {
+        Store::computeFSClosure(paths, out, flipDirection, includeOutputs, includeDerivers, onPathDiscovered);
         return;
     }
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1072,9 +1072,16 @@ void copyClosure(
     if (&srcStore == &dstStore)
         return;
 
-    StorePathSet closure;
-    srcStore.computeFSClosure(storePaths, closure);
-    copyPaths(srcStore, dstStore, closure, repair, checkSigs, substitute);
+    StorePathSet pathsToCopy;
+
+    auto onPathDiscovered = [&](const StorePath & path) -> bool {
+        // Only recurse if the path does not already exist in `dstStore`
+        return repair || !dstStore.isValidPath(path);
+    };
+    srcStore.computeFSClosure(storePaths, pathsToCopy, false, false, false, onPathDiscovered);
+    pathsToCopy.insert(storePaths.begin(), storePaths.end());
+
+    copyPaths(srcStore, dstStore, pathsToCopy, repair, checkSigs, substitute);
 }
 
 std::optional<ValidPathInfo>


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Copying closures between devices currently requires resolving the full closure on the "source" store. This is usually fast because the path info is cached, but for devices which are infrequently updated (so the cache is expired) this can add a significant amount of unnecessary work.

This PR adds a callback to `computeFSClosure` that allows it to short-circuit, and then uses it from `copyClosure` to query only the set of missing paths. I tested this by deleting my narinfo cache & downloading a closure from HTTP cache with 1442 paths, where 1396 of those paths were already available locally.

**Before this PR it took 5m 14s**, where resolving all the `*.narinfo` files took ~4 minutes before any download started.

**After this PR it took 1m 12s**, with downloads starting essentially instantly.

## Context

I am working through the C API, but it would be great if this also applied to the `nix copy` CLI, but it's a pretty different code path that made this PR a lot more complicated.


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
