### PR TITLE
WIP get rid of global `Settings` in libstore

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -4,6 +4,7 @@
 #include "nix/cmd/command.hh"
 #include "nix/cmd/legacy.hh"
 #include "nix/cmd/markdown.hh"
+#include "nix/main/shared.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/store-open.hh"
 #include "nix/store/local-fs-store.hh"
@@ -75,7 +76,7 @@ ref<StoreConfig> StoreConfigCommand::getStoreConfig()
 
 ref<StoreConfig> StoreConfigCommand::createStoreConfig()
 {
-    return resolveStoreConfig(StoreReference{settings.storeUri.get()});
+    return resolveStoreConfig(settings, StoreReference{settings.storeUri.get()});
 }
 
 void StoreConfigCommand::run()
@@ -129,7 +130,7 @@ CopyCommand::CopyCommand()
 
 ref<StoreConfig> CopyCommand::createStoreConfig()
 {
-    return !srcUri ? StoreCommand::createStoreConfig() : resolveStoreConfig(StoreReference{*srcUri});
+    return !srcUri ? StoreCommand::createStoreConfig() : resolveStoreConfig(settings, StoreReference{*srcUri});
 }
 
 ref<Store> CopyCommand::getDstStore()
@@ -137,7 +138,7 @@ ref<Store> CopyCommand::getDstStore()
     if (!srcUri && !dstUri)
         throw UsageError("you must pass '--from' and/or '--to'");
 
-    return !dstUri ? openStore() : openStore(StoreReference{*dstUri});
+    return !dstUri ? openStore(settings) : openStore(settings, StoreReference{*dstUri});
 }
 
 EvalCommand::EvalCommand()
@@ -159,7 +160,7 @@ EvalCommand::~EvalCommand()
 ref<Store> EvalCommand::getEvalStore()
 {
     if (!evalStore)
-        evalStore = evalStoreUrl ? openStore(StoreReference{*evalStoreUrl}) : getStore();
+        evalStore = evalStoreUrl ? openStore(settings, StoreReference{*evalStoreUrl}) : getStore();
     return ref<Store>(evalStore);
 }
 

--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -19,12 +19,12 @@
 
 namespace nix {
 
-fetchers::Settings fetchSettings;
+fetchers::Settings fetchSettings{settings};
 
 static GlobalConfig::Register rFetchSettings(&fetchSettings);
 
 EvalSettings evalSettings{
-    settings.readOnlyMode,
+    settings,
     {
         {
             "flake",
@@ -135,7 +135,7 @@ MixEvalArgs::MixEvalArgs()
             fetchers::overrideRegistry(from.input, to.input, extraAttrs);
         }},
         .completer = {[&](AddCompletions & completions, size_t, std::string_view prefix) {
-            completeFlakeRef(completions, openStore(), prefix);
+            completeFlakeRef(completions, openStore(settings), prefix);
         }},
     });
 

--- a/src/libcmd/get-build-log.cc
+++ b/src/libcmd/get-build-log.cc
@@ -4,9 +4,9 @@
 
 namespace nix {
 
-std::string fetchBuildLog(ref<Store> store, const StorePath & path, std::string_view what)
+std::string fetchBuildLog(Settings & settings, ref<Store> store, const StorePath & path, std::string_view what)
 {
-    auto subs = getDefaultSubstituters();
+    auto subs = getDefaultSubstituters(settings);
 
     subs.push_front(store);
 

--- a/src/libcmd/include/nix/cmd/get-build-log.hh
+++ b/src/libcmd/include/nix/cmd/get-build-log.hh
@@ -8,6 +8,8 @@
 
 namespace nix {
 
+class Settings;
+
 /**
  * Fetch the build log for a store path, searching the store and its
  * substituters.
@@ -18,6 +20,6 @@ namespace nix {
  * @return The build log content.
  * @throws Error if the build log is not available.
  */
-std::string fetchBuildLog(ref<Store> store, const StorePath & path, std::string_view what);
+std::string fetchBuildLog(Settings & settings, ref<Store> store, const StorePath & path, std::string_view what);
 
 } // namespace nix

--- a/src/libcmd/include/nix/cmd/installable-attr-path.hh
+++ b/src/libcmd/include/nix/cmd/installable-attr-path.hh
@@ -1,7 +1,6 @@
 #pragma once
 ///@file
 
-#include "nix/store/globals.hh"
 #include "nix/cmd/installable-value.hh"
 #include "nix/store/outputs-spec.hh"
 #include "nix/cmd/command.hh"

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -564,7 +564,7 @@ ProcessLineResult NixRepl::processLine(std::string line)
             settings.readOnlyMode = true;
             Finally roModeReset([&]() { settings.readOnlyMode = false; });
             RunPager pager;
-            auto log = fetchBuildLog(state->store, drvPath, drvPathRaw);
+            auto log = fetchBuildLog(settings, state->store, drvPath, drvPathRaw);
             logger->writeToStdout(log);
         } else {
             runNix("nix-shell", {drvPathRaw});

--- a/src/libexpr-c/nix_api_expr.cc
+++ b/src/libexpr-c/nix_api_expr.cc
@@ -132,9 +132,8 @@ nix_eval_state_builder * nix_eval_state_builder_new(nix_c_context * context, Sto
         return unsafe_new_with_self<nix_eval_state_builder>([&](auto * self) {
             return nix_eval_state_builder{
                 .store = nix::ref<nix::Store>(store->ptr),
-                .settings = nix::EvalSettings{/* &bool */ self->readOnlyMode},
-                .fetchSettings = nix::fetchers::Settings{},
-                .readOnlyMode = true,
+                .settings = nix::EvalSettings{cStoreSettings},
+                .fetchSettings = nix::fetchers::Settings{cStoreSettings},
             };
         });
     }
@@ -153,8 +152,7 @@ nix_err nix_eval_state_builder_load(nix_c_context * context, nix_eval_state_buil
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        // TODO: load in one go?
-        builder->settings.readOnlyMode = nix::settings.readOnlyMode;
+        loadConfFile(cStoreSettings);
         loadConfFile(builder->settings);
         loadConfFile(builder->fetchSettings);
     }

--- a/src/libexpr-c/nix_api_expr_internal.h
+++ b/src/libexpr-c/nix_api_expr_internal.h
@@ -16,8 +16,6 @@ struct nix_eval_state_builder
     nix::EvalSettings settings;
     nix::fetchers::Settings fetchSettings;
     nix::LookupPath lookupPath;
-    // TODO: make an EvalSettings setting own this instead?
-    bool readOnlyMode;
 };
 
 struct EvalState

--- a/src/libexpr-test-support/include/nix/expr/tests/libexpr.hh
+++ b/src/libexpr-test-support/include/nix/expr/tests/libexpr.hh
@@ -26,18 +26,18 @@ public:
     }
 
 protected:
-    LibExprTest(ref<Store> store, auto && makeEvalSettings)
-        : LibStoreTest()
-        , evalSettings(makeEvalSettings(readOnlyMode))
+    LibExprTest(auto && makeEvalSettings, auto &&... args)
+        : LibStoreTest(args...)
+        , evalSettings(makeEvalSettings(settings))
         , state({}, store, fetchSettings, evalSettings, nullptr)
     {
     }
 
     LibExprTest()
-        : LibExprTest(openStore("dummy://"), [](bool & readOnlyMode) {
-            EvalSettings settings{readOnlyMode};
-            settings.nixPath = {};
-            return settings;
+        : LibExprTest([](Settings & settings) {
+            EvalSettings evalSettings{settings};
+            evalSettings.nixPath = {};
+            return evalSettings;
         })
     {
     }
@@ -66,8 +66,8 @@ protected:
     }
 
     bool readOnlyMode = true;
-    fetchers::Settings fetchSettings{};
-    EvalSettings evalSettings{readOnlyMode};
+    fetchers::Settings fetchSettings{settings};
+    EvalSettings evalSettings{settings};
     EvalState state;
 };
 

--- a/src/libexpr-tests/eval.cc
+++ b/src/libexpr-tests/eval.cc
@@ -179,12 +179,15 @@ class PureEvalTest : public LibExprTest
 {
 public:
     PureEvalTest()
-        : LibExprTest(openStore("dummy://", {{"read-only", "false"}}), [](bool & readOnlyMode) {
-            EvalSettings settings{readOnlyMode};
-            settings.pureEval = true;
-            settings.restrictEval = true;
-            return settings;
-        })
+        : LibExprTest{
+              [](auto & settings) {
+                  EvalSettings evalSettings{settings};
+                  evalSettings.pureEval = true;
+                  evalSettings.restrictEval = true;
+                  return evalSettings;
+              },
+              [](auto & settings) { return openStore(settings, "dummy://", {{"read-only", "false"}}); },
+          }
     {
     }
 };

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -63,7 +63,7 @@ struct AttrDb
 
     SymbolTable & symbols;
 
-    AttrDb(const StoreDirConfig & cfg, const Hash & fingerprint, SymbolTable & symbols)
+    AttrDb(bool useSQLiteWAL, const StoreDirConfig & cfg, const Hash & fingerprint, SymbolTable & symbols)
         : cfg(cfg)
         , _state(std::make_unique<Sync<State>>())
         , symbols(symbols)
@@ -75,7 +75,7 @@ struct AttrDb
 
         auto dbPath = cacheDir / (fingerprint.to_string(HashFormat::Base16, false) + ".sqlite");
 
-        state->db = SQLite(dbPath, {.useWAL = settings.useSQLiteWAL});
+        state->db = SQLite(dbPath, {.useWAL = useSQLiteWAL});
         state->db.isCache();
         state->db.exec(schema);
 
@@ -287,10 +287,11 @@ struct AttrDb
     }
 };
 
