### PR TITLE
More IO portability cleanups

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -69,8 +69,7 @@ void LocalStore::createTempRootsFile()
 
         /* Check whether the garbage collector didn't get in our
            way. */
-        auto st = nix::fstat(fromDescriptorReadOnly(fdTempRoots->get()));
-        if (st.st_size == 0)
+        if (getFileSize(fdTempRoots->get()) == 0)
             break;
 
         /* The garbage collector deleted this file before we could get

--- a/src/libstore/windows/pathlocks.cc
+++ b/src/libstore/windows/pathlocks.cc
@@ -129,10 +129,7 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
 
             debug("lock acquired on %1%", PathFmt(lockPath));
 
-            struct _stat st;
-            if (_fstat(fromDescriptorReadOnly(fd.get()), &st) == -1)
-                throw SysError("statting lock file %1%", PathFmt(lockPath));
-            if (st.st_size != 0)
+            if (getFileSize(fd.get()) != 0)
                 debug("open lock file %1% has become stale", PathFmt(lockPath));
             else
                 break;

--- a/src/libutil/file-descriptor.cc
+++ b/src/libutil/file-descriptor.cc
@@ -18,18 +18,84 @@ void writeLine(Descriptor fd, std::string s)
     writeFull(fd, s);
 }
 
-std::string drainFD(Descriptor fd, bool block, const size_t reserveSize)
+std::string readFile(Descriptor fd)
+{
+    auto size = getFileSize(fd);
+    // We can't rely on size being correct, most files in /proc have a nominal size of 0
+    return drainFD(fd, {.size = size, .expected = false});
+}
+
+void drainFD(Descriptor fd, Sink & sink, DrainFdSinkOpts opts)
+{
+#ifndef _WIN32
+    // silence GCC maybe-uninitialized warning in finally
+    int saved = 0;
+
+    if (!opts.block) {
+        saved = fcntl(fd, F_GETFL);
+        if (fcntl(fd, F_SETFL, saved | O_NONBLOCK) == -1)
+            throw SysError("making file descriptor non-blocking");
+    }
+
+    Finally finally([&]() {
+        if (!opts.block) {
+            if (fcntl(fd, F_SETFL, saved) == -1)
+                throw SysError("making file descriptor blocking");
+        }
+    });
+#endif
+
+    size_t bytesRead = 0;
+    std::array<std::byte, 64 * 1024> buf;
+    while (1) {
+        checkInterrupt();
+
+        size_t toRead = buf.size();
+        if (opts.expectedSize) {
+            size_t remaining = *opts.expectedSize - bytesRead;
+            if (remaining == 0)
+                break;
+            toRead = std::min(toRead, remaining);
+        }
+
+        size_t n;
+        try {
+            n = read(fd, std::span(buf.data(), toRead));
+        } catch (SystemError & e) {
+#ifndef _WIN32
+            if (!opts.block
+                && (e.is(std::errc::resource_unavailable_try_again) || e.is(std::errc::operation_would_block)))
+                break;
+#endif
+            if (e.is(std::errc::interrupted))
+                continue;
+            throw;
+        }
+
+        if (n == 0) {
+            if (opts.expectedSize && bytesRead < *opts.expectedSize)
+                throw EndOfFile("unexpected end-of-file");
+            break;
+        }
+
+        bytesRead += n;
+        sink(std::string_view(reinterpret_cast<const char *>(buf.data()), n));
+    }
+}
+
+std::string drainFD(Descriptor fd, DrainFdOpts opts)
 {
     // the parser needs two extra bytes to append terminating characters, other users will
     // not care very much about the extra memory.
+    size_t reserveSize = opts.expected ? 0 : opts.size;
     StringSink sink(reserveSize + 2);
-#ifdef _WIN32
-    // non-blocking is not supported this way on Windows
-    assert(block);
-    drainFD(fd, sink);
-#else
-    drainFD(fd, sink, block);
+    DrainFdSinkOpts sinkOpts{
+        .expectedSize = opts.expected ? std::optional<size_t>(opts.size) : std::nullopt,
+#ifndef _WIN32
+        .block = opts.block,
 #endif
+    };
+    drainFD(fd, sink, sinkOpts);
     return std::move(sink.s);
 }
 

--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -48,24 +48,33 @@ static inline Descriptor toDescriptor(int fd)
 }
 
 /**
- * Convert a POSIX file descriptor to a native `Descriptor` in read-only
- * mode.
- *
- * This is a no-op except on Windows.
- */
-static inline int fromDescriptorReadOnly(Descriptor fd)
-{
-#ifdef _WIN32
-    return _open_osfhandle(reinterpret_cast<intptr_t>(fd), _O_RDONLY);
-#else
-    return fd;
-#endif
-}
-
-/**
  * Read the contents of a resource into a string.
  */
 std::string readFile(Descriptor fd);
+
+/**
+ * Platform-specific read into a buffer.
+ *
+ * Thin wrapper around ::read (Unix) or ReadFile (Windows).
+ * Does NOT handle EINTR on Unix - caller must catch and retry if needed.
+ *
+ * @param fd The file descriptor to read from
+ * @param buffer The buffer to read into
+ * @return The number of bytes actually read (0 indicates EOF)
+ * @throws SystemError on failure
+ */
+size_t read(Descriptor fd, std::span<std::byte> buffer);
+
+/**
+ * Get the size of a file.
+ *
+ * Thin wrapper around fstat (Unix) or GetFileSizeEx (Windows).
+ *
+ * @param fd The file descriptor
+ * @return The file size
+ * @throws SystemError on failure
+ */
+std::make_unsigned_t<off_t> getFileSize(Descriptor fd);
 
 /**
  * Platform-specific positioned read into a buffer.
@@ -116,21 +125,63 @@ std::string readLine(Descriptor fd, bool eofOk = false, char terminator = '\n');
 void writeLine(Descriptor fd, std::string s);
 
 /**
- * Read a file descriptor until EOF occurs.
+ * Options for draining a file descriptor to a sink.
  */
