### PR TITLE
Print IDs for repeated values

### DIFF
--- a/doc/manual/rl-next/print-ids-for-repeated-values.md
+++ b/doc/manual/rl-next/print-ids-for-repeated-values.md
@@ -1,0 +1,51 @@
+---
+synopsis: Print IDs when values are repeated to disambiguate which values are repeated
+issues: [10447]
+prs: [15024]
+---
+
+Printing values in the nix repl will now assign IDs to repeated values and print these IDs.
+This allows identifying which value is repeated.
+Previously you would have to know from context what the repeated value is.
+
+For example:
+
+```
+nix-repl> a = { foo = "uwu"; }
+
+nix-repl> b = { bar = "snacc"; }
+
+nix-repl> c = { baz = "boo"; }
+
+nix-repl> [ a b c a b ]
+[
+  { ... } /* 0 */
+  { ... } /* 1 */
+  { ... }
+  «repeated@0»
+  «repeated@1»
+]
+```
+
+In the last output you can e.g. see the `repeated@0` referencing the first value in the array, which has a comment `/* 0 */` to mark that it has the ID 0.
+
+For a more complex example:
+
+```
+nix-repl> :p { a = { b = 2; }; s = "string"; n = 1234; x = rec { y = { z = { inherit y; }; }; }; }
+{
+  a = { b = 2; };
+  n = 1234;
+  s = "string";
+  x = {
+    y = {
+      z = {
+        y = «repeated@0»;
+      };
+    } /* 0 */;
+  };
+}
+```
+
+The drawback of this is that we need to fully scan the value twice: once to assign the IDs of repeated values and then again to actually print it.
+This is also a stark UX change: when printing very large values there will be a long period where no user feedback is provided, whereas previously you would see lots of streaming output.

--- a/src/libexpr-tests/value/print.cc
+++ b/src/libexpr-tests/value/print.cc
@@ -580,7 +580,10 @@ TEST_F(ValuePrintingTests, ansiColorsAttrsRepeated)
     Value vAttrs;
     vAttrs.mkAttrs(builder.finish());
 
-    test(vAttrs, "{ a = { }; b = " ANSI_MAGENTA "«repeated»" ANSI_NORMAL "; }", PrintOptions{.ansiColors = true});
+    test(
+        vAttrs,
+        "{ a = { } /* 0 */; b = " ANSI_MAGENTA "«repeated@0»" ANSI_NORMAL "; }",
+        PrintOptions{.ansiColors = true});
 }
 
 TEST_F(ValuePrintingTests, ansiColorsListRepeated)
@@ -596,7 +599,7 @@ TEST_F(ValuePrintingTests, ansiColorsListRepeated)
     Value vList;
     vList.mkList(list);
 
-    test(vList, "[ { } " ANSI_MAGENTA "«repeated»" ANSI_NORMAL " ]", PrintOptions{.ansiColors = true});
+    test(vList, "[ { } /* 0 */ " ANSI_MAGENTA "«repeated@0»" ANSI_NORMAL " ]", PrintOptions{.ansiColors = true});
 }
 
 TEST_F(ValuePrintingTests, listRepeated)
@@ -612,7 +615,7 @@ TEST_F(ValuePrintingTests, listRepeated)
     Value vList;
     vList.mkList(list);
 
-    test(vList, "[ { } «repeated» ]", PrintOptions{});
+    test(vList, "[ { } /* 0 */ «repeated@0» ]", PrintOptions{});
     test(vList, "[ { } { } ]", PrintOptions{.trackRepeated = false});
 }
 

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -11,6 +11,14 @@
 
 #include <boost/unordered/unordered_flat_set.hpp>
 
+struct NullBuffer : std::streambuf
+{
+    int overflow(int c) override
+    {
+        return c;
+    }
+};
+
 namespace nix {
 
 void printElided(
@@ -163,6 +171,7 @@ private:
     EvalState & state;
     PrintOptions options;
     std::optional<ValuesSeen> seen;
+    std::optional<std::unordered_map<const void *, size_t>> repeated;
     size_t totalAttrsPrinted = 0;
     size_t totalListItemsPrinted = 0;
     std::string indent;
@@ -197,11 +206,11 @@ private:
         }
     }
 
-    void printRepeated()
+    void printRepeated(size_t id)
     {
         if (options.ansiColors)
             output << ANSI_MAGENTA;
-        output << "«repeated»";
+        output << "«repeated@" << id << "»";
         if (options.ansiColors)
             output << ANSI_NORMAL;
     }
@@ -331,7 +340,8 @@ private:
     void printAttrs(Value & v, size_t depth)
     {
         if (seen && !seen->insert(v.attrs()).second) {
-            printRepeated();
+            auto repeated_id = repeated->insert(std::make_pair(v.attrs(), repeated->size()));
+            printRepeated(repeated_id.first->second);
             return;
         }
 
@@ -376,6 +386,12 @@ private:
         } else {
             output << "{ ... }";
         }
