### PR TITLE
check `isFlake` in `nixpkgsFlakeRef`

### DIFF
--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -203,8 +203,10 @@ FlakeRef InstallableFlake::nixpkgsFlakeRef() const
 
     if (auto nixpkgsInput = lockedFlake->lockFile.findInput({"nixpkgs"})) {
         if (auto lockedNode = std::dynamic_pointer_cast<const flake::LockedNode>(nixpkgsInput)) {
-            debug("using nixpkgs flake '%s'", lockedNode->lockedRef);
-            return std::move(lockedNode->lockedRef);
+            if (lockedNode->isFlake) {
+                debug("using nixpkgs flake '%s'", lockedNode->lockedRef);
+                return std::move(lockedNode->lockedRef);
+            }
         }
     }
 


### PR DESCRIPTION
Add a check for `isFlake` in `nixpkgsFlakeRef`.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

To get `bashInteractive`, `nix develop` currently [gets a flake reference to nixpkgs](https://github.com/NixOS/nix/blob/3b473c4be5e6abc58aa43271f35ff127af806c55/src/nix/develop.cc#L650-L658), either from [`inputs.nixpkgs`](https://github.com/NixOS/nix/blob/3b473c4be5e6abc58aa43271f35ff127af806c55/src/libcmd/installable-flake.cc#L204) or [flake registry entry `nixpkgs`](https://github.com/NixOS/nix/blob/3b473c4be5e6abc58aa43271f35ff127af806c55/src/libcmd/include/nix/cmd/installable-flake.hh#L87).

Currently, this is done by name for any (locked) reference. For any `nixpkgs` reference lacking a `flake.nix`, `nix develop` thus errors:

```
error (ignored): path '.../flake.nix' does not exist
```

Now, given a `inputs.<name>.flake = false;`, we may know in advance that our reference should not be a reference to a flake.

This change incorporates this knowledge, so that given `inputs.nixpkgs.flake = false;`, `nix develop` will fall back to flake registry entry `nixpkgs` to use as its flake for `bashInteractive`.

While Nixpkgs itself of course does expose a flake, this check is relevant in particular for dummy inputs (e.g. inputs using `{ url = "file:/dev/null"; flake = false; }`), which may be overridden by `--override-input` or `.follows`, yet do not expose (flake) code themselves.

## Context

- Note that this change takes at face value the name `nixpkgsFlakeReference`, which reflects current use of the function, although the `fetch-tree` experimental feature has broadened the use of what were historically called flake references beyond use to refer to flake-enabled source trees.
- I made an example for such use of dummy inputs at https://codeberg.org/kiara/poc-override-nix-deps.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
