### PR TITLE
C API: Add query_path_info_json to Store API

### DIFF
--- a/doc/manual/rl-next/c-api-new-store-methods.md
+++ b/doc/manual/rl-next/c-api-new-store-methods.md
@@ -6,3 +6,4 @@ prs: [14766]
 The C API now includes additional methods:
 
 - `nix_store_query_path_from_hash_part()` - Get the full store path given its hash part
+- `nix_store_query_path_info_json()` - Get the JSON representation of a path's info.

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -270,6 +270,24 @@ nix_derivation * nix_store_drv_from_store_path(nix_c_context * context, Store * 
  */
 StorePath * nix_store_query_path_from_hash_part(nix_c_context * context, Store * store, const char * hash);
 
+/**
+ * @brief Queries for the nix store path info as JSON.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] store nix store reference
+ * @param[in] store_path A store path
+ * @param[in] format The JSON format version to use
+ * @param[in] userdata The data to pass to the callback
+ * @param[in] callback Called for when the path info is resolved
+ */
+nix_err nix_store_query_path_info_json(
+    nix_c_context * context,
+    Store * store,
+    const StorePath * store_path,
+    unsigned int format,
+    nix_get_string_callback callback,
+    void * userdata);
+
 // cffi end
 #ifdef __cplusplus
 }

--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -532,6 +532,16 @@ TEST_F(nix_api_store_test_base, nix_store_realise_builder_no_output)
     nix_store_free(store);
 }
 
+TEST_F(NixApiStoreTestWithRealisedPath, nix_store_query_path_info_json)
+{
+    std::string pathInfoJson;
+    auto ret = nix_store_query_path_info_json(ctx, store, outPath, 2, OBSERVE_STRING(pathInfoJson));
+    assert_ctx_ok();
+    ASSERT_EQ(NIX_OK, ret);
+    // JSON should be non-empty string
+    ASSERT_TRUE(pathInfoJson.size() > 0);
+}
+
 TEST_F(NixApiStoreTestWithRealisedPath, nix_store_get_fs_closure_with_outputs)
 {
     // Test closure computation with include_outputs on a derivation path


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Adds `nix_store_query_path_info_json` to C store API. With https://github.com/NixOS/nix/pull/14766, this API allows implementing a minimal HTTP Binary Cache (in the style of nix-serve) without forking so many commands.

## Context

This API is nearly directly picked from https://github.com/NixOS/nix/pull/14031, since that PR seems to have stalled after being partially merged with https://github.com/NixOS/nix/pull/14555. There are a few modifications:
- Renamed `nix_store_query_path_info` -> `nix_store_query_path_info_json` : Since once nix format is matured, we could theoretically implement the former over shared struct rather than JSON. This also follows several other C APIs which use `_json` suffix.
- Added `format` parameter to be compatible with recent changes.
- Added test



<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
