### PR TITLE
Support `readLinkAt` and `openFileEnsureBeneathNoSymlinks` on Windows too

### DIFF
--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -69,7 +69,6 @@ static std::filesystem::path append(const std::filesystem::path & src, const Can
     return dst;
 }
 
-#ifndef _WIN32
 void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallback callback)
 {
     if (path.isRoot()) {
@@ -83,15 +82,23 @@ void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallba
 
     RestoreSink dirSink{startFsync};
     dirSink.dstPath = append(dstPath, path);
-    dirSink.dirFd =
-        unix::openFileEnsureBeneathNoSymlinks(dirFd.get(), path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    dirSink.dirFd = openFileEnsureBeneathNoSymlinks(
+        dirFd.get(),
+        path,
+#ifdef _WIN32
+        FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        FILE_DIRECTORY_FILE
+#else
+        O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC,
+        0
+#endif
+    );
 
     if (!dirSink.dirFd)
         throw SysError("opening directory %s", PathFmt(dirSink.dstPath));
 
     callback(dirSink, CanonPath::root);
 }
-#endif
 
 void RestoreSink::createDirectory(const CanonPath & path)
 {
@@ -174,7 +181,7 @@ void RestoreSink::createRegularFile(const CanonPath & path, std::function<void(C
             constexpr int flags = O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC;
             if (!dirFd)
                 return ::open(p.c_str(), flags, 0666);
-            return unix::openFileEnsureBeneathNoSymlinks(dirFd.get(), path, flags, 0666);
+            return openFileEnsureBeneathNoSymlinks(dirFd.get(), path, flags, 0666);
         }()
 #endif
     );

--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -3,6 +3,7 @@
 
 #include "nix/util/canon-path.hh"
 #include "nix/util/error.hh"
+#include "nix/util/os-string.hh"
 
 #ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
@@ -132,6 +133,14 @@ void drainFD(
 );
 
 /**
+ * Read a symlink relative to a directory file descriptor.
+ *
+ * @throws SystemError on any I/O errors.
+ * @throws Interrupted if interrupted.
+ */
+OsString readLinkAt(Descriptor dirFd, const CanonPath & path);
+
+/**
  * Get [Standard Input](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin))
  */
 [[gnu::always_inline]]
@@ -247,38 +256,42 @@ std::optional<Descriptor> openat2(Descriptor dirFd, const char * path, uint64_t 
 } // namespace linux
 #endif
 
-#if defined(_WIN32) && _WIN32_WINNT >= 0x0600
-namespace windows {
-
-Path handleToPath(Descriptor handle);
-std::wstring handleToFileName(Descriptor handle);
-
-} // namespace windows
-#endif
-
-#ifndef _WIN32
-namespace unix {
-
 /**
- * Safe(r) function to open \param path file relative to \param dirFd, while
- * disallowing escaping from a directory and resolving any symlinks in the
- * process.
+ * Safe(r) function to open a file relative to dirFd, while
+ * disallowing escaping from a directory and any symlinks in the process.
  *
- * @note When not on Linux or when openat2 is not available this is implemented
- * via openat single path component traversal. Uses RESOLVE_BENEATH with openat2
- * or O_RESOLVE_BENEATH.
+ * @note On Windows, implemented via NtCreateFile single path component traversal
+ * with FILE_OPEN_REPARSE_POINT. On Unix, uses RESOLVE_BENEATH with openat2 when
+ * available, or falls back to openat single path component traversal.
  *
- * @note Since this is Unix-only path is specified as CanonPath, which models
- * Unix-style paths and ensures that there are no .. or . components.
- *
- * @param flags O_* flags
- * @param mode Mode for O_{CREAT,TMPFILE}
+ * @param dirFd Directory handle to open relative to
+ * @param path Relative path (no .. or . components)
+ * @param desiredAccess (Windows) Windows ACCESS_MASK (e.g., GENERIC_READ, FILE_WRITE_DATA)
+ * @param createOptions (Windows) Windows create options (e.g., FILE_NON_DIRECTORY_FILE)
+ * @param createDisposition (Windows) FILE_OPEN, FILE_CREATE, etc.
+ * @param flags (Unix) O_* flags
+ * @param mode (Unix) Mode for O_{CREAT,TMPFILE}
  *
  * @pre path.isRoot() is false
  *
- * @throws SymlinkNotAllowed if any path components
+ * @throws SymlinkNotAllowed if any path components are symlinks
+ * @throws SystemError on other errors
  */
-Descriptor openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & path, int flags, mode_t mode = 0);
+Descriptor openFileEnsureBeneathNoSymlinks(
+    Descriptor dirFd,
+    const CanonPath & path,
+#ifdef _WIN32
+    ACCESS_MASK desiredAccess,
+    ULONG createOptions,
+    ULONG createDisposition = FILE_OPEN
+#else
+    int flags,
+    mode_t mode = 0
+#endif
+);
+
+#ifndef _WIN32
+namespace unix {
 
 /**
  * Try to change the mode of file named by \ref path relative to the parent directory denoted by \ref dirFd.
@@ -290,14 +303,6 @@ Descriptor openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & p
  * @throws SysError if any operation fails
  */
 void fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t mode);
-
-/*
- * Read a symlink relative to a directory file descriptor.
- *
- * @throws SysError on any I/O errors.
- * @throws Interrupted if interrupted. SysError::errNo can never be EINTR.
- */
-std::string readLinkAt(Descriptor dirFd, const CanonPath & path);
 
 } // namespace unix
 #endif

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -166,6 +166,22 @@ Path readLink(const Path & path);
  */
 std::filesystem::path readLink(const std::filesystem::path & path);
 
+#ifdef _WIN32
+namespace windows {
+
+/**
+ * Get the path associated with a file handle.
+ *
+ * @note One MUST only use this for error handling, because it creates
+ * TOCTOU issues. We don't mind if error messages point to out of date
+ * paths (that is a rather trivial TOCTOU --- the error message is best
+ * effort) but for anything else we do.
+ */
+std::filesystem::path handleToPath(Descriptor handle);
+
+} // namespace windows
+#endif
+
 /**
  * Open a `Descriptor` with read-only access to the given directory.
  */

--- a/src/libutil/include/nix/util/fs-sink.hh
+++ b/src/libutil/include/nix/util/fs-sink.hh
@@ -99,7 +99,6 @@ struct NullFileSystemObjectSink : FileSystemObjectSink
 struct RestoreSink : FileSystemObjectSink
 {
     std::filesystem::path dstPath;
-#ifndef _WIN32
     /**
      * File descriptor for the directory located at dstPath. Used for *at
      * operations relative to this file descriptor. This sink must *never*
@@ -110,7 +109,6 @@ struct RestoreSink : FileSystemObjectSink
      * is not susceptible to symlink replacement.
      */
     AutoCloseFD dirFd;
-#endif
     bool startFsync = false;
 
     explicit RestoreSink(bool startFsync)
@@ -120,9 +118,7 @@ struct RestoreSink : FileSystemObjectSink
 
     void createDirectory(const CanonPath & path) override;
 
-#ifndef _WIN32
     void createDirectory(const CanonPath & path, DirectoryCreatedCallback callback) override;
-#endif
 
     void createRegularFile(const CanonPath & path, std::function<void(CreateRegularFileSink &)>) override;
 

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -407,7 +407,7 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
     return res;
 }
 
-Descriptor unix::openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & path, int flags, mode_t mode)
+Descriptor openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & path, int flags, mode_t mode)
 {
     assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
     assert(!path.isRoot());
@@ -423,7 +423,7 @@ Descriptor unix::openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPa
     return openFileEnsureBeneathNoSymlinksIterative(dirFd, path, flags, mode);
 }
 
