### PR TITLE
Use direct PATH manipulation to avoid conflicts with user's `fish_user_paths`

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -8,14 +8,9 @@ set --global --export __ETC_PROFILE_NIX_SOURCED 1
 # Local helpers
 
 function add_path --argument-names new_path
-    if type -q fish_add_path
-        # fish 3.2.0 or newer
-        fish_add_path --prepend --global $new_path
-    else
-        # older versions of fish
-        if not contains $new_path $fish_user_paths
-            set --global fish_user_paths $new_path $fish_user_paths
-        end
+    # Directly manipulate PATH to avoid conflicts with user's fish_user_paths
+    if not contains $new_path $PATH
+        set --global --export --prepend PATH $new_path
     end
 end
 

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -8,14 +8,9 @@ set --global --export __ETC_PROFILE_NIX_SOURCED 1
 # Local helpers
 
 function add_path --argument-names new_path
-    if type -q fish_add_path
-        # fish 3.2.0 or newer
-        fish_add_path --prepend --global $new_path
-    else
-        # older versions of fish
-        if not contains $new_path $fish_user_paths
-            set --global fish_user_paths $new_path $fish_user_paths
-        end
+    # Directly manipulate PATH to avoid conflicts with user's fish_user_paths
+    if not contains $new_path $PATH
+        set --global --export --prepend PATH $new_path
     end
 end
 


### PR DESCRIPTION
## Motivation

The current `nix-profile{,-daemon}.fish` sets `fish_user_paths` as a global variable, which shadows the
user's universal `fish_user_paths`, causing paths added via `fish_add_path` not to persist across
sessions as many users expect.

## Context

This is the same issue that affected asdf:
- asdf-vm/asdf#1629
- asdf-vm/asdf#1709

The fix directly manipulates `$PATH` instead of using `fish_user_paths`, as noted in
asdf-vm/asdf#1709:

> avoids assumptions about $fish_user_paths being global or universal, which should be the shell user's
> decision. Note that in fish $PATH cannot be a universal variable (it's simply inherited from the
> parent process), so it does not have this issue.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to
[schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
