### PR TITLE
build-result: throw better

### DIFF
--- a/src/libstore/build-result.cc
+++ b/src/libstore/build-result.cc
@@ -75,6 +75,11 @@ static BuildResult::Failure::Status failureStatusFromString(std::string_view str
     throw Error("unknown built result failure status '%s'", str);
 }
 
+[[noreturn]] void BuildResult::Failure::rethrow() const
+{
+    throw BuildError(status, "%s", errorMsg);
+}
+
 } // namespace nix
 
 namespace nlohmann {

--- a/src/libstore/include/nix/store/build-result.hh
+++ b/src/libstore/include/nix/store/build-result.hh
@@ -95,10 +95,7 @@ struct BuildResult
         bool operator==(const BuildResult::Failure &) const noexcept;
         std::strong_ordering operator<=>(const BuildResult::Failure &) const noexcept;
 
-        [[noreturn]] void rethrow() const
-        {
-            throw Error("%s", errorMsg);
-        }
+        [[noreturn]] void rethrow() const;
     };
 
     std::variant<Success, Failure> inner = Failure{};


### PR DESCRIPTION
 Small PR that includes the failure status in `BuildError` when rethrowing build failures for better error diagnostics.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
