### PR TITLE
libutil: relax git URL parsing to accept paths without a user component

### DIFF
--- a/doc/manual/rl-next/git-url-scp.md
+++ b/doc/manual/rl-next/git-url-scp.md
@@ -1,0 +1,30 @@
+---
+synopsis: Support SCP-like URLs in fetchGit and type = "git" flake inputs
+prs: [14863]
+issues: [14852, 14867]
+---
+
+Nix now (once again) recognizes [SCP-like syntax for Git URLs](https://git-scm.com/docs/git-clone#_git_urls). This partially
+restores compatibility with Nix 2.3 for `fetchGit`. The following syntax is once again supported:
+
+```nix
+builtins.fetchGit "host:/absolute/path/to/repo"
+```
+
+Nix also passes through the tilde (for home directories) verbatim:
+
+```nix
+builtins.fetchGit "host:~/relative/to/home"
+```
+
+IPv6 addresses also supported when bracketed:
+
+```nix
+builtins.fetchGit "user@[::1]:~/relative/to/home"
+```
+
+`builtins.fetchTree` also supports this syntax now:
+
+```nix
+builtins.fetchTree { type = "git"; url = "host:/path/to/repo"; }
+```

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -600,7 +600,12 @@ static RegisterPrimOp primop_fetchGit({
 
       - `url`
 
-        The URL of the repo.
+        The [Git URL] of the repo. SCP-like syntax is supported, but relative
+        paths are rewritten to absolute ones. For example:
+
+        `git@github.com:repo/path` becomes `ssh://git@github.com/repo/path`
+
+        [Git URL]: https://git-scm.com/docs/git-clone#_git_urls
 
       - `name` (default: `source`)
 

--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -63,6 +63,50 @@ INSTANTIATE_TEST_SUITE_P(
                     .path = {"", "owner", "repo.git"},
                 },
         },
+        // SCP-like URL, no user (rewritten to ssh://)
+        FixGitURLParam{
+            .input = "github.com:owner/repo.git",
+            .expected = "ssh://github.com/owner/repo.git",
+            .parsed =
+                ParsedURL{
+                    .scheme = "ssh",
+                    .authority =
+                        ParsedURL::Authority{
+                            .host = "github.com",
+                        },
+                    .path = {"", "owner", "repo.git"},
+                },
+        },
+        // SCP-like URL, no user, absolute path (rewritten to ssh://)
+        FixGitURLParam{
+            .input = "github.com:/owner/repo.git",
+            .expected = "ssh://github.com/owner/repo.git",
+            .parsed =
+                ParsedURL{
+                    .scheme = "ssh",
+                    .authority =
+                        ParsedURL::Authority{
+                            .host = "github.com",
+                        },
+                    .path = {"", "owner", "repo.git"},
+                },
+        },
+        // SCP-like URL (rewritten to ssh://)
+        FixGitURLParam{
+            .input = "user@server.com:/path/to/repo",
+            .expected = "ssh://user@server.com/path/to/repo",
+            .parsed =
+                ParsedURL{
+                    .scheme = "ssh",
+                    .authority =
+                        ParsedURL::Authority{
+                            .host = "server.com",
+                            .user = "user",
+                        },
+                    .path = {"", "path", "to", "repo"},
+                },
+        },
+#ifndef _WIN32
         // Absolute path (becomes file:)
         FixGitURLParam{
             .input = "/home/me/repo",
@@ -74,9 +118,20 @@ INSTANTIATE_TEST_SUITE_P(
                     .path = {"", "home", "me", "repo"},
                 },
         },
+#else
+        // Absolute path (becomes file:) (Windows)
+        FixGitURLParam{
+            .input = "C:\\home\\me\\repo",
+            .expected = "file:///C:/home/me/repo",
+            .parsed =
+                ParsedURL{
+                    .scheme = "file",
+                    .authority = ParsedURL::Authority{},
+                    .path = {"", "C:", "home", "me", "repo"},
+                },
+        },
+#endif
         // Already file: scheme
-        // NOTE: Git/SCP treat this as a `<hostname>:<path>`, so we are
-        // failing to "fix up" this case.
         FixGitURLParam{
             .input = "file:/var/repos/x",
             .expected = "file:/var/repos/x",
@@ -87,10 +142,68 @@ INSTANTIATE_TEST_SUITE_P(
                     .path = {"", "var", "repos", "x"},
                 },
         },
+        // git+file scheme
+        FixGitURLParam{
+            .input = "git+file:///var/repos/x",
+            .expected = "file:///var/repos/x",
+            .parsed =
+                ParsedURL{
+                    .scheme = "file",
+                    .authority = ParsedURL::Authority{},
+                    .path = {"", "var", "repos", "x"},
+                },
+        },
+#ifndef _WIN32
+        // absolute path with a space
+        FixGitURLParam{
+            .input = "/repos/git repo",
+            .expected = "file:///repos/git%20repo",
+            .parsed =
+                ParsedURL{
+                    .scheme = "file",
+                    .authority = ParsedURL::Authority{},
+                    .path = {"", "repos", "git repo"},
+                },
+        },
+        // quoted path
+        FixGitURLParam{
+            .input = "/repos/\"git repo\"",
+            .expected = "file:///repos/%22git%20repo%22",
+            .parsed =
+                ParsedURL{
+                    .scheme = "file",
+                    .authority = ParsedURL::Authority{},
+                    .path = {"", "repos", "\"git repo\""},
+                },
+        },
+#else
+        // absolute path with a space (Windows)
+        FixGitURLParam{
+            .input = "C:\\repos\\git repo",
+            .expected = "file:///C:/repos/git%20repo",
+            .parsed =
+                ParsedURL{
+                    .scheme = "file",
+                    .authority = ParsedURL::Authority{},
+                    .path = {"", "C:", "repos", "git repo"},
+                },
+        },
+        // quoted path (Windows)
+        FixGitURLParam{
+            .input = "C:\\repos\\\"git repo\"",
+            .expected = "file:///C:/repos/%22git%20repo%22",
+            .parsed =
+                ParsedURL{
+                    .scheme = "file",
+                    .authority = ParsedURL::Authority{},
+                    .path = {"", "C:", "repos", "\"git repo\""},
+                },
+        },
+#endif
         // IPV6 test case
         FixGitURLParam{
             .input = "user@[2001:db8:1::2]:/home/file",
-            .expected = "ssh://user@[2001:db8:1::2]//home/file",
+            .expected = "ssh://user@[2001:db8:1::2]/home/file",
             .parsed =
                 ParsedURL{
                     .scheme = "ssh",
@@ -100,7 +213,139 @@ INSTANTIATE_TEST_SUITE_P(
                             .host = "2001:db8:1::2",
                             .user = "user",
                         },
-                    .path = {"", "", "home", "file"},
+                    .path = {"", "home", "file"},
+                },
+        },
+        // https://github.com/NixOS/nix/issues/14867
+        // Verify input doesn't trigger an assert.
+        // Intent is git@github, but gets parsed as git scheme with a relative path
+        FixGitURLParam{
+            .input = "git:github.com:nixos/nixpkgs",
+            .expected = "git:github.com:nixos/nixpkgs",
+            .parsed =
+                ParsedURL{
+                    .scheme = "git",
+                    .authority = std::nullopt,
+                    .path = {"github.com:nixos", "nixpkgs"},
+                },
+        },
+        // https://github.com/NixOS/nix/issues/14867#issuecomment-3699499232
+        // Verify input doesn't trigger an assert.
+        // The authority should have a "//" prefix, but instead gets parsed as a path component
+        FixGitURLParam{
+            .input = "git+https:/codeberg.org/forgejo/forgejo",
+            .expected = "https:/codeberg.org/forgejo/forgejo",
+            .parsed =
+                ParsedURL{
+                    .scheme = "https",
+                    .authority = std::nullopt,
+                    .path = {"", "codeberg.org", "forgejo", "forgejo"},
+                },
+        },
+        FixGitURLParam{
+            .input = "user%20@[::1]:repo/path",
+            .expected = "ssh://user%2520@[::1]/repo/path",
+            .parsed =
+                ParsedURL{
+                    .scheme = "ssh",
+                    .authority =
+                        ParsedURL::Authority{
+                            .hostType = ParsedURL::Authority::HostType::IPv6,
+                            .host = "::1",
+                            .user = "user%20",
+                        },
+                    .path = {"", "repo", "path"},
+                },
+        },
+        // IPv6 SCP-like. Looks like a port but is actually a path.
+        FixGitURLParam{
+            .input = "[2a02:8071:8192:c100:311d:192d:81ac:11ea]:12345",
+            .expected = "ssh://[2a02:8071:8192:c100:311d:192d:81ac:11ea]/12345",
+            .parsed =
+                ParsedURL{
+                    .scheme = "ssh",
+                    .authority =
+                        ParsedURL::Authority{
+                            .hostType = ParsedURL::Authority::HostType::IPv6,
+                            .host = "2a02:8071:8192:c100:311d:192d:81ac:11ea",
+                            .user = std::nullopt,
+                        },
+                    .path = {"", "12345"},
+                },
+        },
+#ifndef _WIN32
+        // Treats percent as a literal and not pct-encoding.
+        FixGitURLParam{
+            .input = "/a/b/%20",
+            .expected = "file:///a/b/%2520",
+            .parsed =
+                ParsedURL{
+                    .scheme = "file",
+                    .authority = ParsedURL::Authority{},
+                    .path = {"", "a", "b", "%20"},
+                },
+        },
+#else
+        // Treats percent as a literal and not pct-encoding (Windows).
+        FixGitURLParam{
+            .input = "C:\\a\\b\\%20",
+            .expected = "file:///C:/a/b/%2520",
+            .parsed =
+                ParsedURL{
+                    .scheme = "file",
+                    .authority = ParsedURL::Authority{},
+                    .path = {"", "C:", "a", "b", "%20"},
+                },
+        },
+#endif
+        // Brackets in hostname (not IPv6). SSH's valid_hostname() accepts
+        // brackets, so these are legal SSH aliases, even if they are not legal
+        // DNS domains.
+        FixGitURLParam{
+            .input = "host[1]:repo",
+            .expected = "ssh://host%5B1%5D/repo",
+            .parsed =
+                ParsedURL{
+                    .scheme = "ssh",
+                    .authority =
+                        ParsedURL::Authority{
+                            .host = "host[1]",
+                        },
+                    .path = {"", "repo"},
+                },
+        },
+        // Leading `[` with `@[` later: git prefers `@[` (see host_end()
+        // in connect.c), so `[user]` is the username and `[::1]` is IPv6.
+        FixGitURLParam{
+            .input = "[user]@[::1]:path",
+            .expected = "ssh://%5Buser%5D@[::1]/path",
+            .parsed =
+                ParsedURL{
+                    .scheme = "ssh",
+                    .authority =
+                        ParsedURL::Authority{
+                            .hostType = HostType::IPv6,
+                            .host = "::1",
+                            .user = "[user]",
+                        },
+                    .path = {"", "path"},
+                },
+        },
+        // Colon in the path part, not the host. Git splits at the first
+        // `:`, so `notuser` is the host and the rest is path.
+        // $ GIT_TRACE=1 git ls-remote 'notuser:notpass@notjusthost:restofpath'
+        // → ssh notuser 'git-upload-pack notpass@notjusthost:restofpath'
+        FixGitURLParam{
+            .input = "notuser:notpass@notjusthost:restofpath",
+            .expected = "ssh://notuser/notpass@notjusthost:restofpath",
+            .parsed =
+                ParsedURL{
+                    .scheme = "ssh",
+                    .authority =
+                        ParsedURL::Authority{
+                            .host = "notuser",
+                        },
+                    .path = {"", "notpass@notjusthost:restofpath"},
                 },
         }));
 
