### PR TITLE
Fix creation of cgroups

### DIFF
--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -35,7 +35,7 @@ unsigned int getMaxCPU()
         if (!cgroupFS)
             return 0;
 
-        auto cpuFile = *cgroupFS + "/" + getCurrentCgroup() + "/cpu.max";
+        auto cpuFile = *cgroupFS / getCurrentCgroup().rel() / "cpu.max";
 
         auto cpuMax = readFile(cpuFile);
         auto cpuMaxParts = tokenizeString<std::vector<std::string>>(cpuMax, " \n");

--- a/src/libutil/linux/cgroup.cc
+++ b/src/libutil/linux/cgroup.cc
@@ -155,7 +155,7 @@ CgroupStats destroyCgroup(const std::filesystem::path & cgroup)
     return destroyCgroup(cgroup, true);
 }
 
-std::string getCurrentCgroup()
+CanonPath getCurrentCgroup()
 {
     auto cgroupFS = getCgroupFS();
     if (!cgroupFS)
@@ -165,12 +165,12 @@ std::string getCurrentCgroup()
     auto ourCgroup = ourCgroups[""];
     if (ourCgroup == "")
         throw Error("cannot determine cgroup name from /proc/self/cgroup");
-    return ourCgroup;
+    return CanonPath{ourCgroup};
 }
 
-std::string getRootCgroup()
+CanonPath getRootCgroup()
 {
-    static std::string rootCgroup = getCurrentCgroup();
+    static auto rootCgroup = getCurrentCgroup();
     return rootCgroup;
 }
 

--- a/src/libutil/linux/include/nix/util/cgroup.hh
+++ b/src/libutil/linux/include/nix/util/cgroup.hh
@@ -6,6 +6,7 @@
 #include <filesystem>
 
 #include "nix/util/types.hh"
+#include "nix/util/canon-path.hh"
 
 namespace nix {
 
@@ -31,13 +32,13 @@ CgroupStats getCgroupStats(const std::filesystem::path & cgroup);
  */
 CgroupStats destroyCgroup(const std::filesystem::path & cgroup);
 
-std::string getCurrentCgroup();
+CanonPath getCurrentCgroup();
 
 /**
  * Get the cgroup that should be used as the parent when creating new
  * sub-cgroups. The first time this is called, the current cgroup will be
  * returned, and then all subsequent calls will return the original cgroup.
  */
-std::string getRootCgroup();
+CanonPath getRootCgroup();
 
 } // namespace nix

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -333,7 +333,7 @@ static void daemonLoop(std::optional<TrustedFlag> forceTrustClientOpt)
         auto cgroupFS = getCgroupFS();
         if (!cgroupFS)
             throw Error("cannot determine the cgroups file system");
-        auto rootCgroupPath = canonPath(*cgroupFS + "/" + rootCgroup);
+        auto rootCgroupPath = *cgroupFS / rootCgroup.rel();
         if (!pathExists(rootCgroupPath))
             throw Error("expected cgroup directory '%s'", rootCgroupPath);
         auto daemonCgroupPath = rootCgroupPath + "/nix-daemon";


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

A commit in #14800 broke tests around creating cgroups due to incorrect path handling logic.


Fix that logic and represent cgroups as CanonPath.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context
See failure in https://hydra.nixos.org/build/318367985/nixlog/11 and comments on #14800
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
