### PR TITLE
Add warning for non-JSON-object `exportReferencesGraph`

### DIFF
--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -341,8 +341,12 @@ DerivationOptions<SingleDerivedPath> derivationOptionsFromStructuredAttrs(
 
                 if (parsed) {
                     auto * e = optionalValueAt(parsed->structuredAttrs, "exportReferencesGraph");
-                    if (!e || !e->is_object())
+                    if (!e)
                         return ret;
+                    if (!e->is_object()) {
+                        warn("'exportReferencesGraph' in structured attrs is not a JSON object, ignoring");
+                        return ret;
+                    }
                     for (auto & [key, storePathsJson] : getObject(*e)) {
                         StringSet ss;
                         flatten(storePathsJson, ss);

--- a/tests/functional/structured-attrs.sh
+++ b/tests/functional/structured-attrs.sh
@@ -50,3 +50,16 @@ expectStderr 0 nix-instantiate --expr "$hackyExpr" --eval --strict | grepQuiet "
 # Check it works with the expected structured attrs
 hacky=$(nix-instantiate --expr "$hackyExpr")
 nix derivation show "$hacky" | jq --exit-status '.derivations."'"$(basename "$hacky")"'".structuredAttrs | . == {"a": 1}'
+
+# Test warning for non-object exportReferencesGraph in structured attrs
+# shellcheck disable=SC2016
+expectStderr 0 nix-build --expr '
+  with import ./config.nix;
+  mkDerivation {
+    name = "export-graph-non-object";
+    __structuredAttrs = true;
+    exportReferencesGraph = [ "foo" "bar" ];
+    builder = "/bin/sh";
+    args = ["-c" "echo foo > ${builtins.placeholder "out"}"];
+  }
+' | grepQuiet "warning:.*exportReferencesGraph.*not a JSON object"


### PR DESCRIPTION
## Motivation

This will help users debug their mistakes.

## Context

Pulled out of #14754

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
