### PR TITLE
libstore(http): Support `http-headers` setting in HTTP Binary Cache Store types

### DIFF
--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -193,7 +193,13 @@ FileTransferRequest HttpBinaryCacheStore::makeRequest(std::string_view path)
         result.query = config->cacheUri.query;
     }
 
-    return FileTransferRequest(result);
+    auto req = FileTransferRequest(result);
+
+    for (auto & [header, headerValue] : config->httpHeaders.get()) {
+        req.headers.emplace_back(header, headerValue);
+    }
+
+    return req;
 }
 
 void HttpBinaryCacheStore::getFile(const std::string & path, Sink & sink)

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include "nix/util/types.hh"
 #include "nix/util/url.hh"
 #include "nix/store/binary-cache-store.hh"
 #include "nix/store/filetransfer.hh"
@@ -34,6 +35,23 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
           Compression method for `log/*` files. It is recommended to
           use a compression method supported by most web browsers
           (e.g. `brotli`).
+        )"};
+
+    const Setting<StringMap> httpHeaders{
+        this,
+        {},
+        "http-headers",
+        R"(
+          Extra headers to append to all HTTP requests. Accepts a string
+          with header keys and values separated by `=` (e.g. `foo=bar`). Multiple headers 
+          should be separated by a space. May be URL encoded. For example:
+
+          ```bash
+          $ nix path-info \
+                --store http://cache.nixos.org?http-headers=foo=bar ...
+          $ nix path-info \
+                --store http://cache.nixos.org?http-headers=foo%3Dbar%20baz%3Dquux ...
+          ```
         )"};
 
     static const std::string name()


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I would like to attach additional headers to requests made to a particular HTTP store. This is helpful for tracing, auth, routing, etc.

This PR adds an `http-headers` setting to the HTTP binary cache store (& S3 store). It uses the existing `StringMap` type, which parses a string with keys and values separated by `=`.

Example usage:

```bash
$ nix path-info \
        --store http://cache.nixos.org?http-headers=foo=bar ...
  # header => foo: bar
$ nix path-info \
        --store http://cache.nixos.org?http-headers=foo%3Dbar%20baz%3Dquux ...
  # header => foo: bar
  # header => baz: quux
```

#### Secret values
I tested that this setting does not get included in logs in a couple common commands:

```bash
$ ./src/nix/nix copy  --from  http://localhost:8080?http-headers=header=secret-value --offline --refresh /nix/store/cn3gmrrjdwv3b7fz0iwvlzki416alr5m-stdenv-darwin -vvvvvvvv 2>&1 | grep secret-value
<empty>
$ ./src/nix/nix path-info  --store  http://localhost:8080?http-headers=header=secret-value --offline --refresh /nix/store/cn3gmrrjdwv3b7fz0iwvlzki416alr5m-stdenv-darwin -vvvvvvvv 2>&1 | grep secret-value
<empty>
```

#### Limitations
Since this uses `StringMap`, this new setting has the same behavior as [access-tokens](https://nix.dev/manual/nix/2.24/command-ref/conf-file.html#conf-access-tokens) and [impure-env](https://nix.dev/manual/nix/2.24/command-ref/conf-file.html#conf-impure-env): it is limited in what may be included as a header value. Due to the behavior of [parse](https://github.com/NixOS/nix/blob/931f84b72064e2d6c27464d3ed365e3a5693f5a9/src/libutil/configuration.cc#L429), the header value may not include any of `= \t\n\r`.

## Context

I don't see any existing open issues related to this.

Are there existing tests for HTTP stores that I could add to? I only see [this one for S3 stores](https://github.com/NixOS/nix/blob/master/tests/nixos/s3-binary-cache-store.nix).

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
