### PR TITLE
globals: use `StoreReference` types in CLI argument handlers

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -148,7 +148,7 @@ MixEvalArgs::MixEvalArgs()
           )",
         .category = category,
         .labels = {"store-url"},
-        .handler = {&evalStoreUrl},
+        .handler = {[this](std::string s) { evalStoreUrl = StoreReference::parse(s); }},
     });
 }
 

--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -5,6 +5,7 @@
 #include "nix/util/args.hh"
 #include "nix/cmd/common-eval-args.hh"
 #include "nix/store/path.hh"
+#include "nix/store/store-reference.hh"
 #include "nix/flake/lockfile.hh"
 
 #include <optional>
@@ -92,7 +93,7 @@ private:
  */
 struct CopyCommand : virtual StoreCommand
 {
-    std::string srcUri, dstUri;
+    std::optional<StoreReference> srcUri, dstUri;
 
     CopyCommand();
 

--- a/src/libcmd/include/nix/cmd/common-eval-args.hh
+++ b/src/libcmd/include/nix/cmd/common-eval-args.hh
@@ -6,6 +6,7 @@
 #include "nix/main/common-args.hh"
 #include "nix/expr/search-path.hh"
 #include "nix/expr/eval-settings.hh"
+#include "nix/store/store-reference.hh"
 
 #include <filesystem>
 
@@ -55,7 +56,7 @@ struct MixEvalArgs : virtual Args, virtual MixRepair
 
     LookupPath lookupPath;
 
-    std::optional<std::string> evalStoreUrl;
+    std::optional<StoreReference> evalStoreUrl;
 
 private:
     struct AutoArgExpr

--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -9,6 +9,7 @@
 #include "nix/store/path.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/store-open.hh"
+#include "nix/store/store-reference.hh"
 #include "nix/store/build-result.hh"
 #include "nix/store/local-fs-store.hh"
 #include "nix/util/base-nix-32.hh"
@@ -47,14 +48,14 @@ Store * nix_store_open(nix_c_context * context, const char * uri, const char ***
         if (uri_str.empty())
             return new Store{nix::openStore()};
 
-        if (!params)
-            return new Store{nix::openStore(uri_str)};
+        auto storeRef = nix::StoreReference::parse(uri_str);
 
-        nix::Store::Config::Params params_map;
-        for (size_t i = 0; params[i] != nullptr; i++) {
-            params_map[params[i][0]] = params[i][1];
+        if (params) {
+            for (size_t i = 0; params[i] != nullptr; i++) {
+                storeRef.params[params[i][0]] = params[i][1];
+            }
         }
-        return new Store{nix::openStore(uri_str, params_map)};
+        return new Store{nix::openStore(std::move(storeRef))};
     }
     NIXC_CATCH_ERRS_NULL
 }

--- a/src/libstore/include/nix/store/store-reference.hh
+++ b/src/libstore/include/nix/store/store-reference.hh
@@ -93,6 +93,7 @@ struct StoreReference
     Params params;
 
     bool operator==(const StoreReference & rhs) const = default;
+    auto operator<=>(const StoreReference & rhs) const = default;
 
     /**
      * Render the whole store reference as a URI, optionally including parameters.

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -43,7 +43,7 @@ LocalOverlayStore::LocalOverlayStore(ref<const Config> config)
     , LocalFSStore{*config}
     , LocalStore{static_cast<ref<const LocalStore::Config>>(config)}
     , config{config}
-    , lowerStore(openStore(percentDecode(config->lowerStoreUri.get())).dynamic_pointer_cast<LocalFSStore>())
+    , lowerStore(openStore(config->lowerStoreUri.get()).dynamic_pointer_cast<LocalFSStore>())
 {
     if (config->checkMount.get()) {
         std::smatch match;

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1054,7 +1054,7 @@ struct CmdFlakeClone : FlakeCommand
 
 struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun, MixNoCheckSigs
 {
-    std::string dstUri;
+    std::optional<StoreReference> dstUri;
 
     SubstituteFlag substitute = NoSubstitute;
 
@@ -1064,7 +1064,7 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun, MixNoCheckSigs
             .longName = "to",
             .description = "URI of the destination Nix store",
             .labels = {"store-uri"},
-            .handler = {&dstUri},
+            .handler = {[this](std::string s) { dstUri = StoreReference::parse(s); }},
         });
     }
 
@@ -1124,8 +1124,8 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun, MixNoCheckSigs
             traverse(*flake.lockFile.root);
         }
 
-        if (!dryRun && !dstUri.empty()) {
-            ref<Store> dstStore = dstUri.empty() ? openStore() : openStore(dstUri);
+        if (!dryRun && dstUri) {
+            ref<Store> dstStore = openStore(StoreReference{*dstUri});
 
             copyPaths(*store, *dstStore, sources, NoRepair, checkSigs, substitute);
         }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -245,7 +245,11 @@ static void showHelp(std::vector<std::string> subcommand, NixArgs & toplevel)
 
     evalSettings.restrictEval = true;
     evalSettings.pureEval = true;
-    EvalState state({}, openStore("dummy://"), fetchSettings, evalSettings);
+    EvalState state(
+        {},
+        openStore(StoreReference{.variant = StoreReference::Specified{.scheme = "dummy"}}),
+        fetchSettings,
+        evalSettings);
 
     auto vGenerateManpage = state.allocValue();
     state.eval(
@@ -446,7 +450,11 @@ void mainWrapped(int argc, char ** argv)
             Xp::FetchTree,
         };
         evalSettings.pureEval = false;
-        EvalState state({}, openStore("dummy://"), fetchSettings, evalSettings);
+        EvalState state(
+            {},
+            openStore(StoreReference{.variant = StoreReference::Specified{.scheme = "dummy"}}),
+            fetchSettings,
+            evalSettings);
         auto builtinsJson = nlohmann::json::object();
         for (auto & builtinPtr : state.getBuiltins().attrs()->lexicographicOrder(state.symbols)) {
             auto & builtin = *builtinPtr;

--- a/src/nix/make-content-addressed.cc
+++ b/src/nix/make-content-addressed.cc
@@ -30,7 +30,7 @@ struct CmdMakeContentAddressed : virtual CopyCommand, virtual StorePathsCommand,
 
     void run(ref<Store> srcStore, StorePaths && storePaths) override
     {
-        auto dstStore = dstUri.empty() ? openStore() : openStore(dstUri);
+        auto dstStore = !dstUri ? openStore() : openStore(StoreReference{*dstUri});
 
         auto remappings =
             makeContentAddressed(*srcStore, *dstStore, StorePathSet(storePaths.begin(), storePaths.end()));

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -313,7 +313,7 @@ static void main_nix_build(int argc, char ** argv)
         throw UsageError("'-p' and '-E' are mutually exclusive");
 
     auto store = openStore();
-    auto evalStore = myArgs.evalStoreUrl ? openStore(*myArgs.evalStoreUrl) : store;
+    auto evalStore = myArgs.evalStoreUrl ? openStore(StoreReference{*myArgs.evalStoreUrl}) : store;
 
     auto state = std::make_unique<EvalState>(myArgs.lookupPath, evalStore, fetchSettings, evalSettings, store);
     state->repair = myArgs.repair;

--- a/src/nix/nix-copy-closure/nix-copy-closure.cc
+++ b/src/nix/nix-copy-closure/nix-copy-closure.cc
@@ -48,9 +48,13 @@ static int main_nix_copy_closure(int argc, char ** argv)
         if (sshHost.empty())
             throw UsageError("no host name specified");
 
-        auto remoteUri = "ssh://" + sshHost + (gzip ? "?compress=true" : "");
-        auto to = toMode ? openStore(remoteUri) : openStore();
-        auto from = toMode ? openStore() : openStore(remoteUri);
+        StoreReference remoteRef{
+            .variant = StoreReference::Specified{.scheme = "ssh", .authority = sshHost},
+        };
+        if (gzip)
+            remoteRef.params["compress"] = "true";
+        auto to = toMode ? openStore(StoreReference{remoteRef}) : openStore();
+        auto from = toMode ? openStore() : openStore(StoreReference{remoteRef});
 
         RealisedPath::Set storePaths2;
         for (auto & path : storePaths)

--- a/src/nix/nix-instantiate/nix-instantiate.cc
+++ b/src/nix/nix-instantiate/nix-instantiate.cc
@@ -167,7 +167,7 @@ static int main_nix_instantiate(int argc, char ** argv)
             settings.readOnlyMode = true;
 
         auto store = openStore();
-        auto evalStore = myArgs.evalStoreUrl ? openStore(*myArgs.evalStoreUrl) : store;
+        auto evalStore = myArgs.evalStoreUrl ? openStore(StoreReference{*myArgs.evalStoreUrl}) : store;
 
         auto state = std::make_unique<EvalState>(myArgs.lookupPath, evalStore, fetchSettings, evalSettings, store);
         state->repair = myArgs.repair;

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -11,7 +11,7 @@ using namespace nix;
 
 struct CmdCopySigs : StorePathsCommand
 {
-    Strings substituterUris;
+    std::vector<StoreReference> substituterUris;
 
     CmdCopySigs()
     {
@@ -20,7 +20,7 @@ struct CmdCopySigs : StorePathsCommand
             .shortName = 's',
             .description = "Copy signatures from the specified store.",
             .labels = {"store-uri"},
-            .handler = {[&](std::string s) { substituterUris.push_back(s); }},
+            .handler = {[&](std::string s) { substituterUris.push_back(StoreReference::parse(s)); }},
         });
     }
 
@@ -44,7 +44,7 @@ struct CmdCopySigs : StorePathsCommand
         // FIXME: factor out commonality with MixVerify.
         std::vector<ref<Store>> substituters;
         for (auto & s : substituterUris)
-            substituters.push_back(openStore(s));
+            substituters.push_back(openStore(StoreReference{s}));
 
         ThreadPool pool{fileTransferSettings.httpConnections};
 

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -15,7 +15,7 @@ struct CmdVerify : StorePathsCommand
 {
     bool noContents = false;
     bool noTrust = false;
-    Strings substituterUris;
+    std::vector<StoreReference> substituterUris;
     size_t sigsNeeded = 0;
 
     CmdVerify()
@@ -37,7 +37,7 @@ struct CmdVerify : StorePathsCommand
             .shortName = 's',
             .description = "Use signatures from the specified store.",
             .labels = {"store-uri"},
-            .handler = {[&](std::string s) { substituterUris.push_back(s); }},
+            .handler = {[&](std::string s) { substituterUris.push_back(StoreReference::parse(s)); }},
         });
 
         addFlag({
@@ -65,7 +65,7 @@ struct CmdVerify : StorePathsCommand
     {
         std::vector<ref<Store>> substituters;
         for (auto & s : substituterUris)
-            substituters.push_back(openStore(s));
+            substituters.push_back(openStore(StoreReference{s}));
 
         auto publicKeys = getDefaultPublicKeys();
 


### PR DESCRIPTION
## Motivation

The CLI flags `--from`, `--to`, `--eval-store`, and substituter URIs now
parse to `StoreReference` at the argument boundary. `fetchClosure` uses
`StoreReference::parse` instead of `parseURL`. This also adds
`operator<=>` to `StoreReference`.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
