### PR TITLE
libutil/union-source-accessor: Barf on non-existent directories

### DIFF
--- a/src/libutil/union-source-accessor.cc
+++ b/src/libutil/union-source-accessor.cc
@@ -35,14 +35,18 @@ struct UnionSourceAccessor : SourceAccessor
     DirEntries readDirectory(const CanonPath & path) override
     {
         DirEntries result;
+        bool exists = false;
         for (auto & accessor : accessors) {
             auto st = accessor->maybeLstat(path);
             if (!st)
                 continue;
+            exists = true;
             for (auto & entry : accessor->readDirectory(path))
                 // Don't override entries from previous accessors.
                 result.insert(entry);
         }
+        if (!exists)
+            throw FileNotFound("path '%s' does not exist", showPath(path));
         return result;
     }
 

--- a/tests/functional/lang/eval-fail-readDir-nonexistent-1.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-nonexistent-1.err.exp
@@ -1,0 +1,16 @@
+error:
+       … while evaluating the attribute 'absolutePath'
+         at /pwd/lang/eval-fail-readDir-nonexistent-1.nix:2:3:
+            1| {
+            2|   absolutePath = builtins.readDir /this/path/really/should/not/exist;
+             |   ^
+            3| }
+
+       … while calling the 'readDir' builtin
+         at /pwd/lang/eval-fail-readDir-nonexistent-1.nix:2:18:
+            1| {
+            2|   absolutePath = builtins.readDir /this/path/really/should/not/exist;
+             |                  ^
+            3| }
+
+       error: path '/this/path/really/should/not/exist' does not exist

--- a/tests/functional/lang/eval-fail-readDir-nonexistent-1.nix
+++ b/tests/functional/lang/eval-fail-readDir-nonexistent-1.nix
@@ -1,0 +1,3 @@
+{
+  absolutePath = builtins.readDir /this/path/really/should/not/exist;
+}

--- a/tests/functional/lang/eval-fail-readDir-nonexistent-2.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-nonexistent-2.err.exp
@@ -1,0 +1,16 @@
+error:
+       … while evaluating the attribute 'relativePath'
+         at /pwd/lang/eval-fail-readDir-nonexistent-2.nix:2:3:
+            1| {
+            2|   relativePath = builtins.readDir ./this/path/really/should/not/exist;
+             |   ^
+            3| }
+
+       … while calling the 'readDir' builtin
+         at /pwd/lang/eval-fail-readDir-nonexistent-2.nix:2:18:
+            1| {
+            2|   relativePath = builtins.readDir ./this/path/really/should/not/exist;
+             |                  ^
+            3| }
+
+       error: path '/pwd/lang/this/path/really/should/not/exist' does not exist

--- a/tests/functional/lang/eval-fail-readDir-nonexistent-2.nix
+++ b/tests/functional/lang/eval-fail-readDir-nonexistent-2.nix
@@ -1,0 +1,3 @@
+{
+  relativePath = builtins.readDir ./this/path/really/should/not/exist;
+}

--- a/tests/functional/lang/eval-fail-readDir-not-a-directory-1.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-not-a-directory-1.err.exp
@@ -1,0 +1,16 @@
+error:
+       … while evaluating the attribute 'regularFile'
+         at /pwd/lang/eval-fail-readDir-not-a-directory-1.nix:2:3:
+            1| {
+            2|   regularFile = builtins.readDir ./readDir/bar;
+             |   ^
+            3| }
+
+       … while calling the 'readDir' builtin
+         at /pwd/lang/eval-fail-readDir-not-a-directory-1.nix:2:17:
+            1| {
+            2|   regularFile = builtins.readDir ./readDir/bar;
+             |                 ^
+            3| }
+
+       error: cannot read directory "/pwd/lang/readDir/bar": Not a directory

--- a/tests/functional/lang/eval-fail-readDir-not-a-directory-1.nix
+++ b/tests/functional/lang/eval-fail-readDir-not-a-directory-1.nix
@@ -1,0 +1,3 @@
+{
+  regularFile = builtins.readDir ./readDir/bar;
+}

--- a/tests/functional/lang/eval-fail-readDir-not-a-directory-2.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-not-a-directory-2.err.exp
@@ -1,0 +1,16 @@
+error:
+       … while evaluating the attribute 'symlinkedRegularFile'
+         at /pwd/lang/eval-fail-readDir-not-a-directory-2.nix:2:3:
+            1| {
+            2|   symlinkedRegularFile = builtins.readDir ./readDir/linked;
+             |   ^
+            3| }
+
+       … while calling the 'readDir' builtin
+         at /pwd/lang/eval-fail-readDir-not-a-directory-2.nix:2:26:
+            1| {
+            2|   symlinkedRegularFile = builtins.readDir ./readDir/linked;
+             |                          ^
+            3| }
+
+       error: cannot read directory "/pwd/lang/readDir/foo/git-hates-directories": Not a directory

--- a/tests/functional/lang/eval-fail-readDir-not-a-directory-2.nix
+++ b/tests/functional/lang/eval-fail-readDir-not-a-directory-2.nix
@@ -1,0 +1,3 @@
+{
+  symlinkedRegularFile = builtins.readDir ./readDir/linked;
+}

--- a/tests/functional/lang/eval-okay-readDir-symlinked-directory.exp
+++ b/tests/functional/lang/eval-okay-readDir-symlinked-directory.exp
@@ -1,0 +1,1 @@
+{ git-hates-directories = "regular"; }

--- a/tests/functional/lang/eval-okay-readDir-symlinked-directory.nix
+++ b/tests/functional/lang/eval-okay-readDir-symlinked-directory.nix
@@ -1,0 +1,1 @@
+builtins.readDir ./readDir/ldir


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Previously `builtins.readDir` would return an empty attribute set instead of barfing on non-existent paths. This is a regression from 2.32 for impure eval.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
