### PR TITLE
Remove more obsolete daemon operations

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -988,10 +988,6 @@ static void performOp(
         break;
     }
 
-    case WorkerProto::Op::QueryFailedPaths:
-    case WorkerProto::Op::ClearFailedPaths:
-        throw Error("Removed operation %1%", op);
-
     default:
         throw Error("invalid operation %1%", op);
     }

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -161,8 +161,8 @@ enum struct WorkerProto::Op : uint64_t {
     QuerySubstitutablePathInfo = 21,
     QueryDerivationOutputs = 22, // obsolete
     QueryAllValidPaths = 23,
-    QueryFailedPaths = 24,
-    ClearFailedPaths = 25,
+    // QueryFailedPaths = 24, // removed
+    // ClearFailedPaths = 25, // removed
     QueryPathInfo = 26,
     // ImportPaths = 27, // removed
     QueryDerivationOutputNames = 28, // obsolete


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

These have been obsolete since 2016.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
