### PR TITLE
libfetchers: Bump tarball-cache version to v2 [backport 2.33]

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1427,7 +1427,11 @@ namespace fetchers {
 
 ref<GitRepo> Settings::getTarballCache() const
 {
-    static auto repoDir = std::filesystem::path(getCacheDir()) / "tarball-cache";
+    /* v1: Had either only loose objects or thin packfiles referring to loose objects
+     * v2: Must have only packfiles with no loose objects. Should get repacked periodically
+     * for optimal packfiles.
+     */
+    static auto repoDir = std::filesystem::path(getCacheDir()) / "tarball-cache-v2";
     return GitRepo::openRepo(repoDir, /*create=*/true, /*bare=*/true, /*packfilesOnly=*/true);
 }
 


### PR DESCRIPTION
Backport of #14799 to 2.33-maintenance.

Resolved conflict by keeping the positional argument style used in 2.33 while applying the tarball-cache-v2 change.

---

**Original PR description:**

Unfortunately previous tarball caches had loose objects written to them and subsequent switch to thin packfiles. This results in possibly broken thin packfiles when the loose objects backend is disabled. Thin packfiles do not necessarily contain the whole closure of objects. When packfilesOnly is true we end up with an inconsistent state where a tree lives in a packfiles which refers to a blob in the loose objects backend.

Fixes https://github.com/NixOS/nix/issues/14796.