### PR TITLE
libstore: Align LocalFSStore to 8 bytes even on i686-linux

### DIFF
--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -65,7 +65,9 @@ struct BinaryCacheStoreConfig : virtual StoreConfig
  * @note subclasses must implement at least one of the two
  * virtual getFile() methods.
  */
-struct BinaryCacheStore : virtual Store, virtual LogStore
+struct alignas(8) /* Work around ASAN failures on i686-linux. */
+    BinaryCacheStore : virtual Store,
+                       virtual LogStore
 {
     using Config = BinaryCacheStoreConfig;
 

--- a/src/libstore/include/nix/store/local-fs-store.hh
+++ b/src/libstore/include/nix/store/local-fs-store.hh
@@ -66,7 +66,10 @@ public:
         this, rootDir.get() ? *rootDir.get() + "/nix/store" : storeDir, "real", "Physical path of the Nix store."};
 };
 
-struct LocalFSStore : virtual Store, virtual GcStore, virtual LogStore
+struct alignas(8) /* Work around ASAN failures on i686-linux. */
+    LocalFSStore : virtual Store,
+                   virtual GcStore,
+                   virtual LogStore
 {
     using Config = LocalFSStoreConfig;
 

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -37,7 +37,8 @@ StoreReference SSHStoreConfig::getReference() const
     };
 }
 
-struct SSHStore : virtual RemoteStore
+struct alignas(8) /* Work around ASAN failures on i686-linux. */
+    SSHStore : virtual RemoteStore
 {
     using Config = SSHStoreConfig;
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This works around https://hydra.nixos.org/build/314579538/nixlog/1.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