-std::string unix::readLinkAt(Descriptor dirFd, const CanonPath & path)
+OsString readLinkAt(Descriptor dirFd, const CanonPath & path)
 {
     assert(!path.isRoot());
     assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */

--- a/src/libutil/windows/file-descriptor.cc
+++ b/src/libutil/windows/file-descriptor.cc
@@ -3,6 +3,7 @@
 #include "nix/util/finally.hh"
 #include "nix/util/serialise.hh"
 #include "nix/util/file-path.hh"
+#include "nix/util/source-accessor.hh"
 
 #include <span>
 
@@ -12,6 +13,8 @@
 #include <namedpipeapi.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <winioctl.h>
+#include <winternl.h>
 
 namespace nix {
 
@@ -46,16 +49,12 @@ void writeFull(HANDLE handle, std::string_view s, bool allowInterrupts)
         if (allowInterrupts)
             checkInterrupt();
         DWORD res;
-#if _WIN32_WINNT >= 0x0600
-        auto path = handleToPath(handle); // debug; do it before because handleToPath changes lasterror
         if (!WriteFile(handle, s.data(), s.size(), &res, NULL)) {
-            throw WinError("writing to file %1%:%2%", handle, path);
+            // Do this because `handleToPath` will overwrite the last error.
+            auto lastError = GetLastError();
+            auto path = handleToPath(handle);
+            throw WinError(lastError, "writing to file %d:%s", handle, PathFmt(path));
         }
-#else
-        if (!WriteFile(handle, s.data(), s.size(), &res, NULL)) {
-            throw WinError("writing to file %1%", handle);
-        }
-#endif
         if (res > 0)
             s.remove_prefix(res);
     }
@@ -132,37 +131,6 @@ void Pipe::create()
 
 //////////////////////////////////////////////////////////////////////
 
-#if _WIN32_WINNT >= 0x0600
-
-std::wstring windows::handleToFileName(HANDLE handle)
-{
-    std::vector<wchar_t> buf(0x100);
-    DWORD dw = GetFinalPathNameByHandleW(handle, buf.data(), buf.size(), FILE_NAME_OPENED);
-    if (dw == 0) {
-        if (handle == GetStdHandle(STD_INPUT_HANDLE))
-            return L"<stdin>";
-        if (handle == GetStdHandle(STD_OUTPUT_HANDLE))
-            return L"<stdout>";
-        if (handle == GetStdHandle(STD_ERROR_HANDLE))
-            return L"<stderr>";
-        return (boost::wformat(L"<unnnamed handle %X>") % handle).str();
-    }
-    if (dw > buf.size()) {
-        buf.resize(dw);
-        if (GetFinalPathNameByHandleW(handle, buf.data(), buf.size(), FILE_NAME_OPENED) != dw - 1)
-            throw WinError("GetFinalPathNameByHandleW");
-        dw -= 1;
-    }
-    return std::wstring(buf.data(), dw);
-}
-
-Path windows::handleToPath(HANDLE handle)
-{
-    return os_string_to_string(handleToFileName(handle));
-}
-
-#endif
-
 off_t lseek(HANDLE h, off_t offset, int whence)
 {
     DWORD method;
@@ -192,6 +160,298 @@ off_t lseek(HANDLE h, off_t offset, int whence)
     }
 
     return newPos.QuadPart;
+}
+
+namespace windows {
+
+namespace {
+
+/**
+ * Open a file/directory relative to a directory handle using NtCreateFile.
+ *
+ * @param dirFd Directory handle to open relative to
+ * @param pathComponent Single path component (not a full path)
+ * @param desiredAccess Access rights requested
+ * @param createOptions NT create options flags
+ * @param createDisposition FILE_OPEN, FILE_CREATE, etc.
+ * @return Handle to the opened file/directory (caller must close)
+ */
+HANDLE ntOpenAt(
+    Descriptor dirFd,
+    std::wstring_view pathComponent,
+    ACCESS_MASK desiredAccess,
+    ULONG createOptions,
+    ULONG createDisposition = FILE_OPEN)
+{
+    /* Set up UNICODE_STRING for the relative path */
+    UNICODE_STRING pathStr;
+    pathStr.Buffer = const_cast<PWSTR>(pathComponent.data());
+    pathStr.Length = static_cast<USHORT>(pathComponent.size() * sizeof(wchar_t));
+    pathStr.MaximumLength = pathStr.Length;
+
+    /* Set up OBJECT_ATTRIBUTES to open relative to dirFd */
+    OBJECT_ATTRIBUTES objAttrs;
+    InitializeObjectAttributes(
+        &objAttrs,
+        &pathStr,
+        0,      // No special flags
+        dirFd,  // RootDirectory
+        nullptr // No security descriptor
+    );
+
+    /* Open using NT API */
+    IO_STATUS_BLOCK ioStatus;
+    HANDLE h;
+    NTSTATUS status = NtCreateFile(
+        &h,
+        desiredAccess,
+        &objAttrs,
+        &ioStatus,
+        nullptr, // No allocation size
+        FILE_ATTRIBUTE_NORMAL,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        createDisposition,
+        createOptions | FILE_SYNCHRONOUS_IO_NONALERT,
+        nullptr, // No EA buffer
+        0        // No EA length
+    );
+
+    if (status != 0)
+        throw WinError(
+            RtlNtStatusToDosError(status), "opening %s relative to directory handle", PathFmt(pathComponent));
+
+    return h;
+}
+
+/**
+ * Open a symlink relative to a directory handle without following it.
+ *
+ * @param dirFd Directory handle to open relative to
+ * @param path Relative path to the symlink
+ * @return Handle to the symlink (caller must close)
+ */
+HANDLE openSymlinkAt(Descriptor dirFd, const CanonPath & path)
+{
+    assert(!path.isRoot());
+    assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
+
+    std::wstring wpath = string_to_os_string(path.rel());
+    return ntOpenAt(dirFd, wpath, FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+}
+
+/**
+ * This struct isn't defined in the normal Windows SDK, but only in the Windows Driver Kit.
+ *
+ * I (@Ericson2314) would not normally do something like this, but LLVM
+ * has decided that this is in fact stable, per
+ * https://github.com/llvm/llvm-project/blob/main/libcxx/src/filesystem/posix_compat.h,
+ * so I guess that is good enough for us. GCC doesn't support symlinks
+ * at all on windows so we have to put it here, not grab it from private
+ * c++ standard library headers anyways.
+ */
+struct ReparseDataBuffer
+{
+    unsigned long ReparseTag;
+    unsigned short ReparseDataLength;
+    unsigned short Reserved;
+
+    union
+    {
+        struct
+        {
+            unsigned short SubstituteNameOffset;
+            unsigned short SubstituteNameLength;
+            unsigned short PrintNameOffset;
+            unsigned short PrintNameLength;
+            unsigned long Flags;
+            wchar_t PathBuffer[1];
+        } SymbolicLinkReparseBuffer;
+
+        struct
+        {
+            unsigned short SubstituteNameOffset;
+            unsigned short SubstituteNameLength;
+            unsigned short PrintNameOffset;
+            unsigned short PrintNameLength;
+            wchar_t PathBuffer[1];
+        } MountPointReparseBuffer;
+
+        struct
+        {
+            unsigned char DataBuffer[1];
+        } GenericReparseBuffer;
+    };
+};
+
+/**
+ * Read the target of a symlink from an open handle.
+ *
+ * @param linkHandle Handle to a symlink (must have been opened with FILE_OPEN_REPARSE_POINT)
+ * @return The symlink target as a wide string
+ */
+OsString readSymlinkTarget(HANDLE linkHandle)
+{
+    uint8_t buf[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+    DWORD out;
+
+    checkInterrupt();
+
+    if (!DeviceIoControl(linkHandle, FSCTL_GET_REPARSE_POINT, nullptr, 0, buf, sizeof(buf), &out, nullptr))
+        throw WinError("reading reparse point for handle %d", linkHandle);
+
+    const auto * reparse = reinterpret_cast<const ReparseDataBuffer *>(buf);
+    size_t path_buf_offset = offsetof(ReparseDataBuffer, SymbolicLinkReparseBuffer.PathBuffer[0]);
+
+    if (out < path_buf_offset) {
+        auto fullPath = handleToPath(linkHandle);
+        throw WinError(
+            DWORD{ERROR_REPARSE_TAG_INVALID}, "invalid reparse data for %d:%s", linkHandle, PathFmt(fullPath));
+    }
+
+    if (reparse->ReparseTag != IO_REPARSE_TAG_SYMLINK) {
+        auto fullPath = handleToPath(linkHandle);
+        throw WinError(DWORD{ERROR_REPARSE_TAG_INVALID}, "not a symlink: %d:%s", linkHandle, PathFmt(fullPath));
+    }
+
+    const auto & symlink = reparse->SymbolicLinkReparseBuffer;
+    unsigned short name_offset, name_length;
+
+    /* Prefer PrintName over SubstituteName if available */
+    if (symlink.PrintNameLength == 0) {
+        name_offset = symlink.SubstituteNameOffset;
+        name_length = symlink.SubstituteNameLength;
+    } else {
+        name_offset = symlink.PrintNameOffset;
+        name_length = symlink.PrintNameLength;
+    }
+
+    if (path_buf_offset + name_offset + name_length > out) {
+        auto fullPath = handleToPath(linkHandle);
+        throw WinError(
+            DWORD{ERROR_REPARSE_TAG_INVALID}, "invalid symlink data for %d:%s", linkHandle, PathFmt(fullPath));
+    }
+
+    /* Extract the target path */
+    const wchar_t * target_start = &symlink.PathBuffer[name_offset / sizeof(wchar_t)];
+    size_t target_len = name_length / sizeof(wchar_t);
+
+    return {target_start, target_len};
+}
+
+/**
+ * Check if a handle refers to a reparse point (e.g., symlink).
+ *
+ * @param handle Open file/directory handle
+ * @return true if the handle refers to a reparse point
+ */
+bool isReparsePoint(HANDLE handle)
+{
+    FILE_BASIC_INFO basicInfo;
+    if (!GetFileInformationByHandleEx(handle, FileBasicInfo, &basicInfo, sizeof(basicInfo)))
+        throw WinError("GetFileInformationByHandleEx");
+
+    return (basicInfo.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+}
+
+} // anonymous namespace
+
+} // namespace windows
+
+Descriptor openFileEnsureBeneathNoSymlinks(
+    Descriptor dirFd, const CanonPath & path, ACCESS_MASK desiredAccess, ULONG createOptions, ULONG createDisposition)
+{
+    assert(!path.isRoot());
+    assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
+
+    AutoCloseFD parentFd;
+    auto nrComponents = std::ranges::distance(path);
+    assert(nrComponents >= 1);
+    auto components = std::views::take(path, nrComponents - 1); /* Everything but last component */
+    auto getParentFd = [&]() { return parentFd ? parentFd.get() : dirFd; };
+
+    /* Helper to construct CanonPath from components up to (and including) the given iterator */
+    auto pathUpTo = [&](auto it) {
+        return std::ranges::fold_left(components.begin(), it, CanonPath::root, [](auto lhs, auto rhs) {
+            lhs.push(rhs);
+            return lhs;
+        });
+    };
+
+    /* Helper to check if a component is a symlink and throw SymlinkNotAllowed if so */
+    auto throwIfSymlink = [&](std::wstring_view component, const CanonPath & pathForError) {
+        try {
+            auto testFd =
+                ntOpenAt(getParentFd(), component, FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+            AutoCloseFD testHandle(testFd);
+            if (isReparsePoint(testHandle.get()))
+                throw SymlinkNotAllowed(pathForError);
+        } catch (SymlinkNotAllowed &) {
+            throw;
+        } catch (...) {
+            /* If we can't determine, ignore and let caller handle original error */
+        }
+    };
+
+    /* Iterate through each path component to ensure no symlinks in intermediate directories.
+     * This prevents TOCTOU issues by opening each component relative to the parent. */
+    for (auto it = components.begin(); it != components.end(); ++it) {
+        std::wstring wcomponent = string_to_os_string(std::string(*it));
+
+        /* Open directory without following symlinks */
+        AutoCloseFD parentFd2;
+        try {
+            parentFd2 = ntOpenAt(
+                getParentFd(),
+                wcomponent,
+                FILE_TRAVERSE | SYNCHRONIZE,                  // Just need traversal rights
+                FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT // Open directory, don't follow symlinks
+            );
+        } catch (WinError & e) {
+            /* Check if this is because it's a symlink */
+            if (e.lastError == ERROR_CANT_ACCESS_FILE || e.lastError == ERROR_ACCESS_DENIED) {
+                throwIfSymlink(wcomponent, pathUpTo(std::next(it)));
+            }
+            throw;
+        }
+
+        /* Check if what we opened is actually a symlink */
+        if (isReparsePoint(parentFd2.get())) {
+            throw SymlinkNotAllowed(pathUpTo(std::next(it)));
+        }
+
+        parentFd = std::move(parentFd2);
+    }
+
+    /* Now open the final component with requested flags */
+    std::wstring finalComponent = string_to_os_string(std::string(path.baseName().value()));
+
+    HANDLE finalHandle;
+    try {
+        finalHandle = ntOpenAt(
+            getParentFd(),
+            finalComponent,
+            desiredAccess,
+            createOptions | FILE_OPEN_REPARSE_POINT, // Don't follow symlinks on final component either
+            createDisposition);
+    } catch (WinError & e) {
+        /* Check if final component is a symlink when we requested to not follow it */
+        if (e.lastError == ERROR_CANT_ACCESS_FILE) {
+            throwIfSymlink(finalComponent, path);
+        }
+        throw;
+    }
+
+    /* Final check: did we accidentally open a symlink? */
+    if (isReparsePoint(finalHandle))
+        throw SymlinkNotAllowed(path);
+
+    return finalHandle;
+}
+
+OsString readLinkAt(Descriptor dirFd, const CanonPath & path)
+{
+    AutoCloseFD linkHandle(windows::openSymlinkAt(dirFd, path));
+    return windows::readSymlinkTarget(linkHandle.get());
 }
 
 } // namespace nix

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -1,5 +1,11 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/logging.hh"
+#include "nix/util/signals.hh"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <boost/format.hpp>
 
 namespace nix {
 
@@ -62,6 +68,28 @@ void deletePath(const std::filesystem::path & path, uint64_t & bytesFreed)
 {
     bytesFreed = 0;
     deletePath(path);
+}
+
+std::filesystem::path windows::handleToPath(HANDLE handle)
+{
+    std::vector<wchar_t> buf(0x100);
+    DWORD dw = GetFinalPathNameByHandleW(handle, buf.data(), buf.size(), FILE_NAME_OPENED);
+    if (dw == 0) {
+        if (handle == GetStdHandle(STD_INPUT_HANDLE))
+            return L"<stdin>";
+        if (handle == GetStdHandle(STD_OUTPUT_HANDLE))
+            return L"<stdout>";
+        if (handle == GetStdHandle(STD_ERROR_HANDLE))
+            return L"<stderr>";
+        return (boost::wformat(L"<unnnamed handle %X>") % handle).str();
+    }
+    if (dw > buf.size()) {
+        buf.resize(dw);
+        if (GetFinalPathNameByHandleW(handle, buf.data(), buf.size(), FILE_NAME_OPENED) != dw - 1)
+            throw WinError("GetFinalPathNameByHandleW");
+        dw -= 1;
+    }
+    return std::filesystem::path{std::wstring{buf.data(), dw}};
 }
 
 } // namespace nix


### PR DESCRIPTION
## Motivation

This means that `RestoreSink` can work in the TOCTOU-resilliant way on Windows too. And it also bodes will for the upcoming OS source accessor improvements.

A few misc little refactors around error handling and whatnot are done along the way too. (No more attempt to support pre Windows Vista! lol.)

## Context

This cannot be reliably automatically tested until we have a newer version of Wine, but it does build, so I am inclined to say we just try it for now.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
