### PR TITLE
log builder uid if building locally

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -263,23 +263,29 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
                 : buildMode == bmCheck ? "checking outputs of '%s'"
                                        : "building '%s'",
                 worker.store.printStorePath(drvPath));
+
+        std::string builderName;
 #ifndef _WIN32 // TODO enable build hook on Windows
-        if (hook)
-            msg += fmt(" on '%s'", hook->machineName);
+        if (hook) {
+            builderName = fmt("remote builder: %s", hook->machineName);
+        } else if (builder) {
+            auto maybeUID = builder->getBuilderUID();
+            if (maybeUID)
+                builderName = fmt("localhost builder with uid: %s", std::to_string(*maybeUID));
+            else
+                builderName = "";
+        } else {
+            builderName = "";
+        }
+#else
+        builderName = "";
 #endif
+        if (builderName != "")
+            msg += fmt(" on '%s'", builderName);
+
         act = std::make_unique<Activity>(
-            *logger,
-            lvlInfo,
-            actBuild,
-            msg,
-            Logger::Fields{
-                worker.store.printStorePath(drvPath),
-#ifndef _WIN32 // TODO enable build hook on Windows
-                hook ? hook->machineName :
-#endif
-                     "",
-                1,
-                1});
+            *logger, lvlInfo, actBuild, msg, Logger::Fields{worker.store.printStorePath(drvPath), builderName, 1, 1});
+
         mcRunningBuilds = std::make_unique<MaintainCount<uint64_t>>(worker.runningBuilds);
         worker.updateProgress();
     };

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -180,6 +180,13 @@ struct DerivationBuilder : RestrictionContext
      * killed.
      */
     virtual bool killChild() = 0;
+
+    /**
+     * Get the builder UID.
+     *
+     * @returns the builder UID if run on localhost (e.g. if it exists).
+     */
+    virtual std::optional<uid_t> getBuilderUID() = 0;
 };
 
 struct ExternalBuilder

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -415,6 +415,8 @@ public:
 
     bool killChild() override;
 
+    std::optional<uid_t> getBuilderUID() override;
+
 private:
 
     bool decideWhetherDiskFull();
@@ -492,6 +494,11 @@ bool DerivationBuilderImpl::killChild()
         pid.wait();
     }
     return ret;
+}
+
+std::optional<uid_t> DerivationBuilderImpl::getBuilderUID()
+{
+    return (buildUser) ? std::optional<uid_t>(buildUser->getUID()) : std::nullopt;
 }
 
 SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

It might be helpful to know the assigned builder for a drv. I talk about this more in #14639, but my specific usecase is tying processes to a builder for a nix task monitor. But I think this could also be helpful when debugging (for example, if a builder locks up and you want to figure out which derivation it was building)

## Context

The context is also primarily #14639. This change feels relatively small to me, and shouldn't make much of a difference unless someone is parsing the log output.

In terms of testing I ran the check phase. Two tests fail, but they also seem to fail prior to this change (?)

I also ran the daemon and ran some local builds on both macos and nixos. Both targets printed the builder uid. But, I wasn't able to test a remote builder 



---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
