### PR TITLE
fetchTree: improve error message for unknown input types

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -163,6 +163,8 @@ static void fetchTree(
                     .debugThrow();
 
         input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
+        if (!input.scheme)
+            state.error<EvalError>("unsupported input type '%s'", *type).atPos(pos).debugThrow();
     } else {
         auto url = state
                        .coerceToString(

--- a/tests/functional/lang/eval-fail-fetchTree-unknown-type.err.exp
+++ b/tests/functional/lang/eval-fail-fetchTree-unknown-type.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while calling the 'fetchTree' builtin
+         at /pwd/lang/eval-fail-fetchTree-unknown-type.nix:1:1:
+            1| builtins.fetchTree {
+             | ^
+            2|   type = "foo";
+
+       error: unsupported input type 'foo'

--- a/tests/functional/lang/eval-fail-fetchTree-unknown-type.nix
+++ b/tests/functional/lang/eval-fail-fetchTree-unknown-type.nix
@@ -1,0 +1,3 @@
+builtins.fetchTree {
+  type = "foo";
+}


### PR DESCRIPTION
Previously, using an unknown type like `builtins.fetchTree { type = "foo"; }` would produce the confusing message:

    error: cannot show unsupported input '{"type":"foo"}'

This happened because Input::fromAttrs returns a "raw" Input without a scheme for unknown types, and the error was thrown later when trying to display the input.

Now we check immediately after fromAttrs and produce a clearer message:

    error: unsupported input type 'foo'

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
