### PR TITLE
Introduce `unix::sendMessageWithFds` and `unix::receiveMessageWithFds`

### DIFF
--- a/src/libutil-tests/unix/file-system-at.cc
+++ b/src/libutil-tests/unix/file-system-at.cc
@@ -11,8 +11,6 @@
 #  include <sys/mount.h>
 #endif
 
-#include <cstring>
-
 namespace nix {
 
 using namespace nix::unix;

--- a/src/libutil-tests/unix/meson.build
+++ b/src/libutil-tests/unix/meson.build
@@ -1,3 +1,4 @@
 sources += files(
   'file-system-at.cc',
+  'unix-domain-socket.cc',
 )

--- a/src/libutil-tests/unix/unix-domain-socket.cc
+++ b/src/libutil-tests/unix/unix-domain-socket.cc
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+
+#include "nix/util/file-descriptor.hh"
+#include "nix/util/processes.hh"
+#include "nix/util/unix-domain-socket.hh"
+
+#include <algorithm>
+#include <sys/socket.h>
+
+namespace nix {
+
+using namespace nix::unix;
+
+/* ----------------------------------------------------------------------------
+ * sendMessageWithFds / receiveMessageWithFds
+ * --------------------------------------------------------------------------*/
+
+TEST(MessageWithFds, streamWithData)
+{
+    int sockets[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
+    AutoCloseFD sender(sockets[0]);
+    AutoCloseFD receiver(sockets[1]);
+
+    // Create multiple pipes to test sending many fds at once
+    constexpr size_t numPipes = 8;
+    std::vector<Pipe> pipes(numPipes);
+    std::vector<int> fdsToSend;
+    for (auto & p : pipes) {
+        p.create();
+        fdsToSend.push_back(p.readSide.get());
+    }
+
+    auto testData = std::as_bytes(std::span{"test with fds"});
+    auto pipeMsg = std::as_bytes(std::span{std::string_view{"hello from parent"}});
+
+    Pid pid = startProcess([&] {
+        sender.close(); // Child only needs receiver
+        for (auto & p : pipes) {
+            p.readSide.close();
+            p.writeSide.close();
+        }
+
+        std::array<std::byte, 64> buffer;
+        auto result = receiveMessageWithFds(receiver.get(), buffer);
+
+        if (!std::ranges::equal(std::span{buffer.data(), result.bytesReceived}, testData))
+            _exit(1);
+        if (result.fds.size() != numPipes)
+            _exit(2);
+
+        // Read from the first received fd to verify it works
+        std::array<std::byte, 64> readBuf;
+        size_t n = read(result.fds[0].get(), readBuf);
+        if (!std::ranges::equal(std::span{readBuf.data(), n}, pipeMsg))
+            _exit(3);
+
+        _exit(0);
+    });
+
+    receiver.close(); // Parent only needs sender
+
+    // Send message with all the pipe read fds
+    sendMessageWithFds(sender.get(), testData, fdsToSend);
+    for (auto & p : pipes)
+        p.readSide.close(); // Close our copies after sending
+
+    // Write to the first pipe so child can read from the received fd
+    ASSERT_EQ(write(pipes[0].writeSide.get(), pipeMsg, false), pipeMsg.size());
+    for (auto & p : pipes)
+        p.writeSide.close();
+
+    int status = pid.wait();
+    EXPECT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+TEST(MessageWithFds, datagramEmptyData)
+{
+    int sockets[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_DGRAM, 0, sockets), 0);
+    AutoCloseFD sender(sockets[0]);
+    AutoCloseFD receiver(sockets[1]);
+
+    Pipe pipe;
+    pipe.create();
+    std::vector<int> fdsToSend{pipe.readSide.get()};
+
+    auto pipeMsg = std::as_bytes(std::span{std::string_view{"hello from parent"}});
+
+    Pid pid = startProcess([&] {
+        sender.close();
+        pipe.readSide.close();
+        pipe.writeSide.close();
+
+        std::array<std::byte, 64> buffer;
+        auto result = receiveMessageWithFds(receiver.get(), buffer);
+
+        if (result.fds.size() != 1)
+            _exit(1);
+
+        // Verify the received fd works
+        std::array<std::byte, 64> readBuf;
+        size_t n = read(result.fds[0].get(), readBuf);
+        if (!std::ranges::equal(std::span{readBuf.data(), n}, pipeMsg))
+            _exit(2);
+
+        _exit(0);
+    });
+
+    receiver.close();
+
+    sendMessageWithFds(sender.get(), {}, fdsToSend);
+    pipe.readSide.close();
+
+    ASSERT_EQ(write(pipe.writeSide.get(), pipeMsg, false), pipeMsg.size());
+    pipe.writeSide.close();
+
+    int status = pid.wait();
+    EXPECT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+} // namespace nix

--- a/src/libutil/include/nix/util/unix-domain-socket.hh
+++ b/src/libutil/include/nix/util/unix-domain-socket.hh
@@ -5,9 +5,11 @@
 #include "nix/util/file-descriptor.hh"
 #include "nix/util/socket.hh"
 
-#include <unistd.h>
-
 #include <filesystem>
+#include <span>
+#include <vector>
+
+#include <unistd.h>
 
 namespace nix {
 
@@ -35,5 +37,61 @@ void connect(Socket fd, const std::filesystem::path & path);
  * Connect to a Unix domain socket.
  */
 AutoCloseFD connect(const std::filesystem::path & path);
+
+#ifndef _WIN32
+namespace unix {
+
+/**
+ * Send a message with file descriptors over a Unix domain socket using
+ * sendmsg with SCM_RIGHTS.
+ *
+ * On SOCK_STREAM sockets, `data` must be non-empty when `fds` is
+ * non-empty, because the kernel silently drops ancillary data on
+ * zero-length stream sends.
+ *
+ * @param sockfd The socket file descriptor to send the message on
+ * @param data The data to send
+ * @param fds A span of file descriptors to pass via SCM_RIGHTS
+ *
+ * @throws SysError on failure
+ */
+void sendMessageWithFds(Descriptor sockfd, std::span<const std::byte> data, std::span<const Descriptor> fds);
+
+/**
+ * Result of receiving a message with file descriptors.
+ */
+struct ReceivedMessage
+{
+    /**
+     * Number of bytes received into the data buffer
+     */
+    size_t bytesReceived;
+    /**
+     * The file descriptors received via SCM_RIGHTS, wrapped in
+     * AutoCloseFD for RAII.
+     */
+    std::vector<AutoCloseFD> fds;
+};
+
+/**
+ * Receive a message with file descriptors over a Unix domain socket
+ * using recvmsg with SCM_RIGHTS.
+ *
+ * All file descriptors associated with the message will be returned. This
+ * avoids unrecoverably dropping file descriptors with a messages. This is why
+ * a vector is returned, as opposed to the caller passing in a `std::span` with
+ * length of their choosing, as that may not be long enough.
+ *
+ * @param sockfd The socket file descriptor to receive the message on
+ * @param data Buffer to receive data into
+ *
+ * @return A ReceivedMessage containing the bytes received count and file descriptors
+ * @throws SysError on failure
+ * @throws EndOfFile if the connection is closed
+ */
+ReceivedMessage receiveMessageWithFds(Descriptor sockfd, std::span<std::byte> data);
+
+} // namespace unix
+#endif
 
 } // namespace nix

--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -2,6 +2,9 @@
 #include "nix/util/unix-domain-socket.hh"
 #include "nix/util/util.hh"
 
+#include <memory>
+#include <span>
+
 #ifdef _WIN32
 #  include <winsock2.h>
 #  include <afunix.h>
@@ -121,5 +124,158 @@ AutoCloseFD connect(const std::filesystem::path & path)
     nix::connect(toSocket(fd.get()), path);
     return fd;
 }
+
+#ifndef _WIN32
+
+void unix::sendMessageWithFds(Descriptor sockfd, std::span<const std::byte> data, std::span<const Descriptor> fds)
+{
+    // SOCK_STREAM ignores zero-length sends, so the kernel would never
+    // deliver the ancillary FDs. Callers must provide at least one byte
+    // of data when sending FDs over a stream socket.
+    if (data.empty() && !fds.empty()) {
+        int type;
+        socklen_t len = sizeof(type);
+        if (getsockopt(sockfd, SOL_SOCKET, SO_TYPE, &type, &len) < 0)
+            throw SysError("getsockopt SO_TYPE");
+        assert(type != SOCK_STREAM);
+    }
+
+    struct iovec iov{
+        .iov_base = const_cast<std::byte *>(data.data()),
+        .iov_len = data.size(),
+    };
+
+    struct msghdr msg{
+        .msg_iov = &iov,
+        .msg_iovlen = 1,
+        .msg_control = nullptr,
+        .msg_controllen = 0,
+    };
+
+    auto cmsghdrAlign = std::align_val_t{alignof(struct cmsghdr)};
+
+    auto deleteWrapper = [&](void * ptr) { ::operator delete(ptr, cmsghdrAlign); };
+
+    // Allocate control message buffer with proper alignment for struct cmsghdr
+    std::unique_ptr<void, decltype(deleteWrapper)> controlData(nullptr, deleteWrapper);
+
+    if (!fds.empty()) {
+        size_t controlSize = CMSG_SPACE(sizeof(int) * fds.size());
+        controlData.reset(::operator new(controlSize, cmsghdrAlign));
+
+        msg.msg_control = controlData.get();
+        msg.msg_controllen = static_cast<socklen_t>(controlSize);
+
+        auto * cmsg = CMSG_FIRSTHDR(&msg);
+        cmsg->cmsg_len = CMSG_LEN(sizeof(int) * fds.size());
+        cmsg->cmsg_level = SOL_SOCKET;
+        cmsg->cmsg_type = SCM_RIGHTS;
+
+        // Copy file descriptors into the control message.
+        // sendmsg() copies them into the kernel, so the caller retains
+        // ownership and no dup() is needed.
+        auto * fdPtr = reinterpret_cast<int *>(CMSG_DATA(cmsg));
+        for (size_t i = 0; i < fds.size(); ++i) {
+            fdPtr[i] = fds[i];
+        }
+    }
+
+    // Loop to handle partial writes. Ancillary data (FDs) is only
+    // sent with the first successful sendmsg call. Use do/while so
+    // SOCK_DGRAM zero-length messages still trigger sendmsg.
+    do {
+        ssize_t sent = sendmsg(sockfd, &msg, 0);
+        if (sent < 0)
+            throw SysError("sendmsg");
+
+        iov.iov_base = static_cast<char *>(iov.iov_base) + sent;
+        iov.iov_len -= sent;
+
+        // Clear ancillary data after first successful send — the kernel
+        // only delivers it once.
+        msg.msg_control = nullptr;
+        msg.msg_controllen = 0;
+    } while (iov.iov_len > 0);
+}
+
+unix::ReceivedMessage unix::receiveMessageWithFds(Descriptor sockfd, std::span<std::byte> data)
+{
+    static constexpr size_t maxFds =
+#  ifdef __linux__
+        // `SCM_MAX_FD` (defined in kernel `net/scm.h`, not exposed to
+        // userspace) limits `SCM_RIGHTS` to 253 FDs per message.
+        253
+#  else
+        // Darwin:
+        // https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/kern/uipc_usrreq.c#L121
+        // FreeBSD: unknown.
+        512
+#  endif
+        ;
+
+    /* We create a buffer large enough (we think) to hold the maximum
+       number of file descriptors that can be sent in a single message.
+
+       This relates to the fact that while the data may be
+       stream-oriented (and thus we can read much or as little as we
+       want at our leisure, the file descriptors are message oriented,
+       and if we fail to read some file descriptors that were sent as
+       part of a message, they will be lost forever. */
+    alignas(struct cmsghdr) std::byte controlBuf[CMSG_SPACE(sizeof(int) * maxFds)];
+
+    struct iovec iov{
+        .iov_base = data.data(),
+        .iov_len = data.size(),
+    };
+
+    struct msghdr msg{
+        .msg_iov = &iov,
+        .msg_iovlen = 1,
+        .msg_control = controlBuf,
+        .msg_controllen = sizeof(controlBuf),
+    };
+
+    int flags = 0;
+#  ifdef MSG_CMSG_CLOEXEC
+    flags |= MSG_CMSG_CLOEXEC;
+#  endif
+
+    ssize_t bytesReceived = recvmsg(sockfd, &msg, flags);
+    if (bytesReceived < 0)
+        throw SysError("recvmsg");
+    // On SOCK_STREAM, 0 bytes means EOF. On SOCK_DGRAM, 0 bytes is a
+    // valid empty message (possibly carrying ancillary FDs).
+    if (bytesReceived == 0 && !(msg.msg_flags & MSG_CTRUNC) && CMSG_FIRSTHDR(&msg) == nullptr)
+        throw EndOfFile("connection closed");
+
+    /* Sanity check: MSG_CTRUNC indicates control message was truncated.
+       This should never happen since we size the buffer for the maximum
+       number of FDs the kernel allows per message. */
+    assert(!(msg.msg_flags & MSG_CTRUNC));
+
+    // Extract file descriptors from control message
+    std::vector<AutoCloseFD> fds;
+
+    for (struct cmsghdr * cmsg = CMSG_FIRSTHDR(&msg); cmsg != nullptr; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+        if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+            size_t count = (cmsg->cmsg_len - CMSG_LEN(0)) / sizeof(int);
+            auto * fdPtr = reinterpret_cast<int *>(CMSG_DATA(cmsg));
+
+            fds.reserve(count);
+            for (size_t i = 0; i < count; ++i) {
+#  ifndef MSG_CMSG_CLOEXEC
+                /* If we couldn't receive them with this already set, we
+                   manually set it ourselves. */
+                closeOnExec(fdPtr[i]);
+#  endif
+                fds.emplace_back(fdPtr[i]);
+            }
+        }
+    }
+
+    return {static_cast<size_t>(bytesReceived), std::move(fds)};
+}
+
+#endif
 
 } // namespace nix


### PR DESCRIPTION
## Motivation

Add functions for sending and receiving messages with file descriptors over Unix domain sockets using `SCM_RIGHTS`.

## Context

This is currently unused but @xokdvium and ai each have some ideas about what we would use it for. Resurrecting #15103 now that systemd gives us a needed new feature is one of them.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
