### PR TITLE
docs: clarify descriptions for nix-env --delete-generations time and count

### DIFF
--- a/doc/manual/source/command-ref/nix-env/delete-generations.md
+++ b/doc/manual/source/command-ref/nix-env/delete-generations.md
@@ -33,7 +33,7 @@ This operation deletes the specified generations of the current profile.
 
 - <span id="generations-time">[`<number>d`](#generations-time)</span>
 
-  The last *number* days
+  Delete generations older than *number* days.
 
   *Example*: `30d`
 
@@ -42,7 +42,7 @@ This operation deletes the specified generations of the current profile.
 
 - <span id="generations-count">[`+<number>`](#generations-count)</span>
 
-  The last *number* generations up to the present
+  Delete generations more than *number* iterations older than current.
 
   *Example*: `+5`
 


### PR DESCRIPTION
Closes #15112 .


## Motivation

The page following page: https://nix.dev/manual/nix/2.28/command-ref/nix-env/delete-generations.html#generations-count
Says:

```
+<number>

The last number generations up to the present

Example: +5

Keep the last number generations, along with any newer than current.
```

While the last sentence is clear, the first one could be misconstrued to mean "delete the most recent <number> generations" (useful for e.g. "oops my previous four generations had an important mistake, I want to delete them); somebody with this interpretation might accidentally delete all old generations EXCEPT for the broken ones. (Ask me how I know...)

This PR makes that description mildly less confusing, and also updates the description for the <number>d option in the same vein.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
