### PR TITLE
libutil/tarfile: Mention pathname in warning

### DIFF
--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -136,7 +136,7 @@ static void extract_archive(TarArchive & archive, const std::filesystem::path & 
         if (!name)
             throw Error("cannot get archive member name: %s", archive_error_string(archive.archive));
         if (r == ARCHIVE_WARN)
-            warn(archive_error_string(archive.archive));
+            warn("getting archive member '%1%': %2%", name, archive_error_string(archive.archive));
         else
             archive.check(r);
 
@@ -193,7 +193,7 @@ time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & 
             throw Error("cannot get archive member name: %s", archive_error_string(archive.archive));
         auto cpath = CanonPath{path};
         if (r == ARCHIVE_WARN)
-            warn(archive_error_string(archive.archive));
+            warn("getting archive member '%1%': %2%", path, archive_error_string(archive.archive));
         else
             archive.check(r);
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fetching gcc-15.2.0.tar.gz I get a warning about UTF8 archive names. This now mentions problematic pathnames.

```
warning: getting archive member 'gcc-15.2.0/gcc/testsuite/go.test/test/fixedbugs/issue27836.dir/Äfoo.go': Pathname can't be converted from UTF-8 to current locale.
warning: getting archive member 'gcc-15.2.0/gcc/testsuite/go.test/test/fixedbugs/issue27836.dir/Ämain.go': Pathname can't be converted from UTF-8 to current locale.
```

Also apparently libarchive depends on locale (yikes). Fixing reproducibility issues that stem from this is a separate issue. At least having the warning actually mention the pathname should be useful enough even though it's not actionable.

At least using the default locale yields something sane:

```
builtins.readDir "${gcc}/gcc/testsuite/go.test/test/fixedbugs/issue27836.dir"
{
  "Äfoo.go" = "regular";
  "Ämain.go" = "regular";
}
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
