### PR TITLE
Factor out the local NAR cache into its own class

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -13,6 +13,7 @@
 #include "nix/util/callback.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/archive.hh"
+#include "nix/store/nar-cache.hh"
 
 #include <chrono>
 #include <future>
@@ -26,6 +27,7 @@ namespace nix {
 
 BinaryCacheStore::BinaryCacheStore(Config & config)
     : config{config}
+    , narCache{config.localNarCache.get() ? std::make_shared<NarCache>(*config.localNarCache.get()) : nullptr}
 {
     if (config.secretKeyFile != "")
         signers.push_back(std::make_unique<LocalSigner>(SecretKey{readFile(config.secretKeyFile)}));
@@ -552,7 +554,7 @@ void BinaryCacheStore::registerDrvOutput(const Realisation & info)
 
 ref<RemoteFSAccessor> BinaryCacheStore::getRemoteFSAccessor(bool requireValidPath)
 {
-    return make_ref<RemoteFSAccessor>(ref<Store>(shared_from_this()), requireValidPath, config.localNarCache);
+    return make_ref<RemoteFSAccessor>(ref<Store>(shared_from_this()), requireValidPath, narCache);
 }
 
 ref<SourceAccessor> BinaryCacheStore::getFSAccessor(bool requireValidPath)

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -12,6 +12,7 @@
 namespace nix {
 
 struct NarInfo;
+class NarCache;
 class RemoteFSAccessor;
 
 struct BinaryCacheStoreConfig : virtual StoreConfig
@@ -88,6 +89,8 @@ protected:
     constexpr const static std::string realisationsPrefix = "realisations";
 
     constexpr const static std::string cacheInfoFile = "nix-cache-info";
+
+    std::shared_ptr<NarCache> narCache;
 
     BinaryCacheStore(Config &);
 

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -56,6 +56,7 @@ headers = [ config_pub_h ] + files(
   'machines.hh',
   'make-content-addressed.hh',
   'names.hh',
+  'nar-cache.hh',
   'nar-info-disk-cache.hh',
   'nar-info.hh',
   'outputs-spec.hh',

--- a/src/libstore/include/nix/store/nar-cache.hh
+++ b/src/libstore/include/nix/store/nar-cache.hh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "nix/util/hash.hh"
+#include "nix/util/nar-accessor.hh"
+
+#include <filesystem>
+
+namespace nix {
+
+class NarCache
+{
+    const std::filesystem::path cacheDir;
+
+    std::filesystem::path makeCacheFile(const Hash & narHash, const std::string & ext);
+
+public:
+
+    NarCache(std::filesystem::path cacheDir);
+
+    void upsertNar(const Hash & narHash, Source & source);
+
+    void upsertNarListing(const Hash & narHash, std::string_view narListingData);
+
+    // FIXME: use a sink.
+    std::optional<std::string> getNar(const Hash & narHash);
+
+    // FIXME: use a sink.
+    GetNarBytes getNarBytes(const Hash & narHash);
+
+    std::optional<std::string> getNarListing(const Hash & narHash);
+};
+
+} // namespace nix

--- a/src/libstore/include/nix/store/remote-fs-accessor.hh
+++ b/src/libstore/include/nix/store/remote-fs-accessor.hh
@@ -7,6 +7,8 @@
 
 namespace nix {
 
+struct NarCache;
+
 class RemoteFSAccessor : public SourceAccessor
 {
     ref<Store> store;
@@ -25,7 +27,7 @@ class RemoteFSAccessor : public SourceAccessor
 
     bool requireValidPath;
 
-    std::optional<std::filesystem::path> cacheDir;
+    std::shared_ptr<NarCache> narCache;
 
     std::pair<ref<SourceAccessor>, CanonPath> fetch(const CanonPath & path);
 
@@ -38,8 +40,7 @@ public:
      */
     std::shared_ptr<SourceAccessor> accessObject(const StorePath & path);
 
-    RemoteFSAccessor(
-        ref<Store> store, bool requireValidPath = true, std::optional<std::filesystem::path> cacheDir = {});
+    RemoteFSAccessor(ref<Store> store, bool requireValidPath = true, std::shared_ptr<NarCache> narCache = {});
 
     std::optional<Stat> maybeLstat(const CanonPath & path) override;
 

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -318,6 +318,7 @@ sources = files(
   'make-content-addressed.cc',
   'misc.cc',
   'names.cc',
+  'nar-cache.cc',
   'nar-info-disk-cache.cc',
   'nar-info.cc',
   'optimise-store.cc',

--- a/src/libstore/nar-cache.cc
+++ b/src/libstore/nar-cache.cc
@@ -1,0 +1,64 @@
+#include "nix/store/nar-cache.hh"
+#include "nix/util/file-system.hh"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+namespace nix {
+
+NarCache::NarCache(std::filesystem::path cacheDir_)
+    : cacheDir(std::move(cacheDir_))
+{
+    assert(!cacheDir.empty());
+    createDirs(cacheDir);
+}
+
+std::filesystem::path NarCache::makeCacheFile(const Hash & narHash, const std::string & ext)
+{
+    return (cacheDir / narHash.to_string(HashFormat::Nix32, false)) + "." + ext;
+}
+
+void NarCache::upsertNar(const Hash & narHash, Source & source)
+{
+    try {
+        /* FIXME: do this asynchronously. */
+        writeFile(makeCacheFile(narHash, "nar"), source);
+    } catch (SystemError &) {
+        ignoreExceptionExceptInterrupt();
+    }
+}
+
+void NarCache::upsertNarListing(const Hash & narHash, std::string_view narListingData)
+{
+    try {
+        writeFile(makeCacheFile(narHash, "ls"), narListingData);
+    } catch (SystemError &) {
+        ignoreExceptionExceptInterrupt();
+    }
+}
+
+std::optional<std::string> NarCache::getNar(const Hash & narHash)
+{
+    try {
+        return nix::readFile(makeCacheFile(narHash, "nar"));
+    } catch (SystemError &) {
+        return std::nullopt;
+    }
+}
+
+GetNarBytes NarCache::getNarBytes(const Hash & narHash)
+{
+    return seekableGetNarBytes(makeCacheFile(narHash, "nar"));
+}
+
+std::optional<std::string> NarCache::getNarListing(const Hash & narHash)
+{
+    try {
+        return nix::readFile(makeCacheFile(narHash, "ls"));
+    } catch (SystemError &) {
+        return std::nullopt;
+    }
+}
+
+} // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This prepares allowing the NAR cache to be used for substitution (see https://github.com/DeterminateSystems/nix-src/pull/279).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
