### PR TITLE
Use std::filesystem::path instead of Path in libexpr.

### DIFF
--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -103,9 +103,9 @@ const std::string & EvalSettings::getCurrentSystem() const
     return evalSystem != "" ? evalSystem : settings.thisSystem.get();
 }
 
-Path getNixDefExpr()
+std::filesystem::path getNixDefExpr()
 {
-    return settings.useXDGBaseDirectories ? getStateDir() + "/defexpr" : getHome() + "/.nix-defexpr";
+    return settings.useXDGBaseDirectories ? getStateDir() / "defexpr" : getHome() / ".nix-defexpr";
 }
 
 } // namespace nix

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -366,6 +366,6 @@ struct EvalSettings : Config
 /**
  * Conventionally part of the default nix path in impure mode.
  */
-Path getNixDefExpr();
+std::filesystem::path getNixDefExpr();
 
 } // namespace nix

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -389,7 +389,7 @@ path_start
             std::string_view($1.p, $1.l)
         );
     }
-    Path path(getHome() + std::string($1.p + 1, $1.l - 1));
+    Path path(getHome().string() + std::string($1.p + 1, $1.l - 1));
     $$ = state->exprs.add<ExprPath>(state->exprs.alloc, ref<SourceAccessor>(state->rootFS), path);
   }
   ;

--- a/src/libutil/include/nix/util/users.hh
+++ b/src/libutil/include/nix/util/users.hh
@@ -1,6 +1,8 @@
 #pragma once
 ///@file
 
+#include <filesystem>
+
 #include "nix/util/types.hh"
 
 #ifndef _WIN32
@@ -15,43 +17,43 @@ std::string getUserName();
 /**
  * @return the given user's home directory from /etc/passwd.
  */
-Path getHomeOf(uid_t userId);
+std::filesystem::path getHomeOf(uid_t userId);
 #endif
 
 /**
  * @return $HOME or the user's home directory from /etc/passwd.
  */
-Path getHome();
+std::filesystem::path getHome();
 
 /**
  * @return $NIX_CACHE_HOME or $XDG_CACHE_HOME/nix or $HOME/.cache/nix.
  */
-Path getCacheDir();
+std::filesystem::path getCacheDir();
 
 /**
  * @return $NIX_CONFIG_HOME or $XDG_CONFIG_HOME/nix or $HOME/.config/nix.
  */
-Path getConfigDir();
+std::filesystem::path getConfigDir();
 
 /**
  * @return the directories to search for user configuration files
  */
-std::vector<Path> getConfigDirs();
+std::vector<std::filesystem::path> getConfigDirs();
 
 /**
  * @return $NIX_DATA_HOME or $XDG_DATA_HOME/nix or $HOME/.local/share/nix.
  */
-Path getDataDir();
+std::filesystem::path getDataDir();
 
 /**
  * @return $NIX_STATE_HOME or $XDG_STATE_HOME/nix or $HOME/.local/state/nix.
  */
-Path getStateDir();
+std::filesystem::path getStateDir();
 
 /**
  * Create the Nix state directory and return the path to it.
  */
