### PR TITLE
libfetchers: Actually percentDecode path when using the path from fil…

### DIFF
--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -115,7 +115,7 @@ static DownloadTarballResult downloadTarball_(
     // it is not in fact a tarball.
     if (url.rfind("file://", 0) == 0) {
         // Remove "file://" prefix to get the local file path
-        std::string localPath = url.substr(7);
+        std::string localPath = percentDecode(url.substr(7));
         if (!std::filesystem::exists(localPath)) {
             throw Error("tarball '%s' does not exist.", localPath);
         }


### PR DESCRIPTION
…e:// URI

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Special characters like + e.t.c. are pct-encoded.
cc @dramforever. There's also a very stupid issue that leads to test failures because of regexes of all things: https://github.com/NixOS/nix/blob/e44e1cc99c769a794cd89018ef78ab493e60adc2/src/libstore/local-overlay-store.cc#L52, but that's on Linux. With this change the tests pass on darwin with `--build-dir "/nix/var/nix/builds/build-1"`. Not sure what your issue was when testing it out.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
