### PR TITLE
libstore: fix runtime gc on non-standard store paths

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -339,7 +339,7 @@ static void readProcLink(const std::filesystem::path & file, UncheckedRoots & ro
 static std::string quoteRegexChars(const std::string & raw)
 {
     static auto specialRegex = boost::regex(R"([.^$\\*+?()\[\]{}|])");
-    return boost::regex_replace(raw, specialRegex, R"(\$&)");
+    return boost::regex_replace(raw, specialRegex, R"(\\$&)");
 }
 
 #ifdef __linux__

--- a/tests/functional/gc-runtime.nix
+++ b/tests/functional/gc-runtime.nix
@@ -1,17 +1,29 @@
 with import ./config.nix;
 
-mkDerivation {
-  name = "gc-runtime";
-  builder =
-    # Test inline source file definitions.
-    builtins.toFile "builder.sh" ''
-      mkdir $out
+{
+  environ = mkDerivation {
+    name = "gc-runtime-environ";
+    buildCommand = "mkdir $out; echo environ > $out/environ";
+  };
 
-      cat > $out/program <<EOF
-      #! ${shell}
-      sleep 10000
-      EOF
+  open = mkDerivation {
+    name = "gc-runtime-open";
+    buildCommand = "mkdir $out; echo open > $out/open";
+  };
 
-      chmod +x $out/program
-    '';
+  program = mkDerivation {
+    name = "gc-runtime-program";
+    builder =
+      # Test inline source file definitions.
+      builtins.toFile "builder.sh" ''
+        mkdir $out
+
+        cat > $out/program << 'EOF'
+        #! ${shell}
+        sleep 10000 < "$1"
+        EOF
+
+        chmod +x $out/program
+      '';
+  };
 }

--- a/tests/functional/gc-runtime.sh
+++ b/tests/functional/gc-runtime.sh
@@ -16,26 +16,38 @@ TODO_NixOS
 profiles="$NIX_STATE_DIR"/profiles
 rm -rf "$profiles"
 
-nix-env -p "$profiles/test" -f ./gc-runtime.nix -i gc-runtime
+nix-env -p "$profiles/test" -f ./gc-runtime.nix -i gc-runtime-{program,environ,open}
 
-outPath=$(nix-env -p "$profiles/test" -q --no-name --out-path gc-runtime)
-echo "$outPath"
+programPath=$(nix-env -p "$profiles/test" -q --no-name --out-path gc-runtime-program)
+environPath=$(nix-env -p "$profiles/test" -q --no-name --out-path gc-runtime-environ)
+openPath=$(nix-env -p "$profiles/test" -q --no-name --out-path gc-runtime-open)
 
 echo "backgrounding program..."
-"$profiles"/test/program &
+export environPath
+"$profiles"/test/program "$openPath"/open &
 sleep 2 # hack - wait for the program to get started
 child=$!
 echo PID=$child
 
-nix-env -p "$profiles/test" -e gc-runtime
+nix-env -p "$profiles/test" -e gc-runtime-{program,environ,open}
 nix-env -p "$profiles/test" --delete-generations old
 
 nix-store --gc
 
 kill -- -$child
 
-if ! test -e "$outPath"; then
+if ! test -e "$programPath"; then
     echo "running program was garbage collected!"
+    exit 1
+fi
+
+if ! test -e "$environPath"; then
+    echo "file in environment variable was garbage collected!"
+    exit 1
+fi
+
+if ! test -e "$openPath"; then
+    echo "opened file was garbage collected!"
     exit 1
 fi
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
Due to a typo in quoteRegexChars, finding runtime roots for garbage collection was failing on paths that contained a dot, or any other regex chars that would have to be replaced. This happened during functional tests.

At the same time, also add some tests to ensure that runtime gc continues to work. This was originally part of a change I wrote in lix: https://git.lix.systems/lix-project/lix/commit/c03de0df627864fb7e83e9af88201b8a5fcd4930

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
