### PR TITLE
nix flake clone: Support all input types

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -278,7 +278,8 @@ struct GitInputScheme : InputScheme
         return res;
     }
 
-    void clone(const Settings & settings, const Input & input, const std::filesystem::path & destDir) const override
+    void clone(const Settings & settings, ref<Store> store, const Input & input, const std::filesystem::path & destDir)
+        const override
     {
         auto repoInfo = getRepoInfo(input);
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -426,12 +426,13 @@ struct GitHubInputScheme : GitArchiveInputScheme
         return DownloadUrl{parseURL(url), headers};
     }
 
-    void clone(const Settings & settings, const Input & input, const std::filesystem::path & destDir) const override
+    void clone(const Settings & settings, ref<Store> store, const Input & input, const std::filesystem::path & destDir)
+        const override
     {
         auto host = getHost(input);
         Input::fromURL(settings, fmt("git+https://%s/%s/%s.git", host, getOwner(input), getRepo(input)))
             .applyOverrides(input.getRef(), input.getRev())
-            .clone(settings, destDir);
+            .clone(settings, store, destDir);
     }
 };
 
@@ -507,7 +508,8 @@ struct GitLabInputScheme : GitArchiveInputScheme
         return DownloadUrl{parseURL(url), headers};
     }
 
-    void clone(const Settings & settings, const Input & input, const std::filesystem::path & destDir) const override
+    void clone(const Settings & settings, ref<Store> store, const Input & input, const std::filesystem::path & destDir)
+        const override
     {
         auto host = maybeGetStrAttr(input.attrs, "host").value_or("gitlab.com");
         // FIXME: get username somewhere
@@ -515,7 +517,7 @@ struct GitLabInputScheme : GitArchiveInputScheme
             settings,
             fmt("git+https://%s/%s/%s.git", host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo")))
             .applyOverrides(input.getRef(), input.getRev())
-            .clone(settings, destDir);
+            .clone(settings, store, destDir);
     }
 };
 
@@ -596,14 +598,15 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         return DownloadUrl{parseURL(url), headers};
     }
 
-    void clone(const Settings & settings, const Input & input, const std::filesystem::path & destDir) const override
+    void clone(const Settings & settings, ref<Store> store, const Input & input, const std::filesystem::path & destDir)
+        const override
     {
         auto host = maybeGetStrAttr(input.attrs, "host").value_or("git.sr.ht");
         Input::fromURL(
             settings,
             fmt("git+https://%s/%s/%s", host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo")))
             .applyOverrides(input.getRef(), input.getRev())
-            .clone(settings, destDir);
+            .clone(settings, store, destDir);
     }
 };
 

--- a/src/libfetchers/include/nix/fetchers/fetchers.hh
+++ b/src/libfetchers/include/nix/fetchers/fetchers.hh
@@ -143,7 +143,7 @@ public:
 
     Input applyOverrides(std::optional<std::string> ref, std::optional<Hash> rev) const;
 
-    void clone(const Settings & settings, const std::filesystem::path & destDir) const;
+    void clone(const Settings & settings, ref<Store> store, const std::filesystem::path & destDir) const;
 
     std::optional<std::filesystem::path> getSourcePath() const;
 
@@ -216,7 +216,8 @@ struct InputScheme
 
     virtual Input applyOverrides(const Input & input, std::optional<std::string> ref, std::optional<Hash> rev) const;
 
-    virtual void clone(const Settings & settings, const Input & input, const std::filesystem::path & destDir) const;
+    virtual void clone(
+        const Settings & settings, ref<Store> store, const Input & input, const std::filesystem::path & destDir) const;
 
     virtual std::optional<std::filesystem::path> getSourcePath(const Input & input) const;
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1049,7 +1049,7 @@ struct CmdFlakeClone : FlakeCommand
         if (destDir.empty())
             throw Error("missing flag '--dest'");
 
-        getFlakeRef().resolve(fetchSettings, store).input.clone(fetchSettings, destDir);
+        getFlakeRef().resolve(fetchSettings, store).input.clone(fetchSettings, store, destDir);
     }
 };
 

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -369,6 +369,10 @@ tar cfz "$TEST_ROOT"/flake.tar.gz -C "$TEST_ROOT" flake5
 
 nix build -o "$TEST_ROOT"/result file://"$TEST_ROOT"/flake.tar.gz
 
+nix flake clone "file://$TEST_ROOT/flake.tar.gz" --dest "$TEST_ROOT/unpacked"
+[[ -e $TEST_ROOT/unpacked/flake.nix ]]
+expectStderr 1 nix flake clone "file://$TEST_ROOT/flake.tar.gz" --dest "$TEST_ROOT/unpacked" | grep 'existing path'
+
 # Building with a tarball URL containing a SRI hash should also work.
 url=$(nix flake metadata --json file://"$TEST_ROOT"/flake.tar.gz | jq -r .url)
 [[ $url =~ sha256- ]]


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This makes `nix flake clone` work on all input types, including tarballs, e.g.
```
# nix flake clone "https://flakehub.com/f/NixOS/nixpkgs/*" --dest nixpkgs
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Taken from https://github.com/DeterminateSystems/nix-src/pull/229.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
