### PR TITLE
libutil: Remove really dead code for git hashing

### DIFF
--- a/src/libutil/include/nix/util/git.hh
+++ b/src/libutil/include/nix/util/git.hh
@@ -137,13 +137,6 @@ std::optional<Mode> convertMode(SourceAccessor::Type type);
 using RestoreHook = SourcePath(Hash);
 
 /**
- * Wrapper around `parse` and `RestoreSink`
- *
- * @param hashAlgo must be `HashAlgo::SHA1` or `HashAlgo::SHA256` for now.
- */
-void restore(FileSystemObjectSink & sink, Source & source, HashAlgorithm hashAlgo, std::function<RestoreHook> hook);
-
-/**
  * Dumps a single file to a sink
  *
  * @param xpSettings for testing purposes


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

It's not being excersised by anything and already contains bugs (like the fact that copyRecursive only handles the first entry in a directory). Evidently, it can just be removed and was never used by anything.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

https://github.com/NixOS/nix/pull/14597#discussion_r2543994512

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
