### PR TITLE
libstore: Optimize BinaryCacheStore::queryValidPaths

### DIFF
--- a/src/libstore-tests/binary-cache-store.cc
+++ b/src/libstore-tests/binary-cache-store.cc
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+
+#include "nix/store/binary-cache-store.hh"
+#include "nix/store/globals.hh"
+
+namespace nix {
+
+struct TestBinaryCacheStoreConfig : virtual Store::Config, BinaryCacheStoreConfig
+{
+    using Params = StoreReference::Params;
+
+    TestBinaryCacheStoreConfig(const Params & params)
+        : Store::Config(params)
+        , BinaryCacheStoreConfig(params)
+    {
+    }
+
+    ref<Store> openStore() const override
+    {
+        throw Unsupported("openStore");
+    }
+};
+
+struct TestBinaryCacheStore : virtual BinaryCacheStore
+{
+    using Config = TestBinaryCacheStoreConfig;
+
+    ref<Config> config;
+    std::atomic<size_t> fileExistsCalls = 0;
+    std::atomic<size_t> getFileCalls = 0;
+    std::set<std::string> existingFiles;
+
+    TestBinaryCacheStore(ref<Config> config)
+        : Store{*config}
+        , BinaryCacheStore{*config}
+        , config(config)
+    {
+    }
+
+    std::optional<TrustedFlag> isTrustedClient() override
+    {
+        return std::nullopt;
+    }
+
+    bool fileExists(const std::string & path) override
+    {
+        fileExistsCalls++;
+        return existingFiles.contains(path);
+    }
+
+    void upsertFile(
+        const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override
+    {
+        throw Unsupported("upsertFile");
+    }
+
+    void getFile(const std::string & path, Sink & sink) override
+    {
+        getFileCalls++;
+        throw NoSuchBinaryCacheFile("file '%s' does not exist in binary cache", path);
+    }
+};
+
+TEST(BinaryCacheStore, queryValidPathsUsesExistenceChecks)
+{
+    initLibStore(false);
+
+    auto config = make_ref<TestBinaryCacheStoreConfig>(StoreReference::Params{});
+    auto store = std::make_shared<TestBinaryCacheStore>(config);
+
+    StorePathSet paths{
+        StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
+        StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3r-bar"},
+        StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3s-baz"},
+    };
+
+    store->existingFiles = {
+        "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q.narinfo",
+        "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3s.narinfo",
+    };
+
+    auto valid = store->queryValidPaths(paths);
+
+    EXPECT_EQ(valid.size(), 2u);
+    EXPECT_EQ(valid.count(StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"}), 1u);
+    EXPECT_EQ(valid.count(StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3s-baz"}), 1u);
+
+    EXPECT_EQ(store->fileExistsCalls, paths.size());
+    EXPECT_EQ(store->getFileCalls, 0u);
+}
+
+} // namespace nix

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -54,6 +54,7 @@ deps_private += gtest
 subdir('nix-meson-build-support/common')
 
 sources = files(
+  'binary-cache-store.cc',
   'build-result.cc',
   'common-protocol.cc',
   'content-address.cc',

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -168,6 +168,8 @@ public:
 
     bool isValidPathUncached(const StorePath & path) override;
 
+    StorePathSet queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute = NoSubstitute) override;
+
     void queryPathInfoUncached(
         const StorePath & path, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;
 


### PR DESCRIPTION
Store::queryValidPaths() uses queryPathInfo() per path. For HTTP binary caches, that means GET hash.narinfo and parsing it. Override BinaryCacheStore::queryValidPaths() to use isValidPath() instead. For binary caches, isValidPathUncached() is already implemented in terms of fileExists(hash.narinfo); HttpBinaryCacheStore::fileExists() uses HEAD probes rather than GET+parse.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
