### PR TITLE
libutil: Use openFileEnsureBeneathNoSymlinks in RestoreSink::createRe…

### DIFF
--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -351,6 +351,10 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
             sink.createDirectory(
                 CanonPath("a/b/c/f"), [](FileSystemObjectSink & dirSink, const CanonPath & relPath) {}),
             SymlinkNotAllowed);
+        ASSERT_THROW(
+            sink.createRegularFile(
+                CanonPath("a/b/c/regular"), [](CreateRegularFileSink & crf) { crf("some contents"); }),
+            SymlinkNotAllowed);
     }
 
     AutoCloseFD dirFd = openDirectory(tmpDir);

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -170,7 +170,7 @@ void RestoreSink::createRegularFile(const CanonPath & path, std::function<void(C
             constexpr int flags = O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC;
             if (!dirFd)
                 return ::open(p.c_str(), flags, 0666);
-            return ::openat(dirFd.get(), path.rel_c_str(), flags, 0666);
+            return unix::openFileEnsureBeneathNoSymlinks(dirFd.get(), path, flags, 0666);
         }();
 #endif
         ;

--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -263,6 +263,8 @@ struct SymlinkNotAllowed : public Error
  * @param flags O_* flags
  * @param mode Mode for O_{CREAT,TMPFILE}
  *
+ * @pre path.isRoot() is false
+ *
  * @throws SymlinkNotAllowed if any path components
  */
 Descriptor openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & path, int flags, mode_t mode = 0);

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -269,6 +269,7 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
 {
     AutoCloseFD parentFd;
     auto nrComponents = std::ranges::distance(path);
+    assert(nrComponents >= 1);
     auto components = std::views::take(path, nrComponents - 1); /* Everything but last component */
     auto getParentFd = [&]() { return parentFd ? parentFd.get() : dirFd; };
 
@@ -320,6 +321,8 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
 
 Descriptor unix::openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & path, int flags, mode_t mode)
 {
+    assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
+    assert(!path.isRoot());
 #ifdef __linux__
     auto maybeFd = linux::openat2(
         dirFd, path.rel_c_str(), flags, static_cast<uint64_t>(mode), RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS);


### PR DESCRIPTION
…gularFile

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Add more assertions for preconditions of openFileEnsureBeneathNoSymlinks to prevent misuse. Also start using it for regular file creation as well.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
