### PR TITLE
tests/functional: fix nix-shell fixed-output derivation test

### DIFF
--- a/tests/functional/nix-shell.sh
+++ b/tests/functional/nix-shell.sh
@@ -280,9 +280,6 @@ assert (!(args ? inNixShell));
 EOF
 nix-shell "$TEST_ROOT"/shell-ellipsis.nix --run "true"
 
-# FIXME unclear why this (newly made) test is failing in this case.
-if ! isTestOnNixOS; then
-  # `nix develop` should also work with fixed-output derivations
-  # shellcheck disable=SC2016
-  nix develop -f "$shellDotNix" fixed -c bash -c '[[ -n $stdenv ]]'
-fi
+# `nix develop` should also work with fixed-output derivations
+# shellcheck disable=SC2016
+nix develop -f "$shellDotNix" fixed -c bash -c '[[ $FOO == "was a fixed-output derivation" ]]'


### PR DESCRIPTION
The test was checking for `$stdenv` but the `fixed` derivation doesn't actually have stdenv, it just has `FOO`. I've updated it to check the value of `FOO` instead.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
