### PR TITLE
libutil: add useful functions to Pid

### DIFF
--- a/src/libutil/include/nix/util/processes.hh
+++ b/src/libutil/include/nix/util/processes.hh
@@ -35,6 +35,10 @@ class Pid
 #endif
 public:
     Pid();
+    Pid(const Pid &) = delete;
+    Pid(Pid && other) noexcept;
+    Pid & operator=(const Pid &) = delete;
+    Pid & operator=(Pid && other) noexcept;
 #ifndef _WIN32
     Pid(pid_t pid);
     void operator=(pid_t pid);
@@ -53,6 +57,18 @@ public:
     void setKillSignal(int signal);
     pid_t release();
 #endif
+
+    friend void swap(Pid & lhs, Pid & rhs) noexcept
+    {
+        using std::swap;
+#ifndef _WIN32
+        swap(lhs.pid, rhs.pid);
+        swap(lhs.separatePG, rhs.separatePG);
+        swap(lhs.killSignal, rhs.killSignal);
+#else
+        swap(lhs.pid, rhs.pid);
+#endif
+    }
 };
 
 #ifndef _WIN32

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -156,6 +156,7 @@ sources = [ config_priv_h ] + files(
   'pos-table.cc',
   'position.cc',
   'posix-source-accessor.cc',
+  'processes.cc',
   'serialise.cc',
   'signature/local-keys.cc',
   'signature/signer.cc',

--- a/src/libutil/processes.cc
+++ b/src/libutil/processes.cc
@@ -1,0 +1,11 @@
+#include "nix/util/processes.hh"
+
+namespace nix {
+
+Pid & Pid::operator=(Pid && other) noexcept
+{
+    swap(*this, other);
+    return *this;
+}
+
+} // namespace nix

--- a/src/libutil/windows/processes.cc
+++ b/src/libutil/windows/processes.cc
@@ -33,6 +33,11 @@ using namespace nix::windows;
 
 Pid::Pid() {}
 
+Pid::Pid(Pid && other) noexcept
+    : pid(std::move(other.pid))
+{
+}
+
 Pid::Pid(AutoCloseFD pid)
     : pid(std::move(pid))
 {


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The C++ rule of five suggests that when a custom destructor is needed then several other functions are as well. The lack of those makes certain operations challenging.

Add some useful functions to `Pid`
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
