### PR TITLE
libutil/signals: Get rid of setInterruptThrown

### DIFF
--- a/doc/manual/rl-next/repl-interrupt.md
+++ b/doc/manual/rl-next/repl-interrupt.md
@@ -1,0 +1,8 @@
+---
+synopsis: Interrupting REPL commands works more than once
+issues: [13481]
+---
+
+Previously, this only worked once per REPL session; further attempts would be ignored.
+This issue is now fixed, so REPL commands such as `:b` or `:p` can be canceled consistently.
+This is a cherry-pick of the change from the [Lix project](https://gerrit.lix.systems/c/lix/+/1097).

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -321,16 +321,7 @@ int handleExceptions(const std::string & programName, std::function<void()> fun)
 
     std::string error = ANSI_RED "error:" ANSI_NORMAL " ";
     try {
-        try {
-            fun();
-        } catch (...) {
-            /* Subtle: we have to make sure that any `interrupted'
-               condition is discharged before we reach printMsg()
-               below, since otherwise it will throw an (uncaught)
-               exception. */
-            setInterruptThrown();
-            throw;
-        }
+        fun();
     } catch (Exit & e) {
         return e.status;
     } catch (UsageError & e) {

--- a/src/libutil/include/nix/util/signals.hh
+++ b/src/libutil/include/nix/util/signals.hh
@@ -24,11 +24,6 @@ static inline bool getInterrupted();
 /**
  * @note Does nothing on Windows
  */
-void setInterruptThrown();
-
-/**
- * @note Does nothing on Windows
- */
 static inline bool isInterrupted();
 
 /**

--- a/src/libutil/unix/signals.cc
+++ b/src/libutil/unix/signals.cc
@@ -12,24 +12,14 @@ using namespace unix;
 
 std::atomic<bool> unix::_isInterrupted = false;
 
-namespace unix {
-static thread_local bool interruptThrown = false;
-}
-
 thread_local std::function<bool()> unix::interruptCheck;
-
-void setInterruptThrown()
-{
-    unix::interruptThrown = true;
-}
 
 void unix::_interrupted()
 {
     /* Block user interrupts while an exception is being handled.
        Throwing an exception while another exception is being handled
        kills the program! */
-    if (!interruptThrown && !std::uncaught_exceptions()) {
-        interruptThrown = true;
+    if (!std::uncaught_exceptions()) {
         throw Interrupted("interrupted by the user");
     }
 }

--- a/src/libutil/windows/include/nix/util/signals-impl.hh
+++ b/src/libutil/windows/include/nix/util/signals-impl.hh
@@ -17,11 +17,6 @@ static inline bool getInterrupted()
     return false;
 }
 
-inline void setInterruptThrown()
-{
-    /* Do nothing for now */
-}
-
 static inline bool isInterrupted()
 {
     /* Do nothing for now */


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The interrupting code is no longer relevant. Since 054be5025762c5e1c7e853c4fa5d7eed8da1727f logging no longer checks for interrupts and in general logging should be noexcept.

Cherry-picked-from: https://gerrit.lix.systems/c/lix/+/1097

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes https://github.com/NixOS/nix/issues/13481

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
