### PR TITLE
libutil: add `Signature` struct for typed signatures

### DIFF
--- a/src/libstore-tests/common-protocol.cc
+++ b/src/libstore-tests/common-protocol.cc
@@ -140,8 +140,8 @@ CHARACTERIZATION_TEST(
                 .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
                 .signatures =
                     {
-                        "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                        "qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                        Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
+                        Signature{.keyName = "qwer", .sig = std::string(64, '\0')},
                     },
             },
             {
@@ -160,8 +160,8 @@ READ_CHARACTERIZATION_TEST(
                 .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
                 .signatures =
                     {
-                        "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                        "qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                        Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
+                        Signature{.keyName = "qwer", .sig = std::string(64, '\0')},
                     },
             },
             {

--- a/src/libstore-tests/nar-info.cc
+++ b/src/libstore-tests/nar-info.cc
@@ -60,8 +60,8 @@ static NarInfo makeNarInfo(const Store & store, bool includeImpureInfo)
         info.registrationTime = 23423;
         info.ultimate = true;
         info.sigs = {
-            "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-            "qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+            Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
+            Signature{.keyName = "qwer", .sig = std::string(64, '\0')},
         };
 
         info.url = "nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz";

--- a/src/libstore-tests/path-info.cc
+++ b/src/libstore-tests/path-info.cc
@@ -67,8 +67,8 @@ static ValidPathInfo makeFullKeyed(const Store & store, bool includeImpureInfo)
         info.registrationTime = 23423;
         info.ultimate = true;
         info.sigs = {
-            "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-            "qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+            Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
+            Signature{.keyName = "qwer", .sig = std::string(64, '\0')},
         };
     }
     return info;

--- a/src/libstore-tests/realisation.cc
+++ b/src/libstore-tests/realisation.cc
@@ -71,7 +71,7 @@ INSTANTIATE_TEST_SUITE_P(
                 auto r = simple;
                 // FIXME actually sign properly
                 r.signatures = {
-                    "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
                 };
                 return r;
             }(),

--- a/src/libstore-tests/serve-protocol.cc
+++ b/src/libstore-tests/serve-protocol.cc
@@ -111,8 +111,8 @@ VERSIONED_CHARACTERIZATION_TEST(
                 .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
                 .signatures =
                     {
-                        "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                        "qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                        Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
+                        Signature{.keyName = "qwer", .sig = std::string(64, '\0')},
                     },
             },
             {
@@ -133,8 +133,8 @@ VERSIONED_READ_CHARACTERIZATION_TEST(
                 .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
                 .signatures =
                     {
-                        "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                        "qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                        Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
+                        Signature{.keyName = "qwer", .sig = std::string(64, '\0')},
                     },
             },
             {
@@ -329,8 +329,8 @@ VERSIONED_CHARACTERIZATION_TEST(
             info.narSize = 34878;
             info.sigs =
                 {
-                    "fake-sig-1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                    "fake-sig-2:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    Signature{.keyName = "fake-sig-1", .sig = std::string(64, '\0')},
+                    Signature{.keyName = "fake-sig-2", .sig = std::string(64, '\0')},
                 },
             static_cast<UnkeyedValidPathInfo>(std::move(info));
         }),

--- a/src/libstore-tests/worker-protocol.cc
+++ b/src/libstore-tests/worker-protocol.cc
@@ -164,8 +164,8 @@ VERSIONED_CHARACTERIZATION_TEST(
                 .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
                 .signatures =
                     {
-                        "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                        "qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                        Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
+                        Signature{.keyName = "qwer", .sig = std::string(64, '\0')},
                     },
             },
             {
@@ -186,8 +186,8 @@ VERSIONED_READ_CHARACTERIZATION_TEST(
                 .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
                 .signatures =
                     {
-                        "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                        "qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                        Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
+                        Signature{.keyName = "qwer", .sig = std::string(64, '\0')},
                     },
             },
             {
@@ -549,8 +549,8 @@ VERSIONED_CHARACTERIZATION_TEST(
             info.narSize = 34878;
             info.sigs =
                 {
-                    "fake-sig-1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                    "fake-sig-2:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    Signature{.keyName = "fake-sig-1", .sig = std::string(64, '\0')},
+                    Signature{.keyName = "fake-sig-2", .sig = std::string(64, '\0')},
                 },
             info;
         }),

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -565,7 +565,7 @@ std::shared_ptr<SourceAccessor> BinaryCacheStore::getFSAccessor(const StorePath 
     return getRemoteFSAccessor(requireValidPath)->accessObject(storePath);
 }
 
-void BinaryCacheStore::addSignatures(const StorePath & storePath, const StringSet & sigs)
+void BinaryCacheStore::addSignatures(const StorePath & storePath, const std::set<Signature> & sigs)
 {
     /* Note: this is inherently racy since there is no locking on
        binary caches. In particular, with S3 this unreliable, even

--- a/src/libstore/common-protocol.cc
+++ b/src/libstore/common-protocol.cc
@@ -6,6 +6,7 @@
 #include "nix/store/common-protocol-impl.hh"
 #include "nix/util/archive.hh"
 #include "nix/store/derivations.hh"
+#include "nix/util/signature/local-keys.hh"
 
 #include <nlohmann/json.hpp>
 
@@ -97,6 +98,17 @@ void CommonProto::Serialise<std::optional<ContentAddress>>::write(
     const StoreDirConfig & store, CommonProto::WriteConn conn, const std::optional<ContentAddress> & caOpt)
 {
     conn.to << (caOpt ? renderContentAddress(*caOpt) : "");
+}
+
+Signature CommonProto::Serialise<Signature>::read(const StoreDirConfig & store, CommonProto::ReadConn conn)
+{
+    return Signature::parse(readString(conn.from));
+}
+
+void CommonProto::Serialise<Signature>::write(
+    const StoreDirConfig & store, CommonProto::WriteConn conn, const Signature & sig)
+{
+    conn.to << sig.to_string();
 }
 
 } // namespace nix

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -861,7 +861,7 @@ static void performOp(
 
     case WorkerProto::Op::AddSignatures: {
         auto path = WorkerProto::Serialise<StorePath>::read(*store, rconn);
-        StringSet sigs = readStrings<StringSet>(conn.from);
+        auto sigs = WorkerProto::Serialise<std::set<Signature>>::read(*store, rconn);
         logger->startWork();
         store->addSignatures(path, sigs);
         logger->stopWork();
@@ -886,7 +886,7 @@ static void performOp(
         info.deriver = std::move(deriver);
         info.references = WorkerProto::Serialise<StorePathSet>::read(*store, rconn);
         conn.from >> info.registrationTime >> info.narSize >> info.ultimate;
-        info.sigs = readStrings<StringSet>(conn.from);
+        info.sigs = WorkerProto::Serialise<std::set<Signature>>::read(*store, rconn);
         info.ca = ContentAddress::parseOpt(readString(conn.from));
         conn.from >> repair >> dontCheckSigs;
         if (!trusted && dontCheckSigs)

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -205,7 +205,7 @@ public:
 
     std::shared_ptr<SourceAccessor> getFSAccessor(const StorePath &, bool requireValidPath = true) override;
 
-    void addSignatures(const StorePath & storePath, const StringSet & sigs) override;
+    void addSignatures(const StorePath & storePath, const std::set<Signature> & sigs) override;
 
     std::optional<std::string> getBuildLogExact(const StorePath & path) override;
 

--- a/src/libstore/include/nix/store/common-protocol.hh
+++ b/src/libstore/include/nix/store/common-protocol.hh
@@ -13,6 +13,7 @@ class StorePath;
 struct ContentAddress;
 struct DrvOutput;
 struct Realisation;
+struct Signature;
 
 /**
  * Shared serializers between the worker protocol, serve protocol, and a
@@ -72,6 +73,8 @@ template<>
 DECLARE_COMMON_SERIALISER(DrvOutput);
 template<>
 DECLARE_COMMON_SERIALISER(Realisation);
+template<>
+DECLARE_COMMON_SERIALISER(Signature);
 
 #define COMMA_ ,
 template<typename T>

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -368,7 +368,7 @@ public:
 
     void vacuumDB();
 
-    void addSignatures(const StorePath & storePath, const StringSet & sigs) override;
+    void addSignatures(const StorePath & storePath, const std::set<Signature> & sigs) override;
 
     /**
      * If free disk space in /nix/store if below minFree, delete

--- a/src/libstore/include/nix/store/path-info.hh
+++ b/src/libstore/include/nix/store/path-info.hh
@@ -102,7 +102,7 @@ struct UnkeyedValidPathInfo
      */
     bool ultimate = false;
 
-    StringSet sigs; // note: not necessarily verified
+    std::set<Signature> sigs;
 
     /**
      * If non-empty, an assertion that the path is content-addressed,
@@ -200,7 +200,7 @@ struct ValidPathInfo : virtual UnkeyedValidPathInfo
     /**
      * Verify a single signature.
      */
-    bool checkSignature(const StoreDirConfig & store, const PublicKeys & publicKeys, const std::string & sig) const;
+    bool checkSignature(const StoreDirConfig & store, const PublicKeys & publicKeys, const Signature & sig) const;
 
     /**
      * References as store path basenames, including a self reference if it has one.

--- a/src/libstore/include/nix/store/realisation.hh
+++ b/src/libstore/include/nix/store/realisation.hh
@@ -54,13 +54,13 @@ struct UnkeyedRealisation
 {
     StorePath outPath;
 
-    StringSet signatures;
+    std::set<Signature> signatures;
 
     std::string fingerprint(const DrvOutput & key) const;
 
     void sign(const DrvOutput & key, const Signer &);
 
-    bool checkSignature(const DrvOutput & key, const PublicKeys & publicKeys, const std::string & sig) const;
+    bool checkSignature(const DrvOutput & key, const PublicKeys & publicKeys, const Signature & sig) const;
 
     size_t checkSignatures(const DrvOutput & key, const PublicKeys & publicKeys) const;
 

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -140,7 +140,7 @@ struct RemoteStore : public virtual Store, public virtual GcStore, public virtua
         unsupported("repairPath");
     }
 
-    void addSignatures(const StorePath & storePath, const StringSet & sigs) override;
+    void addSignatures(const StorePath & storePath, const std::set<Signature> & sigs) override;
 
     MissingPaths queryMissing(const std::vector<DerivedPath> & targets) override;
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -754,7 +754,7 @@ public:
      * Add signatures to the specified store path. The signatures are
      * not verified.
      */
-    virtual void addSignatures(const StorePath & storePath, const StringSet & sigs)
+    virtual void addSignatures(const StorePath & storePath, const std::set<Signature> & sigs)
     {
         unsupported("addSignatures");
     }

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -153,7 +153,9 @@ void LegacySSHStore::addToStore(const ValidPathInfo & info, Source & source, Rep
              << (info.deriver ? printStorePath(*info.deriver) : "")
              << info.narHash.to_string(HashFormat::Base16, false);
     ServeProto::write(*this, *conn, info.references);
-    conn->to << info.registrationTime << info.narSize << info.ultimate << info.sigs << renderContentAddress(info.ca);
+    conn->to << info.registrationTime << info.narSize << info.ultimate;
+    ServeProto::write(*this, *conn, info.sigs);
+    conn->to << renderContentAddress(info.ca);
     try {
         copyNAR(source, conn->to);
     } catch (...) {

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -619,7 +619,8 @@ void LocalStore::registerDrvOutput(const Realisation & info)
                 auto combinedSignatures = oldR->signatures;
                 combinedSignatures.insert(info.signatures.begin(), info.signatures.end());
                 state->stmts->UpdateRealisedOutput
-                    .use()(concatStringsSep(" ", combinedSignatures))(info.id.strHash())(info.id.outputName)
+                    .use()(concatStringsSep(" ", Signature::toStrings(combinedSignatures)))(info.id.strHash())(
+                        info.id.outputName)
                     .exec();
             } else {
                 throw Error(
@@ -634,7 +635,7 @@ void LocalStore::registerDrvOutput(const Realisation & info)
         } else {
             state->stmts->RegisterRealisedOutput
                 .use()(info.id.strHash())(info.id.outputName)(printStorePath(info.outPath))(
-                    concatStringsSep(" ", info.signatures))
+                    concatStringsSep(" ", Signature::toStrings(info.signatures)))
                 .exec();
         }
     });
@@ -659,7 +660,8 @@ uint64_t LocalStore::addValidPath(State & state, const ValidPathInfo & info)
             info.registrationTime == 0 ? time(0) : info.registrationTime)(
             info.deriver ? printStorePath(*info.deriver) : "",
             (bool) info.deriver)(info.narSize, info.narSize != 0)(info.ultimate ? 1 : 0, info.ultimate)(
-            concatStringsSep(" ", info.sigs), !info.sigs.empty())(renderContentAddress(info.ca), (bool) info.ca)
+            concatStringsSep(" ", Signature::toStrings(info.sigs)),
+            !info.sigs.empty())(renderContentAddress(info.ca), (bool) info.ca)
         .exec();
     uint64_t id = state.db.getLastInsertedRowId();
 
@@ -737,7 +739,7 @@ std::shared_ptr<const ValidPathInfo> LocalStore::queryPathInfoInternal(State & s
 
     s = (const char *) sqlite3_column_text(state.stmts->QueryPathInfo, 6);
     if (s)
-        info->sigs = tokenizeString<StringSet>(s, " ");
+        info->sigs = Signature::parseMany(tokenizeString<StringSet>(s, " "));
 
     s = (const char *) sqlite3_column_text(state.stmts->QueryPathInfo, 7);
     if (s)
@@ -757,7 +759,8 @@ void LocalStore::updatePathInfo(State & state, const ValidPathInfo & info)
 {
     state.stmts->UpdatePathInfo
         .use()(info.narSize, info.narSize != 0)(info.narHash.to_string(HashFormat::Base16, true))(
-            info.ultimate ? 1 : 0, info.ultimate)(concatStringsSep(" ", info.sigs), !info.sigs.empty())(
+            info.ultimate ? 1 : 0,
+            info.ultimate)(concatStringsSep(" ", Signature::toStrings(info.sigs)), !info.sigs.empty())(
             renderContentAddress(info.ca), (bool) info.ca)(printStorePath(info.path))
         .exec();
 }
@@ -1484,7 +1487,7 @@ void LocalStore::vacuumDB()
     _state->lock()->db.exec("vacuum");
 }
 
-void LocalStore::addSignatures(const StorePath & storePath, const StringSet & sigs)
+void LocalStore::addSignatures(const StorePath & storePath, const std::set<Signature> & sigs)
 {
     retrySQLite<void>([&]() {
         auto state(_state->lock());
@@ -1515,7 +1518,7 @@ LocalStore::queryRealisationCore_(LocalStore::State & state, const DrvOutput & i
         {realisationDbId,
          UnkeyedRealisation{
              .outPath = outputPath,
-             .signatures = signatures,
+             .signatures = Signature::parseMany(signatures),
          }}};
 }
 

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -277,7 +277,7 @@ public:
                 if (!queryNAR.isNull(9))
                     narInfo->deriver = StorePath(queryNAR.getStr(9));
                 for (auto & sig : tokenizeString<Strings>(queryNAR.getStr(10), " "))
-                    narInfo->sigs.insert(sig);
+                    narInfo->sigs.insert(Signature::parse(sig));
                 narInfo->ca = ContentAddress::parseOpt(queryNAR.getStr(11));
 
                 return {oValid, narInfo};
@@ -337,8 +337,9 @@ public:
                         narInfo && narInfo->fileHash)(
                         narInfo ? narInfo->fileSize : 0, narInfo != 0 && narInfo->fileSize)(info->narHash.to_string(
                         HashFormat::Nix32, true))(info->narSize)(concatStringsSep(" ", info->shortRefs()))(
-                        info->deriver ? std::string(info->deriver->to_string()) : "", (bool) info->deriver)(
-                        concatStringsSep(" ", info->sigs))(renderContentAddress(info->ca))(time(0))
+                        info->deriver ? std::string(info->deriver->to_string()) : "",
+                        (bool) info->deriver)(concatStringsSep(" ", Signature::toStrings(info->sigs)))(
+                        renderContentAddress(info->ca))(time(0))
                     .exec();
 
             } else {

--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -78,7 +78,7 @@ NarInfo::NarInfo(const StoreDirConfig & store, const std::string & s, const std:
             if (value != "unknown-deriver")
                 deriver = StorePath(value);
         } else if (name == "Sig")
-            sigs.insert(value);
+            sigs.insert(Signature::parse(value));
         else if (name == "CA") {
             if (ca)
                 throw corrupt("extra CA");
@@ -124,7 +124,7 @@ std::string NarInfo::to_string(const StoreDirConfig & store) const
         res += "Deriver: " + std::string(deriver->to_string()) + "\n";
 
     for (const auto & sig : sigs)
-        res += "Sig: " + sig + "\n";
+        res += "Sig: " + sig.to_string() + "\n";
 
     if (ca)
         res += "CA: " + renderContentAddress(*ca) + "\n";

--- a/src/libstore/path-info.cc
+++ b/src/libstore/path-info.cc
@@ -129,7 +129,7 @@ size_t ValidPathInfo::checkSignatures(const StoreDirConfig & store, const Public
 }
 
 bool ValidPathInfo::checkSignature(
-    const StoreDirConfig & store, const PublicKeys & publicKeys, const std::string & sig) const
+    const StoreDirConfig & store, const PublicKeys & publicKeys, const Signature & sig) const
 {
     return verifyDetached(fingerprint(store), sig, publicKeys);
 }
@@ -211,9 +211,7 @@ UnkeyedValidPathInfo::toJSON(const StoreDirConfig * store, bool includeImpureInf
 
         jsonObject["ultimate"] = ultimate;
 
-        auto & sigsObj = jsonObject["signatures"] = json::array();
-        for (auto & sig : sigs)
-            sigsObj.push_back(sig);
+        jsonObject["signatures"] = sigs;
     }
 
     return jsonObject;
@@ -287,7 +285,7 @@ UnkeyedValidPathInfo UnkeyedValidPathInfo::fromJSON(const StoreDirConfig * store
         res.ultimate = getBoolean(*rawUltimate);
 
     if (auto * rawSignatures = optionalValueAt(json, "signatures"))
-        res.sigs = getStringSet(*rawSignatures);
+        res.sigs = *rawSignatures;
 
     return res;
 }

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -38,7 +38,7 @@ void UnkeyedRealisation::sign(const DrvOutput & key, const Signer & signer)
 }
 
 bool UnkeyedRealisation::checkSignature(
-    const DrvOutput & key, const PublicKeys & publicKeys, const std::string & sig) const
+    const DrvOutput & key, const PublicKeys & publicKeys, const Signature & sig) const
 {
     return verifyDetached(fingerprint(key), sig, publicKeys);
 }
