### PR TITLE
nix-profile.fish: $NIX_STATE_HOME: Warn about old .nix-profile

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -24,6 +24,7 @@ end
 # Set up the per-user profile.
 
 set --local NIX_LINK "$HOME/.nix-profile"
+
 set --local NIX_LINK_NEW
 if test -n "$XDG_STATE_HOME"
     set NIX_LINK_NEW "$XDG_STATE_HOME/nix/profile"

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -28,32 +28,33 @@ if test -n "$NIX_STATE_HOME"
     set NIX_LINK "$NIX_STATE_HOME/.nix-profile"
 else
     set NIX_LINK "$HOME/.nix-profile"
-    set --local NIX_LINK_NEW
-    if test -n "$XDG_STATE_HOME"
-        set NIX_LINK_NEW "$XDG_STATE_HOME/nix/profile"
-    else
-        set NIX_LINK_NEW "$HOME/.local/state/nix/profile"
-    end
-    if test -e "$NIX_LINK_NEW"
-        if test -t 2; and test -e "$NIX_LINK"
-            set --local warning "\033[1;35mwarning:\033[0m "
-            printf "$warning Both %s and legacy %s exist; using the former.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
+end
 
-            if test (realpath "$NIX_LINK") = (realpath "$NIX_LINK_NEW")
-                printf "         Since the profiles match, you can safely delete either of them.\n" 1>&2
-            else
-                # This should be an exceptionally rare occasion: the only way to get it would be to
-                # 1. Update to newer Nix;
-                # 2. Remove .nix-profile;
-                # 3. Set the $NIX_LINK_NEW to something other than the default user profile;
-                # 4. Roll back to older Nix.
-                # If someone did all that, they can probably figure out how to migrate the profile.
-                printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
-            end
+set --local NIX_LINK_NEW
+if test -n "$XDG_STATE_HOME"
+    set NIX_LINK_NEW "$XDG_STATE_HOME/nix/profile"
+else
+    set NIX_LINK_NEW "$HOME/.local/state/nix/profile"
+end
+if test -e "$NIX_LINK_NEW"
+    if test -t 2; and test -e "$NIX_LINK"
+        set --local warning "\033[1;35mwarning:\033[0m "
+        printf "$warning Both %s and legacy %s exist; using the former.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
+
+        if test (realpath "$NIX_LINK") = (realpath "$NIX_LINK_NEW")
+            printf "         Since the profiles match, you can safely delete either of them.\n" 1>&2
+        else
+            # This should be an exceptionally rare occasion: the only way to get it would be to
+            # 1. Update to newer Nix;
+            # 2. Remove .nix-profile;
+            # 3. Set the $NIX_LINK_NEW to something other than the default user profile;
+            # 4. Roll back to older Nix.
+            # If someone did all that, they can probably figure out how to migrate the profile.
+            printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
         end
-
-        set NIX_LINK "$NIX_LINK_NEW"
     end
+
+    set NIX_LINK "$NIX_LINK_NEW"
 end
 
 # Set up environment.


### PR DESCRIPTION
## Motivation

It seems reasonable to check if both `.nix-profile` and `.local/state/nix/profile` are present when `$NIX_STATE_HOME` is set.

Even more so, `$XDG_STATE_HOME` is used in the `$NIX_LINK_NEW` logic, that was effectively disabled in `nix-profile.fish`.

Note that `.local/state/nix/profile` is actually an incorrect path, it will be fixed in a subsequent commit.

## Context

This is a follow-up for changes in https://github.com/NixOS/nix/pull/13245.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
