### PR TITLE
globals: change store settings to use `StoreReference` types directly 

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -75,7 +75,7 @@ ref<StoreConfig> StoreConfigCommand::getStoreConfig()
 
 ref<StoreConfig> StoreConfigCommand::createStoreConfig()
 {
-    return resolveStoreConfig(StoreReference::parse(settings.storeUri.get()));
+    return resolveStoreConfig(StoreReference{settings.storeUri.get()});
 }
 
 void StoreConfigCommand::run()

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -253,7 +253,7 @@ LegacyArgs::LegacyArgs(
         .longName = "store",
         .description = "The URL of the Nix store to use.",
         .labels = {"store-uri"},
-        .handler = {&(std::string &) settings.storeUri},
+        .handler = {[](std::string s) { settings.storeUri = StoreReference::parse(s); }},
     });
 }
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -246,25 +246,36 @@ struct ClientSettings
             auto & name(i.first);
             auto & value(i.second);
 
-            auto setSubstituters = [&](Setting<Strings> & res) {
+            auto setSubstituters = [&](Setting<std::vector<StoreReference>> & res) {
                 if (name != res.name && res.aliases.count(name) == 0)
                     return false;
-                StringSet trusted = settings.trustedSubstituters;
-                for (auto & s : settings.substituters.get())
-                    trusted.insert(s);
-                Strings subs;
+                std::set<StoreReference> trusted = settings.trustedSubstituters;
+                for (auto & ref : settings.substituters.get())
+                    trusted.insert(ref);
+                std::vector<StoreReference> subs;
                 auto ss = tokenizeString<Strings>(value);
-                for (auto & s : ss)
-                    if (trusted.count(s))
-                        subs.push_back(s);
-                    else if (!hasSuffix(s, "/") && trusted.count(s + "/"))
-                        subs.push_back(s + "/");
+                for (auto & s : ss) {
+                    auto ref = StoreReference::parse(s);
+                    auto tryTrust = [&] {
+                        if (trusted.count(ref))
+                            return true;
+                        if (auto * specified = std::get_if<StoreReference::Specified>(&ref.variant);
+                            specified && !hasSuffix(specified->authority, "/")) {
+                            specified->authority += "/";
+                            if (trusted.count(ref))
+                                return true;
+                        }
+                        return false;
+                    };
+                    if (tryTrust())
+                        subs.push_back(std::move(ref));
                     else
                         warn(
                             "ignoring untrusted substituter '%s', you are not a trusted user.\n"
                             "Run `man nix.conf` for more information on the `substituters` configuration option.",
                             s);
-                res = subs;
+                }
+                res = std::move(subs);
                 return true;
             };
 

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -8,6 +8,7 @@
 #include "nix/util/environment-variables.hh"
 #include "nix/store/build/derivation-builder.hh"
 #include "nix/store/local-settings.hh"
+#include "nix/store/store-reference.hh"
 
 #include "nix/store/config.hh"
 
@@ -133,9 +134,9 @@ public:
      */
     std::filesystem::path nixDaemonSocketFile;
 
-    Setting<std::string> storeUri{
+    Setting<StoreReference> storeUri{
         this,
-        getEnv("NIX_REMOTE").value_or("auto"),
+        StoreReference::parse(getEnv("NIX_REMOTE").value_or("auto")),
         "store",
         R"(
           The [URL of the Nix store](@docroot@/store/types/index.md#store-url-format)
@@ -616,9 +617,9 @@ public:
         // Don't document the machine-specific default value
         false};
 
-    Setting<Strings> substituters{
+    Setting<std::vector<StoreReference>> substituters{
         this,
-        Strings{"https://cache.nixos.org/"},
+        std::vector<StoreReference>{StoreReference::parse("https://cache.nixos.org/")},
         "substituters",
         R"(
           A list of [URLs of Nix stores](@docroot@/store/types/index.md#store-url-format) to be used as substituters, separated by whitespace.
@@ -637,7 +638,7 @@ public:
         )",
         {"binary-caches"}};
 
-    Setting<StringSet> trustedSubstituters{
+    Setting<std::set<StoreReference>> trustedSubstituters{
         this,
         {},
         "trusted-substituters",

--- a/src/libstore/include/nix/store/store-reference.hh
+++ b/src/libstore/include/nix/store/store-reference.hh
@@ -4,6 +4,8 @@
 #include <variant>
 
 #include "nix/util/types.hh"
+#include "nix/util/json-impls.hh"
+#include "nix/util/json-non-null.hh"
 
 namespace nix {
 
@@ -121,4 +123,10 @@ static inline std::ostream & operator<<(std::ostream & os, const StoreReference 
  */
 std::pair<std::string, StoreReference::Params> splitUriAndParams(const std::string & uri);
 
+template<>
+struct json_avoids_null<StoreReference> : std::true_type
+{};
+
 } // namespace nix
+
+JSON_IMPL(StoreReference)

--- a/src/libstore/store-reference.cc
+++ b/src/libstore/store-reference.cc
@@ -6,6 +6,7 @@
 #include "nix/util/util.hh"
 
 #include <boost/url/ipv6_address.hpp>
+#include <nlohmann/json.hpp>
 
 namespace nix {
 
@@ -184,3 +185,19 @@ std::pair<std::string, StoreReference::Params> splitUriAndParams(const std::stri
 }
 
 } // namespace nix
+
+namespace nlohmann {
+
+using namespace nix;
+
+StoreReference adl_serializer<StoreReference>::from_json(const json & json)
+{
+    return StoreReference::parse(json.get<std::string>());
+}
+
+void adl_serializer<StoreReference>::to_json(json & json, const StoreReference & ref)
+{
+    json = ref.render();
+}
+
+} // namespace nlohmann

--- a/src/libstore/store-registration.cc
+++ b/src/libstore/store-registration.cc
@@ -8,7 +8,7 @@ namespace nix {
 
 ref<Store> openStore()
 {
-    return openStore(settings.storeUri.get());
+    return openStore(StoreReference{settings.storeUri.get()});
 }
 
 ref<Store> openStore(const std::string & uri, const Store::Config::Params & extraParams)
@@ -79,20 +79,20 @@ std::list<ref<Store>> getDefaultSubstituters()
     static auto stores([]() {
         std::list<ref<Store>> stores;
 
-        StringSet done;
+        std::set<StoreReference> done;
 
-        auto addStore = [&](const std::string & uri) {
-            if (!done.insert(uri).second)
+        auto addStore = [&](const StoreReference & ref) {
+            if (!done.insert(ref).second)
                 return;
             try {
-                stores.push_back(openStore(uri));
+                stores.push_back(openStore(StoreReference{ref}));
             } catch (Error & e) {
                 logWarning(e.info());
             }
         };
 
-        for (const auto & uri : settings.substituters.get())
-            addStore(uri);
+        for (const auto & ref : settings.substituters.get())
+            addStore(ref);
 
         stores.sort([](ref<Store> & a, ref<Store> & b) { return a->config.priority < b->config.priority; });
 

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -457,7 +457,7 @@ static int main_nix_daemon(int argc, char ** argv)
             return true;
         });
 
-        runDaemon(resolveStoreConfig(StoreReference::parse(settings.storeUri.get())), stdio, isTrustedOpt, processOps);
+        runDaemon(resolveStoreConfig(StoreReference{settings.storeUri.get()}), stdio, isTrustedOpt, processOps);
 
         return 0;
     }


### PR DESCRIPTION
## Motivation

The `storeUri`, `substituters`, and `trustedSubstituters` settings now
store typed `StoreReference` values directly instead of raw strings,
so callers work with the real types without manual parsing.

## Context

This is a reworked version of #10761.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
