### PR TITLE
tests: fix sandbox-paths in cancelled-builds test

### DIFF
--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -224,9 +224,17 @@ if isDaemonNewer "2.34pre" && canUseSandbox; then
     mkdir -p "$fifoDir"
     mkfifo "$fifoDir/fifo"
     chmod a+rw "$fifoDir/fifo"
+    # When using a separate test store, we need sandbox-paths to access
+    # the system store (where bash/coreutils live). On NixOS, the test
+    # uses the system store directly, so this isn't needed (and would
+    # conflict with input paths).
+    sandboxPathsArg=()
+    if ! isTestOnNixOS; then
+        sandboxPathsArg=(--option sandbox-paths "/nix/store")
+    fi
     out="$(nix flake check ./cancelled-builds --impure -L -j2 \
         --option sandbox true \
-        --option sandbox-paths "${NIX_STORE:-/nix/store}" \
+        "${sandboxPathsArg[@]}" \
         --option sandbox-build-dir /build-tmp \
         --option extra-sandbox-paths "/cancelled-builds-fifo=$fifoDir" \
         2>&1)" && status=0 || status=$?
@@ -245,10 +253,14 @@ if isDaemonNewer "2.34pre" && canUseSandbox; then
     mkdir -p "$fifoDir"
     mkfifo "$fifoDir/fifo"
     chmod a+rw "$fifoDir/fifo"
+    sandboxPathsArg=()
+    if ! isTestOnNixOS; then
+        sandboxPathsArg=(--option sandbox-paths "/nix/store")
+    fi
     system=$(nix eval --raw --impure --expr builtins.currentSystem)
     out="$(nix build --impure -L -j2 \
         --option sandbox true \
-        --option sandbox-paths "${NIX_STORE:-/nix/store}" \
+        "${sandboxPathsArg[@]}" \
         --option sandbox-build-dir /build-tmp \
         --option extra-sandbox-paths "/cancelled-builds-fifo=$fifoDir" \
         "./cancelled-builds#checks.$system.slow" \


### PR DESCRIPTION
Don't add the whole store to sandbox-paths unconditionally. Exposing the entire store defeats the purpose of sandboxing, and when the test store is the same as the system store (NixOS VM), it causes an obscure "Permission denied" error.

Only add `sandbox-paths` `/nix/store` when `NIX_STORE_DIR` is set, indicating a separate test store that needs access to system store build tools.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fix async test failure `nix build '.#hydraJobs.tests.functional_root'`

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Caused by new test in https://github.com/NixOS/nix/pull/14972
- Thank you @xokdvium for finding and pinging

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
