### PR TITLE
libexpr/print: Require decimal point on float printing.

### DIFF
--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -231,9 +231,15 @@ private:
 
     void printFloat(Value & v)
     {
+        const std::ios_base::fmtflags flags = output.flags();
+
         if (options.ansiColors)
             output << ANSI_CYAN;
+
+        output.setf(std::ios::showpoint);
         output << v.fpoint();
+        output.flags(flags);
+
         if (options.ansiColors)
             output << ANSI_NORMAL;
     }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fixes #3077 .


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Tracking down the weird behavior of current nix (per the issue), we see:

<img width="323" height="247" alt="image" src="https://github.com/user-attachments/assets/4142f81f-f3b5-4398-ad46-17597f84fa2f" />

I looked around for a while and realized this was probably happening over in the repl code, so I looked for CYAN and found `printFloat` over in `src/libexpr/print.cc`.

The original code:

```c++
    void printFloat(Value & v)
    {
        if (options.ansiColors)
            output << ANSI_CYAN;
        output << v.fpoint();
        if (options.ansiColors)
            output << ANSI_NORMAL;
    }
```

Now, iostreams by default don't show the decimal point, so we have to force it (after saving the flags):

```c++
    void printFloat(Value & v)
    {
        const std::ios_base::fmtflags flags = output.flags();

        if (options.ansiColors)
            output << ANSI_CYAN;

        output.setf(std::ios::showpoint);
        output << v.fpoint();
        output.flags(flags);

        if (options.ansiColors)
            output << ANSI_NORMAL;
    }
```

This has the desired effect, mostly:

<img width="184" height="155" alt="image" src="https://github.com/user-attachments/assets/73df3821-7f05-42ae-b315-08496974af41" />

Unfortunately, the question of "how do we get this to show the correct decimal precision?" is a bit open-ended.

The open question is:

* Should we always, for floats with no fractional parts, just do a single decimal point? E.g., `4.0000` renders as `4.0`.
* Should floats always render with default precision? E.g., `4.0` renders as `4.00000`...but so does `4.000001`.
* Should floats try to display as much as they can out to machine precision? E.g., `4.00000000000004` displays as `4.00000000000004` but some larger one eventually rounds. If it rounds to all zeros, should that be truncated as well?

There's some test problems as well, but those are less important than this core formatting question.



<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
