### PR TITLE
Add `nix registry resolve` command

### DIFF
--- a/src/nix/registry-resolve.md
+++ b/src/nix/registry-resolve.md
@@ -1,0 +1,28 @@
+R""(
+
+# Examples
+
+* Resolve the `nixpkgs` and `blender-bin` flakerefs:
+
+  ```console
+  # nix registry resolve nixpkgs blender-bin
+  github:NixOS/nixpkgs/nixpkgs-unstable
+  github:edolstra/nix-warez?dir=blender
+  ```
+
+* Resolve an indirect flakeref with a branch override:
+
+  ```console
+  # nix registry resolve nixpkgs/25.05
+  github:NixOS/nixpkgs/25.05
+  ```
+
+# Description
+
+This command resolves indirect flakerefs (e.g. `nixpkgs`) to direct flakerefs (e.g. `github:NixOS/nixpkgs`) using the flake registries. It looks up each provided flakeref in all available registries (flag, user, system, and global) and returns the resolved direct flakeref on a separate line on standard output. It does not fetch any flakes.
+
+The resolution process may apply multiple redirections if necessary until a direct flakeref is found. If an indirect flakeref cannot be found in any registry, an error will be thrown.
+
+See the [`nix registry` manual page](./nix3-registry.md) for more details on the registry.
+
+)""

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -252,15 +252,17 @@ nix flake lock "$flake3Dir"
 nix flake update --flake "$flake3Dir" --override-flake flake2 nixpkgs
 [[ -n $(git -C "$flake3Dir" diff master || echo failed) ]]
 
-# Testing the nix CLI
+# Test `nix registry` commands.
 nix registry add flake1 flake3
 [[ $(nix registry list | wc -l) == 5 ]]
+[[ $(nix registry resolve flake1) = "git+file://$percentEncodedFlake3Dir" ]]
 nix registry pin flake1
 [[ $(nix registry list | wc -l) == 5 ]]
 nix registry pin flake1 flake3
 [[ $(nix registry list | wc -l) == 5 ]]
 nix registry remove flake1
 [[ $(nix registry list | wc -l) == 4 ]]
+[[ $(nix registry resolve flake1) = "git+file://$flake1Dir" ]]
 
 # Test 'nix registry list' with a disabled global registry.
 nix registry add user-flake1 git+file://"$flake1Dir"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This adds a new command `nix registry resolve` for doing registry lookups, e.g.
```
# nix registry resolve nixpkgs
github:NixOS/nixpkgs/nixpkgs-unstable
```

Previously we didn't really have a way to resolve registry indirections from the CLI without fetching the flake.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Taken from https://github.com/DeterminateSystems/nix-src/pull/273.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
