### PR TITLE
libstore: move command-specific settings to their own files

### DIFF
--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -735,29 +735,6 @@ public:
           duplicate files.
         )"};
 
-    Setting<bool> envKeepDerivations{
-        this,
-        false,
-        "keep-env-derivations",
-        R"(
-          If `false` (default), derivations are not stored in Nix user
-          environments. That is, the derivations of any build-time-only
-          dependencies may be garbage-collected.
-
-          If `true`, when you add a Nix derivation to a user environment, the
-          path of the derivation is stored in the user environment. Thus, the
-          derivation isn't garbage-collected until the user environment
-          generation is deleted (`nix-env --delete-generations`). To prevent
-          build-time-only dependencies from being collected, you should also
-          turn on `keep-outputs`.
-
-          The difference between this option and `keep-derivations` is that
-          this one is “sticky”: it applies to any user environment created
-          while this option was enabled, while `keep-derivations` only applies
-          at the moment the garbage collector is run.
-        )",
-        {"env-keep-derivations"}};
-
     Setting<SandboxMode> sandboxMode{
         this,
 #ifdef __linux__
@@ -1422,15 +1399,6 @@ public:
         {},   // aliases
         true, // document default
         Xp::ConfigurableImpureEnv};
-
-    Setting<std::string> upgradeNixStorePathUrl{
-        this,
-        "https://github.com/NixOS/nixpkgs/raw/master/nixos/modules/installer/tools/nix-fallback-paths.nix",
-        "upgrade-nix-store-path-url",
-        R"(
-          Used by `nix upgrade-nix`, the URL of the file that contains the
-          store paths of the latest Nix release.
-        )"};
 
     Setting<uint64_t> warnLargePathThreshold{
         this,


### PR DESCRIPTION
## Motivation

The two settings `envKeepDerivations` and `upgradeNixStorePathUrl` were only used in one command each, so it makes more sense to move them to their own files. This commit moves them both into a small self-contained settings struct and registers them with the global config.

## Context

- This PR progresses on #5638

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
