### PR TITLE
Split out `AutoAllocateUidSettings`

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -235,7 +235,7 @@ protected:
      */
     virtual std::unique_ptr<UserLock> getBuildUser()
     {
-        return acquireUserLock(1, false);
+        return acquireUserLock(settings.buildUsersGroup, 1, false);
     }
 
     /**

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -215,7 +215,7 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
 
     std::unique_ptr<UserLock> getBuildUser() override
     {
-        return acquireUserLock(drvOptions.useUidRange(drv) ? 65536 : 1, true);
+        return acquireUserLock(settings.buildUsersGroup, drvOptions.useUidRange(drv) ? 65536 : 1, true);
     }
 
     void prepareUser() override

--- a/src/libstore/unix/include/nix/store/user-lock.hh
+++ b/src/libstore/unix/include/nix/store/user-lock.hh
@@ -36,7 +36,7 @@ struct UserLock
  * Acquire a user lock for a UID range of size `nrIds`. Note that this
  * may return nullptr if no user is available.
  */
-std::unique_ptr<UserLock> acquireUserLock(uid_t nrIds, bool useUserNamespace);
+std::unique_ptr<UserLock> acquireUserLock(const std::string & userGroup, uid_t nrIds, bool useUserNamespace);
 
 bool useBuildUsers();
 


### PR DESCRIPTION
## Motivation

Progress on #5638

## Context

This is a bit of weird process for a few reasons:

1. I would like to get the struct as in the pair of fields to move out of `globals.hh`, but I don't want to move the settings descriptions to a new header, so I just did a weird split in place.

   Firstly because the setting descriptions (as we agreed) should not be in a header at all, and secondly, because I *do* want to group all these settings together somehow, not pass many unrelated, unnested arguments around.

2. The current settings infrastructure prevents correct data modeling that would allow `autoAllocateUids` to go from a `bool` to a `std::optional<AutoAllocateUidSettings>`. So we are stuck just having a pair of a `bool` and `AutoAllocateUidSettings` which is not correct.

   However, we can compensate for this making the inheritance *private* and making the getter that looks like the field that we want to have. This pattern should be repeated as we break up the structs further, so we can enforce correct access patterns on the users of the globals without first having to overhaul the settings system before making any progress.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
