### PR TITLE
nix-profile{-daemon,}.sh: Unify

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -1,13 +1,22 @@
+# If you are making changes to this file, make sure to make an identical change
+# in `nix-profile.sh.in`, unless there is a very good reason not to.
+#
 # Only execute this file once per shell.
 # This file is tested by tests/installer/default.nix.
 if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
 export __ETC_PROFILE_NIX_SOURCED=1
 
-NIX_LINK=$HOME/.nix-profile
+# Set up the per-user profile.
+
+if [ -n "${NIX_STATE_HOME-}" ]; then
+    NIX_LINK="$NIX_STATE_HOME/profile"
+else
+    NIX_LINK="$HOME/.nix-profile"
+fi
 if [ -n "${XDG_STATE_HOME-}" ]; then
     NIX_LINK_NEW="$XDG_STATE_HOME/nix/profile"
 else
-    NIX_LINK_NEW=$HOME/.local/state/nix/profile
+    NIX_LINK_NEW="$HOME/.local/state/nix/profile"
 fi
 if [ -e "$NIX_LINK_NEW" ]; then
     if [ -t 2 ] && [ -e "$NIX_LINK" ]; then
@@ -49,6 +58,10 @@ elif [ -e /etc/ssl/certs/ca-bundle.crt ]; then # Old NixOS
     export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
 elif [ -e /etc/pki/tls/certs/ca-bundle.crt ]; then # Fedora, CentOS
     export NIX_SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
