### PR TITLE
Remove `nixDataDir`, `NIX_DATA_DIR`

### DIFF
--- a/doc/manual/source/command-ref/env-common.md
+++ b/doc/manual/source/command-ref/env-common.md
@@ -57,11 +57,6 @@ Most Nix commands interpret the following environment variables:
 
   Overrides the location of the Nix store (default `prefix/store`).
 
-- <span id="env-NIX_DATA_DIR">[`NIX_DATA_DIR`](#env-NIX_DATA_DIR)</span>
-
-  Overrides the location of the Nix static data directory (default
-  `prefix/share`).
-
 - <span id="env-NIX_LOG_DIR">[`NIX_LOG_DIR`](#env-NIX_LOG_DIR)</span>
 
   Overrides the location of the Nix log directory (default

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -308,7 +308,6 @@ void printVersion(const std::string & programName)
         std::cout << "User configuration files: " << concatStringsSep(":", settings.nixUserConfFiles) << "\n";
         std::cout << "Store directory: " << settings.nixStore << "\n";
         std::cout << "State directory: " << settings.nixStateDir << "\n";
-        std::cout << "Data directory: " << settings.nixDataDir << "\n";
     }
     throw Exit();
 }

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -82,7 +82,6 @@ Settings::Settings()
           canonPath
 #endif
           (getEnvNonEmpty("NIX_STORE_DIR").value_or(getEnvNonEmpty("NIX_STORE").value_or(NIX_STORE_DIR))))
-    , nixDataDir(canonPath(getEnvNonEmpty("NIX_DATA_DIR").value_or(NIX_DATA_DIR)))
     , nixLogDir(canonPath(getEnvNonEmpty("NIX_LOG_DIR").value_or(NIX_LOG_DIR)))
     , nixStateDir(canonPath(getEnvNonEmpty("NIX_STATE_DIR").value_or(NIX_STATE_DIR)))
     , nixConfDir(canonPath(getEnvOsNonEmpty(OS_STR("NIX_CONF_DIR"))

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -86,8 +86,6 @@ public:
      */
     Path nixStore;
 
-    Path nixDataDir; /* !!! fix */
-
     /**
      * The directory where we log various operations.
      */

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -213,7 +213,6 @@ prefix = get_option('prefix')
 # it is already an absolute path (which is the default for store-dir, localstatedir, and log-dir).
 path_opts = [
   # Meson built-ins.
-  'datadir',
   'mandir',
   'libdir',
   'includedir',
@@ -253,7 +252,6 @@ endif
 # (which is the default for store-dir, localstatedir, and log-dir).
 configdata_priv.set_quoted('NIX_PREFIX', prefix)
 configdata_priv.set_quoted('NIX_STORE_DIR', store_dir)
-configdata_priv.set_quoted('NIX_DATA_DIR', datadir)
 configdata_priv.set_quoted('NIX_STATE_DIR', localstatedir / 'nix')
 configdata_priv.set_quoted('NIX_LOG_DIR', log_dir)
 # On Windows, NIX_CONF_DIR is determined at runtime using the Windows known


### PR DESCRIPTION
Since 25300c0ecdedcd8720b996b41e78dfe1037bfcff it is dead code.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
