### PR TITLE
libstore: make `FileTransfer` injectable into `HttpBinaryCacheStore`

### DIFF
--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -12,13 +12,14 @@
 #include "nix/util/url.hh"
 
 #include "nix/store/config.hh"
-#include "nix/store/globals.hh"
 #if NIX_WITH_AWS_AUTH
 #  include "nix/store/aws-creds.hh"
 #endif
 #include "nix/store/s3-url.hh"
 
 namespace nix {
+
+const std::filesystem::path & nixConfDir();
 
 struct FileTransferSettings : Config
 {
@@ -401,7 +402,7 @@ ref<FileTransfer> getFileTransfer();
  *
  * Prefer getFileTransfer() to this; see its docs for why.
  */
-ref<FileTransfer> makeFileTransfer();
+ref<FileTransfer> makeFileTransfer(const FileTransferSettings & settings = fileTransferSettings);
 
 class FileTransferError : public Error
 {

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -52,6 +52,8 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
 
     static std::string doc();
 
+    ref<Store> openStore(ref<FileTransfer> fileTransfer) const;
+
     ref<Store> openStore() const override;
 
     StoreReference getReference() const override;
@@ -67,13 +69,17 @@ class HttpBinaryCacheStore : public virtual BinaryCacheStore
 
     Sync<State> _state;
 
+protected:
+
+    ref<FileTransfer> fileTransfer;
+
 public:
 
     using Config = HttpBinaryCacheStoreConfig;
 
     ref<Config> config;
 
-    HttpBinaryCacheStore(ref<Config> config);
+    HttpBinaryCacheStore(ref<Config> config, ref<FileTransfer> fileTransfer = getFileTransfer());
 
     void init() override;
 


### PR DESCRIPTION
## Motivation

This commit makes `FileTransfer` self-contained by giving it a reference to `FileTransferSettings` instead of reading from the global. It also adds an optional `FileTransfer` parameter to `HttpBinaryCacheStore` so callers can inject their own instance.

The main motivation is test isolation. The HTTPS store tests now create custom `FileTransferSettings` with the test CA certificate and pass it through `makeFileTransfer()`, avoiding global state mutation entirely.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
