### PR TITLE
nix flake check: free nixosConfigurations values after checking

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1,6 +1,7 @@
 #include "nix/main/common-args.hh"
 #include "nix/main/shared.hh"
 #include "nix/expr/eval.hh"
+#include "nix/expr/eval-gc.hh"
 #include "nix/expr/eval-inline.hh"
 #include "nix/expr/eval-settings.hh"
 #include "nix/expr/get-drvs.hh"
@@ -723,9 +724,22 @@ struct CmdFlakeCheck : FlakeCommand
 
                     else if (name == "nixosConfigurations") {
                         state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs())
+
+                        for (auto & attr : *vOutput.attrs()) {
+                            // Save thunk state before forcing
+                            Value savedValue = *attr.value;
+
                             checkNixOSConfiguration(
                                 fmt("%s.%s", name, state->symbols[attr.name]), *attr.value, attr.pos);
+
+                            // Restore thunk so evaluation tree becomes unreachable
+                            *attr.value = savedValue;
+
+                            // Trigger GC to free the evaluation tree before next config
+#if NIX_USE_BOEHMGC
+                            GC_gcollect();
+#endif
+                        }
                     }
 
                     else if (name == "hydraJobs")


### PR DESCRIPTION
Save each nixosConfiguration's thunk state before checking, then restore
it immediately after. This makes the evaluated configuration tree
unreachable, allowing GC_gcollect() to reclaim memory before processing
the next config. This keeps only one configuration's evaluation tree in
memory at a time, rather than holding all evaluated configurations
simultaneously.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

`github:illustris/flake-check-mem-poc` has 20 minimal nixos configurations for PVE VMs. Without this patch, nix flake check takes up about 5GB. Bumping that to 100 nodes makes the memory usage go to 18GB.

```
        User time (seconds): 275.68
        System time (seconds): 174.27
        Percent of CPU this job got: 140%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 5:19.39
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 18579372
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 4482275
        Minor (reclaiming a frame) page faults: 5513432
        Voluntary context switches: 1069755
        Involuntary context switches: 65697
        Swaps: 0
        File system inputs: 35700044
        File system outputs: 201
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

with the patch:
```
        User time (seconds): 200.35
        System time (seconds): 3.96
        Percent of CPU this job got: 77%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 4:23.93
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1479644
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 1807
        Minor (reclaiming a frame) page faults: 378344
        Voluntary context switches: 1070729
        Involuntary context switches: 31566
        Swaps: 0
        File system inputs: 435937
        File system outputs: 104
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
