### PR TITLE
Use `WorkerProto::Serialise` abstraction for `DrvOutput`

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -964,7 +964,7 @@ static void performOp(
     case WorkerProto::Op::RegisterDrvOutput: {
         logger->startWork();
         if (GET_PROTOCOL_MINOR(conn.protoVersion) < 31) {
-            auto outputId = DrvOutput::parse(readString(conn.from));
+            auto outputId = WorkerProto::Serialise<DrvOutput>::read(*store, rconn);
             auto outputPath = StorePath(readString(conn.from));
             store->registerDrvOutput(Realisation{{.outPath = outputPath}, outputId});
         } else {
@@ -977,7 +977,7 @@ static void performOp(
 
     case WorkerProto::Op::QueryRealisation: {
         logger->startWork();
-        auto outputId = DrvOutput::parse(readString(conn.from));
+        auto outputId = WorkerProto::Serialise<DrvOutput>::read(*store, rconn);
         auto info = store->queryRealisation(outputId);
         logger->stopWork();
         if (GET_PROTOCOL_MINOR(conn.protoVersion) < 31) {

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -493,7 +493,7 @@ void RemoteStore::registerDrvOutput(const Realisation & info)
     auto conn(getConnection());
     conn->to << WorkerProto::Op::RegisterDrvOutput;
     if (GET_PROTOCOL_MINOR(conn->protoVersion) < 31) {
-        conn->to << info.id.to_string();
+        WorkerProto::write(*this, *conn, info.id);
         conn->to << std::string(info.outPath.to_string());
     } else {
         WorkerProto::write(*this, *conn, info);
@@ -513,7 +513,7 @@ void RemoteStore::queryRealisationUncached(
         }
 
         conn->to << WorkerProto::Op::QueryRealisation;
-        conn->to << id.to_string();
+        WorkerProto::write(*this, *conn, id);
         conn.processStderr();
 
         auto real = [&]() -> std::shared_ptr<const UnkeyedRealisation> {


### PR DESCRIPTION
## Motivation

It's better to consistently use the abstraction, rather than code which happens to do the same thing.

## Context

See also d782c5e5863cdcfd3fc8013c84efa1053b3d2e80 for the same sort of change.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
