### PR TITLE
Deduplicate `copyFdRange` with new `readOffset`

### DIFF
--- a/src/libutil/file-descriptor.cc
+++ b/src/libutil/file-descriptor.cc
@@ -1,6 +1,8 @@
 #include "nix/util/serialise.hh"
 #include "nix/util/util.hh"
+#include "nix/util/signals.hh"
 
+#include <span>
 #include <fcntl.h>
 #include <unistd.h>
 #ifdef _WIN32
@@ -29,6 +31,33 @@ std::string drainFD(Descriptor fd, bool block, const size_t reserveSize)
     drainFD(fd, sink, block);
 #endif
     return std::move(sink.s);
+}
+
+void copyFdRange(Descriptor fd, off_t offset, size_t nbytes, Sink & sink)
+{
+    auto left = nbytes;
+    std::array<std::byte, 64 * 1024> buf;
+
+    while (left) {
+        checkInterrupt();
+        auto limit = std::min<size_t>(left, buf.size());
+        /* Should be initialized before we read, because the `catch`
+           block either throws or continues. */
+        size_t n;
+        try {
+            n = readOffset(fd, offset, std::span(buf.data(), limit));
+        } catch (SystemError & e) {
+            if (e.is(std::errc::interrupted))
+                continue;
+            throw;
+        }
+        if (n == 0)
+            throw EndOfFile("unexpected end-of-file");
+        assert(n <= left);
+        sink(std::string_view(reinterpret_cast<const char *>(buf.data()), n));
+        offset += n;
+        left -= n;
+    }
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -68,6 +68,20 @@ static inline int fromDescriptorReadOnly(Descriptor fd)
 std::string readFile(Descriptor fd);
 
 /**
+ * Platform-specific positioned read into a buffer.
+ *
+ * Thin wrapper around pread (Unix) or ReadFile with OVERLAPPED (Windows).
+ * Does NOT handle EINTR on Unix - caller must catch and retry if needed.
+ *
+ * @param fd The file descriptor to read from (must be seekable)
+ * @param offset The offset to read from
+ * @param buffer The buffer to read into
+ * @return The number of bytes actually read (0 indicates EOF)
+ * @throws SystemError on failure
+ */
+size_t readOffset(Descriptor fd, off_t offset, std::span<std::byte> buffer);
+
+/**
  * Read \ref nbytes starting at \ref offset from a seekable file into a sink.
  *
  * @throws SystemError if fd is not seekable or any operation fails


### PR DESCRIPTION
## Motivation

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
