### PR TITLE
clarify(manual): warn about __structuredAttrs not exporting env-vars anymore

### DIFF
--- a/doc/manual/source/language/advanced-attributes.md
+++ b/doc/manual/source/language/advanced-attributes.md
@@ -67,6 +67,14 @@ Derivations can declare some infrequently used optional attributes.
     [`disallowedReferences`](#adv-attr-disallowedReferences) and [`disallowedRequisites`](#adv-attr-disallowedRequisites), maxSize, and maxClosureSize.
     will have no effect.
 
+    > **Warning**
+    >
+    > Attributes of the derivation whose type is `string`, `int`, `float`, or `null`
+    > remain declared as environment variables when sourcing `$NIX_ATTRS_SH_FILE`
+    > but are no longer exported.
+    > When using `stdenv.mkDerivation` from Nixpkgs,
+    > you can move them into the `env` attrset to keep exporting them.
+
 ## Output checks
 
 See the [corresponding section in the derivation output page](@docroot@/store/derivation/outputs/index.md).


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->
Document that setting `__structuredAttrs=true` still `declare`s simple attributes as env-vars but no longer exports them.
And provide guidance to use `env` if needed.

## Context

<!-- Provide context. Reference open issues if available. -->
Fixes https://github.com/NixOS/nix/issues/14847

## CheckList
- [X] `nix build .#nix-manual` succeeds.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
