### PR TITLE
libstore-c: Organize API into separate headers

### DIFF
--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -35,6 +35,8 @@ include_dirs = [ include_directories('.') ]
 
 headers = files(
   'nix_api_store.h',
+  'nix_api_store/derivation.h',
+  'nix_api_store/store_path.h',
 )
 
 # TODO don't install this once tests don't use it and/or move the header into `libstore`, non-`c`

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -12,6 +12,8 @@
  */
 
 #include "nix_api_util.h"
+#include "nix_api_store/store_path.h"
+#include "nix_api_store/derivation.h"
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -21,10 +23,6 @@ extern "C" {
 
 /** @brief Reference to a Nix store */
 typedef struct Store Store;
-/** @brief Nix store path */
-typedef struct StorePath StorePath;
-/** @brief Nix Derivation */
-typedef struct nix_derivation nix_derivation;
 
 /**
  * @brief Initializes the Nix store library
@@ -119,30 +117,6 @@ nix_store_get_storedir(nix_c_context * context, Store * store, nix_get_string_ca
 StorePath * nix_store_parse_path(nix_c_context * context, Store * store, const char * path);
 
 /**
- * @brief Get the path name (e.g. "name" in /nix/store/...-name)
- *
- * @param[in] store_path the path to get the name from
- * @param[in] callback called with the name
- * @param[in] user_data arbitrary data, passed to the callback when it's called.
- */
-void nix_store_path_name(const StorePath * store_path, nix_get_string_callback callback, void * user_data);
-
-/**
- * @brief Copy a StorePath
- *
- * @param[in] p the path to copy
- * @return a new StorePath
- */
-StorePath * nix_store_path_clone(const StorePath * p);
-
-/** @brief Deallocate a StorePath
- *
- * Does not fail.
- * @param[in] p the path to free
- */
-void nix_store_path_free(StorePath * p);
-
-/**
  * @brief Check if a StorePath is valid (i.e. that corresponding store object and its closure of references exists in
  * the store)
  * @param[out] context Optional, stores error information
@@ -228,14 +202,6 @@ nix_derivation * nix_derivation_from_json(nix_c_context * context, Store * store
  * @param[in] derivation nix_derivation to insert into the given store.
  */
 StorePath * nix_add_derivation(nix_c_context * context, Store * store, nix_derivation * derivation);
-
-/**
- * @brief Deallocate a `nix_derivation`
- *
- * Does not fail.
- * @param[in] drv the derivation to free
- */
-void nix_derivation_free(nix_derivation * drv);
 
 /**
  * @brief Copy the closure of `path` from `srcStore` to `dstStore`.

--- a/src/libstore-c/nix_api_store/derivation.h
+++ b/src/libstore-c/nix_api_store/derivation.h
@@ -1,0 +1,38 @@
+#ifndef NIX_API_STORE_DERIVATION_H
+#define NIX_API_STORE_DERIVATION_H
+/**
+ * @defgroup libstore_derivation Derivation
+ * @ingroup libstore
+ * @brief Derivation operations that don't require a Store
+ * @{
+ */
+/** @file
+ * @brief Derivation operations
+ */
+
+#include "nix_api_util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// cffi start
+
+/** @brief Nix Derivation */
+typedef struct nix_derivation nix_derivation;
+
+/**
+ * @brief Deallocate a `nix_derivation`
+ *
+ * Does not fail.
+ * @param[in] drv the derivation to free
+ */
+void nix_derivation_free(nix_derivation * drv);
+
+// cffi end
+#ifdef __cplusplus
+}
+#endif
+/**
+ * @}
+ */
+#endif // NIX_API_STORE_DERIVATION_H

--- a/src/libstore-c/nix_api_store/store_path.h
+++ b/src/libstore-c/nix_api_store/store_path.h
@@ -1,0 +1,54 @@
+#ifndef NIX_API_STORE_STORE_PATH_H
+#define NIX_API_STORE_STORE_PATH_H
+/**
+ * @defgroup libstore_storepath StorePath
+ * @ingroup libstore
+ * @brief Store path operations that don't require a Store
+ * @{
+ */
+/** @file
+ * @brief Store path operations
+ */
+
+#include "nix_api_util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// cffi start
+
+/** @brief Nix store path */
+typedef struct StorePath StorePath;
+
+/**
+ * @brief Copy a StorePath
+ *
+ * @param[in] p the path to copy
+ * @return a new StorePath
+ */
+StorePath * nix_store_path_clone(const StorePath * p);
+
+/** @brief Deallocate a StorePath
+ *
+ * Does not fail.
+ * @param[in] p the path to free
+ */
+void nix_store_path_free(StorePath * p);
+
+/**
+ * @brief Get the path name (e.g. "<name>" in /nix/store/<hash>-<name>)
+ *
+ * @param[in] store_path the path to get the name from
+ * @param[in] callback called with the name
+ * @param[in] user_data arbitrary data, passed to the callback when it's called.
+ */
+void nix_store_path_name(const StorePath * store_path, nix_get_string_callback callback, void * user_data);
+
+// cffi end
+#ifdef __cplusplus
+}
+#endif
+/**
+ * @}
+ */
+#endif // NIX_API_STORE_STORE_PATH_H


### PR DESCRIPTION
## Motivation

Move StorePath and Derivation declarations to their own headers in a backwards compatible way:

- Created nix_api_store/store_path.h for StorePath operations

- Created nix_api_store/derivation.h for Derivation operations

- Main nix_api_store.h includes both headers for backwards compatibility

This reorganization improves modularity and hopefully makes the API easier to navigate.

## Context

I will put some new things in these headers next, with #14555

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
