### PR TITLE
doc: drop rsync dependency from manual build

### DIFF
--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -26,7 +26,6 @@ bash = find_program('bash', native : true)
 # HTML manual dependencies (conditional)
 if get_option('html-manual')
   mdbook = find_program('mdbook', native : true)
-  rsync = find_program('rsync', required : true, native : true)
 endif
 
 pymod = import('python')
@@ -126,7 +125,12 @@ if get_option('html-manual')
           @0@ @INPUT0@ @CURRENT_SOURCE_DIR@ > @DEPFILE@
           @0@ @INPUT1@ summary @2@ < @CURRENT_SOURCE_DIR@/source/SUMMARY.md.in > @2@/source/SUMMARY.md
           sed -e 's|@version@|@3@|g' < @INPUT2@ > @2@/book.toml
-          @4@ -r -L --exclude='*.drv' --include='*.md' @CURRENT_SOURCE_DIR@/ @2@/
+          # Copy source to build directory, excluding the build directory itself
+          # (which is present when built as an individual component).
+          # Use tar with --dereference to copy symlink targets (e.g., JSON examples from tests).
+          (cd @CURRENT_SOURCE_DIR@ && find . -mindepth 1 -maxdepth 1 ! -name build | tar -c --dereference -T - -f -) | (cd @2@ && tar -xf -)
+          chmod -R u+w @2@
+          find @2@ -name '*.drv' -delete
           (cd @2@; RUST_LOG=warn @1@ build -d @2@ 3>&2 2>&1 1>&3) | { grep -Fv "because fragment resolution isn't implemented" || :; } 3>&2 2>&1 1>&3
           rm -rf @2@/manual
           mv @2@/html @2@/manual
@@ -138,7 +142,6 @@ if get_option('html-manual')
         mdbook.full_path(),
         meson.current_build_dir(),
         meson.project_version(),
-        rsync.full_path(),
       ),
     ],
     input : [

--- a/doc/manual/package.nix
+++ b/doc/manual/package.nix
@@ -10,7 +10,6 @@
   mdbook,
   jq,
   python3,
-  rsync,
   nix-cli,
   changelog-d,
   json-schema-for-humans,
@@ -54,6 +53,8 @@ mkMesonDerivation (finalAttrs: {
         ../../src/libstore-tests/data/nar-info
         ../../src/libstore-tests/data/build-result
         ../../src/libstore-tests/data/dummy-store
+        # For derivation examples referenced by symlinks in doc/manual/source/protocols/json/schema/
+        ../../tests/functional/derivation
         # Too many different types of files to filter for now
         ../../doc/manual
         ./.
@@ -90,7 +91,6 @@ mkMesonDerivation (finalAttrs: {
   ]
   ++ lib.optionals buildHtmlManual [
     mdbook
-    rsync
     json-schema-for-humans
   ]
   ++ lib.optionals (!officialRelease && buildHtmlManual) [


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

- Fixes #14776

<!-- Briefly explain what the change is about and why it is desirable. -->


## Context

rsync was only used to copy source files while following symlinks. Replace with tar --dereference, which serves the same purpose. Tried plain cp but couldn't get it to work reliably. tar is already a test dependency.

Add tests/functional/derivation to fileset to include the symlink targets.

Output compares equal

- Fixes #14776

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