@@ -112,16 +357,16 @@ TEST_P(FixGitURLTestSuite, parsesVariedGitUrls)
     EXPECT_EQ(actual.to_string(), p.expected);
 }
 
-TEST(FixGitURLTestSuite, rejectScpLikeNoUser)
+// This is an idempotence-like condition: every SCP URL has a corresponding bona fide URL that will parse correctly.
+TEST_P(FixGitURLTestSuite, parsedNormalized)
 {
-    // SCP-like URL without user. Proper support can be implemented, but this is
-    // a deceptively deep feature - study existing implementations carefully.
-    EXPECT_THAT(
-        []() { fixGitURL("github.com:owner/repo.git"); },
-        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("SCP-like URL")));
+    auto & p = GetParam();
+    const auto actual = fixGitURL(p.expected);
+    EXPECT_EQ(actual, p.parsed);
+    EXPECT_EQ(actual.to_string(), p.expected);
 }
 
-TEST(FixGitURLTestSuite, properlyRejectFileURLWithAuthority)
+TEST(FixGitURLTestSuite, rejectFileURLWithAuthority)
 {
     /* From the underlying `parseURL` validations. */
     EXPECT_THAT(
@@ -130,24 +375,120 @@ TEST(FixGitURLTestSuite, properlyRejectFileURLWithAuthority)
             testing::HasSubstrIgnoreANSIMatcher("file:// URL 'file://var/repos/x' has unexpected authority 'var'")));
 }
 
