### PR TITLE
worker-protocol: embed features in `Version` and add `Number` inner type

### DIFF
--- a/src/libstore/include/nix/store/worker-protocol-connection.hh
+++ b/src/libstore/include/nix/store/worker-protocol-connection.hh
@@ -24,11 +24,6 @@ struct WorkerProto::BasicConnection
     WorkerProto::Version protoVersion;
 
     /**
-     * The set of features that both sides support.
-     */
-    FeatureSet features;
-
-    /**
      * Coercion to `WorkerProto::ReadConn`. This makes it easy to use the
      * factored out serve protocol serializers with a
      * `LegacySSHStore::Connection`.
@@ -87,13 +82,11 @@ struct WorkerProto::BasicClientConnection : WorkerProto::BasicConnection
      * @param from Taken by reference to allow for various error
      * handling mechanisms.
      *
-     * @param localVersion Our version which is sent over.
-     *
-     * @param supportedFeatures The protocol features that we support.
+     * @param localVersion Our version (number + supported features)
+     * which is sent over.
      */
     // FIXME: this should probably be a constructor.
-    static std::tuple<Version, FeatureSet> handshake(
-        BufferedSink & to, Source & from, WorkerProto::Version localVersion, const FeatureSet & supportedFeatures);
+    static Version handshake(BufferedSink & to, Source & from, const Version & localVersion);
 
     /**
      * After calling handshake, must call this to exchange some basic
@@ -146,13 +139,11 @@ struct WorkerProto::BasicServerConnection : WorkerProto::BasicConnection
      * @param from Taken by reference to allow for various error
      * handling mechanisms.
      *
-     * @param localVersion Our version which is sent over.
-     *
-     * @param supportedFeatures The protocol features that we support.
+     * @param localVersion Our version (number + supported features)
+     * which is sent over.
      */
     // FIXME: this should probably be a constructor.
-    static std::tuple<Version, FeatureSet> handshake(
-        BufferedSink & to, Source & from, WorkerProto::Version localVersion, const FeatureSet & supportedFeatures);
+    static Version handshake(BufferedSink & to, Source & from, const Version & localVersion);
 
     /**
      * After calling handshake, must call this to exchange some basic

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1494,7 +1494,7 @@ void LocalStore::verifyPath(
 
 unsigned int LocalStore::getProtocol()
 {
-    return WorkerProto::latest.toWire();
+    return WorkerProto::latest.number.toWire();
 }
 
 std::optional<TrustedFlag> LocalStore::isTrustedClient()

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -199,7 +199,7 @@ void Store::addMultipleToStore(Source & source, RepairFlag repair, CheckSigsFlag
             *this,
             WorkerProto::ReadConn{
                 .from = source,
-                .version = 16,
+                .version = {.number = {.major = 1, .minor = 16}},
             });
         info.ultimate = false;
         addToStore(info, source, repair, checkSigs);

--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -22,7 +22,7 @@ namespace {
 std::string formatProtocol(unsigned int proto)
 {
     if (proto) {
-        auto version = WorkerProto::Version::fromWire(proto);
+        auto version = WorkerProto::Version::Number::fromWire(proto);
         return fmt("%1%.%2%", version.major, version.minor);
     }
     return "unknown";
@@ -152,9 +152,10 @@ struct CmdConfigCheck : StoreCommand
 
     bool checkStoreProtocol(unsigned int storeProto)
     {
-        auto storeVersion = WorkerProto::Version::fromWire(storeProto);
-        unsigned int clientProto = (storeVersion.major == ServeProto::latest.major) ? ServeProto::latest.toWire()
-                                                                                    : WorkerProto::latest.toWire();
+        auto storeVersion = WorkerProto::Version::Number::fromWire(storeProto);
+        unsigned int clientProto = (storeVersion.major == ServeProto::latest.major)
+                                       ? ServeProto::latest.toWire()
+                                       : WorkerProto::latest.number.toWire();
 
         if (clientProto != storeProto) {
             std::ostringstream ss;


### PR DESCRIPTION
## Motivation

This commit embeds the negotiated `FeatureSet` directly into `WorkerProto::Version` and introduces a `Number` inner type with total ordering, so that `Version` itself (number + features) only has partial ordering.

## Context

This is a follow-up to #15155, cleaning up the separate `features` fields on `ReadConn`/`WriteConn`.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
