### PR TITLE
Switch to boost::regex in RootArgs::parseCmdline

### DIFF
--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -8,7 +8,7 @@
 
 #include <fstream>
 #include <string>
-#include <regex>
+#include <boost/regex.hpp>
 #ifndef _WIN32
 #  include <glob.h>
 #endif
@@ -301,10 +301,13 @@ void RootArgs::parseCmdline(const Strings & _cmdline, bool allowShebang)
                 while (std::getline(stream, line) && !line.empty() && commentChars.find(line[0]) != std::string::npos) {
                     line = chomp(line);
 
-                    std::smatch match;
+                    static const auto nixLineRegex =
+                        boost::regex("^#!\\s*nix(:? |$)(.*)$", boost::regex_constants::optimize);
+
+                    boost::smatch match;
                     // We match one space after `nix` so that we preserve indentation.
                     // No space is necessary for an empty line. An empty line has basically no effect.
-                    if (std::regex_match(line, match, std::regex("^#!\\s*nix(:? |$)(.*)$")))
+                    if (boost::regex_match(line, match, nixLineRegex))
                         shebangContent += std::string_view{match[2].first, match[2].second} + "\n";
                 }
                 for (const auto & word : parseShebangContent(shebangContent)) {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
