### PR TITLE
libstore: Split FileTransferRequest::verb into verb + noun

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -101,7 +101,7 @@ struct curlFileTransfer : public FileTransfer
             , act(*logger,
                   lvlTalkative,
                   actFileTransfer,
-                  fmt("%sing '%s'", request.verb(), request.uri),
+                  fmt("%s '%s'", request.verb(/*continuous=*/true), request.uri),
                   {request.uri.to_string()},
                   request.parentAct)
             , callback(std::move(callback))
@@ -166,7 +166,7 @@ struct curlFileTransfer : public FileTransfer
                 std::rethrow_exception(ex);
             } catch (nix::Error & e) {
                 /* Add more context to the error message. */
-                e.addTrace({}, "during %s of '%s'", Uncolored(request.verb()), request.uri.to_string());
+                e.addTrace({}, "during %s of '%s'", Uncolored(request.noun()), request.uri.to_string());
             } catch (...) {
                 /* Can't add more context to the error. */
             }
@@ -510,7 +510,7 @@ struct curlFileTransfer : public FileTransfer
 
             debug(
                 "finished %s of '%s'; curl status = %d, HTTP status = %d, body = %d bytes, duration = %.2f s",
-                request.verb(),
+                request.noun(),
                 request.uri,
                 code,
                 httpStatus,
@@ -610,7 +610,7 @@ struct curlFileTransfer : public FileTransfer
                                                                                        Interrupted,
                                                                                        std::move(response),
                                                                                        "%s of '%s' was interrupted",
-                                                                                       request.verb(),
+                                                                                       request.noun(),
                                                                                        request.uri)
                            : httpStatus != 0
                                ? FileTransferError(
@@ -845,7 +845,7 @@ struct curlFileTransfer : public FileTransfer
             }
 
             for (auto & item : incoming) {
-                debug("starting %s of %s", item->request.verb(), item->request.uri);
+                debug("starting %s of %s", item->request.noun(), item->request.uri);
                 item->init();
                 curl_multi_add_handle(curlm, item->req);
                 item->active = true;

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -169,11 +169,25 @@ struct FileTransferRequest
     }
 
     /**
-     * Returns the verb root for logging purposes.
-     * The returned string is intended to be concatenated with "ing" to form the gerund,
-     * e.g., "download" + "ing" -> "downloading", "upload" + "ing" -> "uploading".
+     * Returns the method description for logging purposes.
      */
-    std::string verb() const
+    std::string verb(bool continuous = false) const
+    {
+        switch (method) {
+        case HttpMethod::Head:
+        case HttpMethod::Get:
+            return continuous ? "downloading" : "download";
+        case HttpMethod::Put:
+        case HttpMethod::Post:
+            assert(data);
+            return continuous ? "uploading" : "upload";
+        case HttpMethod::Delete:
+            return continuous ? "deleting" : "delete";
+        }
+        unreachable();
+    }
+
+    std::string noun() const
     {
         switch (method) {
         case HttpMethod::Head:
@@ -184,7 +198,7 @@ struct FileTransferRequest
             assert(data);
             return "upload";
         case HttpMethod::Delete:
-            return "delet";
+            return "deletion";
         }
         unreachable();
     }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

With the addition of "delete" method we can no longer rely on just concatenating "ing" to get the continuous form of the verb. Also some use-cases actually need a noun instead.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

@cole-h mentioned at some point that this would be nice to do.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
