### PR TITLE
fix: use narHash as fetchToStore cache key in substitution fast path

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -333,7 +333,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
 
             auto accessor = store.requireStoreObjectAccessor(storePath);
 
-            accessor->fingerprint = getFingerprint(store);
+            accessor->fingerprint = getNarHash()->to_string(HashFormat::SRI, true);
 
             // Store a cache entry for the substituted tree so later fetches
             // can reuse the existing nar instead of copying the unpacked

--- a/tests/functional/flakes/cache-poisoning.sh
+++ b/tests/functional/flakes/cache-poisoning.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+source ./common.sh
+TODO_NixOS
+requireGit
+
+clearStore
+rm -rf "$TEST_HOME"/.cache "$TEST_HOME"/.config
+
+# Force all commits to use the same timestamp so that lastModified is
+# identical for both revisions, reproducing the exact NAR hash mismatch
+# error seen in CI (rather than a lastModified mismatch).
+export GIT_COMMITTER_DATE="2000-01-01T00:00:00+0000"
+export GIT_AUTHOR_DATE="2000-01-01T00:00:00+0000"
+
+# Create a git repo to use as a flake input.
+depDir="$TEST_ROOT/dep"
+createGitRepo "$depDir" ""
+cat > "$depDir/flake.nix" <<EOF
+{
+  outputs = { self }: { expr = "rev1"; };
+}
+EOF
+git -C "$depDir" add flake.nix
+git -C "$depDir" commit -m 'rev1'
+
+# Create a consumer flake that depends on it.
+consumerDir="$TEST_ROOT/consumer"
+createGitRepo "$consumerDir" ""
+cat > "$consumerDir/flake.nix" <<EOF
+{
+  inputs.dep.url = "git+file://$depDir";
+  outputs = { self, dep }: { expr = dep.expr; };
+}
+EOF
+git -C "$consumerDir" add flake.nix
+git -C "$consumerDir" commit -m 'Initial'
+
+# Step 1: Lock correctly — populates store with rev1 content.
+nix flake lock "$consumerDir"
+git -C "$consumerDir" add flake.lock
+git -C "$consumerDir" commit -m 'Lock'
+
+# Capture the narHash for rev1.
+oldNarHash=$(jq -r '.nodes.dep.locked.narHash' "$consumerDir/flake.lock")
+
+# Evaluate to ensure rev1 content is in the store and cached.
+[[ $(nix eval "$consumerDir#expr") = '"rev1"' ]]
+
+# Create a new commit in dep (same timestamp → same lastModified).
+cat > "$depDir/flake.nix" <<EOF
+{
+  outputs = { self }: { expr = "rev2"; };
+}
+EOF
+git -C "$depDir" add flake.nix
+git -C "$depDir" commit -m 'rev2'
+rev2=$(git -C "$depDir" rev-parse HEAD)
+
+# Step 2: Compute the correct narHash for rev2 by exporting its git tree
+# to a clean directory (avoiding nix store/cache contamination).
+exportDir="$TEST_ROOT/export"
+rm -rf "$exportDir"
+git -C "$depDir" archive --format=tar HEAD | (mkdir -p "$exportDir" && tar -xf - -C "$exportDir")
+correctNarHash=$(nix hash path --type sha256 --sri "$exportDir")
+
+# Sanity: the correct narHash must differ from the old one.
+[[ "$oldNarHash" != "$correctNarHash" ]]
+
+# Step 3: Manually edit consumer lock to new rev but keep OLD narHash (the bug trigger).
+jq --arg rev "$rev2" '.nodes.dep.locked.rev = $rev' \
+  "$consumerDir/flake.lock" > "$consumerDir/flake.lock.tmp"
+mv "$consumerDir/flake.lock.tmp" "$consumerDir/flake.lock"
+git -C "$consumerDir" add flake.lock
+git -C "$consumerDir" commit -m 'Bad manual edit'
+
+# Step 4: Evaluate with poisoned lock — silently serves old content, poisoning
+# the fetchToStore cache: rev2_fingerprint → old_store_path.
+nix eval "$consumerDir#expr" || true
+
+# Step 5: Construct a correct lock file with rev2 + correct narHash.
+jq --arg rev "$rev2" --arg narHash "$correctNarHash" \
+  '.nodes.dep.locked.rev = $rev | .nodes.dep.locked.narHash = $narHash' \
+  "$consumerDir/flake.lock" > "$consumerDir/flake.lock.tmp"
+mv "$consumerDir/flake.lock.tmp" "$consumerDir/flake.lock"
+git -C "$consumerDir" add flake.lock
+git -C "$consumerDir" commit -m 'Correct lock'
+
+# Step 6: Evaluate with correct lock — MUST NOT fail with narHash mismatch.
+# BUG: Before fix, fails with:
+#   error: NAR hash mismatch in input '...', expected '...' but got '...'
+# because the poisoned fetchToStore cache maps rev2_fingerprint → old_store_path.
+# FIXED: After fix, the fast-path cache key uses narHash (not rev fingerprint),
+# so the poisoned entry is keyed under old_narHash and doesn't collide.
+result=$(nix eval "$consumerDir#expr")
+[[ "$result" = '"rev2"' ]]

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -34,6 +34,7 @@ suites += {
     'source-paths.sh',
     'old-lockfiles.sh',
     'trace-ifd.sh',
+    'cache-poisoning.sh',
   ],
   'workdir' : meson.current_source_dir(),
 }


