### PR TITLE
libstore: make substitution use the per-store `getReadOnly` method

### DIFF
--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -37,7 +37,7 @@ Goal::Co PathSubstitutionGoal::init()
         co_return doneSuccess(BuildResult::Success{.status = BuildResult::Success::AlreadyValid});
     }
 
-    if (settings.readOnlyMode)
+    if (worker.store.config.getReadOnly())
         throw Error(
             "cannot substitute path '%s' - no write access to the Nix store", worker.store.printStorePath(storePath));
 

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -119,6 +119,11 @@ ref<Store> DummyStoreConfig::openStore() const
     return openDummyStore();
 }
 
+bool DummyStoreConfig::getReadOnly() const
+{
+    return readOnly.get() || StoreConfig::getReadOnly();
+}
+
 struct DummyStoreImpl : DummyStore
 {
     using Config = DummyStoreConfig;

--- a/src/libstore/include/nix/store/dummy-store.hh
+++ b/src/libstore/include/nix/store/dummy-store.hh
@@ -35,6 +35,8 @@ struct DummyStoreConfig : public std::enable_shared_from_this<DummyStoreConfig>,
           No additional memory will be used, because no information needs to be stored.
         )"};
 
+    bool getReadOnly() const override;
+
     static const std::string name()
     {
         return "Dummy Store";

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -117,6 +117,8 @@ public:
           > While the filesystem the database resides on might appear to be read-only, consider whether another user or system might have write access to it.
         )"};
 
+    bool getReadOnly() const override;
+
     Setting<bool> ignoreGcDeleteFailure{
         this,
         false,

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -219,6 +219,12 @@ struct StoreConfig : public StoreConfigBase, public StoreDirConfig
         false};
 
     /**
+     * Whether we're allowed to write to this store, also takes into account
+     * global `readOnly`'s mode setting, not just any per-store settings.
+     */
+    virtual bool getReadOnly() const;
+
+    /**
      * Open a store of the type corresponding to this configuration
      * type.
      */

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -473,6 +473,11 @@ StoreReference LocalStoreConfig::getReference() const
     };
 }
 
+bool LocalStoreConfig::getReadOnly() const
+{
+    return readOnly.get() || StoreConfig::getReadOnly();
+}
+
 int LocalStore::getSchema()
 {
     int curSchema = 0;

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -333,6 +333,11 @@ StoreReference StoreConfig::getReference() const
     return {.variant = StoreReference::Auto{}};
 }
 
+bool StoreConfig::getReadOnly() const
+{
+    return settings.readOnlyMode;
+}
+
 bool Store::PathInfoCacheValue::isKnownNow()
 {
     std::chrono::duration ttl = didExist() ? std::chrono::seconds(settings.ttlPositiveNarInfoCache)


### PR DESCRIPTION
## Motivation

This commit introduces a `getReadOnly` method on the store config that returns if the current store is read only or not. This is then used in subtitution, so we fail gracefully with a nice error message if only the individual store is read-only.

As a bonus, it gets us one step closer to getting rid of the global because we can use the per-store method instead.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
