### PR TITLE
libcmd: add new `StoreConfigCommand` class

### DIFF
--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -182,7 +182,7 @@ struct CmdBuild : InstallablesCommand, MixOutLinkByDefault, MixDryRun, MixJSON, 
         BuiltPaths buildables2;
         for (auto & b : buildables)
             buildables2.push_back(b.path);
-        updateProfile(buildables2);
+        updateProfile(*store, buildables2);
     }
 };
 

--- a/src/nix/copy.cc
+++ b/src/nix/copy.cc
@@ -63,7 +63,7 @@ struct CmdCopy : virtual CopyCommand, virtual BuiltPathsCommand, MixProfile, Mix
 
         copyPaths(*srcStore, *dstStore, stuffToCopy, NoRepair, checkSigs, substitute);
 
-        updateProfile(rootPaths);
+        updateProfile(*dstStore, rootPaths);
 
         if (outLink) {
             if (auto store2 = dstStore.dynamic_pointer_cast<LocalFSStore>())

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -501,7 +501,7 @@ struct Common : InstallableCommand, MixProfile
     {
         auto shellOutPath = getShellOutPath(store, installable);
 
-        updateProfile(shellOutPath);
+        updateProfile(*store, shellOutPath);
 
         debug("reading environment file '%s'", store->printStorePath(shellOutPath));
 

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -412,7 +412,7 @@ struct CmdProfileAdd : InstallablesCommand, MixDefaultProfile
         }
 
         try {
-            updateProfile(manifest.build(store));
+            updateProfile(*store, manifest.build(store));
         } catch (BuildEnvFileConflictError & conflictError) {
             // FIXME use C++20 std::ranges once macOS has it
             //       See
@@ -668,7 +668,7 @@ struct CmdProfileRemove : virtual EvalCommand, MixDefaultProfile, MixProfileElem
         auto removedCount = oldManifest.elements.size() - newManifest.elements.size();
         printInfo("removed %d packages, kept %d packages", removedCount, newManifest.elements.size());
 
-        updateProfile(newManifest.build(store));
+        updateProfile(*store, newManifest.build(store));
     }
 };
 
@@ -775,7 +775,7 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixDefaultProfile, MixProf
             element.updateStorePaths(getEvalStore(), store, builtPaths.find(&*installable)->second.first);
         }
 
-        updateProfile(manifest.build(store));
+        updateProfile(*store, manifest.build(store));
     }
 };
 


### PR DESCRIPTION
## Motivation

I needed this change in #15143, but it is not related to any of the features in that PR. it may also be useful for other future commands that want store configuration without opening the store, as a StoreCommand would do.

At the same time, make copy commands more clear by making store choice
for `updateProfile` explicit and removing the unused `getDstStore` function
in `StoreCommand`. This was a layer violation, as `StoreCommand` does
not have a concept of a source/destination store distinction.

## Context

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
