### PR TITLE
libstore: Fix double quotes in debug logs for pathlocks

### DIFF
--- a/src/libstore/unix/pathlocks.cc
+++ b/src/libstore/unix/pathlocks.cc
@@ -19,7 +19,7 @@ AutoCloseFD openLockFile(const std::filesystem::path & path, bool create)
 
     fd = open(path.c_str(), O_CLOEXEC | O_RDWR | (create ? O_CREAT : 0), 0600);
     if (!fd && (create || errno != ENOENT))
-        throw SysError("opening lock file '%1%'", path);
+        throw SysError("opening lock file %1%", path);
 
     return fd;
 }
@@ -83,7 +83,7 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
         checkInterrupt();
         std::filesystem::path lockPath = path + ".lock";
 
-        debug("locking path '%1%'", path);
+        debug("locking path %1%", path);
 
         AutoCloseFD fd;
 
@@ -106,19 +106,19 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
                 }
             }
 
-            debug("lock acquired on '%1%'", lockPath);
+            debug("lock acquired on %1%", lockPath);
 
             /* Check that the lock file hasn't become stale (i.e.,
                hasn't been unlinked). */
             struct stat st;
             if (fstat(fd.get(), &st) == -1)
-                throw SysError("statting lock file '%1%'", lockPath);
+                throw SysError("statting lock file %1%", lockPath);
             if (st.st_size != 0)
                 /* This lock file has been unlinked, so we're holding
                    a lock on a deleted file.  This means that other
                    processes may create and acquire a lock on
                    `lockPath', and proceed.  So we must retry. */
-                debug("open lock file '%1%' has become stale", lockPath);
+                debug("open lock file %1% has become stale", lockPath);
             else
                 break;
         }
@@ -137,9 +137,9 @@ void PathLocks::unlock()
             deleteLockFile(i.second, i.first);
 
         if (close(i.first) == -1)
-            printError("error (ignored): cannot close lock file on '%1%'", i.second);
+            printError("error (ignored): cannot close lock file on %1%", i.second);
 
-        debug("lock released on '%1%'", i.second);
+        debug("lock released on %1%", i.second);
     }
 
     fds.clear();

--- a/src/libstore/windows/pathlocks.cc
+++ b/src/libstore/windows/pathlocks.cc
@@ -28,9 +28,9 @@ void PathLocks::unlock()
             deleteLockFile(i.second, i.first);
 
         if (CloseHandle(i.first) == -1)
-            printError("error (ignored): cannot close lock file on '%1%'", i.second);
+            printError("error (ignored): cannot close lock file on %1%", i.second);
 
-        debug("lock released on '%1%'", i.second);
+        debug("lock released on %1%", i.second);
     }
 
     fds.clear();
@@ -111,7 +111,7 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
         checkInterrupt();
         std::filesystem::path lockPath = path;
         lockPath += L".lock";
-        debug("locking path '%1%'", path);
+        debug("locking path %1%", path);
 
         AutoCloseFD fd;
 
@@ -128,13 +128,13 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
                 }
             }
 
-            debug("lock acquired on '%1%'", lockPath);
+            debug("lock acquired on %1%", lockPath);
 
             struct _stat st;
             if (_fstat(fromDescriptorReadOnly(fd.get()), &st) == -1)
-                throw SysError("statting lock file '%1%'", lockPath);
+                throw SysError("statting lock file %1%", lockPath);
             if (st.st_size != 0)
-                debug("open lock file '%1%' has become stale", lockPath);
+                debug("open lock file %1% has become stale", lockPath);
             else
                 break;
         }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is now using std::filesystem which gets double-quoted.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
