### PR TITLE
Attribute selection operator is left-associative

### DIFF
--- a/doc/manual/source/language/operators.md
+++ b/doc/manual/source/language/operators.md
@@ -2,7 +2,7 @@
 
 | Name                                   | Syntax                                     | Associativity | Precedence |
 |----------------------------------------|--------------------------------------------|---------------|------------|
-| [Attribute selection]                  | *attrset* `.` *attrpath* \[ `or` *expr* \] | none          | 1          |
+| [Attribute selection]                  | *attrset* `.` *attrpath* \[ `or` *expr* \] | left          | 1          |
 | [Function application]                 | *func* *expr*                              | left          | 2          |
 | [Arithmetic negation][arithmetic]      | `-` *number*                               | none          | 3          |
 | [Has attribute]                        | *attrset* `?` *attrpath*                   | none          | 4          |


### PR DESCRIPTION
## Motivation

The reference document says the attribute selection operator `.` is non-associative. But it is really left-associative.

## Context

fixes #14683

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
