### PR TITLE
ci: Drop magic-nix-cache

### DIFF
--- a/.github/actions/install-nix-action/action.yaml
+++ b/.github/actions/install-nix-action/action.yaml
@@ -24,8 +24,8 @@ inputs:
     description: "Github token"
     required: true
   use_cache:
-    description: "Whether to setup magic-nix-cache"
-    default: true
+    description: "Whether to setup github actions cache (not implemented currently)"
+    default: false
     required: false
 runs:
   using: "composite"
@@ -122,10 +122,3 @@ runs:
         source-url: ${{ inputs.experimental-installer-version != 'latest' && 'https://artifacts.nixos.org/experimental-installer/tag/${{ inputs.experimental-installer-version }}/${{ env.EXPERIMENTAL_INSTALLER_ARTIFACT }}' || '' }}
         nix-package-url: ${{ inputs.dogfood == 'true' && steps.download-nix-installer.outputs.tarball-path || (inputs.tarball_url || '') }}
         extra-conf: ${{ inputs.extra_nix_config }}
-    - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
-      if: ${{ inputs.use_cache == 'true' }}
-      with:
-        diagnostic-endpoint: ''
-        use-flakehub: false
-        use-gha-cache: true
-        source-revision: 93bcd50961a03a468b29fac9d96b7efd037cb507 # main


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

We are now seeing. I guess we are out with the cache. When the API responds with 418 (I'm a teapot) it seems like the only reasonable solution is to oblige.

```
error: unable to download 'http://127.0.0.1:37515/7ms9f25xyxavf32pvdc3vb28nzzmkbn3.narinfo': HTTP error 418
       response body:
       GitHub API error: GitHub Actions Cache throttled Magic Nix Cache. Not trying to use it again on this run.
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
