### PR TITLE
ci: Move docker_push_image into a separate workflow 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,9 @@ jobs:
     needs: [flake_regressions, installer_test]
     if: github.event_name == 'push' && github.ref_name == 'master'
     uses: ./.github/workflows/docker-push.yml
+    with:
+      ref: ${{ github.sha }}
+      is_master: true
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -2,6 +2,15 @@ name: "Push Docker Image"
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to build the docker image from"
+        required: true
+        type: string
+      is_master:
+        description: "Whether run from master branch"
+        required: true
+        type: boolean
     secrets:
       DOCKERHUB_USERNAME:
         required: true
@@ -42,6 +51,7 @@ jobs:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         fetch-depth: 0
+        ref: ${{ inputs.ref }}
     - uses: ./.github/actions/install-nix-action
       with:
         dogfood: false
@@ -50,8 +60,6 @@ jobs:
     - run: echo NIX_VERSION="$(nix eval .\#nix.version | tr -d \")" >> $GITHUB_ENV
     - run: nix build .#dockerImage -L
     - run: docker load -i ./result/image.tar.gz
-    - run: docker tag nix:$NIX_VERSION ${{ secrets.DOCKERHUB_USERNAME }}/nix:$NIX_VERSION
-    - run: docker tag nix:$NIX_VERSION ${{ secrets.DOCKERHUB_USERNAME }}/nix:master
     # We'll deploy the newly built image to both Docker Hub and Github Container Registry.
     #
     # Push to Docker Hub first
@@ -60,8 +68,17 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/nix:$NIX_VERSION
-    - run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/nix:master
+    - name: Push to Docker Hub
+      env:
+        IS_MASTER: ${{ inputs.is_master }}
+        DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/nix
+      run: |
+        docker tag nix:$NIX_VERSION $DOCKERHUB_REPO:$NIX_VERSION
+        docker push $DOCKERHUB_REPO:$NIX_VERSION
+        if [ "$IS_MASTER" = "true" ]; then
+          docker tag nix:$NIX_VERSION $DOCKERHUB_REPO:master
+          docker push $DOCKERHUB_REPO:master
+        fi
     # Push to GitHub Container Registry as well
     - name: Login to GitHub Container Registry
       uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -69,16 +86,21 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Push image
+    - name: Push to GHCR
+      env:
+        IS_MASTER: ${{ inputs.is_master }}
       run: |
         IMAGE_ID=ghcr.io/${{ github.repository_owner }}/nix
-        # Change all uppercase to lowercase
         IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
 
         docker tag nix:$NIX_VERSION $IMAGE_ID:$NIX_VERSION
-        docker tag nix:$NIX_VERSION $IMAGE_ID:latest
         docker push $IMAGE_ID:$NIX_VERSION
-        docker push $IMAGE_ID:latest
-        # deprecated 2024-02-24
-        docker tag nix:$NIX_VERSION $IMAGE_ID:master
-        docker push $IMAGE_ID:master
+        if [ "$IS_MASTER" = "true" ]; then
+          # FIXME: Do not tag master as latest. Upload to GHCR as part of
+          # releng instead. Possibly adapt this reusable workflow for the (yet
+          # nonexistent) release workflow.
+          docker tag nix:$NIX_VERSION $IMAGE_ID:latest
+          docker tag nix:$NIX_VERSION $IMAGE_ID:master
+          docker push $IMAGE_ID:latest
+          docker push $IMAGE_ID:master
+        fi


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This should allow reusing this workflow (with more tweaks)
in the releng workflow. Best reviewed with -w --color-moved.
Currently this workflow is only run for master branch, but in the future
we'll adapt it for maintenance- branches too.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
