### PR TITLE
doc: add nix-cache-info format documentation

### DIFF
--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -135,6 +135,7 @@
   - [Serving Tarball Flakes](protocols/tarball-fetcher.md)
   - [Store Path Specification](protocols/store-path.md)
   - [Nix Archive (NAR) Format](protocols/nix-archive/index.md)
+  - [Nix Cache Info Format](protocols/nix-cache-info.md)
   - [Derivation "ATerm" file format](protocols/derivation-aterm.md)
 - [C API](c-api.md)
 - [Glossary](glossary.md)

--- a/doc/manual/source/package-management/binary-cache-substituter.md
+++ b/doc/manual/source/package-management/binary-cache-substituter.md
@@ -19,17 +19,16 @@ whatever port you like:
 $ nix-serve -p 8080
 ```
 
-To check whether it works, try the following on the client:
+To check whether it works, try fetching the [`nix-cache-info`](@docroot@/protocols/nix-cache-info.md) file on the client:
 
 ```console
 $ curl http://avalon:8080/nix-cache-info
+StoreDir: /nix/store
+WantMassQuery: 1
+Priority: 30
 ```
 
-which should print something like:
-
-    StoreDir: /nix/store
-    WantMassQuery: 1
-    Priority: 30
+When writing to a binary cache (e.g., with [`nix copy`](@docroot@/command-ref/new-cli/nix3-copy.md)), Nix creates [`nix-cache-info`](@docroot@/protocols/nix-cache-info.md) automatically if it doesn't exist.
 
 On the client side, you can tell Nix to use your binary cache using
 `--substituters`, e.g.:

--- a/doc/manual/source/protocols/nix-cache-info.md
+++ b/doc/manual/source/protocols/nix-cache-info.md
@@ -1,0 +1,55 @@
+# Nix Cache Info Format
+
+The `nix-cache-info` file is a metadata file at the root of a [binary cache](@docroot@/package-management/binary-cache-substituter.md) (e.g., `https://cache.example.com/nix-cache-info`).
+
+MIME type: `text/x-nix-cache-info`
+
+## Format
+
+Line-based key-value format:
+
+```
+Key: value
+```
+
+Leading and trailing whitespace is trimmed from values.
+Lines without a colon are ignored.
+Unknown keys are silently ignored.
+
+## Fields
+
+### `StoreDir`
+
+The Nix store directory path that this cache was built for (e.g., `/nix/store`).
+
+If present, Nix verifies that this matches the client's store directory:
+
+```
+error: binary cache 'https://example.com' is for Nix stores with prefix '/nix/store', not '/home/user/nix/store'
+```
+
+### `WantMassQuery`
+
+`1` or `0`. Sets the default for [`want-mass-query`](@docroot@/store/types/http-binary-cache-store.md#store-http-binary-cache-store-want-mass-query).
+
+### `Priority`
+
+Integer. Sets the default for [`priority`](@docroot@/store/types/http-binary-cache-store.md#store-http-binary-cache-store-priority).
+
+## Example
+
+```
+StoreDir: /nix/store
+WantMassQuery: 1
+Priority: 30
+```
+
+## Caching Behavior
+
+Nix caches `nix-cache-info` in the [cache directory](@docroot@/command-ref/env-common.md#env-NIX_CACHE_HOME) with a 7-day TTL.
+
+## See Also
+
+- [HTTP Binary Cache Store](@docroot@/store/types/http-binary-cache-store.md)
+- [Serving a Nix store via HTTP](@docroot@/package-management/binary-cache-substituter.md)
+- [`substituters`](@docroot@/command-ref/conf-file.md#conf-substituters)


### PR DESCRIPTION
Document the nix-cache-info file format used by binary caches, including the StoreDir, WantMassQuery, and Priority fields, their behavior, and links to related store options.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

## Context

- https://github.com/NixOS/rfcs/pull/195

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
