### PR TITLE
refactor(libutil): convert Verbosity to enum class

### DIFF
--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -78,7 +78,7 @@ InstallableFlake::InstallableFlake(
 
 DerivedPathsWithInfo InstallableFlake::toDerivedPaths()
 {
-    Activity act(*logger, lvlTalkative, actUnknown, fmt("evaluating derivation '%s'", what()));
+    Activity act(*logger, Verbosity::Talkative, actUnknown, fmt("evaluating derivation '%s'", what()));
 
     auto attr = getCursor(*state);
 

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -584,7 +584,7 @@ static void throwBuildErrors(std::vector<KeyedBuildResult> & buildResults, const
                 if (!failedResult->second->errorMsg.empty()) {
                     logError(
                         ErrorInfo{
-                            .level = lvlError,
+                            .level = Verbosity::Error,
                             .msg = failedResult->second->errorMsg,
                         });
                 }
@@ -623,7 +623,7 @@ std::vector<std::pair<ref<Installable>, BuiltPathWithResult>> Installable::build
 
     case Realise::Nothing:
     case Realise::Derivation:
-        printMissing(store, pathsToBuild, lvlError);
+        printMissing(store, pathsToBuild, Verbosity::Error);
 
         for (auto & path : pathsToBuild) {
             for (auto & aux : backmap[path]) {
@@ -653,7 +653,7 @@ std::vector<std::pair<ref<Installable>, BuiltPathWithResult>> Installable::build
 
     case Realise::Outputs: {
         if (settings.printMissing)
-            printMissing(store, pathsToBuild, lvlInfo);
+            printMissing(store, pathsToBuild, Verbosity::Info);
 
         auto buildResults = store->buildPathsWithResults(pathsToBuild, bMode, evalStore);
         throwBuildErrors(buildResults, *store);

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -219,9 +219,9 @@ ReplExitStatus NixRepl::mainLoop()
         } catch (IncompleteReplExpr &) {
             continue;
         } catch (Error & e) {
-            printMsg(lvlError, e.msg());
+            printMsg(Verbosity::Error, e.msg());
         } catch (Interrupted & e) {
-            printMsg(lvlError, e.msg());
+            printMsg(Verbosity::Error, e.msg());
         }
 
         // We handled the current input fully, so we should clear it

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -795,7 +795,7 @@ void EvalState::runDebugRepl(const Error * error, const Env & env, const Expr & 
     if (error) {
         printError("%s\n", error->what());
 
-        if (trylevel > 0 && error->info().level != lvlInfo)
+        if (trylevel > 0 && error->info().level != Verbosity::Info)
             printError(
                 "This exception occurred in a 'tryEval' call. Use " ANSI_GREEN "--ignore-try" ANSI_NORMAL
                 " to skip these.\n");
@@ -2509,7 +2509,7 @@ StorePath EvalState::copyPathToStore(NixStringContext & context, const SourcePat
             repair);
         allowPath(dstPath);
         srcToStore->try_emplace(path, dstPath);
-        printMsg(lvlChatty, "copied source '%1%' -> '%2%'", path, store->printStorePath(dstPath));
+        printMsg(Verbosity::Chatty, "copied source '%1%' -> '%2%'", path, store->printStorePath(dstPath));
         return dstPath;
     }();
 
@@ -3133,7 +3133,7 @@ Expr * EvalState::parseStdin()
     // NOTE this method (and parseExprFromString) must take care to *fully copy* their
     // input into their respective Pos::Origin until the parser stops overwriting its
     // input data.
-    // Activity act(*logger, lvlTalkative, "parsing standard input");
+    // Activity act(*logger, Verbosity::Talkative, "parsing standard input");
     auto buffer = drainFD(0);
     // drainFD should have left some extra space for terminators
     buffer.append("\0\0", 2);

--- a/src/libexpr/function-trace.cc
+++ b/src/libexpr/function-trace.cc
@@ -8,7 +8,7 @@ void FunctionCallTrace::preFunctionCallHook(
 {
     auto duration = std::chrono::high_resolution_clock::now().time_since_epoch();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
-    printMsg(lvlInfo, "function-trace entered %1% at %2%", state.positions[pos], ns.count());
+    printMsg(Verbosity::Info, "function-trace entered %1% at %2%", state.positions[pos], ns.count());
 }
 
 void FunctionCallTrace::postFunctionCallHook(
@@ -16,7 +16,7 @@ void FunctionCallTrace::postFunctionCallHook(
 {
     auto duration = std::chrono::high_resolution_clock::now().time_since_epoch();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
-    printMsg(lvlInfo, "function-trace exited %1% at %2%", state.positions[pos], ns.count());
+    printMsg(Verbosity::Info, "function-trace exited %1% at %2%", state.positions[pos], ns.count());
 }
 
 } // namespace nix

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -928,7 +928,7 @@ static RegisterPrimOp primop_break(
          if (state.canDebug()) {
              auto error = Error(
                  ErrorInfo{
-                     .level = lvlInfo,
+                     .level = Verbosity::Info,
                      .msg = HintFmt("breakpoint reached"),
                      .pos = state.positions[pos],
                  });
@@ -1278,7 +1278,7 @@ static void prim_warn(EvalState & state, const PosIdx pos, Value ** args, Value 
         BaseError msg(std::string{msgStr});
         msg.atPos(state.positions[pos]);
         auto info = msg.info();
-        info.level = lvlWarn;
+        info.level = Verbosity::Warn;
         info.isFromExpr = true;
         logWarning(info);
     }
@@ -1781,7 +1781,7 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
     auto drvPath = writeDerivation(*state.store, drv, state.repair);
     auto drvPathS = state.store->printStorePath(drvPath);
 
-    printMsg(lvlChatty, "instantiated '%1%' -> '%2%'", drvName, drvPathS);
+    printMsg(Verbosity::Chatty, "instantiated '%1%' -> '%2%'", drvName, drvPathS);
 
     /* Optimisation, but required in read-only mode! because in that
        case we don't actually write store derivations, so we can't

--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -47,7 +47,7 @@ StorePath fetchToStore(
 
     Activity act(
         *logger,
-        lvlChatty,
+        Verbosity::Chatty,
         actUnknown,
         fmt(mode == FetchMode::DryRun ? "hashing '%s'" : "copying '%s' to the store", path));
 

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -493,7 +493,7 @@ void InputScheme::clone(
 
     auto [accessor, input2] = getAccessor(settings, store, input);
 
-    Activity act(*logger, lvlTalkative, actUnknown, fmt("copying '%s' to %s...", input2.to_string(), destDir));
+    Activity act(*logger, Verbosity::Talkative, actUnknown, fmt("copying '%s' to %s...", input2.to_string(), destDir));
 
     RestoreSink sink(/*startFsync=*/false);
     sink.dstPath = destDir;

--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -240,7 +240,7 @@ std::vector<nlohmann::json> Fetch::fetchUrls(const std::vector<Pointer> & pointe
 
         return objects;
     } catch (const nlohmann::json::parse_error & e) {
-        printMsg(lvlTalkative, "Full response: '%1%'", responseString);
+        printMsg(Verbosity::Talkative, "Full response: '%1%'", responseString);
         throw Error("response did not parse as json: %s", e.what());
     }
 }

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -576,7 +576,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
     void fetch(const std::string & url, const std::string & refspec, bool shallow) override
     {
-        Activity act(*logger, lvlTalkative, actFetchTree, fmt("fetching Git repository '%s'", url));
+        Activity act(*logger, Verbosity::Talkative, actFetchTree, fmt("fetching Git repository '%s'", url));
 
         // TODO: implement git-credential helper support (preferably via libgit2, which as of 2024-01 does not support
         // that)

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -724,7 +724,10 @@ struct GitInputScheme : InputScheme
             return getIntAttr(*revCountAttrs, "revCount");
 
         Activity act(
-            *logger, lvlChatty, actUnknown, fmt("getting Git revision count of '%s'", repoInfo.locationToArg()));
+            *logger,
+            Verbosity::Chatty,
+            actUnknown,
+            fmt("getting Git revision count of '%s'", repoInfo.locationToArg()));
 
         auto revCount = GitRepo::openRepo(repoDir)->getRevCount(rev);
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -312,7 +312,7 @@ struct GitArchiveInputScheme : InputScheme
         });
 
         auto act = std::make_unique<Activity>(
-            *logger, lvlInfo, actUnknown, fmt("unpacking '%s' into the Git cache", input.to_string()));
+            *logger, Verbosity::Info, actUnknown, fmt("unpacking '%s' into the Git cache", input.to_string()));
 
         TarArchive archive{*source};
         auto tarballCache = settings.getTarballCache();

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -284,7 +284,8 @@ struct MercurialInputScheme : InputScheme
               && runProgram(hgOptions({"log", "-R", cacheDir, "-r", input.getRev()->gitRev(), "--template", "1"}))
                          .second
                      == "1")) {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("fetching Mercurial repository '%s'", actualUrl));
+            Activity act(
+                *logger, Verbosity::Talkative, actUnknown, fmt("fetching Mercurial repository '%s'", actualUrl));
 
             if (pathExists(cacheDir)) {
                 try {

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -154,7 +154,7 @@ struct PathInputScheme : InputScheme
 
         time_t mtime = 0;
         if (!storePath || storePath->name() != "source" || !store.isValidPath(*storePath)) {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying %s to the store", absPath));
+            Activity act(*logger, Verbosity::Talkative, actUnknown, fmt("copying %s to the store", absPath));
             // FIXME: try to substitute storePath.
             auto src = sinkToSource(
                 [&](Sink & sink) { mtime = dumpPathAndGetMtime(absPath.string(), sink, defaultPathFilter); });

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -158,7 +158,8 @@ static DownloadTarballResult downloadTarball_(
 
     // TODO: fall back to cached value if download fails.
 
-    auto act = std::make_unique<Activity>(*logger, lvlInfo, actUnknown, fmt("unpacking '%s' into the Git cache", url));
+    auto act =
+        std::make_unique<Activity>(*logger, Verbosity::Info, actUnknown, fmt("unpacking '%s' into the Git cache", url));
 
     AutoDelete cleanupTemp;
 

--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -19,23 +19,21 @@ MixCommonArgs::MixCommonArgs(const std::string & programName)
         .shortName = 'v',
         .description = "Increase the logging verbosity level.",
         .category = loggingCategory,
-        .handler = {[]() {
-            verbosity = (Verbosity) std::min<std::underlying_type_t<Verbosity>>(verbosity + 1, lvlVomit);
-        }},
+        .handler = {[]() { ++verbosity; }},
     });
 
     addFlag({
         .longName = "quiet",
         .description = "Decrease the logging verbosity level.",
         .category = loggingCategory,
-        .handler = {[]() { verbosity = verbosity > lvlError ? (Verbosity) (verbosity - 1) : lvlError; }},
+        .handler = {[]() { --verbosity; }},
     });
 
     addFlag({
         .longName = "debug",
         .description = "Set the logging verbosity level to 'debug'.",
         .category = loggingCategory,
-        .handler = {[]() { verbosity = lvlDebug; }},
+        .handler = {[]() { verbosity = Verbosity::Debug; }},
     });
 
     addFlag({

--- a/src/libmain/include/nix/main/shared.hh
+++ b/src/libmain/include/nix/main/shared.hh
@@ -39,9 +39,9 @@ void printGCWarning();
 class Store;
 struct MissingPaths;
 
-void printMissing(ref<Store> store, const std::vector<DerivedPath> & paths, Verbosity lvl = lvlInfo);
+void printMissing(ref<Store> store, const std::vector<DerivedPath> & paths, Verbosity lvl = Verbosity::Info);
 
-void printMissing(ref<Store> store, const MissingPaths & missing, Verbosity lvl = lvlInfo);
+void printMissing(ref<Store> store, const MissingPaths & missing, Verbosity lvl = Verbosity::Info);
 
 std::string getArg(const std::string & opt, Strings::iterator & i, const Strings::iterator & end);
 

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -150,7 +150,8 @@ public:
     {
         auto state(state_.lock());
         if (state->suspensions == 0) {
-            log(lvlError, "nix::ProgressBar: resume() called without a matching preceding pause(). This is a bug.");
+            log(Verbosity::Error,
+                "nix::ProgressBar: resume() called without a matching preceding pause(). This is a bug.");
             return;
         } else {
             state->suspensions--;
@@ -320,7 +321,9 @@ public:
                 if (type == resPostBuildLogLine) {
                     suffix = " (post)> ";
                 }
-                log(*state, lvlInfo, ANSI_FAINT + info.name.value_or("unnamed") + suffix + ANSI_NORMAL + lastLine);
+                log(*state,
+                    Verbosity::Info,
+                    ANSI_FAINT + info.name.value_or("unnamed") + suffix + ANSI_NORMAL + lastLine);
             } else {
                 state->activities.erase(i->second);
                 info.lastLine = lastLine;

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -295,7 +295,7 @@ void parseCmdLine(
 void printVersion(const std::string & programName)
 {
     std::cout << fmt("%1% (Nix) %2%", programName, nixVersion) << std::endl;
-    if (verbosity > lvlInfo) {
+    if (verbosity > Verbosity::Info) {
         Strings cfg;
 #if NIX_USE_BOEHMGC
         cfg.push_back("gc");

--- a/src/libstore/aws-creds.cc
+++ b/src/libstore/aws-creds.cc
@@ -81,11 +81,11 @@ public:
     {
         // Map Nix's verbosity to AWS CRT log level
         Aws::Crt::LogLevel logLevel;
-        if (verbosity >= lvlVomit) {
+        if (verbosity >= Verbosity::Vomit) {
             logLevel = Aws::Crt::LogLevel::Trace;
-        } else if (verbosity >= lvlDebug) {
+        } else if (verbosity >= Verbosity::Debug) {
             logLevel = Aws::Crt::LogLevel::Debug;
-        } else if (verbosity >= lvlChatty) {
+        } else if (verbosity >= Verbosity::Chatty) {
             logLevel = Aws::Crt::LogLevel::Info;
         } else {
             logLevel = Aws::Crt::LogLevel::Warn;

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -183,7 +183,7 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
 
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now2 - now1).count();
     printMsg(
-        lvlTalkative,
+        Verbosity::Talkative,
         "copying path '%1%' (%2% bytes, compressed %3$.1f%% in %4% ms) to binary cache",
         printStorePath(narInfo->path),
         info.narSize,
@@ -237,7 +237,7 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
                 if (fileExists(key))
                     return;
 
-                printMsg(lvlTalkative, "creating debuginfo link from '%s' to '%s'", key, target);
+                printMsg(Verbosity::Talkative, "creating debuginfo link from '%s' to '%s'", key, target);
 
                 upsertFile(key, json.dump(), "application/json");
             };
@@ -451,7 +451,7 @@ void BinaryCacheStore::queryPathInfoUncached(
     auto storePathS = printStorePath(storePath);
     auto act = std::make_shared<Activity>(
         *logger,
-        lvlTalkative,
+        Verbosity::Talkative,
         actQueryPathInfo,
         fmt("querying info about '%s' on '%s'", storePathS, uri),
         Logger::Fields{storePathS, uri});

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -269,7 +269,7 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
 #endif
         act = std::make_unique<Activity>(
             *logger,
-            lvlInfo,
+            Verbosity::Info,
             actBuild,
             msg,
             Logger::Fields{
@@ -328,7 +328,10 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
 
         if (!outputLocks.lockPaths(lockFiles, "", false)) {
             Activity act(
-                *logger, lvlWarn, actBuildWaiting, fmt("waiting for lock on %s", Magenta(showPaths(lockFiles))));
+                *logger,
+                Verbosity::Warn,
+                actBuildWaiting,
+                fmt("waiting for lock on %s", Magenta(showPaths(lockFiles))));
 
             /* Wait then try locking again, repeat until success (returned
                boolean is true). */
@@ -386,7 +389,7 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
                 if (!actLock)
                     actLock = std::make_unique<Activity>(
                         *logger,
-                        lvlWarn,
+                        Verbosity::Warn,
                         actBuildWaiting,
                         fmt("waiting for a machine to build '%s'", Magenta(worker.store.printStorePath(drvPath))));
                 outputLocks.unlock();
@@ -649,7 +652,7 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
             if (!actLock)
                 actLock = std::make_unique<Activity>(
                     *logger,
-                    lvlWarn,
+                    Verbosity::Warn,
                     actBuildWaiting,
                     fmt("waiting for a free build user ID for '%s'", Magenta(worker.store.printStorePath(drvPath))));
             co_await waitForAWhile();
@@ -738,7 +741,7 @@ static void runPostBuildHook(
 
     Activity act(
         logger,
-        lvlTalkative,
+        Verbosity::Talkative,
         actPostBuildHook,
         fmt("running post-build-hook '%s'", settings.postBuildHook),
         Logger::Fields{store.printStorePath(drvPath)});

--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -172,7 +172,7 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
                     worker.store.printStorePath(pathResolved));
             act = std::make_unique<Activity>(
                 *logger,
-                lvlInfo,
+                Verbosity::Info,
                 actBuildWaiting,
                 msg,
                 Logger::Fields{

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -288,7 +288,7 @@ Goal::Co PathSubstitutionGoal::tryToRun(
 
     worker.markContentsGood(storePath);
 
-    printMsg(lvlChatty, "substitution of path '%s' succeeded", worker.store.printStorePath(storePath));
+    printMsg(Verbosity::Chatty, "substitution of path '%s' succeeded", worker.store.printStorePath(storePath));
 
     maintainRunningSubstitutions.reset();
 

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -383,7 +383,7 @@ void Worker::run(const Goals & _topGoals)
 
 void Worker::waitForInput()
 {
-    printMsg(lvlVomit, "waiting for children");
+    printMsg(Verbosity::Vomit, "waiting for children");
 
     /* Process output from the file descriptors attached to the
        children, namely log output and output path creation commands.
@@ -468,7 +468,7 @@ void Worker::waitForInput()
         state.iterate(
             j->channels,
             [&](Descriptor k, std::string_view data) {
-                printMsg(lvlVomit, "%1%: read %2% bytes", goal->getName(), data.size());
+                printMsg(Verbosity::Vomit, "%1%: read %2% bytes", goal->getName(), data.size());
                 j->lastOutput = after;
                 goal->handleChildOutput(k, data);
             },

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -155,7 +155,7 @@ struct TunnelLogger : public Logger
         }
 
         StringSink buf;
-        buf << STDERR_START_ACTIVITY << act << lvl << type << s << fields << parent;
+        buf << STDERR_START_ACTIVITY << act << static_cast<uint64_t>(lvl) << type << s << fields << parent;
         enqueueMsg(buf.s);
     }
 
@@ -776,7 +776,7 @@ static void performOp(
         clientSettings.maxBuildJobs = readInt(conn.from);
         clientSettings.maxSilentTime = readInt(conn.from);
         readInt(conn.from); // obsolete useBuildHook
-        clientSettings.verboseBuild = lvlError == (Verbosity) readInt(conn.from);
+        clientSettings.verboseBuild = Verbosity::Error == (Verbosity) readInt(conn.from);
         readInt(conn.from); // obsolete logType
         readInt(conn.from); // obsolete printBuildTrace
         clientSettings.buildCores = readInt(conn.from);
@@ -1055,7 +1055,7 @@ void processConnection(ref<Store> store, FdSource && from, FdSink && to, Trusted
 
     Finally finally([&]() {
         setInterrupted(false);
-        printMsgUsing(prevLogger, lvlDebug, "%d operations", opCount);
+        printMsgUsing(prevLogger, Verbosity::Debug, "%d operations", opCount);
     });
 
     conn.postHandshake(
@@ -1086,7 +1086,7 @@ void processConnection(ref<Store> store, FdSource && from, FdSink && to, Trusted
                 break;
             }
 
-            printMsgUsing(prevLogger, lvlDebug, "received daemon op %d", op);
+            printMsgUsing(prevLogger, Verbosity::Debug, "received daemon op %d", op);
 
             opCount++;
 

--- a/src/libstore/export-import.cc
+++ b/src/libstore/export-import.cc
@@ -69,7 +69,7 @@ StorePaths importPaths(Store & store, Source & source, CheckSigsFlag checkSigs)
 
         auto path = store.parseStorePath(readString(source));
 
-        // Activity act(*logger, lvlInfo, "importing path '%s'", info.path);
+        // Activity act(*logger, Verbosity::Info, "importing path '%s'", info.path);
 
         auto references = CommonProto::Serialise<StorePathSet>::read(store, CommonProto::ReadConn{.from = source});
         auto deriver = readString(source);

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -99,7 +99,7 @@ struct curlFileTransfer : public FileTransfer
             : fileTransfer(fileTransfer)
             , request(request)
             , act(*logger,
-                  lvlTalkative,
+                  Verbosity::Talkative,
                   actFileTransfer,
                   fmt("%sing '%s'", request.verb(), request.uri),
                   {request.uri.to_string()},
@@ -234,7 +234,7 @@ struct curlFileTransfer : public FileTransfer
         try {
             size_t realSize = size * nmemb;
             std::string line((char *) contents, realSize);
-            printMsg(lvlVomit, "got header for '%s': %s", request.uri, trim(line));
+            printMsg(Verbosity::Vomit, "got header for '%s': %s", request.uri, trim(line));
 
             static std::regex statusLine("HTTP/[^ ]+ +[0-9]+(.*)", std::regex::extended | std::regex::icase);
             if (std::smatch match; std::regex_match(line, match, statusLine)) {
@@ -395,7 +395,7 @@ struct curlFileTransfer : public FileTransfer
 
             curl_easy_reset(req);
 
-            if (verbosity >= lvlVomit) {
+            if (verbosity >= Verbosity::Vomit) {
                 curl_easy_setopt(req, CURLOPT_VERBOSE, 1);
                 curl_easy_setopt(req, CURLOPT_DEBUGFUNCTION, TransferItem::debugCallback);
             }

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -887,7 +887,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 continue;
             }
 
-            printMsg(lvlTalkative, "deleting unused link '%1%'", path);
+            printMsg(Verbosity::Talkative, "deleting unused link '%1%'", path);
 
             if (unlink(path.c_str()) == -1)
                 throw SysError("deleting '%1%'", path);

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1382,7 +1382,7 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
         for (auto & link : DirectoryIterator{linksDir}) {
             checkInterrupt();
             auto name = link.path().filename();
-            printMsg(lvlTalkative, "checking contents of %s", name);
+            printMsg(Verbosity::Talkative, "checking contents of %s", name);
             std::string hash =
                 hashPath(makeFSSourceAccessor(link.path()), FileIngestionMethod::NixArchive, HashAlgorithm::SHA256)
                     .first.to_string(HashFormat::Nix32, false);
@@ -1407,7 +1407,7 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
                     std::const_pointer_cast<ValidPathInfo>(std::shared_ptr<const ValidPathInfo>(queryPathInfo(i)));
 
                 /* Check the content hash (optionally - slow). */
-                printMsg(lvlTalkative, "checking contents of '%s'", printStorePath(i));
+                printMsg(Verbosity::Talkative, "checking contents of '%s'", printStorePath(i));
 
                 auto hashSink = HashSink(info->narHash.algo);
 

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -100,7 +100,7 @@ const ContentAddress * getDerivationCA(const BasicDerivation & drv)
 
 MissingPaths Store::queryMissing(const std::vector<DerivedPath> & targets)
 {
-    Activity act(*logger, lvlDebug, actUnknown, "querying info about missing paths");
+    Activity act(*logger, Verbosity::Debug, actUnknown, "querying info about missing paths");
 
     // FIXME: make async.
     ThreadPool pool(fileTransferSettings.httpConnections);

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -63,7 +63,7 @@ LocalStore::InodeHash LocalStore::loadInodeHash()
     if (errno)
         throw SysError("reading directory '%1%'", linksDir);
 
-    printMsg(lvlTalkative, "loaded %1% hash inodes", inodeHash.size());
+    printMsg(Verbosity::Talkative, "loaded %1% hash inodes", inodeHash.size());
 
     return inodeHash;
 }
@@ -220,7 +220,7 @@ void LocalStore::optimisePath_(
         return;
     }
 
-    printMsg(lvlTalkative, "linking '%1%' to %2%", path, linkPath);
+    printMsg(Verbosity::Talkative, "linking '%1%' to %2%", path, linkPath);
 
     /* Make the containing directory writable, but only if it's not
        the store itself (we don't want or need to mess with its
@@ -298,7 +298,7 @@ void LocalStore::optimiseStore(OptimiseStats & stats)
         if (!isValidPath(i))
             continue; /* path was GC'ed, probably */
         {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("optimising path '%s'", printStorePath(i)));
+            Activity act(*logger, Verbosity::Talkative, actUnknown, fmt("optimising path '%s'", printStorePath(i)));
             optimisePath_(&act, stats, config->realStoreDir + "/" + std::string(i.to_string()), inodeHash, NoRepair);
         }
         done++;

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -106,9 +106,10 @@ void RemoteStore::initConnection(Connection & conn)
 void RemoteStore::setOptions(Connection & conn)
 {
     conn.to << WorkerProto::Op::SetOptions << settings.keepFailed << settings.keepGoing << settings.tryFallback
-            << verbosity << settings.maxBuildJobs << settings.maxSilentTime << true
-            << (settings.verboseBuild ? lvlError : lvlVomit) << 0 // obsolete log type
-            << 0                                                  /* obsolete print build trace */
+            << static_cast<uint64_t>(verbosity) << settings.maxBuildJobs << settings.maxSilentTime << true
+            << static_cast<uint64_t>(settings.verboseBuild ? Verbosity::Error : Verbosity::Vomit)
+            << 0 // obsolete log type
+            << 0 /* obsolete print build trace */
             << settings.buildCores << settings.useSubstitutes;
 
     std::map<std::string, nix::Config::SettingInfo> overrides;

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -186,7 +186,7 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(Strings && comman
                 addCommonSSHOpts(args);
                 if (socketPath != "")
                     args.insert(args.end(), {"-S", socketPath});
-                if (verbosity >= lvlChatty)
+                if (verbosity >= Verbosity::Chatty)
                     args.push_back("-v");
                 args.splice(args.end(), std::move(extraSshArgs));
                 args.push_back("--");
@@ -261,7 +261,7 @@ Path SSHMaster::startMaster()
                 throw SysError("duping over stdout");
 
             Strings args = {"ssh", hostnameAndUser.c_str(), "-M", "-N", "-S", state->socketPath};
-            if (verbosity >= lvlChatty)
+            if (verbosity >= Verbosity::Chatty)
                 args.push_back("-v");
             addCommonSSHOpts(args);
             auto env = createSSHEnv();

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -178,7 +178,7 @@ void Store::addMultipleToStore(PathsSource && pathsToCopy, Activity & act, Repai
                     nrFailed++;
                     if (!settings.keepGoing)
                         throw e;
-                    printMsg(lvlError, "could not copy %s: %s", printStorePath(path), e.what());
+                    printMsg(Verbosity::Error, "could not copy %s: %s", printStorePath(path), e.what());
                     showProgress();
                     return;
                 }
@@ -861,7 +861,7 @@ void copyStorePath(
     auto storePathS = srcStore.printStorePath(storePath);
     Activity act(
         *logger,
-        lvlInfo,
+        Verbosity::Info,
         actCopyPath,
         makeCopyPathMessage(srcCfg, dstCfg, storePathS),
         {storePathS, srcCfg.getHumanReadableURI(), dstCfg.getHumanReadableURI()});
@@ -973,7 +973,7 @@ std::map<StorePath, StorePath> copyPaths(
         if (!valid.count(path))
             missing.insert(path);
 
-    Activity act(*logger, lvlInfo, actCopyPaths, fmt("copying %d paths", missing.size()));
+    Activity act(*logger, Verbosity::Info, actCopyPaths, fmt("copying %d paths", missing.size()));
 
     // In the general case, `addMultipleToStore` requires a sorted list of
     // store paths to add, so sort them right now
@@ -1022,7 +1022,7 @@ std::map<StorePath, StorePath> copyPaths(
             auto storePathS = srcStore.printStorePath(missingPath);
             Activity act(
                 *logger,
-                lvlInfo,
+                Verbosity::Info,
                 actCopyPath,
                 makeCopyPathMessage(srcCfg, dstCfg, storePathS),
                 {storePathS, srcCfg.getHumanReadableURI(), dstCfg.getHumanReadableURI()});

--- a/src/libstore/unix/build/chroot-derivation-builder.cc
+++ b/src/libstore/unix/build/chroot-derivation-builder.cc
@@ -64,7 +64,7 @@ struct ChrootDerivationBuilder : virtual DerivationBuilderImpl
         /* Clean up the chroot directory automatically. */
         autoDelChroot = std::make_shared<AutoDelete>(chrootParentDir);
 
-        printMsg(lvlChatty, "setting up chroot environment in '%1%'", chrootParentDir);
+        printMsg(Verbosity::Chatty, "setting up chroot environment in '%1%'", chrootParentDir);
 
         if (mkdir(chrootParentDir.c_str(), 0700) == -1)
             throw SysError("cannot create '%s'", chrootRootDir);

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -798,10 +798,10 @@ std::optional<Descriptor> DerivationBuilderImpl::startBuild()
         startDaemon();
 
     /* Run the builder. */
-    printMsg(lvlChatty, "executing builder '%1%'", drv.builder);
-    printMsg(lvlChatty, "using builder args '%1%'", concatStringsSep(" ", drv.args));
+    printMsg(Verbosity::Chatty, "executing builder '%1%'", drv.builder);
+    printMsg(Verbosity::Chatty, "using builder args '%1%'", concatStringsSep(" ", drv.args));
     for (auto & i : drv.env)
-        printMsg(lvlVomit, "setting builder env variable '%1%'='%2%'", i.first, i.second);
+        printMsg(Verbosity::Vomit, "setting builder env variable '%1%'='%2%'", i.first, i.second);
 
     /* Create the log file. */
     miscMethods->openLogFile();
@@ -884,7 +884,7 @@ PathsInChroot DerivationBuilderImpl::getPathsInSandbox()
     }
 
     if (settings.preBuildHook != "") {
-        printMsg(lvlChatty, "executing pre-build hook '%1%'", settings.preBuildHook);
+        printMsg(Verbosity::Chatty, "executing pre-build hook '%1%'", settings.preBuildHook);
 
         enum BuildHookState { stBegin, stExtraChrootDirs };
 

--- a/src/libstore/unix/build/hook-instance.cc
+++ b/src/libstore/unix/build/hook-instance.cc
@@ -33,7 +33,7 @@ HookInstance::HookInstance()
     for (auto & arg : buildHookArgs)
         args.push_back(arg);
 
-    args.push_back(std::to_string(verbosity));
+    args.push_back(std::to_string(static_cast<int>(verbosity)));
 
     /* Create a pipe to get the output of the child. */
     fromHook.create();

--- a/src/libutil-tests/logging.cc
+++ b/src/libutil-tests/logging.cc
@@ -93,7 +93,7 @@ namespace nix {
     TEST(logEI, loggingErrorOnInfoLevel) {
         testing::internal::CaptureStderr();
 
-        logger->logEI({ .level = lvlInfo,
+        logger->logEI({ .level = Verbosity::Info,
                         .name = "Info name",
             });
 
@@ -102,11 +102,11 @@ namespace nix {
     }
 
     TEST(logEI, loggingErrorOnTalkativeLevel) {
-        verbosity = lvlTalkative;
+        verbosity = Verbosity::Talkative;
 
         testing::internal::CaptureStderr();
 
-        logger->logEI({ .level = lvlTalkative,
+        logger->logEI({ .level = Verbosity::Talkative,
                         .name = "Talkative name",
             });
 
@@ -115,11 +115,11 @@ namespace nix {
     }
 
     TEST(logEI, loggingErrorOnChattyLevel) {
-        verbosity = lvlChatty;
+        verbosity = Verbosity::Chatty;
 
         testing::internal::CaptureStderr();
 
-        logger->logEI({ .level = lvlChatty,
+        logger->logEI({ .level = Verbosity::Chatty,
                         .name = "Chatty name",
             });
 
@@ -128,11 +128,11 @@ namespace nix {
     }
 
     TEST(logEI, loggingErrorOnDebugLevel) {
-        verbosity = lvlDebug;
+        verbosity = Verbosity::Debug;
 
         testing::internal::CaptureStderr();
 
-        logger->logEI({ .level = lvlDebug,
+        logger->logEI({ .level = Verbosity::Debug,
                         .name = "Debug name",
             });
 
@@ -141,11 +141,11 @@ namespace nix {
     }
 
     TEST(logEI, loggingErrorOnVomitLevel) {
-        verbosity = lvlVomit;
+        verbosity = Verbosity::Vomit;
 
         testing::internal::CaptureStderr();
 
-        logger->logEI({ .level = lvlVomit,
+        logger->logEI({ .level = Verbosity::Vomit,
                         .name = "Vomit name",
             });
 

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -276,7 +276,7 @@ void RootArgs::parseCmdline(const Strings & _cmdline, bool allowShebang)
         assert(n > 0 && n <= cmdline.size());
         *std::next(cmdline.begin(), n - 1) += completionMarker;
         completions = std::make_shared<Completions>();
-        verbosity = lvlError;
+        verbosity = Verbosity::Error;
     }
 
     // Heuristic to see if we're invoked as a shebang script, namely,

--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -49,7 +49,7 @@ unsigned int getMaxCPU()
         if (quota != "max")
             return std::ceil(std::stoi(quota) / std::stof(period));
     } catch (Error &) {
-        ignoreExceptionInDestructor(lvlDebug);
+        ignoreExceptionInDestructor(Verbosity::Debug);
     }
 #endif
 
@@ -69,7 +69,7 @@ void setStackSize(size_t stackSize)
         if (limit.rlim_max < static_cast<rlim_t>(stackSize)) {
             if (getEnv("_NIX_TEST_NO_ENVIRONMENT_WARNINGS") != "1") {
                 logger->log(
-                    lvlWarn,
+                    Verbosity::Warn,
                     HintFmt(
                         "Stack size hard limit is %1%, which is less than the desired %2%. If possible, increase the hard limit, e.g. with 'ulimit -Hs %3%'.",
                         limit.rlim_max,
@@ -82,7 +82,7 @@ void setStackSize(size_t stackSize)
         limit.rlim_cur = requestedSize;
         if (setrlimit(RLIMIT_STACK, &limit) != 0) {
             logger->log(
-                lvlError,
+                Verbosity::Error,
                 HintFmt(
                     "Failed to increase stack size from %1% to %2% (desired: %3%, maximum allowed: %4%): %5%",
                     savedStackSize,

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -211,38 +211,38 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
 {
     std::string prefix;
     switch (einfo.level) {
-    case Verbosity::lvlError: {
+    case Verbosity::Error: {
         prefix = ANSI_RED "error";
         break;
     }
-    case Verbosity::lvlNotice: {
+    case Verbosity::Notice: {
         prefix = ANSI_RED "note";
         break;
     }
-    case Verbosity::lvlWarn: {
+    case Verbosity::Warn: {
         if (einfo.isFromExpr)
             prefix = ANSI_WARNING "evaluation warning";
         else
             prefix = ANSI_WARNING "warning";
         break;
     }
-    case Verbosity::lvlInfo: {
+    case Verbosity::Info: {
         prefix = ANSI_GREEN "info";
         break;
     }
-    case Verbosity::lvlTalkative: {
+    case Verbosity::Talkative: {
         prefix = ANSI_GREEN "talk";
         break;
     }
-    case Verbosity::lvlChatty: {
+    case Verbosity::Chatty: {
         prefix = ANSI_GREEN "chat";
         break;
     }
-    case Verbosity::lvlVomit: {
+    case Verbosity::Vomit: {
         prefix = ANSI_GREEN "vomit";
         break;
     }
-    case Verbosity::lvlDebug: {
+    case Verbosity::Debug: {
         prefix = ANSI_WARNING "debug";
         break;
     }

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -583,7 +583,7 @@ void createDirs(const std::filesystem::path & path)
 
 void deletePath(const std::filesystem::path & path, uint64_t & bytesFreed)
 {
-    // Activity act(*logger, lvlDebug, "recursively deleting path '%1%'", path);
+    // Activity act(*logger, Verbosity::Debug, "recursively deleting path '%1%'", path);
 #ifdef __FreeBSD__
     std::set<Path> mountedPaths;
     struct statfs * mntbuf;

--- a/src/libutil/include/nix/util/error.hh
+++ b/src/libutil/include/nix/util/error.hh
@@ -30,7 +30,32 @@
 
 namespace nix {
 
-typedef enum { lvlError = 0, lvlWarn, lvlNotice, lvlInfo, lvlTalkative, lvlChatty, lvlDebug, lvlVomit } Verbosity;
+enum class Verbosity {
+    Error = 0,
+    Warn,
+    Notice,
+    Info,
+    Talkative,
+    Chatty,
+    Debug,
+    Vomit,
+};
+
+/// Increment verbosity, clamping at Vomit
+constexpr Verbosity & operator++(Verbosity & v)
+{
+    if (v != Verbosity::Vomit)
+        v = static_cast<Verbosity>(static_cast<int>(v) + 1);
+    return v;
+}
+
+/// Decrement verbosity, clamping at Error
+constexpr Verbosity & operator--(Verbosity & v)
+{
+    if (v != Verbosity::Error)
+        v = static_cast<Verbosity>(static_cast<int>(v) - 1);
+    return v;
+}
 
 /**
  * The lines of code surrounding an error.
@@ -124,24 +149,24 @@ public:
 
     template<typename... Args>
     BaseError(unsigned int status, const Args &... args)
-        : err{.level = lvlError, .msg = HintFmt(args...), .status = status}
+        : err{.level = Verbosity::Error, .msg = HintFmt(args...), .status = status}
     {
     }
 
     template<typename... Args>
     explicit BaseError(const std::string & fs, const Args &... args)
-        : err{.level = lvlError, .msg = HintFmt(fs, args...)}
+        : err{.level = Verbosity::Error, .msg = HintFmt(fs, args...)}
     {
     }
 
     template<typename... Args>
     BaseError(const Suggestions & sug, const Args &... args)
-        : err{.level = lvlError, .msg = HintFmt(args...), .suggestions = sug}
+        : err{.level = Verbosity::Error, .msg = HintFmt(args...), .suggestions = sug}
     {
     }
 
     BaseError(HintFmt hint)
-        : err{.level = lvlError, .msg = hint}
+        : err{.level = Verbosity::Error, .msg = hint}
     {
     }
 

--- a/src/libutil/include/nix/util/logging.hh
+++ b/src/libutil/include/nix/util/logging.hh
@@ -133,7 +133,7 @@ public:
 
     void log(std::string_view s)
     {
-        log(lvlInfo, s);
+        log(Verbosity::Info, s);
     }
 
     virtual void logEI(const ErrorInfo & ei) = 0;
@@ -206,7 +206,7 @@ struct Activity
 
     Activity(
         Logger & logger, ActivityType type, const Logger::Fields & fields = {}, ActivityId parent = getCurActivity())
-        : Activity(logger, lvlError, type, "", fields, parent) {};
+        : Activity(logger, Verbosity::Error, type, "", fields, parent) {};
 
     Activity(const Activity & act) = delete;
 
@@ -315,8 +315,8 @@ extern Verbosity verbosity;
         }                                      \
     } while (0)
 
-#define logError(errorInfo...) logErrorInfo(lvlError, errorInfo)
-#define logWarning(errorInfo...) logErrorInfo(lvlWarn, errorInfo)
+#define logError(errorInfo...) logErrorInfo(Verbosity::Error, errorInfo)
+#define logWarning(errorInfo...) logErrorInfo(Verbosity::Warn, errorInfo)
 
 /**
  * Print a string message if the current log level is at least the specified
@@ -332,15 +332,15 @@ extern Verbosity verbosity;
     } while (0)
 #define printMsg(level, args...) printMsgUsing(logger, level, args)
 
-#define printError(args...) printMsg(lvlError, args)
-#define notice(args...) printMsg(lvlNotice, args)
-#define printInfo(args...) printMsg(lvlInfo, args)
-#define printTalkative(args...) printMsg(lvlTalkative, args)
-#define debug(args...) printMsg(lvlDebug, args)
-#define vomit(args...) printMsg(lvlVomit, args)
+#define printError(args...) printMsg(Verbosity::Error, args)
+#define notice(args...) printMsg(Verbosity::Notice, args)
+#define printInfo(args...) printMsg(Verbosity::Info, args)
+#define printTalkative(args...) printMsg(Verbosity::Talkative, args)
+#define debug(args...) printMsg(Verbosity::Debug, args)
+#define vomit(args...) printMsg(Verbosity::Vomit, args)
 
 /**
- * if verbosity >= lvlWarn, print a message with a yellow 'warning:' prefix.
+ * if verbosity >= Verbosity::Warn, print a message with a yellow 'warning:' prefix.
  */
 template<typename... Args>
 inline void warn(const std::string & fs, const Args &... args)

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -216,7 +216,7 @@ std::string escapeShellArgAlways(const std::string_view s);
  * but ideally we propagate the exception using an exception_ptr in such cases.
  * See e.g. `PackBuilderContext`
  */
-void ignoreExceptionInDestructor(Verbosity lvl = lvlError);
+void ignoreExceptionInDestructor(Verbosity lvl = Verbosity::Error);
 
 /**
  * Not destructor-safe.
@@ -225,7 +225,7 @@ void ignoreExceptionInDestructor(Verbosity lvl = lvlError);
  *
  * This may be used in a few places where Interrupt can't happen, but that's ok.
  */
-void ignoreExceptionExceptInterrupt(Verbosity lvl = lvlError);
+void ignoreExceptionExceptInterrupt(Verbosity lvl = Verbosity::Error);
 
 /**
  * Tree formatting.

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -36,7 +36,7 @@ std::unique_ptr<Logger> logger = makeSimpleLogger(true);
 
 void Logger::warn(const std::string & msg)
 {
-    log(lvlWarn, ANSI_WARNING "warning:" ANSI_NORMAL " " + msg);
+    log(Verbosity::Warn, ANSI_WARNING "warning:" ANSI_NORMAL " " + msg);
 }
 
 void Logger::writeToStdout(std::string_view s)
@@ -88,22 +88,22 @@ public:
         if (systemd) {
             char c;
             switch (lvl) {
-            case lvlError:
+            case Verbosity::Error:
                 c = '3';
                 break;
-            case lvlWarn:
+            case Verbosity::Warn:
                 c = '4';
                 break;
-            case lvlNotice:
-            case lvlInfo:
+            case Verbosity::Notice:
+            case Verbosity::Info:
                 c = '5';
                 break;
-            case lvlTalkative:
-            case lvlChatty:
+            case Verbosity::Talkative:
+            case Verbosity::Chatty:
                 c = '6';
                 break;
-            case lvlDebug:
-            case lvlVomit:
+            case Verbosity::Debug:
+            case Verbosity::Vomit:
                 c = '7';
                 break;
             default:
@@ -148,7 +148,7 @@ public:
     }
 };
 
-Verbosity verbosity = lvlInfo;
+Verbosity verbosity = Verbosity::Info;
 
 void writeToStderr(std::string_view s)
 {

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -424,8 +424,8 @@ Sink & operator<<(Sink & sink, const StringSet & s)
 Sink & operator<<(Sink & sink, const Error & ex)
 {
     auto & info = ex.info();
-    sink << "Error" << info.level << "Error" // removed
-         << info.msg.str() << 0              // FIXME: info.errPos
+    sink << "Error" << static_cast<uint64_t>(info.level) << "Error" // removed
+         << info.msg.str() << 0                                     // FIXME: info.errPos
          << info.traces.size();
     for (auto & trace : info.traces) {
         sink << 0; // FIXME: trace.pos

--- a/src/libutil/windows/muxable-pipe.cc
+++ b/src/libutil/windows/muxable-pipe.cc
@@ -34,7 +34,7 @@ void MuxablePipePollState::iterate(
         ++nextp;
         for (ULONG i = 0; i < removed; i++) {
             if (oentries[i].lpCompletionKey == ((ULONG_PTR) ((*p)->readSide.get()) ^ 0x5555)) {
-                printMsg(lvlVomit, "read %s bytes", oentries[i].dwNumberOfBytesTransferred);
+                printMsg(Verbosity::Vomit, "read %s bytes", oentries[i].dwNumberOfBytesTransferred);
                 if (oentries[i].dwNumberOfBytesTransferred > 0) {
                     std::string data{
                         (char *) (*p)->buffer.data(),

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -214,7 +214,7 @@ static int main_build_remote(int argc, char ** argv)
                                 % concatStringsSep<StringSet>(", ", m.supportedFeatures)
                                 % concatStringsSep<StringSet>(", ", m.mandatoryFeatures);
 
-                        printMsg(couldBuildLocally ? lvlChatty : lvlWarn, error.str());
+                        printMsg(couldBuildLocally ? Verbosity::Chatty : Verbosity::Warn, error.str());
 
                         std::cerr << "# decline\n";
                     }
@@ -232,7 +232,7 @@ static int main_build_remote(int argc, char ** argv)
                 try {
                     storeUri = bestMachine->storeUri.render();
 
-                    Activity act(*logger, lvlTalkative, actUnknown, fmt("connecting to '%s'", storeUri));
+                    Activity act(*logger, Verbosity::Talkative, actUnknown, fmt("connecting to '%s'", storeUri));
 
                     sshStore = bestMachine->openStore();
                     sshStore->connect();
@@ -274,7 +274,8 @@ static int main_build_remote(int argc, char ** argv)
         }
 
         {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("waiting for the upload lock to '%s'", storeUri));
+            Activity act(
+                *logger, Verbosity::Talkative, actUnknown, fmt("waiting for the upload lock to '%s'", storeUri));
 
             auto old = signal(SIGALRM, handleAlarm);
             alarm(15 * 60);
@@ -287,7 +288,7 @@ static int main_build_remote(int argc, char ** argv)
         auto substitute = settings.buildersUseSubstitutes ? Substitute : NoSubstitute;
 
         {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying dependencies to '%s'", storeUri));
+            Activity act(*logger, Verbosity::Talkative, actUnknown, fmt("copying dependencies to '%s'", storeUri));
             copyPaths(*store, *sshStore, store->parseStorePathSet(inputs), NoRepair, NoCheckSigs, substitute);
         }
 
@@ -377,7 +378,7 @@ static int main_build_remote(int argc, char ** argv)
         }
 
         if (!missingPaths.empty()) {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying outputs from '%s'", storeUri));
+            Activity act(*logger, Verbosity::Talkative, actUnknown, fmt("copying outputs from '%s'", storeUri));
             if (auto localStore = store.dynamic_pointer_cast<LocalStore>())
                 for (auto & path : missingPaths)
                     localStore->locksHeld.insert(store->printStorePath(path)); /* FIXME: ugly */

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -147,7 +147,7 @@ struct CmdBuild : InstallablesCommand, MixOutLinkByDefault, MixDryRun, MixJSON, 
                 for (auto & b : i->toDerivedPaths())
                     pathsToBuild.push_back(b.path);
 
-            printMissing(store, pathsToBuild, lvlError);
+            printMissing(store, pathsToBuild, Verbosity::Error);
 
             if (json)
                 printJSON(derivedPathsToJSON(pathsToBuild, *store));

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -597,7 +597,7 @@ struct CmdDevelop : Common, MixEnvironment
 
         auto script = makeRcScript(store, buildEnvironment, tmpDir);
 
-        if (verbosity >= lvlDebug)
+        if (verbosity >= Verbosity::Debug)
             script += "set -x\n";
 
         script += fmt("command rm -f '%s'\n", rcFilePath);

--- a/src/nix/flake-prefetch-inputs.cc
+++ b/src/nix/flake-prefetch-inputs.cc
@@ -44,7 +44,7 @@ struct CmdFlakePrefetchInputs : FlakeCommand
 
             if (auto lockedNode = dynamic_cast<const LockedNode *>(&node)) {
                 try {
-                    Activity act(*logger, lvlInfo, actUnknown, fmt("fetching '%s'", lockedNode->lockedRef));
+                    Activity act(*logger, Verbosity::Info, actUnknown, fmt("fetching '%s'", lockedNode->lockedRef));
                     auto accessor = lockedNode->lockedRef.input.getAccessor(fetchSettings, *store).first;
                     fetchToStore(
                         fetchSettings, *store, accessor, FetchMode::Copy, lockedNode->lockedRef.input.getName());

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -427,9 +427,9 @@ void mainWrapped(int argc, char ** argv)
 
     // If on a terminal, progress will be displayed via progress bars etc. (thus verbosity=notice)
     if (nix::isTTY()) {
-        verbosity = lvlNotice;
+        verbosity = Verbosity::Notice;
     } else {
-        verbosity = lvlInfo;
+        verbosity = Verbosity::Info;
     }
 
     NixArgs args;

--- a/src/nix/nix-copy-closure/nix-copy-closure.cc
+++ b/src/nix/nix-copy-closure/nix-copy-closure.cc
@@ -33,7 +33,7 @@ static int main_nix_copy_closure(int argc, char ** argv)
             else if (*arg == "--include-outputs")
                 includeOutputs = true;
             else if (*arg == "--show-progress")
-                printMsg(lvlError, "Warning: '--show-progress' is not implemented");
+                printMsg(Verbosity::Error, "Warning: '--show-progress' is not implemented");
             else if (*arg == "--dry-run")
                 dryRun = true;
             else if (*arg == "--use-substitutes" || *arg == "-s")

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -945,7 +945,10 @@ queryJSON(Globals & globals, std::vector<PackageInfo> & elems, bool printOutPath
                 }
             }
         } catch (AssertionError & e) {
-            printMsg(lvlTalkative, "skipping derivation named '%1%' which gives an assertion failure", i.queryName());
+            printMsg(
+                Verbosity::Talkative,
+                "skipping derivation named '%1%' which gives an assertion failure",
+                i.queryName());
         } catch (Error & e) {
             e.addTrace(nullptr, "while querying the derivation named '%1%'", i.queryName());
             throw;
@@ -1059,7 +1062,9 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                 paths.insert(i.queryOutPath());
             } catch (AssertionError & e) {
                 printMsg(
-                    lvlTalkative, "skipping derivation named '%s' which gives an assertion failure", i.queryName());
+                    Verbosity::Talkative,
+                    "skipping derivation named '%s' which gives an assertion failure",
+                    i.queryName());
                 i.setFailed();
             }
         validPaths = store.queryValidPaths(paths);
@@ -1086,7 +1091,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
             if (i.hasFailed())
                 continue;
 
-            // Activity act(*logger, lvlDebug, "outputting query result '%1%'", i.attrPath);
+            // Activity act(*logger, Verbosity::Debug, "outputting query result '%1%'", i.attrPath);
 
             if (globals.prebuiltOnly && !validPaths.count(i.queryOutPath())
                 && !substitutablePaths.count(i.queryOutPath()))
@@ -1273,7 +1278,10 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
             cout.flush();
 
         } catch (AssertionError & e) {
-            printMsg(lvlTalkative, "skipping derivation named '%1%' which gives an assertion failure", i.queryName());
+            printMsg(
+                Verbosity::Talkative,
+                "skipping derivation named '%1%' which gives an assertion failure",
+                i.queryName());
         } catch (Error & e) {
             e.addTrace(nullptr, "while querying the derivation named '%1%'", i.queryName());
             throw;

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -838,7 +838,7 @@ static void opVerifyPath(Strings opFlags, Strings opArgs)
 
     for (auto & i : opArgs) {
         auto path = store->followLinksToStorePath(i);
-        printMsg(lvlTalkative, "checking path '%s'...", store->printStorePath(path));
+        printMsg(Verbosity::Talkative, "checking path '%s'...", store->printStorePath(path));
         auto info = store->queryPathInfo(path);
         HashSink sink(info->narHash.algo);
         store->narFromPath(path, sink);
@@ -908,7 +908,7 @@ static void opServe(Strings opFlags, Strings opArgs)
     auto getBuildSettings = [&]() {
         // FIXME: changing options here doesn't work if we're
         // building through the daemon.
-        verbosity = lvlError;
+        verbosity = Verbosity::Error;
         settings.keepLog = false;
         settings.useSubstitutes = false;
 

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -125,7 +125,7 @@ std::tuple<StorePath, Hash> prefetchFile(
 
         /* Optionally unpack the file. */
         if (unpack) {
-            Activity act(*logger, lvlChatty, actUnknown, fmt("unpacking '%s'", url.to_string()));
+            Activity act(*logger, Verbosity::Chatty, actUnknown, fmt("unpacking '%s'", url.to_string()));
             auto unpacked = (tmpDir.path() / "unpacked").string();
             createDirs(unpacked);
             unpackTarfile(tmpFile.string(), unpacked);
@@ -141,7 +141,7 @@ std::tuple<StorePath, Hash> prefetchFile(
             }
         }
 
-        Activity act(*logger, lvlChatty, actUnknown, fmt("adding '%s' to the store", url.to_string()));
+        Activity act(*logger, Verbosity::Chatty, actUnknown, fmt("adding '%s' to the store", url.to_string()));
 
         auto info = store->addToStoreSlow(name, makeFSSourceAccessor(tmpFile), method, hashAlgo, {}, expectedHash);
         storePath = info.path;

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -720,7 +720,8 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixDefaultProfile, MixProf
 
             upgradedCount++;
 
-            Activity act(*logger, lvlChatty, actUnknown, fmt("checking '%s' for updates", element.source->attrPath));
+            Activity act(
+                *logger, Verbosity::Chatty, actUnknown, fmt("checking '%s' for updates", element.source->attrPath));
 
             auto installable = make_ref<InstallableFlake>(
                 this,

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -96,7 +96,8 @@ struct CmdSearch : InstallableValueCommand, MixJSON
         visit = [&](eval_cache::AttrCursor & cursor, const std::vector<Symbol> & attrPath, bool initialRecurse) {
             auto attrPathS = state->symbols.resolve(attrPath);
 
-            Activity act(*logger, lvlInfo, actUnknown, fmt("evaluating '%s'", concatStringsSep(".", attrPathS)));
+            Activity act(
+                *logger, Verbosity::Info, actUnknown, fmt("evaluating '%s'", concatStringsSep(".", attrPathS)));
             try {
                 auto recurse = [&]() {
                     for (const auto & attr : cursor.getAttrs()) {

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -53,7 +53,7 @@ struct CmdCopySigs : StorePathsCommand
         // logger->setExpected(doneLabel, storePaths.size());
 
         auto doPath = [&](const Path & storePathS) {
-            // Activity act(*logger, lvlInfo, "getting signatures for '%s'", storePath);
+            // Activity act(*logger, Verbosity::Info, "getting signatures for '%s'", storePath);
 
             checkInterrupt();
 

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -80,13 +80,17 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         }
 
         {
-            Activity act(*logger, lvlInfo, actUnknown, fmt("downloading '%s'...", store->printStorePath(storePath)));
+            Activity act(
+                *logger, Verbosity::Info, actUnknown, fmt("downloading '%s'...", store->printStorePath(storePath)));
             store->ensurePath(storePath);
         }
 
         {
             Activity act(
-                *logger, lvlInfo, actUnknown, fmt("verifying that '%s' works...", store->printStorePath(storePath)));
+                *logger,
+                Verbosity::Info,
+                actUnknown,
+                fmt("verifying that '%s' works...", store->printStorePath(storePath)));
             auto program = store->printStorePath(storePath) + "/bin/nix-env";
             auto s = runProgram(program, false, {"--version"});
             if (s.find("Nix") == std::string::npos)
@@ -98,7 +102,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         {
             Activity act(
                 *logger,
-                lvlInfo,
+                Verbosity::Info,
                 actUnknown,
                 fmt("installing '%s' into profile %s...", store->printStorePath(storePath), profileDir));
 
@@ -153,7 +157,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
     /* Return the store path of the latest stable Nix. */
     StorePath getLatestNix(ref<Store> store)
     {
-        Activity act(*logger, lvlInfo, actUnknown, "querying latest Nix version");
+        Activity act(*logger, Verbosity::Info, actUnknown, "querying latest Nix version");
 
         // FIXME: use nixos.org?
         auto req = FileTransferRequest(parseURL(settings.upgradeNixStorePathUrl.get()));

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -93,7 +93,8 @@ struct CmdVerify : StorePathsCommand
                 // Note: info->path can be different from storePath
                 // for binary cache stores when using --all (since we
                 // can't enumerate names efficiently).
-                Activity act2(*logger, lvlInfo, actUnknown, fmt("checking '%s'", store->printStorePath(info->path)));
+                Activity act2(
+                    *logger, Verbosity::Info, actUnknown, fmt("checking '%s'", store->printStorePath(info->path)));
 
                 if (!noContents) {
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Convert the Verbosity enum from old-style `typedef enum` to modern
`enum class` with cleaner value names:

- lvlError -> Verbosity::Error
- lvlWarn -> Verbosity::Warn
- lvlNotice -> Verbosity::Notice
- lvlInfo -> Verbosity::Info
- lvlTalkative -> Verbosity::Talkative
- lvlChatty -> Verbosity::Chatty
- lvlDebug -> Verbosity::Debug
- lvlVomit -> Verbosity::Vomit

I also added ++/-- operators with clamping for verbosity adjustments, and
explicit casts where Verbosity is serialized to integers.

## Context

Part-Of: #14658

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
