### PR TITLE
nix_api_expr: ensure destructors are called for builder/state

### DIFF
--- a/src/libexpr-c/nix_api_expr.cc
+++ b/src/libexpr-c/nix_api_expr.cc
@@ -137,6 +137,8 @@ nix_eval_state_builder * nix_eval_state_builder_new(nix_c_context * context, Sto
 
 void nix_eval_state_builder_free(nix_eval_state_builder * builder)
 {
+    if (builder)
+        builder->~nix_eval_state_builder();
     operator delete(builder, static_cast<std::align_val_t>(alignof(nix_eval_state_builder)));
 }
 
@@ -203,6 +205,8 @@ EvalState * nix_state_create(nix_c_context * context, const char ** lookupPath_c
 
 void nix_state_free(EvalState * state)
 {
+    if (state)
+        state->~EvalState();
     operator delete(state, static_cast<std::align_val_t>(alignof(EvalState)));
 }
 


### PR DESCRIPTION
I found this because of a test failure on cygwin in nix_api_expr_test.nix_eval_state_lookup_path:

 'std::filesystem::__cxx11::filesystem_error'
   what():  filesystem error: cannot remove all: Device or resource busy
   [...]
   [.../my_state/db/db.sqlite]

LocalState was never getting destroyed due to a reference leak.  These _free functions use an 'operator delete' which doesn't call the destructor for the type.

Fixes: 309d55807c088ec3172f35d576522329972a1904