### PR TITLE
libstore: fix curl version check to allow 8.17.0

### DIFF
--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -114,7 +114,9 @@ boost = dependency(
 deps_other += boost
 
 curl = dependency('libcurl', 'curl', version : '>= 7.75.0')
-if curl.version().version_compare('>=8.16.0 <8.17.0')
+if curl.version().version_compare('>=8.16.0') and curl.version().version_compare(
+  '<8.17.0',
+)
   # Out of precaution, avoid building with libcurl version that suffer from https://github.com/curl/curl/issues/19334.
   error(
     'curl @0@ has issues with write pausing, please use libcurl < 8.16 or >= 8.17, see https://github.com/curl/curl/issues/19334'.format(


### PR DESCRIPTION
The single-string syntax '>=8.16.0 <8.17.0' only applied the lower bound, causing curl 8.17.0 to be incorrectly rejected. Split into two separate version_compare() calls for compatibility with Meson 1.1, since multi-argument syntax requires Meson 1.8+.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Meson wouldn't let me configure Nix with curl 8.17.0, even though the write pausing bug should be fixed in this version:

```
> Run-time dependency libcurl found: YES 8.17.0
>
> meson.build:119:2: ERROR: Problem encountered: curl 8.17.0 has issues with write pausing, please use libcurl < 8.16 or >= 8.17, see https://github.com/curl/curl/issues/19334
```

## Context

The version check introduced in #14614 incorrectly rejects curl 8.17.0. The single-string version comparison syntax `'>=8.16.0 <8.17.0'` only applied the lower bound in Meson, causing builds with curl 8.17.0 to fail even though the bug (curl/curl#19334) was fixed in that version.

Split into two separate `version_compare()` calls to work correctly and maintain compatibility with Meson 1.1 (multi-argument syntax requires Meson 1.8+).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
