### PR TITLE
Fix registry pin ref lookup

### DIFF
--- a/src/nix/registry.cc
+++ b/src/nix/registry.cc
@@ -189,7 +189,6 @@ struct CmdRegistryPin : RegistryCommand, EvalCommand
         auto registry = getRegistry();
         auto ref = parseFlakeRef(fetchSettings, url);
         auto lockedRef = parseFlakeRef(fetchSettings, locked);
-        registry->remove(ref.input);
         auto resolvedInput = lockedRef.resolve(fetchSettings, store).input;
         auto resolved = resolvedInput.getAccessor(fetchSettings, store).second;
         if (!resolved.isLocked(fetchSettings))
@@ -197,6 +196,7 @@ struct CmdRegistryPin : RegistryCommand, EvalCommand
         fetchers::Attrs extraAttrs;
         if (ref.subdir != "")
             extraAttrs["dir"] = ref.subdir;
+        registry->remove(ref.input);
         registry->add(ref.input, resolved, extraAttrs);
         registry->write(getRegistryPath());
     }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Closes #14342 

The ref was being removed before the `lockedRef.resolve` lookup. This happened whenever the `url` was previously in the registry returned by `getRegistry()`. The user registry errs by default, but you get the same error by specifying `--registry`:

```
$ nix registry add foo github:NixOS/nixpkgs/master --registry ./custom.json
$ nix registry pin foo --registry ./custom.json
error: cannot find flake 'flake:foo' in the flake registries
```

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
