### PR TITLE
tests/functional: Work around stack overflows under ASAN in doc-funct…

### DIFF
--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -350,10 +350,9 @@ runRepl () {
   local testDirNoUnderscores
   testDirNoUnderscores="${testDir//_/}"
 
-  # TODO: pass arguments to nix repl; see lang.sh
   _NIX_TEST_RAW_MARKDOWN=1 \
   _NIX_TEST_REPL_ECHO=1 \
-  nix repl 2>&1 \
+  nix repl "$@" 2>&1 \
     | stripColors \
     | tr -d '\0' \
     | stripEmptyLinesBeforePrompt \
@@ -373,7 +372,12 @@ for test in $(cd "$testDir/repl"; echo *.in); do
     in="$testDir/repl/$test.in"
     actual="$TEST_ROOT/$test.actual"
     expected="$testDir/repl/$test.expected"
-    (cd "$testDir/repl"; set +x; runRepl 2>&1) < "$in" > "$actual" || {
+    declare -a flags=()
+    if test -e "$testDir/repl/$test.flags"; then
+      read -r -a flags < "$testDir/repl/$test.flags"
+    fi
+
+    (cd "$testDir/repl"; set +x; runRepl "${flags[@]}" 2>&1) < "$in" > "$actual" || {
         echo "FAIL: $test (exit code $?)" >&2
         badExitCode=1
     }

--- a/tests/functional/repl/doc-functor.expected
+++ b/tests/functional/repl/doc-functor.expected
@@ -43,7 +43,7 @@ error:
              |                       ^
            91|   };
 
-       (19999 duplicate frames omitted)
+       (199 duplicate frames omitted)
 
        error: stack overflow; max-call-depth exceeded
        at /path/to/tests/functional/repl/doc-functor.nix:90:23:
@@ -56,7 +56,7 @@ nix-repl> :doc diverging
 error:
        … while partially calling '__functor' to retrieve documentation
 
-       (10000 duplicate frames omitted)
+       (100 duplicate frames omitted)
 
        … while calling '__functor'
          at /path/to/tests/functional/repl/doc-functor.nix:103:21:

--- a/tests/functional/repl/doc-functor.flags
+++ b/tests/functional/repl/doc-functor.flags
@@ -1,0 +1,1 @@
+--max-call-depth 100


### PR DESCRIPTION
…or tests

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This was failing under ASAN in https://hydra.nixos.org/build/315173638/nixlog/1. ASAN uses a bit more stack space and the default max call depth is not enough. Not sure what's so special about this particular test.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
