### PR TITLE
libstore: add `PersonalityArgs` struct for `setPersonality`

### DIFF
--- a/src/libstore/linux/include/nix/store/personality.hh
+++ b/src/libstore/linux/include/nix/store/personality.hh
@@ -5,6 +5,12 @@
 
 namespace nix::linux {
 
-void setPersonality(std::string_view system);
+struct PersonalityArgs
+{
+    std::string_view system;
+    bool impersonateLinux26;
+};
 
-}
+void setPersonality(PersonalityArgs args);
+
+} // namespace nix::linux

--- a/src/libstore/linux/personality.cc
+++ b/src/libstore/linux/personality.cc
@@ -8,23 +8,23 @@
 
 namespace nix::linux {
 
-void setPersonality(std::string_view system)
+void setPersonality(PersonalityArgs args)
 {
     /* Change the personality to 32-bit if we're doing an
        i686-linux build on an x86_64-linux machine. */
     struct utsname utsbuf;
     uname(&utsbuf);
-    if ((system == "i686-linux"
+    if ((args.system == "i686-linux"
          && (std::string_view(NIX_LOCAL_SYSTEM) == "x86_64-linux"
              || (!strcmp(utsbuf.sysname, "Linux") && !strcmp(utsbuf.machine, "x86_64"))))
-        || system == "armv7l-linux" || system == "armv6l-linux" || system == "armv5tel-linux") {
+        || args.system == "armv7l-linux" || args.system == "armv6l-linux" || args.system == "armv5tel-linux") {
         if (personality(PER_LINUX32) == -1)
             throw SysError("cannot set 32-bit personality");
     }
 
     /* Impersonate a Linux 2.6 machine to get some determinism in
        builds that depend on the kernel version. */
-    if ((system == "i686-linux" || system == "x86_64-linux") && settings.impersonateLinux26) {
+    if ((args.system == "i686-linux" || args.system == "x86_64-linux") && args.impersonateLinux26) {
         int cur = personality(0xffffffff);
         if (cur != -1)
             personality(cur | 0x0020000 /* == UNAME26 */);

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -163,7 +163,10 @@ struct LinuxDerivationBuilder : virtual DerivationBuilderImpl
     {
         setupSeccomp();
 
-        linux::setPersonality(drv.platform);
+        linux::setPersonality({
+            .system = drv.platform,
+            .impersonateLinux26 = settings.impersonateLinux26,
+        });
     }
 };
 

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -96,7 +96,10 @@ void execProgramInStore(
 
 #ifdef __linux__
     if (system)
-        linux::setPersonality(*system);
+        linux::setPersonality({
+            .system = *system,
+            .impersonateLinux26 = settings.impersonateLinux26,
+        });
 #endif
 
     if (useLookupPath == UseLookupPath::Use) {
@@ -251,7 +254,10 @@ void chrootHelper(int argc, char ** argv)
 
 #  ifdef __linux__
     if (system != "")
-        linux::setPersonality(system);
+        linux::setPersonality({
+            .system = system,
+            .impersonateLinux26 = settings.impersonateLinux26,
+        });
 #  endif
 
     execvp(cmd.c_str(), stringsToCharPtrs(args).data());


### PR DESCRIPTION
## Motivation

This introduces a `PersonalityArgs` struct to pass named arguments to `setPersonality`. The `impersonateLinux26` setting is now passed from the call site rather than read from settings inside the function.

## Context

This was parted out from https://github.com/NixOS/nix/pull/15101

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