-TEST(FixGitURLTestSuite, rejectScpLikeNoUserLeadingSlash)
+TEST(FixGitURLTestSuite, rejectRelativePath)
 {
+    /* From the underlying `parseURL` validations. */
     EXPECT_THAT(
-        []() { fixGitURL("github.com:/owner/repo.git"); },
-        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("SCP-like URL")));
+        []() { fixGitURL("relative/repo"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("doesn't have a scheme")));
 }
 
-TEST(FixGitURLTestSuite, relativePath)
+TEST(FixGitURLTestSuite, rejectEmptyPathGitScp)
 {
-    // Relative path - parsed as file path without authority
-    auto parsed = fixGitURL("relative/repo");
-    EXPECT_EQ(
-        parsed,
-        (ParsedURL{
-            .scheme = "file",
-            .path = {"relative", "repo"},
-        }));
-    EXPECT_EQ(parsed.to_string(), "file:relative/repo");
+    /* Reject SCP-style URLs with no path component. */
+    EXPECT_THAT(
+        []() { fixGitURL("host:"); },
+        ::testing::ThrowsMessage<BadURL>(
+            testing::HasSubstrIgnoreANSIMatcher("SCP-style Git URL 'host:' has an empty path")));
+}
+
+TEST(FixGitURLTestSuite, rejectMalformedBracketedURLs)
+{
+    /* Brackets not in host position go through the colon-based path,
+       consistent with git (which also finds the first colon). These
+       are garbage parses, but SSH's `valid_hostname()` accepts brackets
+       so they can't be rejected outright. */
+
+    /* First colon is inside brackets → schemeOrHost = "user[2001". */
+    auto parsed1 = fixGitURL("user[2001:db8:1::2]:/home/@file");
+    EXPECT_EQ(parsed1.scheme, "ssh");
+    EXPECT_EQ(parsed1.authority->host, "user[2001");
+
+    /* First colon is before brackets → schemeOrHost = "user". */
+    auto parsed2 = fixGitURL("user:[2001:db8:1::2]:/home/@file");
+    EXPECT_EQ(parsed2.scheme, "ssh");
+    EXPECT_EQ(parsed2.authority->host, "user");
+
+    /* `user:@[...]` has `@[` so enters the IPv6 bracket path.
+       The bracket regex matches on `[2001:db8:1::2]:/home/file`,
+       and everything before `@[` becomes the username (`user:`). */
+    auto parsed3 = fixGitURL("user:@[2001:db8:1::2]:/home/file");
+    EXPECT_EQ(parsed3.scheme, "ssh");
+    EXPECT_EQ(parsed3.authority->host, "2001:db8:1::2");
+    EXPECT_EQ(parsed3.authority->user, "user:");
+}
+
+TEST(FixGitURLTestSuite, mismatchedBrackets)
+{
+    /* Missing `]`: git's `host_end()` falls back to `end = host` and
+       finds the first `:` as separator. We do the same — fall through
+       to the colon-based path.
+       $ GIT_TRACE=1 git ls-remote 'user@[host:path'
+       → ssh 'user@[host' 'git-upload-pack path' */
+    auto parsed1 = fixGitURL("user@[host:path");
+    EXPECT_EQ(parsed1.scheme, "ssh");
+    EXPECT_EQ(parsed1.authority->user, "user");
+    EXPECT_EQ(parsed1.authority->host, "[host");
+
+    /* Leading `[` with no `]`: same fallback to colon-based path.
+       $ GIT_TRACE=1 git ls-remote '[:path'
+       → ssh '[' 'git-upload-pack path' */
+    auto parsed2 = fixGitURL("[:path");
+    EXPECT_EQ(parsed2.scheme, "ssh");
+    EXPECT_EQ(parsed2.authority->host, "[");
+
+    /* `]` present but not followed by `:` — not SCP-style, let
+       parseURL handle it. */
+    EXPECT_THAT(
+        []() { fixGitURL("user@[::1]/path"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("is not a valid URL")));
+
+    /* Nested `[` inside brackets: `[[]:path` has `]` at position 2
+       followed by `:`. Parsed as bracketed host `[[]`, but `[` is
+       not valid IPv6. Git also parses this way (strips brackets,
+       gets host `[`, SSH rejects).
+       $ GIT_TRACE=1 git ls-remote '[[]:path'
+       → ssh '[' 'git-upload-pack path' */
+    EXPECT_THAT(
+        []() { fixGitURL("[[]:path"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("is not a valid IPv6 address")));
+}
+
+TEST(FixGitURLTestSuite, slashBeforeColonIsNotScp)
+{
+    /* A slash before the first colon means it's not SCP — consistent
+       with git's `url_is_local_not_ssh()`. */
+    EXPECT_THAT(
+        []() { fixGitURL("x@foo/bar:baz"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("doesn't have a scheme")));
+}
+
+TEST(FixGitURLTestSuite, noColonIsNotScp)
+{
+    /* No `:` at all means not SCP — consistent with git's
+       `url_is_local_not_ssh()` in `connect.c`.
+       $ GIT_TRACE=1 git ls-remote 'user@[host]'
+       → git-upload-pack ']'  (treated as local, not SCP)
+       $ GIT_TRACE=1 git ls-remote 'user@[host]/path'
+       → git-upload-pack ']/path'  (treated as local, not SCP) */
+    EXPECT_THAT(
+        []() { fixGitURL("user@[host]"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("is not a valid URL")));
+    EXPECT_THAT(
+        []() { fixGitURL("user@[host]/path"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("is not a valid URL")));
+}
+
+TEST(FixGitURLTestSuite, gitBugDiscardedCharsBetweenBracketAndColon)
+{
+    /* Git's `host_end()` returns `end` past `]`, then `strchr(end, ':')`
+       finds `:` anywhere after — silently discarding characters between
+       `]` and `:`. This is a git bug; we refuse to parse as SCP.
+       $ GIT_TRACE=1 git ls-remote 'user@[::1]foo:path'
+       → ssh user@::1 'git-upload-pack path'  (git discards `foo`) */
+    EXPECT_THAT(
+        []() { fixGitURL("user@[::1]foo:path"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("is not a valid URL")));
 }
 
 struct ParseURLSuccessCase

--- a/src/libutil/include/nix/util/url.hh
+++ b/src/libutil/include/nix/util/url.hh
@@ -332,6 +332,25 @@ ParsedUrlScheme parseUrlScheme(std::string_view scheme);
  * them by removing the `:` and assuming a scheme of `ssh://`. Also
  * drops `git+` from the scheme (e.g. `git+https://` to `https://`)
  * and changes absolute paths into `file://` URLs.
+ *
+ * @see https://git-scm.com/docs/git-clone#_git_urls
+ *
+ * ssh://[<user>@]<host>[:<port>]/<path-to-git-repo>
+ * git://<host>[:<port>]/<path-to-git-repo>
+ * http[s]://<host>[:<port>]/<path-to-git-repo>
+ * ftp[s]://<host>[:<port>]/<path-to-git-repo>
+ *
+ * An alternative scp-like syntax may also be used with the ssh protocol:
+ * [<user>@]<host>:/<path-to-git-repo>
+ * This syntax is only recognized if there are no slashes before the first colon.
+ *
+ * For local repositories, also supported by Git natively, the following syntaxes may be used:
+ * /path/to/repo.git/
+ * file:///path/to/repo.git/
+ *
+ * @note file:/path/to/repo is recognised by libfetchers, but not git so this functions accepts
+ * it too. Technically this conflicts with the SCP-like syntax where file is the hostname, but
+ * it's special-cased.
  */
 ParsedURL fixGitURL(std::string url);
 

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -8,6 +8,8 @@
 
 #include <boost/url.hpp>
 
+#include <unordered_set>
+
 namespace nix {
 
 std::regex refRegex(refRegexS, std::regex::ECMAScript);
@@ -401,41 +403,308 @@ ParsedUrlScheme parseUrlScheme(std::string_view scheme)
     };
 }
 
+/**
+ * If is SCP style, return the parsed URL.
+ *
+ * This syntax is only recognized if there are no slashes before the
+ * first colon, and no double slash immediately after the colon (://).
+ *
+ * When Git encounters a URL of the form <transport>://<address>, where
+ * <transport> is a protocol that it cannot handle natively, it
+ * automatically invokes git remote-<transport> with the full URL as the
+ * second argument. https://git-scm.com/docs/gitremote-helpers. If the
+ * url doesn't look like it would be accepted by the remote helper,
+ * treat it as a SCP-style one. Don't do any pct-decoding in that case.
+ * Schemes supported by git are excluded.
+ *
+ * Use
+ *
+ * ```bash GIT_TRACE=1 git ls-remote "$URL" ```
+ *
+ * to manual test this, e.g. with our unit test URLs that should cover
+ * all code paths.
+ *
+ * @note This function is called in one spot, where we've already
+ * deduced that `url` is not valid as an absolute path on the current
+ * OS.
+ */
+static std::optional<ParsedURL> tryParseScpStyle(std::string_view url)
+{
+    /* The funny functional structure indicates how this happens in two
+       parts.
+
+       The first part decides whether we have a SCP-style pseudo-URL or not ---
+       and throwing errors rather than returning std::nullopt is just a chance
+       to improve error messages and should not change the meaning (i.e. regular
+       `parseURL` would have thrown in that case).
+
+       The second part, if we have committed to parsing as SCP-style, finishes
+       the job without any bailing out --- either we throw and error, or we
+       finish parsing. */
+
+    auto opt = [&]() -> std::optional<std::pair<std::string_view, std::string_view>> {
+        /* If the URL contains `://`, it's not SCP-style. This matches git's
+           `parse_connect_url()` which checks for `://` first. Note: this
+           doesn't catch all valid URLs per RFC 3986 (e.g. `scheme:path` without
+           authority is valid), but SCP URLs do "steal syntax" from that. */
+        if (url.find("://") != url.npos)
+            return std::nullopt;
+
+        /* SCP-style requires a `:` separator (`host:path`). If there
+           is no `:` at all, or if a `/` appears before the first `:`, then this
+           is a local path, not SCP. This matches git's `url_is_local_not_ssh()`
+           in `connect.c` [1].
+
+           The caller (`fixGitURL`) already handles some absolute paths via
+           `is_absolute()`, `foo/bar:baz` is not an absolute path, so the
+           `/`-before-`:` check is still needed for all platforms.
+
+           (Also note that on windows Windows `/foo/bar:baz` is also not
+           absolute (root-relative without a drive letter), so this
+           check is *especially* needed there, as more strings will
+           reach this point in the control flow.)
+
+           [1]: https://github.com/git/git/blob/68cb7f9e92a5d8e9824f5b52ac3d0a9d8f653dbe/connect.c#L966-L970 */
+        auto firstColon = url.find(':');
+        if (firstColon == url.npos)
+            return std::nullopt;
+        auto schemeOrHost = url.substr(0, firstColon);
+        if (schemeOrHost.find('/') != schemeOrHost.npos)
+            return std::nullopt;
+
+        /* Intentionally diverging from Git's algorithm in this next bit!
+
+           Purely to improve diagnostics for cases like
+           `git+https:/host/owner/repo` when users forget to specify an
+           authority (`://)`. Otherwise we'd recognize it as an SCP-like URL
+           (as we rightfully should).
+
+           HACK: Also include `file` / `git+file` in this set. SCP
+           syntax overlaps with `file:/path/to/repo`. Git itself doesn't
+           recognize it (or rather treats `file` as the host name), but Nix
+           accepts `file:/path/to/repo` as well as `file:///path/to/repo`.
+         */
+        static const auto schemesSupportedByGit = []() {
+            std::unordered_set<std::string, StringViewHash, std::equal_to<>> res;
+            for (auto scheme : {"ssh", "http", "https", "file", "ftp", "ftps", "git"}) {
+                res.insert(scheme);
+                res.insert(std::string("git+") + scheme);
+            }
+            return res;
+        }();
+        if (schemesSupportedByGit.contains(schemeOrHost))
+            return std::nullopt;
+
+        /* Only enter the IPv6 bracket parsing path when brackets are in the
+           host position. Following git's `host_end()` in `connect.c` [1], first
+           look for `@[` (e.g. `user@[::1]:path`); only if not found, check for
+           a leading `[` (e.g. `[::1]:path`).
+
+           This is, frankly, super janky, but we need to match it exactly (for
+           URLs that will succeed) for compat.
+
+           For an example of this jankiness, this algorithm has
+           `[user]@[::1]:path` parsed with `[::1]` being the host, and `[user]`
+           as the user.
+
+           Brackets elsewhere (e.g. `host[1]:repo`) go through the normal
+           colon-based path instead. This matters because SSH's
+           `valid_hostname()` [2] accepts `[` and `]` — they are not in its
+           reject set (`'` `` ` `` `"$\;&<>|(){},` plus whitespace and control
+           chars) — so such hostnames are legal SSH aliases even though they are
+           not valid DNS names.
+
+           [1]: https://github.com/git/git/blob/68cb7f9e92a5d8e9824f5b52ac3d0a9d8f653dbe/connect.c#L747-L769
+           [2]: https://github.com/openssh/openssh-portable/blob/master/ssh.c */
+
+        // We become an index != url.npos if found
+        size_t bracketStart = url.npos;
+        if (auto atBracketPos = url.find("@["); atBracketPos != url.npos)
+            bracketStart = atBracketPos + 1;
+        else if (url.starts_with('['))
+            bracketStart = 0;
+
+        if (bracketStart != url.npos) {
+            assert(url[bracketStart] == '[');
+            auto closeBracket = url.find(']', bracketStart + 1);
+            if (closeBracket == url.npos) {
+                /* No `]` at all — fall through to colon-based path.
+                   Git's `host_end()` also falls back to `end = host`
+                   in this case. */
+            } else {
+                /* Found `]`. Expect `:` immediately after for SCP-style. */
+                if (closeBracket + 1 < url.size() && url[closeBracket + 1] == ':') {
+                    schemeOrHost = url.substr(0, closeBracket + 1);
+                } else if (url.find(':', closeBracket + 1) != url.npos) {
+                    /* `:` exists after `]` but not immediately — git's
+                       `strchr(end, ':')` would find it, silently discarding
+                       characters between `]` and `:` (e.g.
+                       `user@[::1]foo:path` -> host `::1`, `foo` is lost).
+                       This is a git bug; bail out of SCP parsing. */
+                    debug(
+                        "not treating '%s' as SCP-style: `:` after `]` is not immediate (git would silently discard characters in between)",
+                        url);
+                    return std::nullopt;
+                } else {
+                    /* No `:` after `]` at all — not SCP-style.
+                       Git intentionally rejects this ("no path specified"). */
+                    return std::nullopt;
+                }
+            }
+        }
+
+        /* schemeOrHost is a prefix of url in memory in both code paths. That it
+           is in memory makes this check cheaper (don't have to check for
+           character equality), but the next step just relies on it being a
+           semantic prefix. */
+        assert(schemeOrHost.data() == url.data());
+        auto possiblyPathView = url.substr(schemeOrHost.size());
+
+        assert(possiblyPathView.starts_with(':'));
+        /* Trim the colon. */
+        possiblyPathView.remove_prefix(1);
+
+        return std::pair{schemeOrHost, possiblyPathView};
+    }();
+
+    return opt.transform([&](std::pair<std::string_view, std::string_view> pair) -> ParsedURL {
+        auto [host, pathView] = pair;
+        ParsedURL::Authority authority;
+
+        /* Handle userinfo. SCP-like case thankfully can't provide a
+           password in the userinfo component. */
+        auto username = splitPrefixTo(host, '@');
+
+        auto maybeIPv6 = [](std::string_view host) -> std::optional<ParsedURL::Authority> {
+            if (host.starts_with('[') && host.ends_with(']')) {
+                host.remove_prefix(1);
+                host.remove_suffix(1);
+                auto ipv6 = boost::urls::parse_ipv6_address(host);
+                if (!ipv6) {
+                    /* We are intentionally diverging
+                       from git here which accepts anything inbetween the square
+                       brackets. libgit2 also rejects such cases.
+
+                       Possibly another git bug... */
+                    throw BadURL("Git SCP bracketed URL is not valid: '%s' is not a valid IPv6 address", host);
+                }
+                return ParsedURL::Authority{
+                    .hostType = ParsedURL::Authority::HostType::IPv6,
+                    .host = ipv6->to_string(),
+                };
+            }
+            return std::nullopt;
+        };
+
+        if (auto ipv4 = boost::urls::parse_ipv4_address(host)) {
+            authority = ParsedURL::Authority{
+                .hostType = ParsedURL::Authority::HostType::IPv4,
+                .host = ipv4->to_string(),
+            };
+        } else if (auto ipv6Authority = maybeIPv6(host)) {
+            authority = *ipv6Authority;
+        } else {
+            authority = ParsedURL::Authority{
+                .hostType = ParsedURL::Authority::HostType::Name,
+                .host = std::string(host),
+            };
+        }
+
+        authority.user = username;
+
+        if (pathView.empty())
+            throw BadURL("SCP-style Git URL '%s' has an empty path", url);
+
+        ParsedURL res = {
+            .scheme = "ssh",
+            .authority = std::move(authority),
+            /* Everything else is the path. */
+            .path = splitString<std::vector<std::string>>(pathView, "/"),
+        };
+
+        /* Force path to be absolute.
+
+           SCP-style relative paths (e.g.
+           `host:repo`) cannot be faithfully represented as ssh:// URLs,
+           since the path component of a URL is always absolute. Git
+           sends relative paths as-is (resolved from the remote user's
+           home directory), but `ssh://host/repo` sends `/repo`
+           (absolute). This works with forges like GitHub that ignore
+           the leading `/`, but would break on a real SSH server.
+
+           Paths starting with `~` are also fine: git strips the `/` before
+           `~` at the transport layer (see git's `connect.c`).
+
+           FIXME: Turn warning into hard error, or talk to upstream git about
+           some way to make this possible to represent.
+         */
+        if (auto & path = res.path; !path.empty() && !path.front().empty()) {
+            /* Make the path absolute for the ssh:// URL. */
+            path.insert(path.begin(), "");
+
+            if (!path[1].starts_with("~")) {
+                auto scpAbsolute = host + ":/" + std::string(pathView);
+                auto scpTilde = host + ":~/" + std::string(pathView);
+                auto sshAbsolute = res.to_string();
+                /* Construct the ssh:// tilde equivalent. Git strips
+                   the `/` before `~` at the transport layer (see
+                   connect.c), so ssh://host/~/path works. */
+                auto sshTildeUrl = res;
+                sshTildeUrl.path.insert(sshTildeUrl.path.begin() + 1, "~");
+                warn(
+                    "SCP-style URL '%s' has a relative path which cannot be faithfully converted to an SSH URL: "
+                    "we will convert it to an absolute path when making an SSH URL.\n\n"
+                    "Use an explicit absolute path:\n\n"
+                    "    %s\n\n"
+                    "or with an explicit SSH URL:\n\n"
+                    "    %s\n\n"
+                    "instead, to explicitly use an absolute path (and silence this warning). "
+                    "Or, to be relative to the remote user's home directory:\n\n"
+                    "    %s\n\n"
+                    "or with an explicit SSH URL:\n\n"
+                    "    %s",
+                    url,
+                    scpAbsolute,
+                    sshAbsolute,
+                    scpTilde,
+                    sshTildeUrl.to_string());
+            }
+        }
+
+        return res;
+    });
+}
+
 ParsedURL fixGitURL(std::string url)
 {
-    std::regex scpRegex("([^/]*)@(.*):(.*)");
-    if (!hasPrefix(url, "/") && std::regex_match(url, scpRegex))
-        url = std::regex_replace(url, scpRegex, "ssh://$1@$2/$3");
-    if (!hasPrefix(url, "file:") && !hasPrefix(url, "git+file:") && url.find("://") == std::string::npos) {
-        auto path = splitString<std::vector<std::string>>(url, "/");
-#ifdef _WIN32
-        // Windows drive letters (e.g., "C:") look like SCP hosts but are local paths
-        bool hasDriveLetter = !path.empty() && path[0].size() == 2
-                              && std::isalpha(static_cast<unsigned char>(path[0][0])) && path[0][1] == ':';
-#else
-        constexpr bool hasDriveLetter = false;
-#endif
-        // Reject SCP-like URLs without user (e.g., "github.com:path") - colon in first component
-        if (!path.empty() && path[0].find(':') != std::string::npos && !hasDriveLetter)
-            throw BadURL("SCP-like URL '%s' is not supported; use SSH URL syntax instead (ssh://...)", url);
-        // Absolute paths get an empty authority (file:///path), relative paths get none (file:path)
-        if (hasPrefix(url, "/") || hasDriveLetter)
-            return ParsedURL{
-                .scheme = "file",
-                .authority = ParsedURL::Authority{},
-                .path = hasDriveLetter ? pathToUrlPath(std::filesystem::path(url)) : path,
-            };
-        else
-            return ParsedURL{
-                .scheme = "file",
-                .path = path,
-            };
+    /* First handle the absolute path case. TODO: Windows file:// URLs are tricky. See RFC8089.
+       Needs a forward slash before the drive letter: file:///C:/
+       > Instead, such a reference ought to be constructed with a
+       > leading slash "/" character (e.g., "/c:/foo.txt").
+       Git is non-compliant here and doesn't handle the necessary triple slash it seems.
+       https://github.com/git/git/blob/68cb7f9e92a5d8e9824f5b52ac3d0a9d8f653dbe/connect.c#L1122-L1123 */
+    if (std::filesystem::path path = url; path.is_absolute()) {
+        /* Note that we don't do any percent decoding here, as we shouldn't since the input is not a URL but a local
+         * path. Any pct-encoded sequences get treated as literals. Should probably use
+         * std::filesystem::path::generic_string here for normalization, but that would be a slight behaviour change. */
+        return ParsedURL{
+            .scheme = "file",
+            .authority = ParsedURL::Authority{},
+            .path = pathToUrlPath(path),
+        };
     }
+
+    /* Next, try parsing as an SCP-style URL. */
+    if (auto scpStyle = tryParseScpStyle(url))
+        return *scpStyle;
+
+    /* TODO: What to do about query parameters? Git should pass those to the * http(s) remotes. Ignore for now and
+     * just pass through. Will fail later. */
     auto parsed = parseURL(url);
     // Drop the superfluous "git+" from the scheme.
-    auto scheme = parseUrlScheme(parsed.scheme);
-    if (scheme.application == "git")
+    if (auto scheme = parseUrlScheme(parsed.scheme); scheme.application == "git") {
         parsed.scheme = scheme.transport;
+    }
     return parsed;
 }
 


### PR DESCRIPTION
## Motivation

This change resolves several deficiencies with the current url normalization.  Tests documenting these deficiencies have been corrected and new tests added to cover additional fetchGit test expectations.

## Context

fixes #14852
fixes #14867

The primary new functionality is that SCP-like paths no longer require specifying the user component of the uri authority.  This complicates the implementation as there is now overlap with simple uris.  To prevent processing uris as SCP paths we now attempt to filter them, but the regex for uri and scp detection are definitely more complicated.

While this effort keeps the url normalization logic in `fixGitURL` it feels like it's poorly duplicating boosts parsing logic.  However, I understand parsing urls has a lot of edge cases, so leveraging a high-quality external library is likely still the right strategy.  These regex are only trying to identify enough shape to differentiate them from SCP-like paths.

I'm very new to Nix/NixOS.  I'd like to confirm this build fixes the `nixos-rebuild` error motivating this change but can't figure out how to get it to use my custom build.  Having it in the path (from `nix develop` in the source tree) was not sufficient.  Is there any documentation on how to do this?

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
