### PR TITLE
Correct `build-dir` error in manual, link relevant settings

### DIFF
--- a/doc/manual/source/store/building.md
+++ b/doc/manual/source/store/building.md
@@ -12,9 +12,10 @@
 
 The [`builder`](./derivation/index.md#builder) is executed as follows:
 
-- A temporary directory is created under the directory specified by
-  `TMPDIR` (default `/tmp`) where the build will take place. The
+- A temporary directory is created where the build will take place. The
   current directory is changed to this directory.
+
+  See the per-store [`build-dir`](@docroot@/store/types/local-store.md#store-local-store-build-dir) setting for more information.
 
 - The environment is cleared and set to the derivation attributes, as
   specified above.

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -794,6 +794,8 @@ public:
         "build-dir",
         R"(
             Override the `build-dir` store setting for all stores that have this setting.
+
+            See also the per-store [`build-dir`](@docroot@/store/types/local-store.md#store-local-store-build-dir) setting.
         )"};
 
     Setting<PathSet> allowedImpureHostPrefixes{

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -61,6 +61,8 @@ private:
             > `build-dir` must not be set to a world-writable directory.
             > Placing temporary build directories in a world-writable place allows other users to access or modify build data that is currently in use.
             > This alone is merely an impurity, but combined with another factor this has allowed malicious derivations to escape the build sandbox.
+
+            See also the global [`build-dir`](@docroot@/command-ref/conf-file.md#conf-build-dir) setting.
         )"};
 public:
     Path getBuildDir() const;


### PR DESCRIPTION
## Motivation

This fixes out-of-date information that is no longer true, and makes the up-to-date information more accessible.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
