### PR TITLE
libstore: pass `stateDir` to `acquireUserLock` instead of using global

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -270,7 +270,7 @@ protected:
      */
     virtual std::unique_ptr<UserLock> getBuildUser()
     {
-        return acquireUserLock(localSettings, 1, false);
+        return acquireUserLock(settings.nixStateDir, localSettings, 1, false);
     }
 
     /**

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -222,7 +222,8 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
 
     std::unique_ptr<UserLock> getBuildUser() override
     {
-        return acquireUserLock(store.config->getLocalSettings(), drvOptions.useUidRange(drv) ? 65536 : 1, true);
+        return acquireUserLock(
+            settings.nixStateDir, store.config->getLocalSettings(), drvOptions.useUidRange(drv) ? 65536 : 1, true);
     }
 
     void prepareUser() override

--- a/src/libstore/unix/include/nix/store/user-lock.hh
+++ b/src/libstore/unix/include/nix/store/user-lock.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include <filesystem>
 #include <memory>
 #include <vector>
 #include <sys/types.h>
@@ -38,7 +39,8 @@ struct UserLock
  * Acquire a user lock for a UID range of size `nrIds`. Note that this
  * may return nullptr if no user is available.
  */
-std::unique_ptr<UserLock> acquireUserLock(const LocalSettings & localSettings, uid_t nrIds, bool useUserNamespace);
+std::unique_ptr<UserLock> acquireUserLock(
+    const std::filesystem::path & stateDir, const LocalSettings & localSettings, uid_t nrIds, bool useUserNamespace);
 
 bool useBuildUsers(const LocalSettings &);
 

--- a/src/libstore/unix/user-lock.cc
+++ b/src/libstore/unix/user-lock.cc
@@ -214,14 +214,15 @@ struct AutoUserLock : UserLock
     }
 };
 
-std::unique_ptr<UserLock> acquireUserLock(const LocalSettings & localSettings, uid_t nrIds, bool useUserNamespace)
+std::unique_ptr<UserLock> acquireUserLock(
+    const std::filesystem::path & stateDir, const LocalSettings & localSettings, uid_t nrIds, bool useUserNamespace)
 {
     if (auto * uidSettings = localSettings.getAutoAllocateUidSettings()) {
-        auto userPoolDir = settings.nixStateDir / "userpool2";
+        auto userPoolDir = stateDir / "userpool2";
         createDirs(userPoolDir);
         return AutoUserLock::acquire(userPoolDir, localSettings.buildUsersGroup, nrIds, useUserNamespace, *uidSettings);
     } else {
-        auto userPoolDir = settings.nixStateDir / "userpool";
+        auto userPoolDir = stateDir / "userpool";
         createDirs(userPoolDir);
         return SimpleUserLock::acquire(userPoolDir, localSettings.buildUsersGroup);
     }


### PR DESCRIPTION
## Motivation

This makes `acquireUserLock` take an explicit stateDir parameter,
since it was previously reaching into the global settings object
just to read `nixStateDir` for constructing the userpool paths.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
