### PR TITLE
libutil-tests: fix openFileEnsureBeneathNoSymlinks.works on cygwin

### DIFF
--- a/src/libutil-tests/unix/file-descriptor.cc
+++ b/src/libutil-tests/unix/file-descriptor.cc
@@ -64,9 +64,12 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
     EXPECT_THROW(open("a/absolute_symlink/c/d", O_RDONLY), SymlinkNotAllowed);
     EXPECT_THROW(open("a/relative_symlink/c", O_RDONLY), SymlinkNotAllowed);
     EXPECT_THROW(open("a/b/c/d", O_RDONLY), SymlinkNotAllowed);
+#ifndef __CYGWIN__
+    // this returns ELOOP on cygwin when O_NOFOLLOW is used
     EXPECT_EQ(open("a/broken_symlink", O_CREAT | O_WRONLY | O_EXCL, 0666), INVALID_DESCRIPTOR);
     /* Sanity check, no symlink shenanigans and behaves the same as regular openat with O_EXCL | O_CREAT. */
     EXPECT_EQ(errno, EEXIST);
+#endif
     EXPECT_THROW(open("a/absolute_symlink/broken_symlink", O_CREAT | O_WRONLY | O_EXCL, 0666), SymlinkNotAllowed);
     EXPECT_EQ(open("c/d/regular/a", O_RDONLY), INVALID_DESCRIPTOR);
     EXPECT_EQ(open("c/d/regular", O_RDONLY | O_DIRECTORY), INVALID_DESCRIPTOR);


### PR DESCRIPTION
## Motivation

This fixes a test failure I get on cygwin.

## Context


```
[----------] 1 test from openFileEnsureBeneathNoSymlinks
[ RUN      ] openFileEnsureBeneathNoSymlinks.works
unknown file: Failure
C++ exception with description "error: relative path 'a/broken_symlink' points to a symlink, which is not allowed" thrown in the test body.

[  FAILED  ] openFileEnsureBeneathNoSymlinks.works (12 ms)
[----------] 1 test from openFileEnsureBeneathNoSymlinks (12 ms total)
```

> EEXIST
>    pathname already exists and O_CREAT and O_EXCL were used. 

> ELOOP
>    Too many symbolic links were encountered in resolving pathname, or O_NOFOLLOW was specified but pathname was a symbolic link. 

If I understand correctly, both of these conditions are true, so maybe cygwin isn't actually doing anything wrong?  If so, we could check for both codes, but the fact that ELOOP gets turned into an exception makes that a little ugly.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
