### PR TITLE
libstore: always use the socket if it exists

### DIFF
--- a/doc/manual/rl-next/daemon-first-store-selection.md
+++ b/doc/manual/rl-next/daemon-first-store-selection.md
@@ -1,0 +1,11 @@
+---
+synopsis: Nix now prefers the daemon over direct store access
+---
+
+When using `auto` or the default store (without explicit `--store`), Nix now connects to the daemon if the socket exists, even when the user has write access to the store.
+
+Previously, Nix would bypass the daemon and access the store directly if the store directory was writable. This led to several issues:
+- Inconsistent behavior between users with different permissions
+- The `max-jobs` counter not being shared between Nix instances
+
+To explicitly use the local store without the daemon, use `--store local`.

--- a/src/libstore/local-store.md
+++ b/src/libstore/local-store.md
@@ -8,6 +8,9 @@ prefixed to other directories such as the Nix store directory. The
 store pseudo-URL `local` denotes a store that uses `/` as its root
 directory.
 
+Use `--store local` to bypass the daemon and access the store directly.
+This can be useful for debugging or when the daemon is not running.
+
 A store that uses a *root* other than `/` is called a *chroot
 store*. With such stores, the store directory is "logically" still
 `/nix/store`, so programs stored in them can only be built and


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->
This change modifies the behaviour of Nix to always communicate with the
daemon, even if the store is writable to that user.

Bypassing the daemon had a number of issues. Mainly, the client
behaviour is not always consistent between users leading to confusion.
The max-jobs counter is not shared between various instances of the Nix
client. The clients fight between each-other to hold the lock on the
sqlite database.

By making the access consistent, it opens the road for the daemon to
permanently hold the lock on the sqlite database, and get rid of the
\"sqlite is busy\" type of errors.

Reviving this after 5 years. See #4263

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
