### PR TITLE
Support garbage collection in external daemon

### DIFF
--- a/doc/manual/rl-next/roots-daemon.md
+++ b/doc/manual/rl-next/roots-daemon.md
@@ -1,0 +1,11 @@
+---
+synopsis: New command `nix store roots-daemon` for serving GC roots
+prs: [15143]
+---
+
+New command [`nix store roots-daemon`](@docroot@/command-ref/new-cli/nix3-store-roots-daemon.md) runs a daemon that serves garbage collector roots over a Unix domain socket.
+It enables the garbage collector to discover runtime roots when the main Nix daemon doesn't have `CAP_SYS_PTRACE` capability and therefore cannot scan `/proc`.
+
+The garbage collector can be configured to use this daemon via the [`use-roots-daemon`](@docroot@/store/types/local-store.md#store-experimental-option-use-roots-daemon) store setting.
+
+This feature requires the [`local-overlay-store` experimental feature](@docroot@/development/experimental-features.md#xp-feature-local-overlay-store).

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -133,6 +133,27 @@ public:
         Xp::LocalOverlayStore,
     };
 
+    Setting<bool> useRootsDaemon{
+        this,
+        false,
+        "use-roots-daemon",
+        R"(
+          Whether to request garbage collector roots from an external daemon.
+
+          When enabled, the garbage collector connects to a Unix domain socket
+          at [`<state-dir>`](@docroot@/store/types/local-store.md#store-option-state)`/gc-roots-socket/socket` to discover additional roots
+          that should not be collected. This is useful when the Nix daemon runs
+          without root privileges and cannot scan `/proc` for runtime roots.
+
+          The daemon can be started with [`nix store roots-daemon`](@docroot@/command-ref/new-cli/nix3-store-roots-daemon.md).
+        )",
+        {},
+        true,
+        Xp::LocalOverlayStore,
+    };
+
+    std::filesystem::path getRootsSocketPath() const;
+
     static const std::string name()
     {
         return "Local Store";

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -457,6 +457,11 @@ LocalStore::~LocalStore()
     }
 }
 
