### PR TITLE
Get rid of the settings-dependent `writeDerivation` wrapper

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1814,8 +1814,13 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
         drv.fillInOutputPaths(*state.store);
     }
 
-    /* Write the resulting term into the Nix store directory. */
-    auto drvPath = writeDerivation(*state.store, drv, state.repair);
+    /* Write the resulting term into the Nix store directory.
+
+       Unless we are in read-only mode, that is, in which case we do not
+       write anything. Users commonly do this to speed up evaluation in
+       contexts where they don't actually want to build anything. */
+    auto drvPath =
+        settings.readOnlyMode ? computeStorePath(*state.store, drv) : state.store->writeDerivation(drv, state.repair);
     auto drvPathS = state.store->printStorePath(drvPath);
 
     printMsg(lvlChatty, "instantiated '%1%' -> '%2%'", drvName, drvPathS);

--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -308,7 +308,12 @@ StorePath * nix_add_derivation(nix_c_context * context, Store * store, nix_deriv
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto ret = nix::writeDerivation(*store->ptr, derivation->drv, nix::NoRepair);
+        /* Quite dubious that users would want this to silently suceed
+           without actually writing the derivation if this setting is
+           set, but it was that way already, so we are doing this for
+           back-compat for now. */
+        auto ret = nix::settings.readOnlyMode ? nix::computeStorePath(*store->ptr, derivation->drv)
+                                              : store->ptr->writeDerivation(derivation->drv, nix::NoRepair);
 
         return new StorePath{ret};
     }

--- a/src/libstore-tests/derivation/invariants.cc
+++ b/src/libstore-tests/derivation/invariants.cc
@@ -51,7 +51,7 @@ protected:
         depDrv.fillInOutputPaths(*store);
 
         // Write the dependency to the store
-        return writeDerivation(*store, depDrv, NoRepair);
+        return store->writeDerivation(depDrv, NoRepair);
     }
 
 public:

--- a/src/libstore-tests/worker-substitution.cc
+++ b/src/libstore-tests/worker-substitution.cc
@@ -193,7 +193,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutput)
     };
 
     // Write the derivation to the destination store
-    auto drvPath = writeDerivation(*dummyStore, drv);
+    auto drvPath = dummyStore->writeDerivation(drv);
 
     // Snapshot the destination store before
     checkpointJson("ca-drv/store-before", dummyStore);
@@ -297,7 +297,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
     };
 
     // Write the dependency derivation to the destination store
-    auto depDrvPath = writeDerivation(*dummyStore, depDrv);
+    auto depDrvPath = dummyStore->writeDerivation(depDrv);
 
     // Compute the hash modulo for the dependency derivation
     auto depHashModulo = hashDerivationModulo(*dummyStore, depDrv, true);
@@ -348,7 +348,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
     rootDrv.inputDrvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
 
     // Write the root derivation to the destination store
-    auto rootDrvPath = writeDerivation(*dummyStore, rootDrv);
+    auto rootDrvPath = dummyStore->writeDerivation(rootDrv);
 
     // Snapshot the destination store before
     checkpointJson("issue-11928/store-before", dummyStore);

--- a/src/libstore-tests/write-derivation.cc
+++ b/src/libstore-tests/write-derivation.cc
@@ -44,12 +44,12 @@ TEST_F(WriteDerivationTest, addToStoreFromDumpCalledOnce)
 {
     auto drv = makeSimpleDrv();
 
-    auto path1 = writeDerivation(*store, drv, NoRepair);
+    auto path1 = store->writeDerivation(drv, NoRepair);
     config->readOnly = true;
-    auto path2 = writeDerivation(*store, drv, NoRepair);
+    auto path2 = computeStorePath(*store, drv);
     EXPECT_EQ(path1, path2);
     EXPECT_THAT(
-        [&] { writeDerivation(*store, drv, Repair); },
+        [&] { store->writeDerivation(drv, Repair); },
         ::testing::ThrowsMessage<Error>(
             testing::HasSubstrIgnoreANSIMatcher("operation 'writeDerivation' is not supported by store 'dummy://'")));
 }

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -123,7 +123,7 @@ Goal::Co DerivationBuildingGoal::gaveUpOnSubstitution(bool storeDerivation)
         assert(drv->inputDrvs.map.empty());
         /* Store the resolved derivation, as part of the record of
            what we're actually building */
-        writeDerivation(worker.store, *drv);
+        worker.store.writeDerivation(*drv);
     }
 
     StorePathSet inputPaths;

--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -144,7 +144,7 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
             }
             assert(attempt);
 
