### PR TITLE
Create proper serializer for BuildResult status

### DIFF
--- a/src/libstore/common-protocol.cc
+++ b/src/libstore/common-protocol.cc
@@ -111,4 +111,51 @@ void CommonProto::Serialise<Signature>::write(
     conn.to << sig.to_string();
 }
 
+/**
+ * Mapping from protocol wire values to BuildResultStatus.
+ *
+ * The array index is the wire value.
+ * Note: HashMismatch is not in the protocol; it gets converted
+ * to OutputRejected before serialization.
+ */
+constexpr static BuildResultStatus buildResultStatusTable[] = {
+    BuildResultSuccessStatus::Built,                  // 0
+    BuildResultSuccessStatus::Substituted,            // 1
+    BuildResultSuccessStatus::AlreadyValid,           // 2
+    BuildResultFailureStatus::PermanentFailure,       // 3
+    BuildResultFailureStatus::InputRejected,          // 4
+    BuildResultFailureStatus::OutputRejected,         // 5
+    BuildResultFailureStatus::TransientFailure,       // 6
+    BuildResultFailureStatus::CachedFailure,          // 7
+    BuildResultFailureStatus::TimedOut,               // 8
+    BuildResultFailureStatus::MiscFailure,            // 9
+    BuildResultFailureStatus::DependencyFailed,       // 10
+    BuildResultFailureStatus::LogLimitExceeded,       // 11
+    BuildResultFailureStatus::NotDeterministic,       // 12
+    BuildResultSuccessStatus::ResolvesToAlreadyValid, // 13
+    BuildResultFailureStatus::NoSubstituters,         // 14
+};
+
+BuildResultStatus
+CommonProto::Serialise<BuildResultStatus>::read(const StoreDirConfig & store, CommonProto::ReadConn conn)
+{
+    auto rawStatus = readNum<uint8_t>(conn.from);
+
+    if (rawStatus >= std::size(buildResultStatusTable))
+        throw Error("Invalid BuildResult status %d from remote", rawStatus);
+
+    return buildResultStatusTable[rawStatus];
+}
+
+void CommonProto::Serialise<BuildResultStatus>::write(
+    const StoreDirConfig & store, CommonProto::WriteConn conn, const BuildResultStatus & status)
+{
+    for (auto && [wire, val] : enumerate(buildResultStatusTable))
+        if (val == status) {
+            conn.to << uint8_t(wire);
+            return;
+        }
+    unreachable();
+}
+
 } // namespace nix

