### PR TITLE
Allow nested login shells to retain nix in PATH

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -1,7 +1,7 @@
 # Only execute this file once per shell.
 # This file is tested by tests/installer/default.nix.
 if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
-export __ETC_PROFILE_NIX_SOURCED=1
+__ETC_PROFILE_NIX_SOURCED=1
 
 NIX_LINK=$HOME/.nix-profile
 if [ -n "${XDG_STATE_HOME-}" ]; then


### PR DESCRIPTION
This reverts commit 2b4e3fa1443c8d56ead43865adf037efa92c3fd7.

This commit prevents PATH from being configured when a login shell is started nested in another login shell.

Linux distros might reset PATH when running a login shell (or when executing /etc/profile manually) but nix-daemon.sh will be skipped because __ETC_PROFILE_NIX_SOURCED will remain set. As a result PATH will no longer contain the path to the nix binary.

This PR fixes [#13255](https://github.com/NixOS/nix/issues/13255) and [#13355](https://github.com/NixOS/nix/issues/13355).
In my opinion it is better to have duplicates in your PATH than it not being set at all because nested login shells are used.
