### PR TITLE
Fix `MAKE_WRAPPER_CONSTRUCTOR` to not override special constructors

### DIFF
--- a/src/libutil/include/nix/util/variant-wrapper.hh
+++ b/src/libutil/include/nix/util/variant-wrapper.hh
@@ -22,10 +22,12 @@
  *
  * The moral equivalent of `using Raw::Raw;`
  */
-#define MAKE_WRAPPER_CONSTRUCTOR(CLASS_NAME)       \
-    FORCE_DEFAULT_CONSTRUCTORS(CLASS_NAME)         \
-                                                   \
-    CLASS_NAME(auto &&... arg)                     \
-        : raw(std::forward<decltype(arg)>(arg)...) \
-    {                                              \
+#define MAKE_WRAPPER_CONSTRUCTOR(CLASS_NAME)                                                                \
+    FORCE_DEFAULT_CONSTRUCTORS(CLASS_NAME)                                                                  \
+                                                                                                            \
+    template<typename... Args>                                                                              \
+        requires(!(sizeof...(Args) == 1 && (std::is_same_v<std::remove_cvref_t<Args>, CLASS_NAME> && ...))) \
+    CLASS_NAME(Args &&... arg)                                                                              \
+        : raw(std::forward<Args>(arg)...)                                                                   \
+    {                                                                                                       \
     }


### PR DESCRIPTION
It should not effect move / copy / etc. constructors.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
