### PR TITLE
libutil: Make MemorySourceAccessor throw more precise errors

### DIFF
--- a/src/libutil-tests/memory-source-accessor.cc
+++ b/src/libutil-tests/memory-source-accessor.cc
@@ -1,7 +1,11 @@
-#include <string_view>
-
 #include "nix/util/memory-source-accessor.hh"
 #include "nix/util/tests/json-characterization.hh"
+#include "nix/util/tests/gmock-matchers.hh"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string_view>
 
 namespace nix {
 
@@ -58,6 +62,163 @@ ref<MemorySourceAccessor> exampleComplex()
 }
 
 } // namespace memory_source_accessor
+
+/* ----------------------------------------------------------------------------
+ * MemorySourceAccessor
+ * --------------------------------------------------------------------------*/
+
+using ::nix::testing::HasSubstrIgnoreANSIMatcher;
+
+class MemorySourceAccessorTestErrors : public ::testing::Test
+{
+protected:
+    ref<MemorySourceAccessor> accessor = make_ref<MemorySourceAccessor>();
+    MemorySink sink{*accessor};
+
+    void SetUp() override
+    {
+        accessor->setPathDisplay("somepath");
+        sink.createDirectory(CanonPath::root);
+    }
+};
+
+TEST_F(MemorySourceAccessorTestErrors, readFileNotFound)
+{
+    EXPECT_THAT(
+        [&] { accessor->readFile(CanonPath("nonexistent")); },
+        ThrowsMessage<FileNotFound>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/nonexistent"), HasSubstrIgnoreANSIMatcher("does not exist"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, readFileNotARegularFile)
+{
+    sink.createDirectory(CanonPath("subdir"));
+
+    EXPECT_THAT(
+        [&] { accessor->readFile(CanonPath("subdir")); },
+        ThrowsMessage<NotARegularFile>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/subdir"), HasSubstrIgnoreANSIMatcher("is not a regular file"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, readDirectoryNotFound)
+{
+    EXPECT_THAT(
+        [&] { accessor->readDirectory(CanonPath("nonexistent")); },
+        ThrowsMessage<FileNotFound>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/nonexistent"), HasSubstrIgnoreANSIMatcher("does not exist"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, readDirectoryNotADirectory)
+{
+    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+
+    EXPECT_THAT(
+        [&] { accessor->readDirectory(CanonPath("file")); },
+        ThrowsMessage<NotADirectory>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/file"), HasSubstrIgnoreANSIMatcher("is not a directory"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, readLinkNotFound)
+{
+    EXPECT_THAT(
+        [&] { accessor->readLink(CanonPath("nonexistent")); },
+        ThrowsMessage<FileNotFound>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/nonexistent"), HasSubstrIgnoreANSIMatcher("does not exist"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, readLinkNotASymlink)
+{
+    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+
+    EXPECT_THAT(
+        [&] { accessor->readLink(CanonPath("file")); },
+        ThrowsMessage<NotASymlink>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/file"), HasSubstrIgnoreANSIMatcher("is not a symbolic link"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, addFileParentNotDirectory)
+{
+    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+
+    EXPECT_THAT(
+        [&] { accessor->addFile(CanonPath("file/child"), "contents"); },
+        ThrowsMessage<Error>(AllOf(
+            HasSubstrIgnoreANSIMatcher("somepath/file/child"),
+            HasSubstrIgnoreANSIMatcher("cannot be created because some parent file is not a directory"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, addFileNotARegularFile)
+{
+    sink.createDirectory(CanonPath("subdir"));
+
+    EXPECT_THAT(
+        [&] { accessor->addFile(CanonPath("subdir"), "contents"); },
+        ThrowsMessage<NotARegularFile>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/subdir"), HasSubstrIgnoreANSIMatcher("is not a regular file"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, createDirectoryParentNotDirectory)
+{
+    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+
+    EXPECT_THAT(
+        [&] { sink.createDirectory(CanonPath("file/child")); },
+        ThrowsMessage<Error>(AllOf(
+            HasSubstrIgnoreANSIMatcher("somepath/file/child"),
+            HasSubstrIgnoreANSIMatcher("cannot be created because some parent file is not a directory"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, createDirectoryNotADirectory)
+{
+    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+
+    EXPECT_THAT(
+        [&] { sink.createDirectory(CanonPath("file")); },
+        ThrowsMessage<NotADirectory>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/file"), HasSubstrIgnoreANSIMatcher("is not a directory"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, createRegularFileParentNotDirectory)
+{
+    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+
+    EXPECT_THAT(
+        [&] { sink.createRegularFile(CanonPath("file/child"), [](CreateRegularFileSink &) {}); },
+        ThrowsMessage<Error>(AllOf(
+            HasSubstrIgnoreANSIMatcher("file/child"),
+            HasSubstrIgnoreANSIMatcher("cannot be created because some parent file is not a directory"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, createRegularFileNotARegularFile)
+{
+    sink.createDirectory(CanonPath("subdir"));
+
+    EXPECT_THAT(
+        [&] { sink.createRegularFile(CanonPath("subdir"), [](CreateRegularFileSink &) {}); },
+        ThrowsMessage<NotARegularFile>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/subdir"), HasSubstrIgnoreANSIMatcher("is not a regular file"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, createSymlinkParentNotDirectory)
+{
+    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+
+    EXPECT_THAT(
+        [&] { sink.createSymlink(CanonPath("file/child"), "target"); },
+        ThrowsMessage<Error>(AllOf(
+            HasSubstrIgnoreANSIMatcher("somepath/file/child"),
+            HasSubstrIgnoreANSIMatcher("cannot be created because some parent file is not a directory"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, createSymlinkNotASymlink)
+{
+    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+
+    EXPECT_THAT(
+        [&] { sink.createSymlink(CanonPath("file"), "target"); },
+        ThrowsMessage<NotASymlink>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/file"), HasSubstrIgnoreANSIMatcher("is not a symbolic link"))));
+}
 
 /* ----------------------------------------------------------------------------
  * JSON

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -30,7 +30,11 @@ enum class SymlinkResolution {
     Full,
 };
 
-MakeError(FileNotFound, Error);
+MakeError(SourceAccessorError, Error);
+MakeError(FileNotFound, SourceAccessorError);
+MakeError(NotASymlink, SourceAccessorError);
+MakeError(NotADirectory, SourceAccessorError);
+MakeError(NotARegularFile, SourceAccessorError);
 
 /**
  * A read-only filesystem abstraction. This is used by the Nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Makes the error messages render paths correctly, also introduces a new hierarchy of error classes for SourceAccessor related errors that we might want to handle differently (e.g. like when doing a readFile on a directory and such). This should make it easier to implement better UnionSourceAccessor and AllowListSourceAccessor by catching these errors consistently.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
