### PR TITLE
Turn one unsafe C cast into a safe `static_cast`

### DIFF
--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -322,7 +322,7 @@ static int main_build_remote(int argc, char ** argv)
             //    output ids, which break CA derivations
             if (!drv.inputDrvs.map.empty())
                 drv.inputSrcs = store->parseStorePathSet(inputs);
-            optResult = sshStore->buildDerivation(*drvPath, (const BasicDerivation &) drv);
+            optResult = sshStore->buildDerivation(*drvPath, static_cast<const BasicDerivation &>(drv));
             auto & result = *optResult;
             if (auto * failureP = result.tryGetFailure()) {
                 if (settings.keepFailed) {


### PR DESCRIPTION
## Motivation

Safety is better.

## Context

This bit me during a refactor.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
