### PR TITLE
libexpr: Add filterAttrs builtin

### DIFF
--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -320,6 +320,31 @@ TEST_F(PrimOpTest, mapAttrs)
     ASSERT_THAT(*b->value, IsIntEq(20));
 }
 
+TEST_F(PrimOpTest, filterAttrs)
+{
+    auto v = eval("builtins.filterAttrs (name: value: value > 5) { a = 3; b = 10; c = 7; }");
+    ASSERT_THAT(v, IsAttrsOfSize(2));
+
+    auto a = v.attrs()->get(createSymbol("a"));
+    ASSERT_EQ(a, nullptr);
+
+    auto b = v.attrs()->get(createSymbol("b"));
+    ASSERT_NE(b, nullptr);
+    state.forceValue(*b->value, noPos);
+    ASSERT_THAT(*b->value, IsIntEq(10));
+
+    auto c = v.attrs()->get(createSymbol("c"));
+    ASSERT_NE(c, nullptr);
+    state.forceValue(*c->value, noPos);
+    ASSERT_THAT(*c->value, IsIntEq(7));
+}
+
+TEST_F(PrimOpTest, filterAttrsEmpty)
+{
+    auto v = eval("builtins.filterAttrs (name: value: false) { a = 1; b = 2; }");
+    ASSERT_THAT(v, IsAttrsOfSize(0));
+}
+
 TEST_F(PrimOpTest, isList)
 {
     auto v = eval("builtins.isList []");


### PR DESCRIPTION
Resubmission of #14753 by @not-ronjinger

## Motivation

The implementation in nixpkgs is slightly inefficient:
```
filterAttrs = pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set));
```

Namely, it has to create a temporary list of names `attrNames set`, then has to scan through the entries with `filter`, apply the predicate which needs to dereference the value, then pass it to `removeAttrs`, which then needs to do another scan of names which failed the predicate. It's likely as good as you can get without creating a specific builtin.

With a native builtin, we should be able to eliminate the need for generating the temporary list, the initial scan should be a bit faster as there is less indirection with looking up the value, and the need to do another scan for removeAttrs should be eliminated altogether.

Re-introducing this to nixpkgs/lib should be easy with a `builtins ? filterAttrs` check.

## Context

Gotta go fast :rocket: 