### PR TITLE
SourceAccessor: Allow the lstat cache to be invalidated

### DIFF
--- a/src/libfetchers/filtering-source-accessor.cc
+++ b/src/libfetchers/filtering-source-accessor.cc
@@ -61,6 +61,11 @@ std::pair<CanonPath, std::optional<std::string>> FilteringSourceAccessor::getFin
     return next->getFingerprint(prefix / path);
 }
 
+void FilteringSourceAccessor::invalidateCache(const CanonPath & path)
+{
+    next->invalidateCache(prefix / path);
+}
+
 void FilteringSourceAccessor::checkAccess(const CanonPath & path)
 {
     if (!isAllowed(path))

--- a/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
+++ b/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
@@ -52,6 +52,8 @@ struct FilteringSourceAccessor : SourceAccessor
 
     std::pair<CanonPath, std::optional<std::string>> getFingerprint(const CanonPath & path) override;
 
+    void invalidateCache(const CanonPath & path) override;
+
     /**
      * Call `makeNotAllowedError` to throw a `RestrictedPathError`
      * exception if `isAllowed()` returns `false` for `path`.

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -876,6 +876,8 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
                                 CanonPath((topRef.subdir == "" ? "" : topRef.subdir + "/") + "flake.lock"),
                                 newLockFileS,
                                 commitMessage);
+
+                            flake.lockFilePath().invalidateCache();
                         }
 
                         /* Rewriting the lockfile changed the top-level

--- a/src/libutil/include/nix/util/posix-source-accessor.hh
+++ b/src/libutil/include/nix/util/posix-source-accessor.hh
@@ -80,6 +80,8 @@ public:
         return trackLastModified ? std::optional{mtime} : std::nullopt;
     }
 
+    void invalidateCache(const CanonPath & path) override;
+
 private:
 
     /**

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -213,6 +213,11 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
     {
         return std::nullopt;
     }
+
+    /**
+     * Invalidate any cached value the accessor may have for the specified path.
+     */
+    virtual void invalidateCache(const CanonPath & path) {}
 };
 
 /**

--- a/src/libutil/include/nix/util/source-path.hh
+++ b/src/libutil/include/nix/util/source-path.hh
@@ -114,6 +114,11 @@ struct SourcePath
         return {accessor, accessor->resolveSymlinks(path, mode)};
     }
 
+    void invalidateCache() const
+    {
+        accessor->invalidateCache(path);
+    }
+
     friend class std::hash<nix::SourcePath>;
 };
 

--- a/src/libutil/mounted-source-accessor.cc
+++ b/src/libutil/mounted-source-accessor.cc
@@ -99,6 +99,12 @@ struct MountedSourceAccessorImpl : MountedSourceAccessor
         auto [accessor, subpath] = resolve(path);
         return accessor->getFingerprint(subpath);
     }
+
+    void invalidateCache(const CanonPath & path) override
+    {
+        auto [accessor, subpath] = resolve(path);
+        accessor->invalidateCache(subpath);
+    }
 };
 
 ref<MountedSourceAccessor> makeMountedSourceAccessor(std::map<CanonPath, ref<SourceAccessor>> mounts)

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -85,11 +85,11 @@ bool PosixSourceAccessor::pathExists(const CanonPath & path)
     return nix::pathExists(makeAbsPath(path).string());
 }
 
+using Cache = boost::concurrent_flat_map<Path, std::optional<PosixStat>>;
+static Cache cache;
+
 std::optional<PosixStat> PosixSourceAccessor::cachedLstat(const CanonPath & path)
 {
-    using Cache = boost::concurrent_flat_map<Path, std::optional<PosixStat>>;
-    static Cache cache;
-
     // Note: we convert std::filesystem::path to Path because the
     // former is not hashable on libc++.
     Path absPath = makeAbsPath(path).string();
@@ -104,6 +104,11 @@ std::optional<PosixStat> PosixSourceAccessor::cachedLstat(const CanonPath & path
     cache.emplace(std::move(absPath), st);
 
     return st;
+}
+
+void PosixSourceAccessor::invalidateCache(const CanonPath & path)
+{
+    cache.erase(makeAbsPath(path).string());
 }
 
 std::optional<SourceAccessor::Stat> PosixSourceAccessor::maybeLstat(const CanonPath & path)

--- a/src/libutil/union-source-accessor.cc
+++ b/src/libutil/union-source-accessor.cc
@@ -90,6 +90,12 @@ struct UnionSourceAccessor : SourceAccessor
         }
         return {path, std::nullopt};
     }
+
+    void invalidateCache(const CanonPath & path) override
+    {
+        for (auto & accessor : accessors)
+            accessor->invalidateCache(path);
+    }
 };
 
 ref<SourceAccessor> makeUnionSourceAccessor(std::vector<ref<SourceAccessor>> && accessors)


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

After `lockFlake()` creates a `flake.lock` in a `PosixSourceAccessor`, it needs to be able to invalidate the lstat cache, otherwise a subsequent attempt to read `flake.lock` will fail with an erroneous "path does not exist" error.

This isn't an issue yet on master,  but it arises when we make the path fetcher lazy (https://github.com/DeterminateSystems/nix-src/pull/312).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