-std::string drainFD(Descriptor fd, bool block = true, const size_t reserveSize = 0);
+struct DrainFdSinkOpts
+{
+    /**
+     * If provided, read exactly this many bytes (throws EndOfFile if EOF occurs before reading all bytes).
+     */
+    std::optional<std::make_unsigned_t<off_t>> expectedSize = {};
+
+#ifndef _WIN32
+    /**
+     * Whether to block on read.
+     */
+    bool block = true;
+#endif
+};
 
 /**
- * The Windows version is always blocking.
+ * Options for draining a file descriptor to a string.
  */
-void drainFD(
-    Descriptor fd,
-    Sink & sink
+struct DrainFdOpts
+{
+    /**
+     * If expected=true: read exactly this many bytes (throws EndOfFile if EOF occurs before reading all bytes).
+     * If expected=false: size hint for string allocation.
+     */
+    std::make_unsigned_t<off_t> size = 0;
+
+    /**
+     * If true, size is exact expected size. If false, size is just a reservation hint.
+     */
+    bool expected = false;
+
 #ifndef _WIN32
-    ,
-    bool block = true
+    /**
+     * Whether to block on read.
+     */
+    bool block = true;
 #endif
-);
+};
+
+/**
+ * Read a file descriptor until EOF occurs.
+ *
+ * @param fd The file descriptor to drain
+ * @param opts Options for the drain operation
+ */
+std::string drainFD(Descriptor fd, DrainFdOpts opts = {});
+
+/**
+ * Read a file descriptor until EOF occurs, writing to a sink.
+ *
+ * @param fd The file descriptor to drain
+ * @param sink The sink to write data to
+ * @param opts Options for the drain operation
+ */
+void drainFD(Descriptor fd, Sink & sink, DrainFdSinkOpts opts = {});
 
 /**
  * Get [Standard Input](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin))

--- a/src/libutil/unix/muxable-pipe.cc
+++ b/src/libutil/unix/muxable-pipe.cc
@@ -27,7 +27,7 @@ void MuxablePipePollState::iterate(
         assert(fdPollStatusId);
         assert(*fdPollStatusId < pollStatus.size());
         if (pollStatus.at(*fdPollStatusId).revents) {
-            ssize_t rd = ::read(fromDescriptorReadOnly(k), buffer.data(), buffer.size());
+            ssize_t rd = ::read(k, buffer.data(), buffer.size());
             // FIXME: is there a cleaner way to handle pt close
             // than EIO? Is this even standard?
             if (rd == 0 || (rd == -1 && errno == EIO)) {

--- a/src/libutil/windows/file-descriptor.cc
+++ b/src/libutil/windows/file-descriptor.cc
@@ -17,13 +17,12 @@ namespace nix {
 
 using namespace nix::windows;
 
-std::string readFile(HANDLE handle)
+std::make_unsigned_t<off_t> getFileSize(Descriptor fd)
 {
     LARGE_INTEGER li;
-    if (!GetFileSizeEx(handle, &li))
-        throw WinError("%s:%d statting file", __FILE__, __LINE__);
-
-    return drainFD(handle, true, li.QuadPart);
+    if (!GetFileSizeEx(fd, &li))
+        throw WinError("GetFileSizeEx");
+    return li.QuadPart;
 }
 
 void readFull(HANDLE handle, char * buf, size_t count)
@@ -84,21 +83,12 @@ std::string readLine(HANDLE handle, bool eofOk)
     }
 }
 
-void drainFD(HANDLE handle, Sink & sink /*, bool block*/)
+size_t read(Descriptor fd, std::span<std::byte> buffer)
 {
-    std::vector<unsigned char> buf(64 * 1024);
-    while (1) {
-        checkInterrupt();
-        DWORD rd;
-        if (!ReadFile(handle, buf.data(), buf.size(), &rd, NULL)) {
-            WinError winError("%s:%d reading from handle %p", __FILE__, __LINE__, handle);
-            if (winError.lastError == ERROR_BROKEN_PIPE)
-                break;
-            throw winError;
-        } else if (rd == 0)
-            break;
-        sink({(char *) buf.data(), (size_t) rd});
-    }
+    DWORD n;
+    if (!ReadFile(fd, buffer.data(), static_cast<DWORD>(buffer.size()), &n, NULL))
+        throw WinError("ReadFile of %1% bytes", buffer.size());
+    return static_cast<size_t>(n);
 }
 
 size_t readOffset(Descriptor fd, off_t offset, std::span<std::byte> buffer)

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -237,7 +237,7 @@ static int main_build_remote(int argc, char ** argv)
                     sshStore = bestMachine->openStore();
                     sshStore->connect();
                 } catch (std::exception & e) {
-                    auto msg = chomp(drainFD(5, false));
+                    auto msg = chomp(drainFD(5, {.block = false}));
                     printError("cannot build on '%s': %s%s", storeUri, e.what(), msg.empty() ? "" : ": " + msg);
                     bestMachine->enabled = false;
                     continue;


### PR DESCRIPTION
## Motivation

- options structs for `drainFD` (both versions)
- portable `read` wrapper
- portable `GetFileSize` wrapper
- dedup `readFile` and `drainFD` using the above
- Use `drainFD` in `PosixSourceAccessor`, avoiding manual IO
- Remove `fromDescriptorReadOnly` entirely!

## Context

Depends on #15028

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
