### PR TITLE
Refactor fstat into a wrapper in libutil

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -7,6 +7,7 @@
 #include "nix/util/signals.hh"
 #include "nix/util/serialise.hh"
 #include "nix/util/util.hh"
+#include "nix/util/file-system.hh"
 #include "nix/store/posix-fs-canonicalise.hh"
 
 #include "store-config-private.hh"
@@ -68,9 +69,7 @@ void LocalStore::createTempRootsFile()
 
         /* Check whether the garbage collector didn't get in our
            way. */
-        PosixStat st;
-        if (fstat(fromDescriptorReadOnly(fdTempRoots->get()), &st) == -1)
-            throw SysError("statting '%1%'", fnTempRoots);
+        auto st = nix::fstat(fromDescriptorReadOnly(fdTempRoots->get()));
         if (st.st_size == 0)
             break;
 

--- a/src/libstore/unix/pathlocks.cc
+++ b/src/libstore/unix/pathlocks.cc
@@ -111,9 +111,7 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
 
             /* Check that the lock file hasn't become stale (i.e.,
                hasn't been unlinked). */
-            PosixStat st;
-            if (fstat(fd.get(), &st) == -1)
-                throw SysError("statting lock file %1%", PathFmt(lockPath));
+            auto st = nix::fstat(fd.get());
             if (st.st_size != 0)
                 /* This lock file has been unlinked, so we're holding
                    a lock on a deleted file.  This means that other

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -217,6 +217,20 @@ PosixStat lstat(const std::filesystem::path & path)
     return st;
 }
 
+PosixStat fstat(int fd)
+{
+    PosixStat st;
+    if (
+#ifdef _WIN32
+        _fstat64
+#else
+        ::fstat
+#endif
+        (fd, &st))
+        throw SysError("getting status of fd %d", fd);
+    return st;
+}
+
 std::optional<PosixStat> maybeStat(const std::filesystem::path & path)
 {
     std::optional<PosixStat> st{std::in_place};

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -189,9 +189,7 @@ void RestoreRegularFile::isExecutable()
     // Windows doesn't have a notion of executable file permissions we
     // care about here, right?
 #ifndef _WIN32
-    PosixStat st;
-    if (fstat(fd.get(), &st) == -1)
-        throw SysError("fstat");
+    auto st = nix::fstat(fd.get());
     if (fchmod(fd.get(), st.st_mode | (S_IXUSR | S_IXGRP | S_IXOTH)) == -1)
         throw SysError("fchmod");
 #endif

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -131,6 +131,10 @@ PosixStat lstat(const std::filesystem::path & path);
  */
 PosixStat stat(const std::filesystem::path & path);
 /**
+ * Get status of an open file descriptor.
+ */
+PosixStat fstat(int fd);
+/**
  * `lstat` the given path if it exists.
  * @return std::nullopt if the path doesn't exist, or an optional containing the result of `lstat` otherwise
  */

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -55,9 +55,7 @@ void PosixSourceAccessor::readFile(const CanonPath & path, Sink & sink, std::fun
     if (!fd)
         throw SysError("opening file '%1%'", ap.string());
 
-    PosixStat st;
-    if (fstat(fromDescriptorReadOnly(fd.get()), &st) == -1)
-        throw SysError("statting file");
+    auto st = nix::fstat(fromDescriptorReadOnly(fd.get()));
 
     sizeCallback(st.st_size);
 

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -51,10 +51,7 @@ void pollFD(int fd, int events)
 
 std::string readFile(int fd)
 {
-    PosixStat st;
-    if (fstat(fd, &st) == -1)
-        throw SysError("statting file");
-
+    auto st = nix::fstat(fd);
     return drainFD(fd, true, st.st_size);
 }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

We use a different fstat on posix and windows systems, and not all fstat users were using the correct one. Factor out fstat to make the change easier.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

See also a13de50df378e5502a6fb5faf016c2f12f5c7bb8 for other stat functions

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