+        if (repeated) {
+            auto repeated_id = repeated->find(v.attrs());
+            if (repeated_id != repeated->end()) {
+                output << " /* " << repeated_id->second << " */";
+            }
+        }
     }
 
     /**
@@ -409,7 +425,8 @@ private:
     void printList(Value & v, size_t depth)
     {
         if (seen && v.listSize() && !seen->insert(&v).second) {
-            printRepeated();
+            auto repeated_id = repeated->insert(std::make_pair(&v, repeated->size()));
+            printRepeated(repeated_id.first->second);
             return;
         }
 
@@ -443,6 +460,12 @@ private:
             output << "]";
         } else {
             output << "[ ... ]";
+        }
+        if (repeated) {
+            auto repeated_id = repeated->find(&v);
+            if (repeated_id != repeated->end()) {
+                output << " /* " << repeated_id->second << " */";
+            }
         }
     }
 
@@ -646,13 +669,30 @@ public:
         indent.clear();
 
         if (options.trackRepeated) {
+            // Record IDs for repeated values
             seen.emplace();
+            repeated.emplace();
+
+            NullBuffer nullBuffer;
+            auto s = output.rdbuf(&nullBuffer);
+
+            print(v, 0);
+
+            // Now actually print (with IDs for repeated values)
+            totalAttrsPrinted = 0;
+            totalListItemsPrinted = 0;
+
+            indent.clear();
+            seen.emplace();
+
+            output.rdbuf(s);
+
+            print(v, 0);
         } else {
             seen.reset();
+            repeated.reset();
+            print(v, 0);
         }
-
-        ValuesSeen seen;
-        print(v, 0);
     }
 };
 

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -34,7 +34,7 @@ nix-instantiate --eval -E 'let x = builtins.trace { x = x; } true; in x' \
   2>&1 | grepQuiet -E 'trace: { x = «potential infinite recursion»; }'
 
 nix-instantiate --eval -E 'let x = { repeating = x; tracing = builtins.trace x true; }; in x.tracing'\
-  2>&1 | grepQuiet -F 'trace: { repeating = «repeated»; tracing = «potential infinite recursion»; }'
+  2>&1 | grepQuiet -F 'trace: { repeating = «repeated@0»; tracing = «potential infinite recursion»; } /* 0 */'
 
 nix-instantiate --eval -E 'builtins.warn "Hello" 123' 2>&1 | grepQuiet 'warning: Hello'
 # shellcheck disable=SC2016 # The ${} in this is Nix, not shell

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -313,9 +313,9 @@ testReplResponseNoRegex '
 let x = { y = { a = 1; }; inherit x; }; in x
 ' \
 '{
-  x = «repeated»;
+  x = «repeated@0»;
   y = { ... };
-}
+} /* 0 */
 '
 
 # The :p command should recursively print sets, but prevent infinite recursion
@@ -329,9 +329,9 @@ testReplResponseNoRegex '
   x = {
     y = {
       z = {
-        y = «repeated»;
+        y = «repeated@0»;
       };
-    };
+    } /* 0 */;
   };
 }
 '
@@ -348,8 +348,8 @@ testReplResponseNoRegex '
     a = 1;
     b = {
       a = 1;
-      b = «repeated»;
-    };
+      b = «repeated@0»;
+    } /* 0 */;
   }
   [
     1
@@ -364,9 +364,9 @@ testReplResponseNoRegex '
 :p let x = { y = { a = 1; }; inherit x; }; in x
 ' \
 '{
-  x = «repeated»;
+  x = «repeated@0»;
   y = { a = 1; };
-}
+} /* 0 */
 '
 
 testReplResponseNoRegex '


### PR DESCRIPTION
PoC implementation for assigning IDs to values that are repeated to be able to identify the source of a repeated value.

Before:

```
nix-repl> a = { foo = "uwu"; }

nix-repl> b = { bar = "snacc"; }

nix-repl> c = { baz = "boo"; }

nix-repl> [ a b c a b ]
[
  { ... }
  { ... }
  { ... }
  «repeated»
  «repeated»
]
```

After:

```
nix-repl> a = { foo = "uwu"; }

nix-repl> b = { bar = "snacc"; }

nix-repl> c = { baz = "boo"; }

nix-repl> [ a b c a b ]
[
  { ... } /* 0 */
  { ... } /* 1 */
  { ... }
  «repeated@0»
  «repeated@1»
]
```

Evaluating e.g. `legacyPackages.x86_64-linux` we can now see which derivation is repeated by another package.

<img width="1052" height="235" alt="image" src="https://github.com/user-attachments/assets/c207a6a1-2496-476d-ba89-1dbdfbdefa14" />


## Motivation

Being able to identify what the printed value actually contains seems useful. Without this you'd need to either take an educated guess or go in and actually inspect the value.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

Fixes #10447 

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

### Implementation

Two-scan approach: first we identify which values are repeated and assign sequential IDs to them. The Printer code is re-used for this - we just give it a NullStream that ignores all input. Then, in the second scan, we actually print values using the IDs recorded in the first scan.

There's one obvious downside to all of this: we effectively do twice the work. You will also only see output once the first scan has fully completed.

The NullStream struct could maybe be replaced with boost's null sink but I couldn't get it to work. 

Some tests currently fail, but as far as I can tell only because they test for exact repl output.

#### Potential Improvements

Maybe the injected comments could be colored correctly/more gray when color output is enabled.

If there's only one repeated value we could skip printing IDs since there's no ambiguity.

### Considered Alternatives

#10447 suggests printing full attribute paths, but I think this is probably too verbose? Just assigning IDs has the benefit of remaining concise. Also I think the implementation would be more complex.

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
---

If this kind of contribution is welcome I'd be happy to fix the tests and polish up the implementation.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
