### PR TITLE
C API: Add query_from_hash_part to Store API

### DIFF
--- a/doc/manual/rl-next/c-api-new-store-methods.md
+++ b/doc/manual/rl-next/c-api-new-store-methods.md
@@ -1,0 +1,8 @@
+---
+synopsis: "C API: New store API methods"
+prs: [14766]
+---
+
+The C API now includes additional methods:
+
+- `nix_store_query_path_from_hash_part()` - Get the full store path given its hash part

--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -338,4 +338,20 @@ nix_derivation * nix_store_drv_from_store_path(nix_c_context * context, Store * 
     NIXC_CATCH_ERRS_NULL
 }
 
+StorePath * nix_store_query_path_from_hash_part(nix_c_context * context, Store * store, const char * hash)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        std::optional<nix::StorePath> s = store->ptr->queryPathFromHashPart(hash);
+
+        if (!s.has_value()) {
+            return nullptr;
+        }
+
+        return new StorePath{std::move(s.value())};
+    }
+    NIXC_CATCH_ERRS_NULL
+}
+
 } // extern "C"

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -259,6 +259,17 @@ nix_err nix_store_get_fs_closure(
  */
 nix_derivation * nix_store_drv_from_store_path(nix_c_context * context, Store * store, const StorePath * path);
 
+/**
+ * @brief Query the full store path given the hash part of a valid store
+ * path, or empty if no matching path is found.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] store nix store reference
+ * @param[in] hash Hash part of path as a string
+ * @return Store path reference, NULL if no matching path is found.
+ */
+StorePath * nix_store_query_path_from_hash_part(nix_c_context * context, Store * store, const char * hash);
+
 // cffi end
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Along with `nix_store_query_path_info` from https://github.com/NixOS/nix/pull/14031, this API allows implementing a minimal HTTP Binary Cache (in the style of nix-serve) without forking so many commands.

## Context

Is https://github.com/NixOS/nix/pull/14031 still active? It seems that it was partially merged with https://github.com/NixOS/nix/pull/14555, but that omitted `nix_store_query_path_info`.

Tested on my fork calling from Rust.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
