### PR TITLE
systemd: Delegate cgroup management without turning on controllers.

### DIFF
--- a/misc/systemd/nix-daemon.service.in
+++ b/misc/systemd/nix-daemon.service.in
@@ -11,7 +11,7 @@ ExecStart=@@bindir@/nix-daemon nix-daemon --daemon
 KillMode=process
 LimitNOFILE=1048576
 TasksMax=1048576
-Delegate=yes
+Delegate=
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Nix currently doesn't do any resource control, and Delegate=yes turns on all the controllers.

In particular, this enables using cpusets with cgroups V1 alongside the Nix daemon.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
