### PR TITLE
worker-protocol: replace version bit-shifting with structs

### DIFF
--- a/src/libstore-test-support/include/nix/store/tests/protocol.hh
+++ b/src/libstore-test-support/include/nix/store/tests/protocol.hh
@@ -100,26 +100,26 @@ public:
         writeProtoTest(STEM, VERSION, VALUE);                                              \
     }
 
-#define VERSIONED_CHARACTERIZATION_TEST_NO_JSON(FIXTURE, NAME, STEM, VERSION, VALUE)  \
-    VERSIONED_READ_CHARACTERIZATION_TEST_NO_JSON(FIXTURE, NAME, STEM, VERSION, VALUE) \
-    VERSIONED_WRITE_CHARACTERIZATION_TEST_NO_JSON(FIXTURE, NAME, STEM, VERSION, VALUE)
+#define VERSIONED_CHARACTERIZATION_TEST_NO_JSON(FIXTURE, NAME, STEM, VERSION, VALUE)    \
+    VERSIONED_READ_CHARACTERIZATION_TEST_NO_JSON(FIXTURE, NAME, STEM, (VERSION), VALUE) \
+    VERSIONED_WRITE_CHARACTERIZATION_TEST_NO_JSON(FIXTURE, NAME, STEM, (VERSION), VALUE)
 
