### PR TITLE
Catch `SystemError` in portable code

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1425,7 +1425,7 @@ std::vector<std::tuple<GitRepoImpl::Submodule, Hash>> GitRepoImpl::getSubmodules
     auto [fdTemp, pathTemp] = createTempFile("nix-git-submodules");
     try {
         writeFull(fdTemp.get(), configS);
-    } catch (SysError & e) {
+    } catch (SystemError & e) {
         e.addTrace({}, "while writing .gitmodules file to temporary file");
         throw;
     }

--- a/src/libmain/plugin.cc
+++ b/src/libmain/plugin.cc
@@ -83,8 +83,8 @@ void initPlugins()
                 checkInterrupt();
                 pluginFiles.emplace_back(ent.path());
             }
-        } catch (SysError & e) {
-            if (e.errNo != ENOTDIR)
+        } catch (SystemError & e) {
+            if (!e.is(std::errc::not_a_directory))
                 throw;
             pluginFiles.emplace_back(pluginFile);
         }

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1028,8 +1028,8 @@ HookReply DerivationBuildingGoal::tryBuildHook(const DerivationOptions<StorePath
         else if (reply != "accept")
             throw Error("bad hook reply '%s'", reply);
 
-    } catch (SysError & e) {
-        if (e.errNo == EPIPE) {
+    } catch (SystemError & e) {
+        if (e.is(std::errc::broken_pipe)) {
             printError("build hook died unexpectedly: %s", chomp(drainFD(worker.hook->fromHook.readSide.get())));
             worker.hook = 0;
             return rpDecline;

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -33,8 +33,8 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
 
     try {
         srcFiles = DirectoryIterator{srcDir};
-    } catch (SysError & e) {
-        if (e.errNo == ENOTDIR) {
+    } catch (SystemError & e) {
+        if (e.is(std::errc::not_a_directory)) {
             warn("not including '%s' in the user environment because it's not a directory", srcDir);
             return;
         }
@@ -54,8 +54,8 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
         try {
             if (stat(srcFile.c_str(), &srcSt) == -1)
                 throw SysError("getting status of '%1%'", srcFile);
-        } catch (SysError & e) {
-            if (e.errNo == ENOENT || e.errNo == ENOTDIR) {
+        } catch (SystemError & e) {
+            if (e.is(std::errc::no_such_file_or_directory) || e.is(std::errc::not_a_directory)) {
                 warn("skipping dangling symlink '%s'", dstFile);
                 continue;
             }
@@ -141,8 +141,8 @@ void buildProfile(const Path & out, Packages && pkgs)
                      readFile(pkgDir + "/nix-support/propagated-user-env-packages"), " \n"))
                 if (!done.count(p))
                     postponed.insert(p);
-        } catch (SysError & e) {
-            if (e.errNo != ENOENT && e.errNo != ENOTDIR)
+        } catch (SystemError & e) {
+            if (!e.is(std::errc::no_such_file_or_directory) && !e.is(std::errc::not_a_directory))
                 throw;
         }
     };

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -234,8 +234,8 @@ LocalStore::LocalStore(ref<const Config> config)
         Path globalLockPath = dbDir + "/big-lock";
         try {
             globalLock = openLockFile(globalLockPath.c_str(), true);
-        } catch (SysError & e) {
-            if (e.errNo == EACCES || e.errNo == EPERM) {
+        } catch (SystemError & e) {
+            if (e.is(std::errc::permission_denied) || e.is(std::errc::operation_not_permitted)) {
                 e.addTrace(
                     {},
                     "This command may have been run as non-root in a single-user Nix installation,\n"

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -377,10 +377,10 @@ ref<const ValidPathInfo> RemoteStore::addCAToStore(
                     }
                 }
                 conn.processStderr();
-            } catch (SysError & e) {
+            } catch (SystemError & e) {
                 /* Daemon closed while we were sending the path. Probably OOM
                   or I/O error. */
-                if (e.errNo == EPIPE)
+                if (e.is(std::errc::broken_pipe))
                     try {
                         conn.processStderr();
                     } catch (EndOfFile & e) {

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -236,9 +236,9 @@ bool pathAccessible(const std::filesystem::path & path)
 {
     try {
         return pathExists(path.string());
-    } catch (SysError & e) {
+    } catch (SystemError & e) {
         // swallow EPERM
-        if (e.errNo == EPERM)
+        if (e.is(std::errc::operation_not_permitted))
             return false;
         throw;
     }

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -264,8 +264,8 @@ static int main_build_remote(int argc, char ** argv)
             };
             try {
                 setUpdateLock(storeUri);
-            } catch (SysError & e) {
-                if (e.errNo != ENAMETOOLONG)
+            } catch (SystemError & e) {
+                if (!e.is(std::errc::filename_too_long))
                     throw;
                 // Try again hashing the store URL so we have a shorter path
                 auto h = hashString(HashAlgorithm::MD5, storeUri);


### PR DESCRIPTION
## Motivation

This will ensure this catching works on Windows too, not just Unix.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
