### PR TITLE
nix run: improve error when package lacks meta.mainProgram

### DIFF
--- a/doc/manual/rl-next/nix-run-mainprogram-error.md
+++ b/doc/manual/rl-next/nix-run-mainprogram-error.md
@@ -1,0 +1,23 @@
+---
+synopsis: "Improved error message when `nix run` cannot find a main program"
+issues: [15138]
+---
+
+When `nix run` is used on a derivation and the binary does not exist, the error message now preserves the original system error and adds context about where the program name was determined from (`meta.mainProgram`, `pname`, or `name`).
+
+Previously, this would produce a confusing OS-level error:
+
+```
+error: unable to execute '/nix/store/.../bin/xyz': No such file or directory
+```
+
+Now it produces:
+
+```
+error:
+       … while running program 'xyz' (determined from 'pname') of derivation 'xyz-1.0'
+
+       … consider setting 'meta.mainProgram' or using 'nix shell' instead
+
+       error: unable to execute '/nix/store/.../bin/xyz': No such file or directory
+```

--- a/src/libcmd/include/nix/cmd/installable-value.hh
+++ b/src/libcmd/include/nix/cmd/installable-value.hh
@@ -14,10 +14,40 @@ class EvalCache;
 class AttrCursor;
 } // namespace eval_cache
 
+/**
+ * Where the main program name came from.
+ * Used to produce a better error message when the binary does not exist.
+ */
+enum class MainProgramNameProvenance : uint8_t {
+    Unset,           ///< app-type outputs where the program path is given directly
+    MetaMainProgram, ///< explicitly specified via meta.mainProgram
+    Pname,           ///< inferred from pname attribute
+    Name,            ///< inferred from derivation name
+};
+
+/**
+ * Return the Nix attribute name that this provenance corresponds to,
+ * for use in diagnostic messages.
+ */
+inline std::string_view showMainProgramNameProvenance(MainProgramNameProvenance p)
+{
+    switch (p) {
+        case MainProgramNameProvenance::Unset: return "";
+        case MainProgramNameProvenance::MetaMainProgram: return "meta.mainProgram";
+        case MainProgramNameProvenance::Pname: return "pname";
+        case MainProgramNameProvenance::Name: return "name";
+    }
+}
+
 struct App
 {
     std::vector<DerivedPath> context;
     std::filesystem::path program;
+    MainProgramNameProvenance mainProgramNameProvenance = MainProgramNameProvenance::Unset;
+    /**
+     * The derivation name (e.g. "hello-2.12.1"), used in diagnostics.
+     */
+    std::string derivationName;
     // FIXME: add args, sandbox settings, metadata, ...
 };
 

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -110,6 +110,11 @@ UnresolvedApp InstallableValue::toApp(EvalState & state)
         auto aMeta = cursor->maybeGetAttr(state.s.meta);
         auto aMainProgram = aMeta ? aMeta->maybeGetAttr("mainProgram") : nullptr;
         auto mainProgram = aMainProgram ? aMainProgram->getString() : aPname ? aPname->getString() : DrvName(name).name;
+
+        auto provenance = aMainProgram ? MainProgramNameProvenance::MetaMainProgram
+            : aPname ? MainProgramNameProvenance::Pname
+            : MainProgramNameProvenance::Name;
+
         auto program = outPath + "/bin/" + mainProgram;
         return UnresolvedApp{App{
             .context = {DerivedPath::Built{
@@ -117,6 +122,8 @@ UnresolvedApp InstallableValue::toApp(EvalState & state)
                 .outputs = OutputsSpec::Names{outputName},
             }},
             .program = program,
+            .mainProgramNameProvenance = provenance,
+            .derivationName = name,
         }};
     }
 

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -173,7 +173,20 @@ struct CmdRun : InstallableValueCommand, MixEnvironment
 
         setEnviron();
 
