### PR TITLE
Use std::filesystem::path instead of Path in libcmd

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -165,7 +165,7 @@ Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
                         state.parseExprFromString(
                             arg.expr,
                             compatibilitySettings.nixShellShebangArgumentsRelativeToScript
-                                ? state.rootPath(absPath(getCommandBaseDir()))
+                                ? state.rootPath(absPath(getCommandBaseDir()).string())
                                 : state.rootPath(".")));
                 },
                 [&](const AutoArgString & arg) { v->mkString(arg.s, state.mem); },
@@ -177,7 +177,7 @@ Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
     return res.finish();
 }
 
-SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * baseDir)
+SourcePath lookupFileArg(EvalState & state, std::string_view s, const std::filesystem::path * baseDir)
 {
     if (EvalSettings::isPseudoUrl(s)) {
         auto accessor = fetchers::downloadTarball(*state.store, state.fetchSettings, EvalSettings::resolvePseudoUrl(s));
@@ -197,12 +197,13 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * bas
     }
 
     else if (s.size() > 2 && s.at(0) == '<' && s.at(s.size() - 1) == '>') {
-        Path p(s.substr(1, s.size() - 2));
+        // Should perhaps be a `CanonPath`?
+        std::string p(s.substr(1, s.size() - 2));
         return state.findFile(p);
     }
 
     else
-        return state.rootPath(baseDir ? absPath(s, *baseDir) : absPath(s));
+        return state.rootPath(absPath(std::filesystem::path{s}, baseDir).string());
 }
 
 } // namespace nix

--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -134,7 +134,7 @@ struct MixFlakeOptions : virtual Args, EvalCommand
 
 struct SourceExprCommand : virtual Args, MixFlakeOptions
 {
-    std::optional<Path> file;
+    std::optional<std::filesystem::path> file;
     std::optional<std::string> expr;
 
     SourceExprCommand();
@@ -310,7 +310,7 @@ static RegisterCommand registerCommand2(std::vector<std::string> && name)
 
 struct MixProfile : virtual StoreCommand
 {
-    std::optional<Path> profile;
+    std::optional<std::filesystem::path> profile;
 
     MixProfile();
 

--- a/src/libcmd/include/nix/cmd/common-eval-args.hh
+++ b/src/libcmd/include/nix/cmd/common-eval-args.hh
@@ -84,6 +84,6 @@ private:
 /**
  * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary#gloss-base-directory)
  */
-SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * baseDir = nullptr);
+SourcePath lookupFileArg(EvalState & state, std::string_view s, const std::filesystem::path * baseDir = nullptr);
 
 } // namespace nix

--- a/src/libcmd/include/nix/cmd/installable-value.hh
+++ b/src/libcmd/include/nix/cmd/installable-value.hh
@@ -17,7 +17,7 @@ class AttrCursor;
 struct App
 {
     std::vector<DerivedPath> context;
-    Path program;
+    std::filesystem::path program;
     // FIXME: add args, sandbox settings, metadata, ...
 };
 

--- a/src/libcmd/include/nix/cmd/repl.hh
+++ b/src/libcmd/include/nix/cmd/repl.hh
@@ -19,7 +19,16 @@ struct AbstractNixRepl
 
     typedef std::vector<std::pair<Value *, std::string>> AnnotatedValues;
 
-    using RunNix = void(Path program, const Strings & args, const std::optional<std::string> & input);
+    /**
+     * Run a nix executable
+     *
+     * @todo this is a layer violation
+     *
+     * @param programName Name of the command, e.g. `nix` or `nix-env`.
+     * @param args aguments to the command.
+     */
+    using RunNix =
+        void(const std::string & programName, const Strings & args, const std::optional<std::string> & input);
 
     /**
      * @param runNix Function to run the nix CLI to support various

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -371,13 +371,13 @@ void RootArgs::parseCmdline(const Strings & _cmdline, bool allowShebang)
         d.completer(*completions, d.n, d.prefix);
 }
 
-Path Args::getCommandBaseDir() const
+std::filesystem::path Args::getCommandBaseDir() const
 {
     assert(parent);
     return parent->getCommandBaseDir();
 }
 
-Path RootArgs::getCommandBaseDir() const
+std::filesystem::path RootArgs::getCommandBaseDir() const
 {
     return commandBaseDir;
 }

--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -59,7 +59,7 @@ public:
      *
      * This only returns the correct value after parseCmdline() has run.
      */
-    virtual Path getCommandBaseDir() const;
+    virtual std::filesystem::path getCommandBaseDir() const;
 
 protected:
 

--- a/src/libutil/include/nix/util/args/root.hh
+++ b/src/libutil/include/nix/util/args/root.hh
@@ -38,7 +38,7 @@ protected:
      *
      * @see getCommandBaseDir()
      */
-    Path commandBaseDir = ".";
+    std::filesystem::path commandBaseDir = ".";
 
 public:
     /** Parse the command line, throwing a UsageError if something goes
@@ -48,7 +48,7 @@ public:
 
     std::shared_ptr<Completions> completions;
 
-    Path getCommandBaseDir() const override;
+    std::filesystem::path getCommandBaseDir() const override;
 
 protected:
 

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -140,9 +140,9 @@ App UnresolvedApp::resolve(ref<Store> evalStore, ref<Store> store)
     auto res = unresolved;
 
     auto builtContext = build(evalStore, store);
-    res.program = resolveString(*store, unresolved.program, builtContext);
-    if (!store->isInStore(res.program))
-        throw Error("app program '%s' is not in the Nix store", res.program);
+    res.program = resolveString(*store, unresolved.program.string(), builtContext);
+    if (!store->isInStore(res.program.string()))
+        throw Error("app program '%s' is not in the Nix store", res.program.string());
 
     return res;
 }

--- a/src/nix/formatter.cc
+++ b/src/nix/formatter.cc
@@ -84,7 +84,7 @@ struct CmdFormatterRun : MixFormatter, MixJSON
         assert(maybeFlakeDir.has_value());
         auto flakeDir = maybeFlakeDir.value();
 
-        Strings programArgs{app.program};
+        Strings programArgs{app.program.string()};
 
         // Propagate arguments from the CLI
         for (auto & i : args) {
@@ -103,7 +103,7 @@ struct CmdFormatterRun : MixFormatter, MixJSON
         execProgramInStore(
             store,
             UseLookupPath::DontUse,
-            app.program,
+            app.program.string(),
             programArgs,
             std::nullopt, // Use default system
             env);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -11,7 +11,7 @@
 
 namespace nix {
 
-void runNix(Path program, const Strings & args, const std::optional<std::string> & input = {})
+void runNix(const std::string & program, const Strings & args, const std::optional<std::string> & input = {})
 {
     auto subprocessEnv = getEnv();
     subprocessEnv["NIX_CONFIG"] = globalConfig.toKeyValue();

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -160,7 +160,7 @@ struct CmdRun : InstallableValueCommand, MixEnvironment
         lockFlags.applyNixConfig = true;
         auto app = installable->toApp(*state).resolve(getEvalStore(), store);
 
-        Strings allArgs{app.program};
+        Strings allArgs{app.program.string()};
         for (auto & i : args)
             allArgs.push_back(i);
 
@@ -170,7 +170,7 @@ struct CmdRun : InstallableValueCommand, MixEnvironment
 
         setEnviron();
 
-        execProgramInStore(store, UseLookupPath::DontUse, app.program, allArgs);
+        execProgramInStore(store, UseLookupPath::DontUse, app.program.string(), allArgs);
     }
 };
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Update libcmd to use std::filesystem::path instead of Path

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

https://github.com/NixOS/nix/issues/9205

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
