### PR TITLE
WIP SLOP use descriptors to avoid TOCTOU for canonicalising file system meta data

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -14,8 +14,12 @@
 #include "nix/util/json-utils.hh"
 #include "nix/util/archive.hh"
 #include "nix/util/mounted-source-accessor.hh"
+#include "nix/util/file-descriptor.hh"
+#include "nix/util/file-system-at.hh"
+#include "nix/util/canon-path.hh"
 
 #include <sys/time.h>
+#include <fcntl.h>
 
 #ifndef _WIN32
 #  include <sys/wait.h>
@@ -863,8 +867,13 @@ struct GitInputScheme : InputScheme
                 }
 
                 try {
-                    if (!input.getRev())
-                        setWriteTime(localRefFile, now, now);
+                    if (!input.getRev()) {
+                        auto parent = localRefFile.parent_path();
+                        auto name = localRefFile.filename();
+                        AutoCloseFD dirFd = openDirectory(parent);
+                        if (dirFd)
+                            setWriteTime(dirFd.get(), name, now, now);
+                    }
                 } catch (Error & e) {
                     warn("could not update mtime for file %s: %s", PathFmt(localRefFile), e.info().msg);
                 }

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -239,6 +239,12 @@ public:
     const std::filesystem::path tempRootsDir;
     const std::filesystem::path fnTempRoots;
 
+    /**
+     * An open file descriptor to the real store directory, for use
+     * with `*at` system calls.
+     */
+    AutoCloseFD realStoreDirFd;
+
 private:
 
     const PublicKeys & getPublicKeys();

--- a/src/libstore/include/nix/store/posix-fs-canonicalise.hh
+++ b/src/libstore/include/nix/store/posix-fs-canonicalise.hh
@@ -8,6 +8,8 @@
 
 #include "nix/util/types.hh"
 #include "nix/util/error.hh"
+#include "nix/util/file-descriptor.hh"
+#include "nix/util/os-filename.hh"
 #include "nix/store/config.hh"
 
 namespace nix {
@@ -63,11 +65,11 @@ struct CanonicalizePathMetadataOptions
  *   running as root. (Unix only.)
  */
 void canonicalisePathMetaData(
-    const std::filesystem::path & path, CanonicalizePathMetadataOptions options, InodesSeen & inodesSeen);
+    Descriptor dirFd, const OsFilename & path, CanonicalizePathMetadataOptions options, InodesSeen & inodesSeen);
 
-void canonicalisePathMetaData(const std::filesystem::path & path, CanonicalizePathMetadataOptions options);
+void canonicalisePathMetaData(Descriptor dirFd, const OsFilename & path, CanonicalizePathMetadataOptions options);
 
-void canonicaliseTimestampAndPermissions(const std::filesystem::path & path);
+void canonicaliseTimestampAndPermissions(Descriptor dirFd, const OsFilename & path);
 
 MakeError(PathInUse, Error);
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -14,6 +14,7 @@
 #include "nix/util/signals.hh"
 #include "nix/store/posix-fs-canonicalise.hh"
 #include "nix/util/posix-source-accessor.hh"
+#include "nix/util/file-system.hh"
 #include "nix/store/keys.hh"
 #include "nix/util/users.hh"
 #include "nix/store/store-registration.hh"
@@ -130,6 +131,9 @@ LocalStore::LocalStore(ref<const Config> config)
 
     /* Create missing state directories if they don't already exist. */
     createDirs(config->realStoreDir.get());
+    realStoreDirFd = openDirectory(config->realStoreDir.get());
+    if (!realStoreDirFd)
+        throw SysError("opening store directory %s", PathFmt(config->realStoreDir.get()));
     if (config->readOnly) {
         experimentalFeatureSettings.require(Xp::ReadOnlyLocalStore);
     } else {
@@ -1111,7 +1115,10 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
 
                 autoGC();
 
-                canonicalisePathMetaData(realPath, {NIX_WHEN_SUPPORT_ACLS(config->getLocalSettings().ignoredAcls)});
+                canonicalisePathMetaData(
+                    realStoreDirFd.get(),
+                    OsFilename{realPath.filename()},
+                    {NIX_WHEN_SUPPORT_ACLS(config->getLocalSettings().ignoredAcls)});
 
                 optimisePath(realPath, repair); // FIXME: combine with hashPath()
 
@@ -1273,7 +1280,9 @@ StorePath LocalStore::addToStoreFromDump(
             }
 
             canonicalisePathMetaData(
-                realPath, {NIX_WHEN_SUPPORT_ACLS(localSettings.ignoredAcls)}); // FIXME: merge into restorePath
+                realStoreDirFd.get(),
+                OsFilename{realPath.filename()},
+                {NIX_WHEN_SUPPORT_ACLS(localSettings.ignoredAcls)}); // FIXME: merge into restorePath
 
             optimisePath(realPath, repair);
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1305,7 +1305,7 @@ std::pair<std::filesystem::path, AutoCloseFD> LocalStore::createTempDirInStore()
            the GC between createTempDir() and when we acquire a lock on it.
            We'll repeat until 'tmpDir' exists and we've locked it.
            Make the directory accessible only to the current user. */
-        tmpDirFn = createTempDir(std::filesystem::path{config->realStoreDir.get()}, "tmp", /*mode=*/0700);
+        tmpDirFn = createTempDir(config->realStoreDir.get(), "tmp", /*mode=*/0700);
         tmpDirFd = openDirectory(tmpDirFn, FinalSymlink::DontFollow);
         if (!tmpDirFd) {
             continue;

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -39,8 +39,15 @@ struct MakeReadOnly
     {
         try {
             /* This will make the path read-only. */
-            if (!path.empty())
-                canonicaliseTimestampAndPermissions(path.string());
+            if (!path.empty()) {
+                auto parent = path.parent_path();
+                if (parent.empty())
+                    parent = ".";
+                AutoCloseFD dirFd = openDirectory(parent);
+                if (!dirFd)
+                    throw SysError("opening parent directory of %s", PathFmt(path));
+                canonicaliseTimestampAndPermissions(dirFd.get(), OsFilename{path.filename()});
+            }
         } catch (...) {
             ignoreExceptionInDestructor();
         }

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -3,7 +3,17 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/signals.hh"
 #include "nix/store/store-api.hh"
+#include "nix/util/file-descriptor.hh"
 #include "nix/util/file-system-at.hh"
+#include "nix/util/os-filename.hh"
+#include "nix/util/canon-path.hh"
+#include "store-config-private.hh"
+
+#ifndef _WIN32
+#  include <fcntl.h>
+#  include <dirent.h>
+#  include <sys/stat.h>
+#endif
 
 #if NIX_SUPPORT_ACL
 #  include <sys/xattr.h>
@@ -13,34 +23,34 @@ namespace nix {
 
 const time_t mtimeStore = 1; /* 1 second into the epoch */
 
-static void canonicaliseTimestampAndPermissions(const std::filesystem::path & path, const PosixStat & st)
+static void canonicaliseTimestampAndPermissions(Descriptor dirFd, const OsFilename & path, const PosixStat & st)
 {
     if (!S_ISLNK(st.st_mode)) {
-
         /* Mask out all type related bits. */
         mode_t mode = st.st_mode & ~S_IFMT;
         bool isDir = S_ISDIR(st.st_mode);
         if ((mode != 0444 || isDir) && mode != 0555) {
-            mode = (st.st_mode & S_IFMT) | 0444 | (st.st_mode & S_IXUSR || isDir ? 0111 : 0);
-            chmod(path, mode);
+            mode = 0444 | (st.st_mode & S_IXUSR || isDir ? 0111 : 0);
+#ifndef _WIN32
+            unix::fchmodatTryNoFollow(dirFd, path, mode);
+#else
+            // TODO: implement fchmodatTryNoFollow for Windows
+#endif
         }
     }
 
-#ifndef _WIN32 // TODO implement
     if (st.st_mtime != mtimeStore) {
-        PosixStat st2 = st;
-        st2.st_mtime = mtimeStore, setWriteTime(path, st2);
+        setWriteTime(dirFd, path, st.st_atime, mtimeStore);
     }
-#endif
 }
 
-void canonicaliseTimestampAndPermissions(const std::filesystem::path & path)
+void canonicaliseTimestampAndPermissions(Descriptor dirFd, const OsFilename & path)
 {
-    canonicaliseTimestampAndPermissions(path, lstat(path));
+    canonicaliseTimestampAndPermissions(dirFd, path, fstatat(dirFd, path));
 }
 
 static void canonicalisePathMetaData_(
-    const std::filesystem::path & path, CanonicalizePathMetadataOptions options, InodesSeen & inodesSeen)
+    Descriptor dirFd, const OsFilename & path, CanonicalizePathMetadataOptions options, InodesSeen & inodesSeen)
 {
     checkInterrupt();
 
@@ -48,21 +58,35 @@ static void canonicalisePathMetaData_(
     /* Remove flags, in particular UF_IMMUTABLE which would prevent
        the file from being garbage-collected. FIXME: Use
        setattrlist() to remove other attributes as well. */
-    if (lchflags(path.c_str(), 0)) {
+    AutoCloseFD fd = openat(dirFd, path.path().c_str(), O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (!fd)
+        throw SysError("opening %s to clear flags", PathFmt(path));
+    if (fchflags(fd.get(), 0)) {
         if (errno != ENOTSUP)
-            throw SysError("clearing flags of path %1%", PathFmt(path));
+            throw SysError("clearing flags of path %s", PathFmt(path));
     }
 #endif
-
-    auto st = lstat(path);
+    auto st = fstatat(dirFd, path);
 
     /* Really make sure that the path is of a supported type. */
     if (!(S_ISREG(st.st_mode) || S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode)))
-        throw Error("file %1% has an unsupported type", PathFmt(path));
+        throw Error("file %s has an unsupported type", PathFmt(path));
 
 #if NIX_SUPPORT_ACL
     /* Remove extended attributes / ACLs. */
-    ssize_t eaSize = llistxattr(path.c_str(), nullptr, 0);
+    /* We need a file descriptor for xattr operations on Linux. */
+    AutoCloseFD fd = openat(
+        dirFd,
+        path.path().c_str(),
+        O_RDONLY | O_NOFOLLOW | O_CLOEXEC
+#  ifdef O_PATH
+            | O_PATH
+#  endif
+    );
+    if (!fd)
+        throw SysError("opening %s to remove extended attributes", PathFmt(path));
+
+    ssize_t eaSize = flistxattr(fd.get(), nullptr, 0);
 
     if (eaSize < 0) {
         if (errno != ENOTSUP && errno != ENODATA)
@@ -70,13 +94,13 @@ static void canonicalisePathMetaData_(
     } else if (eaSize > 0) {
         std::vector<char> eaBuf(eaSize);
 
-        if ((eaSize = llistxattr(path.c_str(), eaBuf.data(), eaBuf.size())) < 0)
+        if ((eaSize = flistxattr(fd.get(), eaBuf.data(), eaBuf.size())) < 0)
             throw SysError("querying extended attributes of %s", PathFmt(path));
 
         for (auto & eaName : tokenizeString<Strings>(std::string(eaBuf.data(), eaSize), std::string("\000", 1))) {
             if (options.ignoredAcls.count(eaName))
                 continue;
-            if (lremovexattr(path.c_str(), eaName.c_str()) == -1)
+            if (fremovexattr(fd.get(), eaName.c_str()) == -1)
                 throw SysError("removing extended attribute '%s' from %s", eaName, PathFmt(path));
         }
     }
@@ -91,7 +115,7 @@ static void canonicalisePathMetaData_(
        (i.e. "touch $out/foo; ln $out/foo $out/bar"). */
     if (options.uidRange && (st.st_uid < options.uidRange->first || st.st_uid > options.uidRange->second)) {
         if (S_ISDIR(st.st_mode) || !inodesSeen.count(Inode(st.st_dev, st.st_ino)))
-            throw BuildError(BuildResult::Failure::OutputRejected, "invalid ownership on file %1%", PathFmt(path));
+            throw BuildError(BuildResult::Failure::OutputRejected, "invalid ownership on file %s", PathFmt(path));
         mode_t mode = st.st_mode & ~S_IFMT;
         assert(
             S_ISLNK(st.st_mode)
@@ -102,34 +126,68 @@ static void canonicalisePathMetaData_(
 
     inodesSeen.insert(Inode(st.st_dev, st.st_ino));
 
-    canonicaliseTimestampAndPermissions(path, st);
+    canonicaliseTimestampAndPermissions(dirFd, path, st);
 
 #ifndef _WIN32
     /* Change ownership to the current uid. */
     if (st.st_uid != geteuid()) {
-        if (lchown(path.c_str(), geteuid(), getegid()) == -1)
-            throw SysError("changing owner of %1% to %2%", PathFmt(path), geteuid());
+        if (fchownat(dirFd, path.path().c_str(), geteuid(), getegid(), AT_SYMLINK_NOFOLLOW) == -1)
+            throw SysError("changing owner of %s to %2%", PathFmt(path), geteuid());
     }
 #endif
 
     if (S_ISDIR(st.st_mode)) {
-        for (auto & i : DirectoryIterator{path}) {
+        AutoCloseFD childDirFd = openFileEnsureBeneathNoSymlinks(
+            dirFd,
+            path,
+#ifdef _WIN32
+            FILE_LIST_DIRECTORY | SYNCHRONIZE,
+            FILE_DIRECTORY_FILE
+#else
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC
+#endif
+        );
+        if (!childDirFd)
+            throw SysError("opening directory %s", PathFmt(path));
+
+#ifndef _WIN32
+        AutoCloseDir dir(fdopendir(dup(childDirFd.get())));
+        if (!dir)
+            throw SysError("opening directory %s for iteration", PathFmt(path));
+
+        struct dirent * dirent;
+        while (errno = 0, dirent = readdir(dir.get())) {
             checkInterrupt();
-            canonicalisePathMetaData_(i.path(), options, inodesSeen);
+            std::string childName = dirent->d_name;
+            if (childName == "." || childName == "..")
+                continue;
+            OsFilename childName_{std::filesystem::path(childName)};
+            canonicalisePathMetaData(childDirFd.get(), childName_, options, inodesSeen);
         }
+        if (errno)
+            throw SysError("reading directory %s", PathFmt(path));
+#else
+        // TODO: use NtQueryDirectoryFile or similar to iterate
+        // relative to childDirFd instead of by path.
+        for (auto & i : DirectoryIterator{descriptorToPath(childDirFd.get())}) {
+            checkInterrupt();
+            OsFilename childName{i.path().filename()};
+            canonicalisePathMetaData(childDirFd.get(), childName, options, inodesSeen);
+        }
+#endif
     }
 }
 
 void canonicalisePathMetaData(
-    const std::filesystem::path & path, CanonicalizePathMetadataOptions options, InodesSeen & inodesSeen)
+    Descriptor dirFd, const OsFilename & path, CanonicalizePathMetadataOptions options, InodesSeen & inodesSeen)
 {
-    canonicalisePathMetaData_(path, options, inodesSeen);
+    canonicalisePathMetaData_(dirFd, path, options, inodesSeen);
 }
 
-void canonicalisePathMetaData(const std::filesystem::path & path, CanonicalizePathMetadataOptions options)
+void canonicalisePathMetaData(Descriptor dirFd, const OsFilename & path, CanonicalizePathMetadataOptions options)
 {
     InodesSeen inodesSeen;
-    canonicalisePathMetaData_(path, options, inodesSeen);
+    canonicalisePathMetaData(dirFd, path, options, inodesSeen);
 }
 
 } // namespace nix

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -3,6 +3,7 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/signals.hh"
 #include "nix/store/store-api.hh"
+#include "nix/util/file-system-at.hh"
 
 #if NIX_SUPPORT_ACL
 #  include <sys/xattr.h>

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1271,7 +1271,7 @@ void DerivationBuilderImpl::chownToBuilder(int fd, const std::filesystem::path &
 void DerivationBuilderImpl::writeBuilderFile(const OsFilename & name, std::string_view contents)
 {
     AutoCloseFD fd = openFileEnsureBeneathNoSymlinks(
-        tmpDirFd.get(), {name}, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL, 0666);
+        tmpDirFd.get(), OsCanonPath{name}, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL, 0666);
     auto path = tmpDir / name.path(); /* This is used only for error messages. */
     if (!fd)
         throw SysError("creating file %s", PathFmt(path));

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1512,7 +1512,8 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
            rewriting doesn't contain a hard link to /etc/shadow or
            something like that. */
         canonicalisePathMetaData(
-            actualPath,
+            store.realStoreDirFd.get(),
+            OsFilename{actualPath.filename()},
             {
 #ifndef _WIN32
                 .uidRange = buildUser ? std::optional(buildUser->getUIDRange()) : std::nullopt,
@@ -1648,7 +1649,8 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                 /* FIXME: set proper permissions in restorePath() so
                    we don't have to do another traversal. */
                 canonicalisePathMetaData(
-                    actualPath,
+                    store.realStoreDirFd.get(),
+                    OsFilename{actualPath.filename()},
                     {
 #ifndef _WIN32
                         // builder UIDs are already dealt with
@@ -1827,7 +1829,8 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         /* FIXME: set proper permissions in restorePath() so
             we don't have to do another traversal. */
         canonicalisePathMetaData(
-            actualPath,
+            store.realStoreDirFd.get(),
+            OsFilename{actualPath.filename()},
             {
 #ifndef _WIN32
                 // builder UIDs are already dealt with

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1,5 +1,6 @@
 #include "nix/store/build/derivation-builder.hh"
 #include "nix/util/file-system-at.hh"
+#include "nix/util/os-filename.hh"
 #include "nix/util/file-system.hh"
 #include "nix/store/local-store.hh"
 #include "nix/util/processes.hh"
@@ -396,7 +397,7 @@ protected:
      * @param Name must not contain more than one path segment and none of them must be `..`, `.`
      * Otherwise this function throws an Error.
      */
-    void writeBuilderFile(const std::string & name, std::string_view contents);
+    void writeBuilderFile(const OsFilename & name, std::string_view contents);
 
     /**
      * Arguments passed to runChild().
@@ -1094,7 +1095,8 @@ void DerivationBuilderImpl::initEnv()
 
     /* Add extra files, similar to `finalEnv` */
     for (const auto & [fileName, value] : desugaredEnv.extraFiles) {
-        writeBuilderFile(fileName, rewriteStrings(value, inputRewrites));
+        writeBuilderFile(
+            OsFilename::fromPathThrowing(std::filesystem::path(fileName)), rewriteStrings(value, inputRewrites));
     }
 
     /* For convenience, set an environment pointing to the top build
@@ -1266,15 +1268,11 @@ void DerivationBuilderImpl::chownToBuilder(int fd, const std::filesystem::path &
         throw SysError("cannot change ownership of file %1%", PathFmt(path));
 }
 
-void DerivationBuilderImpl::writeBuilderFile(const std::string & name, std::string_view contents)
+void DerivationBuilderImpl::writeBuilderFile(const OsFilename & name, std::string_view contents)
 {
-    /* Path must be the same after normalisation. This is an additional sanity check in addition to
-       existing parsing checks for non-structured attrs exportReferencesGraph. In practice we only expect
-       a single path component without any `..`, `.` components. */
-    auto relPath = CanonPath::fromFilename(name);
     AutoCloseFD fd = openFileEnsureBeneathNoSymlinks(
-        tmpDirFd.get(), relPath, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL, 0666);
-    auto path = tmpDir / relPath.rel(); /* This is used only for error messages. */
+        tmpDirFd.get(), {name}, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL, 0666);
+    auto path = tmpDir / name.path(); /* This is used only for error messages. */
     if (!fd)
         throw SysError("creating file %s", PathFmt(path));
     writeFile(fd.get(), contents);

--- a/src/libutil-test-support/include/nix/util/tests/gmock-matchers.hh
+++ b/src/libutil-test-support/include/nix/util/tests/gmock-matchers.hh
@@ -66,4 +66,19 @@ inline auto ThrowsSysError(int expected)
     return ::testing::Throws<SysError>(::testing::Field(&SysError::errNo, expected));
 }
 
+#ifdef _WIN32
+/**
+ * Matches a callable that throws `WinError` whose `lastError` equals `expected`.
+ *
+ * Example:
+ *
+ *     EXPECT_THAT([&]{ openFile("nope"); }, ThrowsWinError(ERROR_FILE_NOT_FOUND));
+ */
+inline auto ThrowsWinError(DWORD expected)
+{
+    return ::testing::Throws<windows::WinError>(::testing::Field(&windows::WinError::lastError, expected));
+}
+
+#endif
+
 } // namespace nix::testing

--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -301,7 +301,7 @@ TEST(BufferedSourceReadLine, BufferExhaustedThenEof)
 TEST(WriteFull, RespectsAllowInterrupts)
 {
 #ifdef _WIN32
-    GTEST_SKIP() << "Broken on Windows";
+    GTEST_SKIP() << "Interrupt support on Windows not expected to work";
 #endif
     Pipe pipe;
     pipe.create();

--- a/src/libutil-tests/file-system-at.cc
+++ b/src/libutil-tests/file-system-at.cc
@@ -5,6 +5,9 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/fs-sink.hh"
 #include "nix/util/tests/gmock-matchers.hh"
+#ifdef _WIN32
+#  include "nix/util/windows-environment.hh"
+#endif
 
 namespace nix {
 
@@ -14,9 +17,6 @@ namespace nix {
 
 TEST(readLinkAt, works)
 {
-#ifdef _WIN32
-    GTEST_SKIP() << "Broken on Windows";
-#endif
     std::filesystem::path tmpDir = nix::createTempDir();
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
@@ -35,7 +35,16 @@ TEST(readLinkAt, works)
         RestoreSink sink(/*startFsync=*/false);
         sink.dstPath = tmpDir;
         sink.dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
-        sink.createSymlink(CanonPath("link"), "target");
+        try {
+            sink.createSymlink(CanonPath("link"), "target");
+        } catch (SystemError &) {
+#ifdef _WIN32
+            // It works in @ericson2314's local wine build, but not in the Nix sandbox
+            if (windows::isWine())
+                GTEST_SKIP() << "symlink creation not supported in Wine only on some file systems";
+#endif
+            throw;
+        }
         sink.createSymlink(CanonPath("relative"), "../relative/path");
         sink.createSymlink(CanonPath("absolute"), "/absolute/path");
         try {
@@ -57,12 +66,12 @@ TEST(readLinkAt, works)
 
     auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
 
-    EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("link")), OS_STR("target"));
-    EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("relative")), OS_STR("../relative/path"));
-    EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("absolute")), OS_STR("/absolute/path"));
+    EXPECT_EQ(readLinkAt(dirFd.get(), OsFilename{"link"}), OS_STR("target"));
+    EXPECT_EQ(readLinkAt(dirFd.get(), OsFilename{"relative"}), OS_STR("../relative/path"));
+    EXPECT_EQ(readLinkAt(dirFd.get(), OsFilename{"absolute"}), OS_STR("/absolute/path"));
     if (hasLongSymlinks) {
-        EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("medium")), string_to_os_string(mediumTarget));
-        EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("long")), string_to_os_string(longTarget));
+        EXPECT_EQ(readLinkAt(dirFd.get(), OsFilename{"medium"}), string_to_os_string(mediumTarget));
+        EXPECT_EQ(readLinkAt(dirFd.get(), OsFilename{"long"}), string_to_os_string(longTarget));
     }
     EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("a/b/link")), OS_STR("nested_target"));
 
@@ -70,9 +79,9 @@ TEST(readLinkAt, works)
     EXPECT_EQ(readLinkAt(subDirFd.get(), CanonPath("b/link")), OS_STR("nested_target"));
 
     // Test error cases - expect SystemError on both platforms
-    EXPECT_THROW(readLinkAt(dirFd.get(), CanonPath("regular")), SystemError);
-    EXPECT_THROW(readLinkAt(dirFd.get(), CanonPath("dir")), SystemError);
-    EXPECT_THROW(readLinkAt(dirFd.get(), CanonPath("nonexistent")), SystemError);
+    EXPECT_THROW(readLinkAt(dirFd.get(), OsFilename{"regular"}), SystemError);
+    EXPECT_THROW(readLinkAt(dirFd.get(), OsFilename{"dir"}), SystemError);
+    EXPECT_THROW(readLinkAt(dirFd.get(), OsFilename{"nonexistent"}), SystemError);
 }
 
 /* ----------------------------------------------------------------------------
@@ -81,9 +90,6 @@ TEST(readLinkAt, works)
 
 TEST(openFileEnsureBeneathNoSymlinks, works)
 {
-#ifdef _WIN32
-    GTEST_SKIP() << "Broken on Windows";
-#endif
     std::filesystem::path tmpDir = nix::createTempDir();
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
@@ -95,7 +101,16 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
         sink.createDirectory(CanonPath("c"));
         sink.createDirectory(CanonPath("c/d"));
         sink.createRegularFile(CanonPath("c/d/regular"), [](CreateRegularFileSink & crf) { crf("some contents"); });
-        sink.createSymlink(CanonPath("a/absolute_symlink"), tmpDir.string());
+        try {
+            sink.createSymlink(CanonPath("a/absolute_symlink"), tmpDir.string());
+        } catch (SystemError &) {
+#ifdef _WIN32
+            // It works in @ericson2314's local wine build, but not in the Nix sandbox
+            if (windows::isWine())
+                GTEST_SKIP() << "symlink creation not supported in Wine only on some file systems";
+#endif
+            throw;
+        }
         sink.createSymlink(CanonPath("a/relative_symlink"), "../.");
         sink.createSymlink(CanonPath("a/broken_symlink"), "./nonexistent");
         sink.createDirectory(CanonPath("a/b"), [](FileSystemObjectSink & dirSink, const CanonPath & relPath) {
@@ -124,7 +139,7 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
        `.errNo`. */
     auto check = [](std::string_view what, AutoCloseFD fd) {
         if (!fd)
-            throw SysError("openFileEnsureBeneathNoSymlinks: %s", what);
+            throw NativeSysError("openFileEnsureBeneathNoSymlinks: %s", what);
         return fd;
     };
 
@@ -163,10 +178,13 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
 #if defined(__linux__)
     auto openReadDirPath = [&](std::string_view path) -> AutoCloseFD {
         return check(
-            path, openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath(path), O_PATH | O_DIRECTORY | O_CLOEXEC, 0));
+            path,
+            openFileEnsureBeneathNoSymlinks(
+                dirFd.get(), CanonPath(path), O_PATH | O_DIRECTORY | O_CLOEXEC, 0));
     };
     auto openPath = [&](std::string_view path) -> AutoCloseFD {
-        return check(path, openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath(path), O_PATH | O_CLOEXEC, 0));
+        return check(
+            path, openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath(path), O_PATH | O_CLOEXEC, 0));
     };
 #endif
 
