### PR TITLE
doc: Switch installation examples to use temporary file

### DIFF
--- a/doc/manual/source/installation/env-variables.md
+++ b/doc/manual/source/installation/env-variables.md
@@ -27,7 +27,12 @@ Set the environment variable and install Nix
 
 ```console
 $ export NIX_SSL_CERT_FILE=/etc/ssl/my-certificate-bundle.crt
-$ curl -L https://nixos.org/nix/install | sh
+
+# For multi-user install
+$ bash <(curl -L https://nixos.org/nix/install) --daemon
+
+# For single-user install
+$ bash <(curl -L https://nixos.org/nix/install) --no-daemon
 ```
 
 In the shell profile and rc files (for example, `/etc/bashrc`,

--- a/doc/manual/source/installation/index.md
+++ b/doc/manual/source/installation/index.md
@@ -23,7 +23,7 @@ This option requires either:
 > when running Nix commands, refer to GitHub issue [NixOS/nix#10892](https://github.com/NixOS/nix/issues/10892) for instructions to fix your installation without reinstalling.
 
 ```console
-$ curl -L https://nixos.org/nix/install | sh -s -- --daemon
+$ bash <(curl -L https://nixos.org/nix/install) --daemon
 ```
 
 ## Single-user
@@ -38,7 +38,7 @@ cannot offer equivalent sharing, isolation, or security.
 This option is suitable for systems without systemd.
 
 ```console
-$ curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
+$ bash <(curl -L https://nixos.org/nix/install) --no-daemon
 ```
 
 ## Distributions

--- a/doc/manual/source/installation/installing-binary.md
+++ b/doc/manual/source/installation/installing-binary.md
@@ -43,7 +43,7 @@ All installation scripts are invoked the same way:
 
 ```console
 $ export VERSION=2.19.2 
-$ curl -L https://releases.nixos.org/nix/nix-$VERSION/install | sh
+$ bash <(curl -L https://releases.nixos.org/nix/nix-$VERSION/install)
 ```
 
 # Multi User Installation

--- a/doc/manual/source/quick-start.md
+++ b/doc/manual/source/quick-start.md
@@ -6,7 +6,11 @@ For more in-depth information you are kindly referred to subsequent chapters.
 1. Install Nix:
 
    ```console
-   $ curl -L https://nixos.org/nix/install | sh
+   # For multi-user install
+   $ bash <(curl -L https://nixos.org/nix/install) --daemon
+
+   # For single-user install
+   $ bash <(curl -L https://nixos.org/nix/install) --no-daemon
    ```
 
    The install script will use `sudo`, so make sure you have sufficient rights.


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The installation script checks if the stdin is a terminal, and if it is not, it switches to a non-interactive mode.
Considering these examples expect an interactive installation, it is better to use the same code as in `doc/manual/source/installation/installing-binary.md`, where the installation script is downloaded into a temporary file.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).