### PR TITLE
fix(FreeBSD): remove null terminator from executable path

### DIFF
--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -134,6 +134,11 @@ std::optional<Path> getSelfExe()
             return std::nullopt;
         }
 
+        // FreeBSD's sysctl(KERN_PROC_PATHNAME) includes the null terminator in
+        // pathLen. Strip it to prevent Nix evaluation errors when the path is
+        // serialized to JSON and evaluated as a Nix string.
+        path.pop_back();
+
         return Path(path.begin(), path.end());
 #else
         return std::nullopt;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

On FreeBSD, sysctl(KERN_PROC_PATHNAME) returns a null-terminated string with pathLen including the terminator. This causes Nix to fail during manual generation with:

```
  error:
         … while calling the 'concatStringsSep' builtin
           at /nix/var/nix/builds/nix-63232-402489527/source/doc/manual/generate-settings.nix:99:1:
             98| in
             99| concatStrings (attrValues (mapAttrs (showSetting prefix) settingsInfo))
               | ^
            100|

         error: input string '/nix/store/gq89cj02b5zs67cbd85vzg5cgsgnd8mj-nix-2.31.2/bin/nix␀'
                cannot be represented as Nix string because it contains null bytes
```

The issue occurs because generate-settings.nix reads the nix binary path from JSON and evaluates it as a Nix string, which cannot contain null bytes. Normal C++ string operations don't trigger this since they handle null-terminated strings correctly.

Strip the null terminator on FreeBSD to match other platforms (Linux uses /proc/self/exe, macOS uses _NSGetExecutablePath).

Credit: @wahjava (FreeBSD ports and Nixpkgs contributor)

## Context

Building Nix using Nix on FreeBSD (testing native compilation of NixBSD)

This patch comes from [freebsd-ports](https://github.com/freebsd/freebsd-ports/blob/90bba547a3324ba5512ef3d67f72c6d6772bdd1b/sysutils/nix/files/patch-src_libutil_current-process.cc), I tried to improve the explanation and rationale in the comment and commit message. It's helpful to have this change upstream so that it does not need to be patched in manually, and it is relevant for NixBSD.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
