### PR TITLE
Clean up `AutoRemoveJail`, `AutoDelete`, and `AutoUnmount`

### DIFF
--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -177,7 +177,8 @@ static DownloadTarballResult downloadTarball_(
            the entire file to disk so libarchive can access it
            in random-access mode. */
         auto [fdTemp, path] = createTempFile("nix-zipfile");
-        cleanupTemp.reset(path);
+        cleanupTemp.cancel();
+        cleanupTemp = {path};
         debug("downloading '%s' into '%s'...", url, path);
         {
             FdSink sink(fdTemp.get());

--- a/src/libutil/freebsd/freebsd-jail.cc
+++ b/src/libutil/freebsd/freebsd-jail.cc
@@ -11,39 +11,35 @@
 
 namespace nix {
 
-AutoRemoveJail::AutoRemoveJail()
-    : del{false}
-{
-}
+AutoRemoveJail::AutoRemoveJail() = default;
 
 AutoRemoveJail::AutoRemoveJail(int jid)
     : jid(jid)
-    , del(true)
 {
+}
+
+void AutoRemoveJail::remove()
+{
+    if (jid != INVALID_JAIL) {
+        if (jail_remove(jid) < 0) {
+            throw SysError("Failed to remove jail %1%", jid);
+        }
+    }
+    cancel();
 }
 
 AutoRemoveJail::~AutoRemoveJail()
 {
     try {
-        if (del) {
-            if (jail_remove(jid) < 0) {
-                throw SysError("Failed to remove jail %1%", jid);
-            }
-        }
+        remove();
     } catch (...) {
         ignoreExceptionInDestructor();
     }
 }
 
-void AutoRemoveJail::cancel()
+void AutoRemoveJail::cancel() noexcept
 {
-    del = false;
-}
-
-void AutoRemoveJail::reset(int j)
-{
-    del = true;
-    jid = j;
+    jid = INVALID_JAIL;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/libutil/freebsd/include/nix/util/freebsd-jail.hh
+++ b/src/libutil/freebsd/include/nix/util/freebsd-jail.hh
@@ -7,32 +7,51 @@ namespace nix {
 
 class AutoRemoveJail
 {
-    int jid;
-    bool del;
+    static constexpr int INVALID_JAIL = -1;
+    int jid = INVALID_JAIL;
 public:
+    AutoRemoveJail() = default;
     AutoRemoveJail(int jid);
     AutoRemoveJail(const AutoRemoveJail &) = delete;
     AutoRemoveJail & operator=(const AutoRemoveJail &) = delete;
 
     AutoRemoveJail(AutoRemoveJail && other) noexcept
         : jid(other.jid)
-        , del(other.del)
     {
         other.cancel();
     }
 
     AutoRemoveJail & operator=(AutoRemoveJail && other) noexcept
     {
-        jid = other.jid;
-        del = other.del;
-        other.cancel();
+        swap(*this, other);
         return *this;
     }
 
-    AutoRemoveJail();
+    friend void swap(AutoRemoveJail & lhs, AutoRemoveJail & rhs) noexcept
+    {
+        using std::swap;
+        swap(lhs.jid, rhs.jid);
+    }
+
+    operator int() const
+    {
+        return jid;
+    }
+
     ~AutoRemoveJail();
-    void cancel();
-    void reset(int j);
+
+    /**
+     * Remove the jail and cancel this `AutoRemoveJail`, so jail removal is not
+     * attempted a second time by the destructor.
+     *
+     * The destructor calls this ignoring any exception.
+     */
+    void remove();
+
+    /**
+     * Cancel the jail removal.
+     */
+    void cancel() noexcept;
 };
 
 } // namespace nix


### PR DESCRIPTION
## Motivation

- Extract destructor logic into named methods (`deletePath()`, `unmount()`, and `remove()`) that can be called explicitly. These ones will throw exceptions normally, unlike the destructor which must quash them to avoid double-exceptions.

- Use `std::filesystem::path` in `AutoUnmount` (changed from `Path`)

- Remove `del` field from `AutoRemoveJail`, using `INVALID_JAIL` sentinel value instead.

- Add move assignment operators implemented via friend `swap` functions for all three RAII classes.

- Remove old `reset(...)` methods that took parameters. These were a bit misleading --- do they cancel or immediately destroy? --- and doing it explicitly with cancel and then assignment is not hard.

## Context

Needed for some sandboxing cleanups.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
