### PR TITLE
libstore/aws-creds: Shut logs by default

### DIFF
--- a/src/libstore/aws-creds.cc
+++ b/src/libstore/aws-creds.cc
@@ -79,6 +79,8 @@ class AwsCredentialProviderImpl : public AwsCredentialProvider
 public:
     AwsCredentialProviderImpl()
     {
+        ::FILE * fp = ::stderr;
+
         // Map Nix's verbosity to AWS CRT log level
         Aws::Crt::LogLevel logLevel;
         if (verbosity >= lvlVomit) {
@@ -88,9 +90,14 @@ public:
         } else if (verbosity >= lvlChatty) {
             logLevel = Aws::Crt::LogLevel::Info;
         } else {
-            logLevel = Aws::Crt::LogLevel::Warn;
+            /* By default the sdk is very chatty and barf unwanted messages if e.g.
+               .aws/config doesn't exist and such. Shut it since it would spam messages
+               if you only set up creds via the environment. */
+            logLevel = Aws::Crt::LogLevel::None;
+            fp = nullptr;
         }
-        apiHandle.InitializeLogging(logLevel, stderr);
+
+        apiHandle.InitializeLogging(logLevel, fp);
     }
 
     AwsCredentials getCredentialsRaw(const std::string & profile);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

By default the sdk is very chatty and barf unwanted messages if e.g.
.aws/config doesn't exist and such. Shut it since it would spam messages
if you only set up creds via the environment. That is poor UX and the sdk provides a very bad default.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
