### PR TITLE
Bring `nix derivation show` in compliance with JSON guidelines

### DIFF
--- a/doc/manual/source/release-notes/rl-2.33.md
+++ b/doc/manual/source/release-notes/rl-2.33.md
@@ -180,6 +180,21 @@ Additionally the following fields are added to both formats:
 
 The derivation JSON format has been updated from version 3 to version 4:
 
+- **Nested structure with top-level metadata**:
+
+  The output of `nix derivation show` is now wrapped in an object with `version` and `derivations` fields:
+
+  ```json
+  {
+    "version": 4,
+    "derivations": { ... }
+  }
+  ```
+
+  The map from derivation paths to derivation info is nested under the `derivations` field.
+
+  This matches the structure used for `nix path-info --json --json-format 2`, and likewise brings this command into compliance with the JSON guidelines.
+
 - **Restructured inputs**:
 
   Inputs are now nested under an `inputs` object:

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -1489,8 +1489,6 @@ adl_serializer<DerivationOutput>::from_json(const json & _json, const Experiment
     }
 }
 
-static unsigned constexpr expectedJsonVersionDerivation = 4;
-
 void adl_serializer<Derivation>::to_json(json & res, const Derivation & d)
 {
     res = nlohmann::json::object();

--- a/src/libstore/include/nix/store/derivations.hh
+++ b/src/libstore/include/nix/store/derivations.hh
@@ -586,6 +586,12 @@ void writeDerivation(Sink & out, const StoreDirConfig & store, const BasicDeriva
  */
 std::string hashPlaceholder(const OutputNameView outputName);
 
+/**
+ * The expected JSON version for derivation serialization.
+ * Used by `nix derivation show` and `nix derivation add`.
+ */
+constexpr unsigned expectedJsonVersionDerivation = 4;
+
 } // namespace nix
 
 JSON_IMPL_WITH_XP_FEATURES(nix::DerivationOutput)

--- a/src/nix/derivation-show.cc
+++ b/src/nix/derivation-show.cc
@@ -60,7 +60,11 @@ struct CmdShowDerivation : InstallablesCommand, MixPrintJSON
 
             jsonRoot[drvPath.to_string()] = store->readDerivation(drvPath);
         }
-        printJSON(jsonRoot);
+        printJSON(
+            nlohmann::json{
+                {"version", expectedJsonVersionDerivation},
+                {"derivations", std::move(jsonRoot)},
+            });
     }
 };
 

--- a/tests/functional/ca/derivation-json.sh
+++ b/tests/functional/ca/derivation-json.sh
@@ -6,7 +6,7 @@ export NIX_TESTS_CA_BY_DEFAULT=1
 
 drvPath=$(nix-instantiate ../simple.nix)
 
-nix derivation show "$drvPath" | jq .[] > "$TEST_HOME"/simple.json
+nix derivation show "$drvPath" | jq '.derivations[]' > "$TEST_HOME"/simple.json
 
 drvPath2=$(nix derivation add < "$TEST_HOME"/simple.json)
 
@@ -27,5 +27,5 @@ drvPath4=$(nix derivation add < "$TEST_HOME"/foo.json)
 [[ -e "$drvPath3" ]]
 
 # The modified derivation read back as JSON matches
-nix derivation show "$drvPath3" | jq .[] > "$TEST_HOME"/foo-read.json
+nix derivation show "$drvPath3" | jq '.derivations[]' > "$TEST_HOME"/foo-read.json
 diff "$TEST_HOME"/foo.json "$TEST_HOME"/foo-read.json

--- a/tests/functional/derivation-json.sh
+++ b/tests/functional/derivation-json.sh
@@ -4,7 +4,7 @@ source common.sh
 
 drvPath=$(nix-instantiate simple.nix)
 
-nix derivation show "$drvPath" | jq '.[]' > "$TEST_HOME/simple.json"
+nix derivation show "$drvPath" | jq '.derivations[]' > "$TEST_HOME/simple.json"
 
 # Round tripping to JSON works
 drvPath2=$(nix derivation add < "$TEST_HOME/simple.json")

--- a/tests/functional/dyn-drv/recursive-mod-json.nix
+++ b/tests/functional/dyn-drv/recursive-mod-json.nix
@@ -18,7 +18,7 @@ mkDerivation rec {
     PATH=${builtins.getEnv "EXTRA_PATH"}:$PATH
 
     # JSON of pre-existing drv
-    nix derivation show $drv | jq .[] > drv0.json
+    nix derivation show $drv | jq '.derivations[]' > drv0.json
 
     # Fix name
     jq < drv0.json '.name = "${innerName}"' > drv1.json

--- a/tests/functional/impure-derivations.sh
+++ b/tests/functional/impure-derivations.sh
@@ -16,7 +16,7 @@ printf 0 > "$TEST_ROOT"/counter
 
 # `nix derivation add` with impure derivations work
 drvPath=$(nix-instantiate ./impure-derivations.nix -A impure)
-nix derivation show "$drvPath" | jq .[] > "$TEST_HOME"/impure-drv.json
+nix derivation show "$drvPath" | jq '.derivations[]' > "$TEST_HOME"/impure-drv.json
 drvPath2=$(nix derivation add < "$TEST_HOME"/impure-drv.json)
 [[ "$drvPath" = "$drvPath2" ]]
 
@@ -50,8 +50,8 @@ path4=$(nix build -L --no-link --json --file ./impure-derivations.nix impureOnIm
 (! nix build -L --no-link --json --file ./impure-derivations.nix inputAddressed 2>&1) | grep 'depends on impure derivation'
 
 drvPath=$(nix eval --json --file ./impure-derivations.nix impure.drvPath | jq -r .)
-[[ $(nix derivation show "$drvPath" | jq ".[\"$(basename "$drvPath")\"].outputs.out.impure") = true ]]
-[[ $(nix derivation show "$drvPath" | jq ".[\"$(basename "$drvPath")\"].outputs.stuff.impure") = true ]]
+[[ $(nix derivation show "$drvPath" | jq ".derivations[\"$(basename "$drvPath")\"].outputs.out.impure") = true ]]
+[[ $(nix derivation show "$drvPath" | jq ".derivations[\"$(basename "$drvPath")\"].outputs.stuff.impure") = true ]]
 
 # Fixed-output derivations *can* depend on impure derivations.
 path5=$(nix build -L --no-link --json --file ./impure-derivations.nix contentAddressed | jq -r .[].outputs.out)

--- a/tests/functional/structured-attrs.sh
+++ b/tests/functional/structured-attrs.sh
@@ -49,4 +49,4 @@ expectStderr 0 nix-instantiate --expr "$hackyExpr" --eval --strict | grepQuiet "
 
 # Check it works with the expected structured attrs
 hacky=$(nix-instantiate --expr "$hackyExpr")
-nix derivation show "$hacky" | jq --exit-status '."'"$(basename "$hacky")"'".structuredAttrs | . == {"a": 1}'
+nix derivation show "$hacky" | jq --exit-status '.derivations."'"$(basename "$hacky")"'".structuredAttrs | . == {"a": 1}'


### PR DESCRIPTION
## Motivation

This matches what we just did for `nix path-info`, and I hope will allow us to avoiding any more breaking changes to this command for the foreseeable future.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
