### PR TITLE
Backport #14690 to 2.30: Support mdbook 0.5.x

### DIFF
--- a/doc/manual/anchors.jq
+++ b/doc/manual/anchors.jq
@@ -24,8 +24,15 @@ def map_contents_recursively(transformer):
 def process_command:
     .[0] as $context |
     .[1] as $body |
-    $body + {
-        sections: $body.sections | map(map_contents_recursively(if $context.renderer == "html" then transform_anchors_html else transform_anchors_strip end)),
-    };
+    # mdbook 0.5.x uses 'items' instead of 'sections'
+    if $body.items then
+        $body + {
+            items: $body.items | map(map_contents_recursively(if $context.renderer == "html" then transform_anchors_html else transform_anchors_strip end)),
+        }
+    else
+        $body + {
+            sections: $body.sections | map(map_contents_recursively(if $context.renderer == "html" then transform_anchors_html else transform_anchors_strip end)),
+        }
+    end;
 
 process_command

--- a/doc/manual/book.toml.in
+++ b/doc/manual/book.toml.in
@@ -23,12 +23,3 @@ renderers = ["html"]
 command = "jq --from-file ./anchors.jq"
 
 [output.markdown]
-
-[output.linkcheck]
-# no Internet during the build (in the sandbox)
-follow-web-links = false
-
-# mdbook-linkcheck does not understand [foo]{#bar} style links, resulting in
-# excessive "Potential incomplete link" warnings. No other kind of warning was
-# produced at the time of writing.
-warning-policy = "ignore"

--- a/doc/manual/package.nix
+++ b/doc/manual/package.nix
@@ -6,7 +6,6 @@
   ninja,
   lowdown-unsandboxed,
   mdbook,
-  mdbook-linkcheck,
   jq,
   python3,
   rsync,
@@ -51,7 +50,6 @@ mkMesonDerivation (finalAttrs: {
     ninja
     (lib.getBin lowdown-unsandboxed)
     mdbook
-    mdbook-linkcheck
     jq
     python3
     rsync

--- a/doc/manual/substitute.py
+++ b/doc/manual/substitute.py
@@ -41,6 +41,10 @@ def recursive_replace(data: dict[str, t.Any], book_root: Path, search_path: Path
             return data | dict(
                 sections = [recursive_replace(section, book_root, search_path) for section in sections],
             )
+        case {'items': items}:
+            return data | dict(
+                items = [recursive_replace(item, book_root, search_path) for item in items],
+            )
         case {'Chapter': chapter}:
             path_to_chapter = Path(chapter['path'])
             chapter_content = chapter['content']


### PR DESCRIPTION
- Unblocks https://github.com/NixOS/nixpkgs/pull/467009
- Backport of #14690 to the 2.30-maintenance branch.
- Fixes #14628

This backport includes:
- Remove mdbook-linkcheck dependency and configuration (was blocking upgrades to mdbook 0.5.0+)
- Update substitute.py and anchors.jq to handle 'items' (mdbook 0.5.x) in addition to 'sections' (mdbook 0.4.x)

**Note:** The second commit from the original PR (lowdown override fix) was not applicable to 2.30 as that code doesn't exist in this branch.