### PR TITLE
libutil: add terminator option to readLine

### DIFF
--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -104,10 +104,11 @@ void writeFull(Descriptor fd, std::string_view s, bool allowInterrupts = true);
  *
  * @param fd The file descriptor to read from
  * @param eofOk If true, return an unterminated line if EOF is reached. (e.g. the empty string)
+ * @param terminator The chartacter that ends the line
  *
  * @return A line of text ending in `\n`, or a string without `\n` if `eofOk` is true and EOF is reached.
  */
-std::string readLine(Descriptor fd, bool eofOk = false);
+std::string readLine(Descriptor fd, bool eofOk = false, char terminator = '\n');
 
 /**
  * Write a line to a file descriptor.

--- a/src/libutil/include/nix/util/serialise.hh
+++ b/src/libutil/include/nix/util/serialise.hh
@@ -121,7 +121,7 @@ struct BufferedSource : virtual Source
 
     size_t read(char * data, size_t len) override;
 
-    std::string readLine(bool eofOk = false);
+    std::string readLine(bool eofOk = false, char terminator = '\n');
 
     /**
      * Return true if the buffer is not empty.

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -138,7 +138,7 @@ size_t BufferedSource::read(char * data, size_t len)
     return n;
 }
 
-std::string BufferedSource::readLine(bool eofOk)
+std::string BufferedSource::readLine(bool eofOk, char terminator)
 {
     if (!buffer)
         buffer = std::make_unique_for_overwrite<char[]>(bufSize);
@@ -148,7 +148,7 @@ std::string BufferedSource::readLine(bool eofOk)
         if (bufPosOut < bufPosIn) {
             auto * start = buffer.get() + bufPosOut;
             auto * end = buffer.get() + bufPosIn;
-            if (auto * newline = static_cast<char *>(memchr(start, '\n', end - start))) {
+            if (auto * newline = static_cast<char *>(memchr(start, terminator, end - start))) {
                 line.append(start, newline - start);
                 bufPosOut = (newline - buffer.get()) + 1;
                 if (bufPosOut == bufPosIn)

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -98,7 +98,7 @@ void writeFull(int fd, std::string_view s, bool allowInterrupts)
     }
 }
 
-std::string readLine(int fd, bool eofOk)
+std::string readLine(int fd, bool eofOk, char terminator)
 {
     std::string s;
     while (1) {
@@ -123,7 +123,7 @@ std::string readLine(int fd, bool eofOk)
             else
                 throw EndOfFile("unexpected EOF reading a line");
         } else {
-            if (ch == '\n')
+            if (ch == terminator)
                 return s;
             s += ch;
         }


### PR DESCRIPTION
Some APIs use "lines" that end in `\0` instead of `\n`.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is a rather minimal change that I have already needed in two separate PRs (#15143 and #15026). it would be convenient if we could merge this in separately to my major changes

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
