### PR TITLE
libstore(filetransfer): Support store-specific `http-version` setting

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -437,10 +437,7 @@ struct curlFileTransfer : public FileTransfer
                  + (fileTransferSettings.userAgentSuffix != "" ? " " + fileTransferSettings.userAgentSuffix.get() : ""))
                     .c_str());
             curl_easy_setopt(req, CURLOPT_PIPEWAIT, 1);
-            if (fileTransferSettings.enableHttp2)
-                curl_easy_setopt(req, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
-            else
-                curl_easy_setopt(req, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+            curl_easy_setopt(req, CURLOPT_HTTP_VERSION, curlHttpVersion(request.httpVersion));
             curl_easy_setopt(req, CURLOPT_WRITEFUNCTION, TransferItem::writeCallbackWrapper);
             curl_easy_setopt(req, CURLOPT_WRITEDATA, this);
             curl_easy_setopt(req, CURLOPT_HEADERFUNCTION, TransferItem::headerCallbackWrapper);
@@ -1131,6 +1128,29 @@ FileTransferError::FileTransferError(
         err.msg = HintFmt("%1%\n\nresponse body:\n\n%2%", Uncolored(hf.str()), chomp(*response));
     else
         err.msg = hf;
+}
+
+long curlHttpVersion(HttpVersion httpVersion)
+{
+    switch (httpVersion) {
+    case HttpVersion::None:
+        return CURL_HTTP_VERSION_NONE;
+    case HttpVersion::Http1_1:
+        return CURL_HTTP_VERSION_1_1;
+    case HttpVersion::Http2:
+        return CURL_HTTP_VERSION_2_0;
+    case HttpVersion::Http2PriorKnowledge:
+#if LIBCURL_VERSION_NUM >= 0x073100
+        return CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE;
+#endif
+    case HttpVersion::Http3:
+#if LIBCURL_VERSION_NUM >= 0x074200
+        return CURL_HTTP_VERSION_3;
+#endif
+    default:
+        // If we get here somehow, let curl decide
+        return CURL_HTTP_VERSION_NONE;
+    }
 }
 
 } // namespace nix

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -4,6 +4,8 @@
 #include "nix/store/nar-info-disk-cache.hh"
 #include "nix/util/callback.hh"
 #include "nix/store/store-registration.hh"
+#include "nix/util/configuration.hh"
+#include "nix/util/args.hh"
 
 namespace nix {
 
@@ -88,6 +90,15 @@ std::optional<std::string> HttpBinaryCacheStore::getCompressionMethod(const std:
         return config->logCompression;
     else
         return std::nullopt;
+}
+
+HttpVersion HttpBinaryCacheStore::getHttpVersion()
+{
+    // Check filetransfer settings for backwards compatibility
+    if (config->httpVersion == HttpVersion::None && !fileTransferSettings.enableHttp2) {
+        return HttpVersion::Http1_1;
+    }
+    return config->httpVersion;
 }
 
 void HttpBinaryCacheStore::maybeDisable()
@@ -193,7 +204,9 @@ FileTransferRequest HttpBinaryCacheStore::makeRequest(std::string_view path)
         result.query = config->cacheUri.query;
     }
 
-    return FileTransferRequest(result);
+    auto req = FileTransferRequest(result);
+    req.httpVersion = getHttpVersion();
+    return req;
 }
 
 void HttpBinaryCacheStore::getFile(const std::string & path, Sink & sink)
@@ -272,6 +285,111 @@ ref<Store> HttpBinaryCacheStore::Config::openStore() const
         ref{// FIXME we shouldn't actually need a mutable config
             std::const_pointer_cast<HttpBinaryCacheStore::Config>(shared_from_this())});
 }
