### PR TITLE
libcmd/repl: Fix issues with :ll before anything is loaded, get rid o…

### DIFF
--- a/src/libcmd/include/nix/cmd/repl.hh
+++ b/src/libcmd/include/nix/cmd/repl.hh
@@ -25,7 +25,7 @@ struct AbstractNixRepl
      * @todo this is a layer violation
      *
      * @param programName Name of the command, e.g. `nix` or `nix-env`.
-     * @param args aguments to the command.
+     * @param args arguments to the command.
      */
     using RunNix =
         void(const std::string & programName, const Strings & args, const std::optional<std::string> & input);
@@ -37,7 +37,6 @@ struct AbstractNixRepl
      */
     static std::unique_ptr<AbstractNixRepl> create(
         const LookupPath & lookupPath,
-        nix::ref<Store> store,
         ref<EvalState> state,
         std::function<AnnotatedValues()> getValues,
         RunNix * runNix = nullptr);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -99,7 +99,7 @@ struct CmdRepl : RawInstallablesCommand
             }
             return values;
         };
-        auto repl = AbstractNixRepl::create(lookupPath, openStore(), state, getValues, runNix);
+        auto repl = AbstractNixRepl::create(lookupPath, state, getValues, runNix);
         repl->autoArgs = getAutoArgs(*repl->state);
         repl->initEnv();
         repl->mainLoop();

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -311,6 +311,12 @@ testReplResponseNoRegex '
 }
 '
 
+testReplResponseNoRegex '
+:ll
+' \
+'error: nothing has been loaded yet
+'
+
 # Don't prompt for more input when getting unexpected EOF in imported files.
 testReplResponse "
 import $testDir/lang/parse-fail-eof-pos.nix


### PR DESCRIPTION
…f store parameters to constructors

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fixes abort on :ll if nothing has been loaded yet. Also gets rid of redundant openStore() calls that were dead code (store can be extracted from EvalState already) and arguably openStore is a layer violation.

Also catches EPIPE in case the pager gets interrupted to avoid superfluous error messages.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes https://github.com/NixOS/nix/issues/15128.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