-            auto pathResolved = writeDerivation(worker.store, *attempt, NoRepair, /*readOnly =*/true);
+            auto pathResolved = computeStorePath(worker.store, Derivation{*attempt});
 
             auto msg =
                 fmt("resolved derivation: '%s' -> '%s'",

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -647,7 +647,7 @@ static void performOp(
 
             Derivation drv2;
             static_cast<BasicDerivation &>(drv2) = drv;
-            drvPath = writeDerivation(*store, Derivation{drv2});
+            drvPath = store->writeDerivation(Derivation{drv2});
         }
 
         auto res = store->buildDerivation(drvPath, drv, buildMode);

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -106,7 +106,7 @@ bool BasicDerivation::isBuiltin() const
     return builder.substr(0, 8) == "builtin:";
 }
 
-static auto infoForDerivation(Store & store, const Derivation & drv)
+static auto infoForDerivation(const StoreDirConfig & store, const Derivation & drv)
 {
     auto references = drv.inputSrcs;
     for (auto & i : drv.inputDrvs.map)
@@ -126,13 +126,10 @@ static auto infoForDerivation(Store & store, const Derivation & drv)
     };
 }
 
-StorePath writeDerivation(Store & store, const Derivation & drv, RepairFlag repair, bool readOnly)
+StorePath computeStorePath(const StoreDirConfig & store, const Derivation & drv)
 {
-    if (readOnly || settings.readOnlyMode) {
-        auto [_x, _y, _z, path] = infoForDerivation(store, drv);
-        return path;
-    } else
-        return store.writeDerivation(drv, repair);
+    auto [_suffix, _contents, _references, path] = infoForDerivation(store, drv);
+    return path;
 }
 
 StorePath Store::writeDerivation(const Derivation & drv, RepairFlag repair)

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -301,7 +301,7 @@ struct DummyStoreImpl : DummyStore
 
     StorePath writeDerivation(const Derivation & drv, RepairFlag repair = NoRepair) override
     {
-        auto drvPath = ::nix::writeDerivation(*this, drv, repair, /*readonly=*/true);
+        auto drvPath = nix::computeStorePath(*this, drv);
 
         if (!derivations.contains(drvPath) || repair) {
             if (config->readOnly)

--- a/src/libstore/include/nix/store/derivations.hh
+++ b/src/libstore/include/nix/store/derivations.hh
@@ -466,9 +466,11 @@ struct Derivation : BasicDerivation
 class Store;
 
 /**
- * Write a derivation to the Nix store, and return its path.
+ * Compute the store path that would be used for a derivation without writing it.
+ *
+ * This is a pure computation based on the derivation content and store directory.
  */
-StorePath writeDerivation(Store & store, const Derivation & drv, RepairFlag repair = NoRepair, bool readOnly = false);
+StorePath computeStorePath(const StoreDirConfig & store, const Derivation & drv);
 
 /**
  * Read a derivation from a file.

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1212,7 +1212,7 @@ std::optional<StorePath> Store::getBuildDerivationPath(const StorePath & path)
         // resolved derivation, so we need to get it first
         auto resolvedDrv = drv.tryResolve(*this);
         if (resolvedDrv)
-            return ::nix::writeDerivation(*this, *resolvedDrv, NoRepair, true);
+            return nix::computeStorePath(*this, Derivation{*resolvedDrv});
     }
 
     return path;

--- a/src/nix/derivation-add.cc
+++ b/src/nix/derivation-add.cc
@@ -5,6 +5,7 @@
 #include "nix/store/store-api.hh"
 #include "nix/util/archive.hh"
 #include "nix/store/derivations.hh"
+#include "nix/store/globals.hh"
 #include <nlohmann/json.hpp>
 
 using namespace nix;
@@ -35,9 +36,8 @@ struct CmdAddDerivation : MixDryRun, StoreCommand
 
         auto drv = Derivation::parseJsonAndValidate(*store, json);
 
-        auto drvPath = writeDerivation(*store, drv, NoRepair, /* read only */ dryRun);
-
-        writeDerivation(*store, drv, NoRepair, dryRun);
+        auto drvPath =
+            (dryRun || settings.readOnlyMode) ? computeStorePath(*store, drv) : store->writeDerivation(drv, NoRepair);
 
         logger->cout("%s", store->printStorePath(drvPath));
     }

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -291,7 +291,7 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
     }
     drv.fillInOutputPaths(*evalStore);
 
-    auto shellDrvPath = writeDerivation(*evalStore, drv);
+    auto shellDrvPath = evalStore->writeDerivation(drv);
 
     /* Build the derivation. */
     store->buildPaths(


### PR DESCRIPTION
## Motivation

It was a crude hack that this one low-level function was dependent on the high-level read-only mode setting --- all the more so because rather than making derivation writing fail, that setting made it silently "succeed" while not actually writing the derivation. (Also, for context, we didn't have an such behavior for any other store-mutating operations, just for this one function.)

## Context

I have gotten rid of the wrapper, and updated the call sites accordingly.

- For the ones that should remain dependent on this setting, I made this explicit, and added a comment.

- For others, surrounding operations assumed writability (e.g. we had written something before, or were about to try to read back the written derivation after), and so I just made those do the underlying `Store::writeDerivation` operation.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
