### PR TITLE
treewide: Add Store::requireStoreObjectAccessor, simplify uses of get…

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -332,8 +332,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
 
             debug("using substituted/cached input '%s' in '%s'", to_string(), store->printStorePath(storePath));
 
-            // We just ensured the store object was there
-            auto accessor = ref{store->getFSAccessor(storePath)};
+            auto accessor = store->requireStoreObjectAccessor(storePath);
 
             accessor->fingerprint = getFingerprint(store);
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -399,7 +399,8 @@ struct GitHubInputScheme : GitArchiveInputScheme
         Headers headers = makeHeadersWithAuthTokens(*input.settings, host, input);
 
         auto downloadResult = downloadFile(store, *input.settings, url, "source", headers);
-        auto json = nlohmann::json::parse(store->getFSAccessor(downloadResult.storePath)->readFile(CanonPath::root));
+        auto json = nlohmann::json::parse(
+            store->requireStoreObjectAccessor(downloadResult.storePath)->readFile(CanonPath::root));
 
         return RefInfo{
             .rev = Hash::parseAny(std::string{json["sha"]}, HashAlgorithm::SHA1),
@@ -473,7 +474,8 @@ struct GitLabInputScheme : GitArchiveInputScheme
         Headers headers = makeHeadersWithAuthTokens(*input.settings, host, input);
 
         auto downloadResult = downloadFile(store, *input.settings, url, "source", headers);
-        auto json = nlohmann::json::parse(store->getFSAccessor(downloadResult.storePath)->readFile(CanonPath::root));
+        auto json = nlohmann::json::parse(
+            store->requireStoreObjectAccessor(downloadResult.storePath)->readFile(CanonPath::root));
 
         if (json.is_array() && json.size() >= 1 && json[0]["id"] != nullptr) {
             return RefInfo{.rev = Hash::parseAny(std::string(json[0]["id"]), HashAlgorithm::SHA1)};

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -329,9 +329,7 @@ struct MercurialInputScheme : InputScheme
         Input input(_input);
 
         auto storePath = fetchToStore(store, input);
-
-        // We just added it, it should be there.
-        auto accessor = ref{store->getFSAccessor(storePath)};
+        auto accessor = store->requireStoreObjectAccessor(storePath);
 
         accessor->setPathDisplay("«" + input.to_string() + "»");
 

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -138,7 +138,7 @@ struct PathInputScheme : InputScheme
             storePath = store->addToStoreFromDump(*src, "source");
         }
 
-        auto accessor = ref{store->getFSAccessor(*storePath)};
+        auto accessor = store->requireStoreObjectAccessor(*storePath);
 
         // To prevent `fetchToStore()` copying the path again to Nix
         // store, pre-create an entry in the fetcher cache.

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -724,9 +724,27 @@ public:
      * the Nix store.
      *
      * @return nullptr if the store doesn't contain an object at the
-     * givine path.
+     * given path.
      */
     virtual std::shared_ptr<SourceAccessor> getFSAccessor(const StorePath & path, bool requireValidPath = true) = 0;
+
+    /**
+     * Get an accessor for the store object or throw an Error if it's invalid or
+     * doesn't exist.
+     *
+     * @throws InvalidPath if the store object doesn't exist or (if requireValidPath = true) is
+     * invalid.
+     */
+    [[nodiscard]] ref<SourceAccessor> requireStoreObjectAccessor(const StorePath & path, bool requireValidPath = true)
+    {
+        auto accessor = getFSAccessor(path, requireValidPath);
+        if (!accessor) {
+            throw InvalidPath(
+                requireValidPath ? "path '%1%' is not a valid store path" : "store path '%1%' does not exist",
+                printStorePath(path));
+        }
+        return ref<SourceAccessor>{accessor};
+    }
 
     /**
      * Repair the contents of the given path by redownloading it using

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1130,7 +1130,7 @@ Derivation Store::derivationFromPath(const StorePath & drvPath)
 
 static Derivation readDerivationCommon(Store & store, const StorePath & drvPath, bool requireValidPath)
 {
-    auto accessor = store.getFSAccessor(drvPath, requireValidPath);
+    auto accessor = store.requireStoreObjectAccessor(drvPath, requireValidPath);
     try {
         return parseDerivation(store, accessor->readFile(CanonPath::root), Derivation::nameFromPath(drvPath));
     } catch (FormatError & e) {

--- a/src/nix/cat.cc
+++ b/src/nix/cat.cc
@@ -41,10 +41,7 @@ struct CmdCatStore : StoreCommand, MixCat
     void run(ref<Store> store) override
     {
         auto [storePath, rest] = store->toStorePath(path);
-        auto accessor = store->getFSAccessor(storePath);
-        if (!accessor)
-            throw InvalidPath("path '%1%' is not a valid store path", store->printStorePath(storePath));
-        cat(ref{std::move(accessor)}, CanonPath{rest});
+        cat(store->requireStoreObjectAccessor(storePath), CanonPath{rest});
     }
 };
 

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -115,10 +115,7 @@ struct CmdLsStore : StoreCommand, MixLs
     void run(ref<Store> store) override
     {
         auto [storePath, rest] = store->toStorePath(path);
-        auto accessor = store->getFSAccessor(storePath);
-        if (!accessor)
-            throw InvalidPath("path '%1%' is not a valid store path", store->printStorePath(storePath));
-        list(ref{std::move(accessor)}, CanonPath{rest});
+        list(store->requireStoreObjectAccessor(storePath), CanonPath{rest});
     }
 };
 

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -603,7 +603,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
 #endif
             if (!hashGiven) {
                 HashResult hash = hashPath(
-                    {ref{store->getFSAccessor(info->path, false)}},
+                    {store->requireStoreObjectAccessor(info->path, /*requireValidPath=*/false)},
                     FileSerialisationMethod::NixArchive,
                     HashAlgorithm::SHA256);
                 info->narHash = hash.hash;

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -207,7 +207,7 @@ struct CmdWhyDepends : SourceExprCommand, MixOperateOnOptions
                contain the reference. */
             std::map<std::string, Strings> hits;
 
-            auto accessor = store->getFSAccessor(node.path);
+            auto accessor = store->requireStoreObjectAccessor(node.path);
 
             auto visitPath = [&](this auto && recur, const CanonPath & p) -> void {
                 auto st = accessor->maybeLstat(p);


### PR DESCRIPTION
…FSAccessor

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is a simple wrapper around getFSAccessor that throws an InvalidPath error. This simplifies usage in callsites that only care about getting a non-null accessor.

(cherry picked from commit 0c32fb3fa2d66448615744b502d06b6dea21d66e)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes https://github.com/NixOS/nix/issues/14571.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
