### PR TITLE
source nix-profile.sh only once

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,4 +1,8 @@
+# Only execute this file once per shell.
 # This file is tested by tests/installer/default.nix.
+if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
+export __ETC_PROFILE_NIX_SOURCED=1
+
 if [ -n "${HOME-}" ] && [ -n "${USER-}" ]; then
 
     # Set up the per-user profile.


### PR DESCRIPTION
This is basically #12805 (nix-daemon.sh) for profile.d/nix.sh.

See https://github.com/NixOS/nix/issues/5950#issuecomment-3691699590

- Add a check to ensure the script executes only once per shell.

This makes bash behave the same way as fish, 
which checks `__ETC_PROFILE_NIX_SOURCED` in both nix.fish and nix-daemon.fish.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
