### PR TITLE
BinaryCacheStore::queryPathInfoUncached(): Ensure noexcept

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -435,37 +435,41 @@ void BinaryCacheStore::narFromPath(const StorePath & storePath, Sink & sink)
 void BinaryCacheStore::queryPathInfoUncached(
     const StorePath & storePath, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
 {
-    auto uri = config.getReference().render(/*FIXME withParams=*/false);
-    auto storePathS = printStorePath(storePath);
-    auto act = std::make_shared<Activity>(
-        *logger,
-        lvlTalkative,
-        actQueryPathInfo,
-        fmt("querying info about '%s' on '%s'", storePathS, uri),
-        Logger::Fields{storePathS, uri});
-    PushActivity pact(act->id);
-
-    auto narInfoFile = narInfoFileFor(storePath);
-
     auto callbackPtr = std::make_shared<decltype(callback)>(std::move(callback));
 
-    getFile(narInfoFile, {[=, this](std::future<std::optional<std::string>> fut) {
-                try {
-                    auto data = fut.get();
+    try {
+        auto uri = config.getReference().render(/*FIXME withParams=*/false);
+        auto storePathS = printStorePath(storePath);
+        auto act = std::make_shared<Activity>(
+            *logger,
+            lvlTalkative,
+            actQueryPathInfo,
+            fmt("querying info about '%s' on '%s'", storePathS, uri),
+            Logger::Fields{storePathS, uri});
+        PushActivity pact(act->id);
 
-                    if (!data)
-                        return (*callbackPtr)({});
+        auto narInfoFile = narInfoFileFor(storePath);
 
-                    stats.narInfoRead++;
+        getFile(narInfoFile, {[=, this](std::future<std::optional<std::string>> fut) {
+                    try {
+                        auto data = fut.get();
 
-                    (*callbackPtr)(
-                        (std::shared_ptr<ValidPathInfo>) std::make_shared<NarInfo>(*this, *data, narInfoFile));
+                        if (!data)
+                            return (*callbackPtr)({});
 
-                    (void) act; // force Activity into this lambda to ensure it stays alive
-                } catch (...) {
-                    callbackPtr->rethrow();
-                }
-            }});
+                        stats.narInfoRead++;
+
+                        (*callbackPtr)(
+                            (std::shared_ptr<ValidPathInfo>) std::make_shared<NarInfo>(*this, *data, narInfoFile));
+
+                        (void) act; // force Activity into this lambda to ensure it stays alive
+                    } catch (...) {
+                        callbackPtr->rethrow();
+                    }
+                }});
+    } catch (...) {
+        callbackPtr->rethrow();
+    }
 }
 
 StorePath BinaryCacheStore::addToStore(


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Make sure we don't throw an exception, since that will terminate the program. Seen in a stack trace in the wild.

https://github.com/DeterminateSystems/nix-src/pull/336

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
