### PR TITLE
docs: fixup a few relative links to use ./ prefix for consistency

### DIFF
--- a/doc/manual/source/command-ref/nix-build.md
+++ b/doc/manual/source/command-ref/nix-build.md
@@ -36,7 +36,7 @@ to a temporary location. The tarball must include a single top-level
 directory containing at least a file named `default.nix`.
 
 `nix-build` is essentially a wrapper around
-[`nix-instantiate`](nix-instantiate.md) (to translate a high-level Nix
+[`nix-instantiate`](./nix-instantiate.md) (to translate a high-level Nix
 expression to a low-level [store derivation]) and [`nix-store
 --realise`](@docroot@/command-ref/nix-store/realise.md) (to build the store
 derivation).
@@ -52,8 +52,8 @@ derivation).
 # Options
 
 All options not listed here are passed to
-[`nix-store --realise`](nix-store/realise.md),
-except for `--arg` and `--attr` / `-A` which are passed to [`nix-instantiate`](nix-instantiate.md).
+[`nix-store --realise`](./nix-store/realise.md),
+except for `--arg` and `--attr` / `-A` which are passed to [`nix-instantiate`](./nix-instantiate.md).
 
 - <span id="opt-no-out-link">[`--no-out-link`](#opt-no-out-link)<span>
 

--- a/doc/manual/source/command-ref/nix-instantiate.md
+++ b/doc/manual/source/command-ref/nix-instantiate.md
@@ -32,7 +32,7 @@ standard input.
 
 - `--add-root` *path*
 
-  See the [corresponding option](nix-store.md) in `nix-store`.
+  See the [corresponding option](./nix-store.md) in `nix-store`.
 
 - `--parse`
 

--- a/src/nix/profile-diff-closures.md
+++ b/src/nix/profile-diff-closures.md
@@ -23,6 +23,6 @@ R""(
 
 This command shows the difference between the closures of subsequent
 versions of a profile. See [`nix store
-diff-closures`](nix3-store-diff-closures.md) for details.
+diff-closures`](./nix3-store-diff-closures.md) for details.
 
 )""


### PR DESCRIPTION
"./" prefix is already used almost everywhere

## Motivation

This also makes it easier to clean away rellinks from manpages (until lowdown is improved - see https://github.com/kristapsdz/lowdown/issues/170)

## Context

- https://github.com/kristapsdz/lowdown/issues/170
- https://github.com/NixOS/nix/pull/13780

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
