### PR TITLE
C API: Add copy_path to Store API

### DIFF
--- a/doc/manual/rl-next/c-api-new-store-methods.md
+++ b/doc/manual/rl-next/c-api-new-store-methods.md
@@ -6,3 +6,4 @@ prs: [14766]
 The C API now includes additional methods:
 
 - `nix_store_query_path_from_hash_part()` - Get the full store path given its hash part
+- `nix_store_copy_path()` - Copy a single store path between two stores, allows repairs and configuring signature checking

--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -352,4 +352,26 @@ StorePath * nix_store_query_path_from_hash_part(nix_c_context * context, Store *
     NIXC_CATCH_ERRS_NULL
 }
 
+nix_err nix_store_copy_path(
+    nix_c_context * context, Store * srcStore, Store * dstStore, const StorePath * path, bool repair, bool checkSigs)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        if (srcStore == nullptr)
+            return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "Source store is null");
+
+        if (dstStore == nullptr)
+            return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "Destination store is null");
+
+        if (path == nullptr)
+            return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "Store path is null");
+
+        auto repairFlag = repair ? nix::RepairFlag::Repair : nix::RepairFlag::NoRepair;
+        auto checkSigsFlag = checkSigs ? nix::CheckSigsFlag::CheckSigs : nix::CheckSigsFlag::NoCheckSigs;
+        nix::copyStorePath(*srcStore->ptr, *dstStore->ptr, path->path, repairFlag, checkSigsFlag);
+    }
+    NIXC_CATCH_ERRS
+}
+
 } // extern "C"

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -270,6 +270,19 @@ nix_derivation * nix_store_drv_from_store_path(nix_c_context * context, Store * 
  */
 StorePath * nix_store_query_path_from_hash_part(nix_c_context * context, Store * store, const char * hash);
 
+/**
+ * @brief Copy a path from one store to another.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] srcStore nix source store reference
+ * @param[in] dstStore nix destination store reference
+ * @param[in] path The path to copy
+ * @param[in] repair Whether to repair the path
+ * @param[in] checkSigs Whether to check path signatures are trusted before copying
+ */
+nix_err nix_store_copy_path(
+    nix_c_context * context, Store * srcStore, Store * dstStore, const StorePath * path, bool repair, bool checkSigs);
+
 // cffi end
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This provides more granular control over paths as they are copied in a few ways:
- Ability to control timing of copied paths
- Ability to repair an individual path
- Ability to control signature checking

My primary motivation is to be able to monitor copy progress on a per-path basis. AFAIK the alternative way to do this is to log & parse the JSON format--not possible from FFI (?). Secondarily, I'd like to repair individual paths without copying the entire closure (otherwise I'd just add the `repair` param to the existing `copyClosure`).

## Context

Tested on my fork calling from Rust.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
