### PR TITLE
tests/functional: isolate git tests from host signing config

### DIFF
--- a/tests/functional/common/vars.sh
+++ b/tests/functional/common/vars.sh
@@ -64,6 +64,9 @@ unset XDG_CONFIG_HOME
 unset XDG_CONFIG_DIRS
 unset XDG_CACHE_HOME
 unset GIT_DIR
+# Isolate tests from host git config (signing, url rewrites, etc.)
+export GIT_CONFIG_SYSTEM=/dev/null
+export GIT_CONFIG_GLOBAL=/dev/null
 
 export IMPURE_VAR1=foo
 export IMPURE_VAR2=bar

--- a/tests/functional/fetchGitSubmodules.sh
+++ b/tests/functional/fetchGitSubmodules.sh
@@ -18,9 +18,11 @@ rm -rf "${rootRepo}" "${subRepo}" "$TEST_HOME"/.cache/nix
 # submodule is intentionally local and it's all trusted, so we
 # disable this restriction. Setting it per repo is not sufficient, as
 # the repo-local config does not apply to the commands run from
-# outside the repos by Nix.
-export XDG_CONFIG_HOME=$TEST_HOME/.config
-git config --global protocol.file.allow always
+# outside the repos by Nix. We use environment variables to avoid
+# attempting to write to a read-only system git config.
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=protocol.file.allow
+export GIT_CONFIG_VALUE_0=always
 
 addGitContent() {
     echo "lorem ipsum" > "$1"/content

--- a/tests/functional/flakes/flake-in-submodule.sh
+++ b/tests/functional/flakes/flake-in-submodule.sh
@@ -21,8 +21,9 @@ clearStore
 
 # Submodules can't be fetched locally by default.
 # See fetchGitSubmodules.sh
-export XDG_CONFIG_HOME=$TEST_HOME/.config
-git config --global protocol.file.allow always
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=protocol.file.allow
+export GIT_CONFIG_VALUE_0=always
 
 
 rootRepo=$TEST_ROOT/rootRepo


### PR DESCRIPTION
## Motivation

Currently, tests fail when the host system has `commit.gpgsign` or `tag.gpgsign` enabled at the system level (in my case, a custom path located at `/etc/git/config`), since the signing key is unavailable in the test sandbox.

## Context

The tests set `HOME=$TEST_HOME` to isolate themselves, which bypasses the user-level git config (`~/.gitconfig`). However, if a user sets the system-level config via `GIT_CONFIG_GLOBAL` or `GIT_CONFIG_SYSTEM`, it still applies, causing commits to fail when signing is enabled there.

In this PR, I explicitly set `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `/dev/null` so that the user's system config is never read from or written to. I've also replaced `git config --global protocol.file.allow always` with `GIT_CONFIG_*` environment variables to avoid writing to `/dev/null`.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
