### PR TITLE
tests: Add Nix 1.11.16 compatibility test

### DIFF
--- a/packaging/hydra.nix
+++ b/packaging/hydra.nix
@@ -304,12 +304,14 @@ rec {
     system:
     let
       pkgs = nixpkgsFor.${system}.native;
+      nix-1_11 = pkgs.callPackage ./testing/nix-1.11.nix { };
     in
     pkgs.runCommand "install-tests" {
       againstSelf = testNixVersions pkgs pkgs.nix;
       againstCurrentLatest =
         # FIXME: temporarily disable this on macOS because of #3605.
         if system == "x86_64-linux" then testNixVersions pkgs pkgs.nixVersions.latest else null;
+      against-1_11 = if system == "x86_64-linux" then testNixVersions pkgs nix-1_11 else null;
       # Disabled because the latest stable version doesn't handle
       # `NIX_DAEMON_SOCKET_PATH` which is required for the tests to work
       # againstLatestStable = testNixVersions pkgs pkgs.nixStable;

--- a/packaging/testing/nix-1.11-socket-path.patch
+++ b/packaging/testing/nix-1.11-socket-path.patch
@@ -1,0 +1,14 @@
+diff --git a/src/libstore/globals.cc b/src/libstore/globals.cc
+--- a/src/libstore/globals.cc
++++ b/src/libstore/globals.cc
+@@ -77,7 +77,9 @@ void Settings::processEnvironment()
+     nixConfDir = canonPath(getEnv("NIX_CONF_DIR", NIX_CONF_DIR));
+     nixLibexecDir = canonPath(getEnv("NIX_LIBEXEC_DIR", NIX_LIBEXEC_DIR));
+     nixBinDir = canonPath(getEnv("NIX_BIN_DIR", NIX_BIN_DIR));
+-    nixDaemonSocketFile = canonPath(nixStateDir + DEFAULT_SOCKET_PATH);
++    nixDaemonSocketFile = canonPath(
++        getEnv("NIX_DAEMON_SOCKET_PATH",
++               nixStateDir + DEFAULT_SOCKET_PATH));
+
+     // should be set with the other config options, but depends on nixLibexecDir
+ #ifdef __APPLE__

--- a/packaging/testing/nix-1.11.nix
+++ b/packaging/testing/nix-1.11.nix
@@ -1,0 +1,104 @@
+# Build Nix 1.11.x from the 1.11-maintenance branch for compatibility testing.
+# Not directly exposed, for testing only.
+# See .#checks.x86_64-linux.installTests.against-1_11
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  autoconf-archive,
+  bison,
+  flex,
+  curl,
+  perl,
+  perlPackages,
+  bzip2,
+  xz,
+  openssl,
+  pkg-config,
+  sqlite,
+  boehmgc,
+  libseccomp,
+  libsodium,
+}:
+
+stdenv.mkDerivation {
+  pname = "nix";
+  version = "1.11.16";
+
+  src = fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nix";
+    rev = "c6e15c43222cbec54969322b863c9eb426f58499"; # 1.11.16
+    hash = "sha256-hGZ/Dvm2s6QIQsyDLlxDetC7qGExxDwMkWYk5E2+oj8=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    bison
+    flex
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    perl
+    bzip2
+    xz
+    openssl
+    sqlite
+    boehmgc
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux libseccomp
+  ++ lib.optional (stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isDarwin) libsodium;
+
+  configureFlags = [
+    "--disable-init-state"
+    "--with-dbi=${perlPackages.DBI}/${perl.libPrefix}"
+    "--with-dbd-sqlite=${perlPackages.DBDSQLite}/${perl.libPrefix}"
+    "--with-www-curl=${perlPackages.WWWCurl}/${perl.libPrefix}"
+    "--enable-gc"
+    "--sysconfdir=${placeholder "out"}/etc"
+  ];
+
+  makeFlags = [
+    "profiledir=$(out)/etc/profile.d"
+  ];
+
+  installFlags = [
+    "sysconfdir=$(out)/etc"
+  ];
+
+  enableParallelBuilding = true;
+
+  patches = [
+    # Support NIX_DAEMON_SOCKET_PATH for compatibility tests
+    ./nix-1.11-socket-path.patch
+  ];
+
+  postPatch = ''
+    # -Wno-unneeded-internal-declaration and -Wno-deprecated-register are clang-only
+    sed -i 's/-Wno-unneeded-internal-declaration//' local.mk
+    sed -i 's/-Wno-deprecated-register//' src/libexpr/local.mk
+    # Missing <cstdint> for uint32_t/uint64_t (implicit headers changed in GCC 11+)
+    sed -i '1i #include <cstdint>' src/libutil/serialise.hh src/libexpr/attr-set.hh
+    # Don't build docs (missing docbook dependencies)
+    sed -i '/doc\/manual/d' Makefile
+  '';
+  # Shift-count-overflow warnings in serialise.hh (32-bit time_t code paths)
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=shift-count-overflow";
+  # bdw-gc C++ support (GC_throw_bad_alloc) is in separate library
+  env.NIX_LDFLAGS = "-lgccpp";
+
+  # Tests require a functional /nix/store
+  doCheck = false;
+  doInstallCheck = false;
+
+  meta = {
+    description = "Nix 1.11.x for compatibility testing";
+    homepage = "https://nixos.org/nix/";
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -198,6 +198,11 @@ elif isDaemonNewer "2.29pre"; then
     <<<"$out" grepQuiet -E "error: Cannot build '.*-x4\\.drv'"
     <<<"$out" grepQuiet -E "Reason: 1 dependency failed."
     <<<"$out" grepQuiet -E "Build failed due to failed dependency"
+elif ! isDaemonNewer "2.0"; then
+    # Observed with Nix 1.11.16: new client with very old daemon still produces new-style messages.
+    # TODO: if the `else` branch (2.0 to 2.29pre) also produces new-style messages, merge these branches.
+    <<<"$out" grepQuiet -E "error: Cannot build '.*-x4\\.drv'"
+    <<<"$out" grepQuiet -E "Reason: 1 dependency failed."
 else
     <<<"$out" grepQuiet -E "error: 1 dependencies of derivation '.*-x4\\.drv' failed to build"
 fi
@@ -209,6 +214,11 @@ test "$status" = 1
 # Precise number of errors depends on daemon version / goal refactorings
 (( "$(<<<"$out" grep -cE '^error:')" >= 3 ))
 if isDaemonNewer "2.29pre"; then
+    <<<"$out" grepQuiet -E "error: Cannot build '.*-x4\\.drv'"
+    <<<"$out" grepQuiet -E "Reason: 2 dependencies failed."
+elif ! isDaemonNewer "2.0"; then
+    # Observed with Nix 1.11.16: new client with very old daemon still produces new-style messages.
+    # TODO: if the `else` branch (2.0 to 2.29pre) also produces new-style messages, merge these branches.
     <<<"$out" grepQuiet -E "error: Cannot build '.*-x4\\.drv'"
     <<<"$out" grepQuiet -E "Reason: 2 dependencies failed."
 else

--- a/tests/functional/common/functions.sh
+++ b/tests/functional/common/functions.sh
@@ -135,7 +135,12 @@ isDaemonNewer () {
   [[ -n "${NIX_DAEMON_PACKAGE:-}" ]] || return 0
   local requiredVersion="$1"
   local daemonVersion
-  daemonVersion=$("$NIX_DAEMON_PACKAGE/bin/nix" daemon --version | cut -d' ' -f3)
+  # Nix 2.4+ has unified 'nix' command; older versions only have nix-store etc.
+  if [[ -x "$NIX_DAEMON_PACKAGE/bin/nix" ]]; then
+    daemonVersion=$("$NIX_DAEMON_PACKAGE/bin/nix" daemon --version | cut -d' ' -f3)
+  else
+    daemonVersion=$("$NIX_DAEMON_PACKAGE/bin/nix-store" --version | cut -d' ' -f3)
+  fi
   [[ $(nix eval --expr "builtins.compareVersions ''$daemonVersion'' ''$requiredVersion''") -ge 0 ]]
 }
 

--- a/tests/functional/common/init.sh
+++ b/tests/functional/common/init.sh
@@ -52,15 +52,27 @@ gc-reserved-space = 0
 substituters =
 flake-registry = $TEST_ROOT/registry.json
 show-trace = true
-include nix.conf.extra
 trusted-users = $(whoami)
 EOF
 
-cat > "$NIX_CONF_DIR"/nix.conf.extra <<EOF
+# 'include' directive not available in Nix 1.11. Exact version of introduction TBD.
+if isDaemonNewer "2.0"; then
+  cat >> "$NIX_CONF_DIR"/nix.conf <<EOF
+include nix.conf.extra
+EOF
+
+  cat > "$NIX_CONF_DIR"/nix.conf.extra <<EOF
 fsync-metadata = false
 extra-experimental-features = flakes
 !include nix.conf.extra.not-there
 EOF
+else
+  # Inline the extra config for older daemons that don't support include
+  cat >> "$NIX_CONF_DIR"/nix.conf <<EOF
+fsync-metadata = false
+extra-experimental-features = flakes
+EOF
+fi
 
 # Initialise the database.
 # The flag itself does nothing, but running the command touches the store

--- a/tests/functional/db-migration.sh
+++ b/tests/functional/db-migration.sh
@@ -10,6 +10,12 @@ if [[ -z "${NIX_DAEMON_PACKAGE-}" ]]; then
     skipTest "not using the Nix daemon"
 fi
 
+# --secret-key-files not available in Nix 1.11. Exact version of introduction TBD.
+# TODO: skip or conditionalize individual test cases instead of skipping the whole file
+if ! isDaemonNewer "2.0"; then
+    skipTest "Daemon too old for this test"
+fi
+
 TODO_NixOS
 
 killDaemon

--- a/tests/functional/dyn-drv/old-daemon-error-hack.sh
+++ b/tests/functional/dyn-drv/old-daemon-error-hack.sh
@@ -2,6 +2,9 @@
 # Purposely bypassing our usual common for this subgroup
 source ../common.sh
 
+# ca-derivations and dynamic-derivations not available in Nix 1.11. Exact version of introduction TBD.
+requireDaemonNewerThan "2.4"
+
 # Need backend to support text-hashing too
 isDaemonNewer "2.18.0pre20230906" && skipTest "Daemon is too new"
 

--- a/tests/functional/post-hook.sh
+++ b/tests/functional/post-hook.sh
@@ -2,6 +2,10 @@
 
 source common.sh
 
+# --post-build-hook not available in Nix 1.11. Exact version of introduction TBD.
+# TODO: skip or conditionalize individual test cases instead of skipping the whole file
+requireDaemonNewerThan "2.0"
+
 TODO_NixOS
 
 clearStore

--- a/tests/functional/remote-store.sh
+++ b/tests/functional/remote-store.sh
@@ -2,6 +2,10 @@
 
 source common.sh
 
+# 'nix store info' protocol not compatible with Nix 1.11 daemon. Exact version of introduction TBD.
+# TODO: skip or conditionalize individual test cases instead of skipping the whole file
+requireDaemonNewerThan "2.0"
+
 TODO_NixOS
 
 clearStore

--- a/tests/functional/user-envs-migration.sh
+++ b/tests/functional/user-envs-migration.sh
@@ -9,6 +9,12 @@ if isDaemonNewer "2.4pre20211005"; then
     skipTest "Daemon is too new"
 fi
 
+# Manifest format with 'escaped' variable not available in Nix 1.11. Exact version of introduction TBD.
+# TODO: skip or conditionalize individual test cases instead of skipping the whole file
+if ! isDaemonNewer "2.0"; then
+    skipTest "Daemon too old for this test"
+fi
+
 
 killDaemon
 unset NIX_REMOTE


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Helps catch protocol compatibility issues with very old daemons.

I've used this to verify something about the worker protocol.

It's not perfect but works and catches a possible mistake; see #15168.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Originally written to help test https://github.com/NixOS/nix/pull/15168

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
