### PR TITLE
tests/functional: Reduce max-call-depth for stack overflow tests

### DIFF
--- a/tests/functional/eval.sh
+++ b/tests/functional/eval.sh
@@ -43,24 +43,24 @@ ln -sfn cycle.nix "$TEST_ROOT/cycle.nix"
 # The expression creates a non-cyclic but infinitely deep structure:
 # f returns immediately with a thunk, so Nix call depth stays at 1,
 # but Printer::print recurses on the C++ stack.
-expectStderr 1 nix eval --expr 'let f = n: { inner = f (n + 1); }; in f 0' \
+expectStderr 1 nix eval --expr 'let f = n: { inner = f (n + 1); }; in f 0' --max-call-depth 100 \
   | grepQuiet "stack overflow; max-call-depth exceeded"
 
 # Same for builtins.toXML
-expectStderr 1 nix eval --expr 'builtins.toXML (let f = n: { inner = f (n + 1); }; in f 0)' \
+expectStderr 1 nix eval --expr 'builtins.toXML (let f = n: { inner = f (n + 1); }; in f 0)' --max-call-depth 100 \
   | grepQuiet "stack overflow; max-call-depth exceeded"
 
 # Same for equality comparison (n is not observable, so structures are equal)
-expectStderr 1 nix eval --expr 'let f = n: { inner = f (n + 1); }; in f 0 == f 1' \
+expectStderr 1 nix eval --expr 'let f = n: { inner = f (n + 1); }; in f 0 == f 1' --max-call-depth 100 \
   | grepQuiet "stack overflow; max-call-depth exceeded"
 
 # Same for assert with equality (uses assertEqValues)
-expectStderr 1 nix eval --expr 'let f = n: { inner = f (n + 1); }; in assert f 0 == f 1; true' \
+expectStderr 1 nix eval --expr 'let f = n: { inner = f (n + 1); }; in assert f 0 == f 1; true' --max-call-depth 100 \
   | grepQuiet "stack overflow; max-call-depth exceeded"
 
 # Same for string coercion with __toString
 # shellcheck disable=SC2016
-expectStderr 1 nix eval --expr 'let f = n: { __toString = _: f (n + 1); }; in "${f 0}"' \
+expectStderr 1 nix eval --expr 'let f = n: { __toString = _: f (n + 1); }; in "${f 0}"' --max-call-depth 100 \
   | grepQuiet "stack overflow; max-call-depth exceeded"
 
 # --file and --pure-eval don't mix.


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This OOMs VM tests in CI and it's just wasteful.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
