### PR TITLE
libstore: split out `LogFileSettings`

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -69,6 +69,11 @@ static std::filesystem::path resolveNixConfDir()
 #endif
 }
 
+LogFileSettings::LogFileSettings()
+    : nixLogDir(canonPath(getEnvNonEmpty("NIX_LOG_DIR").value_or(NIX_LOG_DIR)))
+{
+}
+
 Settings settings;
 
 static GlobalConfig::Register rSettings(&settings);
@@ -81,7 +86,6 @@ Settings::Settings()
           canonPath
 #endif
           (getEnvNonEmpty("NIX_STORE_DIR").value_or(getEnvNonEmpty("NIX_STORE").value_or(NIX_STORE_DIR))))
-    , nixLogDir(canonPath(getEnvNonEmpty("NIX_LOG_DIR").value_or(NIX_LOG_DIR)))
     , nixStateDir(canonPath(getEnvNonEmpty("NIX_STATE_DIR").value_or(NIX_STATE_DIR)))
     , nixConfDir(canonPath(getEnvOsNonEmpty(OS_STR("NIX_CONF_DIR"))
                                .transform([](auto && s) { return std::filesystem::path(s); })

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -143,7 +143,42 @@ struct GCSettings : public virtual Config
     };
 };
 
-class Settings : public virtual Config, private GCSettings
+struct LogFileSettings : public virtual Config
+{
+    /**
+     * The directory where we log various operations.
+     */
+    const Path nixLogDir;
+
+protected:
+    LogFileSettings();
+
+public:
+    Setting<bool> keepLog{
+        this,
+        true,
+        "keep-build-log",
+        R"(
+          If set to `true` (the default), Nix writes the build log of a
+          derivation (i.e. the standard output and error of its builder) to
+          the directory `/nix/var/log/nix/drvs`. The build log can be
+          retrieved using the command `nix-store -l path`.
+        )",
+        {"build-keep-log"}};
+
+    Setting<bool> compressLog{
+        this,
+        true,
+        "compress-build-log",
+        R"(
+          If set to `true` (the default), build logs written to
+          `/nix/var/log/nix/drvs` are compressed on the fly using bzip2.
+          Otherwise, they are not compressed.
+        )",
+        {"build-compress-log"}};
+};
+
+class Settings : public virtual Config, private GCSettings, private LogFileSettings
 {
 
     StringSet getDefaultSystemFeatures();
@@ -171,17 +206,25 @@ public:
         return *this;
     }
 
+    /**
+     * Get the log file settings.
+     */
+    LogFileSettings & getLogFileSettings()
+    {
+        return *this;
+    }
+
+    const LogFileSettings & getLogFileSettings() const
+    {
+        return *this;
+    }
+
     static unsigned int getDefaultCores();
 
     /**
      * The directory where we store sources and derived files.
      */
     Path nixStore;
-
-    /**
-     * The directory where we log various operations.
-     */
-    Path nixLogDir;
 
     /**
      * The directory where state is stored.
@@ -655,29 +698,6 @@ public:
         "impersonate-linux-26",
         "Whether to impersonate a Linux 2.6 machine on newer kernels.",
         {"build-impersonate-linux-26"}};
-
-    Setting<bool> keepLog{
-        this,
-        true,
-        "keep-build-log",
-        R"(
-          If set to `true` (the default), Nix writes the build log of a
-          derivation (i.e. the standard output and error of its builder) to
-          the directory `/nix/var/log/nix/drvs`. The build log can be
-          retrieved using the command `nix-store -l path`.
-        )",
-        {"build-keep-log"}};
-
-    Setting<bool> compressLog{
-        this,
-        true,
-        "compress-build-log",
-        R"(
-          If set to `true` (the default), build logs written to
-          `/nix/var/log/nix/drvs` are compressed on the fly using bzip2.
-          Otherwise, they are not compressed.
-        )",
-        {"build-compress-log"}};
 
     Setting<unsigned long> maxLogSize{
         this,

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -15,7 +15,7 @@ Path LocalFSStoreConfig::getDefaultStateDir()
 
 Path LocalFSStoreConfig::getDefaultLogDir()
 {
-    return settings.nixLogDir;
+    return settings.getLogFileSettings().nixLogDir;
 }
 
 LocalFSStoreConfig::LocalFSStoreConfig(PathView rootDir, const Params & params)

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -910,7 +910,7 @@ static void opServe(Strings opFlags, Strings opArgs)
         // FIXME: changing options here doesn't work if we're
         // building through the daemon.
         verbosity = lvlError;
-        settings.keepLog = false;
+        settings.getLogFileSettings().keepLog = false;
         settings.useSubstitutes = false;
 
         auto options = ServeProto::Serialise<ServeProto::BuildOptions>::read(*store, rconn);


### PR DESCRIPTION
## Motivation

This PR progresses on #5638 

The log file settings (`nixLogDir`, `keepLog`, `compressLog`) are logically related but scattered in the large `Settings` class.

## Context

This follows the same pattern as #15043 in that we:

- Create a `LogFileSettings` struct that inherits from `virtual Config`
- Have `Settings` privately inherit from it
- Re-export the members via `using` declarations to preserve the existing API
- Add a `getLogFileSettings()` getter for explicit dependency injection

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
