### PR TITLE
treewide: Fix MinGW build

### DIFF
--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -209,7 +209,7 @@ std::vector<nlohmann::json> Fetch::fetchUrls(const std::vector<Pointer> & pointe
     auto url = api.endpoint + "/objects/batch";
     const auto & authHeader = api.authHeader;
     FileTransferRequest request(parseURL(url));
-    request.method = HttpMethod::POST;
+    request.method = HttpMethod::Post;
     Headers headers;
     if (authHeader.has_value())
         headers.push_back({"Authorization", *authHeader});

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -386,17 +386,17 @@ struct curlFileTransfer : public FileTransfer
             if (settings.downloadSpeed.get() > 0)
                 curl_easy_setopt(req, CURLOPT_MAX_RECV_SPEED_LARGE, (curl_off_t) (settings.downloadSpeed.get() * 1024));
 
-            if (request.method == HttpMethod::HEAD)
+            if (request.method == HttpMethod::Head)
                 curl_easy_setopt(req, CURLOPT_NOBODY, 1);
 
-            if (request.method == HttpMethod::DELETE)
+            if (request.method == HttpMethod::Delete)
                 curl_easy_setopt(req, CURLOPT_CUSTOMREQUEST, "DELETE");
 
             if (request.data) {
-                if (request.method == HttpMethod::POST) {
+                if (request.method == HttpMethod::Post) {
                     curl_easy_setopt(req, CURLOPT_POST, 1L);
                     curl_easy_setopt(req, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) request.data->sizeHint);
-                } else if (request.method == HttpMethod::PUT) {
+                } else if (request.method == HttpMethod::Put) {
                     curl_easy_setopt(req, CURLOPT_UPLOAD, 1L);
                     curl_easy_setopt(req, CURLOPT_INFILESIZE_LARGE, (curl_off_t) request.data->sizeHint);
                 } else {

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -120,7 +120,7 @@ bool HttpBinaryCacheStore::fileExists(const std::string & path)
 
     try {
         FileTransferRequest request(makeRequest(path));
-        request.method = HttpMethod::HEAD;
+        request.method = HttpMethod::Head;
         getFileTransfer()->download(request);
         return true;
     } catch (FileTransferError & e) {
@@ -141,7 +141,7 @@ void HttpBinaryCacheStore::upload(
     std::optional<Headers> headers)
 {
     auto req = makeRequest(path);
-    req.method = HttpMethod::PUT;
+    req.method = HttpMethod::Put;
 
     if (headers) {
         req.headers.reserve(req.headers.size() + headers->size());

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -87,11 +87,11 @@ extern const unsigned int RETRY_TIME_MS_DEFAULT;
  * HTTP methods supported by FileTransfer.
  */
 enum struct HttpMethod {
-    GET,
-    PUT,
-    HEAD,
-    POST,
-    DELETE,
+    Get,
+    Put,
+    Head,
+    Post,
+    Delete,
 };
 
 /**
@@ -110,7 +110,7 @@ struct FileTransferRequest
     VerbatimURL uri;
     Headers headers;
     std::string expectedETag;
-    HttpMethod method = HttpMethod::GET;
+    HttpMethod method = HttpMethod::Get;
     size_t tries = fileTransferSettings.tries;
     unsigned int baseRetryTimeMs = RETRY_TIME_MS_DEFAULT;
     ActivityId parentAct;
@@ -164,14 +164,14 @@ struct FileTransferRequest
     std::string verb() const
     {
         switch (method) {
-        case HttpMethod::HEAD:
-        case HttpMethod::GET:
+        case HttpMethod::Head:
+        case HttpMethod::Get:
             return "download";
-        case HttpMethod::PUT:
-        case HttpMethod::POST:
+        case HttpMethod::Put:
+        case HttpMethod::Post:
             assert(data);
             return "upload";
-        case HttpMethod::DELETE:
+        case HttpMethod::Delete:
             return "delet";
         }
         unreachable();

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -295,7 +295,7 @@ std::string S3BinaryCacheStore::createMultipartUpload(
     url.query["uploads"] = "";
     req.uri = VerbatimURL(url);
 
-    req.method = HttpMethod::POST;
+    req.method = HttpMethod::Post;
     StringSource payload{std::string_view("")};
     req.data = {payload};
     req.mimeType = mimeType;
@@ -325,7 +325,7 @@ S3BinaryCacheStore::uploadPart(std::string_view key, std::string_view uploadId, 
     }
 
     auto req = makeRequest(key);
-    req.method = HttpMethod::PUT;
+    req.method = HttpMethod::Put;
     req.setupForS3();
 
     auto url = req.uri.parsed();
@@ -355,7 +355,7 @@ void S3BinaryCacheStore::abortMultipartUpload(std::string_view key, std::string_
         auto url = req.uri.parsed();
         url.query["uploadId"] = uploadId;
         req.uri = VerbatimURL(url);
-        req.method = HttpMethod::DELETE;
+        req.method = HttpMethod::Delete;
 
         getFileTransfer()->enqueueFileTransfer(req).get();
     } catch (...) {
@@ -372,7 +372,7 @@ void S3BinaryCacheStore::completeMultipartUpload(
     auto url = req.uri.parsed();
     url.query["uploadId"] = uploadId;
     req.uri = VerbatimURL(url);
-    req.method = HttpMethod::POST;
+    req.method = HttpMethod::Post;
 
     std::string xml = "<CompleteMultipartUpload>";
     for (const auto & [idx, etag] : enumerate(partEtags)) {

--- a/src/libutil/include/nix/util/terminal.hh
+++ b/src/libutil/include/nix/util/terminal.hh
@@ -4,7 +4,15 @@
 #include <limits>
 #include <string>
 
+#include "nix/util/file-descriptor.hh"
+
 namespace nix {
+
+/**
+ * Determine whether \param fd is a terminal.
+ */
+bool isTTY(Descriptor fd);
+
 /**
  * Determine whether ANSI escape sequences are appropriate for the
  * present output.

--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -64,6 +64,16 @@ inline std::pair<int, size_t> charWidthUTF8Helper(std::string_view s)
 
 namespace nix {
 
+bool isTTY(Descriptor fd)
+{
+#ifndef _WIN32
+    return isatty(fd);
+#else
+    DWORD mode;
+    return GetConsoleMode(fd, &mode);
+#endif
+}
+
 bool isTTY()
 {
     static const bool tty = isatty(STDERR_FILENO) && getEnv("TERM").value_or("dumb") != "dumb"

--- a/src/nix/cat.cc
+++ b/src/nix/cat.cc
@@ -75,7 +75,7 @@ struct CmdCatNar : StoreCommand, MixCat
 
     void run(ref<Store> store) override
     {
-        AutoCloseFD fd = open(narPath.c_str(), O_RDONLY);
+        AutoCloseFD fd = toDescriptor(open(narPath.c_str(), O_RDONLY));
         if (!fd)
             throw SysError("opening NAR file '%s'", narPath);
         auto source = FdSource{fd.get()};

--- a/src/nix/dump-path.cc
+++ b/src/nix/dump-path.cc
@@ -1,13 +1,14 @@
 #include "nix/cmd/command.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/archive.hh"
+#include "nix/util/terminal.hh"
 
 using namespace nix;
 
 static FdSink getNarSink()
 {
     auto fd = getStandardOutput();
-    if (isatty(fd))
+    if (isTTY(fd))
         throw UsageError("refusing to write NAR to a terminal");
     return FdSink(std::move(fd));
 }

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -145,7 +145,7 @@ struct CmdLsNar : Command, MixLs
 
     void run() override
     {
-        AutoCloseFD fd = open(narPath.c_str(), O_RDONLY);
+        AutoCloseFD fd = toDescriptor(open(narPath.c_str(), O_RDONLY));
         if (!fd)
             throw SysError("opening NAR file '%s'", narPath);
         auto source = FdSource{fd.get()};


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Several bugs to squash:

- Apparently DELETE is an already used macro with Win32. We can avoid it by using Camel case instead (slightly hacky but also fits the naming convention better)

- Gets rid of the raw usage of isatty. Added an isTTY impl to abstract over the raw API.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

https://hydra.nixos.org/build/313563592

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
