### PR TITLE
tests: fix fetchers-substitute test for new narHash JSON format

### DIFF
--- a/tests/nixos/fetchers-substitute.nix
+++ b/tests/nixos/fetchers-substitute.nix
@@ -120,7 +120,9 @@
       path_info_json = substituter.succeed(f"nix path-info --json {tarball_store_path}").strip()
       path_info_dict = json.loads(path_info_json)
       # nix path-info returns a dict with store paths as keys
-      tarball_hash_sri = path_info_dict[tarball_store_path]["narHash"]
+      narHash_obj = path_info_dict[tarball_store_path]["narHash"]
+      # Convert from structured format {"algorithm": "sha256", "format": "base64", "hash": "..."} to SRI string
+      tarball_hash_sri = f"{narHash_obj['algorithm']}-{narHash_obj['hash']}"
       print(f"Tarball NAR hash (SRI): {tarball_hash_sri}")
 
       # Also get the old format hash for fetchTarball (which uses sha256 parameter)


### PR DESCRIPTION
## Motivation

The test was failing because `nix path-info --json` now returns `narHash` as a structured dictionary `{"algorithm": "sha256", "format": "base64", "hash": "..."}` instead of an SRI string `"sha256-..."`.

This change was introduced in commit 5e7ee808d. The functional test `path-info.sh` was updated at that time, but this NixOS test was missed.

The fix converts the dictionary format to SRI format inline:
```
tarball_hash_sri = f"{narHash_obj['algorithm']}-{narHash_obj['hash']}"
```

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
