### PR TITLE
libflake-tests: fix leak in nix_api_store_test.nix_api_load_flake_with_flags

### DIFF
--- a/src/libflake-tests/nix_api_flake.cc
+++ b/src/libflake-tests/nix_api_flake.cc
@@ -377,6 +377,7 @@ TEST_F(nix_api_store_test, nix_api_load_flake_with_flags)
     assert_ctx_ok();
     ASSERT_EQ("Claire", helloStr);
 
+    nix_locked_flake_free(lockedFlake);
     nix_flake_reference_parse_flags_free(parseFlags);
     nix_flake_lock_flags_free(lockFlags);
     nix_flake_reference_free(flakeReference);


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This test fails on cygwin:

```
[ RUN      ] nix_api_store_test.nix_api_load_flake_with_flags
warning: not writing modified lock file of flake 'path:/nix/var/nix/builds/nix-42403-950678037/nix-42408-3476222066/a':
• Added input 'b':
    'path:/nix/var/nix/builds/nix-42403-950678037/nix-42408-3476222066/b?lastModified=1767989117&narHash=sha256-nmA1vVxlRS1Y1wCpntvetQpa61NB/OvvroPCiZwRc%2BM%3D' (2026-01-09)
warning: creating lock file "/nix/var/nix/builds/nix-42403-950678037/nix-42408-3476222066/a/flake.lock":
• Added input 'b':
    'path:/nix/var/nix/builds/nix-42403-950678037/nix-42408-3476222066/b?lastModified=1767989117&narHash=sha256-nmA1vVxlRS1Y1wCpntvetQpa61NB/OvvroPCiZwRc%2BM%3D' (2026-01-09)
warning: not writing modified lock file of flake 'path:/nix/var/nix/builds/nix-42403-950678037/nix-42408-3476222066/a':
• Updated input 'b':
    'path:/nix/var/nix/builds/nix-42403-950678037/nix-42408-3476222066/b?lastModified=1767989117&narHash=sha256-nmA1vVxlRS1Y1wCpntvetQpa61NB/OvvroPCiZwRc%2BM%3D' (2026-01-09)
  → 'path:/nix/var/nix/builds/nix-42403-950678037/nix-42408-3476222066/c?lastModified=1767989117&narHash=sha256-7aeUAJM1XBrPeH/XiwlMaFnz3RPCqTgvlNSGEK8cR10%3D' (2026-01-09)
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: cannot remove all: Device or resource busy [/nix/var/nix/builds/nix-42403-950678037/tests_nix-store.pUTLXB] [/nix/var/nix/builds/nix-42403-950678037/tests_nix-store.pUTLXB/my_state/db/db.sqlite]
/nix/var/nix/builds/nix-42403-950678037/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 3: 42408 Aborted                    /nix/store/hl337315ycb68z69mrhwwr8h0w8w8q6g-exec/bin/exec /nix/store/ppa17sj1x080dans4nhrwhxd22ic1lxa-nix-flake-tests-2.34pre20251217_b6add8dc+5/bin/nix-flake-tests.exe
```

## Context

A fix for the problem described [here](https://github.com/NixOS/nix/pull/14040#issuecomment-3730329569) may also be required for this test to actually pass.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
