### PR TITLE
DerivedPath: Remove superfluous operator ==

### DIFF
--- a/src/libstore/include/nix/store/derived-path.hh
+++ b/src/libstore/include/nix/store/derived-path.hh
@@ -234,10 +234,6 @@ struct DerivedPath : _DerivedPathRaw
         return static_cast<const Raw &>(*this);
     }
 
-    bool operator==(const DerivedPath &) const = default;
-    // TODO libc++ 16 (used by darwin) missing `std::set::operator <=>`, can't do yet.
-    // auto operator <=> (const DerivedPath &) const = default;
-
     /**
      * Get the store path this is ultimately derived from (by realising
      * and projecting outputs).


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is already implied by the fact that it inherits from std::variant.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Triggered by this (incorrect) coderabbit comment: https://github.com/DeterminateSystems/nix-src/pull/285#discussion_r2590904514

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
