### PR TITLE
libutil: Avoid repeated memory reallocation in BaseNix32::decode

### DIFF
--- a/src/libutil/include/nix/util/base-nix-32.hh
+++ b/src/libutil/include/nix/util/base-nix-32.hh
@@ -36,7 +36,17 @@ public:
      */
     [[nodiscard]] constexpr static inline size_t encodedLength(size_t originalLength)
     {
+        if (originalLength == 0)
+            return 0;
         return (originalLength * 8 - 1) / 5 + 1;
+    }
+
+    /**
+     * Upper bound for the number of bytes produced by decoding a base-32 string.
+     */
+    [[nodiscard]] constexpr static inline size_t maxDecodedLength(size_t encodedLength)
+    {
+        return (encodedLength * 5 + 7) / 8; // ceiling(encodedLength * 5/8)
     }
 
     static std::string encode(std::span<const std::byte> originalData);


### PR DESCRIPTION
```
assert(used <= maxSize);
res.resize(used);
```

Downsizing is essentially free whereas res.resize(i + 1) causes heavy memory realloc.

Also fixed a small bug where encodedLength(0) would return a really big number (no real imapct).

Plus made some minor type adjustments where made sense to me (size_t is more idiomatic for len/size).

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
