### PR TITLE
libutil: RestoreRegularFile is an FdSink

### DIFF
--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -126,10 +126,17 @@ void RestoreSink::createDirectory(const CanonPath & path)
 #endif
 };
 
-struct RestoreRegularFile : CreateRegularFileSink
+struct RestoreRegularFile : CreateRegularFileSink, FdSink
 {
     AutoCloseFD fd;
     bool startFsync = false;
+
+    RestoreRegularFile(bool startFSync_, AutoCloseFD fd_)
+        : FdSink(fd_.get())
+        , fd(std::move(fd_))
+        , startFsync(startFSync_)
+    {
+    }
 
     ~RestoreRegularFile()
     {
@@ -141,7 +148,6 @@ struct RestoreRegularFile : CreateRegularFileSink
             fd.startFsync();
     }
 
-    void operator()(std::string_view data) override;
     void isExecutable() override;
     void preallocateContents(uint64_t size) override;
 };
@@ -150,9 +156,8 @@ void RestoreSink::createRegularFile(const CanonPath & path, std::function<void(C
 {
     auto p = append(dstPath, path);
 
-    RestoreRegularFile crf;
-    crf.startFsync = startFsync;
-    crf.fd =
+    auto crf = RestoreRegularFile(
+        startFsync,
 #ifdef _WIN32
         CreateFileW(
             p.c_str(),
@@ -165,17 +170,18 @@ void RestoreSink::createRegularFile(const CanonPath & path, std::function<void(C
 #else
         [&]() {
             /* O_EXCL together with O_CREAT ensures symbolic links in the last
-              component are not followed. */
+               component are not followed. */
             constexpr int flags = O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC;
             if (!dirFd)
                 return ::open(p.c_str(), flags, 0666);
             return unix::openFileEnsureBeneathNoSymlinks(dirFd.get(), path, flags, 0666);
-        }();
+        }()
 #endif
-        ;
+    );
     if (!crf.fd)
         throw NativeSysError("creating file '%1%'", p);
     func(crf);
+    crf.flush();
 }
 
 void RestoreRegularFile::isExecutable()
@@ -207,11 +213,6 @@ void RestoreRegularFile::preallocateContents(uint64_t len)
             throw SysError("preallocating file of %1% bytes", len);
     }
 #endif
-}
-
-void RestoreRegularFile::operator()(std::string_view data)
-{
-    writeFull(fd.get(), data);
 }
 
 void RestoreSink::createSymlink(const CanonPath & path, const std::string & target)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

It correctly models the is-a relation. This will be useful for doing a dynamic_cast in downstream code that wants to copy from a file descriptor to a file descriptor.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
