### PR TITLE
Document and test -- separator behavior with installables

### DIFF
--- a/src/nix/run.md
+++ b/src/nix/run.md
@@ -33,6 +33,16 @@ R""(
   # nix run nixpkgs#vim -- --help
   ```
 
+* Run the default app from the current directory with arguments:
+
+  ```console
+  # nix run . -- arg1 arg2
+  ```
+
+  Note: The first positional argument is always treated as the *installable*,
+  even after `--`. To pass arguments to the default installable, specify it
+  explicitly: `nix run . -- arg1 arg2` or `nix run -- . arg1 arg2`.
+
 # Description
 
 `nix run` builds and runs [*installable*](./nix.md#installables), which must evaluate to an


### PR DESCRIPTION
Clarifies that the first positional argument is always treated as the installable, even after --. Adds tests to prevent accidental change.

Addresses https://github.com/NixOS/nix/issues/13994

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

- Closes #13994

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
