### PR TITLE
eval-cache: fix parsing of contexts

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -265,7 +265,7 @@ struct AttrDb
         case AttrType::String: {
             NixStringContext context;
             if (!queryAttribute.isNull(3))
-                for (auto & s : tokenizeString<std::vector<std::string>>(queryAttribute.getStr(3), ";"))
+                for (auto & s : tokenizeString<std::vector<std::string>>(queryAttribute.getStr(3), " "))
                     context.insert(NixStringContextElem::parse(s));
             return {{rowId, string_t{queryAttribute.getStr(2), context}}};
         }


### PR DESCRIPTION
## Motivation

Fixing a small correctness bug -- the delimiter used for serialization and parsing should match.

## Context

Storage of string contexts in the evaluation cache was introduced with https://github.com/NixOS/nix/commit/50f13b06fb1b2f50a97323c000d1094d090f08ea. Currently it looks like:

https://github.com/NixOS/nix/blob/b17034ba59df14730168f415d968e0525aff63c5/src/libexpr/eval-cache.cc#L139-L161

However, the delimiter used for parsing doesn't match:

https://github.com/NixOS/nix/blob/b17034ba59df14730168f415d968e0525aff63c5/src/libexpr/eval-cache.cc#L265-L271

Since this change doesn't modify the values written to the cache there's no need to bump the cache version.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
