### PR TITLE
docs: document older let expression syntax

### DIFF
--- a/doc/manual/source/language/syntax.md
+++ b/doc/manual/source/language/syntax.md
@@ -285,6 +285,27 @@ in x + y
 
 This evaluates to `"foobar"`.
 
+There is also another, older, syntax for let expressions that should not be used in new code:
+
+> *let* = `let` `{` *identifier* = *expr* `;` [ *identifier* = *expr* `;`]...  `}`
+
+In this form, the attribute set between the `{` `}` is recursive.
+
+One of the attributes must have the special name `body`,
+which is the result of the expression.
+
+Example:
+
+```nix
+let {
+  foo = bar;
+  bar = "baz";
+  body = foo;
+}
+```
+
+This evaluates to "baz".
+
 ## Inheriting attributes
 
 When defining an [attribute set](./types.md#type-attrs) or in a [let-expression](#let-expressions) it is often convenient to copy variables from the surrounding lexical scope (e.g., when you want to propagate attributes).


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Even though it's older, it's still part of the language, and I think it should be documented accordingly.

## Context

I learned of this from reading Eelco Dolstra's PhD thesis (pp. 69, 73-74).  I chose a slightly different example in order to display that attributes other than `body` can refer to other attributes recursively too.

## Unresolved issues
- [ ] Is this syntax deprecated? If so, I should mark it as such.
- [ ] If it's not deprecated, should it be?
- [ ] Should the documentation note how this syntax is equivalent to  `rec { body = ...; [ ident = expr; ]... }.body`?
---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
