### PR TITLE
libstore/derivations: speed up DerivationOutput JSON parsing

### DIFF
--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -1425,11 +1425,7 @@ void adl_serializer<DerivationOutput>::to_json(json & res, const DerivationOutpu
 DerivationOutput
 adl_serializer<DerivationOutput>::from_json(const json & _json, const ExperimentalFeatureSettings & xpSettings)
 {
-    std::set<std::string_view> keys;
     auto & json = getObject(_json);
-
-    for (const auto & [key, _] : json)
-        keys.insert(key);
 
     auto methodAlgo = [&]() -> std::pair<ContentAddressMethod, HashAlgorithm> {
         ContentAddressMethod method = ContentAddressMethod::parse(getString(valueAt(json, "method")));
@@ -1440,52 +1436,57 @@ adl_serializer<DerivationOutput>::from_json(const json & _json, const Experiment
         return {std::move(method), std::move(hashAlgo)};
     };
 
-    if (keys == (std::set<std::string_view>{"path"})) {
-        return DerivationOutput::InputAddressed{
-            .path = valueAt(json, "path"),
-        };
-    }
-
-    else if (keys == (std::set<std::string_view>{"method", "hash"})) {
-        auto dof = DerivationOutput::CAFixed{
-            .ca = static_cast<ContentAddress>(_json),
-        };
-        if (dof.ca.method == ContentAddressMethod::Raw::Text)
-            xpSettings.require(Xp::DynamicDerivations, "text-hashed derivation output in JSON");
-        /* We no longer produce this (denormalized) field (for the
-           reasons described above), so we don't need to check it. */
-#if 0
-        if (dof.path(store, drvName, outputName) != static_cast<StorePath>(valueAt(json, "path")))
-            throw Error("Path doesn't match derivation output");
-#endif
-        return dof;
-    }
-
-    else if (keys == (std::set<std::string_view>{"method", "hashAlgo"})) {
-        xpSettings.require(Xp::CaDerivations);
-        auto [method, hashAlgo] = methodAlgo();
-        return DerivationOutput::CAFloating{
-            .method = std::move(method),
-            .hashAlgo = std::move(hashAlgo),
-        };
-    }
-
-    else if (keys == (std::set<std::string_view>{})) {
+    switch (json.size()) {
+    case 0:
         return DerivationOutput::Deferred{};
+    case 1:
+        if (auto * path = optionalValueAt(json, "path"))
+            return DerivationOutput::InputAddressed{
+                .path = *path,
+            };
+        break;
+    case 2: {
+        const bool hasMethod = optionalValueAt(json, "method");
+
+        if (hasMethod && optionalValueAt(json, "hash")) {
+            auto dof = DerivationOutput::CAFixed{
+                .ca = static_cast<ContentAddress>(_json),
+            };
+            if (dof.ca.method == ContentAddressMethod::Raw::Text)
+                xpSettings.require(Xp::DynamicDerivations, "text-hashed derivation output in JSON");
+            /* We no longer produce this (denormalized) field (for the
+               reasons described above), so we don't need to check it. */
+#if 0
+            if (dof.path(store, drvName, outputName) != static_cast<StorePath>(valueAt(json, "path")))
+                throw Error("Path doesn't match derivation output");
+#endif
+            return dof;
+        }
+
+        if (hasMethod && optionalValueAt(json, "hashAlgo")) {
+            xpSettings.require(Xp::CaDerivations);
+            auto [method, hashAlgo] = methodAlgo();
+            return DerivationOutput::CAFloating{
+                .method = std::move(method),
+                .hashAlgo = std::move(hashAlgo),
+            };
+        }
+
+        break;
+    }
+    case 3:
+        if (optionalValueAt(json, "method") && optionalValueAt(json, "hashAlgo") && optionalValueAt(json, "impure")) {
+            xpSettings.require(Xp::ImpureDerivations);
+            auto [method, hashAlgo] = methodAlgo();
+            return DerivationOutput::Impure{
+                .method = std::move(method),
+                .hashAlgo = hashAlgo,
+            };
+        }
+        break;
     }
 
-    else if (keys == (std::set<std::string_view>{"method", "hashAlgo", "impure"})) {
-        xpSettings.require(Xp::ImpureDerivations);
-        auto [method, hashAlgo] = methodAlgo();
-        return DerivationOutput::Impure{
-            .method = std::move(method),
-            .hashAlgo = hashAlgo,
-        };
-    }
-
-    else {
-        throw Error("invalid JSON for derivation output");
-    }
+    throw Error("invalid JSON for derivation output");
 }
 
 void adl_serializer<Derivation>::to_json(json & res, const Derivation & d)


### PR DESCRIPTION
adl_serializer\<DerivationOutput\> previously built a std::set\<std::string_view\> of keys and compared against multiple temporary std::sets to select the output variant. Replaced this with a json.size() switch and direct key presence checks (optionalValueAt(...)) to avoid per-parse allocations and tree balancing.

The measured speedup is typically around 25%-80%, with Deferred case being 350% faster.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