--- a/src/libstore/include/nix/store/build-result.hh
+++ b/src/libstore/include/nix/store/build-result.hh
@@ -11,24 +11,52 @@
 
 namespace nix {
 
+/**
+ * Names must be disjoint with `BuildResultFailureStatus`.
+ *
+ * @note Prefer using `BuildResult::Success::Status`, this name is just
+ * for sake of forward declarations.
+ */
+enum struct BuildResultSuccessStatus : uint8_t {
+    Built,
+    Substituted,
+    AlreadyValid,
+    ResolvesToAlreadyValid,
+};
+
+/**
+ * Names must be disjoint with `BuildResultSuccessStatus`.
+ *
+ * @note Prefer using `BuildResult::Failure::Status`, this name is just
+ * for sake of forward declarations.
+ */
+enum struct BuildResultFailureStatus : uint8_t {
+    PermanentFailure,
+    InputRejected,
+    OutputRejected,
+    /// possibly transient
+    TransientFailure,
+    /// no longer used
+    CachedFailure,
+    TimedOut,
+    MiscFailure,
+    DependencyFailed,
+    LogLimitExceeded,
+    NotDeterministic,
+    NoSubstituters,
+    /// A certain type of `OutputRejected`. The protocols do not yet
+    /// know about this one, so change it back to `OutputRejected`
+    /// before serialization.
+    HashMismatch,
+};
+
 struct BuildResult
 {
     struct Success
     {
-        /**
-         * @note This is directly used in the nix-store --serve protocol.
-         * That means we need to worry about compatibility across versions.
-         * Therefore, don't remove status codes, and only add new status
-         * codes at the end of the list.
-         *
-         * Must be disjoint with `Failure::Status`.
-         */
-        enum Status : uint8_t {
-            Built = 0,
-            Substituted = 1,
-            AlreadyValid = 2,
-            ResolvesToAlreadyValid = 13,
-        } status;
+        using Status = enum BuildResultSuccessStatus;
+        using enum Status;
+        Status status;
 
         /**
          * For derivations, a mapping from the names of the wanted outputs
@@ -38,43 +66,13 @@ struct BuildResult
 
         bool operator==(const BuildResult::Success &) const noexcept;
         std::strong_ordering operator<=>(const BuildResult::Success &) const noexcept;
-
-        static bool statusIs(uint8_t status)
-        {
-            return status == Built || status == Substituted || status == AlreadyValid
-                   || status == ResolvesToAlreadyValid;
-        }
     };
 
     struct Failure
     {
-        /**
-         * @note This is directly used in the nix-store --serve protocol.
-         * That means we need to worry about compatibility across versions.
-         * Therefore, don't remove status codes, and only add new status
-         * codes at the end of the list.
-         *
-         * Must be disjoint with `Success::Status`.
-         */
-        enum Status : uint8_t {
-            PermanentFailure = 3,
-            InputRejected = 4,
-            OutputRejected = 5,
-            /// possibly transient
-            TransientFailure = 6,
-            /// no longer used
-            CachedFailure = 7,
-            TimedOut = 8,
-            MiscFailure = 9,
-            DependencyFailed = 10,
-            LogLimitExceeded = 11,
-            NotDeterministic = 12,
-            NoSubstituters = 14,
-            /// A certain type of `OutputRejected`. The protocols do not yet
-            /// know about this one, so change it back to `OutputRejected`
-            /// before serialization.
-            HashMismatch = 15,
-        } status = MiscFailure;
+        using Status = enum BuildResultFailureStatus;
+        using enum Status;
+        Status status = MiscFailure;
 
         /**
          * Information about the error if the build failed.

--- a/src/libstore/include/nix/store/common-protocol.hh
+++ b/src/libstore/include/nix/store/common-protocol.hh
@@ -3,6 +3,8 @@
 
 #include "nix/util/serialise.hh"
 
+#include <variant>
+
 namespace nix {
 
 struct StoreDirConfig;
@@ -14,6 +16,8 @@ struct ContentAddress;
 struct DrvOutput;
 struct Realisation;
 struct Signature;
+enum struct BuildResultSuccessStatus : uint8_t;
+enum struct BuildResultFailureStatus : uint8_t;
 
 /**
  * Shared serializers between the worker protocol, serve protocol, and a
@@ -86,7 +90,6 @@ DECLARE_COMMON_SERIALISER(std::tuple<Ts...>);
 
 template<typename K, typename V>
 DECLARE_COMMON_SERIALISER(std::map<K COMMA_ V>);
-#undef COMMA_
 
 /**
  * These use the empty string for the null case, relying on the fact
@@ -106,5 +109,15 @@ template<>
 DECLARE_COMMON_SERIALISER(std::optional<StorePath>);
 template<>
 DECLARE_COMMON_SERIALISER(std::optional<ContentAddress>);
+
+/**
+ * The success and failure codes never overlay in enum tag values in the wire formats
+ */
+using BuildResultStatus = std::variant<BuildResultSuccessStatus, BuildResultFailureStatus>;
+
+template<>
+DECLARE_COMMON_SERIALISER(BuildResultStatus);
+
+#undef COMMA_
 
 } // namespace nix

--- a/src/libstore/serve-protocol.cc
+++ b/src/libstore/serve-protocol.cc
@@ -2,6 +2,7 @@
 #include "nix/store/path-with-outputs.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/build-result.hh"
+#include "nix/store/common-protocol.hh"
 #include "nix/store/serve-protocol.hh"
 #include "nix/store/serve-protocol-impl.hh"
 #include "nix/util/archive.hh"
@@ -15,30 +16,35 @@ namespace nix {
 
 BuildResult ServeProto::Serialise<BuildResult>::read(const StoreDirConfig & store, ServeProto::ReadConn conn)
 {
-    BuildResult status;
+    BuildResult res;
     BuildResult::Success success;
     BuildResult::Failure failure;
 
-    auto rawStatus = readInt(conn.from);
+    auto status = ServeProto::Serialise<BuildResultStatus>::read(store, {conn.from});
     conn.from >> failure.errorMsg;
 
     if (GET_PROTOCOL_MINOR(conn.version) >= 3)
-        conn.from >> status.timesBuilt >> failure.isNonDeterministic >> status.startTime >> status.stopTime;
+        conn.from >> res.timesBuilt >> failure.isNonDeterministic >> res.startTime >> res.stopTime;
     if (GET_PROTOCOL_MINOR(conn.version) >= 6) {
         auto builtOutputs = ServeProto::Serialise<DrvOutputs>::read(store, conn);
         for (auto && [output, realisation] : builtOutputs)
             success.builtOutputs.insert_or_assign(std::move(output.outputName), std::move(realisation));
     }
 
-    if (BuildResult::Success::statusIs(rawStatus)) {
-        success.status = static_cast<BuildResult::Success::Status>(rawStatus);
-        status.inner = std::move(success);
-    } else {
-        failure.status = static_cast<BuildResult::Failure::Status>(rawStatus);
-        status.inner = std::move(failure);
-    }
+    res.inner = std::visit(
+        overloaded{
+            [&](BuildResult::Success::Status s) -> decltype(res.inner) {
+                success.status = s;
+                return std::move(success);
+            },
+            [&](BuildResult::Failure::Status s) -> decltype(res.inner) {
+                failure.status = s;
+                return std::move(failure);
+            },
+        },
+        status);
 
-    return status;
+    return res;
 }
 
 void ServeProto::Serialise<BuildResult>::write(
@@ -63,11 +69,11 @@ void ServeProto::Serialise<BuildResult>::write(
     std::visit(
         overloaded{
             [&](const BuildResult::Failure & failure) {
-                conn.to << failure.status;
+                ServeProto::write(store, {conn.to}, BuildResultStatus{failure.status});
                 common(failure.errorMsg, failure.isNonDeterministic, decltype(BuildResult::Success::builtOutputs){});
             },
             [&](const BuildResult::Success & success) {
-                conn.to << success.status;
+                ServeProto::write(store, {conn.to}, BuildResultStatus{success.status});
                 common(/*errorMsg=*/"", /*isNonDeterministic=*/false, success.builtOutputs);
             },
         },


### PR DESCRIPTION
## Motivation

The casts were not safe with respect to unknown values, but these are.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
