### PR TITLE
ci: Bump magic-nix-cache to disable on 429

### DIFF
--- a/.github/actions/install-nix-action/action.yaml
+++ b/.github/actions/install-nix-action/action.yaml
@@ -128,4 +128,4 @@ runs:
         diagnostic-endpoint: ''
         use-flakehub: false
         use-gha-cache: true
-        source-revision: 92d9581367be2233c2d5714a2640e1339f4087d8 # main
+        source-revision: 93bcd50961a03a468b29fac9d96b7efd037cb507 # main


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

https://github.com/DeterminateSystems/magic-nix-cache/issues/172
https://github.com/NixOS/nix/issues/15016

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
