### PR TITLE
libexpr-c: fix changing eval settings having no effect

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -19,13 +19,8 @@
 
 namespace nix {
 
-fetchers::Settings fetchSettings;
-
-static GlobalConfig::Register rFetchSettings(&fetchSettings);
-
-EvalSettings evalSettings{
-    settings.readOnlyMode,
-    {
+static GlobalConfig::Register rEvalSettings(&evalSettings, [] {
+    evalSettings.lookupPathHooks = {
         {
             "flake",
             [](EvalState & state, std::string_view rest) {
@@ -45,10 +40,8 @@ EvalSettings evalSettings{
                 return state.storePath(storePath);
             },
         },
-    },
-};
-
-static GlobalConfig::Register rEvalSettings(&evalSettings);
+    };
+});
 
 flake::Settings flakeSettings;
 

--- a/src/libexpr-c/nix_api_expr_internal.h
+++ b/src/libexpr-c/nix_api_expr_internal.h
@@ -13,8 +13,8 @@ extern "C" {
 struct nix_eval_state_builder
 {
     nix::ref<nix::Store> store;
-    nix::EvalSettings settings;
-    nix::fetchers::Settings fetchSettings;
+    nix::EvalSettings * settings;
+    nix::fetchers::Settings * fetchSettings;
     nix::LookupPath lookupPath;
     // TODO: make an EvalSettings setting own this instead?
     bool readOnlyMode;
@@ -22,8 +22,8 @@ struct nix_eval_state_builder
 
 struct EvalState
 {
-    nix::fetchers::Settings fetchSettings;
-    nix::EvalSettings settings;
+    nix::fetchers::Settings * fetchSettings;
+    nix::EvalSettings * settings;
     nix::EvalState state;
 };
 

--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -1,4 +1,5 @@
 #include "nix/util/users.hh"
+#include "nix/util/config-global.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/profiles.hh"
 #include "nix/expr/eval.hh"
@@ -107,5 +108,9 @@ std::filesystem::path getNixDefExpr()
 {
     return settings.useXDGBaseDirectories ? getStateDir() / "defexpr" : getHome() / ".nix-defexpr";
 }
+
+EvalSettings evalSettings{settings.readOnlyMode};
+
+static GlobalConfig::Register rEvalSettings(&evalSettings);
 
 } // namespace nix

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -368,4 +368,9 @@ struct EvalSettings : Config
  */
 std::filesystem::path getNixDefExpr();
 
+/**
+ * EvalSettings instance from libexpr.
+ */
+extern EvalSettings evalSettings;
+
 } // namespace nix

--- a/src/libfetchers/fetch-settings.cc
+++ b/src/libfetchers/fetch-settings.cc
@@ -1,7 +1,16 @@
 #include "nix/fetchers/fetch-settings.hh"
+#include "nix/util/config-global.hh"
 
 namespace nix::fetchers {
 
 Settings::Settings() {}
 
 } // namespace nix::fetchers
+
+namespace nix {
+
+fetchers::Settings fetchSettings;
+
+static GlobalConfig::Register rFetchSettings(&fetchSettings);
+
+} // namespace nix

--- a/src/libfetchers/include/nix/fetchers/fetch-settings.hh
+++ b/src/libfetchers/include/nix/fetchers/fetch-settings.hh
@@ -138,3 +138,12 @@ private:
 };
 
 } // namespace nix::fetchers
+
+namespace nix {
+
+/**
+ * @todo Get rid of global settings variables
+ */
+extern fetchers::Settings fetchSettings;
+
+} // namespace nix

--- a/src/libflake-c/nix_api_flake.cc
+++ b/src/libflake-c/nix_api_flake.cc
@@ -32,7 +32,7 @@ nix_err nix_flake_settings_add_to_eval_state_builder(
 {
     nix_clear_err(context);
     try {
-        settings->settings->configureEvalSettings(builder->settings);
+        settings->settings->configureEvalSettings(*builder->settings);
     }
     NIXC_CATCH_ERRS
 }

--- a/src/libutil/config-global.cc
+++ b/src/libutil/config-global.cc
@@ -61,7 +61,16 @@ GlobalConfig globalConfig;
 
 GlobalConfig::Register::Register(Config * config)
 {
-    configRegistrations().emplace_back(config);
+    auto regs = configRegistrations();
+    if (std::find(regs.begin(), regs.end(), config) == regs.end()) {
+        configRegistrations().emplace_back(config);
+    }
+}
+
+GlobalConfig::Register::Register(Config * config, std::function<void()> && callback)
+    : Register(config)
+{
+    callback();
 }
 
 ExperimentalFeatureSettings experimentalFeatureSettings;

--- a/src/libutil/include/nix/util/config-global.hh
+++ b/src/libutil/include/nix/util/config-global.hh
@@ -26,6 +26,7 @@ struct GlobalConfig : public AbstractConfig
     struct Register
     {
         Register(Config * config);
+        Register(Config * config, std::function<void()> && callback);
     };
 };
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Using the Rust bindings (which call into the C bindings) to set eval-related settings was not working.

Since EvalSettings were defined in libcmd, we need to move them to libexpr if libexpr-c wants to use them. Since libcmd enforces a dependency on libflake, we also need to modify config-global to absorb duplicate registrations and support callbacks for customizing behavior that we only need in libcmd.

Note that we add back some of the global setting variables with this, but this does fix the C API.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Implementation strategy, since this was slightly nontrivial:

- Move registration for eval (and fetcher settings, which had the same issue but was easier to solve) to libexpr and libfetchers.
- Absorb duplicate config registrations in config-global.cc.
- Add a new GlobalConfig registration constructor allowing the caller to pass a callback; use this to break the hard libflake dependency.
- Use pointers to the global eval and fetcher config in libexpr-c instead of creating new instances that are not bound to Nix's settings.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
