### PR TITLE
libstore: make withAWS depend on aws-c-common availability

### DIFF
--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -9,6 +9,7 @@
   nix-util,
   boost,
   curl,
+  aws-c-common,
   aws-crt-cpp,
   libseccomp,
   nlohmann_json,
@@ -24,7 +25,7 @@
 
   withAWS ?
     # Default is this way because there have been issues building this dependency
-    stdenv.hostPlatform == stdenv.buildPlatform && (stdenv.isLinux || stdenv.isDarwin),
+    lib.meta.availableOn stdenv.hostPlatform aws-c-common,
 }:
 
 let


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

From Nixpkgs: https://github.com/NixOS/nixpkgs/pull/481712

## Motivation

```
error: Package ‘aws-c-common-0.12.4’ in /home/puna/Development/nixpkgs/pkgs/by-name/aw/aws-c-common/package.nix:56 is not available on the requested hostPlatform:
  hostPlatform.system = "powerpc64-linux"
```

## Context

https://github.com/NixOS/nixpkgs/pull/481712
https://github.com/NixOS/nixpkgs/pull/425407

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
