### PR TITLE
meson: Add -Werror=return-type and -Werror=non-virtual-dtor flags

### DIFF
--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -22,6 +22,8 @@ add_project_arguments(
   '-Werror=undef',
   '-Werror=unused-result',
   '-Werror=sign-compare',
+  '-Werror=return-type',
+  '-Werror=non-virtual-dtor',
   '-Wignored-qualifiers',
   '-Wimplicit-fallthrough',
   '-Wno-deprecated-declarations',

--- a/src/libcmd/include/nix/cmd/repl-interacter.hh
+++ b/src/libcmd/include/nix/cmd/repl-interacter.hh
@@ -14,6 +14,7 @@ namespace detail {
 struct ReplCompleterMixin
 {
     virtual StringSet completePrefix(const std::string & prefix) = 0;
+    virtual ~ReplCompleterMixin() = default;
 };
 }; // namespace detail
 

--- a/src/libstore/include/nix/store/restricted-store.hh
+++ b/src/libstore/include/nix/store/restricted-store.hh
@@ -59,6 +59,8 @@ struct RestrictionContext
         addDependencyImpl(path);
     }
 
+    virtual ~RestrictionContext() = default;
+
 protected:
 
     /**

--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -61,6 +61,8 @@ public:
      */
     virtual std::filesystem::path getCommandBaseDir() const;
 
+    virtual ~Args() = default;
+
 protected:
 
     /**
@@ -481,6 +483,8 @@ public:
      * Add a single completion to the collection
      */
     virtual void add(std::string completion, std::string description = "") = 0;
+
+    virtual ~AddCompletions() = default;
 };
 
 Strings parseShebangContent(std::string_view s);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Some easy compile-time safety features to catch mistakes earlier. Fixes some missing virtual destructors.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
