### PR TITLE
Remove `Settings::nixPrefix`

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -74,8 +74,7 @@ Settings settings;
 static GlobalConfig::Register rSettings(&settings);
 
 Settings::Settings()
-    : nixPrefix(NIX_PREFIX)
-    , nixStore(
+    : nixStore(
 #ifndef _WIN32
           // On Windows `/nix/store` is not a canonical path, but we dont'
           // want to deal with that yet.

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -79,8 +79,6 @@ public:
 
     static unsigned int getDefaultCores();
 
-    Path nixPrefix;
-
     /**
      * The directory where we store sources and derived files.
      */

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -251,7 +251,6 @@ endif
 # Aside from prefix itself, each of these was made into an absolute path
 # by joining it with prefix, unless it was already an absolute path
 # (which is the default for store-dir, localstatedir, and log-dir).
-configdata_priv.set_quoted('NIX_PREFIX', prefix)
 configdata_priv.set_quoted('NIX_STORE_DIR', store_dir)
 configdata_priv.set_quoted('NIX_DATA_DIR', datadir)
 configdata_priv.set_quoted('NIX_STATE_DIR', localstatedir / 'nix')


### PR DESCRIPTION
It has been dead code since c9f51e87057652db0013289a95deffba495b35e7

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
