### PR TITLE
test: add shebangs to shell.nix test scripts

### DIFF
--- a/tests/functional/shell.nix
+++ b/tests/functional/shell.nix
@@ -106,14 +106,16 @@ let
 
     foo = runCommand "foo" { } ''
       mkdir -p $out/bin
-      echo 'echo ${fooContents}' > $out/bin/foo
+      echo '#!${shell}' > $out/bin/foo
+      echo 'echo ${fooContents}' >> $out/bin/foo
       chmod a+rx $out/bin/foo
       ln -s ${shell} $out/bin/bash
     '';
 
     bar = runCommand "bar" { } ''
       mkdir -p $out/bin
-      echo 'echo bar' > $out/bin/bar
+      echo '#!${shell}' > $out/bin/bar
+      echo 'echo bar' >> $out/bin/bar
       chmod a+rx $out/bin/bar
     '';
 
@@ -126,7 +128,8 @@ let
     # ruby "interpreter" that outputs "$@"
     ruby = runCommand "ruby" { } ''
       mkdir -p $out/bin
-      echo 'printf %s "$*"' > $out/bin/ruby
+      echo '#!${shell}' > $out/bin/ruby
+      echo 'printf %s "$*"' >> $out/bin/ruby
       chmod a+rx $out/bin/ruby
     '';
 


### PR DESCRIPTION
## Summary

Adds shebangs to the `foo`, `bar`, and `ruby` test scripts in `tests/functional/shell.nix` to fix intermittent SIGSEGV crashes on macOS.

## Motivation

Some of the test scripts used for the functional test are created without shebangs, which causes a ~50% build failure rate on macOS (particularly Apple Silicon) caused by SIGSEGVs when the scripts are executed via command substitution inside the nix sandbox.

See #12121 for my root cause analysis and a minimal reproduction script.

## Solution

Add `#!${shell}` shebangs to each test script. With this fix, builds pass consistently (10/10 vs 5/10 without the patch).

## Testing

- Verified fix with 10 consecutive builds on macOS Sequoia 15.1 (M4)
- Minimal reproduction in #13106 confirms the issue and fix

Likely fixes some of the problems people had in #13106, though not all test failures reported are caused by this.