### PR TITLE
logging: signal upfront build/substitution totals before work begins

### DIFF
--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -330,8 +330,15 @@ void Worker::run(const Goals & _topGoals)
         }
     }
 
-    /* Call queryMissing() to efficiently query substitutes. */
-    store.queryMissing(topPaths);
+    /* Call queryMissing() to efficiently query substitutes and get upfront totals. */
+    auto missing = store.queryMissing(topPaths);
+    upfrontBuilds = missing.willBuild.size();
+    upfrontSubstitutions = missing.willSubstitute.size();
+    upfrontDownloadSize = missing.downloadSize;
+    upfrontNarSize = missing.narSize;
+
+    /* Signal upfront totals before starting work. */
+    updateProgress();
 
     debug("entered goal loop");
 

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -199,6 +199,15 @@ public:
     uint64_t doneNarSize = 0;
 
     /**
+     * Upfront totals from queryMissing(), signaled before work begins.
+     * These represent the total expected work computed at the start.
+     */
+    uint64_t upfrontBuilds = 0;
+    uint64_t upfrontSubstitutions = 0;
+    uint64_t upfrontDownloadSize = 0;
+    uint64_t upfrontNarSize = 0;
+
+    /**
      * Whether to ask the build hook if it can build a derivation. If
      * it answers with "decline-permanently", we don't try again.
      */
@@ -373,11 +382,24 @@ public:
 
     void updateProgress()
     {
-        actDerivations.progress(doneBuilds, expectedBuilds + doneBuilds, runningBuilds, failedBuilds);
-        actSubstitutions.progress(
-            doneSubstitutions, expectedSubstitutions + doneSubstitutions, runningSubstitutions, failedSubstitutions);
-        act.setExpected(actFileTransfer, expectedDownloadSize + doneDownloadSize);
-        act.setExpected(actCopyPath, expectedNarSize + doneNarSize);
+        // Report done/running/failed via progress(), but set expected=0 to avoid double-counting
+        // with the setExpected() calls below which set the total expected counts.
+        actDerivations.progress(doneBuilds, 0, runningBuilds, failedBuilds);
+        actSubstitutions.progress(doneSubstitutions, 0, runningSubstitutions, failedSubstitutions);
+
+        // Use upfront totals if available (from queryMissing), otherwise fall back to dynamic tracking.
+        // setExpected() signals the total expected count for each activity type.
+        auto totalBuilds = upfrontBuilds > 0 ? upfrontBuilds : expectedBuilds + doneBuilds;
+        auto totalSubstitutions =
+            upfrontSubstitutions > 0 ? upfrontSubstitutions : expectedSubstitutions + doneSubstitutions;
+        auto totalDownloadSize =
+            upfrontDownloadSize > 0 ? upfrontDownloadSize : expectedDownloadSize + doneDownloadSize;
+        auto totalNarSize = upfrontNarSize > 0 ? upfrontNarSize : expectedNarSize + doneNarSize;
+
+        act.setExpected(actBuilds, totalBuilds);
+        act.setExpected(actCopyPaths, totalSubstitutions);
+        act.setExpected(actFileTransfer, totalDownloadSize);
+        act.setExpected(actCopyPath, totalNarSize);
     }
 };
 


### PR DESCRIPTION
Use queryMissing() results to signal the total expected builds, substitutions, download bytes, and NAR bytes via setExpected() at the start of Worker::run(), before any goals execute.

This allows external tools consuming JSON logs to know the full expected workload upfront rather than watching expected counts grow dynamically as goals are created.
