### PR TITLE
nix/prefetch: Avoid full directory scan when unpacking

### DIFF
--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -126,18 +126,19 @@ std::tuple<StorePath, Hash> prefetchFile(
         /* Optionally unpack the file. */
         if (unpack) {
             Activity act(*logger, lvlChatty, actUnknown, fmt("unpacking '%s'", url.to_string()));
-            auto unpacked = (tmpDir.path() / "unpacked").string();
+            auto unpacked = tmpDir.path() / "unpacked";
             createDirs(unpacked);
-            unpackTarfile(tmpFile.string(), unpacked);
+            unpackTarfile(tmpFile, unpacked);
+            tmpFile = unpacked;
 
-            auto entries = DirectoryIterator{unpacked};
+            auto entries = DirectoryIterator{tmpFile};
             /* If the archive unpacks to a single file/directory, then use
                that as the top-level. */
-            tmpFile = entries->path();
-            auto fileCount = std::distance(entries, DirectoryIterator{});
-            if (fileCount != 1) {
-                /* otherwise, use the directory itself */
-                tmpFile = unpacked;
+            auto end = DirectoryIterator{};
+            if (entries != end) {
+                auto firstEntry = entries->path();
+                if (++entries == end)
+                    tmpFile = std::move(firstEntry);
             }
         }
 


### PR DESCRIPTION
Self explanatory.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