@@ -188,6 +206,9 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
     };
 
     using nix::testing::ThrowsSysError;
+#ifdef _WIN32
+    using nix::testing::ThrowsWinError;
+#endif
 
     // Symlinks in the path (any position) are rejected.
     EXPECT_THROW(openRead("a/absolute_symlink"), SymlinkNotAllowed);
@@ -234,10 +255,31 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
 #endif
     EXPECT_THROW(openCreateExclusive("a/absolute_symlink/broken_symlink"), SymlinkNotAllowed);
 
-    // Non-symlink failure modes: errno must survive.
-    EXPECT_THAT([&] { openRead("c/d/regular/a"); }, ThrowsSysError(ENOTDIR));
-    EXPECT_THAT([&] { openReadDir("c/d/regular"); }, ThrowsSysError(ENOTDIR));
-    EXPECT_THAT([&] { openRead("c/d/nonexistent"); }, ThrowsSysError(ENOENT));
+    // Non-symlink failure modes: error codes must survive.
+    EXPECT_THAT(
+        [&] { openRead("c/d/regular/a"); },
+#ifdef _WIN32
+        ThrowsWinError(ERROR_DIRECTORY)
+#else
+        ThrowsSysError(ENOTDIR)
+#endif
+    );
+    EXPECT_THAT(
+        [&] { openReadDir("c/d/regular"); },
+#ifdef _WIN32
+        ThrowsWinError(ERROR_DIRECTORY)
+#else
+        ThrowsSysError(ENOTDIR)
+#endif
+    );
+    EXPECT_THAT(
+        [&] { openRead("c/d/nonexistent"); },
+#ifdef _WIN32
+        ThrowsWinError(ERROR_FILE_NOT_FOUND)
+#else
+        ThrowsSysError(ENOENT)
+#endif
+    );
 
     // Happy paths.
     EXPECT_TRUE(openRead("c/d/regular"));
@@ -275,14 +317,19 @@ TEST(openFileEnsureBeneathNoSymlinksDeathTest, rejectsONofollow)
        owns symlink policy. Verify the assert fires for every flag
        combination that includes `O_NOFOLLOW`. */
     EXPECT_DEATH(
-        openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_RDONLY | O_NOFOLLOW, 0), "O_NOFOLLOW");
+        openFileEnsureBeneathNoSymlinks(dirFd.get(), OsFilename{"file"}, O_RDONLY | O_NOFOLLOW, 0),
+        "O_NOFOLLOW");
     EXPECT_DEATH(
-        openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_RDONLY | O_DIRECTORY | O_NOFOLLOW, 0),
+        openFileEnsureBeneathNoSymlinks(
+            dirFd.get(), OsFilename{"file"}, O_RDONLY | O_DIRECTORY | O_NOFOLLOW, 0),
         "O_NOFOLLOW");
 #  if defined(__linux__)
-    EXPECT_DEATH(openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_PATH | O_NOFOLLOW, 0), "O_NOFOLLOW");
     EXPECT_DEATH(
-        openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_PATH | O_DIRECTORY | O_NOFOLLOW, 0),
+        openFileEnsureBeneathNoSymlinks(dirFd.get(), OsFilename{"file"}, O_PATH | O_NOFOLLOW, 0),
+        "O_NOFOLLOW");
+    EXPECT_DEATH(
+        openFileEnsureBeneathNoSymlinks(
+            dirFd.get(), OsFilename{"file"}, O_PATH | O_DIRECTORY | O_NOFOLLOW, 0),
         "O_NOFOLLOW");
 #  endif
 }

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -265,7 +265,7 @@ TEST(chmodIfNeeded, works)
 #ifdef _WIN32
     // Windows doesn't support Unix-style permission bits - lstat always
     // returns the same mode regardless of what chmod sets.
