### PR TITLE
Fix build failures on systems with unprivileged_userns_clone=0

### DIFF
--- a/src/libstore/unix/build/chroot-derivation-builder.cc
+++ b/src/libstore/unix/build/chroot-derivation-builder.cc
@@ -100,15 +100,6 @@ struct ChrootDerivationBuilder : virtual DerivationBuilderImpl
                 "feature 'uid-range' requires the setting '%s' to be enabled",
                 store.config->getLocalSettings().autoAllocateUids.name);
 
-        /* Declare the build user's group so that programs get a consistent
-           view of the system (e.g., "id -gn"). */
-        writeFile(
-            chrootRootDir / "etc" / "group",
-            fmt("root:x:0:\n"
-                "nixbld:!:%1%:\n"
-                "nogroup:x:65534:\n",
-                sandboxGid()));
-
         /* Create /etc/hosts with localhost entry. */
         if (derivationType.isSandboxed())
             writeFile(chrootRootDir / "etc" / "hosts", "127.0.0.1 localhost\n::1 localhost\n");

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -425,8 +425,8 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
                     "cannot perform a sandboxed build because user namespaces are not enabled; check /proc/sys/user/max_user_namespaces");
         }
 
-        /* Now that we now the sandbox uid, we can write
-           /etc/passwd. */
+        /* Now that we know the sandbox uid/gid, we can write
+           /etc/passwd and /etc/group. */
         writeFile(
             chrootRootDir / "etc" / "passwd",
             fmt("root:x:0:0:Nix build user:%3%:/noshell\n"
@@ -435,6 +435,13 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
                 sandboxUid(),
                 sandboxGid(),
                 store.config->getLocalSettings().sandboxBuildDir));
+
+        writeFile(
+            chrootRootDir / "etc" / "group",
+            fmt("root:x:0:\n"
+                "nixbld:!:%1%:\n"
+                "nogroup:x:65534:\n",
+                sandboxGid()));
 
         /* Save the mount- and user namespace of the child. We have to do this
          *before* the child does a chroot. */


### PR DESCRIPTION
## Motivation

Currently certain builds failed on hardened systems, exactly with `kernel.unprivileged_userns_clone=0`.
The error happens only on GID lookup, because nix didn't setup `/etc/group` inside the sandbox.
While the file exists in the sandbox, it has incorrect GID (100). This PR fixes this to match host value.

I've tested this briefly locally and it does seem to fix the issue.

## Context

+ https://github.com/NixOS/nixpkgs/issues/287194
+ https://github.com/NixOS/nix/issues/6898
+ https://github.com/NixOS/nixpkgs/issues/374401

This is my first PR to nix without deeper understanding of what potential implications this might have (especially on security).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
