### PR TITLE
Fix Non-virtual interface pattern for `RestrictedStore::addDependency`

### DIFF
--- a/src/libstore/unix/build/chroot-derivation-builder.cc
+++ b/src/libstore/unix/build/chroot-derivation-builder.cc
@@ -181,7 +181,7 @@ struct ChrootDerivationBuilder : virtual DerivationBuilderImpl
 
     std::pair<Path, Path> addDependencyPrep(const StorePath & path)
     {
-        DerivationBuilderImpl::addDependency(path);
+        DerivationBuilderImpl::addDependencyImpl(path);
 
         debug("materialising '%s' in the sandbox", store.printStorePath(path));
 

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -711,9 +711,6 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
 
     void addDependencyImpl(const StorePath & path) override
     {
-        if (isAllowed(path))
-            return;
-
         auto [source, target] = ChrootDerivationBuilder::addDependencyPrep(path);
 
         /* Bind-mount the path into the sandbox. This requires


### PR DESCRIPTION
## Motivation

I didn't do things quite right in 496e43ec72643ad4fc48ce15e6b7220763e823a8:

- Forgot to remove the now-redundant `isAllowed` check.

- Called the non-virtual, not the superclass's impl, in `addDependencyPrep`, causing bad recursion / UB.

Doing this fixes a crash I encountered with manual testing an Nix Ninja --- hopefully we will get Nix Ninja or similar in a NixOS test longer term to defend against this thing happening again.

## Context

496e43ec72643ad4fc48ce15e6b7220763e823a8

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