-    GTEST_SKIP() << "Broken on Windows";
+    GTEST_SKIP() << "chmod on Windows not expected to work";
 #endif
     auto [autoClose_, tmpFile] = nix::createTempFile();
     auto deleteTmpFile = AutoDelete(tmpFile);

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -84,6 +84,8 @@ sources = files(
   'nar-listing.cc',
   'nix_api_util.cc',
   'nix_api_util_internal.cc',
+  'os-canon-path.cc',
+  'os-filename.cc',
   'pool.cc',
   'position.cc',
   'processes.cc',

--- a/src/libutil-tests/os-canon-path.cc
+++ b/src/libutil-tests/os-canon-path.cc
@@ -1,0 +1,139 @@
+#include "nix/util/os-canon-path.hh"
+
+#include <gtest/gtest.h>
+
+namespace nix {
+
+TEST(OsCanonPath, emptyPath)
+{
+    OsCanonPath empty;
+    ASSERT_TRUE(empty.empty());
+    ASSERT_EQ(empty.path(), std::filesystem::path{});
+}
+
+TEST(OsCanonPath, singleComponent)
+{
+    OsCanonPath p{std::filesystem::path{"foo"}};
+    ASSERT_FALSE(p.empty());
+    ASSERT_EQ(p.path(), "foo");
+}
+
+TEST(OsCanonPath, multipleComponents)
+{
+    OsCanonPath p{std::filesystem::path{"foo"} / "bar" / "baz"};
+    ASSERT_EQ(p.path(), std::filesystem::path{"foo"} / "bar" / "baz");
+}
+
+TEST(OsCanonPath, fromOsFilename)
+{
+    OsFilename name{"hello"};
+    OsCanonPath p{name};
+    ASSERT_EQ(p.path(), "hello");
+}
+
+TEST(OsCanonPath, equality)
+{
+    OsCanonPath a{std::filesystem::path{"foo"} / "bar"};
+    OsCanonPath b{std::filesystem::path{"foo"} / "bar"};
+    OsCanonPath c{std::filesystem::path{"foo"} / "baz"};
+
+    ASSERT_EQ(a, b);
+    ASSERT_NE(a, c);
+}
+
+TEST(OsCanonPath, concatTwoNonEmpty)
+{
+    OsCanonPath a{std::filesystem::path{"foo"}};
+    OsCanonPath b{std::filesystem::path{"bar"} / "baz"};
+    auto result = a / b;
+    ASSERT_EQ(result.path(), std::filesystem::path{"foo"} / "bar" / "baz");
+}
+
+TEST(OsCanonPath, concatWithEmptyLhs)
+{
+    OsCanonPath empty;
+    OsCanonPath b{std::filesystem::path{"bar"}};
+    auto result = empty / b;
+    ASSERT_EQ(result.path(), "bar");
+}
+
+TEST(OsCanonPath, concatWithEmptyRhs)
+{
+    OsCanonPath a{std::filesystem::path{"foo"}};
+    OsCanonPath empty;
+    auto result = a / empty;
+    ASSERT_EQ(result.path(), "foo");
+}
+
+TEST(OsCanonPath, concatBothEmpty)
+{
+    OsCanonPath empty;
+    auto result = empty / empty;
+    ASSERT_TRUE(result.empty());
+}
+
+TEST(OsCanonPath, concatOsCanonPathWithOsFilename)
+{
+    OsCanonPath base{std::filesystem::path{"foo"}};
+    OsFilename name{"bar"};
+    auto result = base / name;
+    ASSERT_EQ(result.path(), std::filesystem::path{"foo"} / "bar");
+}
+
+TEST(OsCanonPath, concatEmptyOsCanonPathWithOsFilename)
+{
+    OsCanonPath empty;
+    OsFilename name{"bar"};
+    auto result = empty / name;
+    ASSERT_EQ(result.path(), "bar");
+}
+
+TEST(OsCanonPath, concatOsFilenameWithOsCanonPath)
+{
+    OsFilename name{"foo"};
+    OsCanonPath tail{std::filesystem::path{"bar"} / "baz"};
+    auto result = name / tail;
+    ASSERT_EQ(result.path(), std::filesystem::path{"foo"} / "bar" / "baz");
+}
+
+TEST(OsCanonPath, concatOsFilenameWithEmptyOsCanonPath)
+{
+    OsFilename name{"foo"};
+    OsCanonPath empty;
+    auto result = name / empty;
+    ASSERT_EQ(result.path(), "foo");
+}
+
+TEST(OsCanonPath, concatOsFilenameWithOsFilename)
+{
+    OsFilename a{"foo"};
+    OsFilename b{"bar"};
+    // LHS converts to OsCanonPath via implicit conversion,
+    // then uses OsCanonPath::operator/(const OsFilename &)
+    OsCanonPath result = a / b;
+    ASSERT_EQ(result.path(), std::filesystem::path{"foo"} / "bar");
+}
+
+TEST(OsCanonPath, absolutePathFails)
+{
+    ASSERT_DEATH(OsCanonPath(std::filesystem::path{"/foo"}), "cannot have a root path");
+}
+
+TEST(OsCanonPath, dotComponentFails)
+{
+    ASSERT_DEATH(OsCanonPath(std::filesystem::path{"foo"} / "." / "bar"), "cannot have '\\.' components");
+}
+
+TEST(OsCanonPath, dotDotComponentFails)
+{
+    ASSERT_DEATH(OsCanonPath(std::filesystem::path{"foo"} / ".." / "bar"), "cannot have '\\.\\.' components");
+}
+
+#ifdef _WIN32
+TEST(OsCanonPath, windowsDriveLetterFails)
+{
+    ASSERT_DEATH(OsCanonPath(std::filesystem::path{"C:\\foo"}), "cannot have a root path");
+}
+#endif
+
+} // namespace nix

--- a/src/libutil-tests/os-filename.cc
+++ b/src/libutil-tests/os-filename.cc
@@ -1,0 +1,80 @@
+#include "nix/util/os-filename.hh"
+
+#include <gtest/gtest.h>
+
+namespace nix {
+
+TEST(OsFilename, validFilenames)
+{
+    // Simple filename
+    OsFilename f1("foo");
+    ASSERT_EQ(f1.path(), "foo");
+
+    // Filename with extension
+    OsFilename f2("bar.txt");
+    ASSERT_EQ(f2.path(), "bar.txt");
+
+    // Filename with multiple dots
+    OsFilename f3("file.tar.gz");
+    ASSERT_EQ(f3.path(), "file.tar.gz");
+
+    // Filename starting with dot (hidden file)
+    OsFilename f4(".hidden");
+    ASSERT_EQ(f4.path(), ".hidden");
+}
+
+TEST(OsFilename, equality)
+{
+    OsFilename a("foo");
+    OsFilename b("foo");
+    OsFilename c("bar");
+
+    ASSERT_EQ(a, b);
+    ASSERT_NE(a, c);
+}
+
+TEST(OsFilename, implicitConversion)
+{
+    OsFilename f("test.txt");
+    std::filesystem::path p = f;
+    ASSERT_EQ(p, "test.txt");
+}
+
+TEST(OsFilename, emptyFails)
+{
+    ASSERT_DEATH(OsFilename(""), "cannot be empty");
+}
+
+TEST(OsFilename, dotFails)
+{
+    ASSERT_DEATH(OsFilename("."), "cannot be '\\.'");
+}
+
+TEST(OsFilename, dotDotFails)
+{
+    ASSERT_DEATH(OsFilename(".."), "cannot be '\\.\\.'");
+}
+
+TEST(OsFilename, absolutePathFails)
+{
+    ASSERT_DEATH(OsFilename("/foo"), "cannot have a root path");
+}
+
+TEST(OsFilename, relativePathWithDirFails)
+{
+    ASSERT_DEATH(OsFilename("foo/bar"), "cannot have a parent path");
+}
+
+#ifdef _WIN32
+TEST(OsFilename, windowsDriveLetterFails)
+{
+    ASSERT_DEATH(OsFilename("C:\\foo"), "cannot have a root path");
+}
+
+TEST(OsFilename, windowsBackslashFails)
+{
+    ASSERT_DEATH(OsFilename("foo\\bar"), "cannot have a parent path");
+}
+#endif
+
+} // namespace nix

--- a/src/libutil-tests/unix/file-system-at.cc
+++ b/src/libutil-tests/unix/file-system-at.cc
@@ -66,7 +66,8 @@ TEST(fchmodatTryNoFollow, works)
        property we actually care about. */
     auto expectSymlinkChmod = [&](std::string_view path, mode_t mode) {
 #if defined(__linux__)
-        EXPECT_THAT([&] { fchmodatTryNoFollow(dirFd.get(), CanonPath(path), mode); }, ThrowsSysError(EOPNOTSUPP));
+        EXPECT_THAT(
+            [&] { fchmodatTryNoFollow(dirFd.get(), CanonPath(path), mode); }, ThrowsSysError(EOPNOTSUPP));
 #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) \
     || defined(__DragonFly__)
         EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), CanonPath(path), mode));
@@ -87,13 +88,14 @@ TEST(fchmodatTryNoFollow, works)
 
     /* Check fchmodatTryNoFollow works on regular files and directories. */
 
-    EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), CanonPath("file"), 0600));
+    EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), OsFilename{"file"}, 0600));
     ASSERT_EQ(stat(tmpDir / "file").st_mode & 0777, 0600);
 
-    EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), CanonPath("dir"), 0700));
+    EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), OsFilename{"dir"}, 0700));
     ASSERT_EQ(stat(tmpDir / "dir").st_mode & 0777, 0700);
 
-    EXPECT_THAT([&] { fchmodatTryNoFollow(dirFd.get(), CanonPath("nonexistent"), 0600); }, ThrowsSysError(ENOENT));
+    EXPECT_THAT(
+        [&] { fchmodatTryNoFollow(dirFd.get(), OsFilename{"nonexistent"}, 0600); }, ThrowsSysError(ENOENT));
 }
 
 #ifdef __linux__
@@ -134,13 +136,13 @@ TEST(fchmodatTryNoFollow, fallbackWithoutProc)
                 _exit(3);
 
             try {
-                fchmodatTryNoFollow(dirFd.get(), CanonPath("file"), 0600);
+                fchmodatTryNoFollow(dirFd.get(), OsFilename{"file"}, 0600);
             } catch (SysError & e) {
                 _exit(4);
             }
 
             try {
-                fchmodatTryNoFollow(dirFd.get(), CanonPath("link"), 0777);
+                fchmodatTryNoFollow(dirFd.get(), OsFilename{"link"}, 0777);
             } catch (SysError & e) {
                 if (e.errNo == EOPNOTSUPP)
                     _exit(0); /* Success. */

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -1,4 +1,5 @@
 #include <cerrno>
+#include <fcntl.h>
 #include <map>
 
 #include <strings.h> // for strcasecmp

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -1,9 +1,11 @@
 #include "nix/util/file-system.hh"
+#include "nix/util/file-system-at.hh"
 #include "nix/util/file-path.hh"
 #include "nix/util/file-path-impl.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/finally.hh"
 #include "nix/util/serialise.hh"
+#include "nix/util/source-accessor.hh"
 #include "nix/util/util.hh"
 
 #include <atomic>
@@ -215,11 +217,19 @@ bool pathAccessible(const std::filesystem::path & path)
 std::filesystem::path readLink(const std::filesystem::path & path)
 {
     checkInterrupt();
+#ifdef _WIN32
+    // libstdc++ doesn't implement std::filesystem::read_symlink on Windows yet
+    auto parentDir = openDirectory(path.parent_path(), FinalSymlink::Follow);
+    if (!parentDir)
+        throw NativeSysError("opening parent directory of %s", PathFmt(path));
+    return readLinkAt(parentDir.get(), OsFilename{path.filename()});
+#else
     try {
         return std::filesystem::read_symlink(path);
     } catch (std::filesystem::filesystem_error & e) {
         throw SystemError(e.code(), "reading symbolic link %s", PathFmt(path));
     }
+#endif
 }
 
 std::string readFile(const std::filesystem::path & path)
@@ -541,10 +551,18 @@ std::filesystem::path makeTempPath(const std::filesystem::path & root, const std
 
 void createSymlink(const std::filesystem::path & target, const std::filesystem::path & link)
 {
+#ifdef _WIN32
+    // libstdc++ doesn't implement std::filesystem::create_symlink on Windows yet
+    auto parentDir = openDirectory(link.parent_path(), FinalSymlink::Follow);
+    if (!parentDir)
+        throw NativeSysError("opening parent directory of %s", PathFmt(link));
+    createUnknownSymlinkAt(parentDir.get(), OsFilename{link.filename()}, target.native());
+#else
     std::error_code ec;
     std::filesystem::create_symlink(target, link, ec);
     if (ec)
-        throw SysError(ec.value(), "creating symlink %s -> %s", PathFmt(link), PathFmt(target));
+        throw SystemError(ec, "creating symlink %s -> %s", PathFmt(link), PathFmt(target));
+#endif
 }
 
 void replaceSymlink(const std::filesystem::path & target, const std::filesystem::path & link)
@@ -554,11 +572,11 @@ void replaceSymlink(const std::filesystem::path & target, const std::filesystem:
         tmp = tmp.lexically_normal();
 
         try {
-            std::filesystem::create_symlink(target, tmp);
-        } catch (std::filesystem::filesystem_error & e) {
-            if (e.code() == std::errc::file_exists)
+            createSymlink(target, tmp);
+        } catch (SystemError & e) {
+            if (e.is(std::errc::file_exists))
                 continue;
-            throw SystemError(e.code(), "creating symlink %1% -> %2%", PathFmt(tmp), PathFmt(target));
+            throw;
         }
 
         try {
@@ -628,15 +646,14 @@ void moveFile(const std::filesystem::path & oldName, const std::filesystem::path
         auto newPath = newName;
         // For the move to be as atomic as possible, copy to a temporary
         // directory
-        std::filesystem::path temp = createTempDir(os_string_to_string(PathView{newPath.parent_path()}), "rename-tmp");
+        std::filesystem::path temp = createTempDir(newPath.parent_path(), "rename-tmp");
         Finally removeTemp = [&]() { std::filesystem::remove(temp); };
         auto tempCopyTarget = temp / "copy-target";
         if (e.code().value() == EXDEV) {
             std::filesystem::remove(newPath);
             warn("can’t rename %s as %s, copying instead", PathFmt(oldName), PathFmt(newName));
             copyFile(oldPath, tempCopyTarget, true);
-            std::filesystem::rename(
-                os_string_to_string(PathView{tempCopyTarget}), os_string_to_string(PathView{newPath}));
+            std::filesystem::rename(tempCopyTarget, newPath);
         }
     }
 }

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -591,11 +591,6 @@ void replaceSymlink(const std::filesystem::path & target, const std::filesystem:
     }
 }
 
-void setWriteTime(const std::filesystem::path & path, const PosixStat & st)
-{
-    setWriteTime(path, st.st_atime, st.st_mtime, S_ISLNK(st.st_mode));
-}
-
 void copyFile(const std::filesystem::path & from, const std::filesystem::path & to, bool andDelete, bool contents)
 {
     auto fromStatus = std::filesystem::symlink_status(from);
@@ -626,7 +621,7 @@ void copyFile(const std::filesystem::path & from, const std::filesystem::path & 
         throw Error("file %s has an unsupported type", PathFmt(from));
     }
 
-    setWriteTime(to, lstat(from));
+    // Note: we don't preserve timestamps anymore
     if (andDelete) {
         if (!std::filesystem::is_symlink(fromStatus))
             std::filesystem::permissions(

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -72,7 +72,6 @@ static std::filesystem::path append(const std::filesystem::path & src, const Can
     return dst;
 }
 
-#ifndef _WIN32
 /**
  * Return a descriptor and single-component name suitable for
  * `*at` operations. The returned `CanonPath` is always a pure
@@ -94,7 +93,17 @@ getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, cons
         auto name = OsFilename{std::filesystem::path{std::string{*path.baseName()}}};
         if (parent->isRoot())
             return {AutoCloseFD{}, dirFd, std::move(name)};
-        auto parentFd = openFileEnsureBeneathNoSymlinks(dirFd, *parent, O_RDONLY | O_DIRECTORY | O_CLOEXEC, 0);
+        auto parentFd = openFileEnsureBeneathNoSymlinks(
+            dirFd,
+            *parent,
+#ifdef _WIN32
+            FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+            FILE_DIRECTORY_FILE
+#else
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC,
+            0
+#endif
+        );
         if (!parentFd)
             throw SysError("opening parent directory of %s", PathFmt(append(dstPath, path)));
         auto fd = parentFd.get();
@@ -111,8 +120,7 @@ getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, cons
         throw Error("restore destination path is empty");
     auto filename = p.filename();
     if (filename == "." || filename == "..")
-        throw Error(
-            "restore destination '%s' ends in '%s', which is not a valid filename", p.native(), filename.native());
+        throw Error("restore destination %s ends in %s, which is not a valid filename", PathFmt(p), PathFmt(filename));
     auto parentPath = p.parent_path();
     /* Relative path with no directory component (e.g. "out") —
        the parent is the current working directory. Open it so we
@@ -120,13 +128,12 @@ getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, cons
        changes the working directory mid-unpack. */
     if (parentPath.empty())
         parentPath = ".";
-    AutoCloseFD parentFd{::open(parentPath.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC)};
+    auto parentFd = openDirectory(parentPath, FinalSymlink::Follow);
     if (!parentFd)
-        throw SysError("opening parent directory of %s", PathFmt(p));
+        throw NativeSysError("opening parent directory of %s", PathFmt(p));
     auto fd = parentFd.get();
     return {std::move(parentFd), fd, OsFilename{p.filename()}};
 }
-#endif
 
 void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallback callback)
 {
@@ -161,28 +168,32 @@ void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallba
 
 void RestoreSink::createDirectory(const CanonPath & path)
 {
-#ifndef _WIN32
     if (dirFd && path.isRoot())
-        /* Trying to create a directory that we already have a file descriptor for. */
         throw Error("path %s already exists", PathFmt(append(dstPath, path)));
 
     auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
 
-    if (::mkdirat(fd, name.c_str(), 0777) == -1)
-        throw SysError("creating directory %s", PathFmt(append(dstPath, path)));
+    if (auto result = openDirectoryAt(fd, OsCanonPath{name}, true); !result) {
+        throw SystemError(result.error(), "creating directory %s", PathFmt(append(dstPath, path)));
+    }
 
     if (!dirFd) {
         /* Open directory for further *at operations relative to the sink root
            directory. */
-        dirFd = openFileEnsureBeneathNoSymlinks(fd, name, O_RDONLY | O_DIRECTORY | O_CLOEXEC, 0);
-        if (!dirFd)
-            throw SysError("opening directory %s", PathFmt(append(dstPath, path)));
-    }
+        dirFd = openFileEnsureBeneathNoSymlinks(
+            fd,
+            OsCanonPath{name},
+#ifdef _WIN32
+            FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+            FILE_DIRECTORY_FILE
 #else
-    auto p = append(dstPath, path);
-    if (!std::filesystem::create_directory(p))
-        throw Error("path '%s' already exists", p.string());
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC,
+            0
 #endif
+        );
+        if (!dirFd)
+            throw NativeSysError("opening directory %s", PathFmt(append(dstPath, path)));
+    }
 };
 
 struct RestoreRegularFile : CreateRegularFileSink, FdSink
@@ -223,29 +234,23 @@ struct RestoreRegularFile : CreateRegularFileSink, FdSink
 
 void RestoreSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)
 {
+    auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
     auto crf = RestoreRegularFile(
         startFsync,
+        openFileEnsureBeneathNoSymlinks(
+            fd,
+            OsCanonPath{name},
 #ifdef _WIN32
-        CreateFileW(
-            append(dstPath, path).c_str(),
-            GENERIC_READ | GENERIC_WRITE,
-            FILE_SHARE_READ | FILE_SHARE_WRITE,
-            NULL,
-            CREATE_NEW,
-            FILE_ATTRIBUTE_NORMAL,
-            NULL)
+            FILE_WRITE_DATA | SYNCHRONIZE,
+            0,
+            FILE_CREATE
 #else
-        [&]() {
-            /* O_EXCL together with O_CREAT ensures symbolic links in the last
-               component are not followed. */
-            constexpr int flags = O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC;
-            auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
-            return openFileEnsureBeneathNoSymlinks(fd, name, flags, 0666);
-        }()
+            O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC,
+            0666
 #endif
-    );
+            ));
     if (!crf.fd)
-        throw NativeSysError("creating file %1%", PathFmt(append(dstPath, path)));
+        throw NativeSysError("creating file %s", PathFmt(append(dstPath, path)));
     func(crf);
     crf.flush();
 }
@@ -281,13 +286,8 @@ void RestoreRegularFile::preallocateContents(uint64_t len)
 
 void RestoreSink::createSymlink(const CanonPath & path, const std::string & target)
 {
-#ifndef _WIN32
     auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
-    if (::symlinkat(requireCString(target), fd, name.c_str()) == -1)
-        throw SysError("creating symlink from %1% -> '%2%'", PathFmt(append(dstPath, path)), target);
-#else
-    nix::createSymlink(target, append(dstPath, path).string());
-#endif
+    createUnknownSymlinkAt(fd, OsCanonPath{name}, string_to_os_string(target));
 }
 
 void RegularFileSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -82,7 +82,7 @@ static std::filesystem::path append(const std::filesystem::path & src, const Can
  * `Descriptor` borrows from `dirFd`. When `dirFd` is not set,
  * temporarily opens the parent of `dstPath`.
  */
-static std::tuple<AutoCloseFD, Descriptor, CanonPath>
+static std::tuple<AutoCloseFD, Descriptor, OsFilename>
 getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, const CanonPath & path)
 {
     if (dirFd != INVALID_DESCRIPTOR) {
@@ -91,13 +91,14 @@ getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, cons
            root) within it. */
         assert(!path.isRoot());
         auto parent = path.parent();
+        auto name = OsFilename{std::filesystem::path{std::string{*path.baseName()}}};
         if (parent->isRoot())
-            return {AutoCloseFD{}, dirFd, CanonPath::fromFilename(*path.baseName())};
+            return {AutoCloseFD{}, dirFd, std::move(name)};
         auto parentFd = openFileEnsureBeneathNoSymlinks(dirFd, *parent, O_RDONLY | O_DIRECTORY | O_CLOEXEC, 0);
         if (!parentFd)
             throw SysError("opening parent directory of %s", PathFmt(append(dstPath, path)));
         auto fd = parentFd.get();
-        return {std::move(parentFd), fd, CanonPath::fromFilename(*path.baseName())};
+        return {std::move(parentFd), fd, std::move(name)};
     }
 
     /* Without dirFd, we're creating the root entry itself, so path
@@ -123,7 +124,7 @@ getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, cons
     if (!parentFd)
         throw SysError("opening parent directory of %s", PathFmt(p));
     auto fd = parentFd.get();
-    return {std::move(parentFd), fd, CanonPath::fromFilename(p.filename().native())};
+    return {std::move(parentFd), fd, OsFilename{p.filename()}};
 }
 #endif
 
@@ -167,7 +168,7 @@ void RestoreSink::createDirectory(const CanonPath & path)
 
     auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
 
-    if (::mkdirat(fd, name.rel_c_str(), 0777) == -1)
+    if (::mkdirat(fd, name.c_str(), 0777) == -1)
         throw SysError("creating directory %s", PathFmt(append(dstPath, path)));
 
     if (!dirFd) {
@@ -282,7 +283,7 @@ void RestoreSink::createSymlink(const CanonPath & path, const std::string & targ
 {
 #ifndef _WIN32
     auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
-    if (::symlinkat(requireCString(target), fd, name.rel_c_str()) == -1)
+    if (::symlinkat(requireCString(target), fd, name.c_str()) == -1)
         throw SysError("creating symlink from %1% -> '%2%'", PathFmt(append(dstPath, path)), target);
 #else
     nix::createSymlink(target, append(dstPath, path).string());

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -16,6 +16,7 @@
 
 #include "nix/util/file-descriptor.hh"
 #include "nix/util/file-system.hh"
+#include "nix/util/os-canon-path.hh"
 
 #include <optional>
 
@@ -69,7 +70,7 @@ PosixStat fstatat(Descriptor dirFd, const std::filesystem::path & path);
  * @throws SystemError on any I/O errors.
  * @throws Interrupted if interrupted.
  */
-OsString readLinkAt(Descriptor dirFd, const CanonPath & path);
+OsString readLinkAt(Descriptor dirFd, const OsCanonPath & path);
 
 /**
  * Open a file relative to @p dirFd, ensuring the path stays beneath
@@ -92,7 +93,7 @@ OsString readLinkAt(Descriptor dirFd, const CanonPath & path);
  *
  * @param dirFdCallback Callback invoked that gets the ownership of an intermediate directory fd.
  *
- * @pre `path.isRoot()` is false
+ * @pre `path.empty()` is false
  *
  * @throws SymlinkNotAllowed if an interior path component is a
  *     symlink, or if the final component is a symlink and `O_PATH`
@@ -116,7 +117,7 @@ OsString readLinkAt(Descriptor dirFd, const CanonPath & path);
  */
 AutoCloseFD openFileEnsureBeneathNoSymlinks(
     Descriptor dirFd,
-    const CanonPath & path,
+    const OsCanonPath & path,
 #ifdef _WIN32
     ACCESS_MASK desiredAccess,
     ULONG createOptions,
@@ -125,7 +126,7 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
     int flags,
     mode_t mode = 0,
 #endif
-    std::function<void(AutoCloseFD dirFd, CanonPath relPath)> dirFdCallback = nullptr);
+    std::function<void(AutoCloseFD dirFd, OsCanonPath relPath)> dirFdCallback = nullptr);
 
 #ifdef __linux__
 namespace linux {
@@ -160,7 +161,7 @@ namespace unix {
  * @pre path.isRoot() is false
  * @throws SysError if any operation fails
  */
-void fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t mode);
+void fchmodatTryNoFollow(Descriptor dirFd, const OsCanonPath & path, mode_t mode);
 
 } // namespace unix
 #endif

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -207,6 +207,14 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
 #endif
     std::function<void(AutoCloseFD dirFd, OsCanonPath relPath)> dirFdCallback = nullptr);
 
