### PR TITLE
AutoDelete: Add move constructor

### DIFF
--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -294,7 +294,7 @@ class AutoDelete
 public:
     AutoDelete();
 
-    AutoDelete(AutoDelete && x)
+    AutoDelete(AutoDelete && x) noexcept
     {
         _path = std::move(x._path);
         del = x.del;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Previously, moving `AutoDelete` would quietly perform the deletion twice (especially bad if the original is a temporary, since then the path is destroyed while it's still needed).

Taken from https://github.com/DeterminateSystems/nix-src/pull/282. (While cherry-picking I noticed that @xokdvium just did 40e3f5c0a471075d02e258e950c0f2c931b36177.)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context



<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
