### PR TITLE
c api: add EvalState argument to nix_init_*

### DIFF
--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -485,7 +485,7 @@ const char * nix_get_attr_name_byidx(nix_c_context * context, nix_value * value,
     NIXC_CATCH_ERRS_NULL
 }
 
-nix_err nix_init_bool(nix_c_context * context, nix_value * value, bool b)
+nix_err nix_init_bool(nix_c_context * context, EvalState * state, nix_value * value, bool b)
 {
     if (context)
         context->last_err_code = NIX_OK;
@@ -497,7 +497,7 @@ nix_err nix_init_bool(nix_c_context * context, nix_value * value, bool b)
 }
 
 // todo string context
-nix_err nix_init_string(nix_c_context * context, nix_value * value, const char * str)
+nix_err nix_init_string(nix_c_context * context, EvalState * state, nix_value * value, const char * str)
 {
     if (context)
         context->last_err_code = NIX_OK;
@@ -508,18 +508,18 @@ nix_err nix_init_string(nix_c_context * context, nix_value * value, const char *
     NIXC_CATCH_ERRS
 }
 
-nix_err nix_init_path_string(nix_c_context * context, EvalState * s, nix_value * value, const char * str)
+nix_err nix_init_path_string(nix_c_context * context, EvalState * state, nix_value * value, const char * str)
 {
     if (context)
         context->last_err_code = NIX_OK;
     try {
         auto & v = check_value_out(value);
-        v.mkPath(s->state.rootPath(nix::CanonPath(str)));
+        v.mkPath(state->state.rootPath(nix::CanonPath(str)));
     }
     NIXC_CATCH_ERRS
 }
 
-nix_err nix_init_float(nix_c_context * context, nix_value * value, double d)
+nix_err nix_init_float(nix_c_context * context, EvalState * state, nix_value * value, double d)
 {
     if (context)
         context->last_err_code = NIX_OK;
@@ -530,7 +530,7 @@ nix_err nix_init_float(nix_c_context * context, nix_value * value, double d)
     NIXC_CATCH_ERRS
 }
 
-nix_err nix_init_int(nix_c_context * context, nix_value * value, int64_t i)
+nix_err nix_init_int(nix_c_context * context, EvalState * state, nix_value * value, int64_t i)
 {
     if (context)
         context->last_err_code = NIX_OK;
@@ -541,7 +541,7 @@ nix_err nix_init_int(nix_c_context * context, nix_value * value, int64_t i)
     NIXC_CATCH_ERRS
 }
 
-nix_err nix_init_null(nix_c_context * context, nix_value * value)
+nix_err nix_init_null(nix_c_context * context, EvalState * state, nix_value * value)
 {
     if (context)
         context->last_err_code = NIX_OK;
@@ -552,7 +552,7 @@ nix_err nix_init_null(nix_c_context * context, nix_value * value)
     NIXC_CATCH_ERRS
 }
 
-nix_err nix_init_apply(nix_c_context * context, nix_value * value, nix_value * fn, nix_value * arg)
+nix_err nix_init_apply(nix_c_context * context, EvalState * state, nix_value * value, nix_value * fn, nix_value * arg)
 {
     if (context)
         context->last_err_code = NIX_OK;
@@ -565,7 +565,7 @@ nix_err nix_init_apply(nix_c_context * context, nix_value * value, nix_value * f
     NIXC_CATCH_ERRS
 }
 
-nix_err nix_init_external(nix_c_context * context, nix_value * value, ExternalValue * val)
+nix_err nix_init_external(nix_c_context * context, EvalState * state, nix_value * value, ExternalValue * val)
 {
     if (context)
         context->last_err_code = NIX_OK;
@@ -624,7 +624,7 @@ nix_err nix_make_list(nix_c_context * context, ListBuilder * list_builder, nix_v
     NIXC_CATCH_ERRS
 }
 
-nix_err nix_init_primop(nix_c_context * context, nix_value * value, PrimOp * p)
+nix_err nix_init_primop(nix_c_context * context, EvalState * state, nix_value * value, PrimOp * p)
 {
     if (context)
         context->last_err_code = NIX_OK;

--- a/src/libexpr-c/nix_api_value.h
+++ b/src/libexpr-c/nix_api_value.h
@@ -507,55 +507,61 @@ const char * nix_get_attr_name_byidx(nix_c_context * context, nix_value * value,
 /** @brief Set boolean value
  * @ingroup value_create
  * @param[out] context Optional, stores error information
+ * @param[in] state nix evaluator state
  * @param[out] value Nix value to modify
  * @param[in] b the boolean value
  * @return error code, NIX_OK on success.
  */
-nix_err nix_init_bool(nix_c_context * context, nix_value * value, bool b);
+nix_err nix_init_bool(nix_c_context * context, EvalState * state, nix_value * value, bool b);
 
 /** @brief Set a string
  * @ingroup value_create
  * @param[out] context Optional, stores error information
+ * @param[in] state nix evaluator state
  * @param[out] value Nix value to modify
  * @param[in] str the string, copied
  * @return error code, NIX_OK on success.
  */
-nix_err nix_init_string(nix_c_context * context, nix_value * value, const char * str);
+nix_err nix_init_string(nix_c_context * context, EvalState * state, nix_value * value, const char * str);
 
 /** @brief Set a path
  * @ingroup value_create
  * @param[out] context Optional, stores error information
+ * @param[in] state nix evaluator state
  * @param[out] value Nix value to modify
  * @param[in] str the path string, copied
  * @return error code, NIX_OK on success.
  */
-nix_err nix_init_path_string(nix_c_context * context, EvalState * s, nix_value * value, const char * str);
+nix_err nix_init_path_string(nix_c_context * context, EvalState * state, nix_value * value, const char * str);
 
 /** @brief Set a float
  * @ingroup value_create
  * @param[out] context Optional, stores error information
+ * @param[in] state nix evaluator state
  * @param[out] value Nix value to modify
  * @param[in] d the float, 64-bits
  * @return error code, NIX_OK on success.
  */
-nix_err nix_init_float(nix_c_context * context, nix_value * value, double d);
+nix_err nix_init_float(nix_c_context * context, EvalState * state, nix_value * value, double d);
 
 /** @brief Set an int
  * @ingroup value_create
  * @param[out] context Optional, stores error information
+ * @param[in] state nix evaluator state
  * @param[out] value Nix value to modify
  * @param[in] i the int
  * @return error code, NIX_OK on success.
  */
 
-nix_err nix_init_int(nix_c_context * context, nix_value * value, int64_t i);
+nix_err nix_init_int(nix_c_context * context, EvalState * state, nix_value * value, int64_t i);
 /** @brief Set null
  * @ingroup value_create
  * @param[out] context Optional, stores error information
+ * @param[in] state nix evaluator state
  * @param[out] value Nix value to modify
  * @return error code, NIX_OK on success.
  */
-nix_err nix_init_null(nix_c_context * context, nix_value * value);
+nix_err nix_init_null(nix_c_context * context, EvalState * state, nix_value * value);
 
 /** @brief Set the value to a thunk that will perform a function application when needed.
  * @ingroup value_create
@@ -565,6 +571,7 @@ nix_err nix_init_null(nix_c_context * context, nix_value * value);
  * In such cases, you may use nix_value_call() instead (but note the different argument order).
  *
  * @param[out] context Optional, stores error information
+ * @param[in] state nix evaluator state
  * @param[out] value Nix value to modify
  * @param[in] fn function to call
  * @param[in] arg argument to pass
@@ -572,16 +579,17 @@ nix_err nix_init_null(nix_c_context * context, nix_value * value);
  * @see nix_value_call() for a similar function that performs the call immediately and only stores the return value.
  *      Note the different argument order.
  */
-nix_err nix_init_apply(nix_c_context * context, nix_value * value, nix_value * fn, nix_value * arg);
+nix_err nix_init_apply(nix_c_context * context, EvalState * state, nix_value * value, nix_value * fn, nix_value * arg);
 
 /** @brief Set an external value
  * @ingroup value_create
  * @param[out] context Optional, stores error information
+ * @param[in] state nix evaluator state
  * @param[out] value Nix value to modify
  * @param[in] val the external value to set. Will be GC-referenced by the value.
  * @return error code, NIX_OK on success.
  */
-nix_err nix_init_external(nix_c_context * context, nix_value * value, ExternalValue * val);
+nix_err nix_init_external(nix_c_context * context, EvalState * state, nix_value * value, ExternalValue * val);
 
 /** @brief Create a list from a list builder
  * @ingroup value_create
@@ -645,7 +653,7 @@ nix_err nix_make_attrs(nix_c_context * context, nix_value * value, BindingsBuild
  * @see nix_alloc_primop
  * @return error code, NIX_OK on success.
  */
-nix_err nix_init_primop(nix_c_context * context, nix_value * value, PrimOp * op);
+nix_err nix_init_primop(nix_c_context * context, EvalState * s, nix_value * value, PrimOp * op);
 /** @brief Copy from another value
  * @ingroup value_create
  * @param[out] context Optional, stores error information

--- a/src/libexpr-tests/nix_api_expr.cc
+++ b/src/libexpr-tests/nix_api_expr.cc
@@ -241,7 +241,7 @@ primop_square(void * user_data, nix_c_context * context, EvalState * state, nix_
     assert(state);
     assert(user_data == SAMPLE_USER_DATA);
     auto i = nix_get_int(context, args[0]);
-    nix_init_int(context, ret, i * i);
+    nix_init_int(context, state, ret, i * i);
 }
 
 TEST_F(nix_api_expr_test, nix_expr_primop)
@@ -251,12 +251,12 @@ TEST_F(nix_api_expr_test, nix_expr_primop)
     assert_ctx_ok();
     nix_value * primopValue = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_primop(ctx, primopValue, primop);
+    nix_init_primop(ctx, state, primopValue, primop);
     assert_ctx_ok();
 
     nix_value * three = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_int(ctx, three, 3);
+    nix_init_int(ctx, state, three, 3);
     assert_ctx_ok();
 
     nix_value * result = nix_alloc_value(ctx, state);
@@ -290,7 +290,7 @@ primop_repeat(void * user_data, nix_c_context * context, EvalState * state, nix_
     for (int i = 0; i < n; ++i)
         result += s;
 
-    nix_init_string(context, ret, result.c_str());
+    nix_init_string(context, state, ret, result.c_str());
 }
 
 TEST_F(nix_api_expr_test, nix_expr_primop_arity_2_multiple_calls)
@@ -300,17 +300,17 @@ TEST_F(nix_api_expr_test, nix_expr_primop_arity_2_multiple_calls)
     assert_ctx_ok();
     nix_value * primopValue = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_primop(ctx, primopValue, primop);
+    nix_init_primop(ctx, state, primopValue, primop);
     assert_ctx_ok();
 
     nix_value * hello = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_string(ctx, hello, "hello");
+    nix_init_string(ctx, state, hello, "hello");
     assert_ctx_ok();
 
     nix_value * three = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_int(ctx, three, 3);
+    nix_init_int(ctx, state, three, 3);
     assert_ctx_ok();
 
     nix_value * partial = nix_alloc_value(ctx, state);
@@ -335,17 +335,17 @@ TEST_F(nix_api_expr_test, nix_expr_primop_arity_2_single_call)
     assert_ctx_ok();
     nix_value * primopValue = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_primop(ctx, primopValue, primop);
+    nix_init_primop(ctx, state, primopValue, primop);
     assert_ctx_ok();
 
     nix_value * hello = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_string(ctx, hello, "hello");
+    nix_init_string(ctx, state, hello, "hello");
     assert_ctx_ok();
 
     nix_value * three = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_int(ctx, three, 3);
+    nix_init_int(ctx, state, three, 3);
     assert_ctx_ok();
 
     nix_value * result = nix_alloc_value(ctx, state);
@@ -372,12 +372,12 @@ TEST_F(nix_api_expr_test, nix_expr_primop_bad_no_return)
     assert_ctx_ok();
     nix_value * primopValue = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_primop(ctx, primopValue, primop);
+    nix_init_primop(ctx, state, primopValue, primop);
     assert_ctx_ok();
 
     nix_value * three = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_int(ctx, three, 3);
+    nix_init_int(ctx, state, three, 3);
     assert_ctx_ok();
 
     nix_value * result = nix_alloc_value(ctx, state);
@@ -393,7 +393,7 @@ TEST_F(nix_api_expr_test, nix_expr_primop_bad_no_return)
 static void primop_bad_return_thunk(
     void * user_data, nix_c_context * context, EvalState * state, nix_value ** args, nix_value * ret)
 {
-    nix_init_apply(context, ret, args[0], args[1]);
+    nix_init_apply(context, state, ret, args[0], args[1]);
 }
 
 TEST_F(nix_api_expr_test, nix_expr_primop_bad_return_thunk)
@@ -403,7 +403,7 @@ TEST_F(nix_api_expr_test, nix_expr_primop_bad_return_thunk)
     assert_ctx_ok();
     nix_value * primopValue = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_primop(ctx, primopValue, primop);
+    nix_init_primop(ctx, state, primopValue, primop);
     assert_ctx_ok();
 
     nix_value * toString = nix_alloc_value(ctx, state);
@@ -413,7 +413,7 @@ TEST_F(nix_api_expr_test, nix_expr_primop_bad_return_thunk)
 
     nix_value * four = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_int(ctx, four, 4);
+    nix_init_int(ctx, state, four, 4);
     assert_ctx_ok();
 
     nix_value * result = nix_alloc_value(ctx, state);
@@ -452,12 +452,12 @@ TEST_F(nix_api_expr_test, nix_expr_primop_nix_err_key_conversion)
     assert_ctx_ok();
     nix_value * primopValue = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_primop(ctx, primopValue, primop);
+    nix_init_primop(ctx, state, primopValue, primop);
     assert_ctx_ok();
 
     nix_value * arg = nix_alloc_value(ctx, state);
     assert_ctx_ok();
-    nix_init_int(ctx, arg, 42);
+    nix_init_int(ctx, state, arg, 42);
     assert_ctx_ok();
 
     nix_value * result = nix_alloc_value(ctx, state);
@@ -479,7 +479,7 @@ TEST_F(nix_api_expr_test, nix_expr_primop_nix_err_key_conversion)
 TEST_F(nix_api_expr_test, nix_value_call_multi_no_args)
 {
     nix_value * n = nix_alloc_value(ctx, state);
-    nix_init_int(ctx, n, 3);
+    nix_init_int(ctx, state, n, 3);
     assert_ctx_ok();
 
     nix_value * r = nix_alloc_value(ctx, state);

--- a/src/libexpr-tests/nix_api_external.cc
+++ b/src/libexpr-tests/nix_api_external.cc
@@ -44,7 +44,7 @@ TEST_F(nix_api_expr_test, nix_expr_eval_external)
 {
     MyExternalValueDesc * external = new MyExternalValueDesc(42);
     ExternalValue * val = nix_create_external_value(ctx, external, external);
-    nix_init_external(ctx, value, val);
+    nix_init_external(ctx, state, value, val);
 
     EvalState * stateResult = nix_state_create(nullptr, nullptr, store);
     nix_value * valueResult = nix_alloc_value(nullptr, stateResult);

--- a/src/libexpr-tests/nix_api_value.cc
+++ b/src/libexpr-tests/nix_api_value.cc
@@ -24,7 +24,7 @@ TEST_F(nix_api_expr_test, nix_value_get_int_invalid)
 TEST_F(nix_api_expr_test, nix_value_set_get_int)
 {
     int myInt = 1;
-    nix_init_int(ctx, value, myInt);
+    nix_init_int(ctx, state, value, myInt);
 
     ASSERT_EQ(myInt, nix_get_int(ctx, value));
     ASSERT_STREQ("an integer", nix_get_typename(ctx, value));
@@ -42,7 +42,7 @@ TEST_F(nix_api_expr_test, nix_value_set_get_float_invalid)
 TEST_F(nix_api_expr_test, nix_value_set_get_float)
 {
     double myDouble = 1.0;
-    nix_init_float(ctx, value, myDouble);
+    nix_init_float(ctx, state, value, myDouble);
 
     ASSERT_DOUBLE_EQ(myDouble, nix_get_float(ctx, value));
     ASSERT_STREQ("a float", nix_get_typename(ctx, value));
@@ -60,7 +60,7 @@ TEST_F(nix_api_expr_test, nix_value_set_get_bool_invalid)
 TEST_F(nix_api_expr_test, nix_value_set_get_bool)
 {
     bool myBool = true;
-    nix_init_bool(ctx, value, myBool);
+    nix_init_bool(ctx, state, value, myBool);
 
     ASSERT_EQ(myBool, nix_get_bool(ctx, value));
     ASSERT_STREQ("a Boolean", nix_get_typename(ctx, value));
@@ -80,7 +80,7 @@ TEST_F(nix_api_expr_test, nix_value_set_get_string)
 {
     std::string string_value;
     const char * myString = "some string";
-    nix_init_string(ctx, value, myString);
+    nix_init_string(ctx, state, value, myString);
 
     nix_get_string(ctx, value, OBSERVE_STRING(string_value));
     ASSERT_STREQ(myString, string_value.c_str());
@@ -96,7 +96,7 @@ TEST_F(nix_api_expr_test, nix_value_set_get_null_invalid)
 
 TEST_F(nix_api_expr_test, nix_value_set_get_null)
 {
-    nix_init_null(ctx, value);
+    nix_init_null(ctx, state, value);
 
     ASSERT_STREQ("null", nix_get_typename(ctx, value));
     ASSERT_EQ(NIX_TYPE_NULL, nix_get_type(ctx, value));
@@ -142,10 +142,10 @@ TEST_F(nix_api_expr_test, nix_build_and_init_list)
     nix_value * intValue2 = nix_alloc_value(ctx, state);
 
     // `init` and `insert` can be called in any order
-    nix_init_int(ctx, intValue, 42);
+    nix_init_int(ctx, state, intValue, 42);
     nix_list_builder_insert(ctx, builder, 0, intValue);
     nix_list_builder_insert(ctx, builder, 1, intValue2);
-    nix_init_int(ctx, intValue2, 43);
+    nix_init_int(ctx, state, intValue2, 43);
 
     nix_make_list(ctx, builder, value);
     nix_list_builder_free(builder);
@@ -167,7 +167,7 @@ TEST_F(nix_api_expr_test, nix_get_list_byidx_large_indices)
     // Create a small list to test extremely large out-of-bounds access
     ListBuilder * builder = nix_make_list_builder(ctx, state, 2);
     nix_value * intValue = nix_alloc_value(ctx, state);
-    nix_init_int(ctx, intValue, 42);
+    nix_init_int(ctx, state, intValue, 42);
     nix_list_builder_insert(ctx, builder, 0, intValue);
     nix_list_builder_insert(ctx, builder, 1, intValue);
     nix_make_list(ctx, builder, value);
@@ -203,12 +203,12 @@ TEST_F(nix_api_expr_test, nix_get_list_byidx_lazy)
         throwingFn);
     assert_ctx_ok();
 
-    nix_init_apply(ctx, throwingValue, throwingFn, throwingFn);
+    nix_init_apply(ctx, state, throwingValue, throwingFn, throwingFn);
     assert_ctx_ok();
 
     // 2. Already evaluated int (not lazy)
     nix_value * intValue = nix_alloc_value(ctx, state);
-    nix_init_int(ctx, intValue, 42);
+    nix_init_int(ctx, state, intValue, 42);
     assert_ctx_ok();
 
     // 3. Lazy function application that would compute increment 5 = 6
@@ -218,10 +218,10 @@ TEST_F(nix_api_expr_test, nix_get_list_byidx_lazy)
 
     nix_expr_eval_from_string(ctx, state, "x: x + 1", "<test>", incrementFn);
     assert_ctx_ok();
-    nix_init_int(ctx, argFive, 5);
+    nix_init_int(ctx, state, argFive, 5);
 
     // Create a lazy application: (x: x + 1) 5
-    nix_init_apply(ctx, lazyApply, incrementFn, argFive);
+    nix_init_apply(ctx, state, lazyApply, incrementFn, argFive);
     assert_ctx_ok();
 
     ListBuilder * builder = nix_make_list_builder(ctx, state, 3);
@@ -303,10 +303,10 @@ TEST_F(nix_api_expr_test, nix_build_and_init_attr)
     BindingsBuilder * builder = nix_make_bindings_builder(ctx, state, size);
 
     nix_value * intValue = nix_alloc_value(ctx, state);
-    nix_init_int(ctx, intValue, 42);
+    nix_init_int(ctx, state, intValue, 42);
 
     nix_value * stringValue = nix_alloc_value(ctx, state);
-    nix_init_string(ctx, stringValue, "foo");
+    nix_init_string(ctx, state, stringValue, "foo");
 
     nix_bindings_builder_insert(ctx, builder, "a", intValue);
     nix_bindings_builder_insert(ctx, builder, "b", stringValue);
@@ -358,7 +358,7 @@ TEST_F(nix_api_expr_test, nix_get_attr_byidx_large_indices)
     const char ** out_name = (const char **) malloc(sizeof(char *));
     BindingsBuilder * builder = nix_make_bindings_builder(ctx, state, 2);
     nix_value * intValue = nix_alloc_value(ctx, state);
-    nix_init_int(ctx, intValue, 42);
+    nix_init_int(ctx, state, intValue, 42);
     nix_bindings_builder_insert(ctx, builder, "test", intValue);
     nix_make_attrs(ctx, value, builder);
     nix_bindings_builder_free(builder);
@@ -402,12 +402,12 @@ TEST_F(nix_api_expr_test, nix_get_attr_byname_lazy)
         throwingFn);
     assert_ctx_ok();
 
-    nix_init_apply(ctx, throwingValue, throwingFn, throwingFn);
+    nix_init_apply(ctx, state, throwingValue, throwingFn, throwingFn);
     assert_ctx_ok();
 
     // 2. Already evaluated int (not lazy)
     nix_value * intValue = nix_alloc_value(ctx, state);
-    nix_init_int(ctx, intValue, 42);
+    nix_init_int(ctx, state, intValue, 42);
     assert_ctx_ok();
 
     // 3. Lazy function application that would compute increment 7 = 8
@@ -417,10 +417,10 @@ TEST_F(nix_api_expr_test, nix_get_attr_byname_lazy)
 
     nix_expr_eval_from_string(ctx, state, "x: x + 1", "<test>", incrementFn);
     assert_ctx_ok();
-    nix_init_int(ctx, argSeven, 7);
+    nix_init_int(ctx, state, argSeven, 7);
 
     // Create a lazy application: (x: x + 1) 7
-    nix_init_apply(ctx, lazyApply, incrementFn, argSeven);
+    nix_init_apply(ctx, state, lazyApply, incrementFn, argSeven);
     assert_ctx_ok();
 
     BindingsBuilder * builder = nix_make_bindings_builder(ctx, state, 3);
@@ -492,12 +492,12 @@ TEST_F(nix_api_expr_test, nix_get_attr_byidx_lazy)
         throwingFn);
     assert_ctx_ok();
 
-    nix_init_apply(ctx, throwingValue, throwingFn, throwingFn);
+    nix_init_apply(ctx, state, throwingValue, throwingFn, throwingFn);
     assert_ctx_ok();
 
     // 2. Already evaluated int (not lazy)
     nix_value * intValue = nix_alloc_value(ctx, state);
-    nix_init_int(ctx, intValue, 99);
+    nix_init_int(ctx, state, intValue, 99);
     assert_ctx_ok();
 
     // 3. Lazy function application that would compute increment 10 = 11
@@ -507,10 +507,10 @@ TEST_F(nix_api_expr_test, nix_get_attr_byidx_lazy)
 
     nix_expr_eval_from_string(ctx, state, "x: x + 1", "<test>", incrementFn);
     assert_ctx_ok();
-    nix_init_int(ctx, argTen, 10);
+    nix_init_int(ctx, state, argTen, 10);
 
     // Create a lazy application: (x: x + 1) 10
-    nix_init_apply(ctx, lazyApply, incrementFn, argTen);
+    nix_init_apply(ctx, state, lazyApply, incrementFn, argTen);
     assert_ctx_ok();
 
     BindingsBuilder * builder = nix_make_bindings_builder(ctx, state, 3);
@@ -579,7 +579,7 @@ TEST_F(nix_api_expr_test, nix_value_init)
     // f = a: a * a;
 
     nix_value * two = nix_alloc_value(ctx, state);
-    nix_init_int(ctx, two, 2);
+    nix_init_int(ctx, state, two, 2);
 
     nix_value * f = nix_alloc_value(ctx, state);
     nix_expr_eval_from_string(
@@ -596,7 +596,7 @@ TEST_F(nix_api_expr_test, nix_value_init)
     // r = f two;
 
     nix_value * r = nix_alloc_value(ctx, state);
-    nix_init_apply(ctx, r, f, two);
+    nix_init_apply(ctx, state, r, f, two);
     assert_ctx_ok();
 
     ValueType t = nix_get_type(ctx, r);
@@ -625,11 +625,11 @@ TEST_F(nix_api_expr_test, nix_value_init)
 TEST_F(nix_api_expr_test, nix_value_init_apply_error)
 {
     nix_value * some_string = nix_alloc_value(ctx, state);
-    nix_init_string(ctx, some_string, "some string");
+    nix_init_string(ctx, state, some_string, "some string");
     assert_ctx_ok();
 
     nix_value * v = nix_alloc_value(ctx, state);
-    nix_init_apply(ctx, v, some_string, some_string);
+    nix_init_apply(ctx, state, v, some_string, some_string);
     assert_ctx_ok();
 
     // All ok. Call has not been evaluated yet.
@@ -679,13 +679,13 @@ TEST_F(nix_api_expr_test, nix_value_init_apply_lazy_arg)
             g);
         assert_ctx_ok();
 
-        nix_init_apply(ctx, e, g, g);
+        nix_init_apply(ctx, state, e, g, g);
         assert_ctx_ok();
         nix_gc_decref(ctx, g);
     }
 
     nix_value * r = nix_alloc_value(ctx, state);
-    nix_init_apply(ctx, r, f, e);
+    nix_init_apply(ctx, state, r, f, e);
     assert_ctx_ok();
 
     nix_value_force(ctx, state, r);
@@ -711,7 +711,7 @@ TEST_F(nix_api_expr_test, nix_copy_value)
 {
     nix_value * source = nix_alloc_value(ctx, state);
 
-    nix_init_int(ctx, source, 42);
+    nix_init_int(ctx, state, source, 42);
     nix_copy_value(ctx, value, source);
 
     ASSERT_EQ(42, nix_get_int(ctx, value));


### PR DESCRIPTION
## Motivation
We will need this argument in the future as we put things in managed memory.

## Context
- See #14584 for an example.
- See [https://github.com/nixos/nix/issues/14088](managed heap tracking issue)

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

<!-- Briefly explain what the change is about and why it is desirable. -->

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
