### PR TITLE
Add BLAKE3-based hardlink farm at .links-b3

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -695,11 +695,12 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                unreachable. We don't use readDirectory() here so that
                GCing can start faster. */
             auto linksName = baseNameOf(linksDir);
+            auto linksNameB3 = baseNameOf(linksDirB3);
             struct dirent * dirent;
             while (errno = 0, dirent = readdir(dir.get())) {
                 checkInterrupt();
                 std::string name = dirent->d_name;
-                if (name == "." || name == ".." || name == linksName)
+                if (name == "." || name == ".." || name == linksName || name == linksNameB3)
                     continue;
 
                 if (auto storePath = maybeParseStorePath(storeDir + "/" + name))
@@ -723,52 +724,67 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
         return;
     }
 
-    /* Unlink all files in /nix/store/.links that have a link count of 1,
-       which indicates that there are no other links and so they can be
-       safely deleted.  FIXME: race condition with optimisePath(): we
-       might see a link count of 1 just before optimisePath() increases
-       the link count. */
+    /* Unlink all files in /nix/store/.links (and .links-b3) that have a
+       link count of 1, which indicates that there are no other links
+       and so they can be safely deleted.  FIXME: race condition with
+       optimisePath(): we might see a link count of 1 just before
+       optimisePath() increases the link count. */
     if (options.action == GCOptions::gcDeleteDead || options.action == GCOptions::gcDeleteSpecific) {
         printInfo("deleting unused links...");
 
-        AutoCloseDir dir(opendir(linksDir.c_str()));
-        if (!dir)
-            throw SysError("opening directory '%1%'", linksDir);
-
         int64_t actualSize = 0, unsharedSize = 0;
 
-        struct dirent * dirent;
-        while (errno = 0, dirent = readdir(dir.get())) {
-            checkInterrupt();
-            std::string name = dirent->d_name;
-            if (name == "." || name == "..")
-                continue;
-            Path path = linksDir + "/" + name;
-
-            auto st = lstat(path);
-
-            if (st.st_nlink != 1) {
-                actualSize += st.st_size;
-                unsharedSize += (st.st_nlink - 1) * st.st_size;
-                continue;
+        auto cleanLinks = [&](const Path & dir) {
+            AutoCloseDir d(opendir(dir.c_str()));
+            if (!d) {
+                if (errno == ENOENT)
+                    return;
+                throw SysError("opening directory '%1%'", dir);
             }
 
-            printMsg(lvlTalkative, "deleting unused link '%1%'", path);
+            struct dirent * dirent;
+            while (errno = 0, dirent = readdir(d.get())) {
+                checkInterrupt();
+                std::string name = dirent->d_name;
+                if (name == "." || name == "..")
+                    continue;
+                Path path = dir + "/" + name;
 
-            if (unlink(path.c_str()) == -1)
-                throw SysError("deleting '%1%'", path);
+                auto st = lstat(path);
 
-            /* Do not account for deleted file here. Rely on deletePath()
-               accounting.  */
-        }
+                if (st.st_nlink != 1) {
+                    actualSize += st.st_size;
+                    unsharedSize += (st.st_nlink - 1) * st.st_size;
+                    continue;
+                }
+
+                printMsg(lvlTalkative, "deleting unused link '%1%'", path);
+
+                if (unlink(path.c_str()) == -1)
+                    throw SysError("deleting '%1%'", path);
+
+                /* Do not account for deleted file here. Rely on deletePath()
+                   accounting.  */
+            }
+        };
+
+        cleanLinks(linksDir);
+        cleanLinks(linksDirB3);
 
         int64_t overhead =
 #ifdef _WIN32
             0
 #else
             [&] {
-                auto st = stat(linksDir);
-                return st.st_blocks * 512ULL;
+                int64_t total = 0;
+                auto addOverhead = [&](const Path & dir) {
+                    auto st = maybeStat(dir);
+                    if (st)
+                        total += st->st_blocks * 512ULL;
+                };
+                addOverhead(linksDir);
+                addOverhead(linksDirB3);
+                return total;
             }()
 #endif
             ;

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -11,9 +11,49 @@
 #include <chrono>
 #include <future>
 #include <string>
+#include <sys/stat.h>
 #include <boost/unordered/unordered_flat_set.hpp>
 
 namespace nix {
+
+/**
+ * Mode bits encoded by .links-b3 link name suffixes.
+ *
+ *   'r' = regular file (not executable)
+ *   'x' = regular file (executable)
+ *   's' = symlink
+ */
+constexpr mode_t linkModeMask = S_IFMT | S_IXUSR;
+
+constexpr mode_t linkModeR = S_IFREG;
+constexpr mode_t linkModeX = S_IFREG | S_IXUSR;
+constexpr mode_t linkModeS = S_IFLNK | S_IXUSR;
+
+inline char linkModeSuffix(mode_t mode)
+{
+    auto m = mode & linkModeMask;
+    if (m == linkModeR)
+        return 'r';
+    if (m == linkModeX)
+        return 'x';
+    if (m == linkModeS)
+        return 's';
+    throw Error("unexpected mode 0%o for .links-b3 entry", mode);
+}
+
+inline mode_t linkSuffixMode(char suffix)
+{
+    switch (suffix) {
+    case 'r':
+        return linkModeR;
+    case 'x':
+        return linkModeX;
+    case 's':
+        return linkModeS;
+    default:
+        throw Error("invalid .links-b3 suffix '%c'", suffix);
+    }
+}
 
 /**
  * Nix store and database schema version.
@@ -207,6 +247,7 @@ public:
 
     const Path dbDir;
     const Path linksDir;
+    const Path linksDirB3;
     const Path reservedPath;
     const Path schemaPath;
     const Path tempRootsDir;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -121,6 +121,7 @@ LocalStore::LocalStore(ref<const Config> config)
     , _state(make_ref<Sync<State>>())
     , dbDir(config->stateDir + "/db")
     , linksDir(config->realStoreDir + "/.links")
+    , linksDirB3(config->realStoreDir + "/.links-b3")
     , reservedPath(dbDir + "/reserved")
     , schemaPath(dbDir + "/schema")
     , tempRootsDir(config->stateDir + "/temproots")
@@ -137,6 +138,8 @@ LocalStore::LocalStore(ref<const Config> config)
         makeStoreWritable();
     }
     createDirs(linksDir);
+    if (experimentalFeatureSettings.isEnabled(Xp::BLAKE3Links))
+        createDirs(linksDirB3);
     Path profilesDir = config->stateDir + "/profiles";
     createDirs(profilesDir);
     createDirs(tempRootsDir);
@@ -1338,6 +1341,59 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
                 } else {
                     errors = true;
                 }
+            }
+        }
+
+        if (experimentalFeatureSettings.isEnabled(Xp::BLAKE3Links) && pathExists(linksDirB3)) {
+            for (auto & link : DirectoryIterator{linksDirB3}) {
+                checkInterrupt();
+                auto name = link.path().filename().string();
+                printMsg(lvlTalkative, "checking contents of %s", PathFmt(name));
+
+                auto corrupt = [&](const std::string & msg) {
+                    printError(msg);
+                    if (repair) {
+                        std::filesystem::remove(link.path());
+                        printInfo("removed link %s", PathFmt(link.path()));
+                    } else {
+                        errors = true;
+                    }
+                };
+
+                if (name.size() < 2 || name[name.size() - 2] != '-') {
+                    corrupt(fmt("link %s has invalid name (missing type suffix)", PathFmt(link.path())));
+                    continue;
+                }
+
+                char suffix = name.back();
+
+                mode_t expectedMode;
+                try {
+                    expectedMode = linkSuffixMode(suffix);
+                } catch (Error &) {
+                    corrupt(fmt("link %s has invalid type suffix '%c'", PathFmt(link.path()), suffix));
+                    continue;
+                }
+
+                auto st = lstat(link.path());
+                if ((st.st_mode & linkModeMask) != expectedMode) {
+                    corrupt(
+                        fmt("link %s has suffix '%c' but mode 0%o does not match expected 0%o",
+                            PathFmt(link.path()),
+                            suffix,
+                            st.st_mode & linkModeMask,
+                            expectedMode));
+                    continue;
+                }
+
+                auto expectedHash = name.substr(0, name.size() - 2);
+                Hash contentHash = (st.st_mode & S_IFMT) == S_IFLNK
+                                       ? hashString(HashAlgorithm::BLAKE3, readLink(link.path()).string())
+                                       : hashFile(HashAlgorithm::BLAKE3, link.path());
+                std::string hash = contentHash.to_string(HashFormat::Nix32, false);
+                if (hash != expectedHash)
+                    corrupt(fmt(
+                        "link %s was modified! expected hash %s, got '%s'", PathFmt(link.path()), expectedHash, hash));
             }
         }
 

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -25,7 +25,7 @@ struct ExperimentalFeatureDetails
  * feature, we either have no issue at all if few features are not added
  * at the end of the list, or a proper merge conflict if they are.
  */
-constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::BLAKE3Hashes);
+constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::BLAKE3Links);
 
 constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails = {{
     {
@@ -318,6 +318,16 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .name = "blake3-hashes",
         .description = R"(
             Enables support for BLAKE3 hashes.
+        )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/60",
+    },
+    {
+        .tag = Xp::BLAKE3Links,
+        .name = "blake3-links",
+        .description = R"(
+            Use BLAKE3 hashes for the store hardlink farm (`.links-b3`),
+            replacing the default SHA-256-based `.links` directory used
+            by `nix-store --optimise`.
         )",
         .trackingUrl = "https://github.com/NixOS/nix/milestone/60",
     },

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -30,7 +30,8 @@ const StringSet hashFormats = {"base64", "nix32", "base16", "sri"};
 Hash::Hash(HashAlgorithm algo, const ExperimentalFeatureSettings & xpSettings)
     : algo(algo)
 {
-    if (algo == HashAlgorithm::BLAKE3) {
+    if (algo == HashAlgorithm::BLAKE3 && !xpSettings.isEnabled(Xp::BLAKE3Hashes)
+        && !xpSettings.isEnabled(Xp::BLAKE3Links)) {
         xpSettings.require(Xp::BLAKE3Hashes);
     }
     hashSize = regularHashSize(algo);

--- a/src/libutil/include/nix/util/experimental-features.hh
+++ b/src/libutil/include/nix/util/experimental-features.hh
@@ -39,6 +39,7 @@ enum struct ExperimentalFeature {
     PipeOperators,
     ExternalBuilders,
     BLAKE3Hashes,
+    BLAKE3Links,
 };
 
 /**

--- a/tests/functional/optimise-store.sh
+++ b/tests/functional/optimise-store.sh
@@ -50,3 +50,95 @@ if [ -n "$(ls "$NIX_STORE_DIR"/.links)" ]; then
     echo ".links directory not empty after GC"
     exit 1
 fi
+
+if [ -d "$NIX_STORE_DIR"/.links-b3 ] && [ -n "$(ls "$NIX_STORE_DIR"/.links-b3)" ]; then
+    echo ".links-b3 directory not empty after GC"
+    exit 1
+fi
+
+# Test BLAKE3-based deduplication
+clearStoreIfPossible
+
+export NIX_CONFIG="extra-experimental-features = blake3-links"
+
+# Build two derivations with identical regular files, an executable, and a symlink
+# shellcheck disable=SC2016
+outPath1b3=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo1"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo; cp $out/foo $out/bar; chmod +x $out/bar; ln -s foo $out/lnk"; }' | nix-build - --no-out-link)
+# shellcheck disable=SC2016
+outPath2b3=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo2"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo; cp $out/foo $out/bar; chmod +x $out/bar; ln -s foo $out/lnk"; }' | nix-build - --no-out-link)
+
+NIX_REMOTE="" nix-store --optimise
+
+# Regular files should be deduplicated
+inode1b3="$(stat --format=%i "$outPath1b3"/foo)"
+inode2b3="$(stat --format=%i "$outPath2b3"/foo)"
+if [ "$inode1b3" != "$inode2b3" ]; then
+    echo "regular file inodes do not match after blake3 optimise"
+    exit 1
+fi
+
+# Executable files should be deduplicated separately
+inode1b3x="$(stat --format=%i "$outPath1b3"/bar)"
+inode2b3x="$(stat --format=%i "$outPath2b3"/bar)"
+if [ "$inode1b3x" != "$inode2b3x" ]; then
+    echo "executable file inodes do not match after blake3 optimise"
+    exit 1
+fi
+
+# Regular and executable should NOT be linked together (same content, different type)
+if [ "$inode1b3" = "$inode1b3x" ]; then
+    echo "regular and executable files should not share inodes"
+    exit 1
+fi
+
+if [ ! -d "$NIX_STORE_DIR"/.links-b3 ]; then
+    echo ".links-b3 directory was not created"
+    exit 1
+fi
+
+# Check that link names have the correct suffixes
+regularLinks=$(find "$NIX_STORE_DIR"/.links-b3/ -name '*-r' | wc -l)
+executableLinks=$(find "$NIX_STORE_DIR"/.links-b3/ -name '*-x' | wc -l)
+if [ "$regularLinks" -eq 0 ]; then
+    echo "no -r suffixed links found"
+    exit 1
+fi
+if [ "$executableLinks" -eq 0 ]; then
+    echo "no -x suffixed links found"
+    exit 1
+fi
+
+# Probe whether the filesystem supports hardlinking symlinks
+probe_dir="$TEST_ROOT/link-probe"
+mkdir -p "$probe_dir"
+touch "$probe_dir/regular"
+ln "$probe_dir/regular" "$probe_dir/hardlink" || { echo "hardlinks do not work at all"; exit 1; }
+ln -s target "$probe_dir/symlink"
+if ln "$probe_dir/symlink" "$probe_dir/symlink-hardlink" 2>/dev/null; then
+    can_link_symlink=1
+else
+    can_link_symlink=0
+fi
+rm -rf "$probe_dir"
+
+if [ "$can_link_symlink" = "1" ]; then
+    inode1b3s="$(stat --format=%i "$outPath1b3"/lnk)"
+    inode2b3s="$(stat --format=%i "$outPath2b3"/lnk)"
+    if [ "$inode1b3s" != "$inode2b3s" ]; then
+        echo "symlink inodes do not match after blake3 optimise"
+        exit 1
+    fi
+
+    symlinkLinks=$(find "$NIX_STORE_DIR"/.links-b3/ -name '*-s' | wc -l)
+    if [ "$symlinkLinks" -eq 0 ]; then
+        echo "no -s suffixed links found"
+        exit 1
+    fi
+fi
+
+nix-store --gc
+
+if [ -n "$(ls "$NIX_STORE_DIR"/.links-b3)" ]; then
+    echo ".links-b3 directory not empty after GC"
+    exit 1
+fi


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Faster store optimisation, and paving a path for closer integration with BLAKE3 castore.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Gated behind a new `blake3-links` experimental feature.

When enabled, `nix-store --optimise` deduplicates using BLAKE3 flat content hashes stored in `.links-b3/` with type suffixes (-r/-x/-s) encoding file mode bits. Either `blake3-links` or `blake3-hashes` suffices to enable BLAKE3 hash construction.

Shared mode constants and helpers (linkModeMask, linkModeSuffix, linkSuffixMode) live in local-store.hh for use by both optimise-store and verifyStore.

GC and verifyStore handle both `.links` and `.links-b3` directories.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
