### PR TITLE
Decouple base `Store` from `NarInfoDiskCache` 

### DIFF
--- a/src/libstore-test-support/include/nix/store/tests/https-store.hh
+++ b/src/libstore-test-support/include/nix/store/tests/https-store.hh
@@ -14,43 +14,6 @@
 
 namespace nix::testing {
 
-class TestHttpBinaryCacheStoreConfig;
-
-/**
- * Test shim for testing. We don't want to use the on-disk narinfo cache in unit
- * tests.
- */
-class TestHttpBinaryCacheStore : public HttpBinaryCacheStore
-{
-public:
-    TestHttpBinaryCacheStore(const TestHttpBinaryCacheStore &) = delete;
-    TestHttpBinaryCacheStore(TestHttpBinaryCacheStore &&) = delete;
-    TestHttpBinaryCacheStore & operator=(const TestHttpBinaryCacheStore &) = delete;
-    TestHttpBinaryCacheStore & operator=(TestHttpBinaryCacheStore &&) = delete;
-
-    TestHttpBinaryCacheStore(ref<HttpBinaryCacheStoreConfig> config, ref<FileTransfer> fileTransfer)
-        : Store{*config}
-        , BinaryCacheStore{*config}
-        , HttpBinaryCacheStore(config, fileTransfer)
-    {
-        diskCache = nullptr; /* Disable caching, we'll be creating a new binary cache for each test. */
-    }
-
-    void init() override;
-};
-
-class TestHttpBinaryCacheStoreConfig : public HttpBinaryCacheStoreConfig
-{
-public:
-    TestHttpBinaryCacheStoreConfig(ParsedURL url, const Store::Config::Params & params)
-        : StoreConfig(params)
-        , HttpBinaryCacheStoreConfig(url, params)
-    {
-    }
-
-    ref<TestHttpBinaryCacheStore> openTestStore(ref<FileTransfer> fileTransfer) const;
-};
-
 class HttpsBinaryCacheStoreTest : public virtual LibStoreNetworkTest
 {
     std::unique_ptr<AutoDelete> delTmpDir;
@@ -86,8 +49,8 @@ protected:
     void TearDown() override;
 
     virtual std::vector<std::string> serverArgs();
-    ref<TestHttpBinaryCacheStoreConfig> makeConfig();
-    ref<TestHttpBinaryCacheStore> openStore(ref<TestHttpBinaryCacheStoreConfig> config);
+    ref<HttpBinaryCacheStore::Config> makeConfig();
+    ref<HttpBinaryCacheStore> openStore(ref<HttpBinaryCacheStore::Config> config);
 };
 
 class HttpsBinaryCacheStoreMtlsTest : public HttpsBinaryCacheStoreTest

--- a/src/libstore/disk-cached-binary-cache-store.cc
+++ b/src/libstore/disk-cached-binary-cache-store.cc
@@ -1,0 +1,171 @@
+#include "nix/store/disk-cached-binary-cache-store.hh"
+#include "nix/util/logging.hh"
+#include "nix/util/callback.hh"
+
+namespace nix {
+
+DiskCachedBinaryCacheStore::DiskCachedBinaryCacheStore(ref<BinaryCacheStore> inner, ref<NarInfoDiskCache> diskCache)
+    : Store{inner->config}
+    , BinaryCacheStore{inner->config}
+    , inner{inner}
+    , diskCache{diskCache}
+{
+}
+
+std::string DiskCachedBinaryCacheStore::cacheUri()
+{
+    return inner->config.getReference().render(/*withParams=*/false);
+}
+
+void DiskCachedBinaryCacheStore::init()
+{
+    auto cacheKey = cacheUri();
+
+    // Check if we have cached info about this binary cache
+    if (auto cacheInfo = diskCache->upToDateCacheExists(cacheKey)) {
+        inner->config.wantMassQuery.setDefault(cacheInfo->wantMassQuery);
+        inner->config.priority.setDefault(cacheInfo->priority);
+    } else {
+        // Initialize the inner store to fetch cache info
+        inner->init();
+        diskCache->createCache(cacheKey, storeDir, inner->config.wantMassQuery, inner->config.priority);
+    }
+}
+
+bool DiskCachedBinaryCacheStore::isValidPathUncached(const StorePath & storePath)
+{
+    auto res = diskCache->lookupNarInfo(cacheUri(), std::string(storePath.hashPart()));
+    if (res.first != NarInfoDiskCache::oUnknown) {
+        stats.narInfoReadAverted++;
+        return res.first == NarInfoDiskCache::oValid;
+    }
+
+    // Call the full isValidPath on inner, which will use inner's caching
+    bool valid = inner->isValidPath(storePath);
+
+    if (!valid)
+        diskCache->upsertNarInfo(cacheUri(), std::string(storePath.hashPart()), 0);
+
+    return valid;
+}
+
+void DiskCachedBinaryCacheStore::queryPathInfoUncached(
+    const StorePath & storePath, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
+{
+    auto hashPart = std::string(storePath.hashPart());
+
+    try {
+        auto res = diskCache->lookupNarInfo(cacheUri(), hashPart);
+        if (res.first != NarInfoDiskCache::oUnknown) {
+            stats.narInfoReadAverted++;
+            if (res.first == NarInfoDiskCache::oValid) {
+                return callback(res.second);
+            } else {
+                return callback(nullptr);
+            }
+        }
+    } catch (...) {
+        return callback.rethrow();
+    }
+
+    auto callbackPtr = std::make_shared<decltype(callback)>(std::move(callback));
+
+    // Call the full queryPathInfo on inner
+    inner->queryPathInfo(storePath, {[this, hashPart, callbackPtr](std::future<ref<const ValidPathInfo>> fut) {
+                             try {
+                                 auto info = fut.get();
+                                 diskCache->upsertNarInfo(cacheUri(), hashPart, info.get_ptr());
+                                 (*callbackPtr)(info.get_ptr());
+                             } catch (InvalidPath &) {
+                                 diskCache->upsertNarInfo(cacheUri(), hashPart, 0);
+                                 (*callbackPtr)(nullptr);
+                             } catch (...) {
+                                 callbackPtr->rethrow();
+                             }
+                         }});
+}
+
+void DiskCachedBinaryCacheStore::queryRealisationUncached(
+    const DrvOutput & id, Callback<std::shared_ptr<const UnkeyedRealisation>> callback) noexcept
+{
+    try {
+        auto [cacheOutcome, maybeCachedRealisation] = diskCache->lookupRealisation(cacheUri(), id);
+        switch (cacheOutcome) {
+        case NarInfoDiskCache::oValid:
+            debug("Returning a cached realisation for %s", id.to_string());
+            callback(maybeCachedRealisation);
+            return;
+        case NarInfoDiskCache::oInvalid:
+            debug("Returning a cached missing realisation for %s", id.to_string());
+            callback(nullptr);
+            return;
+        case NarInfoDiskCache::oUnknown:
+            break;
+        }
+    } catch (...) {
+        return callback.rethrow();
+    }
+
+    auto callbackPtr = std::make_shared<decltype(callback)>(std::move(callback));
+
+    // Call the full queryRealisation on inner
+    inner->queryRealisation(id, {[this, id, callbackPtr](std::future<std::shared_ptr<const UnkeyedRealisation>> fut) {
+                                try {
+                                    auto info = fut.get();
+
+                                    if (info)
+                                        diskCache->upsertRealisation(cacheUri(), {*info, id});
+                                    else
+                                        diskCache->upsertAbsentRealisation(cacheUri(), id);
+
+                                    (*callbackPtr)(std::shared_ptr<const UnkeyedRealisation>(info));
+
+                                } catch (...) {
+                                    callbackPtr->rethrow();
+                                }
+                            }});
+}
+
+void DiskCachedBinaryCacheStore::writeNarInfo(ref<NarInfo> narInfo)
+{
+    inner->writeNarInfo(narInfo);
+
+    diskCache->upsertNarInfo(cacheUri(), std::string(narInfo->path.hashPart()), std::shared_ptr<NarInfo>(narInfo));
+}
+
+void DiskCachedBinaryCacheStore::registerDrvOutput(const Realisation & info)
+{
+    diskCache->upsertRealisation(cacheUri(), info);
+    inner->registerDrvOutput(info);
+}
+
+// Backend storage methods - delegate to inner store
+
+bool DiskCachedBinaryCacheStore::fileExists(const std::string & path)
+{
+    return inner->fileExists(path);
+}
+
+void DiskCachedBinaryCacheStore::upsertFile(
+    const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint)
+{
+    inner->upsertFile(path, source, mimeType, sizeHint);
+}
+
+void DiskCachedBinaryCacheStore::getFile(const std::string & path, Sink & sink)
+{
+    inner->getFile(path, sink);
+}
+
+void DiskCachedBinaryCacheStore::getFile(
+    const std::string & path, Callback<std::optional<std::string>> callback) noexcept
+{
+    inner->getFile(path, std::move(callback));
+}
+
+std::optional<TrustedFlag> DiskCachedBinaryCacheStore::isTrustedClient()
+{
+    return inner->isTrustedClient();
+}
+
+} // namespace nix

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -151,13 +151,15 @@ public:
 
     virtual void init() override;
 
-private:
+    virtual void writeNarInfo(ref<NarInfo> narInfo);
 
-    std::string narMagic;
+protected:
 
     std::string narInfoFileFor(const StorePath & storePath);
 
-    void writeNarInfo(ref<NarInfo> narInfo);
+private:
+
+    std::string narMagic;
 
     ref<const ValidPathInfo> addToStoreCommon(
         Source & narSource,

--- a/src/libstore/include/nix/store/disk-cached-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/disk-cached-binary-cache-store.hh
@@ -1,0 +1,67 @@
+#pragma once
+///@file
+
+#include "nix/store/binary-cache-store.hh"
+#include "nix/store/nar-info-disk-cache.hh"
+
+namespace nix {
+
+/**
+ * A wrapper around a `BinaryCacheStore` that adds local disk caching
+ * of `NarInfo` and realisation lookups.
+ *
+ * This uses the decorator pattern - it wraps another store and intercepts
+ * the `*Uncached` methods to check/update the disk cache before delegating
+ * to the wrapped store.
+ *
+ * Methods like `narFromPath`, `addSignatures`, `getFSAccessor` are NOT overridden
+ * because they internally call `queryPathInfo`, which should go through this
+ * wrapper's disk cache logic.
+ */
+class DiskCachedBinaryCacheStore : public virtual BinaryCacheStore
+{
+protected:
+    ref<BinaryCacheStore> inner;
+    ref<NarInfoDiskCache> diskCache;
+
+    /**
+     * Get the cache key (URI) for this store.
+     */
+    std::string cacheUri();
+
+public:
+    DiskCachedBinaryCacheStore(ref<BinaryCacheStore> inner, ref<NarInfoDiskCache> diskCache);
+
+    void init() override;
+
+protected:
+    // Cache-aware overrides of the `*Uncached` methods
+    bool isValidPathUncached(const StorePath & path) override;
+
+    void queryPathInfoUncached(
+        const StorePath & path, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;
+
+    void queryRealisationUncached(
+        const DrvOutput & id, Callback<std::shared_ptr<const UnkeyedRealisation>> callback) noexcept override;
+
+    void writeNarInfo(ref<NarInfo> narInfo) override;
+
+public:
+    void registerDrvOutput(const Realisation & info) override;
+
+protected:
+    // Backend storage methods - delegate to inner store
+    bool fileExists(const std::string & path) override;
+
+    void upsertFile(
+        const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override;
+
+    void getFile(const std::string & path, Sink & sink) override;
+
+    void getFile(const std::string & path, Callback<std::optional<std::string>> callback) noexcept override;
+
+public:
+    std::optional<TrustedFlag> isTrustedClient() override;
+};
+
+} // namespace nix

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -36,6 +36,7 @@ headers = [ config_pub_h ] + files(
   'derivations.hh',
   'derived-path-map.hh',
   'derived-path.hh',
+  'disk-cached-binary-cache-store.hh',
   'downstream-placeholder.hh',
   'dummy-store-impl.hh',
   'dummy-store.hh',

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -40,7 +40,6 @@ struct BasicDerivation;
 struct Derivation;
 
 struct SourceAccessor;
-class NarInfoDiskCache;
 class Store;
 
 typedef std::map<std::string, StorePath> OutputPathMap;
@@ -311,8 +310,6 @@ protected:
     // Note: this is a `ref` to avoid false sharing with immutable
     // bits of `Store`.
     ref<SharedSync<LRUCache<StorePath, PathInfoCacheValue>>> pathInfoCache;
-
-    std::shared_ptr<NarInfoDiskCache> diskCache;
 
     Store(const Store::Config & config);
 

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -303,6 +303,7 @@ sources = files(
   'derivations.cc',
   'derived-path-map.cc',
   'derived-path.cc',
+  'disk-cached-binary-cache-store.cc',
   'downstream-placeholder.cc',
   'dummy-store.cc',
   'export-import.cc',


### PR DESCRIPTION
## Motivation

Before we had an awkward situation where `Store` had an optional `diskCache` field and corresponding optional support for using this in the default methods. Only `HttpBinaryCacheStore` (and its subclass, `S3BinaryCacheStore`) actually used the disk cache, it was dead code for everything else.

Worse, while `HttpBinaryCacheStore` unconditionally used the disk cache, we actually don't want this in the unit test, so we had to create and ungainly `TestHttpBinaryCacheStore` subclass to remove it.

## Context

With this PR, we solve both the dead code / layer violation problem, and the testing problem. We have a wrapper `DiskCachedBinaryCacheStore` that can wrap any `BinaryCacheStore` to add disk caching support. Neither the
base `Store` class nor `HttpBinaryCacheStore` knows about the disk cache at all. By default, when one calls `HttpBinaryCacheStore::Config::openStore` (and also `S3BinaryCacheStore::Config::openStore`), one gets the wrapped store so there is still disk store support in both case. However, for unit testing purposes, we construct `HttpBinaryCacheStore`, avoiding any disk caching so no `TestHttpBinaryCacheStore` is needed anymore.

Credit to Sergei for the idea. Credit to Claude for doing most of the grunt work ;).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