-        execProgramInStore(store, UseLookupPath::DontUse, app.program.string(), allArgs);
+        try {
+            execProgramInStore(store, UseLookupPath::DontUse, app.program.string(), allArgs);
+        } catch (Error & e) {
+            if (app.mainProgramNameProvenance != MainProgramNameProvenance::Unset) {
+                if (app.mainProgramNameProvenance != MainProgramNameProvenance::MetaMainProgram)
+                    e.addTrace(nullptr, "consider setting 'meta.mainProgram' or using 'nix shell' instead");
+                e.addTrace(nullptr,
+                    "while running program '%1%' (determined from '%2%') of derivation '%3%'",
+                    app.program.filename().string(),
+                    std::string(showMainProgramNameProvenance(app.mainProgramNameProvenance)),
+                    app.derivationName);
+            }
+            throw;
+        }
     }
 };
 

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -6,6 +6,7 @@ suites += {
     'develop.sh',
     'edit.sh',
     'run.sh',
+    'run-mainprogram-error.sh',
     'mercurial.sh',
     'circular.sh',
     'init.sh',

--- a/tests/functional/flakes/run-mainprogram-error.sh
+++ b/tests/functional/flakes/run-mainprogram-error.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+source ../common.sh
+
+TODO_NixOS
+
+# Test that when a package has no meta.mainProgram and the inferred binary
+# doesn't exist, the original error is preserved and a trace hints at the cause.
+clearStore
+rm -rf "$TEST_HOME"/.cache "$TEST_HOME"/.config "$TEST_HOME"/.local
+
+cp ../no-mainprogram.nix ../no-mainprogram-name-only.nix "${config_nix}" "$TEST_HOME"
+cd "$TEST_HOME"
+
+cat <<EOF > flake.nix
+{
+  outputs = { self }: {
+    packages.$system.default = (import ./no-mainprogram.nix);
+  };
+}
+EOF
+
+# Should fail with traces showing provenance and a meta.mainProgram hint,
+# with the original SysError preserved.
+stderr=$(expectStderr 1 nix run --no-write-lock-file .)
+echo "$stderr" | grepQuiet "while running program 'multi-tool'"
+echo "$stderr" | grepQuiet "determined from 'pname'"
+echo "$stderr" | grepQuiet "consider setting 'meta.mainProgram' or using 'nix shell'"
+echo "$stderr" | grepQuiet "unable to execute"
+
+# Also test the 'name' provenance case (no pname, no meta.mainProgram).
+cat <<EOF > flake.nix
+{
+  outputs = { self }: {
+    packages.$system.default = (import ./no-mainprogram-name-only.nix);
+  };
+}
+EOF
+
+stderr=$(expectStderr 1 nix run --no-write-lock-file .)
+echo "$stderr" | grepQuiet "while running program 'mytool'"
+echo "$stderr" | grepQuiet "determined from 'name'"
+echo "$stderr" | grepQuiet "consider setting 'meta.mainProgram' or using 'nix shell'"
+echo "$stderr" | grepQuiet "unable to execute"

--- a/tests/functional/no-mainprogram-name-only.nix
+++ b/tests/functional/no-mainprogram-name-only.nix
@@ -1,0 +1,16 @@
+# A package with only 'name' (no pname, no meta.mainProgram), and only has a
+# binary named differently. Used to test the 'name' provenance case.
+with import ./config.nix;
+
+mkDerivation {
+  name = "mytool-2.0";
+  outputs = [ "out" ];
+  buildCommand = ''
+    mkdir -p $out/bin
+    cat > $out/bin/helper <<EOF
+    #! ${shell}
+    echo "only helper exists, not mytool"
+    EOF
+    chmod +x $out/bin/helper
+  '';
+}

--- a/tests/functional/no-mainprogram.nix
+++ b/tests/functional/no-mainprogram.nix
@@ -1,0 +1,19 @@
+# A package that has pname but no meta.mainProgram, and only has a binary
+# named differently (bin/helper instead of bin/multi-tool). Used to test that
+# "nix run" shows a helpful error when the inferred binary doesn't exist.
+with import ./config.nix;
+
+mkDerivation {
+  pname = "multi-tool";
+  version = "1.0";
+  name = "multi-tool-1.0";
+  outputs = [ "out" ];
+  buildCommand = ''
+    mkdir -p $out/bin
+    cat > $out/bin/helper <<EOF
+    #! ${shell}
+    echo "only helper exists, not multi-tool"
+    EOF
+    chmod +x $out/bin/helper
+  '';
+}


### PR DESCRIPTION
## Summary

- When `nix run` is used on a package without `meta.mainProgram` and the guessed binary (from `pname` or `name`) does not exist, produce a clear error instead of the confusing OS-level `No such file or directory`
- Track whether the main program was explicitly set or inferred, and surface that in the error
- Add a release note entry documenting the improvement

**Before:**
```
error: unable to execute '/nix/store/.../bin/multi-tool': No such file or directory
```

**After:**
```
error: package 'multi-tool-1.0' does not have a 'meta.mainProgram' attribute
       Hint: set 'meta.mainProgram' or use 'nix shell' instead of 'nix run'.
```

Closes: #15138

## Test plan

- [x] Added functional test `tests/functional/flakes/run-mainprogram-error.sh` that verifies the new error message
- [x] Test uses a fixture package (`no-mainprogram.nix`) with `pname` but no `meta.mainProgram`, and only a differently-named binary
- [x] Verified existing `flakes / run` test still passes
- [x] `meson test -C build run-mainprogram-error` passes locally