-Path createNixStateDir();
+std::filesystem::path createNixStateDir();
 
 /**
  * Perform tilde expansion on a path, replacing tilde with the user's

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -6,6 +6,7 @@
 #include "nix/util/logging.hh"
 #include "nix/util/strings.hh"
 
+#include <filesystem>
 #include <functional>
 #include <map>
 #include <sstream>

--- a/src/libutil/unix/users.cc
+++ b/src/libutil/unix/users.cc
@@ -18,7 +18,7 @@ std::string getUserName()
     return name;
 }
 
-Path getHomeOf(uid_t userId)
+std::filesystem::path getHomeOf(uid_t userId)
 {
     std::vector<char> buf(16384);
     struct passwd pwbuf;
@@ -28,9 +28,9 @@ Path getHomeOf(uid_t userId)
     return pw->pw_dir;
 }
 
-Path getHome()
+std::filesystem::path getHome()
 {
-    static Path homeDir = []() {
+    static std::filesystem::path homeDir = []() {
         std::optional<std::string> unownedUserHomeDir = {};
         auto homeDir = getEnv("HOME");
         if (homeDir) {

--- a/src/libutil/users.cc
+++ b/src/libutil/users.cc
@@ -5,7 +5,7 @@
 
 namespace nix {
 
-Path getCacheDir()
+std::filesystem::path getCacheDir()
 {
     auto dir = getEnv("NIX_CACHE_HOME");
     if (dir) {
@@ -13,14 +13,14 @@ Path getCacheDir()
     } else {
         auto xdgDir = getEnv("XDG_CACHE_HOME");
         if (xdgDir) {
-            return *xdgDir + "/nix";
+            return std::filesystem::path{*xdgDir} / "nix";
         } else {
-            return getHome() + "/.cache/nix";
+            return getHome() / ".cache" / "nix";
         }
     }
 }
 
-Path getConfigDir()
+std::filesystem::path getConfigDir()
 {
     auto dir = getEnv("NIX_CONFIG_HOME");
     if (dir) {
@@ -28,26 +28,27 @@ Path getConfigDir()
     } else {
         auto xdgDir = getEnv("XDG_CONFIG_HOME");
         if (xdgDir) {
-            return *xdgDir + "/nix";
+            return std::filesystem::path{*xdgDir} / "nix";
         } else {
-            return getHome() + "/.config/nix";
+            return getHome() / ".config" / "nix";
         }
     }
 }
 
-std::vector<Path> getConfigDirs()
+std::vector<std::filesystem::path> getConfigDirs()
 {
-    Path configHome = getConfigDir();
+    std::filesystem::path configHome = getConfigDir();
     auto configDirs = getEnv("XDG_CONFIG_DIRS").value_or("/etc/xdg");
-    std::vector<Path> result = tokenizeString<std::vector<std::string>>(configDirs, ":");
-    for (auto & p : result) {
-        p += "/nix";
+    auto tokens = tokenizeString<std::vector<std::string>>(configDirs, ":");
+    std::vector<std::filesystem::path> result;
+    result.push_back(configHome);
+    for (auto & token : tokens) {
+        result.push_back(std::filesystem::path{token} / "nix");
     }
-    result.insert(result.begin(), configHome);
     return result;
 }
 
-Path getDataDir()
+std::filesystem::path getDataDir()
 {
     auto dir = getEnv("NIX_DATA_HOME");
     if (dir) {
@@ -55,14 +56,14 @@ Path getDataDir()
     } else {
         auto xdgDir = getEnv("XDG_DATA_HOME");
         if (xdgDir) {
-            return *xdgDir + "/nix";
+            return std::filesystem::path{*xdgDir} / "nix";
         } else {
-            return getHome() + "/.local/share/nix";
+            return getHome() / ".local" / "share" / "nix";
         }
     }
 }
 
-Path getStateDir()
+std::filesystem::path getStateDir()
 {
     auto dir = getEnv("NIX_STATE_HOME");
     if (dir) {
@@ -70,16 +71,16 @@ Path getStateDir()
     } else {
         auto xdgDir = getEnv("XDG_STATE_HOME");
         if (xdgDir) {
-            return *xdgDir + "/nix";
+            return std::filesystem::path{*xdgDir} / "nix";
         } else {
-            return getHome() + "/.local/state/nix";
+            return getHome() / ".local" / "state" / "nix";
         }
     }
 }
 
-Path createNixStateDir()
+std::filesystem::path createNixStateDir()
 {
-    Path dir = getStateDir();
+    std::filesystem::path dir = getStateDir();
     createDirs(dir);
     return dir;
 }

--- a/src/libutil/windows/users.cc
+++ b/src/libutil/windows/users.cc
@@ -35,10 +35,10 @@ std::string getUserName()
     return name;
 }
 
-Path getHome()
+std::filesystem::path getHome()
 {
-    static Path homeDir = []() {
-        Path homeDir = getEnv("USERPROFILE").value_or("C:\\Users\\Default");
+    static std::filesystem::path homeDir = []() {
+        std::filesystem::path homeDir = getEnv("USERPROFILE").value_or("C:\\Users\\Default");
         assert(!homeDir.empty());
         return canonPath(homeDir);
     }();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Use std::filesystem::path instead of Path in libexpr.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

https://github.com/NixOS/nix/issues/9205

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