+/**
+ * Set the access and modification time of a file relative to a directory file descriptor.
+ *
+ * @pre path.isRoot() is false
+ * @throws SysError if any operation fails
+ */
+void setWriteTime(Descriptor dirFd, const std::filesystem::path & path, time_t accessedTime, time_t modificationTime);
+
 #ifdef __linux__
 namespace linux {
 

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -14,11 +14,15 @@
  * issues.
  */
 
+#include "nix/util/error.hh"
 #include "nix/util/file-descriptor.hh"
 #include "nix/util/file-system.hh"
 #include "nix/util/os-canon-path.hh"
+#include "nix/util/source-accessor.hh"
 
+#include <boost/outcome.hpp>
 #include <optional>
+#include <system_error>
 
 #ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
@@ -27,6 +31,91 @@
 
 namespace nix {
 
+namespace outcome = BOOST_OUTCOME_V2_NAMESPACE;
+
+/**
+ * Read a symlink relative to a directory file descriptor.
+ *
+ * @pre `path` must be relative (not absolute).
+ *
+ * @throws SystemError on any I/O errors.
+ * @throws Interrupted if interrupted.
+ */
+OsString readLinkAt(Descriptor dirFd, const OsCanonPath & path);
+
+/**
+ * Create a symlink to a file relative to a directory file descriptor.
+ *
+ * On Windows, creates a file symlink. On Unix, equivalent to symlinkat.
+ *
+ * @param dirFd Directory file descriptor
+ * @param path Relative path for the new symlink
+ * @param target The symlink target (what it points to)
+ *
+ * @pre `path` must be relative (not absolute).
+ *
+ * @throws SystemError on any I/O errors.
+ */
+void createFileSymlinkAt(Descriptor dirFd, const OsCanonPath & path, const OsString & target);
+
+/**
+ * Create a symlink to a directory relative to a directory file descriptor.
+ *
+ * On Windows, creates a directory symlink. On Unix, equivalent to symlinkat.
+ *
+ * @param dirFd Directory file descriptor
+ * @param path Relative path for the new symlink
+ * @param target The symlink target (what it points to)
+ *
+ * @pre `path` must be relative (not absolute).
+ *
+ * @throws SystemError on any I/O errors.
+ */
+void createDirectorySymlinkAt(Descriptor dirFd, const OsCanonPath & path, const OsString & target);
+
+/**
+ * Create a symlink relative to a directory file descriptor, detecting target type.
+ *
+ * On Windows, stats the target to determine whether to create a file or
+ * directory symlink. Falls back to file symlink if the target does not exist.
+ * On Unix, equivalent to symlinkat.
+ *
+ * @param dirFd Directory file descriptor
+ * @param path Relative path for the new symlink
+ * @param target The symlink target (what it points to)
+ *
+ * @pre `path` must be relative (not absolute).
+ *
+ * @throws SystemError on any I/O errors.
+ */
+void createUnknownSymlinkAt(Descriptor dirFd, const OsCanonPath & path, const OsString & target);
+
+/**
+ * Open or create a directory relative to a directory file descriptor.
+ *
+ * @param dirFd Directory file descriptor
+ * @param path Relative path to the directory
+ * @param create If true, create the directory and open it.
+ *               If false, open existing directory.
+ * @param mode File mode for the new directory (only used when `create` is true).
+ *             Unix only.
+ *
+ * @return File descriptor for the directory, or error code on failure.
+ *
+ * @pre `path` must be relative (not absolute).
+ *
+ * @note Does not follow symlinks - if path is a symlink, will fail to open.
+ */
+outcome::unchecked<AutoCloseFD, std::error_code> openDirectoryAt(
+    Descriptor dirFd,
+    const OsCanonPath & path,
+    bool create = false
+#ifndef _WIN32
+    ,
+    mode_t mode = 0777
+#endif
+);
+
 /**
  * Get status of an open file/directory handle.
  *
@@ -34,8 +123,6 @@ namespace nix {
  * @throws SystemError on I/O errors.
  */
 PosixStat fstat(Descriptor fd);
-
-#ifndef _WIN32
 
 /**
  * Get status of a file relative to a directory file descriptor.
@@ -48,7 +135,7 @@ PosixStat fstat(Descriptor fd);
  *
  * @pre `path` must be relative (not absolute) and non-empty.
  */
-std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const std::filesystem::path & path);
+std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const OsCanonPath & path);
 
 /**
  * Get status of a file relative to a directory file descriptor.
@@ -60,17 +147,7 @@ std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const std::filesystem::p
  *
  * @pre `path` must be relative (not absolute) and non-empty.
  */
