### PR TITLE
Cleanup stat usage

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -68,7 +68,7 @@ void LocalStore::createTempRootsFile()
 
         /* Check whether the garbage collector didn't get in our
            way. */
-        struct stat st;
+        PosixStat st;
         if (fstat(fromDescriptorReadOnly(fdTempRoots->get()), &st) == -1)
             throw SysError("statting '%1%'", fnTempRoots);
         if (st.st_size == 0)
@@ -901,9 +901,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                accounting.  */
         }
 
-        struct stat st;
-        if (stat(linksDir.c_str(), &st) == -1)
-            throw SysError("statting '%1%'", linksDir);
+        auto st = stat(linksDir);
         int64_t overhead =
 #ifdef _WIN32
             0

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -169,7 +169,7 @@ void LocalStore::optimisePath_(
 
     /* Maybe delete the link, if it has been corrupted. */
     if (std::filesystem::exists(std::filesystem::symlink_status(linkPath))) {
-        auto stLink = lstat(linkPath.string());
+        auto stLink = lstat(linkPath);
         if (st.st_size != stLink.st_size || (repair && hash != ({
                                                            hashPath(
                                                                makeFSSourceAccessor(linkPath),
@@ -215,7 +215,7 @@ void LocalStore::optimisePath_(
 
     /* Yes!  We've seen a file with the same contents.  Replace the
        current file with a hard link to that file. */
-    auto stLink = lstat(linkPath.string());
+    auto stLink = lstat(linkPath);
 
     if (st.st_ino == stLink.st_ino) {
         debug("%1% is already linked to %2%", PathFmt(path), PathFmt(linkPath));

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -15,7 +15,7 @@ namespace nix {
 
 const time_t mtimeStore = 1; /* 1 second into the epoch */
 
-static void canonicaliseTimestampAndPermissions(const Path & path, const struct stat & st)
+static void canonicaliseTimestampAndPermissions(const Path & path, const PosixStat & st)
 {
     if (!S_ISLNK(st.st_mode)) {
 
@@ -31,7 +31,7 @@ static void canonicaliseTimestampAndPermissions(const Path & path, const struct 
 
 #ifndef _WIN32 // TODO implement
     if (st.st_mtime != mtimeStore) {
-        struct stat st2 = st;
+        PosixStat st2 = st;
         st2.st_mtime = mtimeStore, setWriteTime(path, st2);
     }
 #endif

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1419,7 +1419,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         scratchOutputsInverse.insert_or_assign(path, outputName);
 
     std::map<std::string, std::variant<AlreadyRegistered, PerhapsNeedToRegister>> outputReferencesIfUnregistered;
-    std::map<std::string, struct stat> outputStats;
+    std::map<std::string, PosixStat> outputStats;
     for (auto & [outputName, _] : drv.outputs) {
         auto scratchOutput = get(scratchOutputs, outputName);
         assert(scratchOutput);
@@ -1448,7 +1448,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                 store.printStorePath(drvPath),
                 outputName,
                 PathFmt(actualPath));
-        struct stat & st = *optSt;
+        PosixStat & st = *optSt;
 
 #ifndef __CYGWIN__
         /* Check that the output is not group or world writable, as

--- a/src/libstore/unix/pathlocks.cc
+++ b/src/libstore/unix/pathlocks.cc
@@ -1,4 +1,5 @@
 #include "nix/store/pathlocks.hh"
+#include "nix/util/file-system.hh"
 #include "nix/util/util.hh"
 #include "nix/util/sync.hh"
 #include "nix/util/signals.hh"
@@ -110,7 +111,7 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
 
             /* Check that the lock file hasn't become stale (i.e.,
                hasn't been unlinked). */
-            struct stat st;
+            PosixStat st;
             if (fstat(fd.get(), &st) == -1)
                 throw SysError("statting lock file %1%", PathFmt(lockPath));
             if (st.st_size != 0)

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -189,7 +189,7 @@ void RestoreRegularFile::isExecutable()
     // Windows doesn't have a notion of executable file permissions we
     // care about here, right?
 #ifndef _WIN32
-    struct stat st;
+    PosixStat st;
     if (fstat(fd.get(), &st) == -1)
         throw SysError("fstat");
     if (fchmod(fd.get(), st.st_mode | (S_IXUSR | S_IXGRP | S_IXOTH)) == -1)

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #ifdef _WIN32
 #  include <windef.h>
+#  include <wchar.h>
 #endif
 
 #include <functional>
@@ -111,15 +112,30 @@ bool isInDir(const std::filesystem::path & path, const std::filesystem::path & d
 bool isDirOrInDir(const std::filesystem::path & path, const std::filesystem::path & dir);
 
 /**
+ * `struct stat` is not 64-bit everywhere on Windows.
+ */
+using PosixStat =
+#ifdef _WIN32
+    struct ::__stat64
+#else
+    struct ::stat
+#endif
+    ;
+
+/**
  * Get status of `path`.
  */
-struct stat stat(const Path & path);
-struct stat lstat(const Path & path);
+PosixStat lstat(const std::filesystem::path & path);
+/**
+ * Get status of `path` following symlinks.
+ */
+PosixStat stat(const std::filesystem::path & path);
 /**
  * `lstat` the given path if it exists.
  * @return std::nullopt if the path doesn't exist, or an optional containing the result of `lstat` otherwise
  */
-std::optional<struct stat> maybeLstat(const Path & path);
+std::optional<PosixStat> maybeLstat(const std::filesystem::path & path);
+std::optional<PosixStat> maybeStat(const std::filesystem::path & path);
 
 /**
  * @return true iff the given path exists.
@@ -260,9 +276,9 @@ void setWriteTime(
     std::optional<bool> isSymlink = std::nullopt);
 
 /**
- * Convenience wrapper that takes all arguments from the `struct stat`.
+ * Convenience wrapper that takes all arguments from the `PosixStat`.
  */
-void setWriteTime(const std::filesystem::path & path, const struct stat & st);
+void setWriteTime(const std::filesystem::path & path, const PosixStat & st);
 
 /**
  * Create a symlink.

--- a/src/libutil/include/nix/util/posix-source-accessor.hh
+++ b/src/libutil/include/nix/util/posix-source-accessor.hh
@@ -87,7 +87,7 @@ private:
      */
     void assertNoSymlinks(CanonPath path);
 
-    std::optional<struct stat> cachedLstat(const CanonPath & path);
+    std::optional<PosixStat> cachedLstat(const CanonPath & path);
 
     std::filesystem::path makeAbsPath(const CanonPath & path);
 };

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -55,7 +55,7 @@ void PosixSourceAccessor::readFile(const CanonPath & path, Sink & sink, std::fun
     if (!fd)
         throw SysError("opening file '%1%'", ap.string());
 
-    struct stat st;
+    PosixStat st;
     if (fstat(fromDescriptorReadOnly(fd.get()), &st) == -1)
         throw SysError("statting file");
 
@@ -87,9 +87,9 @@ bool PosixSourceAccessor::pathExists(const CanonPath & path)
     return nix::pathExists(makeAbsPath(path).string());
 }
 
-std::optional<struct stat> PosixSourceAccessor::cachedLstat(const CanonPath & path)
+std::optional<PosixStat> PosixSourceAccessor::cachedLstat(const CanonPath & path)
 {
-    using Cache = boost::concurrent_flat_map<Path, std::optional<struct stat>>;
+    using Cache = boost::concurrent_flat_map<Path, std::optional<PosixStat>>;
     static Cache cache;
 
     // Note: we convert std::filesystem::path to Path because the

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -51,7 +51,7 @@ void pollFD(int fd, int events)
 
 std::string readFile(int fd)
 {
-    struct stat st;
+    PosixStat st;
     if (fstat(fd, &st) == -1)
         throw SysError("statting file");
 

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -110,7 +110,7 @@ static void _deletePath(
     std::string name(path.filename());
     assert(name != "." && name != ".." && !name.empty());
 
-    struct stat st;
+    PosixStat st;
     if (fstatat(parentfd, name.c_str(), &st, AT_SYMLINK_NOFOLLOW) == -1) {
         if (errno == ENOENT)
             return;

--- a/src/nix/nix-channel/nix-channel.cc
+++ b/src/nix/nix-channel/nix-channel.cc
@@ -163,7 +163,7 @@ static void update(const StringSet & channelNames)
     runProgram(getNixBin("nix-env").string(), false, envArgs);
 
     // Make the channels appear in nix-env.
-    struct stat st;
+    PosixStat st;
     if (lstat(nixDefExpr.c_str(), &st) == 0) {
         if (S_ISLNK(st.st_mode))
             // old-skool ~/.nix-defexpr


### PR DESCRIPTION
## Motivation

Use wrappers to make error handling easier.

## Context

On Windows we are using proper 64-bit time and size info.

We still have the problem of no `lstat` on Windows, but this will be dealt with in future PRs.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
