### PR TITLE
Add Nix32 encoding documentation

### DIFF
--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -136,6 +136,7 @@
   - [Store Path Specification](protocols/store-path.md)
   - [Nix Archive (NAR) Format](protocols/nix-archive/index.md)
   - [Derivation "ATerm" file format](protocols/derivation-aterm.md)
+  - [Nix32 Encoding](protocols/nix32.md)
 - [C API](c-api.md)
 - [Glossary](glossary.md)
 - [Development](development/index.md)

--- a/doc/manual/source/language/advanced-attributes.md
+++ b/doc/manual/source/language/advanced-attributes.md
@@ -338,7 +338,7 @@ Here is more information on the `output*` attributes, and what values they may b
     This will specify the output hash of the single output of a [fixed-output derivation].
 
     The `outputHash` attribute must be a string containing the hash in either hexadecimal or "nix32" encoding, or following the format for integrity metadata as defined by [SRI](https://www.w3.org/TR/SRI/).
-    The "nix32" encoding is an adaptation of base-32 encoding.
+    The ["nix32" encoding](@docroot@/protocols/nix32.md) is Nix's variant of base-32 encoding.
 
     > **Note**
     >

--- a/doc/manual/source/protocols/json/schema/store-path-v1.yaml
+++ b/doc/manual/source/protocols/json/schema/store-path-v1.yaml
@@ -24,7 +24,7 @@ description: |
 
   The format follows this pattern: `${digest}-${name}`
 
-  - **hash**: Digest rendered in a custom variant of [Base32](https://en.wikipedia.org/wiki/Base32) (20 arbitrary bytes become 32 ASCII characters)
+  - **hash**: Digest rendered in [Nix32](@docroot@/protocols/nix32.md), a variant of base-32 (20 hash bytes become 32 ASCII characters)
   - **name**: The package name and optional version/suffix information
 
 type: string

--- a/doc/manual/source/protocols/nix32.md
+++ b/doc/manual/source/protocols/nix32.md
@@ -1,0 +1,19 @@
+# Nix32 Encoding
+
+Nix32 is Nix's variant of base-32 encoding, used for [store path digests](@docroot@/protocols/store-path.md), hash output via [`nix hash`](@docroot@/command-ref/new-cli/nix3-hash.md), and the [`outputHash`](@docroot@/language/advanced-attributes.md#adv-attr-outputHash) derivation attribute.
+
+## Alphabet
+
+The Nix32 alphabet consists of these 32 characters:
+
+```
+0 1 2 3 4 5 6 7 8 9 a b c d f g h i j k l m n p q r s v w x y z
+```
+
+The letters `e`, `o`, `u`, and `t` are omitted.
+
+## Byte Order
+
+Nix32 encoding processes the hash bytes from the end (last byte first), while base-16 encoding processes from the beginning (first byte first).
+
+Consequently, the string sort order is determined primarily by the first bytes for base-16, and by the last bytes for Nix32.

--- a/doc/manual/source/protocols/store-path.md
+++ b/doc/manual/source/protocols/store-path.md
@@ -20,12 +20,11 @@ where
 
 - `store-dir` = the [store directory](@docroot@/store/store-path.md#store-directory)
 
-- `digest` = base-32 representation of the compressed to 160 bits [SHA-256] hash of `fingerprint`
+- `digest` = base-32 representation of the compressed to 160 bits [SHA-256] hash of `fingerprint`.
 
-For the definition of the hash compression algorithm, please refer to the section 5.1 of
-the [Nix thesis](https://edolstra.github.io/pubs/phd-thesis.pdf), which also defines the
-specifics of base-32 encoding. Note that base-32 encoding processes the hash bytestring from
-the end, while base-16 processes in from the beginning.
+  Nix uses a custom base-32 encoding called [Nix32](@docroot@/protocols/nix32.md).
+
+  For the definition of the hash compression algorithm, please refer to section 5.1 of the [Nix thesis](https://edolstra.github.io/pubs/phd-thesis.pdf).
 
 ## Fingerprint
 

--- a/doc/manual/source/store/store-path.md
+++ b/doc/manual/source/store/store-path.md
@@ -31,7 +31,7 @@ A store path is rendered to a file system path as the concatenation of
 
 - [Store directory](#store-directory) (typically `/nix/store`)
 - Path separator (`/`)
-- Digest rendered in a custom variant of [Base32](https://en.wikipedia.org/wiki/Base32) (20 arbitrary bytes become 32 ASCII characters)
+- Digest rendered in [Nix32](@docroot@/protocols/nix32.md), a variant of base-32 (20 hash bytes become 32 ASCII characters)
 - Hyphen (`-`)
 - Name
 


### PR DESCRIPTION
Document the Nix32 base-32 variant used for store path digests and hash output. The new page covers:
- The 32-character alphabet (omitting e, o, u, t)
- Byte order differences from base-16 encoding

Also update references throughout the manual to link to the new page.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

- Provide better context for https://github.com/NixOS/rfcs/pull/195

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
