### PR TITLE
globals: refactor `diffHook` settings

### DIFF
--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -906,6 +906,8 @@ public:
           line.
         )"};
 
+private:
+
     OptionalPathSetting diffHook{
         this,
         std::nullopt,
@@ -937,6 +939,16 @@ public:
           When using the Nix daemon, `diff-hook` must be set in the `nix.conf`
           configuration file, and cannot be passed at the command line.
         )"};
+
+public:
+
+    const Path * getDiffHook() const
+    {
+        if (!runDiffHook.get()) {
+            return nullptr;
+        }
+        return get(diffHook.get());
+    }
 
     Setting<Strings> trustedPublicKeys{
         this,


### PR DESCRIPTION
## Motivation

The settings related to diff hook (`run-diff-hook` and `diff-hook`) are a little redundant and don't need to be leaked in derivation-builder when computing the diff hook path to execute.

## Context

Instead of directly using both `runDiffHook` and `diffHook` settings in derivation-builder, we can just encapsulate the logic to determine whether or not we have a diff hook executable to run in a helper function. We also mark `handleDiffHook` as static. Just note that the pr is purely a refactor.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