### PR DESCRIPTION
## Motivation

There's a cache poisoning bug where a stale `narHash` in `flake.lock` (like
after a search&replace or manual edit) can permanently corrupt the fetcher
cache, causing all subsequent evaluations (including nix flake update) to fail
with NAR hash mismatch even after the lock file is corrected.

The only workaround right now is manually deleting
`~/.cache/nix/fetcher-cache-v4.sqlite` or somehow tracking down the exact right
entry.

## Context

Closes: #15198

Related issues (possibly same root cause):
- #6061 with a hash mismatch after GC on local path inputs (commenters confirm deleting `~/.cache/nix` fixes it)
- #6759 with a NAR hash mismatch with nix registry pin (different trigger, but same cache inconsistency mechanism)
- #10146 with a meta-issue about making the fetcher cache more reliable and easier to reason about

In the substitution fast path of `Input::getAccessorUnchecked()`, the
`fetchToStore` cache key uses `getFingerprint(store)` — a rev-based fingerprint for
Git/GitHub/GitLab/SourceHut fetchers. But the store path is derived from `narHash`
via `computeStorePath()`.

When a user manually edits flake.lock to change a rev without updating the
`narHash`, this creates an inconsistent cache entry mapping rev_fingerprint →
wrong_store_path. This entry then poisons all future fetches for that rev,
producing:

```
error: NAR hash mismatch in input 'github:blockfrost/blockfrost-tests/5297592395d1dbd46e88247e459896838c854340?narHash=sha256-4cKMeE/8GptnxWnB6LliJy3gCvjVI34TXTwQHEsHcUA%3D', expected 'sha256-YR+cemfm4AMEJcUEr/tm0cis3rWKQ0dPFbjwhEVrV94=' but got 'sha256-4cKMeE/8GptnxWnB6LliJy3gCvjVI34TXTwQHEsHcUA='
```

The fix changes the fast-path fingerprint from `getFingerprint(store)` (rev-based) to `getNarHash()->to_string(HashFormat::SRI, true)` (narHash-based).
I think this is safe because the fast-path guard (`isFinal() && getNarHash()`) guarantees `narHash` is non-null, and
it makes the cache entry consistent: `narHash → narHash-derived-store-path`.
A stale `narHash` produces a different cache key, so it cannot collide with the
correct one.

The test uses fixed `GIT_COMMITTER_DATE`/`GIT_AUTHOR_DATE` so `lastModified` is
identical across revisions (otherwise a `lastModified` mismatch fires before the
`narHash` one), and computes the correct `narHash` via `git archive` + `nix hash path`
to avoid contaminating the nix store/cache.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
