### PR TITLE
`LocalBinaryCacheStore::upsertFile` support slash in path

### DIFF
--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -56,9 +56,11 @@ protected:
     void upsertFile(
         const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override
     {
-        auto path2 = config->binaryCacheDir + "/" + path;
+        auto path2 = std::filesystem::path{config->binaryCacheDir} / path;
         static std::atomic<int> counter{0};
-        Path tmp = fmt("%s.tmp.%d.%d", path2, getpid(), ++counter);
+        createDirs(path2.parent_path());
+        auto tmp = path2;
+        tmp += fmt(".tmp.%d.%d", getpid(), ++counter);
         AutoDelete del(tmp, false);
         writeFile(tmp, source);
         std::filesystem::rename(tmp, path2);


### PR DESCRIPTION
## Context

While working on #12464, I realized this method was not correct in this case. With the current binary cache format, it is harmless, since we don't create arbitrary directories, but with my change, we started to.

## Motivation

Regardless of whether we need it or not, I think it is better if the function just does the right thing.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