+elif [ -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" ]; then # fall back to cacert in Nix profile
+    export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
+elif [ -e "$NIX_LINK/etc/ca-bundle.crt" ]; then # old cacert in Nix profile
+    export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ca-bundle.crt"
 else
   # Fall back to what is in the nix profiles, favouring whatever is defined last.
   check_nix_profiles() {
@@ -66,6 +79,13 @@ else
   }
   check_nix_profiles
   unset -f check_nix_profiles
+fi
+
+# Only use MANPATH if it is already set. In general `man` will just simply
+# pick up `.nix-profile/share/man` because is it close to `.nix-profile/bin`
+# which is in the $PATH. For more info, run `manpath -d`.
+if [ -n "${MANPATH-}" ]; then
+    export MANPATH="$NIX_LINK/share/man:$MANPATH"
 fi
 
 export PATH="$NIX_LINK/bin:@localstatedir@/nix/profiles/default/bin:$PATH"

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,71 +1,96 @@
+# If you are making changes to this file, make sure to make an identical change
+# in `nix-profile-daemon.sh.in`, unless there is a very good reason not to.
+#
+# Only execute this file once per shell.
 # This file is tested by tests/installer/default.nix.
-if [ -n "${HOME-}" ] && [ -n "${USER-}" ]; then
+if [ -z "${HOME-}" ] || [ -z "${USER-}" ]; then return; fi
 
-    # Set up the per-user profile.
+if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
+export __ETC_PROFILE_NIX_SOURCED=1
 
-    if [ -n "${NIX_STATE_HOME-}" ]; then
-        NIX_LINK="$NIX_STATE_HOME/profile"
-    else
-        NIX_LINK="$HOME/.nix-profile"
-        if [ -n "${XDG_STATE_HOME-}" ]; then
-            NIX_LINK_NEW="$XDG_STATE_HOME/nix/profile"
-        else
-            NIX_LINK_NEW="$HOME/.local/state/nix/profile"
-        fi
-        if [ -e "$NIX_LINK_NEW" ]; then
-            if [ -t 2 ] && [ -e "$NIX_LINK" ]; then
-                warning="\033[1;35mwarning:\033[0m"
-                printf "$warning Both %s and legacy %s exist; using the former.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
-                if [ "$(realpath "$NIX_LINK")" = "$(realpath "$NIX_LINK_NEW")" ]; then
-                    printf "         Since the profiles match, you can safely delete either of them.\n" 1>&2
-                else
-                    # This should be an exceptionally rare occasion: the only way to get it would be to
-                    # 1. Update to newer Nix;
-                    # 2. Remove .nix-profile;
-                    # 3. Set the $NIX_LINK_NEW to something other than the default user profile;
-                    # 4. Roll back to older Nix.
-                    # If someone did all that, they can probably figure out how to migrate the profile.
-                    printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
-                fi
-            fi
-            NIX_LINK="$NIX_LINK_NEW"
-        fi
-    fi
+# Set up the per-user profile.
 
-    # Set up environment.
-    # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
-    export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"
-
-    # Populate bash completions, .desktop files, etc
-    if [ -z "${XDG_DATA_DIRS-}" ]; then
-        # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
-        export XDG_DATA_DIRS="/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
-    else
-        export XDG_DATA_DIRS="$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
-    fi
-
-    # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
-    if [ -e /etc/ssl/certs/ca-certificates.crt ]; then # NixOS, Ubuntu, Debian, Gentoo, Arch
-        export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
-    elif [ -e /etc/ssl/ca-bundle.pem ]; then # openSUSE Tumbleweed
-        export NIX_SSL_CERT_FILE=/etc/ssl/ca-bundle.pem
-    elif [ -e /etc/ssl/certs/ca-bundle.crt ]; then # Old NixOS
-        export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
-    elif [ -e /etc/pki/tls/certs/ca-bundle.crt ]; then # Fedora, CentOS
-        export NIX_SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
-    elif [ -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" ]; then # fall back to cacert in Nix profile
-        export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
-    elif [ -e "$NIX_LINK/etc/ca-bundle.crt" ]; then # old cacert in Nix profile
-        export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ca-bundle.crt"
-    fi
-
-    # Only use MANPATH if it is already set. In general `man` will just simply
-    # pick up `.nix-profile/share/man` because is it close to `.nix-profile/bin`
-    # which is in the $PATH. For more info, run `manpath -d`.
-    if [ -n "${MANPATH-}" ]; then
-        export MANPATH="$NIX_LINK/share/man:$MANPATH"
-    fi
-
-    export PATH="$NIX_LINK/bin:$PATH"
-    unset NIX_LINK NIX_LINK_NEW
+if [ -n "${NIX_STATE_HOME-}" ]; then
+    NIX_LINK="$NIX_STATE_HOME/profile"
+else
+    NIX_LINK="$HOME/.nix-profile"
 fi
+if [ -n "${XDG_STATE_HOME-}" ]; then
+    NIX_LINK_NEW="$XDG_STATE_HOME/nix/profile"
+else
+    NIX_LINK_NEW="$HOME/.local/state/nix/profile"
+fi
+if [ -e "$NIX_LINK_NEW" ]; then
+    if [ -t 2 ] && [ -e "$NIX_LINK" ]; then
+        warning="\033[1;35mwarning:\033[0m"
+        printf "$warning Both %s and legacy %s exist; using the former.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
+        if [ "$(realpath "$NIX_LINK")" = "$(realpath "$NIX_LINK_NEW")" ]; then
+            printf "         Since the profiles match, you can safely delete either of them.\n" 1>&2
+        else
+            # This should be an exceptionally rare occasion: the only way to get it would be to
+            # 1. Update to newer Nix;
+            # 2. Remove .nix-profile;
+            # 3. Set the $NIX_LINK_NEW to something other than the default user profile;
+            # 4. Roll back to older Nix.
+            # If someone did all that, they can probably figure out how to migrate the profile.
+            printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
+        fi
+    fi
+    NIX_LINK="$NIX_LINK_NEW"
+fi
+
+# Set up environment.
+# This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
+export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"
+
+# Populate bash completions, .desktop files, etc
+if [ -z "${XDG_DATA_DIRS-}" ]; then
+    # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
+    export XDG_DATA_DIRS="/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+else
+    export XDG_DATA_DIRS="$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+fi
+
+# Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
+if [ -n "${NIX_SSL_CERT_FILE:-}" ]; then
+    : # Allow users to override the NIX_SSL_CERT_FILE
+elif [ -e /etc/ssl/certs/ca-certificates.crt ]; then # NixOS, Ubuntu, Debian, Gentoo, Arch
+    export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+elif [ -e /etc/ssl/ca-bundle.pem ]; then # openSUSE Tumbleweed
+    export NIX_SSL_CERT_FILE=/etc/ssl/ca-bundle.pem
+elif [ -e /etc/ssl/certs/ca-bundle.crt ]; then # Old NixOS
+    export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+elif [ -e /etc/pki/tls/certs/ca-bundle.crt ]; then # Fedora, CentOS
+    export NIX_SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
+elif [ -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" ]; then # fall back to cacert in Nix profile
+    export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
+elif [ -e "$NIX_LINK/etc/ca-bundle.crt" ]; then # old cacert in Nix profile
+    export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ca-bundle.crt"
+else
+  # Fall back to what is in the nix profiles, favouring whatever is defined last.
+  check_nix_profiles() {
+    if [ -n "${ZSH_VERSION:-}" ]; then
+      # Zsh by default doesn't split words in unquoted parameter expansion.
+      # Set local_options for these options to be reverted at the end of the function
+      # and shwordsplit to force splitting words in $NIX_PROFILES below.
+      setopt local_options shwordsplit
+    fi
+    for i in $NIX_PROFILES; do
+      if [ -e "$i/etc/ssl/certs/ca-bundle.crt" ]; then
+        export NIX_SSL_CERT_FILE=$i/etc/ssl/certs/ca-bundle.crt
+      fi
+    done
+  }
+  check_nix_profiles
+  unset -f check_nix_profiles
+fi
+
+# Only use MANPATH if it is already set. In general `man` will just simply
+# pick up `.nix-profile/share/man` because is it close to `.nix-profile/bin`
+# which is in the $PATH. For more info, run `manpath -d`.
+if [ -n "${MANPATH-}" ]; then
+    export MANPATH="$NIX_LINK/share/man:$MANPATH"
+fi
+
+export PATH="$NIX_LINK/bin:@localstatedir@/nix/profiles/default/bin:$PATH"
+unset NIX_LINK NIX_LINK_NEW


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

User environment needs to be configured mostly (completely?) in the same manner, regardless of if `nix` is running as a daemon or not.  Changes between `nix.sh` and `nix-daemon.sh` seems to be due to files being edited out of sync, rather than due to actually meaningful differences in behavior.

It is better to keep them as identical as possible, as it reduces the maintenance burden.

I have a subsequent change, that fixes the profile path issue in the shell configuration.  I would like to apply it uniformly to all 4 shell configuration scripts.

## Context

I've looked at the differences between `nix-profile.sh.in` and `nix-profile-daemon.sh.in` and merged missing changes in both directions.
One notable difference is that `nix-profile.sh.in` had a lot of extra indentation, as most of the logic was nested inside 2 `if` statements.
The first `if` statement was turned into an early return.
The second `if` statement does not have to apply to the whole file in the first place.
3 other shell scripts run the environment configuration regardless of if `NIX_STATE_HOME` is set or not.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
