### PR TITLE
globals: make store settings private with typed accessors

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -75,7 +75,7 @@ ref<StoreConfig> StoreConfigCommand::getStoreConfig()
 
 ref<StoreConfig> StoreConfigCommand::createStoreConfig()
 {
-    return resolveStoreConfig(StoreReference::parse(settings.storeUri.get()));
+    return resolveStoreConfig(settings.getStoreReference());
 }
 
 void StoreConfigCommand::run()

--- a/src/libstore-test-support/test-main.cc
+++ b/src/libstore-test-support/test-main.cc
@@ -18,7 +18,7 @@ int testMainForBuidingPre(int argc, char ** argv)
     settings.buildHook = {};
 
     // No substituters, unless a test specifically requests.
-    settings.substituters = {};
+    settings.set("substituters", "");
 
 #ifdef __linux__ // should match the conditional around sandboxBuildDir declaration.
 

--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -299,7 +299,7 @@ public:
         nix_api_store_test_base::SetUp();
 
         nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-        nix::settings.substituters = {};
+        nix::settings.set("substituters", "");
 
         store = open_local_store();
 
@@ -354,7 +354,7 @@ TEST_F(nix_api_store_test_base, build_from_json)
 {
     // FIXME get rid of these
     nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-    nix::settings.substituters = {};
+    nix::settings.set("substituters", "");
 
     auto * store = open_local_store();
 
@@ -401,7 +401,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_invalid_system)
 {
     // Test that nix_store_realise properly reports errors when the system is invalid
     nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-    nix::settings.substituters = {};
+    nix::settings.set("substituters", "");
 
     auto * store = open_local_store();
 
@@ -446,7 +446,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_builder_fails)
 {
     // Test that nix_store_realise properly reports errors when the builder fails
     nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-    nix::settings.substituters = {};
+    nix::settings.set("substituters", "");
 
     auto * store = open_local_store();
 
@@ -491,7 +491,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_builder_no_output)
 {
     // Test that nix_store_realise properly reports errors when builder succeeds but produces no output
     nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-    nix::settings.substituters = {};
+    nix::settings.set("substituters", "");
 
     auto * store = open_local_store();
 
@@ -687,7 +687,7 @@ TEST_F(NixApiStoreTestWithRealisedPath, nix_store_realise_output_ordering)
     // This test uses a CA derivation with 10 outputs in randomized input order
     // to verify that the callback order is deterministic and alphabetical.
     nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
-    nix::settings.substituters = {};
+    nix::settings.set("substituters", "");
 
     auto * store = open_local_store();
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -530,4 +530,25 @@ void initLibStore(bool loadConfig)
     initLibStoreDone = true;
 }
 
+StoreReference Settings::getStoreReference() const
+{
+    return StoreReference::parse(storeUri.get());
+}
+
+std::vector<StoreReference> Settings::getSubstituters() const
+{
+    std::vector<StoreReference> res;
+    for (const auto & s : substituters.get())
+        res.push_back(StoreReference::parse(s));
+    return res;
+}
+
+std::set<StoreReference> Settings::getTrustedSubstituters() const
+{
+    std::set<StoreReference> res;
+    for (const auto & s : trustedSubstituters.get())
+        res.insert(StoreReference::parse(s));
+    return res;
+}
+
 } // namespace nix

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -8,6 +8,7 @@
 #include "nix/util/environment-variables.hh"
 #include "nix/store/build/derivation-builder.hh"
 #include "nix/store/local-settings.hh"
+#include "nix/store/store-reference.hh"
 
 #include "nix/store/config.hh"
 
@@ -616,6 +617,8 @@ public:
         // Don't document the machine-specific default value
         false};
 
+private:
+
     Setting<Strings> substituters{
         this,
         Strings{"https://cache.nixos.org/"},
@@ -648,6 +651,8 @@ public:
           Unprivileged users (those set in only [`allowed-users`](#conf-allowed-users) but not [`trusted-users`](#conf-trusted-users)) can pass as `substituters` only those URLs listed in `trusted-substituters`.
         )",
         {"trusted-binary-caches"}};
+
+public:
 
     Setting<unsigned int> ttlNegativeNarInfoCache{
         this,
@@ -864,6 +869,15 @@ public:
      * derivation, or else returns a null pointer.
      */
     const ExternalBuilder * findExternalDerivationBuilderIfSupported(const Derivation & drv);
+
+    /** Gets the store URI setting. */
+    StoreReference getStoreReference() const;
+
+    /** Gets the substituters setting. */
+    std::vector<StoreReference> getSubstituters() const;
+
+    /** Gets the trusted-substituters setting. */
+    std::set<StoreReference> getTrustedSubstituters() const;
 };
 
 // FIXME: don't use a global variable.

--- a/src/libstore/store-registration.cc
+++ b/src/libstore/store-registration.cc
@@ -8,7 +8,7 @@ namespace nix {
 
 ref<Store> openStore()
 {
-    return openStore(settings.storeUri.get());
+    return openStore(settings.getStoreReference());
 }
 
 ref<Store> openStore(const std::string & uri, const Store::Config::Params & extraParams)
@@ -79,20 +79,20 @@ std::list<ref<Store>> getDefaultSubstituters()
     static auto stores([]() {
         std::list<ref<Store>> stores;
 
-        StringSet done;
+        std::set<StoreReference> done;
 
-        auto addStore = [&](const std::string & uri) {
-            if (!done.insert(uri).second)
+        auto addStore = [&](const StoreReference & ref) {
+            if (!done.insert(ref).second)
                 return;
             try {
-                stores.push_back(openStore(uri));
+                stores.push_back(openStore(StoreReference{ref}));
             } catch (Error & e) {
                 logWarning(e.info());
             }
         };
 
-        for (const auto & uri : settings.substituters.get())
-            addStore(uri);
+        for (const auto & ref : settings.getSubstituters())
+            addStore(ref);
 
         stores.sort([](ref<Store> & a, ref<Store> & b) { return a->config.priority < b->config.priority; });
 


### PR DESCRIPTION
## Motivation

The `storeUri`, `substituters`, and `trustedSubstituters` settings were
publicly accessible as raw strings. This commit makes them private and
adds typed accessor methods that return `StoreReference` values, parsing
on demand. String-level accessors are also provided for daemon
client-settings filtering where string comparison is needed.

The CLI flags (`--from`, `--to`, `--eval-store`, and substituter URIs in
`sigs`, `verify`, `flake archive`) now parse directly to
`StoreReference` instead of storing raw strings.


## Context

This is a stepping stone towards NixOS/nix#10761

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
