### PR TITLE
packaging: Unbork win shells with unavailable dependencies

### DIFF
--- a/src/kaitai-struct-checks/package.nix
+++ b/src/kaitai-struct-checks/package.nix
@@ -65,6 +65,6 @@ mkMesonDerivation (finalAttrs: {
   '';
 
   meta = {
-    platforms = lib.platforms.all;
+    platforms = lib.platforms.unix;
   };
 })

--- a/src/perl/package.nix
+++ b/src/perl/package.nix
@@ -74,5 +74,9 @@ perl.pkgs.toPerlModule (
     ];
 
     strictDeps = false;
+
+    meta = {
+      platforms = lib.platforms.unix;
+    };
   })
 )


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Makes the cross-x86_64-w64-mingw32 devshell slightly less broken. It still needs a bit of massaging to function, but that's much less cumbersome now that the generic machinery with genericClosure that evaluates drvPath doesn't barf on unavailable packages.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