-PosixStat fstatat(Descriptor dirFd, const std::filesystem::path & path);
-
-#endif
-
-/**
- * Read a symlink relative to a directory file descriptor.
- *
- * @throws SystemError on any I/O errors.
- * @throws Interrupted if interrupted.
- */
-OsString readLinkAt(Descriptor dirFd, const OsCanonPath & path);
+PosixStat fstatat(Descriptor dirFd, const OsCanonPath & path);
 
 /**
  * Open a file relative to @p dirFd, ensuring the path stays beneath
@@ -87,6 +164,8 @@ OsString readLinkAt(Descriptor dirFd, const OsCanonPath & path);
  * @param desiredAccess (Windows) Windows `ACCESS_MASK`
  * @param createOptions (Windows) Windows create options
  * @param createDisposition (Windows) `FILE_OPEN`, `FILE_CREATE`, etc.
+ *
+ * @pre `path` must be relative (not absolute) and non-empty.
  *
  * @param flags (Unix) `O_*` flags (must not include `O_NOFOLLOW`)
  * @param mode (Unix) Mode for `O_{CREAT,TMPFILE}`
@@ -158,7 +237,7 @@ namespace unix {
  * @note When on linux without fchmodat2 support and without procfs mounted falls back to fchmodat without
  * AT_SYMLINK_NOFOLLOW, since it's the best we can do without failing.
  *
- * @pre path.isRoot() is false
+ * @pre `path` must be relative (not absolute) and non-empty.
  * @throws SysError if any operation fails
  */
 void fchmodatTryNoFollow(Descriptor dirFd, const OsCanonPath & path, mode_t mode);

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -293,30 +293,6 @@ void createDirs(const std::filesystem::path & path);
 void createDir(const std::filesystem::path & path, mode_t mode = 0755);
 
 /**
- * Set the access and modification times of the given path, not
- * following symlinks.
- *
- * @param accessedTime Specified in seconds.
- *
- * @param modificationTime Specified in seconds.
- *
- * @param isSymlink Whether the file in question is a symlink. Used for
- * fallback code where we don't have `lutimes` or similar. if
- * `std::optional` is passed, the information will be recomputed if it
- * is needed. Race conditions are possible so be careful!
- */
-void setWriteTime(
-    const std::filesystem::path & path,
-    time_t accessedTime,
-    time_t modificationTime,
-    std::optional<bool> isSymlink = std::nullopt);
-
-/**
- * Convenience wrapper that takes all arguments from the `PosixStat`.
- */
-void setWriteTime(const std::filesystem::path & path, const PosixStat & st);
-
-/**
  * Create a symlink.
  *
  */

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -66,6 +66,8 @@ headers = [ config_pub_h ] + files(
   'nar-accessor.hh',
   'nar-cache.hh',
   'nar-listing.hh',
+  'os-canon-path.hh',
+  'os-filename.hh',
   'os-string.hh',
   'pool.hh',
   'pos-idx.hh',

--- a/src/libutil/include/nix/util/os-canon-path.hh
+++ b/src/libutil/include/nix/util/os-canon-path.hh
@@ -1,0 +1,192 @@
+#pragma once
+///@file
+
+#include "nix/util/canon-path.hh"
+#include "nix/util/os-filename.hh"
+
+#include <filesystem>
+
+namespace nix {
+
+/**
+ * A newtype around `std::filesystem::path` that asserts at construction
+ * time that the path is a canonical relative path suitable for use with
+ * `openat` and Windows NT equivalents.
+ *
+ * A valid `OsCanonPath`:
+ * - Has no root path or root name (no drive letter on Windows, no leading `/`)
+ * - Has no `.` or `..` components
+ * - Never ends with a directory separator (except the empty path)
+ * - Has no empty components (no `//`)
+ * - The empty path `""` is valid and represents the identity/current directory
+ *
+ * Unlike `CanonPath`, which normalizes its input, `OsCanonPath` asserts
+ * that the input is already canonical. Unlike `CanonPath` which is a
+ * virtual Unix-style path wrapping `std::string`, `OsCanonPath` wraps
+ * `std::filesystem::path` and respects OS-native directory separators.
+ */
+class OsCanonPath
+{
+    std::filesystem::path p;
+
+    void validate() const;
+
+public:
+    /**
+     * Construct the empty `OsCanonPath`, representing the identity path `""`.
+     */
+    OsCanonPath() = default;
+
+    /**
+     * Construct an `OsCanonPath` from a path, asserting that it is
+     * already in canonical relative form.
+     */
+    explicit OsCanonPath(std::filesystem::path p)
+        : p(std::move(p))
+    {
+        validate();
+    }
+
+    /**
+     * Construct an `OsCanonPath` from an `OsFilename`.
+     *
+     * This is always valid since a single filename component is
+     * trivially a canonical relative path.
+     */
+    OsCanonPath(OsFilename name)
+        : p(name.path())
+    {
+    }
+
+    /**
+     * Construct an `OsCanonPath` from a `CanonPath`.
+     *
+     * Builds the path component-by-component using
+     * `std::filesystem::path::operator/`, which produces the correct
+     * OS-native directory separator.
+     */
+    OsCanonPath(const CanonPath & canonPath);
+
+    const std::filesystem::path & path() const noexcept
+    {
+        return p;
+    }
+
+    const std::filesystem::path::value_type * c_str() const noexcept
+    {
+        return p.c_str();
+    }
+
+    /**
+     * Whether this is the empty path.
+     */
+    bool empty() const noexcept
+    {
+        return p.empty();
+    }
+
+    /**
+     * Iterator that yields `OsFilename` for each path component.
+     *
+     * Safe because `OsCanonPath` invariants guarantee every component
+     * is a valid `OsFilename` (no empty, `.`, `..`, or root components).
+     */
+    class Iterator
+    {
+        std::filesystem::path::const_iterator it;
+
+        explicit Iterator(std::filesystem::path::const_iterator it)
+            : it(std::move(it))
+        {
+        }
+
+        friend class OsCanonPath;
+
+    public:
+        using value_type = OsFilename;
+        using reference = const OsFilename &;
+        using pointer = const OsFilename *;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::bidirectional_iterator_tag;
+
+        Iterator() = default;
+
+        const OsFilename & operator*() const
+        {
+            return OsFilename::refFromPath(*it);
+        }
+
+        const OsFilename * operator->() const
+        {
+            return &OsFilename::refFromPath(*it);
+        }
+
+        Iterator & operator++()
+        {
+            ++it;
+            return *this;
+        }
+
+        Iterator operator++(int)
+        {
+            auto tmp = *this;
+            ++it;
+            return tmp;
+        }
+
+        Iterator & operator--()
+        {
+            --it;
+            return *this;
+        }
+
+        Iterator operator--(int)
+        {
+            auto tmp = *this;
+            --it;
+            return tmp;
+        }
+
+        bool operator==(const Iterator &) const = default;
+    };
+
+    Iterator begin() const
+    {
+        return Iterator{p.begin()};
+    }
+
+    Iterator end() const
+    {
+        return Iterator{p.end()};
+    }
+
+    bool operator==(const OsCanonPath &) const = default;
+    auto operator<=>(const OsCanonPath &) const = default;
+
+    /**
+     * Concatenate two `OsCanonPath`s.
+     */
+    OsCanonPath operator/(const OsCanonPath & other) const;
+
+    /**
+     * Append an `OsFilename` to an `OsCanonPath`.
+     */
+    OsCanonPath operator/(const OsFilename & name) const;
+
+    /**
+     * Prepend: `OsFilename / OsCanonPath`.
+     */
+    friend OsCanonPath operator/(const OsFilename & name, const OsCanonPath & path);
+
+    /**
+     * Concatenate two `OsFilename`s into an `OsCanonPath`.
+     *
+     * This explicit overload is needed because `OsFilename / OsFilename`
+     * would otherwise be ambiguous between converting the LHS or RHS.
+     */
+    friend OsCanonPath operator/(const OsFilename & a, const OsFilename & b);
+};
+
+OsCanonPath operator/(const OsFilename & a, const OsFilename & b);
+
+} // namespace nix

--- a/src/libutil/include/nix/util/os-filename.hh
+++ b/src/libutil/include/nix/util/os-filename.hh
@@ -1,0 +1,98 @@
+#pragma once
+///@file
+
+#include <filesystem>
+
+namespace nix {
+
+/**
+ * A newtype around `std::filesystem::path` that asserts at construction
+ * time that the path is a single filename component.
+ *
+ * A valid `OsFilename`:
+ * - Has no root path or root name (no drive letter on Windows, no leading `/`)
+ * - Has no directory separators
+ * - Is not empty
+ * - Is not `.` or `..`
+ *
+ * This type is useful for APIs that expect a bare filename rather than
+ * a full path, providing compile-time documentation and runtime validation.
+ */
+class OsFilename
+{
+    std::filesystem::path name;
+
+    void validateAssert() const;
+
+    static void validateThrow(const std::filesystem::path & p);
+
+public:
+    /**
+     * Construct an `OsFilename` from a path, asserting that it is a
+     * single filename component.
+     *
+     * Use this when we are whitnessing an internal invariant / we as the
+     * programmer know the validation should pass.
+     */
+    explicit OsFilename(std::filesystem::path p)
+        : name(std::move(p))
+    {
+        validateAssert();
+    }
+
+    /**
+     * Construct an `OsFilename` from a path, throwing an `Error` if it
+     * is not a single filename component.
+     *
+     * Use this when the input comes from users / the external world, and we are
+     * not sure whether the invariant will pass.
+     */
+    static OsFilename fromPathThrowing(std::filesystem::path p);
+
+    const std::filesystem::path & path() const noexcept
+    {
+        return name;
+    }
+
+    const std::filesystem::path::value_type * c_str() const noexcept
+    {
+        return name.c_str();
+    }
+
+    /**
+     * Implicit conversion to `const std::filesystem::path &` for
+     * convenience when passing to APIs expecting a path.
+     */
+    operator const std::filesystem::path &() const noexcept
+    {
+        return name;
+    }
+
+    /**
+     * Reinterpret a `std::filesystem::path` reference as an `OsFilename`
+     * reference, asserting the filename invariants.
+     *
+     * This avoids a copy when the path is already known to be stored
+     * somewhere with sufficient lifetime.
+     */
+    /**
+     * Reinterpret a `std::filesystem::path` reference as an `OsFilename`
+     * reference, asserting the filename invariants.
+     *
+     * This avoids a copy when the path is already known to be stored
+     * somewhere with sufficient lifetime.
+     */
+    static const OsFilename & refFromPath(const std::filesystem::path & p)
+    {
+        static_assert(sizeof(OsFilename) == sizeof(std::filesystem::path));
+        static_assert(alignof(OsFilename) == alignof(std::filesystem::path));
+        auto & ref = reinterpret_cast<const OsFilename &>(p);
+        ref.validateAssert();
+        return ref;
+    }
+
+    bool operator==(const OsFilename &) const = default;
+    auto operator<=>(const OsFilename &) const = default;
+};
+
+} // namespace nix

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -243,12 +243,6 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
  */
 ref<SourceAccessor> makeEmptySourceAccessor();
 
-/**
- * Exception thrown when accessing a filtered path (see
- * `FilteringSourceAccessor`).
- */
-MakeError(RestrictedPathError, Error);
-
 struct SymlinkNotAllowed final : public CloneableError<SymlinkNotAllowed, Error>
 {
     std::variant<CanonPath, std::filesystem::path> path;
@@ -282,6 +276,12 @@ struct SymlinkNotAllowed final : public CloneableError<SymlinkNotAllowed, Error>
 private:
     static inline const std::string defaultMsg = "path '%s' is a symlink, which is not allowed";
 };
+
+/**
+ * Exception thrown when accessing a filtered path (see
+ * `FilteringSourceAccessor`).
+ */
+MakeError(RestrictedPathError, Error);
 
 /**
  * Return an accessor for the root filesystem.

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <variant>
 
 #include "nix/util/canon-path.hh"
 #include "nix/util/fun.hh"
@@ -250,10 +251,10 @@ MakeError(RestrictedPathError, Error);
 
 struct SymlinkNotAllowed final : public CloneableError<SymlinkNotAllowed, Error>
 {
-    CanonPath path;
+    std::variant<CanonPath, std::filesystem::path> path;
 
     SymlinkNotAllowed(CanonPath path)
-        : CloneableError("relative path '%s' points to a symlink, which is not allowed", path.rel())
+        : CloneableError(defaultMsg, path.abs())
         , path(std::move(path))
     {
     }
@@ -264,6 +265,22 @@ struct SymlinkNotAllowed final : public CloneableError<SymlinkNotAllowed, Error>
         , path(std::move(path))
     {
     }
+
+    SymlinkNotAllowed(std::filesystem::path path)
+        : CloneableError(defaultMsg, path.string())
+        , path(std::move(path))
+    {
+    }
+
+    template<typename... Args>
+    SymlinkNotAllowed(std::filesystem::path path, const std::string & fs, Args &&... args)
+        : CloneableError(fs, std::forward<Args>(args)...)
+        , path(std::move(path))
+    {
+    }
+
+private:
+    static inline const std::string defaultMsg = "path '%s' is a symlink, which is not allowed";
 };
 
 /**

--- a/src/libutil/include/nix/util/variant-wrapper.hh
+++ b/src/libutil/include/nix/util/variant-wrapper.hh
@@ -4,30 +4,50 @@
 // not used, but will be used by callers
 #include <variant>
 
+#define FORCE_DEFAULT_MOVE_CONSTRUCTORS(CLASS_NAME) \
+    CLASS_NAME(CLASS_NAME &&) = default;            \
+    CLASS_NAME & operator=(CLASS_NAME &&) = default;
+
 /**
  * Force the default versions of all constructors (copy, move, copy
  * assignment).
  */
 #define FORCE_DEFAULT_CONSTRUCTORS(CLASS_NAME)            \
+    FORCE_DEFAULT_MOVE_CONSTRUCTORS(CLASS_NAME)           \
+                                                          \
     CLASS_NAME(const CLASS_NAME &) = default;             \
     CLASS_NAME(CLASS_NAME &) = default;                   \
-    CLASS_NAME(CLASS_NAME &&) = default;                  \
                                                           \
     CLASS_NAME & operator=(const CLASS_NAME &) = default; \
     CLASS_NAME & operator=(CLASS_NAME &) = default;
 
 /**
- * Make a wrapper constructor. All args are forwarded to the
- * construction of the "raw" field. (Which we assume is the only one.)
+ * Forwarding constructor for wrapper types. All args are forwarded to
+ * the construction of the "raw" field.
  *
  * The moral equivalent of `using Raw::Raw;`
  */
-#define MAKE_WRAPPER_CONSTRUCTOR(CLASS_NAME)                                                                \
-    FORCE_DEFAULT_CONSTRUCTORS(CLASS_NAME)                                                                  \
-                                                                                                            \
+#define MAKE_WRAPPER_CONSTRUCTOR_RAW(CLASS_NAME)                                                            \
     template<typename... Args>                                                                              \
         requires(!(sizeof...(Args) == 1 && (std::is_same_v<std::remove_cvref_t<Args>, CLASS_NAME> && ...))) \
     CLASS_NAME(Args &&... arg)                                                                              \
         : raw(std::forward<Args>(arg)...)                                                                   \
     {                                                                                                       \
     }
+
+/**
+ * Make a wrapper constructor. Also defaults move constructor/assignment.
+ * Copy operations will be implicitly defaulted or deleted based on the
+ * Raw type.
+ */
+#define MAKE_WRAPPER_CONSTRUCTOR_MOVE_ONLY(CLASS_NAME) \
+    FORCE_DEFAULT_MOVE_CONSTRUCTORS(CLASS_NAME)        \
+    MAKE_WRAPPER_CONSTRUCTOR_RAW(CLASS_NAME)
+
+/**
+ * Like MAKE_WRAPPER_CONSTRUCTOR, but also explicitly defaults copy
+ * operations for copyable types.
+ */
+#define MAKE_WRAPPER_CONSTRUCTOR(CLASS_NAME) \
+    FORCE_DEFAULT_CONSTRUCTORS(CLASS_NAME)   \
+    MAKE_WRAPPER_CONSTRUCTOR_RAW(CLASS_NAME)

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -165,6 +165,8 @@ sources = [ config_priv_h ] + files(
   'nar-accessor.cc',
   'nar-cache.cc',
   'nar-listing.cc',
+  'os-canon-path.cc',
+  'os-filename.cc',
   'pos-table.cc',
   'position.cc',
   'posix-source-accessor.cc',

--- a/src/libutil/os-canon-path.cc
+++ b/src/libutil/os-canon-path.cc
@@ -1,0 +1,66 @@
+#include "nix/util/os-canon-path.hh"
+
+#include <cassert>
+
+namespace nix {
+
+OsCanonPath::OsCanonPath(const CanonPath & canonPath)
+{
+    for (const auto & component : canonPath) {
+        p /= std::filesystem::path{std::string{component}};
+    }
+    // No need to validate — CanonPath guarantees no empty/dot/dotdot components
+}
+
+void OsCanonPath::validate() const
+{
+    assert(!p.has_root_path() && "OsCanonPath cannot have a root path");
+    for (const auto & component : p) {
+        auto s = component.string();
+        assert(!s.empty() && "OsCanonPath cannot have empty components");
+        assert(s != "." && "OsCanonPath cannot have '.' components");
+        assert(s != ".." && "OsCanonPath cannot have '..' components");
+    }
+}
+
+OsCanonPath OsCanonPath::operator/(const OsCanonPath & other) const
+{
+    if (p.empty())
+        return other;
+    if (other.p.empty())
+        return *this;
+    OsCanonPath result;
+    result.p = p / other.p;
+    return result;
+}
+
+OsCanonPath OsCanonPath::operator/(const OsFilename & name) const
+{
+    OsCanonPath result;
+    if (p.empty())
+        result.p = name.path();
+    else
+        result.p = p / name.path();
+    return result;
+}
+
+OsCanonPath operator/(const OsFilename & name, const OsCanonPath & path)
+{
+    if (path.p.empty()) {
+        OsCanonPath result;
+        result.p = name.path();
+        return result;
+    }
+    OsCanonPath result;
+    result.p = name.path() / path.p;
+    return result;
+}
+
+OsCanonPath operator/(const OsFilename & a, const OsFilename & b)
+{
+    OsCanonPath result;
+    result.p = a.path() / b.path();
+    return result;
+}
+
+} // namespace nix

--- a/src/libutil/os-canon-path.cc
+++ b/src/libutil/os-canon-path.cc
@@ -7,14 +7,21 @@ namespace nix {
 OsCanonPath::OsCanonPath(const CanonPath & canonPath)
 {
     for (const auto & component : canonPath) {
+#ifdef _WIN32
+        assert(component.find('\\') == component.npos && "CanonPath component cannot contain backslash");
+#endif
         p /= std::filesystem::path{std::string{component}};
     }
-    // No need to validate — CanonPath guarantees no empty/dot/dotdot components
+    // No need to further validate — CanonPath guarantees no empty/dot/dotdot components,
+    // and operator/ produces preferred separators.
 }
 
 void OsCanonPath::validate() const
 {
     assert(!p.has_root_path() && "OsCanonPath cannot have a root path");
+#ifdef _WIN32
+    assert(p.native().find(L'/') == std::wstring::npos && "OsCanonPath must use preferred (backslash) separators on Windows");
+#endif
     for (const auto & component : p) {
         auto s = component.string();
         assert(!s.empty() && "OsCanonPath cannot have empty components");

--- a/src/libutil/os-filename.cc
+++ b/src/libutil/os-filename.cc
@@ -1,0 +1,41 @@
+#include "nix/util/os-filename.hh"
+
+#include "nix/util/error.hh"
+
+#include <cassert>
+
+namespace nix {
+
+void OsFilename::validateAssert() const
+{
+    assert(!name.empty() && "OsFilename cannot be empty");
+    assert(!name.has_root_path() && "OsFilename cannot have a root path");
+    assert(!name.has_parent_path() && "OsFilename cannot have a parent path");
+    assert(name.filename() == name && "OsFilename must be a single filename");
+    assert(name != "." && "OsFilename cannot be '.'");
+    assert(name != ".." && "OsFilename cannot be '..'");
+}
+
+void OsFilename::validateThrow(const std::filesystem::path & p)
+{
+    if (p.empty())
+        throw Error("filename cannot be empty");
+    if (p.has_root_path())
+        throw Error("filename cannot have a root path: '%s'", p.string());
+    if (p.has_parent_path())
+        throw Error("filename cannot have a parent path: '%s'", p.string());
+    if (p.filename() != p)
+        throw Error("not a single filename: '%s'", p.string());
+    if (p == ".")
+        throw Error("filename cannot be '.'");
+    if (p == "..")
+        throw Error("filename cannot be '..'");
+}
+
+OsFilename OsFilename::fromPathThrowing(std::filesystem::path p)
+{
+    validateThrow(p);
+    return OsFilename{std::move(p)};
+}
+
+} // namespace nix

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -791,7 +791,7 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackL
         if (!parentFd)
             throw SysError("opening %1%", PathFmt(root));
 
-        auto relPath = CanonPath::fromFilename(root.filename().native());
+        auto relPath = OsFilename{root.filename()};
         if (trackLastModified) {
             auto st = fstatat(parentFd.get(), root.filename());
             mtime = st.st_mtime;

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -711,12 +711,24 @@ std::optional<std::filesystem::path> WindowsSourceAccessor::getPhysicalPath(cons
 
 void WindowsSourceAccessor::assertNoSymlinks(CanonPath path)
 {
+#ifdef _WIN32
+    /* On Windows, iterate from root outward so we detect symlinks before
+       trying to access paths beyond them (which would fail with INVALID_NAME). */
+    CanonPath current = CanonPath::root;
+    for (auto & component : path) {
+        current = current / component;
+        auto st = cachedLstat(current);
+        if (st && S_ISLNK(st->st_mode))
+            throw SymlinkNotAllowed(std::filesystem::path(current.rel()), "path '%s' is a symlink", showPath(current));
+    }
+#else
     while (!path.isRoot()) {
         auto st = cachedLstat(path);
         if (st && S_ISLNK(st->st_mode))
-            throw SymlinkNotAllowed(path, "path '%s' is a symlink", showPath(path));
+            throw SymlinkNotAllowed(std::filesystem::path(path.rel()), "path '%s' is a symlink", showPath(path));
         path.pop();
     }
+#endif
 }
 
 #endif
@@ -793,7 +805,7 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackL
 
         auto relPath = OsFilename{root.filename()};
         if (trackLastModified) {
-            auto st = fstatat(parentFd.get(), root.filename());
+            auto st = fstatat(parentFd.get(), relPath);
             mtime = st.st_mtime;
         }
 

--- a/src/libutil/unix/file-system-at.cc
+++ b/src/libutil/unix/file-system-at.cc
@@ -57,22 +57,22 @@ std::optional<AutoCloseFD> openat2(Descriptor dirFd, const char * path, uint64_t
 
 #endif
 
-void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t mode)
+void unix::fchmodatTryNoFollow(Descriptor dirFd, const OsCanonPath & path, mode_t mode)
 {
-    assert(!path.isRoot());
+    assert(!path.empty());
 
 #if HAVE_FCHMODAT2
     /* Cache whether fchmodat2 is not supported. */
     static std::atomic_flag fchmodat2Unsupported{};
     if (!fchmodat2Unsupported.test()) {
         /* Try with fchmodat2 first. */
-        auto res = ::syscall(__NR_fchmodat2, dirFd, path.rel_c_str(), mode, AT_SYMLINK_NOFOLLOW);
+        auto res = ::syscall(__NR_fchmodat2, dirFd, path.c_str(), mode, AT_SYMLINK_NOFOLLOW);
         /* Cache that the syscall is not supported. */
         if (res < 0) {
             if (errno == ENOSYS)
                 fchmodat2Unsupported.test_and_set();
             else {
-                throw SysError([&] { return HintFmt("fchmodat2 %s", PathFmt(descriptorToPath(dirFd) / path.rel())); });
+                throw SysError([&] { return HintFmt("fchmodat2 %s", PathFmt(descriptorToPath(dirFd) / path.path())); });
             }
         } else
             return;
@@ -80,12 +80,12 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
 #endif
 
 #ifdef __linux__
-    AutoCloseFD pathFd = ::openat(dirFd, path.rel_c_str(), O_PATH | O_NOFOLLOW | O_CLOEXEC);
+    AutoCloseFD pathFd = ::openat(dirFd, path.c_str(), O_PATH | O_NOFOLLOW | O_CLOEXEC);
     if (!pathFd) {
         throw SysError([&] {
             return HintFmt(
                 "opening %s to get an O_PATH file descriptor (fchmodat2 is unsupported)",
-                PathFmt(descriptorToPath(dirFd) / path.rel()));
+                PathFmt(descriptorToPath(dirFd) / path.path()));
         });
     }
 
@@ -94,7 +94,7 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
     auto st = fstat(pathFd.get());
 
     if (S_ISLNK(st.st_mode))
-        throw SysError(EOPNOTSUPP, "can't change mode of symlink %s", PathFmt(descriptorToPath(dirFd) / path.rel()));
+        throw SysError(EOPNOTSUPP, "can't change mode of symlink %s", PathFmt(descriptorToPath(dirFd) / path.path()));
 
     static std::atomic_flag dontHaveProc{};
     if (!dontHaveProc.test()) {
@@ -106,7 +106,7 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
                 dontHaveProc.test_and_set();
             else {
                 throw SysError([&] {
-                    return HintFmt("chmod %s (%s)", selfProcFdPath, PathFmt(descriptorToPath(dirFd) / path.rel()));
+                    return HintFmt("chmod %s (%s)", selfProcFdPath, PathFmt(descriptorToPath(dirFd) / path.path()));
                 });
             }
         } else
@@ -119,7 +119,7 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
 
     int res = ::fchmodat(
         dirFd,
-        path.rel_c_str(),
+        path.c_str(),
         mode,
 #if defined(AT_SYMLINK_NOFOLLOW) && !defined(__linux__)
         AT_SYMLINK_NOFOLLOW
@@ -136,16 +136,16 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
     );
 
     if (res == -1) {
-        throw SysError([&] { return HintFmt("fchmodat %s", PathFmt(descriptorToPath(dirFd) / path.rel())); });
+        throw SysError([&] { return HintFmt("fchmodat %s", PathFmt(descriptorToPath(dirFd) / path.path())); });
     }
 }
 
 static AutoCloseFD openFileEnsureBeneathNoSymlinksIterative(
     Descriptor dirFd,
-    const CanonPath & path,
+    const OsCanonPath & path,
     int flags,
     mode_t mode,
-    std::function<void(AutoCloseFD dirFd, CanonPath relPath)> dirFdCallback)
+    std::function<void(AutoCloseFD dirFd, OsCanonPath relPath)> dirFdCallback)
 {
     AutoCloseFD parentFd;
     auto nrComponents = std::ranges::distance(path);
@@ -154,10 +154,16 @@ static AutoCloseFD openFileEnsureBeneathNoSymlinksIterative(
     auto getParentFd = [&]() { return parentFd ? parentFd.get() : dirFd; };
     auto currentRelPath = CanonPath::root;
 
+    /* Helper to construct OsCanonPath from components up to (and including) the given iterator */
+    auto pathUpTo = [&](auto it) {
+        return std::ranges::fold_left(
+            components.begin(), it, OsCanonPath{}, [](OsCanonPath acc, const OsFilename & comp) { return acc / comp; });
+    };
+
     /* This rather convoluted loop is necessary to avoid TOCTOU when validating that
        no inner path component is a symlink. */
     for (auto it = components.begin(); it != components.end(); ++it) {
-        auto component = std::string(*it);                        /* Copy into a string to make NUL terminated. */
+        auto component = (*it).path().string();
         assert(component != ".." && !component.starts_with('/')); /* In case invariant is broken somehow.. */
         auto prevRelPath = currentRelPath;
         currentRelPath = currentRelPath / *it;
@@ -175,21 +181,15 @@ static AutoCloseFD openFileEnsureBeneathNoSymlinksIterative(
         );
 
         if (!parentFd2) {
-            /* Construct the CanonPath for error message. */
-            auto path2 = std::ranges::fold_left(components.begin(), ++it, CanonPath::root, [](auto lhs, auto rhs) {
-                lhs.push(rhs);
-                return lhs;
-            });
-
             if (errno == ENOTDIR) /* Path component might be a symlink. */ {
                 /* Does not follow final symlink. We know `component` is a
                    single component so we don't have to worry about intermediate
                    symlinks either. */
                 if (auto st = maybeFstatat(getParentFd(), component); st && S_ISLNK(st->st_mode))
-                    throw SymlinkNotAllowed(path2);
+                    throw SymlinkNotAllowed(pathUpTo(std::next(it)).path());
                 errno = ENOTDIR; /* Restore the errno. */
             } else if (errno == ELOOP) {
-                throw SymlinkNotAllowed(path2);
+                throw SymlinkNotAllowed(pathUpTo(std::next(it)).path());
             }
 
             return AutoCloseFD{};
@@ -201,19 +201,19 @@ static AutoCloseFD openFileEnsureBeneathNoSymlinksIterative(
         parentFd = std::move(parentFd2);
     }
 
-    auto lastComponent = std::string(path.baseName().value());
+    auto lastComponent = path.path().filename().string();
     AutoCloseFD res = ::openat(getParentFd(), lastComponent.c_str(), flags | O_NOFOLLOW, mode);
 
     if (!res) {
         if (errno == ELOOP)
-            throw SymlinkNotAllowed(path);
+            throw SymlinkNotAllowed(path.path());
         /* `O_DIRECTORY | O_NOFOLLOW` on a trailing symlink returns
            `ENOTDIR` rather than `ELOOP`. Post-check via `fstatat` to
            disambiguate — only on the error path, so the common
            successful-directory-open case pays no extra syscall. */
         if (errno == ENOTDIR) {
             if (auto st = maybeFstatat(getParentFd(), lastComponent); st && S_ISLNK(st->st_mode))
-                throw SymlinkNotAllowed(path);
+                throw SymlinkNotAllowed(path.path());
             /* Put back errno so the caller will get the original
                error. */
             errno = ENOTDIR;
@@ -233,14 +233,12 @@ static AutoCloseFD openFileEnsureBeneathNoSymlinksIterative(
 
 AutoCloseFD openFileEnsureBeneathNoSymlinks(
     Descriptor dirFd,
-    const CanonPath & path,
+    const OsCanonPath & path,
     int flags,
     mode_t mode,
-    std::function<void(AutoCloseFD dirFd, CanonPath relPath)> dirFdCallback)
+    std::function<void(AutoCloseFD dirFd, OsCanonPath relPath)> dirFdCallback)
 {
-    /* Just in case the invariant is somehow broken. */
-    assert(!path.rel().starts_with('/'));
-    assert(!path.isRoot());
+    assert(!path.empty());
 
     /* We don't want callers of this function to think about the presence or
        absence of `O_NOFOLLOW`. "ensure beneath no symlinks" is in the name, so
@@ -271,9 +269,9 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
     auto flagsAdj = (flags & O_PATH) && !(flags & O_DIRECTORY) ? flags | O_NOFOLLOW : flags;
 
     if (auto maybeFd = linux::openat2(
-            dirFd, path.rel_c_str(), flagsAdj, static_cast<uint64_t>(mode), RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)) {
+            dirFd, path.c_str(), flagsAdj, static_cast<uint64_t>(mode), RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)) {
         if (!*maybeFd && errno == ELOOP)
-            throw SymlinkNotAllowed(path);
+            throw SymlinkNotAllowed(path.path());
         return std::move(*maybeFd);
     }
 #endif
@@ -281,18 +279,17 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
     return openFileEnsureBeneathNoSymlinksIterative(dirFd, path, flags, mode, std::move(dirFdCallback));
 }
 
-OsString readLinkAt(Descriptor dirFd, const CanonPath & path)
+OsString readLinkAt(Descriptor dirFd, const OsCanonPath & path)
 {
-    assert(!path.isRoot());
-    assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
+    assert(!path.empty());
     std::vector<char> buf;
     for (ssize_t bufSize = PATH_MAX / 4; true; bufSize += bufSize / 2) {
         checkInterrupt();
         buf.resize(bufSize);
-        ssize_t rlSize = ::readlinkat(dirFd, path.rel_c_str(), buf.data(), bufSize);
+        ssize_t rlSize = ::readlinkat(dirFd, path.c_str(), buf.data(), bufSize);
         if (rlSize == -1) {
             throw SysError(
-                [&] { return HintFmt("reading symbolic link %1%", PathFmt(descriptorToPath(dirFd) / path.rel())); });
+                [&] { return HintFmt("reading symbolic link %1%", PathFmt(descriptorToPath(dirFd) / path.path())); });
         } else if (rlSize < bufSize)
             return {buf.data(), static_cast<std::size_t>(rlSize)};
     }

--- a/src/libutil/unix/file-system-at.cc
+++ b/src/libutil/unix/file-system-at.cc
@@ -368,4 +368,31 @@ std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const OsCanonPath & path
     return st;
 }
 
+void setWriteTime(Descriptor dirFd, const std::filesystem::path & path, time_t accessedTime, time_t modificationTime)
+{
+    struct timespec times[2] = {
+        {
+            .tv_sec = accessedTime,
+            .tv_nsec = 0,
+        },
+        {
+            .tv_sec = modificationTime,
+            .tv_nsec = 0,
+        },
+    };
+
+#if HAVE_UTIMENSAT && HAVE_DECL_AT_SYMLINK_NOFOLLOW
+    if (utimensat(dirFd, path.c_str(), times, AT_SYMLINK_NOFOLLOW) == -1)
+        throw SysError("changing modification time of %s (using `utimensat`)", PathFmt(path));
+#else
+    // Fallback: open the file and use futimens
+    AutoCloseFD fd = openat(dirFd, path.c_str(), O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (!fd)
+        throw SysError("opening %s to change modification time", PathFmt(path));
+
+    if (futimens(fd.get(), times) == -1)
+        throw SysError("changing modification time of '%s' (using `futimens`)", path);
+#endif
+}
+
 } // namespace nix

--- a/src/libutil/unix/file-system-at.cc
+++ b/src/libutil/unix/file-system-at.cc
@@ -23,6 +23,8 @@
 #  define HAVE_FCHMODAT2 0
 #endif
 
+#include "util-unix-config-private.hh"
+
 namespace nix {
 
 #ifdef __linux__
@@ -98,7 +100,7 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const OsCanonPath & path, mode_
 
     static std::atomic_flag dontHaveProc{};
     if (!dontHaveProc.test()) {
-        static const CanonPath selfProcFd = CanonPath("/proc/self/fd");
+        static const std::filesystem::path selfProcFd = "/proc/self/fd";
 
         auto selfProcFdPath = selfProcFd / std::to_string(pathFd.get());
         if (int res = ::chmod(selfProcFdPath.c_str(), mode); res == -1) {
@@ -106,7 +108,7 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const OsCanonPath & path, mode_
                 dontHaveProc.test_and_set();
             else {
                 throw SysError([&] {
-                    return HintFmt("chmod %s (%s)", selfProcFdPath, PathFmt(descriptorToPath(dirFd) / path.path()));
+                    return HintFmt("chmod %s (%s)", PathFmt(selfProcFdPath), PathFmt(descriptorToPath(dirFd) / path.path()));
                 });
             }
         } else
@@ -185,7 +187,7 @@ static AutoCloseFD openFileEnsureBeneathNoSymlinksIterative(
                 /* Does not follow final symlink. We know `component` is a
                    single component so we don't have to worry about intermediate
                    symlinks either. */
-                if (auto st = maybeFstatat(getParentFd(), component); st && S_ISLNK(st->st_mode))
+                if (auto st = maybeFstatat(getParentFd(), OsFilename{component}); st && S_ISLNK(st->st_mode))
                     throw SymlinkNotAllowed(pathUpTo(std::next(it)).path());
                 errno = ENOTDIR; /* Restore the errno. */
             } else if (errno == ELOOP) {
@@ -212,7 +214,7 @@ static AutoCloseFD openFileEnsureBeneathNoSymlinksIterative(
            disambiguate — only on the error path, so the common
            successful-directory-open case pays no extra syscall. */
         if (errno == ENOTDIR) {
-            if (auto st = maybeFstatat(getParentFd(), lastComponent); st && S_ISLNK(st->st_mode))
+            if (auto st = maybeFstatat(getParentFd(), OsFilename{lastComponent}); st && S_ISLNK(st->st_mode))
                 throw SymlinkNotAllowed(path.path());
             /* Put back errno so the caller will get the original
                error. */
@@ -244,8 +246,6 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
        absence of `O_NOFOLLOW`. "ensure beneath no symlinks" is in the name, so
        we want them to trust us to handle it instead. */
     assert(!(flags & O_NOFOLLOW));
-
-    /* See doxygen in `file-system-at.hh` for why we reject this. */
 
 #if HAVE_OPENAT2
     /* Two things are being fixed here:
@@ -295,6 +295,48 @@ OsString readLinkAt(Descriptor dirFd, const OsCanonPath & path)
     }
 }
 
+static void symlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+    if (::symlinkat(target.c_str(), dirFd, path.c_str()) == -1) {
+        throw SysError(
+            [&] { return HintFmt("creating symlink %1% -> %2%", PathFmt(descriptorToPath(dirFd) / path), target); });
+    }
+}
+
+void createFileSymlinkAt(Descriptor dirFd, const OsCanonPath & path, const OsString & target)
+{
+    symlinkAt(dirFd, path.path(), target);
+}
+
+void createDirectorySymlinkAt(Descriptor dirFd, const OsCanonPath & path, const OsString & target)
+{
+    symlinkAt(dirFd, path.path(), target);
+}
+
+void createUnknownSymlinkAt(Descriptor dirFd, const OsCanonPath & path, const OsString & target)
+{
+    symlinkAt(dirFd, path.path(), target);
+}
+
+outcome::unchecked<AutoCloseFD, std::error_code>
+openDirectoryAt(Descriptor dirFd, const OsCanonPath & path, bool create, mode_t mode)
+{
+    assert(!path.empty());
+    if (create) {
+        if (::mkdirat(dirFd, path.c_str(), mode) == -1) {
+            return outcome::failure(std::error_code(errno, std::system_category()));
+        }
+    }
+    // Use O_NOFOLLOW to avoid following symlinks - if path is a symlink, this will fail with ENOTDIR
+    int fd = ::openat(dirFd, path.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (fd == -1) {
+        return outcome::failure(std::error_code(errno, std::system_category()));
+    }
+    return AutoCloseFD{fd};
+}
+
 PosixStat fstat(Descriptor fd)
 {
     PosixStat st;
@@ -304,26 +346,24 @@ PosixStat fstat(Descriptor fd)
     return st;
 }
 
-PosixStat fstatat(Descriptor dirFd, const std::filesystem::path & path)
+PosixStat fstatat(Descriptor dirFd, const OsCanonPath & path)
 {
-    assert(path.is_relative());
     assert(!path.empty());
     PosixStat st;
     if (::fstatat(dirFd, path.c_str(), &st, AT_SYMLINK_NOFOLLOW)) {
-        throw SysError([&] { return HintFmt("getting status of %s", PathFmt(descriptorToPath(dirFd) / path)); });
+        throw SysError([&] { return HintFmt("getting status of %s", PathFmt(descriptorToPath(dirFd) / path.path())); });
     }
     return st;
 }
 
-std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const std::filesystem::path & path)
+std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const OsCanonPath & path)
 {
-    assert(path.is_relative());
     assert(!path.empty());
     PosixStat st;
     if (::fstatat(dirFd, path.c_str(), &st, AT_SYMLINK_NOFOLLOW)) {
         if (errno == ENOENT || errno == ENOTDIR)
             return std::nullopt;
-        throw SysError([&] { return HintFmt("getting status of %s", PathFmt(descriptorToPath(dirFd) / path)); });
+        throw SysError([&] { return HintFmt("getting status of %s", PathFmt(descriptorToPath(dirFd) / path.path())); });
     }
     return st;
 }

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -169,7 +169,7 @@ static void _deletePath(
 
     auto name = OsFilename{path.filename()};
 
-    auto st_ = maybeFstatat(parentfd, name.path());
+    auto st_ = maybeFstatat(parentfd, OsCanonPath{name});
     if (!st_)
         return;
     auto & st = *st_;
@@ -203,7 +203,7 @@ static void _deletePath(
         const auto PERM_MASK = S_IRUSR | S_IWUSR | S_IXUSR;
         if ((st.st_mode & PERM_MASK) != PERM_MASK)
             try {
-                unix::fchmodatTryNoFollow(parentfd, name, st.st_mode | PERM_MASK);
+                unix::fchmodatTryNoFollow(parentfd, OsCanonPath{name}, st.st_mode | PERM_MASK);
             } catch (SysError & e) {
                 e.addTrace({}, "while making directory %1% accessible for deletion", PathFmt(path));
                 if (e.errNo == EOPNOTSUPP)
@@ -251,7 +251,9 @@ static void _deletePath(const std::filesystem::path & path, uint64_t & bytesFree
     auto parentDirPath = path.parent_path();
     assert(parentDirPath != path);
 
-    AutoCloseFD dirfd = openDirectory(parentDirPath);
+    /* It's ok to follow symlinks in the parent since we only need to
+       ensure that there's no TOCTOU when traversing inside the path. */
+    AutoCloseFD dirfd = openDirectory(parentDirPath, FinalSymlink::Follow);
     if (!dirfd) {
         if (errno == ENOENT)
             return;

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -97,53 +97,6 @@ std::optional<PosixStat> maybeLstat(const std::filesystem::path & path)
     return st;
 }
 
-void setWriteTime(
-    const std::filesystem::path & path, time_t accessedTime, time_t modificationTime, std::optional<bool> optIsSymlink)
-{
-    // Would be nice to use std::filesystem unconditionally, but
-    // doesn't support access time just modification time.
-    //
-    // System clock vs File clock issues also make that annoying.
-#if HAVE_UTIMENSAT && HAVE_DECL_AT_SYMLINK_NOFOLLOW
-    struct timespec times[2] = {
-        {
-            .tv_sec = accessedTime,
-            .tv_nsec = 0,
-        },
-        {
-            .tv_sec = modificationTime,
-            .tv_nsec = 0,
-        },
-    };
-    if (utimensat(AT_FDCWD, path.c_str(), times, AT_SYMLINK_NOFOLLOW) == -1)
-        throw SysError("changing modification time of %s (using `utimensat`)", PathFmt(path));
-#else
-    struct timeval times[2] = {
-        {
-            .tv_sec = accessedTime,
-            .tv_usec = 0,
-        },
-        {
-            .tv_sec = modificationTime,
-            .tv_usec = 0,
-        },
-    };
-#  if HAVE_LUTIMES
-    if (lutimes(path.c_str(), times) == -1)
-        throw SysError("changing modification time of %s", PathFmt{path});
-#  else
-    bool isSymlink = optIsSymlink ? *optIsSymlink : std::filesystem::is_symlink(path);
-
-    if (!isSymlink) {
-        if (utimes(path.c_str(), times) == -1)
-            throw SysError("changing modification time of %s (not a symlink)", PathFmt{path});
-    } else {
-        throw Error("Cannot change modification time of symlink %s", PathFmt{path});
-    }
-#  endif
-#endif
-}
-
 #ifdef __FreeBSD__
 #  define MOUNTEDPATHS_PARAM , std::set<std::filesystem::path> & mountedPaths
 #  define MOUNTEDPATHS_ARG , mountedPaths

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -167,9 +167,9 @@ static void _deletePath(
     }
 #endif
 
-    auto name = CanonPath::fromFilename(path.filename().native());
+    auto name = OsFilename{path.filename()};
 
-    auto st_ = maybeFstatat(parentfd, name.rel());
+    auto st_ = maybeFstatat(parentfd, name.path());
     if (!st_)
         return;
     auto & st = *st_;
@@ -211,7 +211,7 @@ static void _deletePath(
                 throw;
             }
 
-        int fd = openat(parentfd, name.rel_c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+        int fd = openat(parentfd, name.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
         if (fd == -1)
             throw SysError("opening directory %1%", PathFmt(path));
         AutoCloseDir dir(fdopendir(fd));
@@ -231,7 +231,7 @@ static void _deletePath(
     }
 
     int flags = S_ISDIR(st.st_mode) ? AT_REMOVEDIR : 0;
-    if (unlinkat(parentfd, name.rel_c_str(), flags) == -1) {
+    if (unlinkat(parentfd, name.c_str(), flags) == -1) {
         if (errno == ENOENT)
             return;
         try {

--- a/src/libutil/windows/file-system-at.cc
+++ b/src/libutil/windows/file-system-at.cc
@@ -3,9 +3,13 @@
 #include "nix/util/signals.hh"
 #include "nix/util/file-path.hh"
 #include "nix/util/source-accessor.hh"
+#include "nix/util/util.hh"
+#include "nix/util/windows-environment.hh"
+
+#include <boost/outcome.hpp>
+#include <span>
 
 #include <fileapi.h>
-#include <error.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <winioctl.h>
@@ -17,6 +21,8 @@ namespace windows {
 
 namespace {
 
+namespace outcome = BOOST_OUTCOME_V2_NAMESPACE;
+
 /**
  * Open a file/directory relative to a directory handle using NtCreateFile.
  *
@@ -25,9 +31,9 @@ namespace {
  * @param desiredAccess Access rights requested
  * @param createOptions NT create options flags
  * @param createDisposition FILE_OPEN, FILE_CREATE, etc.
- * @return Handle to the opened file/directory (caller must close)
+ * @return Handle to the opened file/directory, or NTSTATUS on error
  */
-AutoCloseFD ntOpenAt(
+outcome::unchecked<AutoCloseFD, NTSTATUS> maybeNtOpenAt(
     Descriptor dirFd,
     std::wstring_view pathComponent,
     ACCESS_MASK desiredAccess,
@@ -68,10 +74,23 @@ AutoCloseFD ntOpenAt(
     );
 
     if (status != 0)
-        throw WinError(
-            RtlNtStatusToDosError(status), "opening %s relative to directory handle", PathFmt(pathComponent));
+        return outcome::failure(status);
 
     return AutoCloseFD{h};
+}
+
+AutoCloseFD ntOpenAt(
+    Descriptor dirFd,
+    std::wstring_view pathComponent,
+    ACCESS_MASK desiredAccess,
+    ULONG createOptions,
+    ULONG createDisposition = FILE_OPEN)
+{
+    auto result = maybeNtOpenAt(dirFd, pathComponent, desiredAccess, createOptions, createDisposition);
+    if (!result)
+        throw WinError(
+            RtlNtStatusToDosError(result.error()), "opening %s relative to directory handle", PathFmt(pathComponent));
+    return std::move(result.value());
 }
 
 /**
@@ -85,8 +104,7 @@ AutoCloseFD openSymlinkAt(Descriptor dirFd, const OsCanonPath & path)
 {
     assert(!path.empty());
 
-    auto wpath = path.path().lexically_normal().make_preferred();
-    return ntOpenAt(dirFd, wpath.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+    return ntOpenAt(dirFd, path.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
 }
 
 /**
@@ -189,6 +207,54 @@ OsString readSymlinkTarget(HANDLE linkHandle)
 }
 
 /**
+ * Write symlink target to an open file handle using reparse point.
+ *
+ * @param handle Open file handle (must have GENERIC_WRITE access)
+ * @param target The symlink target (what it points to)
+ */
+void writeSymlinkTarget(HANDLE handle, const std::filesystem::path & target)
+{
+    /* Build the reparse data buffer for a symbolic link.
+       Layout: SubstituteName and PrintName stored consecutively in PathBuffer.
+       We use the same string for both. */
+    size_t targetBytes = target.native().size() * sizeof(wchar_t);
+    size_t bufSize = offsetof(ReparseDataBuffer, SymbolicLinkReparseBuffer.PathBuffer) + targetBytes * 2;
+    std::vector<uint8_t> buf(bufSize, 0);
+
+    auto * reparse = reinterpret_cast<ReparseDataBuffer *>(buf.data());
+    reparse->ReparseTag = IO_REPARSE_TAG_SYMLINK;
+    reparse->ReparseDataLength =
+        static_cast<unsigned short>(bufSize - offsetof(ReparseDataBuffer, SymbolicLinkReparseBuffer));
+    reparse->Reserved = 0;
+
+    auto & symlink = reparse->SymbolicLinkReparseBuffer;
+    /* SubstituteName comes first */
+    symlink.SubstituteNameOffset = 0;
+    symlink.SubstituteNameLength = static_cast<unsigned short>(targetBytes);
+    /* PrintName follows SubstituteName */
+    symlink.PrintNameOffset = static_cast<unsigned short>(targetBytes);
+    symlink.PrintNameLength = static_cast<unsigned short>(targetBytes);
+    /* SYMLINK_FLAG_RELATIVE = 1 for relative symlinks, 0 for absolute */
+    symlink.Flags = target.is_relative() ? 1 : 0;
+
+    /* Copy target into PathBuffer twice (SubstituteName and PrintName) */
+    memcpy(symlink.PathBuffer, target.c_str(), targetBytes);
+    memcpy(reinterpret_cast<char *>(symlink.PathBuffer) + targetBytes, target.c_str(), targetBytes);
+
+    DWORD bytesReturned;
+    if (!DeviceIoControl(
+            handle,
+            FSCTL_SET_REPARSE_POINT,
+            buf.data(),
+            static_cast<DWORD>(bufSize),
+            nullptr,
+            0,
+            &bytesReturned,
+            nullptr))
+        throw WinError("setting reparse point for symlink");
+}
+
+/**
  * Check if a handle refers to a reparse point (e.g., symlink).
  *
  * @param handle Open file/directory handle
@@ -206,6 +272,92 @@ bool isReparsePoint(HANDLE handle)
 } // anonymous namespace
 
 } // namespace windows
+
+OsString readLinkAt(Descriptor dirFd, const OsCanonPath & path)
+{
+    AutoCloseFD linkHandle(windows::openSymlinkAt(dirFd, path));
+    return windows::readSymlinkTarget(linkHandle.get());
+}
+
+void createFileSymlinkAt(Descriptor dirFd, const OsCanonPath & path, const OsString & target)
+{
+    assert(!path.empty());
+
+    /* Create the file that will become the symlink */
+    auto handle = windows::ntOpenAt(
+        dirFd, path.c_str(), GENERIC_WRITE | DELETE, FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT, FILE_CREATE);
+
+    windows::writeSymlinkTarget(handle.get(), target);
+}
+
+void createDirectorySymlinkAt(Descriptor dirFd, const OsCanonPath & path, const OsString & target)
+{
+    assert(!path.empty());
+
+    /* Create the directory that will become the symlink */
+    auto handle = windows::ntOpenAt(
+        dirFd, path.c_str(), GENERIC_WRITE | DELETE, FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT, FILE_CREATE);
+
+    windows::writeSymlinkTarget(handle.get(), target);
+}
+
+void createUnknownSymlinkAt(Descriptor dirFd, const OsCanonPath & path, const OsString & target)
+{
+    assert(!path.empty());
+
+    std::filesystem::path targetPath(target);
+    bool isDirectory = false;
+
+    if (targetPath.is_absolute()) {
+        /* For absolute targets, use std::filesystem::status directly */
+        std::error_code ec;
+        auto status = std::filesystem::status(targetPath, ec);
+        isDirectory = !ec && std::filesystem::is_directory(status);
+    } else {
+        /* For relative targets, the target is relative to the symlink's parent directory.
+           Open the parent directory first, then try to open the target relative to it. */
+        Descriptor parentFd = dirFd;
+        AutoCloseFD parentFdOwned;
+
+        auto parentPath = path.path().parent_path();
+        if (!parentPath.empty()) {
+            /* Open the parent directory of the symlink */
+            parentFdOwned = windows::ntOpenAt(dirFd, parentPath.c_str(), FILE_TRAVERSE | SYNCHRONIZE, FILE_DIRECTORY_FILE);
+            parentFd = parentFdOwned.get();
+        }
+
+        /* Try to open the target as a directory and verify with fstat. */
+        auto result = windows::maybeNtOpenAt(
+            parentFd, targetPath.make_preferred().wstring(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_DIRECTORY_FILE);
+        if (result) {
+            auto st = fstat(result.value().get());
+            isDirectory = S_ISDIR(st.st_mode);
+        }
+    }
+
+    if (isDirectory)
+        createDirectorySymlinkAt(dirFd, path, target);
+    else
+        createFileSymlinkAt(dirFd, path, target);
+}
+
+outcome::unchecked<AutoCloseFD, std::error_code>
+openDirectoryAt(Descriptor dirFd, const OsCanonPath & path, bool create)
+{
+    assert(!path.empty());
+
+    // Use FILE_OPEN_REPARSE_POINT to avoid following symlinks
+    auto result = windows::maybeNtOpenAt(
+        dirFd,
+        path.c_str(),
+        FILE_TRAVERSE | SYNCHRONIZE,
+        FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
+        create ? FILE_CREATE : FILE_OPEN);
+    if (result)
+        return std::move(result.value());
+
+    return outcome::failure(std::error_code(RtlNtStatusToDosError(result.error()), std::system_category()));
+}
 
 PosixStat fstat(Descriptor fd)
 {
@@ -225,6 +377,31 @@ PosixStat fstat(Descriptor fd)
         info.nNumberOfLinks);
 
     return st;
+}
+
+PosixStat fstatat(Descriptor dirFd, const OsCanonPath & path)
+{
+    assert(!path.empty());
+
+    /* Open the file without following symlinks */
+    auto handle = windows::ntOpenAt(dirFd, path.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+
+    return fstat(handle.get());
+}
+
+std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const OsCanonPath & path)
+{
+    assert(!path.empty());
+
+    auto result =
+        windows::maybeNtOpenAt(dirFd, path.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+    if (result)
+        return fstat(result.value().get());
+
+    auto lastError = RtlNtStatusToDosError(result.error());
+    if (lastError == ERROR_FILE_NOT_FOUND || lastError == ERROR_PATH_NOT_FOUND)
+        return std::nullopt;
+    throw windows::WinError(lastError, "getting status of %s", PathFmt(descriptorToPath(dirFd) / path.path()));
 }
 
 AutoCloseFD openFileEnsureBeneathNoSymlinks(
@@ -267,63 +444,89 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
     /* Iterate through each path component to ensure no symlinks in intermediate directories.
      * This prevents TOCTOU issues by opening each component relative to the parent. */
     for (auto it = components.begin(); it != components.end(); ++it) {
-        const auto & wcomponent = (*it).path().native();
+        auto wcomponent = (*it).path().native();
 
         /* Open directory without following symlinks */
-        AutoCloseFD parentFd2;
-        try {
-            parentFd2 = windows::ntOpenAt(
-                getParentFd(),
-                wcomponent,
-                FILE_TRAVERSE | SYNCHRONIZE,                  // Just need traversal rights
-                FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT // Open directory, don't follow symlinks
-            );
-        } catch (windows::WinError & e) {
-            /* Check if this is because it's a symlink */
-            if (e.lastError == ERROR_CANT_ACCESS_FILE || e.lastError == ERROR_ACCESS_DENIED) {
+        auto result = windows::maybeNtOpenAt(
+            getParentFd(),
+            wcomponent,
+            FILE_TRAVERSE | SYNCHRONIZE,                  // Just need traversal rights
+            FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT // Open directory, don't follow symlinks
+        );
+        if (!result) {
+            auto lastError = RtlNtStatusToDosError(result.error());
+            /* Check if this is because it's a symlink - these errors can indicate
+               we tried to traverse through a symlink or open a symlink as a directory */
+            if (lastError == ERROR_CANT_ACCESS_FILE || lastError == ERROR_ACCESS_DENIED
+                || lastError == ERROR_INVALID_NAME || lastError == ERROR_DIRECTORY) {
                 throwIfSymlink(wcomponent, pathUpTo(std::next(it)));
             }
-            throw;
+            /* ERROR_DIRECTORY means the component is not a directory (e.g., it's a file).
+               Return invalid handle to indicate the path doesn't exist.
+               Set the Win32 error so the caller can inspect it. */
+            if (lastError == ERROR_DIRECTORY || lastError == ERROR_FILE_NOT_FOUND
+                || lastError == ERROR_PATH_NOT_FOUND) {
+                SetLastError(lastError);
+                return AutoCloseFD{};
+            }
+            throw windows::WinError(lastError, "opening directory component '%s'", PathFmt(pathUpTo(std::next(it)).path()));
         }
 
         /* Check if what we opened is actually a symlink */
-        if (windows::isReparsePoint(parentFd2.get())) {
+        if (windows::isReparsePoint(result.value().get())) {
             throw SymlinkNotAllowed(pathUpTo(std::next(it)).path());
         }
 
-        parentFd = std::move(parentFd2);
+        parentFd = std::move(result.value());
     }
 
     /* Now open the final component with requested flags */
     auto finalComponent = path.path().filename().native();
 
-    AutoCloseFD finalHandle;
-    try {
-        finalHandle = windows::ntOpenAt(
-            getParentFd(),
-            finalComponent,
-            desiredAccess,
-            createOptions | FILE_OPEN_REPARSE_POINT, // Don't follow symlinks on final component either
-            createDisposition);
-    } catch (windows::WinError & e) {
-        /* Check if final component is a symlink when we requested to not follow it */
-        if (e.lastError == ERROR_CANT_ACCESS_FILE) {
+    auto finalResult = windows::maybeNtOpenAt(
+        getParentFd(),
+        finalComponent,
+        desiredAccess,
+        createOptions | FILE_OPEN_REPARSE_POINT, // Don't follow symlinks on final component either
+        createDisposition);
+    if (!finalResult) {
+        auto lastError = RtlNtStatusToDosError(finalResult.error());
+        /* Check if final component is a symlink when we requested to not follow it. */
+        if (lastError == ERROR_CANT_ACCESS_FILE || lastError == ERROR_INVALID_NAME) {
             throwIfSymlink(finalComponent, path);
         }
-        throw;
+        /* We suspect Wine incorrectly returns ERROR_DIRECTORY when opening a
+           directory symlink with FILE_OPEN_REPARSE_POINT | FILE_DIRECTORY_FILE,
+           as if it doesn't realize the reparse point itself is directory-typed.
+           Real Windows probably opens it successfully and hits the
+           isReparsePoint check below instead. Not yet verified on real Windows.
+
+           This is Claude's guess, but @Ericson3214 found it plausible enough of
+           a Wine bug to go ahead and do it. This keeps the unit tests passing in
+           Wine now, and if they fail on real Windows (without taking this
+           branch), then we'll update the code and this comment accordingly. On
+           the other hand, if they don't fail, then we'll avoid this bogus
+           "directory is actually symlink" stuff on real Windows where it
+           counts, and we'll have the evidence we need to submit a Wine bug.
+         */
+        if (lastError == ERROR_DIRECTORY && windows::isWine()) {
+            throwIfSymlink(finalComponent, path);
+        }
+        /* Return invalid handle for ENOENT/EEXIST style errors, or when trying to
+           open a non-directory as a directory (ERROR_DIRECTORY).
+           Set the Win32 error so the caller can inspect it. */
+        if (lastError == ERROR_FILE_NOT_FOUND || lastError == ERROR_FILE_EXISTS || lastError == ERROR_DIRECTORY) {
+            SetLastError(lastError);
+            return AutoCloseFD{};
+        }
+        throw windows::WinError(lastError, "opening file '%s'", PathFmt(path.path()));
     }
 
     /* Final check: did we accidentally open a symlink? */
-    if (windows::isReparsePoint(finalHandle.get()))
+    if (windows::isReparsePoint(finalResult.value().get()))
         throw SymlinkNotAllowed(path.path());
 
-    return finalHandle;
-}
-
-OsString readLinkAt(Descriptor dirFd, const OsCanonPath & path)
-{
-    AutoCloseFD linkHandle(windows::openSymlinkAt(dirFd, path));
-    return windows::readSymlinkTarget(linkHandle.get());
+    return std::move(finalResult.value());
 }
 
 } // namespace nix

--- a/src/libutil/windows/file-system-at.cc
+++ b/src/libutil/windows/file-system-at.cc
@@ -269,6 +269,24 @@ bool isReparsePoint(HANDLE handle)
     return (basicInfo.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
 }
 
+/**
+ * Convert Unix time_t to Windows FILETIME.
+ *
+ * FILETIME epoch is January 1, 1601 00:00:00 UTC.
+ * Unix epoch is January 1, 1970 00:00:00 UTC.
+ * Difference is 11644473600 seconds.
+ * FILETIME is in 100-nanosecond intervals.
+ */
+FILETIME timeToFileTime(time_t t)
+{
+    constexpr uint64_t EPOCH_DIFF = 11644473600ULL;
+    uint64_t intervals = (static_cast<uint64_t>(t) + EPOCH_DIFF) * 10000000ULL;
+    FILETIME ft;
+    ft.dwLowDateTime = static_cast<DWORD>(intervals);
+    ft.dwHighDateTime = static_cast<DWORD>(intervals >> 32);
+    return ft;
+}
+
 } // anonymous namespace
 
 } // namespace windows
@@ -387,6 +405,29 @@ PosixStat fstatat(Descriptor dirFd, const OsCanonPath & path)
     auto handle = windows::ntOpenAt(dirFd, path.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
 
     return fstat(handle.get());
+}
+
+void setWriteTime(Descriptor dirFd, const OsCanonPath & path, time_t accessedTime, time_t modificationTime)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+
+    auto wpath = path.lexically_normal().make_preferred();
+
+    /* Open the file with write attributes permission, not following symlinks */
+    AutoCloseFD handle(
+        windows::ntOpenAt(
+            dirFd,
+            wpath.c_str(),
+            FILE_WRITE_ATTRIBUTES | SYNCHRONIZE,
+            FILE_OPEN_REPARSE_POINT /* Don't follow symlinks */
+            ));
+
+    FILETIME atime = windows::timeToFileTime(accessedTime);
+    FILETIME mtime = windows::timeToFileTime(modificationTime);
+
+    if (!SetFileTime(handle.get(), nullptr /* creation time */, &atime, &mtime))
+        throw windows::WinError("changing modification time of %s", PathFmt(path));
 }
 
 std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const OsCanonPath & path)

--- a/src/libutil/windows/file-system-at.cc
+++ b/src/libutil/windows/file-system-at.cc
@@ -81,13 +81,12 @@ AutoCloseFD ntOpenAt(
  * @param path Relative path to the symlink
  * @return Handle to the symlink
  */
-AutoCloseFD openSymlinkAt(Descriptor dirFd, const CanonPath & path)
+AutoCloseFD openSymlinkAt(Descriptor dirFd, const OsCanonPath & path)
 {
-    assert(!path.isRoot());
-    assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
+    assert(!path.empty());
 
-    std::wstring wpath = string_to_os_string(path.rel());
-    return ntOpenAt(dirFd, wpath, FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+    auto wpath = path.path().lexically_normal().make_preferred();
+    return ntOpenAt(dirFd, wpath.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
 }
 
 /**
@@ -230,15 +229,14 @@ PosixStat fstat(Descriptor fd)
 
 AutoCloseFD openFileEnsureBeneathNoSymlinks(
     Descriptor dirFd,
-    const CanonPath & path,
+    const OsCanonPath & path,
     ACCESS_MASK desiredAccess,
     ULONG createOptions,
     ULONG createDisposition,
     /* FIXME: Actually call this callback. */
-    [[maybe_unused]] std::function<void(AutoCloseFD dirFd, CanonPath relPath)> dirFdCallback)
+    [[maybe_unused]] std::function<void(AutoCloseFD dirFd, OsCanonPath relPath)> dirFdCallback)
 {
-    assert(!path.isRoot());
-    assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
+    assert(!path.empty());
 
     AutoCloseFD parentFd;
     auto nrComponents = std::ranges::distance(path);
@@ -246,21 +244,19 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
     auto components = std::views::take(path, nrComponents - 1); /* Everything but last component */
     auto getParentFd = [&]() { return parentFd ? parentFd.get() : dirFd; };
 
-    /* Helper to construct CanonPath from components up to (and including) the given iterator */
+    /* Helper to construct OsCanonPath from components up to (and including) the given iterator */
     auto pathUpTo = [&](auto it) {
-        return std::ranges::fold_left(components.begin(), it, CanonPath::root, [](auto lhs, auto rhs) {
-            lhs.push(rhs);
-            return lhs;
-        });
+        return std::ranges::fold_left(
+            components.begin(), it, OsCanonPath{}, [](OsCanonPath acc, const OsFilename & comp) { return acc / comp; });
     };
 
     /* Helper to check if a component is a symlink and throw SymlinkNotAllowed if so */
-    auto throwIfSymlink = [&](std::wstring_view component, const CanonPath & pathForError) {
+    auto throwIfSymlink = [&](std::wstring_view component, const OsCanonPath & pathForError) {
         try {
             auto testHandle = windows::ntOpenAt(
                 getParentFd(), component, FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
             if (windows::isReparsePoint(testHandle.get()))
-                throw SymlinkNotAllowed(pathForError);
+                throw SymlinkNotAllowed(pathForError.path());
         } catch (SymlinkNotAllowed &) {
             throw;
         } catch (...) {
@@ -271,7 +267,7 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
     /* Iterate through each path component to ensure no symlinks in intermediate directories.
      * This prevents TOCTOU issues by opening each component relative to the parent. */
     for (auto it = components.begin(); it != components.end(); ++it) {
-        std::wstring wcomponent = string_to_os_string(std::string(*it));
+        const auto & wcomponent = (*it).path().native();
 
         /* Open directory without following symlinks */
         AutoCloseFD parentFd2;
@@ -292,14 +288,14 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
 
         /* Check if what we opened is actually a symlink */
         if (windows::isReparsePoint(parentFd2.get())) {
-            throw SymlinkNotAllowed(pathUpTo(std::next(it)));
+            throw SymlinkNotAllowed(pathUpTo(std::next(it)).path());
         }
 
         parentFd = std::move(parentFd2);
     }
 
     /* Now open the final component with requested flags */
-    std::wstring finalComponent = string_to_os_string(std::string(path.baseName().value()));
+    auto finalComponent = path.path().filename().native();
 
     AutoCloseFD finalHandle;
     try {
@@ -319,12 +315,12 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
 
     /* Final check: did we accidentally open a symlink? */
     if (windows::isReparsePoint(finalHandle.get()))
-        throw SymlinkNotAllowed(path);
+        throw SymlinkNotAllowed(path.path());
 
     return finalHandle;
 }
 
-OsString readLinkAt(Descriptor dirFd, const CanonPath & path)
+OsString readLinkAt(Descriptor dirFd, const OsCanonPath & path)
 {
     AutoCloseFD linkHandle(windows::openSymlinkAt(dirFd, path));
     return windows::readSymlinkTarget(linkHandle.get());

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -16,18 +16,6 @@ static_assert(S_IFLNK != S_IFCHR, "S_IFLNK must not equal S_IFCHR");
 
 namespace nix {
 
-void setWriteTime(
-    const std::filesystem::path & path, time_t accessedTime, time_t modificationTime, std::optional<bool> optIsSymlink)
-{
-    // FIXME use `std::filesystem::last_write_time`.
-    //
-    // Would be nice to use std::filesystem unconditionally, but
-    // doesn't support access time just modification time.
-    //
-    // System clock vs File clock issues also make that annoying.
-    warn("Changing file times is not yet implemented on Windows, path is %s", PathFmt(path));
-}
-
 AutoCloseFD openDirectory(const std::filesystem::path & path, FinalSymlink finalSymlink)
 {
     return AutoCloseFD{CreateFileW(

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -590,7 +590,8 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
             /* !!! races */
             if (canonicalise)
                 canonicalisePathMetaData(
-                    store->printStorePath(info->path),
+                    ensureLocalStore()->realStoreDirFd.get(),
+                    OsFilename{std::filesystem::path(info->path.to_string())},
                     {NIX_WHEN_SUPPORT_ACLS(settings.getLocalSettings().ignoredAcls)});
             if (!hashGiven) {
                 HashResult hash = hashPath(

--- a/tests/functional/nars.sh
+++ b/tests/functional/nars.sh
@@ -56,14 +56,14 @@ rm -rf "$TEST_ROOT/out"
 # must already exist, which conflicts with --restore creating
 # something new.
 rm -rf "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet "ends in '\.'.*not a valid filename"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet 'ends in "\.".*not a valid filename'
 
 # Destination with trailing `/..` should fail.
 rm -rf "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out/.." < "$TEST_ROOT/tmp.nar" | grepQuiet "ends in '\.\.'.*not a valid filename"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/.." < "$TEST_ROOT/tmp.nar" | grepQuiet 'ends in "\.\.".*not a valid filename'
 
 # Empty destination should fail.
-expectStderr 1 nix-store --restore "" < "$TEST_ROOT/tmp.nar" | grepQuiet "destination path is empty"
+expectStderr 1 nix-store --restore "" < "$TEST_ROOT/tmp.nar" | grepQuiet 'destination path is empty'
 
 # The same, but for a symlink.
 ln -sfn foo "$TEST_ROOT/symlink"
@@ -93,7 +93,7 @@ rm -rf "$TEST_ROOT/out"
 
 # Trailing `/.` — same baseline as above (currently fails).
 rm -rf "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet "ends in '\.'.*not a valid filename"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet 'ends in "\.".*not a valid filename'
 
 # Check whether restoring and dumping a NAR that contains case
 # collisions is round-tripping, even on a case-insensitive system.
@@ -122,7 +122,7 @@ expectStderr 1 nix-store "${opts[@]}" --dump "$TEST_ROOT/case" > /dev/null
 
 # Trailing `/.` — same baseline as above (currently fails).
 rm -rf "$TEST_ROOT/case"
-expectStderr 1 nix-store "${opts[@]}" --restore "$TEST_ROOT/case/." < case.nar | grepQuiet "ends in '\.'.*not a valid filename"
+expectStderr 1 nix-store "${opts[@]}" --restore "$TEST_ROOT/case/." < case.nar | grepQuiet 'ends in "\.".*not a valid filename'
 
 # Detect NARs that have a directory entry that after case-hacking
 # collides with another entry (e.g. a directory containing 'Test',


### PR DESCRIPTION
## Motivation

I suppose we should have a big issue for all the no TOCTOU, yes `Descriptor` work, to link here.

## Context

This should not happen now, but instead happen after

- https://github.com/NixOS/nix/pull/15119
- https://github.com/NixOS/nix/pull/15060
- https://github.com/NixOS/nix/pull/15718 @xokdvium's upcoming new `Descriptor`-based `SourceAccessor`
- #15244 

I suspect what we'll want to do is expose that source accessor after
all, so we can have some extra methods to get at the underlying file
descriptors. (Or, conversely, maybe this won't be necessary, because enough of the
underlying logic will be factored into `file-descriptor.hh` functions
that the `SourceAccessor` itself will be a small wrapper.)

Either way, at that point we'll not be duplicating stuff here, nor will
be lacking a foundation on Windows, and we can then finish the job.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
