### PR TITLE
Switch to boost::regex in parseLsRemoteLine

### DIFF
--- a/src/libutil/git.cc
+++ b/src/libutil/git.cc
@@ -1,8 +1,9 @@
+#include <algorithm>
 #include <cerrno>
 #include <algorithm>
 #include <vector>
 #include <map>
-#include <regex>
+#include <boost/regex.hpp>
 #include <strings.h> // for strcasecmp
 
 #include "nix/util/signals.hh"
@@ -147,7 +148,7 @@ void parseTree(
         }
 
         Hash hash(hashAlgo);
-        std::copy(hashs.begin(), hashs.end(), hash.hash);
+        std::ranges::copy(hashs, hash.hash);
 
         hook(
             CanonPath{name},
@@ -341,15 +342,18 @@ TreeEntry dumpHash(HashAlgorithm ha, const SourcePath & path, PathFilter & filte
 
 std::optional<LsRemoteRefLine> parseLsRemoteLine(std::string_view line)
 {
-    const static std::regex line_regex("^(ref: *)?([^\\s]+)(?:\\t+(.*))?$");
-    std::match_results<std::string_view::const_iterator> match;
-    if (!std::regex_match(line.cbegin(), line.cend(), match, line_regex))
+    static const auto lineRegex = boost::regex("^(ref: *)?([^\\s]+)(?:\\t+(.*))?$", boost::regex_constants::optimize);
+
+    boost::match_results<std::string_view::const_iterator> match;
+    if (!boost::regex_match(line.begin(), line.end(), match, lineRegex))
         return std::nullopt;
 
     return LsRemoteRefLine{
         .kind = match[1].length() == 0 ? LsRemoteRefLine::Kind::Object : LsRemoteRefLine::Kind::Symbolic,
-        .target = match[2],
-        .reference = match[3].length() == 0 ? std::nullopt : std::optional<std::string>{match[3]}};
+        .target = std::string(match[2].first, match[2].second),
+        .reference = match[3].length() == 0 ? std::nullopt
+                                            : std::optional<std::string>{std::string(match[3].first, match[3].second)},
+    };
 }
 
 } // namespace nix::git


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
