### PR TITLE
feat(libstore): tie AWS CRT logging to Nix verbosity level

### DIFF
--- a/src/libstore/aws-creds.cc
+++ b/src/libstore/aws-creds.cc
@@ -79,7 +79,18 @@ class AwsCredentialProviderImpl : public AwsCredentialProvider
 public:
     AwsCredentialProviderImpl()
     {
-        apiHandle.InitializeLogging(Aws::Crt::LogLevel::Warn, static_cast<FILE *>(nullptr));
+        // Map Nix's verbosity to AWS CRT log level
+        Aws::Crt::LogLevel logLevel;
+        if (verbosity >= lvlVomit) {
+            logLevel = Aws::Crt::LogLevel::Trace;
+        } else if (verbosity >= lvlDebug) {
+            logLevel = Aws::Crt::LogLevel::Debug;
+        } else if (verbosity >= lvlChatty) {
+            logLevel = Aws::Crt::LogLevel::Info;
+        } else {
+            logLevel = Aws::Crt::LogLevel::Warn;
+        }
+        apiHandle.InitializeLogging(logLevel, stderr);
     }
 
     AwsCredentials getCredentialsRaw(const std::string & profile);


### PR DESCRIPTION
## Motivation

Map Nix's verbosity levels to AWS CRT log levels so users can
debug SSO authentication issues without modifying code:

- Default/warn: AWS Warn (errors/warnings only)
- Chatty (-vvv): AWS Info (credential provider actions)
- Debug (-vvvv): AWS Debug (detailed auth flow)
- Vomit (-vvvvv): AWS Trace (full CRT internal tracing)

This makes it easy to diagnose SSO issues with:
  nix copy -vvvv --to s3://bucket?profile=foo ...

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
