### PR TITLE
fix: replace unused-result of set::extract with erase

### DIFF
--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -219,7 +219,7 @@ Goal::Done Goal::amDone(ExitCode result, std::optional<Error> ex)
                 /* If we failed and keepGoing is not set, we remove all
                    remaining waitees. */
                 for (auto & g : goal->waitees) {
-                    g->waiters.extract(goal);
+                    g->waiters.erase(goal);
                 }
                 goal->waitees.clear();
 


### PR DESCRIPTION
As of https://github.com/llvm/llvm-project/pull/169982 this occurence is caught by LLVM, and it's the only such example.

I don't think believe this changes behaviour.

For context, https://github.com/NixOS/nix/pull/5106 introduced the `extract` call.

## Motivation

[Nix builds with `Werror=unused-result`](https://github.com/NixOS/nix/blob/e44e1cc99c769a794cd89018ef78ab493e60adc2/src/perl/meson.build#L29) and as of https://github.com/llvm/llvm-project/pull/169982 that this will catch more cases.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
