### PR TITLE
libstore: introduce `CanonicalizePathMetadataOptions` for `canonicalisePathMetaData`

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1083,7 +1083,7 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
 
                 autoGC();
 
-                canonicalisePathMetaData(realPath);
+                canonicalisePathMetaData(realPath, {NIX_WHEN_SUPPORT_ACLS(settings.ignoredAcls)});
 
                 optimisePath(realPath, repair); // FIXME: combine with hashPath()
 
@@ -1243,7 +1243,8 @@ StorePath LocalStore::addToStoreFromDump(
                 narHash = narSink.finish();
             }
 
-            canonicalisePathMetaData(realPath); // FIXME: merge into restorePath
+            canonicalisePathMetaData(
+                realPath, {NIX_WHEN_SUPPORT_ACLS(settings.ignoredAcls)}); // FIXME: merge into restorePath
 
             optimisePath(realPath, repair);
 

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -1,10 +1,10 @@
 #include "nix/store/posix-fs-canonicalise.hh"
+#include "nix/store/build-result.hh"
 #include "nix/util/file-system.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/util.hh"
-#include "nix/store/globals.hh"
 #include "nix/store/store-api.hh"
-
+#include "nix/store/globals.hh"
 #include "store-config-private.hh"
 
 #if NIX_SUPPORT_ACL
@@ -41,12 +41,8 @@ void canonicaliseTimestampAndPermissions(const Path & path)
     canonicaliseTimestampAndPermissions(path, lstat(path));
 }
 
-static void canonicalisePathMetaData_(
-    const Path & path,
-#ifndef _WIN32
-    std::optional<std::pair<uid_t, uid_t>> uidRange,
-#endif
-    InodesSeen & inodesSeen)
+static void
+canonicalisePathMetaData_(const Path & path, CanonicalizePathMetadataOptions options, InodesSeen & inodesSeen)
 {
     checkInterrupt();
 
@@ -80,7 +76,7 @@ static void canonicalisePathMetaData_(
             throw SysError("querying extended attributes of '%s'", path);
 
         for (auto & eaName : tokenizeString<Strings>(std::string(eaBuf.data(), eaSize), std::string("\000", 1))) {
-            if (settings.ignoredAcls.get().count(eaName))
+            if (options.ignoredAcls.count(eaName))
                 continue;
             if (lremovexattr(path.c_str(), eaName.c_str()) == -1)
                 throw SysError("removing extended attribute '%s' from '%s'", eaName, path);
@@ -95,7 +91,7 @@ static void canonicalisePathMetaData_(
        However, ignore files that we chown'ed ourselves previously to
        ensure that we don't fail on hard links within the same build
        (i.e. "touch $out/foo; ln $out/foo $out/bar"). */
-    if (uidRange && (st.st_uid < uidRange->first || st.st_uid > uidRange->second)) {
+    if (options.uidRange && (st.st_uid < options.uidRange->first || st.st_uid > options.uidRange->second)) {
         if (S_ISDIR(st.st_mode) || !inodesSeen.count(Inode(st.st_dev, st.st_ino)))
             throw BuildError(BuildResult::Failure::OutputRejected, "invalid ownership on file '%1%'", path);
         mode_t mode = st.st_mode & ~S_IFMT;
@@ -131,29 +127,14 @@ static void canonicalisePathMetaData_(
     if (S_ISDIR(st.st_mode)) {
         for (auto & i : DirectoryIterator{path}) {
             checkInterrupt();
-            canonicalisePathMetaData_(
-                i.path().string(),
-#ifndef _WIN32
-                uidRange,
-#endif
-                inodesSeen);
+            canonicalisePathMetaData_(i.path().string(), options, inodesSeen);
         }
     }
 }
 
-void canonicalisePathMetaData(
-    const Path & path,
-#ifndef _WIN32
-    std::optional<std::pair<uid_t, uid_t>> uidRange,
-#endif
-    InodesSeen & inodesSeen)
+void canonicalisePathMetaData(const Path & path, CanonicalizePathMetadataOptions options, InodesSeen & inodesSeen)
 {
-    canonicalisePathMetaData_(
-        path,
-#ifndef _WIN32
-        uidRange,
-#endif
-        inodesSeen);
+    canonicalisePathMetaData_(path, options, inodesSeen);
 
 #ifndef _WIN32
     /* On platforms that don't have lchown(), the top-level path can't
@@ -167,21 +148,10 @@ void canonicalisePathMetaData(
 #endif
 }
 
-void canonicalisePathMetaData(
-    const Path & path
-#ifndef _WIN32
-    ,
-    std::optional<std::pair<uid_t, uid_t>> uidRange
-#endif
-)
+void canonicalisePathMetaData(const Path & path, CanonicalizePathMetadataOptions options)
 {
     InodesSeen inodesSeen;
-    canonicalisePathMetaData_(
-        path,
-#ifndef _WIN32
-        uidRange,
-#endif
-        inodesSeen);
+    canonicalisePathMetaData_(path, options, inodesSeen);
 }
 
 } // namespace nix

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -588,7 +588,8 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
         if (!store->isValidPath(info->path) || reregister) {
             /* !!! races */
             if (canonicalise)
-                canonicalisePathMetaData(store->printStorePath(info->path));
+                canonicalisePathMetaData(
+                    store->printStorePath(info->path), {NIX_WHEN_SUPPORT_ACLS(settings.ignoredAcls)});
             if (!hashGiven) {
                 HashResult hash = hashPath(
                     {store->requireStoreObjectAccessor(info->path, /*requireValidPath=*/false)},


### PR DESCRIPTION
## Motivation

This commit refactors the `canonicalisePathMetaData` function to take an options struct instead of individual parameters with platform-specific `#ifdef`s.

The struct contains a `uidRange` field (Unix only) for build user ownership validation, and an `ignoredAcls` field for ACLs to skip when removing extended attributes.

## Context

This PR splits out some work from #15101

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