-static std::shared_ptr<AttrDb> makeAttrDb(const StoreDirConfig & cfg, const Hash & fingerprint, SymbolTable & symbols)
+static std::shared_ptr<AttrDb>
+makeAttrDb(bool useSQLiteWAL, const StoreDirConfig & cfg, const Hash & fingerprint, SymbolTable & symbols)
 {
     try {
-        return std::make_shared<AttrDb>(cfg, fingerprint, symbols);
+        return std::make_shared<AttrDb>(useSQLiteWAL, cfg, fingerprint, symbols);
     } catch (SQLiteError &) {
         ignoreExceptionExceptInterrupt();
         return nullptr;
@@ -299,7 +300,8 @@ static std::shared_ptr<AttrDb> makeAttrDb(const StoreDirConfig & cfg, const Hash
 
 EvalCache::EvalCache(
     std::optional<std::reference_wrapper<const Hash>> useCache, EvalState & state, RootLoader rootLoader)
-    : db(useCache ? makeAttrDb(*state.store, *useCache, state.symbols) : nullptr)
+    : db(useCache ? makeAttrDb(state.store->config.settings.useSQLiteWAL, *state.store, *useCache, state.symbols)
+                  : nullptr)
     , state(state)
     , rootLoader(rootLoader)
 {
@@ -707,7 +709,7 @@ StorePath AttrCursor::forceDerivation()
     auto aDrvPath = getAttr(root->state.s.drvPath);
     auto drvPath = root->state.store->parseStorePath(aDrvPath->getString());
     drvPath.requireDerivation();
-    if (!root->state.store->isValidPath(drvPath) && !settings.readOnlyMode) {
+    if (!root->state.store->isValidPath(drvPath) && !root->state.store->config.settings.readOnlyMode) {
         /* The eval cache contains 'drvPath', but the actual path has
            been garbage-collected. So force it to be regenerated. */
         aDrvPath->forceValue();

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -15,6 +15,7 @@
 #include "nix/store/filetransfer.hh"
 #include "nix/expr/function-trace.hh"
 #include "nix/store/profiles.hh"
+#include "nix/store/globals.hh"
 #include "nix/expr/print.hh"
 #include "nix/fetchers/filtering-source-accessor.hh"
 #include "nix/util/memory-source-accessor.hh"
@@ -330,7 +331,7 @@ EvalState::EvalState(
             lookupPath.elements.emplace_back(LookupPath::Elem::parse(i));
         }
         if (!settings.restrictEval) {
-            for (auto & i : EvalSettings::getDefaultNixPath()) {
+            for (auto & i : EvalSettings::getDefaultNixPath(store->config.settings)) {
                 lookupPath.elements.emplace_back(LookupPath::Elem::parse(i));
             }
         }
@@ -2508,7 +2509,7 @@ StorePath EvalState::copyPathToStore(NixStringContext & context, const SourcePat
             fetchSettings,
             *store,
             path.resolveSymlinks(SymlinkResolution::Ancestors),
-            settings.readOnlyMode ? FetchMode::DryRun : FetchMode::Copy,
+            settings.storeSettings.readOnlyMode ? FetchMode::DryRun : FetchMode::Copy,
             path.baseName(),
             ContentAddressMethod::Raw::NixArchive,
             nullptr,

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -9,9 +9,15 @@ namespace nix {
 
 class EvalState;
 struct PrimOp;
+class Settings;
 
 struct EvalSettings : Config
 {
+    /**
+     * Reference to the "parent" store-layer settings.
+     */
+    nix::Settings & storeSettings;
+
     /**
      * Function used to interpret look path entries of a given scheme.
      *
@@ -38,11 +44,9 @@ struct EvalSettings : Config
      */
     using LookupPathHooks = std::map<std::string, std::function<LookupPathHook>>;
 
-    EvalSettings(bool & readOnlyMode, LookupPathHooks lookupPathHooks = {});
+    EvalSettings(nix::Settings & settings, LookupPathHooks lookupPathHooks = {});
 
-    bool & readOnlyMode;
-
-    static Strings getDefaultNixPath();
+    static Strings getDefaultNixPath(nix::Settings & settings);
 
     static bool isPseudoUrl(std::string_view s);
 
@@ -366,6 +370,6 @@ struct EvalSettings : Config
 /**
  * Conventionally part of the default nix path in impure mode.
  */
-std::filesystem::path getNixDefExpr();
+std::filesystem::path getNixDefExpr(const Settings & settings);
 
 } // namespace nix

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -271,7 +271,7 @@ static void prim_appendContext(EvalState & state, const PosIdx pos, Value ** arg
         if (!state.store->isStorePath(name))
             state.error<EvalError>("context key '%s' is not a store path", name).atPos(i.pos).debugThrow();
         auto namePath = state.store->parseStorePath(name);
-        if (!settings.readOnlyMode)
+        if (!state.settings.storeSettings.readOnlyMode)
             state.store->ensurePath(namePath);
         state.forceAttrs(*i.value, i.pos, "while evaluating the value of a string context");
 

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -209,7 +209,7 @@ static void prim_fetchClosure(EvalState & state, const PosIdx pos, Value ** args
             {.msg = HintFmt("'fetchClosure' does not support URL query parameters (in '%s')", *fromStoreUrl),
              .pos = state.positions[pos]});
 
-    auto fromStore = openStore(std::move(storeRef));
+    auto fromStore = openStore(state.settings.storeSettings, std::move(storeRef));
 
     if (toPath)
         runFetchClosureWithRewrite(state, pos, *fromStore, *fromPath, *toPath, v);

--- a/src/libfetchers-c/nix_api_fetchers.cc
+++ b/src/libfetchers-c/nix_api_fetchers.cc
@@ -1,13 +1,14 @@
 #include "nix_api_fetchers.h"
 #include "nix_api_fetchers_internal.hh"
 #include "nix_api_util_internal.h"
+#include "nix_api_store_internal.h"
 
 extern "C" {
 
 nix_fetchers_settings * nix_fetchers_settings_new(nix_c_context * context)
 {
     try {
-        auto fetchersSettings = nix::make_ref<nix::fetchers::Settings>(nix::fetchers::Settings{});
+        auto fetchersSettings = nix::make_ref<nix::fetchers::Settings>(nix::fetchers::Settings{cStoreSettings});
         return new nix_fetchers_settings{
             .settings = fetchersSettings,
         };

--- a/src/libfetchers-tests/access-tokens.cc
+++ b/src/libfetchers-tests/access-tokens.cc
@@ -1,9 +1,12 @@
 #include <nlohmann/json.hpp>
 #include <gtest/gtest.h>
 
+#include "nix/util/json-utils.hh"
+#include "nix/store/globals.hh"
 #include "nix/fetchers/fetchers.hh"
 #include "nix/fetchers/fetch-settings.hh"
-#include "nix/util/json-utils.hh"
+
+#include "nix/store/tests/test-main.hh"
 #include "nix/util/tests/characterization.hh"
 
 namespace nix::fetchers {
@@ -25,7 +28,8 @@ public:
 
 TEST_F(AccessKeysTest, singleOrgGitHub)
 {
-    fetchers::Settings fetchSettings = fetchers::Settings{};
+    auto settings = getTestSettings();
+    fetchers::Settings fetchSettings = fetchers::Settings{settings};
     fetchSettings.accessTokens.get().insert({"github.com/a", "token"});
     auto i = Input::fromURL(fetchSettings, "github:a/b");
 
@@ -35,7 +39,8 @@ TEST_F(AccessKeysTest, singleOrgGitHub)
 
 TEST_F(AccessKeysTest, nonMatches)
 {
-    fetchers::Settings fetchSettings = fetchers::Settings{};
+    auto settings = getTestSettings();
+    fetchers::Settings fetchSettings = fetchers::Settings{settings};
     fetchSettings.accessTokens.get().insert({"github.com", "token"});
     auto i = Input::fromURL(fetchSettings, "gitlab:github.com/evil");
 
@@ -45,7 +50,8 @@ TEST_F(AccessKeysTest, nonMatches)
 
 TEST_F(AccessKeysTest, noPartialMatches)
 {
-    fetchers::Settings fetchSettings = fetchers::Settings{};
+    auto settings = getTestSettings();
+    fetchers::Settings fetchSettings = fetchers::Settings{settings};
     fetchSettings.accessTokens.get().insert({"github.com/partial", "token"});
     auto i = Input::fromURL(fetchSettings, "github:partial-match/repo");
 
@@ -55,7 +61,8 @@ TEST_F(AccessKeysTest, noPartialMatches)
 
 TEST_F(AccessKeysTest, repoGitHub)
 {
-    fetchers::Settings fetchSettings = fetchers::Settings{};
+    auto settings = getTestSettings();
+    fetchers::Settings fetchSettings = fetchers::Settings{settings};
     fetchSettings.accessTokens.get().insert({"github.com", "token"});
     fetchSettings.accessTokens.get().insert({"github.com/a/b", "another_token"});
     fetchSettings.accessTokens.get().insert({"github.com/a/c", "yet_another_token"});
@@ -73,7 +80,8 @@ TEST_F(AccessKeysTest, repoGitHub)
 
 TEST_F(AccessKeysTest, multipleGitLab)
 {
-    fetchers::Settings fetchSettings = fetchers::Settings{};
+    auto settings = getTestSettings();
+    fetchers::Settings fetchSettings = fetchers::Settings{settings};
     fetchSettings.accessTokens.get().insert({"gitlab.com", "token"});
     fetchSettings.accessTokens.get().insert({"gitlab.com/a/b", "another_token"});
     auto i = Input::fromURL(fetchSettings, "gitlab:a/b");
@@ -87,7 +95,8 @@ TEST_F(AccessKeysTest, multipleGitLab)
 
 TEST_F(AccessKeysTest, multipleSourceHut)
 {
-    fetchers::Settings fetchSettings = fetchers::Settings{};
+    auto settings = getTestSettings();
+    fetchers::Settings fetchSettings = fetchers::Settings{settings};
     fetchSettings.accessTokens.get().insert({"git.sr.ht", "token"});
     fetchSettings.accessTokens.get().insert({"git.sr.ht/~a/b", "another_token"});
     auto i = Input::fromURL(fetchSettings, "sourcehut:a/b");

--- a/src/libfetchers-tests/input.cc
+++ b/src/libfetchers-tests/input.cc
@@ -1,6 +1,10 @@
+#include "nix/store/globals.hh"
+
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/fetchers/attrs.hh"
 #include "nix/fetchers/fetchers.hh"
+
+#include "nix/store/tests/test-main.hh"
 
 #include <gtest/gtest.h>
 
@@ -23,7 +27,8 @@ class InputFromAttrsTest : public ::testing::WithParamInterface<InputFromAttrsTe
 
 TEST_P(InputFromAttrsTest, attrsAreCorrectAndRoundTrips)
 {
-    fetchers::Settings fetchSettings;
+    auto settings = getTestSettings();
+    fetchers::Settings fetchSettings{settings};
 
     const auto & testCase = GetParam();
 

--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -47,7 +47,7 @@ struct CacheImpl : Cache
         auto dbPath = (getCacheDir() / "fetcher-cache-v4.sqlite").string();
         createDirs(dirOf(dbPath));
 
-        state->db = SQLite(dbPath, {.useWAL = nix::settings.useSQLiteWAL});
+        state->db = SQLite(dbPath, {.useWAL = settings.storeSettings.useSQLiteWAL});
         state->db.isCache();
         state->db.exec(schema);
 

--- a/src/libfetchers/fetch-settings.cc
+++ b/src/libfetchers/fetch-settings.cc
@@ -2,6 +2,9 @@
 
 namespace nix::fetchers {
 
-Settings::Settings() {}
+Settings::Settings(const nix::Settings & storeSettings)
+    : storeSettings(storeSettings)
+{
+}
 
 } // namespace nix::fetchers

--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -76,8 +76,8 @@ std::pair<StorePath, Hash> fetchToStore2(
     auto [storePath, hash] =
         mode == FetchMode::DryRun
             ? [&]() {
-                  auto [storePath, hash] =
-                      store.computeStorePath(name, path, method, HashAlgorithm::SHA256, {}, filter2);
+                  auto [storePath, hash] = store.computeStorePath(
+                      store.config.settings, name, path, method, HashAlgorithm::SHA256, {}, filter2);
                   debug(
                       "hashed '%s' to '%s' (hash '%s')",
                       path,

--- a/src/libfetchers/include/nix/fetchers/fetch-settings.hh
+++ b/src/libfetchers/include/nix/fetchers/fetch-settings.hh
@@ -13,9 +13,10 @@
 
 namespace nix {
 
+class Settings;
 struct GitRepo;
 
-}
+} // namespace nix
 
 namespace nix::fetchers {
 
@@ -23,7 +24,12 @@ struct Cache;
 
 struct Settings : public Config
 {
-    Settings();
+    /**
+     * Reference to the "parent" store-layer settings.
+     */
+    const nix::Settings & storeSettings;
+
+    Settings(const nix::Settings & storeSettings);
 
     Setting<StringMap> accessTokens{
         this,

--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -3,6 +3,7 @@
 #include <string>
 #include <utility>
 
+#include "nix/store/globals.hh"
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/flake/flakeref.hh"
 #include "nix/fetchers/attrs.hh"
@@ -19,7 +20,8 @@ TEST(parseFlakeRef, path)
 {
     experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
 
-    fetchers::Settings fetchSettings;
+    Settings settings;
+    fetchers::Settings fetchSettings{settings};
 
     {
         auto s = "/foo/bar";
@@ -69,7 +71,8 @@ TEST(parseFlakeRef, GitArchiveInput)
 {
     experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
 
-    fetchers::Settings fetchSettings;
+    Settings settings;
+    fetchers::Settings fetchSettings{settings};
 
     {
         auto s = "github:foo/bar/branch%23"; // branch name with `#`
@@ -112,7 +115,8 @@ class InputFromURLTest : public ::testing::WithParamInterface<InputFromURLTestCa
 TEST_P(InputFromURLTest, attrsAreCorrectAndRoundTrips)
 {
     experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
-    fetchers::Settings fetchSettings;
+    Settings settings;
+    fetchers::Settings fetchSettings{settings};
 
     const auto & testCase = GetParam();
 
@@ -274,7 +278,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(to_string, doesntReencodeUrl)
 {
-    fetchers::Settings fetchSettings;
+    Settings settings;
+    fetchers::Settings fetchSettings{settings};
     auto s = "http://localhost:8181/test/+3d.tar.gz";
     auto flakeref = parseFlakeRef(fetchSettings, s);
     auto unparsed = flakeref.to_string();

--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -8,6 +8,7 @@
 #include "nix/main/loggers.hh"
 #include "nix/util/util.hh"
 #include "nix/main/plugin.hh"
+#include "nix/main/shared.hh"
 
 namespace nix {
 

--- a/src/libmain/include/nix/main/shared.hh
+++ b/src/libmain/include/nix/main/shared.hh
@@ -13,6 +13,13 @@
 
 namespace nix {
 
+class Settings;
+
+// FIXME: don't use a global variable.
+extern Settings settings;
+
+int handleExceptions(const std::string & programName, std::function<void()> fun);
+
 /**
  * Don't forget to call initPlugins() after settings are initialized!
  * @param loadConfig Whether to load configuration from `nix.conf`, `NIX_CONFIG`, etc. May be disabled for unit tests.

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -31,11 +31,16 @@
 
 #include "nix/util/exit.hh"
 #include "nix/util/strings.hh"
+#include "nix/util/config-global.hh"
 
 #include "main-config-private.hh"
 #include "nix/expr/config.hh"
 
 namespace nix {
+
+Settings settings;
+
+static GlobalConfig::Register rSettings(&settings);
 
 char ** savedArgv;
 
@@ -335,8 +340,8 @@ void printVersion(const std::string & programName)
         std::cout << "System configuration file: " << nixConfFile() << "\n";
         std::cout << "User configuration files: "
                   << os_string_to_string(ExecutablePath{.directories = nixUserConfFiles()}.render()) << "\n";
-        std::cout << "Store directory: " << resolveStoreConfig(StoreReference{settings.storeUri.get()})->storeDir
-                  << "\n";
+        std::cout << "Store directory: "
+                  << resolveStoreConfig(settings, StoreReference{settings.storeUri.get()})->storeDir << "\n";
         std::cout << "State directory: " << settings.nixStateDir << "\n";
     }
     throw Exit();

--- a/src/libstore-c/nix_api_store_internal.h
+++ b/src/libstore-c/nix_api_store_internal.h
@@ -5,6 +5,8 @@
 
 extern "C" {
 
+extern nix::Settings cStoreSettings;
+
 struct Store
 {
     nix::ref<nix::Store> ptr;

--- a/src/libstore-test-support/https-store.cc
+++ b/src/libstore-test-support/https-store.cc
@@ -1,4 +1,5 @@
 #include "nix/store/tests/https-store.hh"
+#include "nix/store/tests/test-main.hh"
 
 #include <thread>
 
@@ -36,9 +37,9 @@ void HttpsBinaryCacheStoreTest::SetUp()
     cacheDir = tmpDir / "cache";
     delTmpDir = std::make_unique<AutoDelete>(tmpDir);
 
-    localCacheStore =
-        make_ref<LocalBinaryCacheStoreConfig>("file", cacheDir.string(), LocalBinaryCacheStoreConfig::Params{})
-            ->openStore();
+    localCacheStore = make_ref<LocalBinaryCacheStoreConfig>(
+                          settings, "file", cacheDir.string(), LocalBinaryCacheStoreConfig::Params{})
+                          ->openStore();
 
     caCert = tmpDir / "ca.crt";
     caKey = tmpDir / "ca.key";
@@ -121,6 +122,7 @@ std::vector<std::string> HttpsBinaryCacheStoreMtlsTest::serverArgs()
 ref<TestHttpBinaryCacheStoreConfig> HttpsBinaryCacheStoreTest::makeConfig()
 {
     auto res = make_ref<TestHttpBinaryCacheStoreConfig>(
+        settings,
         ParsedURL{
             .scheme = "https",
             .authority =

--- a/src/libstore-test-support/include/nix/store/tests/https-store.hh
+++ b/src/libstore-test-support/include/nix/store/tests/https-store.hh
@@ -12,6 +12,8 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/processes.hh"
 
+#include "nix/store/tests/test-main.hh"
+
 namespace nix::testing {
 
 class TestHttpBinaryCacheStoreConfig;
@@ -42,9 +44,9 @@ public:
 class TestHttpBinaryCacheStoreConfig : public HttpBinaryCacheStoreConfig
 {
 public:
-    TestHttpBinaryCacheStoreConfig(ParsedURL url, const Store::Config::Params & params)
-        : StoreConfig(params)
-        , HttpBinaryCacheStoreConfig(url, params)
+    TestHttpBinaryCacheStoreConfig(nix::Settings & settings, ParsedURL url, const Store::Config::Params & params)
+        : StoreConfig(settings, params)
+        , HttpBinaryCacheStoreConfig(settings, url, params)
     {
     }
 
@@ -56,6 +58,8 @@ class HttpsBinaryCacheStoreTest : public virtual LibStoreNetworkTest
     std::unique_ptr<AutoDelete> delTmpDir;
 
 public:
+    Settings settings = getTestSettings();
+
     static void SetUpTestSuite()
     {
         initLibStore(/*loadConfig=*/false);

--- a/src/libstore-test-support/include/nix/store/tests/libstore.hh
+++ b/src/libstore-test-support/include/nix/store/tests/libstore.hh
@@ -7,6 +7,7 @@
 #include "nix/store/store-api.hh"
 #include "nix/store/store-open.hh"
 #include "nix/store/globals.hh"
+#include "nix/store/tests/test-main.hh"
 
 namespace nix {
 
@@ -18,14 +19,16 @@ public:
         initLibStore(false);
     }
 
+    Settings settings = getTestSettings();
+
 protected:
-    LibStoreTest(ref<Store> store)
-        : store(std::move(store))
+    LibStoreTest(auto && makeStore)
+        : store(makeStore(settings))
     {
     }
 
     LibStoreTest()
-        : LibStoreTest(openStore("dummy://"))
+        : LibStoreTest([](auto & settings) { return openStore(settings, "dummy://"); })
     {
     }
 

--- a/src/libstore-test-support/include/nix/store/tests/test-main.hh
+++ b/src/libstore-test-support/include/nix/store/tests/test-main.hh
@@ -4,6 +4,13 @@
 
 namespace nix {
 
+class Settings;
+
+/**
+ * Get a Settings object configured appropriately for unit testing.
+ */
+Settings getTestSettings();
+
 /**
  * Call this for a GTest test suite that will including performing Nix
  * builds, before running tests.

--- a/src/libstore-test-support/test-main.cc
+++ b/src/libstore-test-support/test-main.cc
@@ -7,12 +7,9 @@
 
 namespace nix {
 
-int testMainForBuidingPre(int argc, char ** argv)
+Settings getTestSettings()
 {
-    if (argc > 1 && std::string_view(argv[1]) == "__build-remote") {
-        printError("test-build-remote: not supported in libexpr unit tests");
-        return EXIT_FAILURE;
-    }
+    Settings settings;
 
     // Disable build hook. We won't be testing remote builds in these unit tests. If we do, fix the above build hook.
     settings.getWorkerSettings().buildHook = {};
@@ -40,6 +37,16 @@ int testMainForBuidingPre(int argc, char ** argv)
     settings.getLocalSettings().sandboxMode = smDisabled;
     setEnv("_NIX_TEST_NO_SANDBOX", "1");
 #endif
+
+    return settings;
+}
+
+int testMainForBuidingPre(int argc, char ** argv)
+{
+    if (argc > 1 && std::string_view(argv[1]) == "__build-remote") {
+        printError("test-build-remote: not supported in libexpr unit tests");
+        return EXIT_FAILURE;
+    }
 
     return EXIT_SUCCESS;
 }

--- a/src/libstore-tests/derivation-advanced-attrs.cc
+++ b/src/libstore-tests/derivation-advanced-attrs.cc
@@ -193,7 +193,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_defaults)
 
         EXPECT_EQ(options, advancedAttributes_defaults);
 
-        EXPECT_EQ(options.substitutesAllowed(settings.getWorkerSettings()), true);
+        EXPECT_EQ(options.substitutesAllowed(this->settings.getWorkerSettings()), true);
         EXPECT_EQ(options.useUidRange(got), false);
     });
 };
@@ -241,7 +241,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes)
 
         EXPECT_EQ(options, expected);
 
-        EXPECT_EQ(options.substitutesAllowed(settings.getWorkerSettings()), false);
+        EXPECT_EQ(options.substitutesAllowed(this->settings.getWorkerSettings()), false);
         EXPECT_EQ(options.useUidRange(got), true);
     });
 };
@@ -333,7 +333,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs_d
 
         EXPECT_EQ(options, advancedAttributes_structuredAttrs_defaults);
 
-        EXPECT_EQ(options.substitutesAllowed(settings.getWorkerSettings()), true);
+        EXPECT_EQ(options.substitutesAllowed(this->settings.getWorkerSettings()), true);
         EXPECT_EQ(options.useUidRange(got), false);
     });
 };
@@ -398,7 +398,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs)
 
         EXPECT_EQ(options, expected);
 
-        EXPECT_EQ(options.substitutesAllowed(settings.getWorkerSettings()), false);
+        EXPECT_EQ(options.substitutesAllowed(this->settings.getWorkerSettings()), false);
         EXPECT_EQ(options.useUidRange(got), true);
     });
 };

--- a/src/libstore-tests/derivation/invariants.cc
+++ b/src/libstore-tests/derivation/invariants.cc
@@ -16,11 +16,11 @@ class FillInOutputPathsTest : public LibStoreTest, public JsonCharacterizationTe
 
 protected:
     FillInOutputPathsTest()
-        : LibStoreTest([]() {
-            auto config = make_ref<DummyStoreConfig>(DummyStoreConfig::Params{});
+        : LibStoreTest([](auto & settings) {
+            auto config = make_ref<DummyStoreConfig>(settings, DummyStoreConfig::Params{});
             config->readOnly = false;
             return config->openDummyStore();
-        }())
+        })
     {
     }
 

--- a/src/libstore-tests/http-binary-cache-store.cc
+++ b/src/libstore-tests/http-binary-cache-store.cc
@@ -1,38 +1,44 @@
 #include <gtest/gtest.h>
 #include <regex>
 
+#include "nix/store/globals.hh"
 #include "nix/store/http-binary-cache-store.hh"
 #include "nix/store/tests/https-store.hh"
 #include "nix/util/fs-sink.hh"
+#include "nix/store/tests/test-main.hh"
 
 namespace nix {
 
 TEST(HttpBinaryCacheStore, constructConfig)
 {
-    HttpBinaryCacheStoreConfig config{"http", "foo.bar.baz", {}};
+    auto settings = getTestSettings();
+    HttpBinaryCacheStoreConfig config{settings, "http", "foo.bar.baz", {}};
 
     EXPECT_EQ(config.cacheUri.to_string(), "http://foo.bar.baz");
 }
 
 TEST(HttpBinaryCacheStore, constructConfigNoTrailingSlash)
 {
-    HttpBinaryCacheStoreConfig config{"https", "foo.bar.baz/a/b/", {}};
+    auto settings = getTestSettings();
+    HttpBinaryCacheStoreConfig config{settings, "https", "foo.bar.baz/a/b/", {}};
 
     EXPECT_EQ(config.cacheUri.to_string(), "https://foo.bar.baz/a/b");
 }
 
 TEST(HttpBinaryCacheStore, constructConfigWithParams)
 {
+    auto settings = getTestSettings();
     StoreConfig::Params params{{"compression", "xz"}};
-    HttpBinaryCacheStoreConfig config{"https", "foo.bar.baz/a/b/", params};
+    HttpBinaryCacheStoreConfig config{settings, "https", "foo.bar.baz/a/b/", params};
     EXPECT_EQ(config.cacheUri.to_string(), "https://foo.bar.baz/a/b");
     EXPECT_EQ(config.getReference().params, params);
 }
 
 TEST(HttpBinaryCacheStore, constructConfigWithParamsAndUrlWithParams)
 {
+    auto settings = getTestSettings();
     StoreConfig::Params params{{"compression", "xz"}};
-    HttpBinaryCacheStoreConfig config{"https", "foo.bar.baz/a/b?some-param=some-value", params};
+    HttpBinaryCacheStoreConfig config{settings, "https", "foo.bar.baz/a/b?some-param=some-value", params};
     EXPECT_EQ(config.cacheUri.to_string(), "https://foo.bar.baz/a/b?some-param=some-value");
     EXPECT_EQ(config.getReference().params, params);
 }

--- a/src/libstore-tests/legacy-ssh-store.cc
+++ b/src/libstore-tests/legacy-ssh-store.cc
@@ -1,12 +1,16 @@
 #include <gtest/gtest.h>
 
+#include "nix/store/globals.hh"
 #include "nix/store/legacy-ssh-store.hh"
+#include "nix/store/tests/test-main.hh"
 
 namespace nix {
 
 TEST(LegacySSHStore, constructConfig)
 {
+    auto settings = getTestSettings();
     LegacySSHStoreConfig config(
+        settings,
         "ssh",
         "me@localhost:2222",
         StoreConfig::Params{

--- a/src/libstore-tests/local-binary-cache-store.cc
+++ b/src/libstore-tests/local-binary-cache-store.cc
@@ -1,12 +1,14 @@
 #include <gtest/gtest.h>
 
+#include "nix/store/globals.hh"
 #include "nix/store/local-binary-cache-store.hh"
 
 namespace nix {
 
 TEST(LocalBinaryCacheStore, constructConfig)
 {
-    LocalBinaryCacheStoreConfig config{"local", "/foo/bar/baz", {}};
+    Settings settings;
+    LocalBinaryCacheStoreConfig config{settings, "local", "/foo/bar/baz", {}};
 
     EXPECT_EQ(config.binaryCacheDir, "/foo/bar/baz");
 }

--- a/src/libstore-tests/local-overlay-store.cc
+++ b/src/libstore-tests/local-overlay-store.cc
@@ -1,12 +1,16 @@
 #include <gtest/gtest.h>
 
+#include "nix/store/globals.hh"
 #include "nix/store/local-overlay-store.hh"
+#include "nix/store/tests/test-main.hh"
 
 namespace nix {
 
 TEST(LocalOverlayStore, constructConfig_rootQueryParam)
 {
+    auto settings = getTestSettings();
     LocalOverlayStoreConfig config{
+        settings,
         "local-overlay",
         "",
         {
@@ -22,7 +26,8 @@ TEST(LocalOverlayStore, constructConfig_rootQueryParam)
 
 TEST(LocalOverlayStore, constructConfig_rootPath)
 {
-    LocalOverlayStoreConfig config{"local-overlay", "/foo/bar", {}};
+    auto settings = getTestSettings();
+    LocalOverlayStoreConfig config{settings, "local-overlay", "/foo/bar", {}};
 
     EXPECT_EQ(config.rootDir.get(), std::optional{"/foo/bar"});
 }

--- a/src/libstore-tests/local-store.cc
+++ b/src/libstore-tests/local-store.cc
@@ -1,18 +1,16 @@
 #include <gtest/gtest.h>
 
+#include "nix/store/globals.hh"
 #include "nix/store/local-store.hh"
-
-// Needed for template specialisations. This is not good! When we
-// overhaul how store configs work, this should be fixed.
-#include "nix/util/args.hh"
-#include "nix/util/config-impl.hh"
-#include "nix/util/abstract-setting-to-json.hh"
+#include "nix/store/tests/test-main.hh"
 
 namespace nix {
 
 TEST(LocalStore, constructConfig_rootQueryParam)
 {
+    auto settings = getTestSettings();
     LocalStoreConfig config{
+        settings,
         "local",
         "",
         {
@@ -28,14 +26,16 @@ TEST(LocalStore, constructConfig_rootQueryParam)
 
 TEST(LocalStore, constructConfig_rootPath)
 {
-    LocalStoreConfig config{"local", "/foo/bar", {}};
+    auto settings = getTestSettings();
+    LocalStoreConfig config{settings, "local", "/foo/bar", {}};
 
     EXPECT_EQ(config.rootDir.get(), std::optional{"/foo/bar"});
 }
 
 TEST(LocalStore, constructConfig_to_string)
 {
-    LocalStoreConfig config{"local", "", {}};
+    auto settings = getTestSettings();
+    LocalStoreConfig config{settings, "local", "", {}};
     EXPECT_EQ(config.getReference().to_string(), "local");
 }
 

--- a/src/libstore-tests/nar-info-disk-cache.cc
+++ b/src/libstore-tests/nar-info-disk-cache.cc
@@ -1,10 +1,12 @@
-#include "nix/store/nar-info-disk-cache.hh"
-
 #include <gtest/gtest.h>
 #include <rapidcheck/gtest.h>
 #include "nix/store/globals.hh"
 #include "nix/store/sqlite.hh"
 #include <sqlite3.h>
+
+#include "nix/store/globals.hh"
+#include "nix/store/sqlite.hh"
+#include "nix/store/nar-info-disk-cache.hh"
 
 namespace nix {
 
@@ -23,6 +25,8 @@ TEST(NarInfoDiskCacheImpl, create_and_read)
     int barId;
     SQLite db;
     SQLiteStmt getIds;
+
+    Settings settings;
 
     {
         auto cache = NarInfoDiskCache::getTest(

--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -299,7 +299,7 @@ public:
         nix_api_store_test_base::SetUp();
 
         nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-        nix::settings.getWorkerSettings().substituters = {};
+        cStoreSettings.getWorkerSettings().substituters = {};
 
         store = open_local_store();
 
@@ -309,7 +309,7 @@ public:
         buffer << t.rdbuf();
 
         // Replace the hardcoded system with the current system
-        std::string jsonStr = nix::replaceStrings(buffer.str(), "x86_64-linux", nix::settings.thisSystem.get());
+        std::string jsonStr = nix::replaceStrings(buffer.str(), "x86_64-linux", cStoreSettings.thisSystem.get());
 
         drv = nix_derivation_from_json(ctx, store, jsonStr.c_str());
         assert_ctx_ok();
@@ -354,7 +354,7 @@ TEST_F(nix_api_store_test_base, build_from_json)
 {
     // FIXME get rid of these
     nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-    nix::settings.getWorkerSettings().substituters = {};
+    cStoreSettings.getWorkerSettings().substituters = {};
 
     auto * store = open_local_store();
 
@@ -365,7 +365,7 @@ TEST_F(nix_api_store_test_base, build_from_json)
     buffer << t.rdbuf();
 
     // Replace the hardcoded system with the current system
-    std::string jsonStr = nix::replaceStrings(buffer.str(), "x86_64-linux", nix::settings.thisSystem.get());
+    std::string jsonStr = nix::replaceStrings(buffer.str(), "x86_64-linux", cStoreSettings.thisSystem.get());
 
     auto * drv = nix_derivation_from_json(ctx, store, jsonStr.c_str());
     assert_ctx_ok();
@@ -401,7 +401,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_invalid_system)
 {
     // Test that nix_store_realise properly reports errors when the system is invalid
     nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-    nix::settings.getWorkerSettings().substituters = {};
+    cStoreSettings.getWorkerSettings().substituters = {};
 
     auto * store = open_local_store();
 
@@ -446,7 +446,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_builder_fails)
 {
     // Test that nix_store_realise properly reports errors when the builder fails
     nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-    nix::settings.getWorkerSettings().substituters = {};
+    cStoreSettings.getWorkerSettings().substituters = {};
 
     auto * store = open_local_store();
 
@@ -456,7 +456,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_builder_fails)
     buffer << t.rdbuf();
 
     // Replace with current system and make builder command fail
-    std::string jsonStr = nix::replaceStrings(buffer.str(), "x86_64-linux", nix::settings.thisSystem.get());
+    std::string jsonStr = nix::replaceStrings(buffer.str(), "x86_64-linux", cStoreSettings.thisSystem.get());
     jsonStr = nix::replaceStrings(jsonStr, "echo $name foo > $out", "exit 1");
 
     auto * drv = nix_derivation_from_json(ctx, store, jsonStr.c_str());
@@ -491,7 +491,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_builder_no_output)
 {
     // Test that nix_store_realise properly reports errors when builder succeeds but produces no output
     nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-    nix::settings.getWorkerSettings().substituters = {};
+    cStoreSettings.getWorkerSettings().substituters = {};
 
     auto * store = open_local_store();
 
@@ -501,7 +501,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_builder_no_output)
     buffer << t.rdbuf();
 
     // Replace with current system and make builder succeed but not produce output
-    std::string jsonStr = nix::replaceStrings(buffer.str(), "x86_64-linux", nix::settings.thisSystem.get());
+    std::string jsonStr = nix::replaceStrings(buffer.str(), "x86_64-linux", cStoreSettings.thisSystem.get());
     jsonStr = nix::replaceStrings(jsonStr, "echo $name foo > $out", "true");
 
     auto * drv = nix_derivation_from_json(ctx, store, jsonStr.c_str());
@@ -687,7 +687,7 @@ TEST_F(NixApiStoreTestWithRealisedPath, nix_store_realise_output_ordering)
     // This test uses a CA derivation with 10 outputs in randomized input order
     // to verify that the callback order is deterministic and alphabetical.
     nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-    nix::settings.getWorkerSettings().substituters = {};
+    cStoreSettings.getWorkerSettings().substituters = {};
 
     auto * store = open_local_store();
 
@@ -706,14 +706,14 @@ TEST_F(NixApiStoreTestWithRealisedPath, nix_store_realise_output_ordering)
     std::string drvJson = R"({
         "version": 4,
         "name": "multi-output-test",
-        "system": ")" + nix::settings.thisSystem.get()
+        "system": ")" + cStoreSettings.thisSystem.get()
                           + R"(",
         "builder": "/bin/sh",
         "args": ["-c", "echo a > $outa; echo b > $outb; echo c > $outc; echo d > $outd; echo e > $oute; echo f > $outf; echo g > $outg; echo h > $outh; echo i > $outi; echo j > $outj"],
         "env": {
             "builder": "/bin/sh",
             "name": "multi-output-test",
-            "system": ")" + nix::settings.thisSystem.get()
+            "system": ")" + cStoreSettings.thisSystem.get()
                           + R"(",
             "outf": ")" + outf_ph
                           + R"(",

--- a/src/libstore-tests/ssh-store.cc
+++ b/src/libstore-tests/ssh-store.cc
@@ -1,14 +1,16 @@
 #include <gtest/gtest.h>
 
+#include "nix/store/globals.hh"
 #include "nix/store/ssh-store.hh"
-#include "nix/util/config-impl.hh"
-#include "nix/util/abstract-setting-to-json.hh"
+#include "nix/store/tests/test-main.hh"
 
 namespace nix {
 
 TEST(SSHStore, constructConfig)
 {
+    auto settings = getTestSettings();
     SSHStoreConfig config{
+        settings,
         "ssh-ng",
         "me@localhost:2222",
         StoreConfig::Params{
@@ -34,7 +36,9 @@ TEST(SSHStore, constructConfig)
 
 TEST(MountedSSHStore, constructConfig)
 {
+    auto settings = getTestSettings();
     MountedSSHStoreConfig config{
+        settings,
         "mounted-ssh",
         "localhost",
         StoreConfig::Params{

--- a/src/libstore-tests/uds-remote-store.cc
+++ b/src/libstore-tests/uds-remote-store.cc
@@ -1,31 +1,38 @@
 #include <gtest/gtest.h>
 
+#include "nix/store/globals.hh"
 #include "nix/store/uds-remote-store.hh"
 
 namespace nix {
 
 TEST(UDSRemoteStore, constructConfig)
 {
-    UDSRemoteStoreConfig config{"unix", "/tmp/socket", {}};
+    Settings settings;
+    UDSRemoteStoreConfig config{settings, "unix", "/tmp/socket", {}};
 
     EXPECT_EQ(config.path, "/tmp/socket");
 }
 
 TEST(UDSRemoteStore, constructConfigWrongScheme)
 {
-    EXPECT_THROW(UDSRemoteStoreConfig("http", "/tmp/socket", {}), UsageError);
+    Settings settings;
+    EXPECT_THROW(UDSRemoteStoreConfig(settings, "http", "/tmp/socket", {}), UsageError);
 }
 
 TEST(UDSRemoteStore, constructConfig_to_string)
 {
-    UDSRemoteStoreConfig config{"unix", "", {}};
+    Settings settings;
+    UDSRemoteStoreConfig config{settings, "unix", "", {}};
     EXPECT_EQ(config.getReference().to_string(), "daemon");
 }
 
 TEST(UDSRemoteStore, constructConfigWithParams)
 {
+    Settings settings;
+
     StoreConfig::Params params{{"max-connections", "1"}};
-    UDSRemoteStoreConfig config{"unix", "/tmp/socket", params};
+    UDSRemoteStoreConfig config{settings, "unix", "/tmp/socket", params};
+
     auto storeReference = config.getReference();
     EXPECT_EQ(storeReference.to_string(), "unix:///tmp/socket?max-connections=1");
     EXPECT_EQ(storeReference.render(/*withParams=*/false), "unix:///tmp/socket");
@@ -34,8 +41,11 @@ TEST(UDSRemoteStore, constructConfigWithParams)
 
 TEST(UDSRemoteStore, constructConfigWithParamsNoPath)
 {
+    Settings settings;
+
     StoreConfig::Params params{{"max-connections", "1"}};
-    UDSRemoteStoreConfig config{"unix", "", params};
+    UDSRemoteStoreConfig config{settings, "unix", "", params};
+
     auto storeReference = config.getReference();
     EXPECT_EQ(storeReference.to_string(), "daemon?max-connections=1");
     EXPECT_EQ(storeReference.render(/*withParams=*/false), "daemon");

--- a/src/libstore-tests/worker-substitution.cc
+++ b/src/libstore-tests/worker-substitution.cc
@@ -21,14 +21,14 @@ protected:
     ref<DummyStore> substituter;
 
     WorkerSubstitutionTest()
-        : LibStoreTest([] {
-            auto config = make_ref<DummyStoreConfig>(DummyStoreConfig::Params{});
+        : LibStoreTest([](auto & settings) {
+            auto config = make_ref<DummyStoreConfig>(settings, DummyStoreConfig::Params{});
             config->readOnly = false;
             return config->openDummyStore();
-        }())
+        })
         , dummyStore(store.dynamic_pointer_cast<DummyStore>())
-        , substituter([] {
-            auto config = make_ref<DummyStoreConfig>(DummyStoreConfig::Params{});
+        , substituter([this] {
+            auto config = make_ref<DummyStoreConfig>(settings, DummyStoreConfig::Params{});
             config->readOnly = false;
             config->isTrusted = true;
             return config->openDummyStore();
@@ -67,10 +67,10 @@ TEST_F(WorkerSubstitutionTest, singleStoreObject)
         HashAlgorithm::SHA256);
 
     // Snapshot the substituter (has one store object)
-    checkpointJson("single/substituter", substituter);
+    checkpointJson("single/substituter", substituter, settings);
 
     // Snapshot the destination store before (should be empty)
-    checkpointJson("../dummy-store/empty", dummyStore);
+    checkpointJson("../dummy-store/empty", dummyStore, settings);
 
     // The path should not exist in the destination store yet
     ASSERT_FALSE(dummyStore->isValidPath(pathInSubstituter));
@@ -92,7 +92,7 @@ TEST_F(WorkerSubstitutionTest, singleStoreObject)
     worker.run(goals);
 
     // Snapshot the destination store after (should match the substituter)
-    checkpointJson("single/substituter", dummyStore);
+    checkpointJson("single/substituter", dummyStore, settings);
 
     // The path should now exist in the destination store
     ASSERT_TRUE(dummyStore->isValidPath(pathInSubstituter));
@@ -138,10 +138,10 @@ TEST_F(WorkerSubstitutionTest, singleRootStoreObjectWithSingleDepStoreObject)
         StorePathSet{dependencyPath});
 
     // Snapshot the substituter (has two store objects)
-    checkpointJson("with-dep/substituter", substituter);
+    checkpointJson("with-dep/substituter", substituter, settings);
 
     // Snapshot the destination store before (should be empty)
-    checkpointJson("../dummy-store/empty", dummyStore);
+    checkpointJson("../dummy-store/empty", dummyStore, settings);
 
     // Neither path should exist in the destination store yet
     ASSERT_FALSE(dummyStore->isValidPath(dependencyPath));
@@ -164,7 +164,7 @@ TEST_F(WorkerSubstitutionTest, singleRootStoreObjectWithSingleDepStoreObject)
     worker.run(goals);
 
     // Snapshot the destination store after (should match the substituter)
-    checkpointJson("with-dep/substituter", dummyStore);
+    checkpointJson("with-dep/substituter", dummyStore, settings);
 
     // Both paths should now exist in the destination store
     ASSERT_TRUE(dummyStore->isValidPath(dependencyPath));
@@ -196,7 +196,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutput)
     auto drvPath = dummyStore->writeDerivation(drv);
 
     // Snapshot the destination store before
-    checkpointJson("ca-drv/store-before", dummyStore);
+    checkpointJson("ca-drv/store-before", dummyStore, settings);
 
     // Compute the hash modulo of the derivation
     // For CA floating derivations, the kind is Deferred since outputs aren't known until build
@@ -233,7 +233,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutput)
         });
 
     // Snapshot the substituter
-    checkpointJson("ca-drv/substituter", substituter);
+    checkpointJson("ca-drv/substituter", substituter, settings);
 
     // The realisation should not exist in the destination store yet
     DrvOutput drvOutput{drvHash, "out"};
@@ -256,7 +256,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutput)
     worker.run(goals);
 
     // Snapshot the destination store after
-    checkpointJson("ca-drv/store-after", dummyStore);
+    checkpointJson("ca-drv/store-after", dummyStore, settings);
 
     // The output path should now exist in the destination store
     ASSERT_TRUE(dummyStore->isValidPath(outputPath));
@@ -351,7 +351,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
     auto rootDrvPath = dummyStore->writeDerivation(rootDrv);
 
     // Snapshot the destination store before
-    checkpointJson("issue-11928/store-before", dummyStore);
+    checkpointJson("issue-11928/store-before", dummyStore, settings);
 
     // Compute the hash modulo for the root derivation
     auto rootHashModulo = hashDerivationModulo(*dummyStore, rootDrv, true);
@@ -395,7 +395,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
 
     // Snapshot the substituter
     // Note: it has realisations for both drvs, but only the root's output store object
-    checkpointJson("issue-11928/substituter", substituter);
+    checkpointJson("issue-11928/substituter", substituter, settings);
 
     // The realisations should not exist in the destination store yet
     ASSERT_FALSE(dummyStore->queryRealisation(depDrvOutput));
@@ -418,7 +418,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
     worker.run(goals);
 
     // Snapshot the destination store after
-    checkpointJson("issue-11928/store-after", dummyStore);
+    checkpointJson("issue-11928/store-after", dummyStore, settings);
 
     // The root output path should now exist in the destination store
     ASSERT_TRUE(dummyStore->isValidPath(rootOutputPath));

--- a/src/libstore-tests/write-derivation.cc
+++ b/src/libstore-tests/write-derivation.cc
@@ -12,19 +12,22 @@ namespace {
 class WriteDerivationTest : public LibStoreTest
 {
 protected:
-    WriteDerivationTest(ref<DummyStoreConfig> config_)
-        : LibStoreTest(config_->openDummyStore())
-        , config(std::move(config_))
+    WriteDerivationTest(auto && makeConfig)
+        : LibStoreTest([&](auto & settings) {
+            this->config = makeConfig(settings);
+            return config->openDummyStore();
+        })
     {
         config->readOnly = false;
     }
 
     WriteDerivationTest()
-        : WriteDerivationTest(make_ref<DummyStoreConfig>(DummyStoreConfig::Params{}))
+        : WriteDerivationTest(
+              [](auto & settings) { return make_ref<DummyStoreConfig>(settings, DummyStoreConfig::Params{}); })
     {
     }
 
-    ref<DummyStoreConfig> config;
+    std::shared_ptr<DummyStoreConfig> config;
 };
 
 static Derivation makeSimpleDrv()

--- a/src/libstore/common-ssh-store-config.cc
+++ b/src/libstore/common-ssh-store-config.cc
@@ -5,14 +5,15 @@
 
 namespace nix {
 
-CommonSSHStoreConfig::CommonSSHStoreConfig(std::string_view scheme, std::string_view authority, const Params & params)
-    : CommonSSHStoreConfig(scheme, ParsedURL::Authority::parse(authority), params)
+CommonSSHStoreConfig::CommonSSHStoreConfig(
+    nix::Settings & settings, std::string_view scheme, std::string_view authority, const Params & params)
+    : CommonSSHStoreConfig(settings, scheme, ParsedURL::Authority::parse(authority), params)
 {
 }
 
 CommonSSHStoreConfig::CommonSSHStoreConfig(
-    std::string_view scheme, const ParsedURL::Authority & authority, const Params & params)
-    : StoreConfig(params)
+    nix::Settings & settings, std::string_view scheme, const ParsedURL::Authority & authority, const Params & params)
+    : StoreConfig(settings, params)
     , authority(authority)
 {
 }

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -230,7 +230,7 @@ struct ClientSettings
     bool useSubstitutes;
     StringMap overrides;
 
-    void apply(TrustedFlag trusted)
+    void apply(Settings & settings, TrustedFlag trusted)
     {
         settings.keepFailed = keepFailed;
         settings.getWorkerSettings().keepGoing = keepGoing;
@@ -783,7 +783,7 @@ static void performOp(
         // FIXME: use some setting in recursive mode. Will need to use
         // non-global variables.
         if (!recursive)
-            clientSettings.apply(trusted);
+            clientSettings.apply(store->config.settings, trusted);
 
         logger->stopWork();
         break;

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -408,10 +408,10 @@ void adl_serializer<DummyStore::PathInfoAndContents>::to_json(json & json, const
     };
 }
 
-ref<DummyStoreConfig> adl_serializer<ref<DummyStore::Config>>::from_json(const json & json)
+ref<DummyStoreConfig> adl_serializer<ref<DummyStore::Config>>::from_json(Settings & settings, const json & json)
 {
     auto & obj = getObject(json);
-    auto cfg = make_ref<DummyStore::Config>(DummyStore::Config::Params{});
+    auto cfg = make_ref<DummyStore::Config>(settings, DummyStore::Config::Params{});
     const_cast<PathSetting &>(cfg->storeDir_).set(getString(valueAt(obj, "store")));
     cfg->readOnly = true;
     return cfg;
@@ -424,10 +424,11 @@ void adl_serializer<DummyStoreConfig>::to_json(json & json, const DummyStoreConf
     };
 }
 
-ref<DummyStore> adl_serializer<ref<DummyStore>>::from_json(const json & json)
+ref<DummyStore> adl_serializer<ref<DummyStore>>::from_json(Settings & settings, const json & json)
 {
     auto & obj = getObject(json);
-    ref<DummyStore> res = adl_serializer<ref<DummyStoreConfig>>::from_json(valueAt(obj, "config"))->openDummyStore();
+    ref<DummyStore> res =
+        adl_serializer<ref<DummyStoreConfig>>::from_json(settings, valueAt(obj, "config"))->openDummyStore();
     for (auto & [k, v] : getObject(valueAt(obj, "contents")))
         res->contents.insert({StorePath{k}, v});
     for (auto & [k, v] : getObject(valueAt(obj, "derivations")))

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -79,10 +79,6 @@ LogFileSettings::LogFileSettings()
 {
 }
 
-Settings settings;
-
-static GlobalConfig::Register rSettings(&settings);
-
 Settings::Settings()
     : nixStateDir(canonPath(getEnvNonEmpty("NIX_STATE_DIR").value_or(NIX_STATE_DIR)))
     , nixDaemonSocketFile(canonPath(getEnvOsNonEmpty(OS_STR("NIX_DAEMON_SOCKET_PATH"))

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -16,6 +16,8 @@
 
 namespace nix {
 
+class Settings;
+
 /**
  * Denotes a build failure that stemmed from the builder exiting with a
  * failing exist status.
@@ -55,6 +57,8 @@ typedef std::map<std::filesystem::path, ChrootPath> PathsInChroot; // maps targe
  */
 struct DerivationBuilderParams
 {
+    Settings & settings;
+
     /** The path of the derivation. */
     const StorePath & drvPath;
 

--- a/src/libstore/include/nix/store/common-ssh-store-config.hh
+++ b/src/libstore/include/nix/store/common-ssh-store-config.hh
@@ -12,8 +12,13 @@ struct CommonSSHStoreConfig : virtual StoreConfig
 {
     using StoreConfig::StoreConfig;
 
-    CommonSSHStoreConfig(std::string_view scheme, const ParsedURL::Authority & authority, const Params & params);
-    CommonSSHStoreConfig(std::string_view scheme, std::string_view authority, const Params & params);
+    CommonSSHStoreConfig(
+        nix::Settings & settings,
+        std::string_view scheme,
+        const ParsedURL::Authority & authority,
+        const Params & params);
+    CommonSSHStoreConfig(
+        nix::Settings & settings, std::string_view scheme, std::string_view authority, const Params & params);
 
     Setting<Path> sshKey{
         this, "", "ssh-key", "Path to the SSH private key used to authenticate to the remote machine."};

--- a/src/libstore/include/nix/store/dummy-store.hh
+++ b/src/libstore/include/nix/store/dummy-store.hh
@@ -12,15 +12,16 @@ struct DummyStore;
 
 struct DummyStoreConfig : public std::enable_shared_from_this<DummyStoreConfig>, virtual StoreConfig
 {
-    DummyStoreConfig(const Params & params)
-        : StoreConfig(params)
+    DummyStoreConfig(nix::Settings & settings, const Params & params)
+        : StoreConfig(settings, params)
     {
         // Disable caching since this a temporary in-memory store.
         pathInfoCacheSize = 0;
     }
 
-    DummyStoreConfig(std::string_view scheme, std::string_view authority, const Params & params)
-        : DummyStoreConfig(params)
+    DummyStoreConfig(
+        nix::Settings & settings, std::string_view scheme, std::string_view authority, const Params & params)
+        : DummyStoreConfig(settings, params)
     {
         if (!authority.empty())
             throw UsageError("`%s` store URIs must not contain an authority part %s", scheme, authority);
@@ -90,11 +91,20 @@ namespace nlohmann {
 
 template<>
 JSON_IMPL_INNER_TO(nix::DummyStoreConfig);
+
 template<>
-JSON_IMPL_INNER_FROM(nix::ref<nix::DummyStoreConfig>);
+struct adl_serializer<nix::ref<nix::DummyStoreConfig>>
+{
+    static nix::ref<nix::DummyStoreConfig> from_json(nix::Settings & settings, const json & json);
+};
+
 template<>
 JSON_IMPL_INNER_TO(nix::DummyStore);
+
 template<>
-JSON_IMPL_INNER_FROM(nix::ref<nix::DummyStore>);
+struct adl_serializer<nix::ref<nix::DummyStore>>
+{
+    static nix::ref<nix::DummyStore> from_json(nix::Settings & settings, const json & json);
+};
 
 } // namespace nlohmann

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -422,9 +422,6 @@ public:
     ProfileDirsOptions getProfileDirsOptions() const;
 };
 
-// FIXME: don't use a global variable.
-extern nix::Settings settings;
-
 /**
  * Load the configuration (from `nix.conf`, `NIX_CONFIG`, etc.) into the
  * given configuration object.

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -17,9 +17,12 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
     using BinaryCacheStoreConfig::BinaryCacheStoreConfig;
 
     HttpBinaryCacheStoreConfig(
-        std::string_view scheme, std::string_view cacheUri, const Store::Config::Params & params);
+        nix::Settings & settings,
+        std::string_view scheme,
+        std::string_view cacheUri,
+        const Store::Config::Params & params);
 
-    HttpBinaryCacheStoreConfig(ParsedURL cacheUri, const Store::Config::Params & params);
+    HttpBinaryCacheStoreConfig(nix::Settings & settings, ParsedURL cacheUri, const Store::Config::Params & params);
 
     ParsedURL cacheUri;
 

--- a/src/libstore/include/nix/store/keys.hh
+++ b/src/libstore/include/nix/store/keys.hh
@@ -5,6 +5,12 @@
 
 namespace nix {
 
-PublicKeys getDefaultPublicKeys();
+class Settings;
 
-}
+/**
+ * @todo use more narrow settings, or rethink whether this is a good
+ * idea at all, vs always associating keys with stores.
+ */
+PublicKeys getDefaultPublicKeys(const Settings & settings);
+
+} // namespace nix

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -14,7 +14,8 @@ struct LegacySSHStoreConfig : std::enable_shared_from_this<LegacySSHStoreConfig>
 {
     using CommonSSHStoreConfig::CommonSSHStoreConfig;
 
-    LegacySSHStoreConfig(std::string_view scheme, std::string_view authority, const Params & params);
+    LegacySSHStoreConfig(
+        nix::Settings & settings, std::string_view scheme, std::string_view authority, const Params & params);
 
 #ifndef _WIN32
     // Hack for getting remote build log output.

--- a/src/libstore/include/nix/store/local-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/local-binary-cache-store.hh
@@ -12,7 +12,8 @@ struct LocalBinaryCacheStoreConfig : std::enable_shared_from_this<LocalBinaryCac
      * @param binaryCacheDir `file://` is a short-hand for `file:///`
      * for now.
      */
-    LocalBinaryCacheStoreConfig(std::string_view scheme, PathView binaryCacheDir, const Params & params);
+    LocalBinaryCacheStoreConfig(
+        nix::Settings & settings, std::string_view scheme, PathView binaryCacheDir, const Params & params);
 
     Path binaryCacheDir;
 

--- a/src/libstore/include/nix/store/local-fs-store.hh
+++ b/src/libstore/include/nix/store/local-fs-store.hh
@@ -30,7 +30,7 @@ public:
      *
      * @todo Make this less error-prone with new store settings system.
      */
-    LocalFSStoreConfig(PathView path, const Params & params);
+    LocalFSStoreConfig(nix::Settings & settings, PathView path, const Params & params);
 
     OptionalPathSetting rootDir = makeRootDirSetting(*this, std::nullopt);
 
@@ -40,25 +40,25 @@ private:
      * An indirection so that we don't need to refer to global settings
      * in headers.
      */
-    static Path getDefaultStateDir();
+    static Path getDefaultStateDir(const nix::Settings & settings);
 
     /**
      * An indirection so that we don't need to refer to global settings
      * in headers.
      */
-    static Path getDefaultLogDir();
+    static Path getDefaultLogDir(const nix::Settings & settings);
 
 public:
 
     PathSetting stateDir{
         this,
-        rootDir.get() ? *rootDir.get() + "/nix/var/nix" : getDefaultStateDir(),
+        rootDir.get() ? *rootDir.get() + "/nix/var/nix" : getDefaultStateDir(settings),
         "state",
         "Directory where Nix stores state."};
 
     PathSetting logDir{
         this,
-        rootDir.get() ? *rootDir.get() + "/nix/var/log/nix" : getDefaultLogDir(),
+        rootDir.get() ? *rootDir.get() + "/nix/var/log/nix" : getDefaultLogDir(settings),
         "log",
         "directory where Nix stores log files."};
 

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -7,15 +7,15 @@ namespace nix {
  */
 struct LocalOverlayStoreConfig : virtual LocalStoreConfig
 {
-    LocalOverlayStoreConfig(const StringMap & params)
-        : LocalOverlayStoreConfig("local-overlay", "", params)
+    LocalOverlayStoreConfig(nix::Settings & settings, const StringMap & params)
+        : LocalOverlayStoreConfig(settings, "local-overlay", "", params)
     {
     }
 
-    LocalOverlayStoreConfig(std::string_view scheme, PathView path, const Params & params)
-        : StoreConfig(params)
-        , LocalFSStoreConfig(path, params)
-        , LocalStoreConfig(scheme, path, params)
+    LocalOverlayStoreConfig(nix::Settings & settings, std::string_view scheme, PathView path, const Params & params)
+        : StoreConfig(settings, params)
+        , LocalFSStoreConfig(settings, path, params)
+        , LocalStoreConfig(settings, scheme, path, params)
     {
     }
 

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -82,7 +82,8 @@ struct LocalStoreConfig : std::enable_shared_from_this<LocalStoreConfig>,
 {
     using LocalFSStoreConfig::LocalFSStoreConfig;
 
-    LocalStoreConfig(std::string_view scheme, std::string_view authority, const Params & params);
+    LocalStoreConfig(
+        nix::Settings & settings, std::string_view scheme, std::string_view authority, const Params & params);
 
 private:
 

--- a/src/libstore/include/nix/store/machines.hh
+++ b/src/libstore/include/nix/store/machines.hh
@@ -6,6 +6,7 @@
 
 namespace nix {
 
+class Settings;
 class Store;
 
 struct Machine;
@@ -67,7 +68,7 @@ struct Machine
      * nix::openStore(completeStoreReference())
      * ```
      */
-    ref<Store> openStore() const;
+    ref<Store> openStore(Settings & settings) const;
 
     /**
      * Parse a machine configuration.

--- a/src/libstore/include/nix/store/profiles.hh
+++ b/src/libstore/include/nix/store/profiles.hh
@@ -16,6 +16,7 @@
 
 namespace nix {
 
+class Settings;
 class StorePath;
 
 /**
@@ -216,7 +217,7 @@ struct ProfileDirsOptions
 };
 
 /**
- * Create and return the path to a directory suitable for storing the user’s
+ * Create and return the path to a directory suitable for storing the user's
  * profiles.
  */
 std::filesystem::path profilesDir(ProfileDirsOptions opts);

--- a/src/libstore/include/nix/store/s3-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/s3-binary-cache-store.hh
@@ -11,7 +11,8 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
 {
     using HttpBinaryCacheStoreConfig::HttpBinaryCacheStoreConfig;
 
-    S3BinaryCacheStoreConfig(std::string_view uriScheme, std::string_view bucketName, const Params & params);
+    S3BinaryCacheStoreConfig(
+        nix::Settings & settings, std::string_view uriScheme, std::string_view bucketName, const Params & params);
 
     Setting<std::string> profile{
         this,

--- a/src/libstore/include/nix/store/ssh-store.hh
+++ b/src/libstore/include/nix/store/ssh-store.hh
@@ -15,7 +15,8 @@ struct SSHStoreConfig : std::enable_shared_from_this<SSHStoreConfig>,
     using CommonSSHStoreConfig::CommonSSHStoreConfig;
     using RemoteStoreConfig::RemoteStoreConfig;
 
-    SSHStoreConfig(std::string_view scheme, std::string_view authority, const Params & params);
+    SSHStoreConfig(
+        nix::Settings & settings, std::string_view scheme, std::string_view authority, const Params & params);
 
     Setting<Strings> remoteProgram{
         this, {"nix-daemon"}, "remote-program", "Path to the `nix-daemon` executable on the remote machine."};
@@ -39,8 +40,8 @@ struct SSHStoreConfig : std::enable_shared_from_this<SSHStoreConfig>,
 
 struct MountedSSHStoreConfig : virtual SSHStoreConfig, virtual LocalFSStoreConfig
 {
-    MountedSSHStoreConfig(StringMap params);
-    MountedSSHStoreConfig(std::string_view scheme, std::string_view host, StringMap params);
+    MountedSSHStoreConfig(nix::Settings & settings, StringMap params);
+    MountedSSHStoreConfig(nix::Settings & settings, std::string_view scheme, std::string_view host, StringMap params);
 
     static const std::string name()
     {

--- a/src/libstore/include/nix/store/store-dir-config.hh
+++ b/src/libstore/include/nix/store/store-dir-config.hh
@@ -11,6 +11,7 @@
 
 namespace nix {
 
+class Settings;
 struct SourcePath;
 
 MakeError(BadStorePath, Error);
@@ -89,6 +90,7 @@ struct StoreDirConfig
      * path for the given file system object.
      */
     std::pair<StorePath, Hash> computeStorePath(
+        const Settings & settings,
         std::string_view name,
         const SourcePath & path,
         ContentAddressMethod method = ContentAddressMethod::Raw::NixArchive,

--- a/src/libstore/include/nix/store/store-open.hh
+++ b/src/libstore/include/nix/store/store-open.hh
@@ -15,32 +15,37 @@
 
 namespace nix {
 
+class Settings;
+
 /**
  * @return The store config denoted by `storeURI` (slight misnomer...).
  */
-ref<StoreConfig> resolveStoreConfig(StoreReference && storeURI);
+ref<StoreConfig> resolveStoreConfig(Settings & settings, StoreReference && storeURI);
 
 /**
  * @return a Store object to access the Nix store denoted by
- * ‘uri’ (slight misnomer...).
+ * 'uri' (slight misnomer...).
  */
-ref<Store> openStore(StoreReference && storeURI);
+ref<Store> openStore(Settings & settings, StoreReference && storeURI);
 
 /**
  * Opens the store at `uri`, where `uri` is in the format expected by
  * `StoreReference::parse`
  */
-ref<Store> openStore(const std::string & uri, const StoreReference::Params & extraParams = StoreReference::Params());
+ref<Store> openStore(
+    Settings & settings,
+    const std::string & uri,
+    const StoreReference::Params & extraParams = StoreReference::Params());
 
 /**
  * Short-hand which opens the default store, according to global settings
  */
-ref<Store> openStore();
+ref<Store> openStore(Settings & settings);
 
 /**
  * @return the default substituter stores, defined by the
- * ‘substituters’ option and various legacy options.
+ * 'substituters' option and various legacy options.
  */
-std::list<ref<Store>> getDefaultSubstituters();
+std::list<ref<Store>> getDefaultSubstituters(Settings & settings);
 
 } // namespace nix

--- a/src/libstore/include/nix/store/uds-remote-store.hh
+++ b/src/libstore/include/nix/store/uds-remote-store.hh
@@ -19,9 +19,10 @@ struct UDSRemoteStoreConfig : std::enable_shared_from_this<UDSRemoteStoreConfig>
     /**
      * @param authority is the socket path.
      */
-    UDSRemoteStoreConfig(std::string_view scheme, std::string_view authority, const Params & params);
+    UDSRemoteStoreConfig(
+        nix::Settings & settings, std::string_view scheme, std::string_view authority, const Params & params);
 
-    UDSRemoteStoreConfig(const Params & params);
+    UDSRemoteStoreConfig(nix::Settings & settings, const Params & params);
 
     static const std::string name()
     {

--- a/src/libstore/keys.cc
+++ b/src/libstore/keys.cc
@@ -4,7 +4,7 @@
 
 namespace nix {
 
-PublicKeys getDefaultPublicKeys()
+PublicKeys getDefaultPublicKeys(const Settings & settings)
 {
     PublicKeys publicKeys;
 

--- a/src/libstore/linux/include/nix/store/personality.hh
+++ b/src/libstore/linux/include/nix/store/personality.hh
@@ -3,6 +3,12 @@
 
 #include <string>
 
+namespace nix {
+
+class Settings;
+
+}
+
 namespace nix::linux {
 
 struct PersonalityArgs

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -9,9 +9,9 @@
 namespace nix {
 
 LocalBinaryCacheStoreConfig::LocalBinaryCacheStoreConfig(
-    std::string_view scheme, PathView binaryCacheDir, const StoreReference::Params & params)
-    : Store::Config{params}
-    , BinaryCacheStoreConfig{params}
+    nix::Settings & settings, std::string_view scheme, PathView binaryCacheDir, const StoreReference::Params & params)
+    : Store::Config{settings, params}
+    , BinaryCacheStoreConfig{settings, params}
     , binaryCacheDir(binaryCacheDir)
 {
 }

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -8,18 +8,18 @@
 
 namespace nix {
 
-Path LocalFSStoreConfig::getDefaultStateDir()
+Path LocalFSStoreConfig::getDefaultStateDir(const nix::Settings & settings)
 {
     return settings.nixStateDir.string();
 }
 
-Path LocalFSStoreConfig::getDefaultLogDir()
+Path LocalFSStoreConfig::getDefaultLogDir(const nix::Settings & settings)
 {
     return settings.getLogFileSettings().nixLogDir.string();
 }
 
-LocalFSStoreConfig::LocalFSStoreConfig(PathView rootDir, const Params & params)
-    : StoreConfig(params)
+LocalFSStoreConfig::LocalFSStoreConfig(nix::Settings & settings, PathView rootDir, const Params & params)
+    : StoreConfig(settings, params)
     /* Default `?root` from `rootDir` if non set
      * NOTE: We would like to just do rootDir.set(...), which would take care of
      * all normalization and error checking for us. Unfortunately we cannot do

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -43,7 +43,7 @@ LocalOverlayStore::LocalOverlayStore(ref<const Config> config)
     , LocalFSStore{*config}
     , LocalStore{static_cast<ref<const LocalStore::Config>>(config)}
     , config{config}
-    , lowerStore(openStore(config->lowerStoreUri.get()).dynamic_pointer_cast<LocalFSStore>())
+    , lowerStore(openStore(config->settings, config->lowerStoreUri.get()).dynamic_pointer_cast<LocalFSStore>())
 {
     if (config->checkMount.get()) {
         std::smatch match;

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -91,9 +91,9 @@ StoreReference Machine::completeStoreReference() const
     return storeUri;
 }
 
-ref<Store> Machine::openStore() const
+ref<Store> Machine::openStore(Settings & settings) const
 {
-    return nix::openStore(completeStoreReference());
+    return nix::openStore(settings, completeStoreReference());
 }
 
 static std::vector<std::string> expandBuilderLines(const std::string & builders)

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -236,8 +236,8 @@ MissingPaths Store::queryMissing(const std::vector<DerivedPath> & targets)
                         throw;
                     }
 
-                    if (!knownOutputPaths && settings.getWorkerSettings().useSubstitutes
-                        && drvOptions.substitutesAllowed(settings.getWorkerSettings())) {
+                    if (!knownOutputPaths && config.settings.getWorkerSettings().useSubstitutes
+                        && drvOptions.substitutesAllowed(config.settings.getWorkerSettings())) {
                         experimentalFeatureSettings.require(Xp::CaDerivations);
 
                         // If there are unknown output paths, attempt to find if the
@@ -250,7 +250,7 @@ MissingPaths Store::queryMissing(const std::vector<DerivedPath> & targets)
                                 continue;
 
                             bool found = false;
-                            for (auto & sub : getDefaultSubstituters()) {
+                            for (auto & sub : getDefaultSubstituters(config.settings)) {
                                 auto realisation = sub->queryRealisation({hash, outputName});
                                 if (!realisation)
                                     continue;
@@ -267,8 +267,8 @@ MissingPaths Store::queryMissing(const std::vector<DerivedPath> & targets)
                         }
                     }
 
-                    if (knownOutputPaths && settings.getWorkerSettings().useSubstitutes
-                        && drvOptions.substitutesAllowed(settings.getWorkerSettings())) {
+                    if (knownOutputPaths && config.settings.getWorkerSettings().useSubstitutes
+                        && drvOptions.substitutesAllowed(config.settings.getWorkerSettings())) {
                         auto drvState = make_ref<Sync<DrvState>>(DrvState(invalid.size()));
                         for (auto & output : invalid)
                             pool.enqueue(std::bind(checkOutput, drvPath, drv, output, drvState));

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -114,6 +114,8 @@ void RemoteStore::initConnection(Connection & conn)
 
 void RemoteStore::setOptions(Connection & conn)
 {
+    auto & settings = config.settings;
+
     conn.to << WorkerProto::Op::SetOptions << settings.keepFailed << settings.getWorkerSettings().keepGoing
             << settings.getWorkerSettings().tryFallback << verbosity << settings.getWorkerSettings().maxBuildJobs
             << settings.getWorkerSettings().maxSilentTime << true << (settings.verboseBuild ? lvlError : lvlVomit)

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -417,9 +417,9 @@ StringSet S3BinaryCacheStoreConfig::uriSchemes()
 }
 
 S3BinaryCacheStoreConfig::S3BinaryCacheStoreConfig(
-    std::string_view scheme, std::string_view _cacheUri, const Params & params)
-    : StoreConfig(params)
-    , HttpBinaryCacheStoreConfig(scheme, _cacheUri, params)
+    nix::Settings & settings, std::string_view scheme, std::string_view _cacheUri, const Params & params)
+    : StoreConfig(settings, params)
+    , HttpBinaryCacheStoreConfig(settings, scheme, _cacheUri, params)
 {
     assert(cacheUri.query.empty());
     assert(cacheUri.scheme == "s3");

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -11,10 +11,11 @@
 
 namespace nix {
 
-SSHStoreConfig::SSHStoreConfig(std::string_view scheme, std::string_view authority, const Params & params)
-    : Store::Config{params}
-    , RemoteStore::Config{params}
-    , CommonSSHStoreConfig{scheme, authority, params}
+SSHStoreConfig::SSHStoreConfig(
+    nix::Settings & settings, std::string_view scheme, std::string_view authority, const Params & params)
+    : Store::Config{settings, params}
+    , RemoteStore::Config{settings, params}
+    , CommonSSHStoreConfig{settings, scheme, authority, params}
 {
 }
 
@@ -88,21 +89,22 @@ protected:
     };
 };
 
-MountedSSHStoreConfig::MountedSSHStoreConfig(StringMap params)
-    : StoreConfig(params)
-    , RemoteStoreConfig(params)
-    , CommonSSHStoreConfig(params)
-    , SSHStoreConfig(params)
-    , LocalFSStoreConfig(params)
+MountedSSHStoreConfig::MountedSSHStoreConfig(nix::Settings & settings, StringMap params)
+    : StoreConfig(settings, params)
+    , RemoteStoreConfig(settings, params)
+    , CommonSSHStoreConfig(settings, params)
+    , SSHStoreConfig(settings, params)
+    , LocalFSStoreConfig(settings, "", params)
 {
 }
 
-MountedSSHStoreConfig::MountedSSHStoreConfig(std::string_view scheme, std::string_view host, StringMap params)
-    : StoreConfig(params)
-    , RemoteStoreConfig(params)
-    , CommonSSHStoreConfig(scheme, host, params)
-    , SSHStoreConfig(scheme, host, params)
-    , LocalFSStoreConfig(params)
+MountedSSHStoreConfig::MountedSSHStoreConfig(
+    nix::Settings & settings, std::string_view scheme, std::string_view host, StringMap params)
+    : StoreConfig(settings, params)
+    , RemoteStoreConfig(settings, params)
+    , CommonSSHStoreConfig(settings, scheme, host, params)
+    , SSHStoreConfig(settings, scheme, host, params)
+    , LocalFSStoreConfig(settings, "", params)
 {
 }
 

--- a/src/libstore/store-dir-config.cc
+++ b/src/libstore/store-dir-config.cc
@@ -149,6 +149,7 @@ StoreDirConfig::makeFixedOutputPathFromCA(std::string_view name, const ContentAd
 }
 
 std::pair<StorePath, Hash> StoreDirConfig::computeStorePath(
+    const Settings & settings,
     std::string_view name,
     const SourcePath & path,
     ContentAddressMethod method,

--- a/src/libstore/store-registration.cc
+++ b/src/libstore/store-registration.cc
@@ -6,24 +6,24 @@
 
 namespace nix {
 
-ref<Store> openStore()
+ref<Store> openStore(Settings & settings)
 {
-    return openStore(StoreReference{settings.storeUri.get()});
+    return openStore(settings, StoreReference{settings.storeUri.get()});
 }
 
-ref<Store> openStore(const std::string & uri, const Store::Config::Params & extraParams)
+ref<Store> openStore(Settings & settings, const std::string & uri, const Store::Config::Params & extraParams)
 {
-    return openStore(StoreReference::parse(uri, extraParams));
+    return openStore(settings, StoreReference::parse(uri, extraParams));
 }
 
-ref<Store> openStore(StoreReference && storeURI)
+ref<Store> openStore(Settings & settings, StoreReference && storeURI)
 {
-    auto store = resolveStoreConfig(std::move(storeURI))->openStore();
+    auto store = resolveStoreConfig(settings, std::move(storeURI))->openStore();
     store->init();
     return store;
 }
 
-ref<StoreConfig> resolveStoreConfig(StoreReference && storeURI)
+ref<StoreConfig> resolveStoreConfig(Settings & settings, StoreReference && storeURI)
 {
     auto & params = storeURI.params;
 
@@ -32,9 +32,9 @@ ref<StoreConfig> resolveStoreConfig(StoreReference && storeURI)
             [&](const StoreReference::Auto &) -> ref<StoreConfig> {
                 auto stateDir = getOr(params, "state", settings.nixStateDir.string());
                 if (access(stateDir.c_str(), R_OK | W_OK) == 0)
-                    return make_ref<LocalStore::Config>(params);
+                    return make_ref<LocalStore::Config>(settings, params);
                 else if (pathExists(settings.nixDaemonSocketFile))
-                    return make_ref<UDSRemoteStore::Config>(params);
+                    return make_ref<UDSRemoteStore::Config>(settings, params);
 #ifdef __linux__
                 else if (
                     !pathExists(stateDir) && params.empty() && !isRootUser() && !getEnv("NIX_STORE_DIR").has_value()
@@ -47,21 +47,21 @@ ref<StoreConfig> resolveStoreConfig(StoreReference && storeURI)
                         try {
                             createDirs(chrootStore);
                         } catch (SystemError & e) {
-                            return make_ref<LocalStore::Config>(params);
+                            return make_ref<LocalStore::Config>(settings, params);
                         }
                         warn("'%s' does not exist, so Nix will use '%s' as a chroot store", stateDir, chrootStore);
                     } else
                         debug("'%s' does not exist, so Nix will use '%s' as a chroot store", stateDir, chrootStore);
-                    return make_ref<LocalStore::Config>("local", chrootStore, params);
+                    return make_ref<LocalStore::Config>(settings, "local", chrootStore, params);
                 }
 #endif
                 else
-                    return make_ref<LocalStore::Config>(params);
+                    return make_ref<LocalStore::Config>(settings, params);
             },
             [&](const StoreReference::Specified & g) {
                 for (const auto & [storeName, implem] : Implementations::registered())
                     if (implem.uriSchemes.count(g.scheme))
-                        return implem.parseConfig(g.scheme, g.authority, params);
+                        return implem.parseConfig(settings, g.scheme, g.authority, params);
 
                 throw Error("don't know how to open Nix store with scheme '%s'", g.scheme);
             },
@@ -74,9 +74,9 @@ ref<StoreConfig> resolveStoreConfig(StoreReference && storeURI)
     return storeConfig;
 }
 
-std::list<ref<Store>> getDefaultSubstituters()
+std::list<ref<Store>> getDefaultSubstituters(Settings & settings)
 {
-    static auto stores([]() {
+    static auto stores([&]() {
         std::list<ref<Store>> stores;
 
         std::set<StoreReference> done;
@@ -85,7 +85,7 @@ std::list<ref<Store>> getDefaultSubstituters()
             if (!done.insert(ref).second)
                 return;
             try {
-                stores.push_back(openStore(StoreReference{ref}));
+                stores.push_back(openStore(settings, StoreReference{ref}));
             } catch (Error & e) {
                 logWarning(e.info());
             }

--- a/src/libstore/uds-remote-store.cc
+++ b/src/libstore/uds-remote-store.cc
@@ -20,11 +20,14 @@
 namespace nix {
 
 UDSRemoteStoreConfig::UDSRemoteStoreConfig(
-    std::string_view scheme, std::string_view authority, const StoreReference::Params & params)
-    : Store::Config{params}
-    , LocalFSStore::Config{params}
-    , RemoteStore::Config{params}
-    , path{authority.empty() ? settings.nixDaemonSocketFile.string() : authority}
+    nix::Settings & settings,
+    std::string_view scheme,
+    std::string_view authority,
+    const StoreReference::Params & params)
+    : Store::Config{settings, params}
+    , LocalFSStore::Config{settings, "", params}
+    , RemoteStore::Config{settings, params}
+    , path{authority.empty() ? settings.nixDaemonSocketFile.string() : std::string{authority}}
 {
     if (uriSchemes().count(scheme) == 0) {
         throw UsageError("Scheme must be 'unix'");
@@ -42,8 +45,8 @@ std::string UDSRemoteStoreConfig::doc()
 // empty string will later default to the same nixDaemonSocketFile. Why
 // don't we just wire it all through? I believe there are cases where it
 // will live reload so we want to continue to account for that.
-UDSRemoteStoreConfig::UDSRemoteStoreConfig(const Params & params)
-    : UDSRemoteStoreConfig(*uriSchemes().begin(), "", params)
+UDSRemoteStoreConfig::UDSRemoteStoreConfig(nix::Settings & settings, const Params & params)
+    : UDSRemoteStoreConfig(settings, *uriSchemes().begin(), "", params)
 {
 }
 

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -40,8 +40,10 @@ struct CmdAddToStore : MixDryRun, StoreCommand
 
         auto sourcePath = PosixSourceAccessor::createAtRoot(makeParentCanonical(path));
 
-        auto storePath = dryRun ? store->computeStorePath(*namePart, sourcePath, caMethod, hashAlgo, {}).first
-                                : store->addToStoreSlow(*namePart, sourcePath, caMethod, hashAlgo, {}).path;
+        auto storePath =
+            dryRun
+                ? store->computeStorePath(store->config.settings, *namePart, sourcePath, caMethod, hashAlgo, {}).first
+                : store->addToStoreSlow(*namePart, sourcePath, caMethod, hashAlgo, {}).path;
 
         logger->cout("%s", store->printStorePath(storePath));
     }

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -13,7 +13,6 @@
 #include "nix/main/shared.hh"
 #include "nix/main/plugin.hh"
 #include "nix/store/pathlocks.hh"
-#include "nix/store/globals.hh"
 #include "nix/util/serialise.hh"
 #include "nix/store/build-result.hh"
 #include "nix/store/store-open.hh"
@@ -81,7 +80,7 @@ static int main_build_remote(int argc, char ** argv)
 
         initPlugins();
 
-        auto store = openStore();
+        auto store = openStore(settings);
 
         /* It would be more appropriate to use $XDG_RUNTIME_DIR, since
            that gets cleared on reboot, but it wouldn't work on macOS. */
@@ -234,7 +233,7 @@ static int main_build_remote(int argc, char ** argv)
 
                     Activity act(*logger, lvlTalkative, actUnknown, fmt("connecting to '%s'", storeUri));
 
-                    sshStore = bestMachine->openStore();
+                    sshStore = bestMachine->openStore(settings);
                     sshStore->connect();
                 } catch (std::exception & e) {
                     auto msg = chomp(drainFD(5, {.block = false}));

--- a/src/nix/derivation-add.cc
+++ b/src/nix/derivation-add.cc
@@ -6,6 +6,7 @@
 #include "nix/util/archive.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/globals.hh"
+#include "nix/main/shared.hh"
 #include <nlohmann/json.hpp>
 
 using namespace nix;

--- a/src/nix/flake-prefetch-inputs.cc
+++ b/src/nix/flake-prefetch-inputs.cc
@@ -1,10 +1,11 @@
-#include "flake-command.hh"
-#include "nix/fetchers/fetch-to-store.hh"
-#include "nix/util/thread-pool.hh"
-#include "nix/store/filetransfer.hh"
-#include "nix/util/exit.hh"
-
 #include <nlohmann/json.hpp>
+
+#include "nix/util/thread-pool.hh"
+#include "nix/util/exit.hh"
+#include "nix/store/filetransfer.hh"
+#include "nix/fetchers/fetch-to-store.hh"
+
+#include "flake-command.hh"
 
 using namespace nix;
 using namespace nix::flake;

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1127,7 +1127,7 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun, MixNoCheckSigs
         }
 
         if (!dryRun && dstUri) {
-            ref<Store> dstStore = openStore(StoreReference{*dstUri});
+            ref<Store> dstStore = openStore(settings, StoreReference{*dstUri});
 
             copyPaths(*store, *dstStore, sources, NoRepair, checkSigs, substitute);
         }

--- a/src/nix/formatter.cc
+++ b/src/nix/formatter.cc
@@ -6,6 +6,7 @@
 #include "nix/cmd/installable-derived-path.hh"
 #include "nix/util/environment-variables.hh"
 #include "nix/store/globals.hh"
+#include "nix/main/shared.hh"
 
 #include "run.hh"
 

--- a/src/nix/log.cc
+++ b/src/nix/log.cc
@@ -41,7 +41,7 @@ struct CmdLog : InstallableCommand
         auto path = resolveDerivedPath(*store, *oneUp);
 
         RunPager pager;
-        auto log = fetchBuildLog(store, path, installable->what());
+        auto log = fetchBuildLog(settings, store, path, installable->what());
         logger->stop();
         writeFull(getStandardOutput(), log);
     }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -249,7 +249,7 @@ static void showHelp(std::vector<std::string> subcommand, NixArgs & toplevel)
     evalSettings.pureEval = true;
     EvalState state(
         {},
-        openStore(StoreReference{.variant = StoreReference::Specified{.scheme = "dummy"}}),
+        openStore(settings, StoreReference{.variant = StoreReference::Specified{.scheme = "dummy"}}),
         fetchSettings,
         evalSettings);
 
@@ -454,7 +454,7 @@ void mainWrapped(int argc, char ** argv)
         evalSettings.pureEval = false;
         EvalState state(
             {},
-            openStore(StoreReference{.variant = StoreReference::Specified{.scheme = "dummy"}}),
+            openStore(settings, StoreReference{.variant = StoreReference::Specified{.scheme = "dummy"}}),
             fetchSettings,
             evalSettings);
         auto builtinsJson = nlohmann::json::object();

--- a/src/nix/make-content-addressed.cc
+++ b/src/nix/make-content-addressed.cc
@@ -1,4 +1,5 @@
 #include "nix/cmd/command.hh"
+#include "nix/main/shared.hh"
 #include "nix/store/store-open.hh"
 #include "nix/store/make-content-addressed.hh"
 #include "nix/main/common-args.hh"
@@ -30,7 +31,7 @@ struct CmdMakeContentAddressed : virtual CopyCommand, virtual StorePathsCommand,
 
     void run(ref<Store> srcStore, StorePaths && storePaths) override
     {
-        auto dstStore = !dstUri ? openStore() : openStore(StoreReference{*dstUri});
+        auto dstStore = !dstUri ? openStore(settings) : openStore(settings, StoreReference{*dstUri});
 
         auto remappings =
             makeContentAddressed(*srcStore, *dstStore, StorePathSet(storePaths.begin(), storePaths.end()));

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -312,8 +312,8 @@ static void main_nix_build(int argc, char ** argv)
     if (packages && fromArgs)
         throw UsageError("'-p' and '-E' are mutually exclusive");
 
-    auto store = openStore();
-    auto evalStore = myArgs.evalStoreUrl ? openStore(StoreReference{*myArgs.evalStoreUrl}) : store;
+    auto store = openStore(settings);
+    auto evalStore = myArgs.evalStoreUrl ? openStore(settings, StoreReference{*myArgs.evalStoreUrl}) : store;
 
     auto state = std::make_unique<EvalState>(myArgs.lookupPath, evalStore, fetchSettings, evalSettings, store);
     state->repair = myArgs.repair;

--- a/src/nix/nix-channel/nix-channel.cc
+++ b/src/nix/nix-channel/nix-channel.cc
@@ -88,7 +88,7 @@ static void update(const StringSet & channelNames)
 {
     readChannels();
 
-    auto store = openStore();
+    auto store = openStore(settings);
 
     auto [fd, unpackChannelPath] = createTempFile();
     writeFull(
@@ -189,7 +189,7 @@ static int main_nix_channel(int argc, char ** argv)
         // Figure out the name of the `.nix-channels' file to use
         auto home = getHome();
         channelsList = settings.useXDGBaseDirectories ? createNixStateDir() + "/channels" : home + "/.nix-channels";
-        nixDefExpr = getNixDefExpr();
+        nixDefExpr = getNixDefExpr(settings);
 
         // Figure out the name of the channels profile.
         profile = profilesDir(settings.getProfileDirsOptions()) + "/channels";

--- a/src/nix/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix/nix-collect-garbage/nix-collect-garbage.cc
@@ -102,7 +102,7 @@ static int main_nix_collect_garbage(int argc, char ** argv)
                 removeOldGenerations(dir);
         }
 
-        auto store = openStore();
+        auto store = openStore(settings);
         auto & gcStore = require<GcStore>(*store);
         options.action = dryRun ? GCOptions::gcReturnDead : GCOptions::gcDeleteDead;
         GCResults results;

--- a/src/nix/nix-copy-closure/nix-copy-closure.cc
+++ b/src/nix/nix-copy-closure/nix-copy-closure.cc
@@ -49,10 +49,10 @@ static int main_nix_copy_closure(int argc, char ** argv)
         if (sshHost.empty())
             throw UsageError("no host name specified");
 
-        auto remoteConfig = make_ref<LegacySSHStoreConfig>("ssh", sshHost, LegacySSHStoreConfig::Params{});
+        auto remoteConfig = make_ref<LegacySSHStoreConfig>(settings, "ssh", sshHost, LegacySSHStoreConfig::Params{});
         remoteConfig->compress |= gzip;
-        auto to = toMode ? remoteConfig->openStore() : openStore();
-        auto from = toMode ? openStore() : remoteConfig->openStore();
+        auto to = toMode ? remoteConfig->openStore() : openStore(settings);
+        auto from = toMode ? openStore(settings) : remoteConfig->openStore();
 
         RealisedPath::Set storePaths2;
         for (auto & path : storePaths)

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -1410,7 +1410,7 @@ static int main_nix_env(int argc, char ** argv)
         globals.instSource.type = srcUnknown;
         globals.instSource.systemFilter = "*";
 
-        std::filesystem::path nixExprPath = getNixDefExpr();
+        std::filesystem::path nixExprPath = getNixDefExpr(settings);
 
         if (!pathExists(nixExprPath)) {
             try {
@@ -1509,7 +1509,7 @@ static int main_nix_env(int argc, char ** argv)
         if (!op)
             throw UsageError("no operation specified");
 
-        auto store = openStore();
+        auto store = openStore(settings);
 
         globals.state =
             std::shared_ptr<EvalState>(new EvalState(myArgs.lookupPath, store, fetchSettings, evalSettings));

--- a/src/nix/nix-instantiate/nix-instantiate.cc
+++ b/src/nix/nix-instantiate/nix-instantiate.cc
@@ -166,8 +166,8 @@ static int main_nix_instantiate(int argc, char ** argv)
         if (evalOnly && !wantsReadWrite)
             settings.readOnlyMode = true;
 
-        auto store = openStore();
-        auto evalStore = myArgs.evalStoreUrl ? openStore(StoreReference{*myArgs.evalStoreUrl}) : store;
+        auto store = openStore(settings);
+        auto evalStore = myArgs.evalStoreUrl ? openStore(settings, StoreReference{*myArgs.evalStoreUrl}) : store;
 
         auto state = std::make_unique<EvalState>(myArgs.lookupPath, evalStore, fetchSettings, evalSettings, store);
         state->repair = myArgs.repair;

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -1232,7 +1232,7 @@ static int main_nix_store(int argc, char ** argv)
             throw UsageError("no operation specified");
 
         if (op != opDump && op != opRestore) /* !!! hack */
-            store = openStore();
+            store = openStore(settings);
 
         op(std::move(opFlags), std::move(opArgs));
 

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -202,7 +202,7 @@ static int main_nix_prefetch_url(int argc, char ** argv)
 
         setLogFormat("bar");
 
-        auto store = openStore();
+        auto store = openStore(settings);
         auto state = std::make_unique<EvalState>(myArgs.lookupPath, store, fetchSettings, evalSettings);
 
         Bindings & autoArgs = *myArgs.getAutoArgs(*state);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -2,6 +2,7 @@
 #include "nix/expr/eval-settings.hh"
 #include "nix/util/config-global.hh"
 #include "nix/store/globals.hh"
+#include "nix/main/shared.hh"
 #include "nix/store/store-open.hh"
 #include "nix/cmd/command.hh"
 #include "nix/cmd/installable-value.hh"

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -44,7 +44,7 @@ struct CmdCopySigs : StorePathsCommand
         // FIXME: factor out commonality with MixVerify.
         std::vector<ref<Store>> substituters;
         for (auto & s : substituterUris)
-            substituters.push_back(openStore(StoreReference{s}));
+            substituters.push_back(openStore(settings, StoreReference{s}));
 
         ThreadPool pool{fileTransferSettings.httpConnections};
 

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -457,7 +457,8 @@ static int main_nix_daemon(int argc, char ** argv)
             return true;
         });
 
-        runDaemon(resolveStoreConfig(StoreReference{settings.storeUri.get()}), stdio, isTrustedOpt, processOps);
+        runDaemon(
+            resolveStoreConfig(settings, StoreReference{settings.storeUri.get()}), stdio, isTrustedOpt, processOps);
 
         return 0;
     }

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -10,6 +10,7 @@
 #include "nix/util/executable-path.hh"
 #include "nix/store/globals.hh"
 #include "nix/util/config-global.hh"
+#include "nix/main/shared.hh"
 #include "self-exe.hh"
 
 using namespace nix;

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -65,9 +65,9 @@ struct CmdVerify : StorePathsCommand
     {
         std::vector<ref<Store>> substituters;
         for (auto & s : substituterUris)
-            substituters.push_back(openStore(StoreReference{s}));
+            substituters.push_back(openStore(settings, StoreReference{s}));
 
-        auto publicKeys = getDefaultPublicKeys();
+        auto publicKeys = getDefaultPublicKeys(settings);
 
         Activity act(*logger, actVerifyPaths);
 

--- a/src/perl/lib/Nix/Store.xs
+++ b/src/perl/lib/Nix/Store.xs
@@ -13,6 +13,9 @@
 #include "nix/util/posix-source-accessor.hh"
 #include "nix/store/export-import.hh"
 
+// TODO get rid of this, and stop relying on global store settings.
+#include "nix/main/shared.hh"
+
 #include <sodium.h>
 #include <nlohmann/json.hpp>
 
@@ -62,13 +65,13 @@ StoreWrapper::new(char * s = nullptr)
                 libStoreInitialized = true;
             }
             if (items == 1) {
-                _store = openStore();
+                _store = openStore(settings);
                 RETVAL = new StoreWrapper {
                     .store = ref<Store>{_store}
                 };
             } else {
                 RETVAL = new StoreWrapper {
-                    .store = openStore(s)
+                    .store = openStore(settings, s)
                 };
             }
         } catch (Error & e) {
@@ -424,4 +427,4 @@ StoreWrapper::addTempRoot(char * storePath)
 
 SV * getStoreDir()
     PPCODE:
-        XPUSHs(sv_2mortal(newSVpv(resolveStoreConfig(StoreReference{settings.storeUri.get()})->storeDir.c_str(), 0)));
+        XPUSHs(sv_2mortal(newSVpv(resolveStoreConfig(settings, StoreReference{settings.storeUri.get()})->storeDir.c_str(), 0)));

--- a/src/perl/meson.build
+++ b/src/perl/meson.build
@@ -77,6 +77,10 @@ libsodium_dep = dependency('libsodium')
 
 nix_store_dep = dependency('nix-store')
 
+# TEMP hack to get global settings, until we extend Perl API with
+# explicit settings loading or similar.
+nix_main_dep = dependency('nix-main')
+
 
 # Finding Perl Headers is a pain. as they do not have
 # pkgconfig available, are not in a standard location,
@@ -170,6 +174,7 @@ nix_perl_store_dep_list = [
   curl_dep,
   libsodium_dep,
   nix_store_dep,
+  nix_main_dep,
 ]
 
 # # build

--- a/src/perl/package.nix
+++ b/src/perl/package.nix
@@ -6,6 +6,7 @@
   perl,
   perlPackages,
   nix-store,
+  nix-main,
   version,
   curl,
   bzip2,
@@ -45,6 +46,7 @@ perl.pkgs.toPerlModule (
 
     buildInputs = [
       nix-store
+      nix-main
       bzip2
       libsodium
       perlPackages.DBI

--- a/tests/functional/test-libstoreconsumer/main.cc
+++ b/tests/functional/test-libstoreconsumer/main.cc
@@ -17,7 +17,9 @@ int main(int argc, char ** argv)
 
         initLibStore();
 
-        auto store = nix::openStore();
+        Settings settings;
+
+        auto store = nix::openStore(settings);
 
         // build the derivation
 


### PR DESCRIPTION
## Motivation

Big progress on #5603

## Context

This is analogous to 52bfccf8d8112ba738e6fc9e4891f85b6b864566 for `EvalSettings`, and 3fc77f281ef3def1f997c959687cba04660dd27d for `FlakeSettings` and `fetchers::Settings`.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
