### PR TITLE
nix config check: improve error when no nix-env in PATH

### DIFF
--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -95,7 +95,9 @@ struct CmdConfigCheck : StoreCommand
                 dirs.insert(std::filesystem::canonical(candidate).parent_path());
         }
 
-        if (dirs.size() != 1) {
+        if (dirs.empty()) {
+            return checkFail("No nix-env found in PATH.");
+        } else if (dirs.size() > 1) {
             std::ostringstream ss;
             ss << "Multiple versions of nix found in PATH:\n";
             for (auto & dir : dirs)


### PR DESCRIPTION
## Motivation

When there is no `nix-env` in PATH the current error message:
```
$ nix config check --verbose
Running checks against store uri: local
[FAIL] Multiple versions of nix found in PATH:

```
is a bit confusing.

This change improves the error message in this case to say
`No nix-env found in PATH.`

Perhaps the current error message could also mention `nix-env`?

## Context

It is possible that the `nix` executable is installed but not `nix-env`
(this may be unusual but for example in Fedora we have a separate `nix-legacy` subpackage,
which includes the `nix-env` symlink).
This makes sense for rootless usage (without `/nix`) or for just pure modern workflows in general.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
