### PR TITLE
release-notes/rl-2.26.md: remove hidden Unicode RLO control chars

### DIFF
--- a/doc/manual/source/release-notes/rl-2.26.md
+++ b/doc/manual/source/release-notes/rl-2.26.md
@@ -112,7 +112,7 @@ This release was made possible by the following 45 contributors:
 - Connor Baker [**(@ConnorBaker)**](https://github.com/ConnorBaker)
 - Cole Helbling [**(@cole-h)**](https://github.com/cole-h)
 - Jack Wilsdon [**(@jackwilsdon)**](https://github.com/jackwilsdon)
-- ‮rekcäH nitraM‮ [**(@dwt)**](https://github.com/dwt)
+- Martin Häcker [**(@dwt)**](https://github.com/dwt)
 - Martin Fischer [**(@not-my-profile)**](https://github.com/not-my-profile)
 - John Ericson [**(@Ericson2314)**](https://github.com/Ericson2314)
 - Graham Christensen [**(@grahamc)**](https://github.com/grahamc)

--- a/maintainers/data/release-credits-handle-to-name.json
+++ b/maintainers/data/release-credits-handle-to-name.json
@@ -118,7 +118,7 @@
     "wh0": null,
     "mupdt": "Matej Urbas",
     "momeemt": "Mutsuha Asada",
-    "dwt": "\u202erekc\u00e4H nitraM\u202e",
+    "dwt": "Martin H\u00e4cker",
     "aidenfoxivey": "Aiden Fox Ivey",
     "ilya-bobyr": "Illia Bobyr",
     "B4dM4n": "Fabian M\u00f6ller",


### PR DESCRIPTION
Closes #14666

These Unicode characters are flagged by Fedora CI checks as a potential security issue.
Use of such raw Right-to-Left control characters (and particularly `RLO`*) in source code is strongly discouraged

[*] RLO = Right-to-Left Override (`U+202E`)

See also https://attack.mitre.org/techniques/T1036/002/