### PR TITLE
libexpr/genericClosure: reduce allocator churn and improve locality

### DIFF
--- a/src/libexpr-tests/generic-closure-bench.cc
+++ b/src/libexpr-tests/generic-closure-bench.cc
@@ -1,0 +1,110 @@
+#include <benchmark/benchmark.h>
+
+#include "nix/expr/eval.hh"
+#include "nix/expr/eval-settings.hh"
+#include "nix/fetchers/fetch-settings.hh"
+#include "nix/store/store-open.hh"
+
+using namespace nix;
+
+namespace {
+
+constexpr size_t genericClosureOutDegree = 8;
+
+static void evalExpr(benchmark::State & state, const std::string & exprStr, size_t itemsProcessed)
+{
+    for (auto _ : state) {
+        state.PauseTiming();
+
+        auto store = openStore("dummy://");
+        fetchers::Settings fetchSettings{};
+        bool readOnlyMode = true;
+        EvalSettings evalSettings{readOnlyMode};
+        evalSettings.nixPath = {};
+
+        EvalState st({}, store, fetchSettings, evalSettings, nullptr);
+        Expr * expr = st.parseExprFromString(exprStr, st.rootPath(CanonPath::root));
+
+        Value v;
+
+        state.ResumeTiming();
+
+        st.eval(expr, v);
+        st.forceValue(v, noPos);
+        benchmark::DoNotOptimize(v);
+    }
+
+    state.SetItemsProcessed(state.iterations() * itemsProcessed);
+}
+
+static std::string mkGenericClosureIntKeysExpr(size_t nodeCount)
+{
+    std::string res;
+    res.reserve(1024);
+
+    res += "let\n";
+    res += "  N = ";
+    res += std::to_string(nodeCount);
+    res += ";\n";
+    res += "  mod = a: b: a - b * (builtins.div a b);\n";
+    res += "  nodes = builtins.genList (n: { key = n; }) N;\n";
+    res += "in builtins.genericClosure {\n";
+    res += "  startSet = [ (builtins.elemAt nodes 0) ];\n";
+    res += "  operator = x:\n";
+    res += "    let k = x.key; in [\n";
+    for (size_t i = 1; i <= genericClosureOutDegree; ++i) {
+        res += "      (builtins.elemAt nodes (mod (k + ";
+        res += std::to_string(i);
+        res += ") N))\n";
+    }
+    res += "    ];\n";
+    res += "}\n";
+
+    return res;
+}
+
+static std::string mkGenericClosureStringKeysExpr(size_t nodeCount)
+{
+    std::string res;
+    res.reserve(1024);
+
+    res += "let\n";
+    res += "  N = ";
+    res += std::to_string(nodeCount);
+    res += ";\n";
+    res += "  mod = a: b: a - b * (builtins.div a b);\n";
+    res += "  keys = builtins.genList builtins.toString N;\n";
+    res += "  nodes = builtins.genList (n: { key = builtins.elemAt keys n; i = n; }) N;\n";
+    res += "in builtins.genericClosure {\n";
+    res += "  startSet = [ (builtins.elemAt nodes 0) ];\n";
+    res += "  operator = x:\n";
+    res += "    let k = x.i; in [\n";
+    for (size_t i = 1; i <= genericClosureOutDegree; ++i) {
+        res += "      (builtins.elemAt nodes (mod (k + ";
+        res += std::to_string(i);
+        res += ") N))\n";
+    }
+    res += "    ];\n";
+    res += "}\n";
+
+    return res;
+}
+
+static void BM_GenericClosure_IntKeys(benchmark::State & state)
+{
+    const auto nodeCount = static_cast<size_t>(state.range(0));
+    const auto exprStr = mkGenericClosureIntKeysExpr(nodeCount);
+    evalExpr(state, exprStr, nodeCount);
+}
+
+static void BM_GenericClosure_StringKeys(benchmark::State & state)
+{
+    const auto nodeCount = static_cast<size_t>(state.range(0));
+    const auto exprStr = mkGenericClosureStringKeysExpr(nodeCount);
+    evalExpr(state, exprStr, nodeCount);
+}
+
+BENCHMARK(BM_GenericClosure_IntKeys)->Arg(1'000)->Arg(5'000)->Arg(20'000);
+BENCHMARK(BM_GenericClosure_StringKeys)->Arg(1'000)->Arg(5'000)->Arg(20'000);
+
+} // namespace

--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -95,6 +95,7 @@ if get_option('benchmarks')
   benchmark_sources = files(
     'bench-main.cc',
     'dynamic-attrs-bench.cc',
+    'generic-closure-bench.cc',
     'get-drvs-bench.cc',
     'regex-cache-bench.cc',
   )


### PR DESCRIPTION
genericClosure is now specialized for String/Path/Int key tracking, which improves performance by ~2x in local measurements and covers all current nixpkgs genericClosure usage. The fast paths use Boost's unordered_flat_set/unordered_flat_map to improve cache locality (open addressing, no per-element pointer indirection). The Int path uses unordered_flat_map so we can promote to the comparator-based fallback if Float keys appear later (Ints and Floats are comparable).

Also replace the internal queue/result list usage with ValueVector to reduce allocator/GC churn and fragmentation; this noticeably improves locality and reduced peak memory usage in local tests (-66%).
 
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
