### PR TITLE
Fix entry for 'directed acyclic graph' in glossary

### DIFF
--- a/doc/manual/source/glossary.md
+++ b/doc/manual/source/glossary.md
@@ -58,6 +58,8 @@
   DAGs are very important to Nix.
   In particular, the non-self-[references][reference] of [store object][store object] form a cycle.
 
+  [directed acyclic graph]: #gloss-directed-acyclic-graph
+
 - [derivation path]{#gloss-derivation-path}
 
   A [store path] which uniquely identifies a [store derivation].


### PR DESCRIPTION
Added the missing line to the glossary entry for 'directed acyclic graph'.

## Motivation

The link to the glossary is broken [here](https://nix.dev/manual/nix/2.28/store/store-object) and maybe somewhere else.

## Context

This is a fix for the issue #14853

I added a line that I saw for other entries that is missing in this case.

I don't know much about the system used to create the manual so that may not be it.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
