### PR TITLE
libstore: decide how to build in one spot

### DIFF
--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
@@ -2,10 +2,10 @@
 ///@file
 
 #include "nix/store/derivations.hh"
+#include "nix/store/local-store.hh"
 #include "nix/store/parsed-derivations.hh"
 #include "nix/store/derivation-options.hh"
 #include "nix/store/build/derivation-building-misc.hh"
-#include "nix/store/outputs-spec.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/pathlocks.hh"
 #include "nix/store/build/goal.hh"
@@ -75,6 +75,7 @@ private:
         DerivationOptions<StorePath> drvOptions,
         PathLocks outputLocks);
     Co buildLocally(
+        LocalStore & localStore,
         StorePathSet inputPaths,
         std::map<std::string, InitialOutput> initialOutputs,
         DerivationOptions<StorePath> drvOptions,


### PR DESCRIPTION
## Motivation

This cleans up the logic for checking if the worker's store is a valid local store when we're not hooking it. If we have a local store, we then pass that as an argument to `DerivationBuildingGoal::buildLocally`, rather than checking inside the function itself.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
