### PR TITLE
libstore: reduce allocations in StoreDirConfig::printStorePath

### DIFF
--- a/src/libstore/store-dir-config.cc
+++ b/src/libstore/store-dir-config.cc
@@ -49,7 +49,13 @@ StorePathSet StoreDirConfig::parseStorePathSet(const PathSet & paths) const
 
 std::string StoreDirConfig::printStorePath(const StorePath & path) const
 {
-    return (storeDir + "/").append(path.to_string());
+    std::string res;
+    auto baseName = path.to_string();
+    res.reserve(storeDir.size() + 1 + baseName.size());
+    res.append(storeDir);
+    res.push_back('/');
+    res.append(baseName);
+    return res;
 }
 
 PathSet StoreDirConfig::printStorePathSet(const StorePathSet & paths) const


### PR DESCRIPTION
StoreDirConfig::printStorePath() previously built an intermediate string via storeDir + "/" and then appended the store-path basename, which can trigger an extra allocation/copy.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
