### PR TITLE
String utils cleanup and modernization

### DIFF
--- a/src/libcmd/editor-for.cc
+++ b/src/libcmd/editor-for.cc
@@ -1,6 +1,11 @@
 #include "nix/cmd/editor-for.hh"
 #include "nix/util/environment-variables.hh"
+#include "nix/util/fmt.hh"
 #include "nix/util/source-path.hh"
+#include "nix/util/strings.hh"
+#include "nix/util/types.hh"
+
+#include <cstdint>
 
 namespace nix {
 
@@ -12,8 +17,7 @@ Strings editorFor(const SourcePath & file, uint32_t line)
     auto editor = getEnv("EDITOR").value_or("cat");
     auto args = tokenizeString<Strings>(editor);
     if (line > 0
-        && (editor.find("emacs") != std::string::npos || editor.find("nano") != std::string::npos
-            || editor.find("vim") != std::string::npos || editor.find("kak") != std::string::npos))
+        && (editor.contains("emacs") || editor.contains("nano") || editor.contains("vim") || editor.contains("kak")))
         args.push_back(fmt("+%d", line));
     args.push_back(path->string());
     return args;

--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -28,8 +28,7 @@ namespace nix {
 std::vector<std::string> InstallableFlake::getActualAttrPaths()
 {
     std::vector<std::string> res;
-    if (attrPaths.size() == 1 && attrPaths.front().starts_with(".")) {
-        attrPaths.front().erase(0, 1);
+    if (attrPaths.size() == 1 && stripPrefix(attrPaths.front(), ".")) {
         res.push_back(attrPaths.front());
         return res;
     }
@@ -179,7 +178,7 @@ std::vector<ref<eval_cache::AttrCursor>> InstallableFlake::getCursors(EvalState 
         }
     }
 
-    if (res.size() == 0)
+    if (res.empty())
         throw Error(suggestions, "flake '%s' does not provide attribute %s", flakeRef, showAttrPaths(attrPaths));
 
     return res;

--- a/src/libcmd/misc-store-flags.cc
+++ b/src/libcmd/misc-store-flags.cc
@@ -5,7 +5,7 @@ namespace nix::flag {
 static void hashFormatCompleter(AddCompletions & completions, size_t index, std::string_view prefix)
 {
     for (auto & format : hashFormats) {
-        if (hasPrefix(format, prefix)) {
+        if (std::string_view{format}.starts_with(prefix)) {
             completions.add(format);
         }
     }
@@ -37,7 +37,7 @@ Args::Flag hashFormatOpt(std::string && longName, std::optional<HashFormat> * oh
 static void hashAlgoCompleter(AddCompletions & completions, size_t index, std::string_view prefix)
 {
     for (auto & algo : hashAlgorithms)
-        if (hasPrefix(algo, prefix))
+        if (std::string_view{algo}.starts_with(prefix))
             completions.add(algo);
 }
 

--- a/src/libexpr-tests/nix_api_expr.cc
+++ b/src/libexpr-tests/nix_api_expr.cc
@@ -10,6 +10,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 #include "expr-tests-config.hh"
 
 namespace nixC {
@@ -49,7 +51,7 @@ TEST_F(nix_api_expr_test, nix_eval_state_lookup_path)
 
     auto pathStr = nix_get_path_string(ctx, value);
     assert_ctx_ok();
-    ASSERT_EQ(0, strcmp(pathStr, nixpkgs.string().c_str()));
+    ASSERT_STREQ(pathStr, nixpkgs.string().c_str());
 
     nix_gc_decref(nullptr, value);
 }
@@ -223,7 +225,7 @@ TEST_F(nix_api_expr_test, nix_expr_realise_context)
         nix_store_path_name(p, OBSERVE_STRING(name));
         names.push_back(name);
     }
-    std::sort(names.begin(), names.end());
+    std::ranges::sort(names);
     ASSERT_EQ(3u, names.size());
     EXPECT_THAT(names[0], testing::StrEq("just-a-file"));
     EXPECT_THAT(names[1], testing::StrEq("letsbuild"));
@@ -505,7 +507,7 @@ TEST_F(nix_api_expr_test, nix_expr_attrset_update)
         assert_ctx_ok();
         values[i].first = name;
     }
-    std::sort(values.begin(), values.end(), [](const auto & lhs, const auto & rhs) { return lhs.first < rhs.first; });
+    std::ranges::sort(values, [](const auto & lhs, const auto & rhs) { return lhs.first < rhs.first; });
 
     nix_value * a = values[0].second;
     ASSERT_EQ("a", values[0].first);

--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -32,7 +32,7 @@ Strings EvalSettings::parseNixPath(const std::string & s)
 
         if (*p == ':') {
             auto prefix = std::string(start2, s.end());
-            if (EvalSettings::isPseudoUrl(prefix) || hasPrefix(prefix, "flake:")) {
+            if (EvalSettings::isPseudoUrl(prefix) || prefix.starts_with("flake:")) {
                 ++p;
                 while (p != s.end() && *p != ':')
                     ++p;
@@ -79,7 +79,7 @@ Strings EvalSettings::getDefaultNixPath()
 
 bool EvalSettings::isPseudoUrl(std::string_view s)
 {
-    if (s.compare(0, 8, "channel:") == 0)
+    if (s.starts_with("channel:"))
         return true;
     size_t pos = s.find("://");
     if (pos == std::string::npos)
@@ -91,7 +91,7 @@ bool EvalSettings::isPseudoUrl(std::string_view s)
 
 std::string EvalSettings::resolvePseudoUrl(std::string_view url)
 {
-    if (hasPrefix(url, "channel:"))
+    if (url.starts_with("channel:"))
         return "https://channels.nixos.org/" + std::string(url.substr(8)) + "/nixexprs.tar.xz";
     else
         return std::string(url);

--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -195,7 +195,7 @@ struct ExprString : Expr
 
     ExprString(std::pmr::polymorphic_allocator<char> & alloc, std::string_view sv)
     {
-        if (sv.size() == 0) {
+        if (sv.empty()) {
             v.mkStringNoCopy(""_sds);
             return;
         }

--- a/src/libexpr/include/nix/expr/parser-state.hh
+++ b/src/libexpr/include/nix/expr/parser-state.hh
@@ -415,7 +415,7 @@ ParserState::stripIndentation(const PosIdx pos, std::span<std::pair<PosIdx, std:
 
     // If there is nothing at all, return the empty string directly.
     // This also ensures that equivalent empty strings result in the same ast, which is helpful when testing formatters.
-    if (es2.size() == 0) {
+    if (es2.empty()) {
         auto * const result = exprs.add<ExprString>(""_sds);
         return result;
     }

--- a/src/libexpr/primops/fetchMercurial.cc
+++ b/src/libexpr/primops/fetchMercurial.cc
@@ -73,7 +73,7 @@ static void prim_fetchMercurial(EvalState & state, const PosIdx pos, Value ** ar
 
     fetchers::Attrs attrs;
     attrs.insert_or_assign("type", "hg");
-    attrs.insert_or_assign("url", url.find("://") != std::string::npos ? url : "file://" + url);
+    attrs.insert_or_assign("url", url.contains("://") ? url : "file://" + url);
     attrs.insert_or_assign("name", std::string(name));
     if (ref)
         attrs.insert_or_assign("ref", *ref);

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -112,7 +112,7 @@ std::ostream & printIdentifier(std::ostream & str, std::string_view s)
 
 static bool isVarName(std::string_view s)
 {
-    if (s.size() == 0)
+    if (s.empty())
         return false;
     if (isReservedKeyword(s))
         return false;

--- a/src/libexpr/search-path.cc
+++ b/src/libexpr/search-path.cc
@@ -1,4 +1,5 @@
 #include "nix/expr/search-path.hh"
+#include "nix/util/split.hh"
 
 namespace nix {
 
@@ -15,7 +16,7 @@ std::optional<std::string_view> LookupPath::Prefix::suffixIfPotentialMatch(std::
     }
 
     /* Prefix must be prefix of this path. */
-    if (path.compare(0, n, s) != 0) {
+    if (!path.starts_with(s)) {
         return std::nullopt;
     }
 
@@ -25,16 +26,16 @@ std::optional<std::string_view> LookupPath::Prefix::suffixIfPotentialMatch(std::
 
 LookupPath::Elem LookupPath::Elem::parse(std::string_view rawElem)
 {
-    size_t pos = rawElem.find('=');
+    auto split = splitOnce(rawElem, '=');
 
     return LookupPath::Elem{
         .prefix =
             Prefix{
-                .s = pos == std::string::npos ? std::string{""} : std::string{rawElem.substr(0, pos)},
+                .s = split ? std::string{split->first} : std::string{""},
             },
         .path =
             Path{
-                .s = std::string{rawElem.substr(pos + 1)},
+                .s = split ? std::string{split->second} : std::string{rawElem},
             },
     };
 }

--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -160,12 +160,12 @@ static std::optional<Pointer> parseLfsPointer(std::string_view content, std::str
         debug("Custom extension '%s' found, ignoring", line);
     }
 
-    if (oid.length() != 64 || !std::all_of(oid.begin(), oid.end(), ::isxdigit)) {
+    if (oid.length() != 64 || !std::all_of(oid.begin(), oid.end(), [](unsigned char c) { return std::isxdigit(c); })) {
         debug("Invalid sha256 %s, skipping", oid);
         return std::nullopt;
     }
 
-    if (size.length() == 0 || !std::all_of(size.begin(), size.end(), ::isdigit)) {
+    if (size.empty() || !std::all_of(size.begin(), size.end(), [](unsigned char c) { return std::isdigit(c); })) {
         debug("Invalid size %s, skipping", size);
         return std::nullopt;
     }

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -805,7 +805,7 @@ struct GitInputScheme : InputScheme
             // We need to set the origin so resolving submodule URLs works
             repo->setRemote("origin", repoUrl.to_string());
 
-            auto localRefFile = ref.compare(0, 5, "refs/") == 0 ? cacheDir / ref : cacheDir / "refs/heads" / ref;
+            auto localRefFile = ref.starts_with("refs/") ? cacheDir / ref : cacheDir / "refs/heads" / ref;
 
             bool doFetch = false;
             time_t now = time(0);
@@ -828,11 +828,11 @@ struct GitInputScheme : InputScheme
             if (doFetch) {
                 bool shallow = getShallowAttr(input);
                 try {
-                    auto fetchRef = getAllRefsAttr(input)             ? "refs/*:refs/*"
-                                    : input.getRev()                  ? input.getRev()->gitRev()
-                                    : ref.compare(0, 5, "refs/") == 0 ? fmt("%1%:%1%", ref)
-                                    : ref == "HEAD"                   ? "HEAD:HEAD"
-                                                                      : fmt("%1%:%1%", "refs/heads/" + ref);
+                    auto fetchRef = getAllRefsAttr(input)      ? "refs/*:refs/*"
+                                    : input.getRev()           ? input.getRev()->gitRev()
+                                    : ref.starts_with("refs/") ? fmt("%1%:%1%", ref)
+                                    : ref == "HEAD"            ? "HEAD:HEAD"
+                                                               : fmt("%1%:%1%", "refs/heads/" + ref);
 
                     repo->fetch(repoUrl.to_string(), fetchRef, shallow);
                 } catch (Error & e) {

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -164,7 +164,7 @@ static DownloadTarballResult downloadTarball_(
 
     /* Note: if the download is cached, `importTarball()` will receive
        no data, which causes it to import an empty tarball. */
-    auto archive = !url.path.empty() && hasSuffix(toLower(url.path.back()), ".zip") ? ({
+    auto archive = !url.path.empty() && toLower(url.path.back()).ends_with(".zip") ? ({
         /* In streaming mode, libarchive doesn't handle
            symlinks in zip files correctly (#10649). So write
            the entire file to disk so libarchive can access it
@@ -178,7 +178,7 @@ static DownloadTarballResult downloadTarball_(
         }
         TarArchive{path};
     })
-                                                                                    : TarArchive{*source};
+                                                                                   : TarArchive{*source};
     auto tarballCache = settings.getTarballCache();
     auto parseSink = tarballCache->getFileSystemObjectSink();
     auto lastModified = unpackTarfileToSink(archive, *parseSink);
@@ -237,9 +237,8 @@ struct CurlInputScheme : InputScheme
         if (url.path.empty())
             return false;
         const auto & path = url.path.back();
-        return hasSuffix(path, ".zip") || hasSuffix(path, ".tar") || hasSuffix(path, ".tgz")
-               || hasSuffix(path, ".tar.gz") || hasSuffix(path, ".tar.xz") || hasSuffix(path, ".tar.bz2")
-               || hasSuffix(path, ".tar.zst");
+        return path.ends_with(".zip") || path.ends_with(".tar") || path.ends_with(".tgz") || path.ends_with(".tar.gz")
+               || path.ends_with(".tar.xz") || path.ends_with(".tar.bz2") || path.ends_with(".tar.zst");
     }
 
     virtual bool isValidURL(const ParsedURL & url, bool requireTree) const = 0;

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -847,7 +847,7 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
 
                             bool lockFileExists = pathExists(outputLockFilePath);
 
-                            auto s = chomp(diff);
+                            auto s = rtrim(diff);
                             if (lockFileExists) {
                                 if (s.empty())
                                     warn("updating lock file %s", outputLockFilePath);
@@ -892,7 +892,7 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
                     throw Error(
                         "cannot write modified lock file of flake '%s' (use '--no-write-lock-file' to ignore)", topRef);
             } else {
-                warn("not writing modified lock file of flake '%s':\n%s", topRef, chomp(diff));
+                warn("not writing modified lock file of flake '%s':\n%s", topRef, rtrim(diff));
                 flake.forceDirty = true;
             }
         }

--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -57,7 +57,7 @@ MixCommonArgs::MixCommonArgs(const std::string & programName)
                     std::map<std::string, Config::SettingInfo> settings;
                     globalConfig.getSettings(settings);
                     for (auto & s : settings)
-                        if (hasPrefix(s.first, prefix))
+                        if (s.first.starts_with(prefix))
                             completions.add(s.first, fmt("Set the `%s` setting.", s.first));
                 }
             },

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -765,7 +765,7 @@ static void runPostBuildHook(
     StringMap hookEnvironment = getEnv();
 
     hookEnvironment.emplace("DRV_PATH", store.printStorePath(drvPath));
-    hookEnvironment.emplace("OUT_PATHS", chomp(concatStringsSep(" ", store.printStorePathSet(outputPaths))));
+    hookEnvironment.emplace("OUT_PATHS", rtrim(concatStringsSep(" ", store.printStorePathSet(outputPaths))));
     hookEnvironment.emplace("NIX_CONFIG", globalConfig.toKeyValue());
 
     struct LogSink : Sink
@@ -881,7 +881,7 @@ HookReply DerivationBuildingGoal::tryBuildHook(
             }();
             if (handleJSONLogMessage(s, worker.act, worker.hook->activities, "the build hook", true))
                 ;
-            else if (s.substr(0, 2) == "# ") {
+            else if (s.starts_with("# ")) {
                 reply = s.substr(2);
                 break;
             } else {
@@ -905,7 +905,7 @@ HookReply DerivationBuildingGoal::tryBuildHook(
 
     } catch (SysError & e) {
         if (e.errNo == EPIPE) {
-            printError("build hook died unexpectedly: %s", chomp(drainFD(worker.hook->fromHook.readSide.get())));
+            printError("build hook died unexpectedly: %s", rtrim(drainFD(worker.hook->fromHook.readSide.get())));
             worker.hook = 0;
             return rpDecline;
         } else

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -295,7 +295,7 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
             /* If the wanted output is not in builtOutputs (e.g., because it
                was already valid and therefore not re-registered), we need to
                add it ourselves to ensure we return the correct information. */
-            if (success.builtOutputs.count(wantedOutput) == 0) {
+            if (!success.builtOutputs.contains(wantedOutput)) {
                 debug(
                     "BUG! wanted output '%s' not in builtOutputs, working around by adding it manually", wantedOutput);
                 success.builtOutputs = {{

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -68,9 +68,9 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
          * Python package brings its own
          * `$out/lib/pythonX.Y/site-packages/easy-install.pth'.)
          */
-        if (hasSuffix(srcFile, "/propagated-build-inputs") || hasSuffix(srcFile, "/nix-support")
-            || hasSuffix(srcFile, "/perllocal.pod") || hasSuffix(srcFile, "/info/dir") || hasSuffix(srcFile, "/log")
-            || hasSuffix(srcFile, "/manifest.nix") || hasSuffix(srcFile, "/manifest.json"))
+        if (srcFile.ends_with("/propagated-build-inputs") || srcFile.ends_with("/nix-support")
+            || srcFile.ends_with("/perllocal.pod") || srcFile.ends_with("/info/dir") || srcFile.ends_with("/log")
+            || srcFile.ends_with("/manifest.nix") || srcFile.ends_with("/manifest.json"))
             continue;
 
         else if (S_ISDIR(srcSt.st_mode)) {
@@ -151,7 +151,7 @@ void buildProfile(const Path & out, Packages && pkgs)
      * user. Process in priority order to reduce unnecessary
      * symlink/unlink steps.
      */
-    std::sort(pkgs.begin(), pkgs.end(), [](const Package & a, const Package & b) {
+    std::ranges::sort(pkgs, [](const Package & a, const Package & b) {
         return a.priority < b.priority || (a.priority == b.priority && a.path < b.path);
     });
     for (const auto & pkg : pkgs)

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -53,7 +53,7 @@ static void builtinFetchurl(const BuiltinBuilderContext & ctx)
             }
 #endif
 
-            auto decompressor = makeDecompressionSink(unpack && hasSuffix(mainUrl, ".xz") ? "xz" : "none", sink);
+            auto decompressor = makeDecompressionSink(unpack && mainUrl.ends_with(".xz") ? "xz" : "none", sink);
             fileTransfer->download(std::move(request), *decompressor);
             decompressor->finish();
         });
@@ -75,7 +75,7 @@ static void builtinFetchurl(const BuiltinBuilderContext & ctx)
     if (dof && dof->ca.method.getFileIngestionMethod() == FileIngestionMethod::Flat)
         for (auto hashedMirror : settings.hashedMirrors.get())
             try {
-                if (!hasSuffix(hashedMirror, "/"))
+                if (!hashedMirror.ends_with("/"))
                     hashedMirror += '/';
                 fetch(
                     hashedMirror + printHashAlgo(dof->ca.hash.algo) + "/"

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -257,7 +257,7 @@ struct ClientSettings
                 for (auto & s : ss)
                     if (trusted.count(s))
                         subs.push_back(s);
-                    else if (!hasSuffix(s, "/") && trusted.count(s + "/"))
+                    else if (!s.ends_with('/') && trusted.count(s + "/"))
                         subs.push_back(s + "/");
                     else
                         warn(

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -655,7 +655,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
         /* There may be temp directories in the store that are still in use
            by another process. We need to be sure that we can acquire an
            exclusive lock before deleting them. */
-        if (baseName.find("tmp-", 0) == 0) {
+        if (baseName.starts_with("tmp-")) {
             AutoCloseFD tmpDirFd = openDirectory(realPath);
             if (!tmpDirFd || !lockFile(tmpDirFd.get(), ltWrite, false)) {
                 debug("skipping locked tempdir '%s'", realPath);

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -80,11 +80,11 @@ void HttpBinaryCacheStore::init()
 
 std::optional<std::string> HttpBinaryCacheStore::getCompressionMethod(const std::string & path)
 {
-    if (hasSuffix(path, ".narinfo") && !config->narinfoCompression.get().empty())
+    if (path.ends_with(".narinfo") && !config->narinfoCompression.get().empty())
         return config->narinfoCompression;
-    else if (hasSuffix(path, ".ls") && !config->lsCompression.get().empty())
+    else if (path.ends_with(".ls") && !config->lsCompression.get().empty())
         return config->lsCompression;
-    else if (hasPrefix(path, "log/") && !config->logCompression.get().empty())
+    else if (path.starts_with("log/") && !config->logCompression.get().empty())
         return config->logCompression;
     else
         return std::nullopt;

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -81,7 +81,7 @@ ref<LegacySSHStore::Connection> LegacySSHStore::openConnection()
             tee.drainInto(nullSink);
         }
         throw Error(
-            "'nix-store --serve' protocol mismatch from '%s', got '%s'", config->authority.host, chomp(saved.s));
+            "'nix-store --serve' protocol mismatch from '%s', got '%s'", config->authority.host, rtrimView(saved.s));
     } catch (EndOfFile & e) {
         throw Error("cannot connect to '%1%'", config->authority.host);
     }

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -85,7 +85,7 @@ protected:
         for (auto & entry : DirectoryIterator{config->binaryCacheDir}) {
             checkInterrupt();
             auto name = entry.path().filename().string();
-            if (name.size() != 40 || !hasSuffix(name, ".narinfo"))
+            if (name.size() != 40 || !name.ends_with(".narinfo"))
                 continue;
             paths.insert(parseStorePath(storeDir + "/" + name.substr(0, name.size() - 8) + "-" + MissingName));
         }

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -861,7 +861,7 @@ std::optional<StorePath> LocalStore::queryPathFromHashPart(const std::string & h
             return {};
 
         const char * s = (const char *) sqlite3_column_text(state->stmts->QueryPathFromHashPart, 0);
-        if (s && prefix.compare(0, prefix.size(), s, prefix.size()) == 0)
+        if (s && std::string_view{s}.starts_with(prefix))
             return parseStorePath(s);
         return {};
     });

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -383,7 +383,7 @@ StorePath resolveDerivedPath(Store & store, const SingleDerivedPath & req, Store
             [&](const SingleDerivedPath::Built & bfd) {
                 auto drvPath = resolveDerivedPath(store, *bfd.drvPath, evalStore_);
                 auto outputPaths = evalStore.queryPartialDerivationOutputMap(drvPath, evalStore_);
-                if (outputPaths.count(bfd.output) == 0)
+                if (!outputPaths.contains(bfd.output))
                     throw Error(
                         "derivation '%s' does not have an output named '%s'",
                         store.printStorePath(drvPath),

--- a/src/libstore/path-with-outputs.cc
+++ b/src/libstore/path-with-outputs.cc
@@ -2,6 +2,7 @@
 
 #include "nix/store/path-with-outputs.hh"
 #include "nix/store/store-api.hh"
+#include "nix/util/split.hh"
 #include "nix/util/strings.hh"
 
 namespace nix {
@@ -79,9 +80,9 @@ StorePathWithOutputs::ParseResult StorePathWithOutputs::tryFromDerivedPath(const
 
 std::pair<std::string_view, StringSet> parsePathWithOutputs(std::string_view s)
 {
-    size_t n = s.find("!");
-    return n == s.npos ? std::make_pair(s, StringSet())
-                       : std::make_pair(s.substr(0, n), tokenizeString<StringSet>(s.substr(n + 1), ","));
+    if (auto split = splitOnce(s, '!'))
+        return {split->first, tokenizeString<StringSet>(split->second, ",")};
+    return {s, {}};
 }
 
 StorePathWithOutputs parsePathWithOutputs(const StoreDirConfig & store, std::string_view pathWithOutputs)

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -2,6 +2,7 @@
 #include "nix/store/store-api.hh"
 #include "nix/util/signature/local-keys.hh"
 #include "nix/util/json-utils.hh"
+#include "nix/util/split.hh"
 #include <nlohmann/json.hpp>
 
 namespace nix {
@@ -10,13 +11,13 @@ MakeError(InvalidDerivationOutputId, Error);
 
 DrvOutput DrvOutput::parse(const std::string & strRep)
 {
-    size_t n = strRep.find("!");
-    if (n == strRep.npos)
+    auto split = splitOnce(strRep, '!');
+    if (!split)
         throw InvalidDerivationOutputId("Invalid derivation output id %s", strRep);
 
     return DrvOutput{
-        .drvHash = Hash::parseAnyPrefixed(strRep.substr(0, n)),
-        .outputName = strRep.substr(n + 1),
+        .drvHash = Hash::parseAnyPrefixed(split->first),
+        .outputName = std::string(split->second),
     };
 }
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -23,6 +23,7 @@
 #  include <sys/socket.h>
 #endif
 
+#include <algorithm>
 #include <nlohmann/json.hpp>
 
 namespace nix {
@@ -91,7 +92,7 @@ void RemoteStore::initConnection(Connection & conn)
                 NullSink nullSink;
                 tee.drainInto(nullSink);
             }
-            throw Error("protocol mismatch, got '%s'", chomp(saved.s));
+            throw Error("protocol mismatch, got '%s'", rtrimView(saved.s));
         }
 
         static_cast<WorkerProto::ClientHandshakeInfo &>(conn) = conn.postHandshake(*this);
@@ -464,7 +465,7 @@ void RemoteStore::addMultipleToStore(
         size_t nrTotal = pathsToCopy.size();
         sink << nrTotal;
         // Reverse, so we can release memory at the original start
-        std::reverse(pathsToCopy.begin(), pathsToCopy.end());
+        std::ranges::reverse(pathsToCopy);
         while (!pathsToCopy.empty()) {
             act.progress(nrTotal - pathsToCopy.size(), nrTotal, size_t(1), size_t(0));
 

--- a/src/libstore/store-reference.cc
+++ b/src/libstore/store-reference.cc
@@ -13,10 +13,10 @@ static bool isNonUriPath(const std::string & spec)
 {
     return
         // is not a URL
-        spec.find("://") == std::string::npos
+        !spec.contains("://")
         // Has at least one path separator, and so isn't a single word that
         // might be special like "auto"
-        && spec.find("/") != std::string::npos;
+        && spec.contains("/");
 }
 
 std::string StoreReference::render(bool withParams) const
@@ -175,10 +175,9 @@ std::pair<std::string, StoreReference::Params> splitUriAndParams(const std::stri
 {
     auto uri(uri_);
     StoreReference::Params params;
-    auto q = uri.find('?');
-    if (q != std::string::npos) {
-        params = decodeQuery(uri.substr(q + 1), /*lenient=*/true);
-        uri = uri_.substr(0, q);
+    if (auto split = splitOnce(uri_, '?')) {
+        params = decodeQuery(split->second, /*lenient=*/true);
+        uri.assign(split->first);
     }
     return {uri, params};
 }

--- a/src/libstore/unix/build/darwin-derivation-builder.cc
+++ b/src/libstore/unix/build/darwin-derivation-builder.cc
@@ -178,8 +178,7 @@ struct DarwinDerivationBuilder : DerivationBuilderImpl
 
         /* They don't like trailing slashes on subpath directives */
         std::string globalTmpDirStr = globalTmpDir.native();
-        while (!globalTmpDirStr.empty() && globalTmpDirStr.back() == '/')
-            globalTmpDirStr.pop_back();
+        stripTrailing(globalTmpDirStr, '/');
 
         if (getEnv("_NIX_TEST_NO_SANDBOX") != "1") {
             Strings sandboxArgs;

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -19,7 +19,9 @@
 #include "nix/store/globals.hh"
 #include "nix/store/build/derivation-env-desugar.hh"
 #include "nix/util/terminal.hh"
+#include "nix/util/split.hh"
 
+#include <algorithm>
 #include <queue>
 
 #include <sys/un.h>
@@ -460,7 +462,7 @@ void handleDiffHook(
                 throw ExecError(diffRes.first, "diff-hook program '%1%' %2%", diffHook, statusToString(diffRes.first));
 
             if (diffRes.second != "")
-                printError(chomp(diffRes.second));
+                printError(rtrimView(diffRes.second));
         } catch (Error & error) {
             ErrorInfo ei = error.info();
             // FIXME: wrap errors.
@@ -852,10 +854,11 @@ PathsInChroot DerivationBuilderImpl::getPathsInSandbox()
        host file system. */
     PathsInChroot pathsInChroot = defaultPathsInChroot;
 
-    if (hasPrefix(store.storeDir, tmpDirInSandbox().native())) {
+    auto sandboxBuildDir = tmpDirInSandbox();
+    if (store.storeDir.starts_with(sandboxBuildDir.native())) {
         throw Error("`sandbox-build-dir` must not contain the storeDir");
     }
-    pathsInChroot[tmpDirInSandbox()] = {.source = tmpDir};
+    pathsInChroot[sandboxBuildDir] = {.source = tmpDir};
 
     PathSet allowedPaths = settings.allowedImpureHostPrefixes;
 
@@ -908,11 +911,11 @@ PathsInChroot DerivationBuilderImpl::getPathsInSandbox()
                 if (line == "") {
                     state = stBegin;
                 } else {
-                    auto p = line.find('=');
-                    if (p == std::string::npos)
+                    if (auto split = splitOnce(line, '=')) {
+                        pathsInChroot[std::string(split->first)] = {.source = std::string(split->second)};
+                    } else {
                         pathsInChroot[line] = {.source = line};
-                    else
-                        pathsInChroot[line.substr(0, p)] = {.source = line.substr(p + 1)};
+                    }
                 }
             }
         }
@@ -1007,9 +1010,9 @@ void DerivationBuilderImpl::processSandboxSetupMessages()
                 throw;
             }
         }();
-        if (msg.substr(0, 1) == "\2")
+        if (msg.starts_with('\2'))
             break;
-        if (msg.substr(0, 1) == "\1") {
+        if (msg.starts_with('\1')) {
             FdSource source(builderOut.get());
             auto ex = readError(source);
             ex.addTrace({}, "while setting up the build environment");
@@ -1529,7 +1532,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
             [](auto & sorted) { return sorted; }},
         topoSortResult);
 
-    std::reverse(sortedOutputNames.begin(), sortedOutputNames.end());
+    std::ranges::reverse(sortedOutputNames);
 
     OutputPathMap finalOutputs;
 

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -75,7 +75,7 @@ WorkerProto::BasicClientConnection::processStderrReturn(Sink * sink, Source * so
         }
 
         else if (msg == STDERR_NEXT)
-            printError(chomp(readString(from)));
+            printError(rtrim(readString(from)));
 
         else if (msg == STDERR_START_ACTIVITY) {
             auto act = readNum<ActivityId>(from);

--- a/src/libutil-tests/logging.cc
+++ b/src/libutil-tests/logging.cc
@@ -317,32 +317,26 @@ namespace nix {
 
         const char *teststr = "this is 100%s correct!";
 
-        ASSERT_STREQ(
-            HintFmt(teststr).str().c_str(),
-            teststr);
+        ASSERT_EQ(HintFmt(teststr).str(), teststr);
 
     }
 
     TEST(HintFmt, fmtToHintfmt) {
 
-        ASSERT_STREQ(
-            HintFmt(fmt("the color of this this text is %1%", "not yellow")).str().c_str(),
-            "the color of this this text is not yellow");
+        ASSERT_EQ(HintFmt(fmt("the color of this this text is %1%", "not yellow")).str(), "the color of this this text is not yellow");
 
     }
 
     TEST(HintFmt, tooFewArguments) {
 
-        ASSERT_STREQ(
-            HintFmt("only one arg %1% %2%", "fulfilled").str().c_str(),
-            "only one arg " ANSI_WARNING "fulfilled" ANSI_NORMAL " ");
+        ASSERT_EQ(HintFmt("only one arg %1% %2%", "fulfilled").str(), "only one arg " ANSI_WARNING "fulfilled" ANSI_NORMAL " ");
 
     }
 
     TEST(HintFmt, tooManyArguments) {
 
-        ASSERT_STREQ(
-            HintFmt("what about this %1% %2%", "%3%", "one", "two").str().c_str(),
+        ASSERT_EQ(
+            HintFmt("what about this %1% %2%", "%3%", "one", "two").str(),
             "what about this " ANSI_WARNING "%3%" ANSI_NORMAL " " ANSI_YELLOW "one" ANSI_NORMAL);
 
     }

--- a/src/libutil/base-nix-32.cc
+++ b/src/libutil/base-nix-32.cc
@@ -8,8 +8,8 @@ namespace nix {
 constexpr const std::array<unsigned char, 256> BaseNix32::reverseMap = [] {
     std::array<unsigned char, 256> map{};
 
-    for (size_t i = 0; i < map.size(); ++i)
-        map[i] = invalid; // invalid
+    for (unsigned char & value : map)
+        value = invalid; // invalid
 
     for (unsigned char i = 0; i < 32; ++i)
         map[static_cast<unsigned char>(characters[i])] = i;
@@ -19,7 +19,7 @@ constexpr const std::array<unsigned char, 256> BaseNix32::reverseMap = [] {
 
 std::string BaseNix32::encode(std::span<const std::byte> bs)
 {
-    if (bs.size() == 0)
+    if (bs.empty())
         return {};
 
     size_t len = encodedLength(bs.size());

--- a/src/libutil/canon-path.cc
+++ b/src/libutil/canon-path.cc
@@ -63,7 +63,7 @@ void CanonPath::pop()
 bool CanonPath::isWithin(const CanonPath & parent) const
 {
     return !(
-        path.size() < parent.path.size() || path.substr(0, parent.path.size()) != parent.path
+        path.size() < parent.path.size() || !path.starts_with(parent.path)
         || (parent.path.size() > 1 && path.size() > parent.path.size() && path[parent.path.size()] != '/'));
 }
 

--- a/src/libutil/configuration.cc
+++ b/src/libutil/configuration.cc
@@ -24,7 +24,7 @@ bool Config::set(const std::string & name, const std::string & value)
     bool append = false;
     auto i = _settings.find(name);
     if (i == _settings.end()) {
-        if (hasPrefix(name, "extra-")) {
+        if (name.starts_with("extra-")) {
             i = _settings.find(std::string(name, 6));
             if (i == _settings.end() || !i->second.setting->isAppendable())
                 return false;

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -3,6 +3,7 @@
 #include "nix/util/error.hh"
 #include "nix/util/environment-variables.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/split.hh"
 #include "nix/util/terminal.hh"
 #include "nix/util/position.hh"
 
@@ -104,14 +105,15 @@ static std::string indent(std::string_view indentFirst, std::string_view indentR
     bool first = true;
 
     while (!s.empty()) {
-        auto end = s.find('\n');
         if (!first)
             res += "\n";
-        res += chomp(std::string(first ? indentFirst : indentRest) + std::string(s.substr(0, end)));
+        auto split = splitOnce(s, '\n');
+        auto line = split ? split->first : s;
+        res += rtrim(std::string(first ? indentFirst : indentRest) + std::string(line));
         first = false;
-        if (end == s.npos)
+        if (!split)
             break;
-        s = s.substr(end + 1);
+        s = split->second;
     }
 
     return res;
@@ -411,7 +413,7 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
         oss << "Did you mean " << suggestions.trim() << "?" << std::endl;
     }
 
-    out << indent(prefix, std::string(filterANSIEscapes(prefix, true).size(), ' '), chomp(oss.str()));
+    out << indent(prefix, std::string(filterANSIEscapes(prefix, true).size(), ' '), rtrim(oss.str()));
 
     return out;
 }

--- a/src/libutil/hilite.cc
+++ b/src/libutil/hilite.cc
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "nix/util/hilite.hh"
 
 namespace nix {
@@ -6,11 +8,10 @@ std::string
 hiliteMatches(std::string_view s, std::vector<std::smatch> matches, std::string_view prefix, std::string_view postfix)
 {
     // Avoid extra work on zero matches
-    if (matches.size() == 0)
+    if (matches.empty())
         return std::string(s);
 
-    std::sort(
-        matches.begin(), matches.end(), [](const auto & a, const auto & b) { return a.position() < b.position(); });
+    std::ranges::sort(matches, [](const auto & a, const auto & b) { return a.position() < b.position(); });
 
     std::string out;
     ssize_t last_end = 0;

--- a/src/libutil/include/nix/util/ascii.hh
+++ b/src/libutil/include/nix/util/ascii.hh
@@ -1,0 +1,23 @@
+#pragma once
+
+///@file
+
+namespace nix {
+
+/**
+ * @return true iff `c` is an ASCII letter (`A-Z` or `a-z`).
+ */
+constexpr bool isAsciiAlpha(char c)
+{
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+/**
+ * @return true iff `c` is an ASCII digit (`0-9`).
+ */
+constexpr bool isAsciiDigit(char c)
+{
+    return c >= '0' && c <= '9';
+}
+
+} // namespace nix

--- a/src/libutil/include/nix/util/file-path-impl.hh
+++ b/src/libutil/include/nix/util/file-path-impl.hh
@@ -8,6 +8,8 @@
 #include <string>
 #include <string_view>
 
+#include "nix/util/ascii.hh"
+
 namespace nix {
 
 /**
@@ -93,7 +95,7 @@ struct WindowsPathTrait
     {
         if (path.size() >= 2 && path[1] == ':') {
             char driveLetter = path[0];
-            if ((driveLetter >= 'A' && driveLetter <= 'Z') || (driveLetter >= 'a' && driveLetter <= 'z'))
+            if (isAsciiAlpha(driveLetter))
                 return 2;
         }
         /* TODO: This needs to also handle UNC paths.

--- a/src/libutil/include/nix/util/split.hh
+++ b/src/libutil/include/nix/util/split.hh
@@ -3,10 +3,30 @@
 
 #include <optional>
 #include <string_view>
-
-#include "nix/util/util.hh"
+#include <utility>
 
 namespace nix {
+
+/**
+ * Split a string once on a single-character separator.
+ *
+ * If `separator` is found, returns `{prefix, suffix}` where `suffix` is the
+ * part after the separator. Otherwise returns `std::nullopt`.
+ */
+static inline std::optional<std::pair<std::string_view, std::string_view>>
+splitOnce(std::string_view string, char separator)
+{
+    auto sepInstance = string.find(separator);
+
+    if (sepInstance != std::string_view::npos) {
+        return std::pair{
+            string.substr(0, sepInstance),
+            string.substr(sepInstance + 1),
+        };
+    }
+
+    return std::nullopt;
+}
 
 /**
  * If `separator` is found, we return the portion of the string before the
@@ -29,7 +49,7 @@ static inline std::optional<std::string_view> splitPrefixTo(std::string_view & s
 
 static inline bool splitPrefix(std::string_view & string, std::string_view prefix)
 {
-    bool res = hasPrefix(string, prefix);
+    bool res = string.starts_with(prefix);
     if (res)
         string.remove_prefix(prefix.length());
     return res;

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -4,6 +4,7 @@
 #include "nix/util/types.hh"
 #include "nix/util/error.hh"
 #include "nix/util/logging.hh"
+#include "nix/util/ascii.hh"
 #include "nix/util/strings.hh"
 
 #include <filesystem>
@@ -66,11 +67,34 @@ inline Strings quoteFSPaths(const std::set<std::filesystem::path> & paths, char 
 }
 
 /**
- * Remove trailing whitespace from a string.
- *
- * \todo return std::string_view.
+ * Remove trailing whitespace from a string, returning a new string.
+ */
+std::string rtrim(std::string_view s, std::string_view whitespace = " \n\r\t");
+
+/**
+ * Deprecated alias for `rtrim`.
  */
 std::string chomp(std::string_view s);
+
+/**
+ * Remove leading whitespace from a string, returning a new string.
+ */
+std::string ltrim(std::string_view s, std::string_view whitespace = " \n\r\t");
+
+/**
+ * Remove trailing whitespace from a string view, returning a view of the original.
+ */
+std::string_view rtrimView(std::string_view s, std::string_view whitespace = " \n\r\t");
+
+/**
+ * Remove leading whitespace from a string view, returning a view of the original.
+ */
+std::string_view ltrimView(std::string_view s, std::string_view whitespace = " \n\r\t");
+
+/**
+ * Remove leading and trailing whitespace from a string view, returning a view of the original.
+ */
+std::string_view trimView(std::string_view s, std::string_view whitespace = " \n\r\t");
 
 /**
  * Remove whitespace from the start and end of a string.
@@ -182,14 +206,40 @@ T readLittleEndian(unsigned char * p)
 }
 
 /**
- * @return true iff `s` starts with `prefix`.
+ * Remove a prefix from a string in-place.
+ *
+ * @return true iff the prefix was present and removed.
  */
-bool hasPrefix(std::string_view s, std::string_view prefix);
+bool stripPrefix(std::string & s, std::string_view prefix);
 
 /**
- * @return true iff `s` ends in `suffix`.
+ * Remove a prefix from a string_view in-place (by shrinking it).
+ *
+ * @return true iff the prefix was present and removed.
  */
-bool hasSuffix(std::string_view s, std::string_view suffix);
+bool stripPrefix(std::string_view & s, std::string_view prefix);
+
+/**
+ * Remove a suffix from a string in-place.
+ *
+ * @return true iff the suffix was present and removed.
+ */
+bool stripSuffix(std::string & s, std::string_view suffix);
+
+/**
+ * Remove a suffix from a string_view in-place (by shrinking it).
+ *
+ * @return true iff the suffix was present and removed.
+ */
+bool stripSuffix(std::string_view & s, std::string_view suffix);
+
+/**
+ * Strip repeated trailing characters.
+ *
+ * The string_view overload returns a view of the original.
+ */
+std::string_view stripTrailing(std::string_view s, char c);
+void stripTrailing(std::string & s, char c);
 
 /**
  * Convert a string to lower case.
@@ -352,16 +402,6 @@ std::optional<typename T::value_type> pop(T & c)
     auto v = std::move(c.front());
     c.pop();
     return v;
-}
-
-/**
- * Append items to a container. TODO: remove this once we can use
- * C++23's `append_range()`.
- */
-template<class C, typename T>
-void append(C & c, std::initializer_list<T> l)
-{
-    c.insert(c.end(), l.begin(), l.end());
 }
 
 template<typename T>

--- a/src/libutil/linux/cgroup.cc
+++ b/src/libutil/linux/cgroup.cc
@@ -42,7 +42,7 @@ StringMap getCgroups(const std::filesystem::path & cgroupFile)
         if (!std::regex_match(line, match, regex))
             throw Error("invalid line '%s' in '%s'", line, cgroupFile);
 
-        std::string name = hasPrefix(std::string(match[2]), "name=") ? std::string(match[2], 5) : match[2];
+        std::string name = std::string(match[2]).starts_with("name=") ? std::string(match[2], 5) : match[2];
         cgroups.insert_or_assign(name, match[3]);
     }
 
@@ -58,14 +58,14 @@ CgroupStats getCgroupStats(const std::filesystem::path & cgroup)
     if (pathExists(cpustatPath)) {
         for (auto & line : tokenizeString<std::vector<std::string>>(readFile(cpustatPath), "\n")) {
             std::string_view userPrefix = "user_usec ";
-            if (hasPrefix(line, userPrefix)) {
+            if (line.starts_with(userPrefix)) {
                 auto n = string2Int<uint64_t>(line.substr(userPrefix.size()));
                 if (n)
                     stats.cpuUser = std::chrono::microseconds(*n);
             }
 
             std::string_view systemPrefix = "system_usec ";
-            if (hasPrefix(line, systemPrefix)) {
+            if (line.starts_with(systemPrefix)) {
                 auto n = string2Int<uint64_t>(line.substr(systemPrefix.size()));
                 if (n)
                     stats.cpuSystem = std::chrono::microseconds(*n);

--- a/src/libutil/signature/local-keys.cc
+++ b/src/libutil/signature/local-keys.cc
@@ -2,6 +2,7 @@
 
 #include "nix/util/file-system.hh"
 #include "nix/util/base-n.hh"
+#include "nix/util/split.hh"
 #include "nix/util/util.hh"
 #include <sodium.h>
 
@@ -9,10 +10,10 @@ namespace nix {
 
 BorrowedCryptoValue BorrowedCryptoValue::parse(std::string_view s)
 {
-    size_t colon = s.find(':');
-    if (colon == std::string::npos || colon == 0)
+    auto split = splitOnce(s, ':');
+    if (!split || split->first.empty())
         return {"", ""};
-    return {s.substr(0, colon), s.substr(colon + 1)};
+    return {split->first, split->second};
 }
 
 Key::Key(std::string_view s, bool sensitiveValue)

--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -86,7 +86,7 @@ bindConnectProcHelper(std::string_view operationName, auto && operation, Socket 
             }
         });
         pipe.writeSide.close();
-        auto errNo = string2Int<int>(chomp(drainFD(pipe.readSide.get())));
+        auto errNo = string2Int<int>(rtrimView(drainFD(pipe.readSide.get())));
         if (!errNo || *errNo == -1)
             throw Error("cannot %s to socket at '%s'", operationName, path);
         else if (*errNo > 0) {

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -415,9 +415,9 @@ ParsedUrlScheme parseUrlScheme(std::string_view scheme)
 ParsedURL fixGitURL(std::string url)
 {
     std::regex scpRegex("([^/]*)@(.*):(.*)");
-    if (!hasPrefix(url, "/") && std::regex_match(url, scpRegex))
+    if (!url.starts_with("/") && std::regex_match(url, scpRegex))
         url = std::regex_replace(url, scpRegex, "ssh://$1@$2/$3");
-    if (!hasPrefix(url, "file:") && !hasPrefix(url, "git+file:") && url.find("://") == std::string::npos)
+    if (!url.starts_with("file:") && !url.starts_with("git+file:") && url.find("://") == std::string::npos)
         return ParsedURL{
             .scheme = "file",
             .authority = ParsedURL::Authority{},

--- a/src/libutil/windows/file-path.cc
+++ b/src/libutil/windows/file-path.cc
@@ -11,8 +11,7 @@ namespace nix {
 
 std::optional<std::filesystem::path> maybePath(PathView path)
 {
-    if (path.length() >= 3 && (('A' <= path[0] && path[0] <= 'Z') || ('a' <= path[0] && path[0] <= 'z'))
-        && path[1] == ':' && WindowsPathTrait<char>::isPathSep(path[2])) {
+    if (path.length() >= 3 && isAsciiAlpha(path[0]) && path[1] == ':' && WindowsPathTrait<char>::isPathSep(path[2])) {
         std::filesystem::path::string_type sw = string_to_os_string(std::string{"\\\\?\\"} + path);
         std::replace(sw.begin(), sw.end(), '/', '\\');
         return sw;

--- a/src/libutil/windows/processes.cc
+++ b/src/libutil/windows/processes.cc
@@ -103,7 +103,7 @@ std::optional<Path> getProgramInterpreter(const Path & program)
     // These extensions are automatically handled by Windows and don't require an interpreter.
     static constexpr const char * exts[] = {".exe", ".cmd", ".bat"};
     for (const auto ext : exts) {
-        if (hasSuffix(program, ext)) {
+        if (program.ends_with(ext)) {
             return {};
         }
     }

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <algorithm>
@@ -31,7 +32,7 @@ static void handleAlarm(int sig) {}
 
 std::string escapeUri(std::string uri)
 {
-    std::replace(uri.begin(), uri.end(), '/', '_');
+    std::ranges::replace(uri, '/', '_');
     return uri;
 }
 
@@ -237,7 +238,7 @@ static int main_build_remote(int argc, char ** argv)
                     sshStore = bestMachine->openStore();
                     sshStore->connect();
                 } catch (std::exception & e) {
-                    auto msg = chomp(drainFD(5, false));
+                    auto msg = rtrim(drainFD(5, false));
                     printError("cannot build on '%s': %s%s", storeUri, e.what(), msg.empty() ? "" : ": " + msg);
                     bestMachine->enabled = false;
                     continue;

--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -122,7 +122,8 @@ struct CmdConfigCheck : StoreCommand
                     return true;
                 };
 
-                if (store->isStorePath(userEnv.string()) && hasSuffix(userEnv.string(), "user-environment")) {
+                auto userEnvStr = userEnv.string();
+                if (store->isStorePath(userEnvStr) && userEnvStr.ends_with("user-environment")) {
                     while (noContainsProfiles() && std::filesystem::is_symlink(profileDir))
                         profileDir = std::filesystem::weakly_canonical(
                             profileDir.parent_path() / std::filesystem::read_symlink(profileDir));

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -13,6 +13,7 @@
 #  include "run.hh"
 #endif
 
+#include <algorithm>
 #include <iterator>
 #include <memory>
 #include <sstream>
@@ -203,7 +204,7 @@ struct BuildEnvironment
             return *arr;
         } else if (auto assoc = std::get_if<Associative>(&value)) {
             Array assocKeys;
-            std::for_each(assoc->begin(), assoc->end(), [&](auto & n) { assocKeys.push_back(n.first); });
+            std::ranges::for_each(*assoc, [&](const auto & n) { assocKeys.push_back(n.first); });
             return assocKeys;
         } else
             throw Error("bash variable is not a string or array");
@@ -480,7 +481,7 @@ struct Common : InstallableCommand, MixProfile
     StorePath getShellOutPath(ref<Store> store, ref<Installable> installable)
     {
         auto path = installable->getStorePath();
-        if (path && hasSuffix(path->to_string(), "-env"))
+        if (path && path->to_string().ends_with("-env"))
             return *path;
         else {
             auto drvs = Installable::toDerivations(store, {installable});

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -380,7 +380,7 @@ struct CmdFlakeCheck : FlakeCommand
 
         auto argHasName = [&](Symbol arg, std::string_view expected) {
             std::string_view name = state->symbols[arg];
-            return name == expected || name == "_" || (hasPrefix(name, "_") && name.substr(1) == expected);
+            return name == expected || name == "_" || (name.starts_with("_") && name.substr(1) == expected);
         };
 
         auto checkSystemName = [&](std::string_view system, const PosIdx pos) {
@@ -921,11 +921,11 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
                 else if (st.type == SourceAccessor::tRegular) {
                     auto contents = from2.readFile();
                     if (std::filesystem::exists(to_st)) {
-                        auto contents2 = readFile(to2.string());
+                        auto contents2 = readFile(to2);
                         if (contents != contents2) {
                             printError(
                                 "refusing to overwrite existing file '%s'\n please merge it manually with '%s'",
-                                to2.string(),
+                                to2,
                                 from2);
                             conflictedFiles.push_back(to2);
                         } else {
@@ -940,7 +940,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
                         if (std::filesystem::read_symlink(to2) != target) {
                             printError(
                                 "refusing to overwrite existing file '%s'\n please merge it manually with '%s'",
-                                to2.string(),
+                                to2,
                                 from2);
                             conflictedFiles.push_back(to2);
                         } else {
@@ -1292,7 +1292,7 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                     }
                 };
 
-                if (attrPath.size() == 0
+                if (attrPath.empty()
                     || (attrPath.size() == 1
                         && (attrPathS[0] == "defaultPackage" || attrPathS[0] == "devShell"
                             || attrPathS[0] == "formatter" || attrPathS[0] == "nixosConfigurations"

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -185,7 +186,7 @@ static void main_nix_build(int argc, char ** argv)
                     savedArgs.push_back(argv[i]);
                 args.clear();
                 for (auto line : lines) {
-                    line = chomp(line);
+                    line = rtrim(line);
                     std::smatch match;
                     if (std::regex_match(line, match, std::regex("^#!\\s*nix-shell\\s+(.*)$")))
                         for (const auto & word : shellwords({match[1].first, match[1].second}))
@@ -387,7 +388,7 @@ static void main_nix_build(int argc, char ** argv)
                 } catch (Error & e) {
                 };
                 auto [path, outputNames] = parsePathWithOutputs(absolute);
-                if (evalStore->isStorePath(path) && hasSuffix(path, ".drv"))
+                if (evalStore->isStorePath(path) && path.ends_with(".drv"))
                     drvs.push_back(PackageInfo(*state, evalStore, absolute));
                 else {
                     /* If we're in a #! script, interpret filenames
@@ -509,7 +510,7 @@ static void main_nix_build(int argc, char ** argv)
             // To get around lambda capturing restrictions in the
             // standard.
             const auto & inputDrv = inputDrv0;
-            if (std::all_of(envExclude.cbegin(), envExclude.cend(), [&](const std::string & exclude) {
+            if (std::ranges::all_of(envExclude, [&](const std::string & exclude) {
                     return !std::regex_search(store->printStorePath(inputDrv), std::regex(exclude));
                 })) {
                 accumDerivedPath(makeConstantStorePathRef(inputDrv), inputNode);

--- a/src/nix/nix-channel/nix-channel.cc
+++ b/src/nix/nix-channel/nix-channel.cc
@@ -6,6 +6,7 @@
 #include "nix/cmd/legacy.hh"
 #include "nix/cmd/common-eval-args.hh"
 #include "nix/expr/eval-settings.hh" // for defexpr
+#include "nix/util/util.hh"
 #include "nix/util/users.hh"
 #include "nix/fetchers/tarball.hh"
 #include "nix/fetchers/fetch-settings.hh"
@@ -15,6 +16,7 @@
 #include <fcntl.h>
 #include <regex>
 #include <pwd.h>
+#include <string_view>
 
 using namespace nix;
 
@@ -210,7 +212,7 @@ static int main_nix_channel(int argc, char ** argv)
             } else if (*arg == "--rollback") {
                 cmd = cRollback;
             } else {
-                if (hasPrefix(*arg, "-"))
+                if (arg->starts_with("-"))
                     throw UsageError("unsupported argument '%s'", *arg);
                 args.push_back(std::move(*arg));
             }
@@ -230,8 +232,8 @@ static int main_nix_channel(int argc, char ** argv)
                     name = args[1];
                 } else {
                     name = baseNameOf(url);
-                    name = std::regex_replace(name, std::regex("-unstable$"), "");
-                    name = std::regex_replace(name, std::regex("-stable$"), "");
+                    stripSuffix(name, "-unstable");
+                    stripSuffix(name, "-stable");
                 }
                 addChannel(url, name);
             }

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -24,8 +24,10 @@
 #  include "nix/store/posix-fs-canonicalise.hh"
 #endif
 
+#include <algorithm>
 #include <iostream>
 #include <algorithm>
+#include <ranges>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -291,7 +293,7 @@ printTree(const StorePath & path, const std::string & firstPad, const std::strin
        input of B, then A is printed first.  This has the effect of
        flattening the tree, preventing deeply nested structures.  */
     auto sorted = store->topoSortPaths(info->references);
-    reverse(sorted.begin(), sorted.end());
+    std::ranges::reverse(sorted);
 
     for (const auto & [n, i] : enumerate(sorted)) {
         bool last = n + 1 == sorted.size();
@@ -343,7 +345,7 @@ static void opQuery(Strings opFlags, Strings opArgs)
         else if (i == "--valid-derivers")
             query = qValidDerivers;
         else if (i == "--binding" || i == "-b") {
-            if (opArgs.size() == 0)
+            if (opArgs.empty())
                 throw UsageError("expected binding name");
             bindingName = opArgs.front();
             opArgs.pop_front();
@@ -413,8 +415,8 @@ static void opQuery(Strings opFlags, Strings opArgs)
             }
         }
         auto sorted = store->topoSortPaths(paths);
-        for (StorePaths::reverse_iterator i = sorted.rbegin(); i != sorted.rend(); ++i)
-            cout << fmt("%s\n", store->printStorePath(*i));
+        for (auto & i : std::ranges::reverse_view(sorted))
+            cout << fmt("%s\n", store->printStorePath(i));
         break;
     }
 
@@ -434,8 +436,8 @@ static void opQuery(Strings opFlags, Strings opArgs)
             }
         }
         auto sorted = store->topoSortPaths(result);
-        for (StorePaths::reverse_iterator i = sorted.rbegin(); i != sorted.rend(); ++i)
-            cout << fmt("%s\n", store->printStorePath(*i));
+        for (auto & i : std::ranges::reverse_view(sorted))
+            cout << fmt("%s\n", store->printStorePath(i));
         break;
     }
 

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -519,7 +519,7 @@ struct StorePathMatcher final : public Matcher
 
     bool matches(const std::string & name, const ProfileElement & element) override
     {
-        return element.storePaths.count(storePath);
+        return element.storePaths.contains(storePath);
     }
 };
 

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -12,6 +12,7 @@
 #include "nix/util/hilite.hh"
 #include "nix/util/strings-inline.hh"
 
+#include <algorithm>
 #include <regex>
 #include <fstream>
 #include <nlohmann/json.hpp>
@@ -113,7 +114,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
                     auto aMeta = cursor.maybeGetAttr(state->s.meta);
                     auto aDescription = aMeta ? aMeta->maybeGetAttr(state->s.description) : nullptr;
                     auto description = aDescription ? aDescription->getString() : "";
-                    std::replace(description.begin(), description.end(), '\n', ' ');
+                    std::ranges::replace(description, '\n', ' ');
 
                     std::vector<std::smatch> attrPathMatches;
                     std::vector<std::smatch> descriptionMatches;
@@ -167,7 +168,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
                 }
 
                 else if (
-                    attrPath.size() == 0 || (attrPathS[0] == "legacyPackages" && attrPath.size() <= 2)
+                    attrPath.empty() || (attrPathS[0] == "legacyPackages" && attrPath.size() <= 2)
                     || (attrPathS[0] == "packages" && attrPath.size() <= 2))
                     recurse();
 

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -177,14 +177,14 @@ static bool matchUser(std::string_view user, const struct group & gr)
 static bool
 matchUser(const std::optional<std::string> & user, const std::optional<std::string> & group, const Strings & users)
 {
-    if (find(users.begin(), users.end(), "*") != users.end())
+    if (std::ranges::find(users, "*") != users.end())
         return true;
 
-    if (user && find(users.begin(), users.end(), *user) != users.end())
+    if (user && std::ranges::find(users, *user) != users.end())
         return true;
 
     for (auto & i : users)
-        if (i.substr(0, 1) == "@") {
+        if (i.starts_with("@")) {
             if (group && *group == i.substr(1))
                 return true;
             struct group * gr = getgrnam(i.c_str() + 1);

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -122,7 +122,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 
         printInfo("found Nix in %s", where);
 
-        if (hasPrefix(where.string(), "/run/current-system"))
+        if (where.string().starts_with("/run/current-system"))
             throw Error("Nix on NixOS must be upgraded via 'nixos-rebuild'");
 
         auto profileDir = where.parent_path();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The new string utils replace many common patterns. Utils like hasPrefix/hasSuffix were removed in favor of idiomatic C++ methods. This serves as the base for the upcoming regex related PRs https://github.com/Zaczero/nix/commits/zaczero/scratchpad/

https://github.com/NixOS/nix/issues/14876

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