-#define VERSIONED_READ_CHARACTERIZATION_TEST(FIXTURE, NAME, STEM, VERSION, VALUE)     \
-    VERSIONED_READ_CHARACTERIZATION_TEST_NO_JSON(FIXTURE, NAME, STEM, VERSION, VALUE) \
-    TEST_F(FIXTURE, NAME##_json_read)                                                 \
-    {                                                                                 \
-        readJsonTest(STEM, VALUE);                                                    \
+#define VERSIONED_READ_CHARACTERIZATION_TEST(FIXTURE, NAME, STEM, VERSION, VALUE)       \
+    VERSIONED_READ_CHARACTERIZATION_TEST_NO_JSON(FIXTURE, NAME, STEM, (VERSION), VALUE) \
+    TEST_F(FIXTURE, NAME##_json_read)                                                   \
+    {                                                                                   \
+        readJsonTest(STEM, VALUE);                                                      \
     }
 
-#define VERSIONED_WRITE_CHARACTERIZATION_TEST(FIXTURE, NAME, STEM, VERSION, VALUE)     \
-    VERSIONED_WRITE_CHARACTERIZATION_TEST_NO_JSON(FIXTURE, NAME, STEM, VERSION, VALUE) \
-    TEST_F(FIXTURE, NAME##_json_write)                                                 \
-    {                                                                                  \
-        writeJsonTest(STEM, VALUE);                                                    \
+#define VERSIONED_WRITE_CHARACTERIZATION_TEST(FIXTURE, NAME, STEM, VERSION, VALUE)       \
+    VERSIONED_WRITE_CHARACTERIZATION_TEST_NO_JSON(FIXTURE, NAME, STEM, (VERSION), VALUE) \
+    TEST_F(FIXTURE, NAME##_json_write)                                                   \
+    {                                                                                    \
+        writeJsonTest(STEM, VALUE);                                                      \
     }
 
-#define VERSIONED_CHARACTERIZATION_TEST(FIXTURE, NAME, STEM, VERSION, VALUE)  \
-    VERSIONED_READ_CHARACTERIZATION_TEST(FIXTURE, NAME, STEM, VERSION, VALUE) \
-    VERSIONED_WRITE_CHARACTERIZATION_TEST(FIXTURE, NAME, STEM, VERSION, VALUE)
+#define VERSIONED_CHARACTERIZATION_TEST(FIXTURE, NAME, STEM, VERSION, VALUE)    \
+    VERSIONED_READ_CHARACTERIZATION_TEST(FIXTURE, NAME, STEM, (VERSION), VALUE) \
+    VERSIONED_WRITE_CHARACTERIZATION_TEST(FIXTURE, NAME, STEM, (VERSION), VALUE)
 
 } // namespace nix

--- a/src/libstore-tests/serve-protocol.cc
+++ b/src/libstore-tests/serve-protocol.cc
@@ -25,7 +25,10 @@ struct ServeProtoTest : VersionedProtoTest<ServeProto, serveProtoDir>
      * For serializers that don't care about the minimum version, we
      * used the oldest one: 2.5.
      */
-    ServeProto::Version defaultVersion = 2 << 8 | 5;
+    ServeProto::Version defaultVersion = {
+        .major = 2,
+        .minor = 5,
+    };
 };
 
 VERSIONED_CHARACTERIZATION_TEST(
@@ -144,54 +147,77 @@ VERSIONED_READ_CHARACTERIZATION_TEST(
         },
     }))
 
-VERSIONED_CHARACTERIZATION_TEST(ServeProtoTest, buildResult_2_2, "build-result-2.2", 2 << 8 | 2, ({
-                                    using namespace std::literals::chrono_literals;
-                                    std::tuple<BuildResult, BuildResult, BuildResult> t{
-                                        BuildResult{.inner{BuildResult::Failure{{
-                                            .status = BuildResult::Failure::OutputRejected,
-                                            .msg = HintFmt("no idea why"),
-                                        }}}},
-                                        BuildResult{.inner{BuildResult::Failure{{
-                                            .status = BuildResult::Failure::NotDeterministic,
-                                            .msg = HintFmt("no idea why"),
-                                        }}}},
-                                        BuildResult{.inner{BuildResult::Success{
-                                            .status = BuildResult::Success::Built,
-                                        }}},
-                                    };
-                                    t;
-                                }))
-
-VERSIONED_CHARACTERIZATION_TEST(ServeProtoTest, buildResult_2_3, "build-result-2.3", 2 << 8 | 3, ({
-                                    using namespace std::literals::chrono_literals;
-                                    std::tuple<BuildResult, BuildResult, BuildResult> t{
-                                        BuildResult{.inner{BuildResult::Failure{{
-                                            .status = BuildResult::Failure::OutputRejected,
-                                            .msg = HintFmt("no idea why"),
-                                        }}}},
-                                        BuildResult{
-                                            .inner{BuildResult::Failure{{
-                                                .status = BuildResult::Failure::NotDeterministic,
-                                                .msg = HintFmt("no idea why"),
-                                                .isNonDeterministic = true,
-                                            }}},
-                                            .timesBuilt = 3,
-                                            .startTime = 30,
-                                            .stopTime = 50,
-                                        },
-                                        BuildResult{
-                                            .inner{BuildResult::Success{
-                                                .status = BuildResult::Success::Built,
-                                            }},
-                                            .startTime = 30,
-                                            .stopTime = 50,
-                                        },
-                                    };
-                                    t;
-                                }))
+VERSIONED_CHARACTERIZATION_TEST(
+    ServeProtoTest,
+    buildResult_2_2,
+    "build-result-2.2",
+    (ServeProto::Version{
+        .major = 2,
+        .minor = 2,
+    }),
+    ({
+        using namespace std::literals::chrono_literals;
+        std::tuple<BuildResult, BuildResult, BuildResult> t{
+            BuildResult{.inner{BuildResult::Failure{{
+                .status = BuildResult::Failure::OutputRejected,
+                .msg = HintFmt("no idea why"),
+            }}}},
+            BuildResult{.inner{BuildResult::Failure{{
+                .status = BuildResult::Failure::NotDeterministic,
+                .msg = HintFmt("no idea why"),
+            }}}},
+            BuildResult{.inner{BuildResult::Success{
+                .status = BuildResult::Success::Built,
+            }}},
+        };
+        t;
+    }))
 
 VERSIONED_CHARACTERIZATION_TEST(
-    ServeProtoTest, buildResult_2_6, "build-result-2.6", 2 << 8 | 6, ({
+    ServeProtoTest,
+    buildResult_2_3,
+    "build-result-2.3",
+    (ServeProto::Version{
+        .major = 2,
+        .minor = 3,
+    }),
+    ({
+        using namespace std::literals::chrono_literals;
+        std::tuple<BuildResult, BuildResult, BuildResult> t{
+            BuildResult{.inner{BuildResult::Failure{{
+                .status = BuildResult::Failure::OutputRejected,
+                .msg = HintFmt("no idea why"),
+            }}}},
+            BuildResult{
+                .inner{BuildResult::Failure{{
+                    .status = BuildResult::Failure::NotDeterministic,
+                    .msg = HintFmt("no idea why"),
+                    .isNonDeterministic = true,
+                }}},
+                .timesBuilt = 3,
+                .startTime = 30,
+                .stopTime = 50,
+            },
+            BuildResult{
+                .inner{BuildResult::Success{
+                    .status = BuildResult::Success::Built,
+                }},
+                .startTime = 30,
+                .stopTime = 50,
+            },
+        };
+        t;
+    }))
+
+VERSIONED_CHARACTERIZATION_TEST(
+    ServeProtoTest,
+    buildResult_2_6,
+    "build-result-2.6",
+    (ServeProto::Version{
+        .major = 2,
+        .minor = 6,
+    }),
+    ({
         using namespace std::literals::chrono_literals;
         std::tuple<BuildResult, BuildResult, BuildResult> t{
             BuildResult{.inner{BuildResult::Failure{{
@@ -260,7 +286,10 @@ VERSIONED_CHARACTERIZATION_TEST(
     ServeProtoTest,
     unkeyedValidPathInfo_2_3,
     "unkeyed-valid-path-info-2.3",
-    2 << 8 | 3,
+    (ServeProto::Version{
+        .major = 2,
+        .minor = 3,
+    }),
     (std::tuple<UnkeyedValidPathInfo, UnkeyedValidPathInfo>{
         ({
             UnkeyedValidPathInfo info{std::string{defaultStoreDir}, Hash::dummy};
@@ -286,7 +315,10 @@ VERSIONED_CHARACTERIZATION_TEST(
     ServeProtoTest,
     unkeyedValidPathInfo_2_4,
     "unkeyed-valid-path-info-2.4",
-    2 << 8 | 4,
+    (ServeProto::Version{
+        .major = 2,
+        .minor = 4,
+    }),
     (std::tuple<UnkeyedValidPathInfo, UnkeyedValidPathInfo>{
         ({
             UnkeyedValidPathInfo info{
@@ -340,7 +372,10 @@ VERSIONED_CHARACTERIZATION_TEST_NO_JSON(
     ServeProtoTest,
     build_options_2_1,
     "build-options-2.1",
-    2 << 8 | 1,
+    (ServeProto::Version{
+        .major = 2,
+        .minor = 1,
+    }),
     (ServeProto::BuildOptions{
         .maxSilentTime = 5,
         .buildTimeout = 6,
@@ -350,7 +385,10 @@ VERSIONED_CHARACTERIZATION_TEST_NO_JSON(
     ServeProtoTest,
     build_options_2_2,
     "build-options-2.2",
-    2 << 8 | 2,
+    (ServeProto::Version{
+        .major = 2,
+        .minor = 2,
+    }),
     (ServeProto::BuildOptions{
         .maxSilentTime = 5,
         .buildTimeout = 6,
@@ -361,7 +399,10 @@ VERSIONED_CHARACTERIZATION_TEST_NO_JSON(
     ServeProtoTest,
     build_options_2_3,
     "build-options-2.3",
-    2 << 8 | 3,
+    (ServeProto::Version{
+        .major = 2,
+        .minor = 3,
+    }),
     (ServeProto::BuildOptions{
         .maxSilentTime = 5,
         .buildTimeout = 6,
@@ -374,7 +415,10 @@ VERSIONED_CHARACTERIZATION_TEST_NO_JSON(
     ServeProtoTest,
     build_options_2_7,
     "build-options-2.7",
-    2 << 8 | 7,
+    (ServeProto::Version{
+        .major = 2,
+        .minor = 7,
+    }),
     (ServeProto::BuildOptions{
         .maxSilentTime = 5,
         .buildTimeout = 6,

--- a/src/libstore-tests/worker-protocol.cc
+++ b/src/libstore-tests/worker-protocol.cc
@@ -25,7 +25,10 @@ struct WorkerProtoTest : VersionedProtoTest<WorkerProto, workerProtoDir>
      * For serializers that don't care about the minimum version, we
      * used the oldest one: 1.10.
      */
-    WorkerProto::Version defaultVersion = 1 << 8 | 10;
+    WorkerProto::Version defaultVersion = {
+        .major = 1,
+        .minor = 10,
+    };
 };
 
 VERSIONED_CHARACTERIZATION_TEST(
@@ -79,7 +82,10 @@ VERSIONED_CHARACTERIZATION_TEST(
     WorkerProtoTest,
     derivedPath_1_29,
     "derived-path-1.29",
-    1 << 8 | 29,
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 29,
+    }),
     (std::tuple<DerivedPath, DerivedPath, DerivedPath>{
         DerivedPath::Opaque{
             .path = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
@@ -104,7 +110,10 @@ VERSIONED_CHARACTERIZATION_TEST(
     WorkerProtoTest,
     derivedPath_1_30,
     "derived-path-1.30",
-    1 << 8 | 30,
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 30,
+    }),
     (std::tuple<DerivedPath, DerivedPath, DerivedPath, DerivedPath>{
         DerivedPath::Opaque{
             .path = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
@@ -197,26 +206,41 @@ VERSIONED_READ_CHARACTERIZATION_TEST(
         },
     }))
 
-VERSIONED_CHARACTERIZATION_TEST(WorkerProtoTest, buildResult_1_27, "build-result-1.27", 1 << 8 | 27, ({
-                                    using namespace std::literals::chrono_literals;
-                                    std::tuple<BuildResult, BuildResult, BuildResult> t{
-                                        BuildResult{.inner{BuildResult::Failure{{
-                                            .status = BuildResult::Failure::OutputRejected,
-                                            .msg = HintFmt("no idea why"),
-                                        }}}},
-                                        BuildResult{.inner{BuildResult::Failure{{
-                                            .status = BuildResult::Failure::NotDeterministic,
-                                            .msg = HintFmt("no idea why"),
-                                        }}}},
-                                        BuildResult{.inner{BuildResult::Success{
-                                            .status = BuildResult::Success::Built,
-                                        }}},
-                                    };
-                                    t;
-                                }))
+VERSIONED_CHARACTERIZATION_TEST(
+    WorkerProtoTest,
+    buildResult_1_27,
+    "build-result-1.27",
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 27,
+    }),
+    ({
+        using namespace std::literals::chrono_literals;
+        std::tuple<BuildResult, BuildResult, BuildResult> t{
+            BuildResult{.inner{BuildResult::Failure{{
+                .status = BuildResult::Failure::OutputRejected,
+                .msg = HintFmt("no idea why"),
+            }}}},
+            BuildResult{.inner{BuildResult::Failure{{
+                .status = BuildResult::Failure::NotDeterministic,
+                .msg = HintFmt("no idea why"),
+            }}}},
+            BuildResult{.inner{BuildResult::Success{
+                .status = BuildResult::Success::Built,
+            }}},
+        };
+        t;
+    }))
 
 VERSIONED_CHARACTERIZATION_TEST(
-    WorkerProtoTest, buildResult_1_28, "build-result-1.28", 1 << 8 | 28, ({
+    WorkerProtoTest,
+    buildResult_1_28,
+    "build-result-1.28",
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 28,
+    }),
+    ({
         using namespace std::literals::chrono_literals;
         std::tuple<BuildResult, BuildResult, BuildResult> t{
             BuildResult{.inner{BuildResult::Failure{{
@@ -262,7 +286,14 @@ VERSIONED_CHARACTERIZATION_TEST(
     }))
 
 VERSIONED_CHARACTERIZATION_TEST(
-    WorkerProtoTest, buildResult_1_29, "build-result-1.29", 1 << 8 | 29, ({
+    WorkerProtoTest,
+    buildResult_1_29,
+    "build-result-1.29",
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 29,
+    }),
+    ({
         using namespace std::literals::chrono_literals;
         std::tuple<BuildResult, BuildResult, BuildResult> t{
             BuildResult{.inner{BuildResult::Failure{{
@@ -321,7 +352,14 @@ VERSIONED_CHARACTERIZATION_TEST(
     }))
 
 VERSIONED_CHARACTERIZATION_TEST(
-    WorkerProtoTest, buildResult_1_37, "build-result-1.37", 1 << 8 | 37, ({
+    WorkerProtoTest,
+    buildResult_1_37,
+    "build-result-1.37",
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 37,
+    }),
+    ({
         using namespace std::literals::chrono_literals;
         std::tuple<BuildResult, BuildResult, BuildResult> t{
             BuildResult{.inner{BuildResult::Failure{{
@@ -381,48 +419,59 @@ VERSIONED_CHARACTERIZATION_TEST(
         t;
     }))
 
-VERSIONED_CHARACTERIZATION_TEST(WorkerProtoTest, keyedBuildResult_1_29, "keyed-build-result-1.29", 1 << 8 | 29, ({
-                                    using namespace std::literals::chrono_literals;
-                                    std::tuple<KeyedBuildResult, KeyedBuildResult /*, KeyedBuildResult*/> t{
-                                        KeyedBuildResult{
-                                            BuildResult{.inner{KeyedBuildResult::Failure{{
-                                                .status = KeyedBuildResult::Failure::OutputRejected,
-                                                .msg = HintFmt("no idea why"),
-                                            }}}},
-                                            /* .path = */
-                                            DerivedPath::Opaque{
-                                                StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-xxx"},
-                                            },
-                                        },
-                                        KeyedBuildResult{
-                                            BuildResult{
-                                                .inner{KeyedBuildResult::Failure{{
-                                                    .status = KeyedBuildResult::Failure::NotDeterministic,
-                                                    .msg = HintFmt("no idea why"),
-                                                    .isNonDeterministic = true,
-                                                }}},
-                                                .timesBuilt = 3,
-                                                .startTime = 30,
-                                                .stopTime = 50,
-                                            },
-                                            /* .path = */
-                                            DerivedPath::Built{
-                                                .drvPath = makeConstantStorePathRef(
-                                                    StorePath{
-                                                        "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
-                                                    }),
-                                                .outputs = OutputsSpec::Names{"out"},
-                                            },
-                                        },
-                                    };
-                                    t;
-                                }))
+VERSIONED_CHARACTERIZATION_TEST(
+    WorkerProtoTest,
+    keyedBuildResult_1_29,
+    "keyed-build-result-1.29",
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 29,
+    }),
+    ({
+        using namespace std::literals::chrono_literals;
+        std::tuple<KeyedBuildResult, KeyedBuildResult /*, KeyedBuildResult*/> t{
+            KeyedBuildResult{
+                BuildResult{.inner{KeyedBuildResult::Failure{{
+                    .status = KeyedBuildResult::Failure::OutputRejected,
+                    .msg = HintFmt("no idea why"),
+                }}}},
+                /* .path = */
+                DerivedPath::Opaque{
+                    StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-xxx"},
+                },
+            },
+            KeyedBuildResult{
+                BuildResult{
+                    .inner{KeyedBuildResult::Failure{{
+                        .status = KeyedBuildResult::Failure::NotDeterministic,
+                        .msg = HintFmt("no idea why"),
+                        .isNonDeterministic = true,
+                    }}},
+                    .timesBuilt = 3,
+                    .startTime = 30,
+                    .stopTime = 50,
+                },
+                /* .path = */
+                DerivedPath::Built{
+                    .drvPath = makeConstantStorePathRef(
+                        StorePath{
+                            "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
+                        }),
+                    .outputs = OutputsSpec::Names{"out"},
+                },
+            },
+        };
+        t;
+    }))
 
 VERSIONED_CHARACTERIZATION_TEST(
     WorkerProtoTest,
     unkeyedValidPathInfo_1_15,
     "unkeyed-valid-path-info-1.15",
-    1 << 8 | 15,
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 15,
+    }),
     (std::tuple<UnkeyedValidPathInfo, UnkeyedValidPathInfo>{
         ({
             UnkeyedValidPathInfo info{
@@ -456,7 +505,10 @@ VERSIONED_CHARACTERIZATION_TEST(
     WorkerProtoTest,
     validPathInfo_1_15,
     "valid-path-info-1.15",
-    1 << 8 | 15,
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 15,
+    }),
     (std::tuple<ValidPathInfo, ValidPathInfo>{
         ({
             ValidPathInfo info{
@@ -505,7 +557,10 @@ VERSIONED_CHARACTERIZATION_TEST(
     WorkerProtoTest,
     validPathInfo_1_16,
     "valid-path-info-1.16",
-    1 << 8 | 16,
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 16,
+    }),
     (std::tuple<ValidPathInfo, ValidPathInfo, ValidPathInfo>{
         ({
             ValidPathInfo info{
@@ -660,7 +715,10 @@ VERSIONED_CHARACTERIZATION_TEST_NO_JSON(
     WorkerProtoTest,
     clientHandshakeInfo_1_30,
     "client-handshake-info_1_30",
-    1 << 8 | 30,
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 30,
+    }),
     (std::tuple<WorkerProto::ClientHandshakeInfo>{
         {},
     }))
@@ -669,7 +727,10 @@ VERSIONED_CHARACTERIZATION_TEST_NO_JSON(
     WorkerProtoTest,
     clientHandshakeInfo_1_33,
     "client-handshake-info_1_33",
-    1 << 8 | 33,
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 33,
+    }),
     (std::tuple<WorkerProto::ClientHandshakeInfo, WorkerProto::ClientHandshakeInfo>{
         {
             .daemonNixVersion = std::optional{"foo"},
@@ -683,7 +744,10 @@ VERSIONED_CHARACTERIZATION_TEST_NO_JSON(
     WorkerProtoTest,
     clientHandshakeInfo_1_35,
     "client-handshake-info_1_35",
-    1 << 8 | 35,
+    (WorkerProto::Version{
+        .major = 1,
+        .minor = 35,
+    }),
     (std::tuple<WorkerProto::ClientHandshakeInfo, WorkerProto::ClientHandshakeInfo>{
         {
             .daemonNixVersion = std::optional{"foo"},
@@ -736,17 +800,36 @@ TEST_F(WorkerProtoTest, handshake_features)
     auto clientThread = std::thread([&]() {
         FdSink out{toServer.writeSide.get()};
         FdSource in{toClient.readSide.get()};
-        clientResult = WorkerProto::BasicClientConnection::handshake(out, in, 123, {"bar", "aap", "mies", "xyzzy"});
+        clientResult = WorkerProto::BasicClientConnection::handshake(
+            out,
+            in,
+            WorkerProto::Version{
+                .major = 1,
+                .minor = 123,
+            },
+            {"bar", "aap", "mies", "xyzzy"});
     });
 
     FdSink out{toClient.writeSide.get()};
     FdSource in{toServer.readSide.get()};
-    auto daemonResult = WorkerProto::BasicServerConnection::handshake(out, in, 456, {"foo", "bar", "xyzzy"});
+    auto daemonResult = WorkerProto::BasicServerConnection::handshake(
+        out,
+        in,
+        WorkerProto::Version{
+            .major = 1,
+            .minor = 200,
+        },
+        {"foo", "bar", "xyzzy"});
 
     clientThread.join();
 
     EXPECT_EQ(clientResult, daemonResult);
-    EXPECT_EQ(std::get<0>(clientResult), 123u);
+    EXPECT_EQ(
+        std::get<0>(clientResult),
+        (WorkerProto::Version{
+            .major = 1,
+            .minor = 123,
+        }));
     EXPECT_EQ(std::get<1>(clientResult), WorkerProto::FeatureSet({"bar", "xyzzy"}));
 }
 

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -73,7 +73,7 @@ ref<LegacySSHStore::Connection> LegacySSHStore::openConnection()
     TeeSource tee(conn->from, saved);
     try {
         conn->remoteVersion =
-            ServeProto::BasicClientConnection::handshake(conn->to, tee, SERVE_PROTOCOL_VERSION, config->authority.host);
+            ServeProto::BasicClientConnection::handshake(conn->to, tee, ServeProto::latest, config->authority.host);
     } catch (SerialisationError & e) {
         // in.close(): Don't let the remote block on us not writing.
         conn->sshConn->in.close();
@@ -290,7 +290,7 @@ void LegacySSHStore::connect()
 unsigned int LegacySSHStore::getProtocol()
 {
     auto conn(connections->get());
-    return conn->remoteVersion;
+    return conn->remoteVersion.toWire();
 }
 
 pid_t LegacySSHStore::getConnectionPid()

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1496,7 +1496,7 @@ void LocalStore::verifyPath(
 
 unsigned int LocalStore::getProtocol()
 {
-    return PROTOCOL_VERSION;
+    return WorkerProto::latest.toWire();
 }
 
 std::optional<TrustedFlag> LocalStore::isTrustedClient()

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -83,9 +83,9 @@ void RemoteStore::initConnection(Connection & conn)
         StringSink saved;
         TeeSource tee(conn.from, saved);
         try {
-            auto [protoVersion, features] =
-                WorkerProto::BasicClientConnection::handshake(conn.to, tee, PROTOCOL_VERSION, WorkerProto::allFeatures);
-            if (protoVersion < MINIMUM_PROTOCOL_VERSION)
+            auto [protoVersion, features] = WorkerProto::BasicClientConnection::handshake(
+                conn.to, tee, WorkerProto::latest, WorkerProto::allFeatures);
+            if (protoVersion < WorkerProto::minimum)
                 throw Error("the Nix daemon version is too old");
             conn.protoVersion = protoVersion;
             conn.features = features;
@@ -208,7 +208,7 @@ void RemoteStore::querySubstitutablePathInfos(const StorePathCAMap & pathsMap, S
     auto conn(getConnection());
 
     conn->to << WorkerProto::Op::QuerySubstitutablePathInfos;
-    if (GET_PROTOCOL_MINOR(conn->protoVersion) < 22) {
+    if (conn->protoVersion < WorkerProto::Version{1, 22}) {
         StorePathSet paths;
         for (auto & path : pathsMap)
             paths.insert(path.first);
@@ -264,7 +264,7 @@ StorePathSet RemoteStore::queryValidDerivers(const StorePath & path)
 
 StorePathSet RemoteStore::queryDerivationOutputs(const StorePath & path)
 {
-    if (GET_PROTOCOL_MINOR(getProtocol()) >= 0x16) {
+    if (WorkerProto::Version::fromWire(getProtocol()) >= WorkerProto::Version{1, 22}) {
         return Store::queryDerivationOutputs(path);
     }
     auto conn(getConnection());
@@ -277,7 +277,7 @@ StorePathSet RemoteStore::queryDerivationOutputs(const StorePath & path)
 std::map<std::string, std::optional<StorePath>>
 RemoteStore::queryPartialDerivationOutputMap(const StorePath & path, Store * evalStore_)
 {
-    if (GET_PROTOCOL_MINOR(getProtocol()) >= 0x16) {
+    if (WorkerProto::Version::fromWire(getProtocol()) >= WorkerProto::Version{1, 22}) {
         if (!evalStore_) {
             auto conn(getConnection());
             conn->to << WorkerProto::Op::QueryDerivationOutputMap;
@@ -328,7 +328,7 @@ ref<const ValidPathInfo> RemoteStore::addCAToStore(
     std::optional<ConnectionHandle> conn_(getConnection());
     auto & conn = *conn_;
 
-    if (GET_PROTOCOL_MINOR(conn->protoVersion) >= 25) {
+    if (conn->protoVersion >= WorkerProto::Version{1, 25}) {
 
         conn->to << WorkerProto::Op::AddToStore << name << caMethod.renderWithAlgo(hashAlgo);
         WorkerProto::write(*this, *conn, references);
@@ -447,9 +447,9 @@ void RemoteStore::addToStore(const ValidPathInfo & info, Source & source, Repair
     WorkerProto::write(*this, *conn, info.sigs);
     conn->to << renderContentAddress(info.ca) << repair << !checkSigs;
 
-    if (GET_PROTOCOL_MINOR(conn->protoVersion) >= 23) {
+    if (conn->protoVersion >= WorkerProto::Version{1, 23}) {
         conn.withFramedSink([&](Sink & sink) { copyNAR(source, sink); });
-    } else if (GET_PROTOCOL_MINOR(conn->protoVersion) >= 21) {
+    } else if (conn->protoVersion >= WorkerProto::Version{1, 21}) {
         conn.processStderr(0, &source);
     } else {
         copyNAR(source, conn->to);
@@ -493,7 +493,7 @@ void RemoteStore::addMultipleToStore(
 
 void RemoteStore::addMultipleToStore(Source & source, RepairFlag repair, CheckSigsFlag checkSigs)
 {
-    if (GET_PROTOCOL_MINOR(getConnection()->protoVersion) >= 32) {
+    if (getConnection()->protoVersion >= WorkerProto::Version{1, 32}) {
         auto conn(getConnection());
         conn->to << WorkerProto::Op::AddMultipleToStore << repair << !checkSigs;
         conn.withFramedSink([&](Sink & sink) { source.drainInto(sink); });
@@ -505,7 +505,7 @@ void RemoteStore::registerDrvOutput(const Realisation & info)
 {
     auto conn(getConnection());
     conn->to << WorkerProto::Op::RegisterDrvOutput;
-    if (GET_PROTOCOL_MINOR(conn->protoVersion) < 31) {
+    if (conn->protoVersion < WorkerProto::Version{1, 31}) {
         WorkerProto::write(*this, *conn, info.id);
         conn->to << std::string(info.outPath.to_string());
     } else {
@@ -520,7 +520,7 @@ void RemoteStore::queryRealisationUncached(
     try {
         auto conn(getConnection());
 
-        if (GET_PROTOCOL_MINOR(conn->protoVersion) < 27) {
+        if (conn->protoVersion < WorkerProto::Version{1, 27}) {
             warn("the daemon is too old to support content-addressing derivations, please upgrade it to 2.4");
             return callback(nullptr);
         }
@@ -530,7 +530,7 @@ void RemoteStore::queryRealisationUncached(
         conn.processStderr();
 
         auto real = [&]() -> std::shared_ptr<const UnkeyedRealisation> {
-            if (GET_PROTOCOL_MINOR(conn->protoVersion) < 31) {
+            if (conn->protoVersion < WorkerProto::Version{1, 31}) {
                 auto outPaths = WorkerProto::Serialise<std::set<StorePath>>::read(*this, *conn);
                 if (outPaths.empty())
                     return nullptr;
@@ -590,7 +590,7 @@ std::vector<KeyedBuildResult> RemoteStore::buildPathsWithResults(
     std::optional<ConnectionHandle> conn_(getConnection());
     auto & conn = *conn_;
 
-    if (GET_PROTOCOL_MINOR(conn->protoVersion) >= 34) {
+    if (conn->protoVersion >= WorkerProto::Version{1, 34}) {
         conn->to << WorkerProto::Op::BuildPathsWithResults;
         WorkerProto::write(*this, *conn, paths);
         conn->to << buildMode;
@@ -754,7 +754,7 @@ MissingPaths RemoteStore::queryMissing(const std::vector<DerivedPath> & targets)
 {
     {
         auto conn(getConnection());
-        if (GET_PROTOCOL_MINOR(conn->protoVersion) < 19)
+        if (conn->protoVersion < WorkerProto::Version{1, 19})
             // Don't hold the connection handle in the fallback case
             // to prevent a deadlock.
             goto fallback;
@@ -796,7 +796,7 @@ void RemoteStore::connect()
 unsigned int RemoteStore::getProtocol()
 {
     auto conn(connections->get());
-    return conn->protoVersion;
+    return conn->protoVersion.toWire();
 }
 
 std::optional<TrustedFlag> RemoteStore::isTrustedClient()

--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -22,9 +22,8 @@ namespace {
 std::string formatProtocol(unsigned int proto)
 {
     if (proto) {
-        auto major = GET_PROTOCOL_MAJOR(proto) >> 8;
-        auto minor = GET_PROTOCOL_MINOR(proto);
-        return fmt("%1%.%2%", major, minor);
+        auto version = WorkerProto::Version::fromWire(proto);
+        return fmt("%1%.%2%", version.major, version.minor);
     }
     return "unknown";
 }
@@ -153,9 +152,9 @@ struct CmdConfigCheck : StoreCommand
 
     bool checkStoreProtocol(unsigned int storeProto)
     {
-        unsigned int clientProto = GET_PROTOCOL_MAJOR(SERVE_PROTOCOL_VERSION) == GET_PROTOCOL_MAJOR(storeProto)
-                                       ? SERVE_PROTOCOL_VERSION
-                                       : PROTOCOL_VERSION;
+        auto storeVersion = WorkerProto::Version::fromWire(storeProto);
+        unsigned int clientProto = (storeVersion.major == ServeProto::latest.major) ? ServeProto::latest.toWire()
+                                                                                    : WorkerProto::latest.toWire();
 
         if (clientProto != storeProto) {
             std::ostringstream ss;

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -881,7 +881,7 @@ static void opServe(Strings opFlags, Strings opArgs)
     FdSink out(getStandardOutput());
 
     /* Exchange the greeting. */
-    ServeProto::Version clientVersion = ServeProto::BasicServerConnection::handshake(out, in, SERVE_PROTOCOL_VERSION);
+    ServeProto::Version clientVersion = ServeProto::BasicServerConnection::handshake(out, in, ServeProto::latest);
 
     ServeProto::ReadConn rconn{
         .from = in,
@@ -908,9 +908,9 @@ static void opServe(Strings opFlags, Strings opArgs)
         // these conditions.
         settings.maxSilentTime = options.maxSilentTime;
         settings.buildTimeout = options.buildTimeout;
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 2)
+        if (clientVersion >= ServeProto::Version{2, 2})
             settings.maxLogSize = options.maxLogSize;
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 3) {
+        if (clientVersion >= ServeProto::Version{2, 3}) {
             if (options.nrRepeats != 0) {
                 throw Error("client requested repeating builds, but this is not currently implemented");
             }
@@ -923,7 +923,7 @@ static void opServe(Strings opFlags, Strings opArgs)
             // client asked for.
             settings.runDiffHook = true;
         }
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 7) {
+        if (clientVersion >= ServeProto::Version{2, 7}) {
             settings.keepFailed = options.keepFailed;
         }
     };


### PR DESCRIPTION
## Motivation

This commit replaces the `GET_PROTOCOL_MINOR(version)` macros with a proper `WorkerProto::Version` struct. As a bonus, this also fixes some version checks that were incorrectly ignoring the major version number.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
