### PR TITLE
fix(libstore/s3-binary-cache-store): include documentation from markdown file

### DIFF
--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -454,11 +454,9 @@ std::string S3BinaryCacheStoreConfig::getHumanReadableURI() const
 
 std::string S3BinaryCacheStoreConfig::doc()
 {
-    return R"(
-        **Store URL format**: `s3://bucket-name`
-
-        This store allows reading and writing a binary cache stored in an AWS S3 bucket.
-    )";
+    return
+#include "s3-binary-cache-store.md"
+        ;
 }
 
 ref<Store> S3BinaryCacheStoreConfig::openStore() const


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The S3BinaryCacheStoreConfig::doc() function was returning a minimal
hardcoded 3-line string instead of including the comprehensive
documentation from s3-binary-cache-store.md.

This was introduced in PR #13752 which moved the prose documentation to
the markdown file but forgot to update the doc() function to use it.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes: #14712

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
