### PR TITLE
libstore: add `HttpBinaryCacheStoreConfig` constructor that takes a ` ParsedURL`

### DIFF
--- a/src/libstore-test-support/https-store.cc
+++ b/src/libstore-test-support/https-store.cc
@@ -121,7 +121,15 @@ std::vector<std::string> HttpsBinaryCacheStoreMtlsTest::serverArgs()
 ref<TestHttpBinaryCacheStoreConfig> HttpsBinaryCacheStoreTest::makeConfig()
 {
     auto res = make_ref<TestHttpBinaryCacheStoreConfig>(
-        "https", fmt("localhost:%d", port), TestHttpBinaryCacheStoreConfig::Params{});
+        ParsedURL{
+            .scheme = "https",
+            .authority =
+                ParsedURL::Authority{
+                    .host = "localhost",
+                    .port = port,
+                },
+        },
+        TestHttpBinaryCacheStoreConfig::Params{});
     res->pathInfoCacheSize = 0; /* We don't want any caching in tests. */
     return res;
 }

--- a/src/libstore-test-support/include/nix/store/tests/https-store.hh
+++ b/src/libstore-test-support/include/nix/store/tests/https-store.hh
@@ -42,10 +42,9 @@ public:
 class TestHttpBinaryCacheStoreConfig : public HttpBinaryCacheStoreConfig
 {
 public:
-    TestHttpBinaryCacheStoreConfig(
-        std::string_view scheme, std::string_view cacheUri, const Store::Config::Params & params)
+    TestHttpBinaryCacheStoreConfig(ParsedURL url, const Store::Config::Params & params)
         : StoreConfig(params)
-        , HttpBinaryCacheStoreConfig(scheme, cacheUri, params)
+        , HttpBinaryCacheStoreConfig(url, params)
     {
     }
 

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -20,12 +20,20 @@ StringSet HttpBinaryCacheStoreConfig::uriSchemes()
 
 HttpBinaryCacheStoreConfig::HttpBinaryCacheStoreConfig(
     std::string_view scheme, std::string_view _cacheUri, const Params & params)
+    : HttpBinaryCacheStoreConfig(
+          parseURL(
+              std::string{scheme} + "://"
+              + (!_cacheUri.empty()
+                     ? _cacheUri
+                     : throw UsageError("`%s` Store requires a non-empty authority in Store URL", scheme))),
+          params)
+{
+}
+
+HttpBinaryCacheStoreConfig::HttpBinaryCacheStoreConfig(ParsedURL _cacheUri, const Params & params)
     : StoreConfig(params)
     , BinaryCacheStoreConfig(params)
-    , cacheUri(parseURL(
-          std::string{scheme} + "://"
-          + (!_cacheUri.empty() ? _cacheUri
-                                : throw UsageError("`%s` Store requires a non-empty authority in Store URL", scheme))))
+    , cacheUri(std::move(_cacheUri))
 {
     while (!cacheUri.path.empty() && cacheUri.path.back() == "")
         cacheUri.path.pop_back();

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -19,6 +19,8 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
     HttpBinaryCacheStoreConfig(
         std::string_view scheme, std::string_view cacheUri, const Store::Config::Params & params);
 
+    HttpBinaryCacheStoreConfig(ParsedURL cacheUri, const Store::Config::Params & params);
+
     ParsedURL cacheUri;
 
     Setting<std::optional<CompressionAlgo>> narinfoCompression{


### PR DESCRIPTION
## Motivation

In the https-store tests, a `TestHttpBinaryCacheStoreConfig` is constructed with a call to format to create the cache uri. This commit adds a constructor to `HttpBinaryCacheStoreConfig` to remove the need for this call, and updates the test type to leverage this so we're no longer manually calling fmt on a string to format the port.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
