### PR TITLE
Remove regex from verifyCommit and fix matching

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -42,7 +42,6 @@
 #include <boost/unordered/unordered_flat_set.hpp>
 #include <iostream>
 #include <queue>
-#include <regex>
 #include <span>
 #include <ranges>
 
@@ -629,6 +628,9 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
     void verifyCommit(const Hash & rev, const std::vector<fetchers::PublicKey> & publicKeys) override
     {
+        if (publicKeys.empty())
+            throw Error("Commit signature verification on commit %s failed: publicKeys is empty", rev.gitRev());
+
         // Map of SSH key types to their internal OpenSSH representations
         static const boost::unordered_flat_map<std::string_view, std::string_view> keyTypeMap = {
             {"ssh-dsa", "ssh-dsa"},
@@ -679,9 +681,13 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
            because the git command might also succeed due to the
            commit being signed by gpg keys that are present in the
            users key agent. */
-        std::string re = R"(Good "git" signature for \* with .* key SHA256:[)";
+
+        if (status != 0)
+            throw Error("Commit signature verification on commit %s failed: %s", rev.gitRev(), output);
+
+        bool fingerprintFound = false;
         for (const fetchers::PublicKey & k : publicKeys) {
-            // Calculate sha256 fingerprint from public key and escape the regex symbol '+' to match the key literally
+            // Calculate sha256 fingerprint from public key and match it literally in output.
             std::string keyDecoded;
             try {
                 keyDecoded = base64::decode(k.key);
@@ -691,14 +697,16 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
             }
             auto fingerprint =
                 trim(hashString(HashAlgorithm::SHA256, keyDecoded).to_string(nix::HashFormat::Base64, false), "=");
-            auto escaped_fingerprint = std::regex_replace(fingerprint, std::regex("\\+"), "\\+");
-            re += "(" + escaped_fingerprint + ")";
+            if (output.contains(std::string("SHA256:") + fingerprint)) {
+                fingerprintFound = true;
+                break;
+            }
         }
-        re += "]";
-        if (status == 0 && std::regex_search(output, std::regex(re)))
-            printTalkative("Signature verification on commit %s succeeded.", rev.gitRev());
-        else
+
+        if (!fingerprintFound)
             throw Error("Commit signature verification on commit %s failed: %s", rev.gitRev(), output);
+
+        printTalkative("Signature verification on commit %s succeeded.", rev.gitRev());
     }
 
     Hash treeHashToNarHash(const fetchers::Settings & settings, const Hash & treeHash) override


### PR DESCRIPTION
I think the original regex solution was broken

SHA256:[(123)|(456)]

would match strings like

SHA256:100

I'm unsure whether not checking for `Good "git" signature for` is okay but it seems like it is? Using the human readable output does not seem like a good practice anyway, ideally it would use --raw output but that's too much to change I guess.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
