### PR TITLE
cygwin: don't allow setting separate process groups

### DIFF
--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -99,7 +99,13 @@ int Pid::wait()
 
 void Pid::setSeparatePG(bool separatePG)
 {
+    /* Cygwin only partially emulates process groups and trying to kill them
+       gives errors. This only logs warnings during builds, but let's not even
+       allow setting this value.
+     */
+#ifndef __CYGWIN__
     this->separatePG = separatePG;
+#endif
 }
 
 void Pid::setKillSignal(int signal)


### PR DESCRIPTION
@corngood 

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Cygwin does not fully implement process groups, so trying to kill them gives ESRCH.

## Context

https://github.com/mirror/newlib-cygwin/blob/1b7c72fdcc4bde7520407d2d3364146f04fb8312/winsup/cygwin/signal.cc#L385

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
