### PR TITLE
Deduplicate `nix repl` and `nix log`

### DIFF
--- a/src/libcmd/get-build-log.cc
+++ b/src/libcmd/get-build-log.cc
@@ -1,0 +1,31 @@
+#include "nix/cmd/get-build-log.hh"
+#include "nix/store/log-store.hh"
+#include "nix/store/store-open.hh"
+
+namespace nix {
+
+std::string fetchBuildLog(ref<Store> store, const StorePath & path, std::string_view what)
+{
+    auto subs = getDefaultSubstituters();
+
+    subs.push_front(store);
+
+    for (auto & sub : subs) {
+        auto * logSubP = dynamic_cast<LogStore *>(&*sub);
+        if (!logSubP) {
+            printInfo("Skipped '%s' which does not support retrieving build logs", sub->config.getHumanReadableURI());
+            continue;
+        }
+        auto & logSub = *logSubP;
+
+        auto log = logSub.getBuildLog(path);
+        if (!log)
+            continue;
+        printInfo("got build log for '%s' from '%s'", what, logSub.config.getHumanReadableURI());
+        return *log;
+    }
+
+    throw Error("build log of '%s' is not available", what);
+}
+
+} // namespace nix

--- a/src/libcmd/include/nix/cmd/get-build-log.hh
+++ b/src/libcmd/include/nix/cmd/get-build-log.hh
@@ -1,0 +1,23 @@
+#pragma once
+///@file
+
+#include "nix/store/store-api.hh"
+
+#include <string>
+#include <string_view>
+
+namespace nix {
+
+/**
+ * Fetch the build log for a store path, searching the store and its
+ * substituters.
+ *
+ * @param store The store to search (and its substituters).
+ * @param path The store path to get the build log for.
+ * @param what A description of what we're fetching the log for (used in messages).
+ * @return The build log content.
+ * @throws Error if the build log is not available.
+ */
+std::string fetchBuildLog(ref<Store> store, const StorePath & path, std::string_view what);
+
+} // namespace nix

--- a/src/libcmd/include/nix/cmd/meson.build
+++ b/src/libcmd/include/nix/cmd/meson.build
@@ -9,6 +9,7 @@ headers = files(
   'common-eval-args.hh',
   'compatibility-settings.hh',
   'editor-for.hh',
+  'get-build-log.hh',
   'installable-attr-path.hh',
   'installable-derived-path.hh',
   'installable-flake.hh',

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -74,6 +74,7 @@ sources = files(
   'command.cc',
   'common-eval-args.cc',
   'editor-for.cc',
+  'get-build-log.cc',
   'installable-attr-path.cc',
   'installable-derived-path.cc',
   'installable-flake.cc',


### PR DESCRIPTION
## Motivation

Deduplicating is good.

## Context

The underlying mechanism is now in a new `fetchBuildLog` function I put in `libcmd`.

I am putting it in here and not in libstore because I have some doubts about `getDefaultSubstituters`, so I would like to keep it in a more "peripheral" part of the codebase for now.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
