### PR TITLE
libexpr: Fix tests on 32 bit systems

### DIFF
--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -58,7 +58,7 @@ static nix::Value & check_value_out(nix_value * value)
     return v;
 }
 
-static inline nix_value * new_nix_value(nix::Value * v, nix::EvalMemory & mem)
+static nix_value * new_nix_value(nix::Value * v, nix::EvalMemory & mem)
 {
     nix_value * ret = new (mem.allocBytes(sizeof(nix_value))) nix_value{
         .value = v,

--- a/src/libexpr-tests/nix_api_value_internal.cc
+++ b/src/libexpr-tests/nix_api_value_internal.cc
@@ -14,12 +14,4 @@
 
 namespace nixC {
 
-TEST_F(nix_api_expr_test, as_nix_value_ptr)
-{
-    // nix_alloc_value casts nix::Value to nix_value
-    // It should be obvious from the decl that that works, but if it doesn't,
-    // the whole implementation would be utterly broken.
-    ASSERT_EQ(sizeof(nix::Value), sizeof(nix_value));
-}
-
 } // namespace nixC


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This test is now pointless and the comment is outdated. Also the test fails on 32 bit systems with:

```
../nix_api_value_internal.cc:22: Failure
Expected equality of these values:
  sizeof(nix::Value)
    Which is: 12
  sizeof(nix_value)
    Which is: 8
```

It just happeneded to work because Value is 16 bytes and nix_value was also 16 bytes.

Also get rid of a pointless `inline` in `new_nix_value`, since it's already `static` and `inline` there does nothing.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
