### PR TITLE
libstore: split out `GCSettings`

### DIFF
--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -408,8 +408,12 @@ void Worker::waitForInput()
        is a build timeout, then wait for input until the first
        deadline for any child. */
     auto nearest = steady_time_point::max(); // nearest deadline
-    if (settings.minFree.get() != 0)
-        // Periodicallty wake up to see if we need to run the garbage collector.
+
+    auto localStore = dynamic_cast<LocalStore *>(&store);
+    if (localStore && localStore->config->getGCSettings().minFree.get() != 0)
+        // If we have a local store (and thus are capable of automatically collecting garbage) and configured to do so,
+        // periodically wake up to see if we need to run the garbage collector. (See the `autoGC` call site above in
+        // this file, also gated on having a local store. when we wake up, we intended to reach that call site.)
         nearest = before + std::chrono::seconds(10);
     for (auto & i : children) {
         if (!i.respectTimeouts)

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -465,9 +465,11 @@ struct GCLimitReached
 
 void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
 {
+    const auto & gcSettings = config->getGCSettings();
+
     bool shouldDelete = options.action == GCOptions::gcDeleteDead || options.action == GCOptions::gcDeleteSpecific;
-    bool gcKeepOutputs = settings.gcKeepOutputs;
-    bool gcKeepDerivations = settings.gcKeepDerivations;
+    bool keepOutputs = gcSettings.keepOutputs;
+    bool keepDerivations = gcSettings.keepDerivations;
 
     boost::unordered_flat_set<StorePath, std::hash<StorePath>> roots, dead, alive;
 
@@ -491,8 +493,8 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
        (the garbage collector will recurse into deleting the outputs
        or derivers, respectively).  So disable them. */
     if (options.action == GCOptions::gcDeleteSpecific && options.ignoreLiveness) {
-        gcKeepOutputs = false;
-        gcKeepDerivations = false;
+        keepOutputs = false;
+        keepDerivations = false;
     }
 
     if (shouldDelete)
@@ -728,8 +730,8 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                         *path,
                         closure,
                         /* flipDirection */ false,
-                        gcKeepOutputs,
-                        gcKeepDerivations);
+                        keepOutputs,
+                        keepDerivations);
                     for (auto & p : closure)
                         alive.insert(p);
                 } catch (InvalidPath &) {
@@ -770,7 +772,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
 
                 /* If keep-derivations is set and this is a
                    derivation, then visit the derivation outputs. */
-                if (gcKeepDerivations && path->isDerivation()) {
+                if (keepDerivations && path->isDerivation()) {
                     for (auto & [name, maybeOutPath] : queryPartialDerivationOutputMap(*path))
                         if (maybeOutPath && isValidPath(*maybeOutPath)
                             && queryPathInfo(*maybeOutPath)->deriver == *path)
@@ -778,7 +780,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 }
 
                 /* If keep-outputs is set, then visit the derivers. */
-                if (gcKeepOutputs) {
+                if (keepOutputs) {
                     auto derivers = queryValidDerivers(*path);
                     for (auto & i : derivers)
                         enqueue(i);
@@ -920,6 +922,8 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
 void LocalStore::autoGC(bool sync)
 {
 #if HAVE_STATVFS
+    const auto & gcSettings = config->getGCSettings();
+
     static auto fakeFreeSpaceFile = getEnv("_NIX_TEST_FREE_SPACE_FILE");
 
     auto getAvail = [this]() -> uint64_t {
@@ -946,14 +950,14 @@ void LocalStore::autoGC(bool sync)
 
         auto now = std::chrono::steady_clock::now();
 
-        if (now < state->lastGCCheck + std::chrono::seconds(settings.minFreeCheckInterval))
+        if (now < state->lastGCCheck + std::chrono::seconds(gcSettings.minFreeCheckInterval))
             return;
 
         auto avail = getAvail();
 
         state->lastGCCheck = now;
 
-        if (avail >= settings.minFree || avail >= settings.maxFree)
+        if (avail >= gcSettings.minFree || avail >= gcSettings.maxFree)
             return;
 
         if (avail > state->availAfterGC * 0.97)
@@ -964,7 +968,7 @@ void LocalStore::autoGC(bool sync)
         std::promise<void> promise;
         future = state->gcFuture = promise.get_future().share();
 
-        std::thread([promise{std::move(promise)}, this, avail, getAvail]() mutable {
+        std::thread([promise{std::move(promise)}, this, avail, getAvail, &gcSettings]() mutable {
             try {
 
                 /* Wake up any threads waiting for the auto-GC to finish. */
@@ -976,7 +980,7 @@ void LocalStore::autoGC(bool sync)
                 });
 
                 GCOptions options;
-                options.maxFreed = settings.maxFree - avail;
+                options.maxFreed = gcSettings.maxFree - avail;
 
                 printInfo("running auto-GC to free %d bytes", options.maxFreed);
 

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -31,6 +31,8 @@ struct OptimiseStats
     uint64_t bytesFreed = 0;
 };
 
+struct GCSettings;
+
 struct LocalBuildStoreConfig : virtual LocalFSStoreConfig
 {
 
@@ -85,6 +87,11 @@ private:
     bool getDefaultRequireSigs();
 
 public:
+    /**
+     * For now, this just grabs the global GC settings, but by having this method we get ready for these being per-store
+     * settings instead.
+     */
+    const GCSettings & getGCSettings() const;
 
     Setting<bool> requireSigs{
         this,

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -503,7 +503,8 @@ static void opQuery(Strings opFlags, Strings opArgs)
                 args.insert(p);
 
         StorePathSet referrers;
-        store->computeFSClosure(args, referrers, true, settings.gcKeepOutputs, settings.gcKeepDerivations);
+        auto & gcSettings = settings.getGCSettings();
+        store->computeFSClosure(args, referrers, true, gcSettings.keepOutputs, gcSettings.keepDerivations);
 
         auto & gcStore = require<GcStore>(*store);
         Roots roots = gcStore.findRoots(false);


### PR DESCRIPTION
## Motivation

The GC settings (`reservedSize`, `keepOutputs`, `keepDerivations`, `minFree`, `maxFree`, `minFreeCheckInterval`) are all related to garbage collection but currently live scattered across the large `Settings` class.

## Context

This PR follows the same approach as #15043 and the [`LogFileSettings`](https://github.com/NixOS/nix/pull/15051) extraction:

- `GCSettings` struct inherits from `virtual Config`                                                                                                                                                                                                                                                                                
- `Settings` privately inherits from it                                                                                                                                                                                                                                                                                             
- Accessed through `getGCSettings()`

The new method on `LocalStoreConfig` anticipates on making these
settings per-store. 0b606aad46e1d96da36d4831df63ad90f11d21c3 added both
the autoGC and periodic wakeups, which is why we think they are related.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
