### PR TITLE
store-config: remove unnecessary `const` from `Setting<>` fields

### DIFF
--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -18,7 +18,7 @@ struct BinaryCacheStoreConfig : virtual StoreConfig
 {
     using StoreConfig::StoreConfig;
 
-    const Setting<CompressionAlgo> compression{
+    Setting<CompressionAlgo> compression{
         this,
         CompressionAlgo::xz,
         "compression",
@@ -27,10 +27,10 @@ struct BinaryCacheStoreConfig : virtual StoreConfig
           To use a particular compression method Nix has to be built with a version of libarchive that natively supports that compression algorithm.
         )"};
 
-    const Setting<bool> writeNARListing{
+    Setting<bool> writeNARListing{
         this, false, "write-nar-listing", "Whether to write a JSON file that lists the files in each NAR."};
 
-    const Setting<bool> writeDebugInfo{
+    Setting<bool> writeDebugInfo{
         this,
         false,
         "index-debug-info",
@@ -39,24 +39,24 @@ struct BinaryCacheStoreConfig : virtual StoreConfig
           fetch debug info on demand
         )"};
 
-    const Setting<Path> secretKeyFile{this, "", "secret-key", "Path to the secret key used to sign the binary cache."};
+    Setting<Path> secretKeyFile{this, "", "secret-key", "Path to the secret key used to sign the binary cache."};
 
-    const Setting<std::string> secretKeyFiles{
+    Setting<std::string> secretKeyFiles{
         this, "", "secret-keys", "List of comma-separated paths to the secret keys used to sign the binary cache."};
 
-    const Setting<std::optional<std::filesystem::path>> localNarCache{
+    Setting<std::optional<std::filesystem::path>> localNarCache{
         this,
         std::nullopt,
         "local-nar-cache",
         "Path to a local cache of NARs fetched from this binary cache, used by commands such as `nix store cat`."};
 
-    const Setting<bool> parallelCompression{
+    Setting<bool> parallelCompression{
         this,
         false,
         "parallel-compression",
         "Enable multi-threaded compression of NARs. This is currently only available for `xz` and `zstd`."};
 
-    const Setting<int> compressionLevel{
+    Setting<int> compressionLevel{
         this,
         -1,
         "compression-level",

--- a/src/libstore/include/nix/store/common-ssh-store-config.hh
+++ b/src/libstore/include/nix/store/common-ssh-store-config.hh
@@ -15,15 +15,15 @@ struct CommonSSHStoreConfig : virtual StoreConfig
     CommonSSHStoreConfig(std::string_view scheme, const ParsedURL::Authority & authority, const Params & params);
     CommonSSHStoreConfig(std::string_view scheme, std::string_view authority, const Params & params);
 
-    const Setting<Path> sshKey{
+    Setting<Path> sshKey{
         this, "", "ssh-key", "Path to the SSH private key used to authenticate to the remote machine."};
 
-    const Setting<std::string> sshPublicHostKey{
+    Setting<std::string> sshPublicHostKey{
         this, "", "base64-ssh-public-host-key", "The public host key of the remote machine."};
 
-    const Setting<bool> compress{this, false, "compress", "Whether to enable SSH compression."};
+    Setting<bool> compress{this, false, "compress", "Whether to enable SSH compression."};
 
-    const Setting<std::string> remoteStore{
+    Setting<std::string> remoteStore{
         this,
         "",
         "remote-store",

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -21,13 +21,13 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
 
     ParsedURL cacheUri;
 
-    const Setting<std::optional<CompressionAlgo>> narinfoCompression{
+    Setting<std::optional<CompressionAlgo>> narinfoCompression{
         this, std::nullopt, "narinfo-compression", "Compression method for `.narinfo` files."};
 
-    const Setting<std::optional<CompressionAlgo>> lsCompression{
+    Setting<std::optional<CompressionAlgo>> lsCompression{
         this, std::nullopt, "ls-compression", "Compression method for `.ls` files."};
 
-    const Setting<std::optional<CompressionAlgo>> logCompression{
+    Setting<std::optional<CompressionAlgo>> logCompression{
         this,
         std::nullopt,
         "log-compression",
@@ -37,10 +37,10 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
           (e.g. `brotli`).
         )"};
 
-    const Setting<std::optional<std::filesystem::path>> tlsCert{
+    Setting<std::optional<std::filesystem::path>> tlsCert{
         this, std::nullopt, "tls-certificate", "Path to an optional TLS client certificate in PEM format."};
 
-    const Setting<std::optional<std::filesystem::path>> tlsKey{
+    Setting<std::optional<std::filesystem::path>> tlsKey{
         this, std::nullopt, "tls-private-key", "Path to an optional TLS client certificate private key in PEM format."};
 
     static const std::string name()

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -20,15 +20,15 @@ struct LegacySSHStoreConfig : std::enable_shared_from_this<LegacySSHStoreConfig>
     // Hack for getting remote build log output.
     // Intentionally not in `LegacySSHStoreConfig` so that it doesn't appear in
     // the documentation
-    const Setting<int> logFD{this, INVALID_DESCRIPTOR, "log-fd", "file descriptor to which SSH's stderr is connected"};
+    Setting<int> logFD{this, INVALID_DESCRIPTOR, "log-fd", "file descriptor to which SSH's stderr is connected"};
 #else
     Descriptor logFD = INVALID_DESCRIPTOR;
 #endif
 
-    const Setting<Strings> remoteProgram{
+    Setting<Strings> remoteProgram{
         this, {"nix-store"}, "remote-program", "Path to the `nix-store` executable on the remote machine."};
 
-    const Setting<int> maxConnections{this, 1, "max-connections", "Maximum number of concurrent SSH connections."};
+    Setting<int> maxConnections{this, 1, "max-connections", "Maximum number of concurrent SSH connections."};
 
     /**
      * Hack for hydra

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -19,7 +19,7 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
     {
     }
 
-    const Setting<std::string> lowerStoreUri{
+    Setting<std::string> lowerStoreUri{
         (StoreConfig *) this,
         "",
         "lower-store",
@@ -31,7 +31,7 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
           Must be used as OverlayFS lower layer for this store's store dir.
         )"};
 
-    const PathSetting upperLayer{
+    PathSetting upperLayer{
         (StoreConfig *) this,
         "",
         "upper-layer",
@@ -53,7 +53,7 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
           default, but can be disabled if needed.
         )"};
 
-    const PathSetting remountHook{
+    PathSetting remountHook{
         (StoreConfig *) this,
         "",
         "remount-hook",

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -25,10 +25,10 @@ struct RemoteStoreConfig : virtual StoreConfig
 {
     using StoreConfig::StoreConfig;
 
-    const Setting<int> maxConnections{
+    Setting<int> maxConnections{
         this, 1, "max-connections", "Maximum number of concurrent connections to the Nix daemon."};
 
-    const Setting<unsigned int> maxConnectionAge{
+    Setting<unsigned int> maxConnectionAge{
         this,
         std::numeric_limits<unsigned int>::max(),
         "max-connection-age",

--- a/src/libstore/include/nix/store/s3-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/s3-binary-cache-store.hh
@@ -12,7 +12,7 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
 
     S3BinaryCacheStoreConfig(std::string_view uriScheme, std::string_view bucketName, const Params & params);
 
-    const Setting<std::string> profile{
+    Setting<std::string> profile{
         this,
         "default",
         "profile",
@@ -21,7 +21,7 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
           Nix uses the `default` profile.
         )"};
 
-    const Setting<std::string> region{
+    Setting<std::string> region{
         this,
         "us-east-1",
         "region",
@@ -31,7 +31,7 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
           parameter.
         )"};
 
-    const Setting<std::string> scheme{
+    Setting<std::string> scheme{
         this,
         "https",
         "scheme",
@@ -46,7 +46,7 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
           > information.
         )"};
 
-    const Setting<std::string> endpoint{
+    Setting<std::string> endpoint{
         this,
         "",
         "endpoint",
@@ -61,7 +61,7 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
           > addressing instead of virtual host based addressing.
         )"};
 
-    const Setting<bool> multipartUpload{
+    Setting<bool> multipartUpload{
         this,
         false,
         "multipart-upload",
@@ -72,7 +72,7 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
           can improve performance and reliability for large uploads.
         )"};
 
-    const Setting<uint64_t> multipartChunkSize{
+    Setting<uint64_t> multipartChunkSize{
         this,
         5 * 1024 * 1024,
         "multipart-chunk-size",
@@ -83,7 +83,7 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
         )",
         {"buffer-size"}};
 
-    const Setting<uint64_t> multipartThreshold{
+    Setting<uint64_t> multipartThreshold{
         this,
         100 * 1024 * 1024,
         "multipart-threshold",
@@ -93,7 +93,7 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
           Default is 100 MiB. Only takes effect when multipart-upload is enabled.
         )"};
 
-    const Setting<std::optional<std::string>> storageClass{
+    Setting<std::optional<std::string>> storageClass{
         this,
         std::nullopt,
         "storage-class",

--- a/src/libstore/include/nix/store/ssh-store.hh
+++ b/src/libstore/include/nix/store/ssh-store.hh
@@ -17,7 +17,7 @@ struct SSHStoreConfig : std::enable_shared_from_this<SSHStoreConfig>,
 
     SSHStoreConfig(std::string_view scheme, std::string_view authority, const Params & params);
 
-    const Setting<Strings> remoteProgram{
+    Setting<Strings> remoteProgram{
         this, {"nix-daemon"}, "remote-program", "Path to the `nix-daemon` executable on the remote machine."};
 
     static const std::string name()


### PR DESCRIPTION
## Motivation

Stores hold their config as `ref<const Config>` or `const Config &`, so `Setting<>` fields are already immutable after store construction. The field-level `const` is redundant and prevents pre-construction mutation which is sometimes useful. This commit updates these settings by dropping the `const` qualifier, as it's not needed.

## Context

Needed to improve https://github.com/NixOS/nix/pull/15197#discussion_r2793393107

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