+std::filesystem::path LocalStoreConfig::getRootsSocketPath() const
+{
+    return std::filesystem::path(stateDir.get()) / "gc-roots-socket" / "socket";
+}
+
 StoreReference LocalStoreConfig::getReference() const
 {
     auto params = getQueryParams();

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -113,6 +113,7 @@ nix_sources = [ config_priv_h ] + files(
 if host_machine.system() != 'windows'
   nix_sources += files(
     'unix/daemon.cc',
+    'unix/store-roots-daemon.cc',
   )
 endif
 

--- a/src/nix/unix/daemon.md
+++ b/src/nix/unix/daemon.md
@@ -52,8 +52,8 @@ sockets:
 
 ```
 [Socket]
-ListenStream=/nix/var/nix/unix/daemon-socket/socket
-ListenStream=/nix/var/nix/unix/daemon-socket/socket-2
+ListenStream=/nix/var/nix/daemon-socket/socket
+ListenStream=/nix/var/nix/daemon-socket/socket-2
 ```
 
 )""

--- a/src/nix/unix/store-roots-daemon.cc
+++ b/src/nix/unix/store-roots-daemon.cc
@@ -1,0 +1,66 @@
+#include "nix/cmd/command.hh"
+#include "nix/cmd/unix-socket-server.hh"
+#include "nix/store/local-store.hh"
+#include "nix/store/store-api.hh"
+#include "nix/store/local-gc.hh"
+#include "nix/util/file-descriptor.hh"
+
+#include <thread>
+
+using namespace nix;
+
+struct CmdRootsDaemon : StoreConfigCommand
+{
+    CmdRootsDaemon() {}
+
+    std::string description() override
+    {
+        return "run a daemon that returns garbage collector roots on request";
+    }
+
+    std::string doc() override
+    {
+        return
+#include "store-roots-daemon.md"
+            ;
+    }
+
+    std::optional<ExperimentalFeature> experimentalFeature() override
+    {
+        return Xp::LocalOverlayStore;
+    }
+
+    void run(ref<StoreConfig> storeConfig) override
+    {
+        auto localStoreConfig = dynamic_cast<LocalStoreConfig *>(&*storeConfig);
+        if (!localStoreConfig) {
+            throw UsageError(
+                "Roots daemon only functions with a local store, not '%s'", storeConfig->getHumanReadableURI());
+        }
+
+        auto gcSocketPath = localStoreConfig->getRootsSocketPath();
+
+        unix::serveUnixSocket(
+            {
+                .socketPath = gcSocketPath,
+                .socketMode = 0666,
+            },
+            [&](AutoCloseFD remote, std::function<void()> closeListeners) {
+                std::thread([&, remote = std::move(remote)]() mutable {
+                    auto roots = findRuntimeRootsUnchecked(*localStoreConfig);
+
+                    FdSink sink(remote.get());
+
+                    for (auto & [key, _] : roots) {
+                        sink(localStoreConfig->printStorePath(key));
+                        sink(std::string_view("\0", 1));
+                    }
+
+                    sink.flush();
+                    remote.close();
+                }).detach();
+            });
+    }
+};
+
+static auto rCmdStoreRootsDaemon = registerCommand2<CmdRootsDaemon>({"store", "roots-daemon"});

--- a/src/nix/unix/store-roots-daemon.md
+++ b/src/nix/unix/store-roots-daemon.md
@@ -1,0 +1,46 @@
+R""(
+
+# Examples
+
+* Run the daemon:
+
+  ```console
+  # nix store roots-daemon
+  ```
+
+# Description
+
+This command runs a daemon that serves garbage collector roots from a Unix domain socket.
+It is not required in all Nix installations, but is useful when the main Nix daemon
+is not running as root and therefore cannot find runtime roots by scanning `/proc`.
+
+When the garbage collector runs with [`use-roots-daemon`](@docroot@/store/types/local-store.md#store-experimental-option-use-roots-daemon)
+enabled, it connects to this daemon to discover additional roots that should not be collected.
+
+The daemon listens on [`<state-dir>`](@docroot@/store/types/local-store.md#store-option-state)`/gc-roots-socket/socket` (typically `/nix/var/nix/gc-roots-socket/socket`).
+
+# Protocol
+
+The protocol is simple.
+For each client-initiated Unix socket connection, the server:
+
+1. Sends zero or more [store paths](@docroot@/store/store-path.md) as NUL-terminated (`\0`) strings.
+2. Closes the connection.
+
+Example (with `\0` shown as newlines for clarity):
+```
+/nix/store/s66mzxpvicwk07gjbjfw9izjfa797vsw-hello-2.12.1
+/nix/store/fvpr7x8l3illdnziggvkhdpf6vikg65w-git-2.44.0
+```
+
+# Security
+
+No information is provided as to which processes are opening which store paths.
+While only the main Nix daemon needs to use this daemon, any user able to talk to the main Nix daemon can already obtain the same information with [`nix-store --gc --print-roots`](@docroot@/command-ref/nix-store/gc.md).
+
+Therefore, restricting this daemon to only accept the Nix daemon as a client is, while recommended for defense-in-depth reasons, strictly speaking not reducing what information can be extracted versus merely restricting this daemon to accept connections from any [allowed user](@docroot@/command-ref/conf-file.md#conf-allowed-users).
+
+# Systemd socket activation
+
+`nix store roots-daemon` supports systemd socket-based activation, [just like `nix-daemon`](@docroot@/command-ref/nix-daemon.md#systemd-socket-activation).
+)""


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Some users may want to run the nix daemon as an unprivileged user, reducing the risk of compromise to their system if the nix daemon is exploited. While there are workarounds for many of the issues faced while running an unprivileged nix daemon, programs need root (or the equivalent `CAP_SYS_PTRACE`) to find the list of runtime garbage collector roots.

With this PR, users can run the minimal garbage-collector roots daemon as root, then the rest of the nix daemon as an unprivileged user, in order to not sacrifice functionality.

_Note from @Ericson2314: The key result from this PR is that fewer GC functional tets are failing within the `hydraJobs.tests.functional_unprivileged-daemon` NixOS VM test than before._

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

This replaces the more invasive #15026. The protocol and implementation in this PR were made as simple and non-invasive as possible: roots are sent from the daemon on connection, separated by null bytes. Existing code was reused wherever possible.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
