### PR TITLE
libutil: Add overflow check to alignUp

### DIFF
--- a/src/libutil-tests/alignment.cc
+++ b/src/libutil-tests/alignment.cc
@@ -15,4 +15,32 @@ TEST(alignUp, notAPowerOf2)
     ASSERT_DEATH({ alignUp(1u, 42); }, "alignment must be a power of 2");
 }
 
+template<typename T>
+class alignUpOverflowTest : public ::testing::Test
+{};
+
+using UnsignedTypes = ::testing::Types<uint8_t, uint16_t, uint32_t, uint64_t>;
+TYPED_TEST_SUITE(alignUpOverflowTest, UnsignedTypes);
+
+TYPED_TEST(alignUpOverflowTest, lastSafeValue)
+{
+    constexpr auto max = std::numeric_limits<TypeParam>::max();
+    ASSERT_EQ(alignUp<TypeParam>(max - 15, 16), (max - 15) & ~TypeParam{15});
+    ASSERT_NO_THROW(alignUp<TypeParam>(max - 15, 16));
+}
+
+TYPED_TEST(alignUpOverflowTest, overflowThrows)
+{
+    constexpr auto max = std::numeric_limits<TypeParam>::max();
+    ASSERT_THROW(alignUp<TypeParam>(max - 14, 16), Error);
+    ASSERT_THROW(alignUp<TypeParam>(max, 16), Error);
+    ASSERT_THROW(alignUp<TypeParam>(max, 2), Error);
+}
+
+TYPED_TEST(alignUpOverflowTest, alignmentOneNeverOverflows)
+{
+    constexpr auto max = std::numeric_limits<TypeParam>::max();
+    ASSERT_EQ(alignUp<TypeParam>(max, 1), max);
+}
+
 } // namespace nix

--- a/src/libutil/include/nix/util/alignment.hh
+++ b/src/libutil/include/nix/util/alignment.hh
@@ -1,9 +1,11 @@
 #pragma once
 ///@file
 
+#include "nix/util/error.hh"
+
 #include <cassert>
+#include <limits>
 #include <type_traits>
-#include <cstdint>
 #include <bit>
 
 namespace nix {
@@ -16,7 +18,10 @@ template<typename T>
 constexpr T alignUp(T val, unsigned alignment)
 {
     assert(std::has_single_bit(alignment) && "alignment must be a power of 2");
-    T mask = ~(T{alignment} - 1u);
+    assert(alignment <= std::numeric_limits<T>::max());
+    T mask = ~(static_cast<T>(alignment) - 1u);
+    if (val > std::numeric_limits<T>::max() - (alignment - 1)) /* Overflow check. */
+        throw Error("can't align %d to %d: value is too large", val, alignment);
     return (val + alignment - 1) & mask;
 }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Old code with `size + (size % 8 ? 8 - (size % 8) : 0)` also suffered from this (prior to 22c73868c396ceb189ff2638768b3eea30120ded).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