@@ -86,13 +86,13 @@ UnkeyedRealisation adl_serializer<UnkeyedRealisation>::from_json(const json & js
 {
     auto json = getObject(json0);
 
-    StringSet signatures;
-    if (auto signaturesOpt = optionalValueAt(json, "signatures"))
-        signatures = *signaturesOpt;
-
     return UnkeyedRealisation{
         .outPath = valueAt(json, "outPath"),
-        .signatures = signatures,
+        .signatures = [&] -> std::set<Signature> {
+            if (auto signaturesOpt = optionalValueAt(json, "signatures"))
+                return *signaturesOpt;
+            return {};
+        }(),
     };
 }
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -437,8 +437,9 @@ void RemoteStore::addToStore(const ValidPathInfo & info, Source & source, Repair
     WorkerProto::write(*this, *conn, info.deriver);
     conn->to << info.narHash.to_string(HashFormat::Base16, false);
     WorkerProto::write(*this, *conn, info.references);
-    conn->to << info.registrationTime << info.narSize << info.ultimate << info.sigs << renderContentAddress(info.ca)
-             << repair << !checkSigs;
+    conn->to << info.registrationTime << info.narSize << info.ultimate;
+    WorkerProto::write(*this, *conn, info.sigs);
+    conn->to << renderContentAddress(info.ca) << repair << !checkSigs;
 
     if (GET_PROTOCOL_MINOR(conn->protoVersion) >= 23) {
         conn.withFramedSink([&](Sink & sink) { copyNAR(source, sink); });
@@ -733,12 +734,12 @@ bool RemoteStore::verifyStore(bool checkContents, RepairFlag repair)
     return readInt(conn->from);
 }
 
-void RemoteStore::addSignatures(const StorePath & storePath, const StringSet & sigs)
+void RemoteStore::addSignatures(const StorePath & storePath, const std::set<Signature> & sigs)
 {
     auto conn(getConnection());
     conn->to << WorkerProto::Op::AddSignatures;
     WorkerProto::write(*this, *conn, storePath);
-    conn->to << sigs;
+    WorkerProto::write(*this, *conn, sigs);
     conn.processStderr();
     readInt(conn->from);
 }

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -134,7 +134,7 @@ struct RestrictedStore : public virtual IndirectRootStore, public virtual GcStor
 
     void collectGarbage(const GCOptions & options, GCResults & results) override {}
 
-    void addSignatures(const StorePath & storePath, const StringSet & sigs) override
+    void addSignatures(const StorePath & storePath, const std::set<Signature> & sigs) override
     {
         unsupported("addSignatures");
     }

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -300,7 +300,7 @@ UnkeyedValidPathInfo WorkerProto::Serialise<UnkeyedValidPathInfo>::read(const St
     conn.from >> info.registrationTime >> info.narSize;
     if (GET_PROTOCOL_MINOR(conn.version) >= 16) {
         conn.from >> info.ultimate;
-        info.sigs = readStrings<StringSet>(conn.from);
+        info.sigs = WorkerProto::Serialise<std::set<Signature>>::read(store, conn);
         info.ca = ContentAddress::parseOpt(readString(conn.from));
     }
     return info;
@@ -314,7 +314,9 @@ void WorkerProto::Serialise<UnkeyedValidPathInfo>::write(
     WorkerProto::write(store, conn, pathInfo.references);
     conn.to << pathInfo.registrationTime << pathInfo.narSize;
     if (GET_PROTOCOL_MINOR(conn.version) >= 16) {
-        conn.to << pathInfo.ultimate << pathInfo.sigs << renderContentAddress(pathInfo.ca);
+        conn.to << pathInfo.ultimate;
+        WorkerProto::write(store, conn, pathInfo.sigs);
+        conn.to << renderContentAddress(pathInfo.ca);
     }
 }
 

--- a/src/libutil/include/nix/util/signature/signer.hh
+++ b/src/libutil/include/nix/util/signature/signer.hh
@@ -29,7 +29,7 @@ struct Signer
      * signature](https://en.wikipedia.org/wiki/Detached_signature),
      * i.e. just the signature itself without a copy of the signed data.
      */
-    virtual std::string signDetached(std::string_view data) const = 0;
+    virtual Signature signDetached(std::string_view data) const = 0;
 
     /**
      * View the public key associated with this `Signer`.
@@ -48,7 +48,7 @@ struct LocalSigner : Signer
 {
     LocalSigner(SecretKey && privateKey);
 
-    std::string signDetached(std::string_view s) const override;
+    Signature signDetached(std::string_view s) const override;
 
     const PublicKey & getPublicKey() override;
 

--- a/src/libutil/signature/signer.cc
+++ b/src/libutil/signature/signer.cc
@@ -11,7 +11,7 @@ LocalSigner::LocalSigner(SecretKey && privateKey)
 {
 }
 
-std::string LocalSigner::signDetached(std::string_view s) const
+Signature LocalSigner::signDetached(std::string_view s) const
 {
     return privateKey.signDetached(s);
 }

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -1066,7 +1066,7 @@ static void opServe(Strings opFlags, Strings opArgs)
                 info.deriver = store->parseStorePath(deriver);
             info.references = ServeProto::Serialise<StorePathSet>::read(*store, rconn);
             in >> info.registrationTime >> info.narSize >> info.ultimate;
-            info.sigs = readStrings<StringSet>(in);
+            info.sigs = ServeProto::Serialise<std::set<Signature>>::read(*store, rconn);
             info.ca = ContentAddress::parseOpt(readString(in));
 
             if (info.narSize == 0)

--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -227,7 +227,7 @@ struct CmdPathInfo : StorePathsCommand, MixJSON
                     if (info->ca)
                         ss.push_back("ca:" + renderContentAddress(*info->ca));
                     for (auto & sig : info->sigs)
-                        ss.push_back(sig);
+                        ss.push_back(sig.to_string());
                     str << concatStringsSep(" ", ss);
                 }
 

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -61,7 +61,7 @@ struct CmdCopySigs : StorePathsCommand
 
             auto info = store->queryPathInfo(storePath);
 
-            StringSet newSigs;
+            std::set<Signature> newSigs;
 
             for (auto & store2 : substituters) {
                 try {

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -123,11 +123,11 @@ struct CmdVerify : StorePathsCommand
 
                     else {
 
-                        StringSet sigsSeen;
+                        std::set<Signature> sigsSeen;
                         size_t actualSigsNeeded = std::max(sigsNeeded, (size_t) 1);
                         size_t validSigs = 0;
 
-                        auto doSigs = [&](StringSet sigs) {
+                        auto doSigs = [&](std::set<Signature> sigs) {
                             for (const auto & sig : sigs) {
                                 if (!sigsSeen.insert(sig).second)
                                     continue;

--- a/src/perl/lib/Nix/Store.xs
+++ b/src/perl/lib/Nix/Store.xs
@@ -156,7 +156,7 @@ StoreWrapper::queryPathInfo(char * path, int base32)
             XPUSHs(sv_2mortal(newRV((SV *) refs)));
             AV * sigs = newAV();
             for (auto & i : info->sigs)
-                av_push(sigs, newSVpv(i.c_str(), 0));
+                av_push(sigs, newSVpv(i.to_string().c_str(), 0));
             XPUSHs(sv_2mortal(newRV((SV *) sigs)));
         } catch (Error & e) {
             croak("%s", e.what());
@@ -301,7 +301,7 @@ SV * convertHash(char * algo, char * s, int toBase32)
 SV * signString(char * secretKey_, char * msg)
     PPCODE:
         try {
-            auto sig = SecretKey(secretKey_).signDetached(msg);
+            auto sig = SecretKey(secretKey_).signDetached(msg).to_string();
             XPUSHs(sv_2mortal(newSVpv(sig.c_str(), sig.size())));
         } catch (Error & e) {
             croak("%s", e.what());


### PR DESCRIPTION
## Motivation

Currently, signatures are represented as raw strings in the format `keyName:base64sig`. This requires parsing at every use site and makes the code less type-safe. This PR introduces a `Signature` struct that encapsulates this representation.

## Context

This PR introduces a `Signature` struct and uses it throughout the codebase. The struct has two string fields, a `keyName` and a `sig` field. The `sig` field contains the raw decoded bytes. All places where signatures were used as strings have been updated to use `Signature` now - for example, sets of signatures were `StringSet` before, but are now `std::set<Signature>`. The JSON output is untouched in this PR; we use `to_string()` when writing to/reading from JSON.                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                             
#15009 builds on top of this by actually changing the JSON output to use a more structured type. This PR is the preliminary scaffolding for that.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
