### PR TITLE
[libstore]: Fix a heap-use-after-free bug

### DIFF
--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -79,7 +79,7 @@ struct DerivationBuilderParams
      */
     const StorePathSet & inputPaths;
 
-    const std::map<std::string, InitialOutput> & initialOutputs;
+    const std::map<std::string, InitialOutput> initialOutputs;
 
     const BuildMode & buildMode;
 


### PR DESCRIPTION
## Motivation

Under high build load, we were seeing the nix daemon segfault around [here](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/unix/build/derivation-builder.cc#L750). Further investigation suggested that this was a heap-use-after-free issue where the [initialOutputs](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/include/nix/store/build/derivation-builder.hh#L82) field referenced data in an activation frame that had since gone out of scope.

I believe the issue is caused by going through [this while loop](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/build/derivation-building-goal.cc#L548) 3+ times:

1. The DerivationBuilder is [constructed](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/build/derivation-building-goal.cc#L620-L631) taking a reference to [initialOutputs](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/build/derivation-building-goal.cc#L233). The build doesn't complete but hits this [continue statement here](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/build/derivation-building-goal.cc#L649-L656). Importantly, the DerivationBuilder is stored in the [DerivationBuildingGoal](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/include/nix/store/build/derivation-building-goal.hh#L92)
2. The number of current builds is greater or equal to the maximum number of builds and we call `co_return tryToBuild()` [here](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/build/derivation-building-goal.cc#L554). Importantly, I believe co_return of this form is [implemented like a tail call](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/include/nix/store/build/goal.hh#L340-L353), so the current tryToBuild activation frame is destroyed and hence initialOutputs referenced by the builder is destroyed too.
3. Inside [builder->startBuild()](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/build/derivation-building-goal.cc#L646) triggers the heap-use-after-free issue.

There are a few other ways this could be fixed:
* ~~by deleting [this line](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/build/derivation-building-goal.cc#L554) and instead performing the build with another iteration of the while loop.~~ Edit: This would cause a nix build without path locks. That would be bad.
* by inserting `builder.reset()` around [this line](https://github.com/NixOS/nix/blob/2.33.0/src/libstore/build/derivation-building-goal.cc#L552).

## Context


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
