### PR TITLE
Add missing shebangs to exorcise Darwin sandbox heisenbug

### DIFF
--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -616,7 +616,7 @@ static void main_nix_build(int argc, char ** argv)
         auto tz = getEnv("TZ");
         auto tzExport = tz ? "export TZ=" + escapeShellArgAlways(*tz) + "; " : "";
         std::string rc = fmt(
-                (R"(_nix_shell_clean_tmpdir() { command rm -rf %1%; };)"s
+                ("#!%8%\n" + R"(_nix_shell_clean_tmpdir() { command rm -rf %1%; };)"s
                   "trap _nix_shell_clean_tmpdir EXIT; "
                   "exitHooks+=(_nix_shell_clean_tmpdir); "
                   "failureHooks+=(_nix_shell_clean_tmpdir); ") +
@@ -649,7 +649,7 @@ static void main_nix_build(int argc, char ** argv)
                 escapeShellArgAlways(dirOf(*shell)),
                 escapeShellArgAlways(*shell),
                 tzExport,
-                envCommand);
+                envCommand, *shell);
         vomit("Sourcing nix-shell with file %s and contents:\n%s", rcfile, rc);
         writeFile(rcfile, rc);
 

--- a/tests/functional/user-envs.builder.sh
+++ b/tests/functional/user-envs.builder.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # shellcheck shell=bash
 # shellcheck disable=SC2154
 mkdir "$out"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Adds missing shebangs that lead to unsafe forks that present themselves as SIGSEGV.

See 7b3d7eb6343f33a14a9ec55be909f806ff6c49ab and https://github.com/NixOS/nixpkgs/issues/476794 Lix patch: https://gerrit.lix.systems/c/lix/+/4891

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