+
+template<>
+HttpVersion BaseSetting<HttpVersion>::parse(const std::string & str) const
+{
+    if (str == "none")
+        return HttpVersion::None;
+    else if (str == "http1.1")
+        return HttpVersion::Http1_1;
+    else if (str == "http2")
+        return HttpVersion::Http2;
+    else if (str == "http2-prior-knowledge")
+        return HttpVersion::Http2PriorKnowledge;
+    else if (str == "http3")
+        return HttpVersion::Http3;
+    else
+        throw UsageError("option '%s' has invalid value '%s'", name, str);
+}
+
+template<>
+struct BaseSetting<HttpVersion>::trait
+{
+    static constexpr bool appendable = false;
+};
+
+template<>
+std::string BaseSetting<HttpVersion>::to_string() const
+{
+    if (value == HttpVersion::None)
+        return "none";
+    else if (value == HttpVersion::Http1_1)
+        return "http1.1";
+    else if (value == HttpVersion::Http2)
+        return "http2";
+    else if (value == HttpVersion::Http2PriorKnowledge)
+        return "http2-prior-knowledge";
+    else if (value == HttpVersion::Http3)
+        return "http3";
+    else
+        unreachable();
+}
+
+template<>
+bool BaseSetting<HttpVersion>::isAppendable()
+{
+    return trait::appendable;
+}
+
+template<>
+void BaseSetting<HttpVersion>::appendOrSet(HttpVersion newValue, bool append)
+{
+    assert(!append);
+
+    value = std::move(newValue);
+}
+
+template<>
+void BaseSetting<HttpVersion>::set(const std::string & str, bool append)
+{
+    if (experimentalFeatureSettings.isEnabled(experimentalFeature))
+        appendOrSet(parse(str), append);
+    else {
+        assert(experimentalFeature);
+        warn(
+            "Ignoring setting '%s' because experimental feature '%s' is not enabled",
+            name,
+            showExperimentalFeature(*experimentalFeature));
+    }
+}
+
+template<>
+void BaseSetting<HttpVersion>::convertToArg(Args & args, const std::string & category)
+{
+    args.addFlag({
+        .longName = name,
+        .aliases = aliases,
+        .description = fmt("Set the `%s` setting.", name),
+        .category = category,
+        .labels = {"value"},
+        .handler = {[this](std::string s) {
+            overridden = true;
+            set(s);
+        }},
+        .experimentalFeature = experimentalFeature,
+    });
+}
+
+template<>
+std::map<std::string, nlohmann::json> BaseSetting<HttpVersion>::toJSONObject() const
+{
+    auto obj = AbstractSetting::toJSONObject();
+    obj.emplace("value", value);
+    obj.emplace("defaultValue", defaultValue);
+    obj.emplace("documentDefault", documentDefault);
+    return obj;
+}
+
+NLOHMANN_JSON_SERIALIZE_ENUM(
+    HttpVersion,
+    {
+        {HttpVersion::None, "none"},
+        {HttpVersion::Http1_1, "http1.1"},
+        {HttpVersion::Http2, "http2"},
+        {HttpVersion::Http2PriorKnowledge, "http2-prior-knowledge"},
+        {HttpVersion::Http3, "http3"},
+    });
 
 static RegisterStoreImplementation<HttpBinaryCacheStore::Config> regHttpBinaryCacheStore;
 

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -83,6 +83,19 @@ extern FileTransferSettings fileTransferSettings;
 
 extern const unsigned int RETRY_TIME_MS_DEFAULT;
 
+enum struct HttpVersion {
+    None,
+    Http1_1,
+    Http2,
+    Http2PriorKnowledge,
+    Http3,
+};
+
+/**
+ * Get the libcurl HTTP Version corresponding to HttpVersion
+ */
+long curlHttpVersion(HttpVersion httpVersion);
+
 /**
  * HTTP methods supported by FileTransfer.
  */
@@ -116,6 +129,7 @@ struct FileTransferRequest
     Headers headers;
     std::string expectedETag;
     HttpMethod method = HttpMethod::Get;
+    HttpVersion httpVersion;
     size_t tries = fileTransferSettings.tries;
     unsigned int baseRetryTimeMs = RETRY_TIME_MS_DEFAULT;
     ActivityId parentAct;

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -36,6 +36,17 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
           (e.g. `brotli`).
         )"};
 
+    const Setting<HttpVersion> httpVersion{this, HttpVersion::None, "http-version", R"(
+        The HTTP version to use. This maps to the HTTP versions supported by
+        [libcurl](https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html). Accepted values are:
+        `none`, `http1.1`, `http2`, `http2-prior-knowledge`, `http3`. The default 
+        value can be globally downgraded to `http1-1` by setting [`http2 = false`](@docroot@/command-ref/conf-file.md#conf-http2).
+        
+        > **Note**
+        > 
+        > HTTPv3 has not been tested, but is included here for completion and
+        > to allow for experimentation.)"};
+
     static const std::string name()
     {
         return "HTTP Binary Cache Store";
@@ -73,6 +84,8 @@ public:
 protected:
 
     std::optional<std::string> getCompressionMethod(const std::string & path);
+
+    HttpVersion getHttpVersion();
 
     void maybeDisable();
 
@@ -113,5 +126,11 @@ protected:
 
     std::optional<TrustedFlag> isTrustedClient() override;
 };
+
+template<>
+HttpVersion BaseSetting<HttpVersion>::parse(const std::string & str) const;
+
+template<>
+std::string BaseSetting<HttpVersion>::to_string() const;
 
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I'd like to allow more flexibility in selecting the HTTP version used for a specific store.

This PR refactors the logic for selecting the [HTTP versions implemented by libcurl](https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html), which is currently controlled by the global `http2` setting. Instead we add an `http-version` setting to the HTTP binary cache store. In addition to allowing experimentation with new protocols, this allows different stores to implement different HTTP versions.

**Backwards compatibility**
When the store setting is `http-version == none` (the default), the global `http2` setting is checked:
- if `http2 == true` (default) -> use `CURL_HTTP_VERSION_NONE` -- this differs from previous behavior using `CURL_HTTP_VERSION_2TLS`, and lets curl decide the best version to use based on the scheme (http/https) and handshake.
- if `http2 == false` -> use `CURL_HTTP_VERSION_1_1` (matching previous behavior)

TLDR; users that have explicitly set `http2 == false` will experience no change. The _default_ behavior, however, is now using `CURL_HTTP_VERSION_NONE` rather than `CURL_HTTP_VERSION_TLS`.

One might also argue for the deprecation of the `http2` setting at this point, and just let folks override directly with `http-version=http1.1` if they want it.

## Context

Some brief discussion around QUIC [here](https://github.com/NixOS/nix/issues/5026#issuecomment-882504022).

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
