### PR TITLE
`BuildError`: set exit status by default

### DIFF
--- a/src/libstore/build-result.cc
+++ b/src/libstore/build-result.cc
@@ -4,6 +4,13 @@
 
 namespace nix {
 
+unsigned int BuildError::exitCodeFromStatus(Status status)
+{
+    ExitStatusFlags flags{};
+    flags.updateFromStatus(status);
+    return flags.failingExitStatus();
+}
+
 void ExitStatusFlags::updateFromStatus(BuildResult::Failure::Status status)
 {
 // Allow selecting a subset of enum values

--- a/src/libstore/include/nix/store/build-result.hh
+++ b/src/libstore/include/nix/store/build-result.hh
@@ -73,14 +73,22 @@ struct BuildError : public Error
      */
     bool isNonDeterministic = false;
 
+private:
+
+    /**
+     * Used in the constructors
+     */
+    static unsigned int exitCodeFromStatus(Status status);
+
 public:
+
     /**
      * Variadic constructor for throwing with format strings.
      * Delegates to the string constructor after formatting.
      */
     template<typename... Args>
     BuildError(Status status, const Args &... args)
-        : Error(args...)
+        : Error(exitCodeFromStatus(status), args...)
         , status{status}
     {
     }
@@ -97,10 +105,9 @@ public:
      * Also used for deserialization.
      */
     BuildError(Args args)
-        : Error(std::move(args.msg))
+        : Error(exitCodeFromStatus(args.status), std::move(args.msg))
         , status{args.status}
         , isNonDeterministic{args.isNonDeterministic}
-
     {
     }
 

--- a/tests/functional/timeout.sh
+++ b/tests/functional/timeout.sh
@@ -17,4 +17,4 @@ expectStderr 101 nix-build timeout.nix -A silent --max-silent-time 2 | grepQuiet
 
 expectStderr 100 nix-build timeout.nix -A closeLog | grepQuiet "builder failed due to signal"
 
-expectStderr 1 nix build -f timeout.nix silent --max-silent-time 2 | grepQuiet "timed out after 2 seconds"
+expectStderr 101 nix build -f timeout.nix silent --max-silent-time 2 | grepQuiet "timed out after 2 seconds"


### PR DESCRIPTION
## Motivation

This commit has `BuildError` compute its exit status by default from its `Status`. While exit codes may sometimes need to be recomputed (e.g., when combining multiple errors), this simplifies the common case.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
