### PR TITLE
ci: Fix docker-push location for dockerhub

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Push to Docker Hub
       env:
         IS_MASTER: ${{ inputs.is_master }}
-        DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/nix
+        DOCKERHUB_REPO: ${{ github.repository_owner == 'NixOS' && 'nixos' || secrets.DOCKERHUB_USERNAME }}/nix
       run: |
         docker tag nix:$NIX_VERSION $DOCKERHUB_REPO:$NIX_VERSION
         docker push $DOCKERHUB_REPO:$NIX_VERSION


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Pre-release stuff was supposed to get pushed to nixos/nix but ended up in nixosautomation/nix duh...

This makes us wonder just how useful having them even pushed is remotely useful to anybody, but let's keep it for now. Maybe this should be a nightly/weekly thing?

Broken in 7e6a7c925858c3720dec1864ed26e62718a36652.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
