### PR TITLE
Optimize nix flake show with system folding

### DIFF
--- a/src/nix/flake-show.md
+++ b/src/nix/flake-show.md
@@ -7,18 +7,10 @@ R""(
   ```console
   github:NixOS/patchelf/f34751b88bd07d7f44f5cd3200fb4122bf916c7e
   ├───checks
-  │   ├───aarch64-linux
-  │   │   └───build: derivation 'patchelf-0.12.20201207.f34751b'
-  │   ├───i686-linux
-  │   │   └───build: derivation 'patchelf-0.12.20201207.f34751b'
-  │   └───x86_64-linux
+  │   └───{[x86_64-linux],i686-linux,aarch64-linux}
   │       └───build: derivation 'patchelf-0.12.20201207.f34751b'
   ├───packages
-  │   ├───aarch64-linux
-  │   │   └───default: package 'patchelf-0.12.20201207.f34751b'
-  │   ├───i686-linux
-  │   │   └───default: package 'patchelf-0.12.20201207.f34751b'
-  │   └───x86_64-linux
+  │   └───{[x86_64-linux],i686-linux,aarch64-linux}
   │       └───default: package 'patchelf-0.12.20201207.f34751b'
   ├───hydraJobs
   │   ├───build
@@ -31,6 +23,24 @@ R""(
   └───overlay: Nixpkgs overlay
   ```
 
+  Systems in the `apps`, `checks`, `devShells`, and `packages` categories are folded by default to reduce visual clutter. The example above is shown as it would appear on an `x86_64-linux` host: the local system is highlighted in bold brackets `[x86_64-linux]` while other systems are shown faintly without brackets.
+
+* Show all systems separately (no folding):
+
+  ```console
+  github:NixOS/patchelf/f34751b88bd07d7f44f5cd3200fb4122bf916c7e
+  ├───checks
+  │   ├───x86_64-linux
+  │   │   └───build: derivation 'patchelf-0.12.20201207.f34751b'
+  │   ├───aarch64-linux
+  │   │   └───build: derivation 'patchelf-0.12.20201207.f34751b'
+  │   └───i686-linux
+  │       └───build: derivation 'patchelf-0.12.20201207.f34751b'
+  └───...
+  ```
+
+  Use `--no-system-folding` to disable system folding and show all systems separately.
+
 # Description
 
 This command shows the output attributes provided by the flake
@@ -38,7 +48,11 @@ specified by flake reference *flake-url*. These are the top-level
 attributes in the `outputs` of the flake, as well as lower-level
 attributes for some standard outputs (e.g. `packages` or `checks`).
 
+By default, system architectures in the `apps`, `checks`, `devShells`, and `packages` categories are folded into a single display node to reduce visual clutter. The local system is highlighted in bold with brackets (e.g., `[x86_64-linux]`), while other systems are shown faintly without brackets (e.g., `aarch64-linux`).
+
+System folding can be disabled with `--no-system-folding` or automatically disabled when using `--json` or `--all-systems` flags.
+
 With `--json`, the output is in a JSON representation suitable for automatic
-processing by other tools.
+processing by other tools. System folding is automatically disabled in JSON mode.
 
 )""

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1169,6 +1169,7 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
 {
     bool showLegacy = false;
     bool showAllSystems = false;
+    bool foldSystems = true;
 
     CmdFlakeShow()
     {
@@ -1181,6 +1182,11 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
             .longName = "all-systems",
             .description = "Show the contents of outputs for all systems.",
             .handler = {&showAllSystems, true},
+        });
+        addFlag({
+            .longName = "no-system-folding",
+            .description = "Do not fold multiple systems into a single display.",
+            .handler = {&foldSystems, false},
         });
     }
 
@@ -1203,6 +1209,49 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
         auto state = getEvalState();
         auto flake = make_ref<flake::LockedFlake>(lockFlake());
         auto localSystem = std::string(settings.thisSystem.get());
+
+        // Whether a node is a system-category root whose direct children are system names.
+        // legacyPackages is intentionally excluded: its content may recurse without the
+        // uniform `<system>` structure that apps/checks/devShells/packages provide.
+        auto isSystemCategory = [](const std::vector<SymbolStr> & attrPathS) -> bool {
+            if (attrPathS.size() != 1)
+                return false;
+            const auto & name = attrPathS[0];
+            return name == "apps" || name == "checks" || name == "devShells" || name == "packages";
+        };
+
+        // Whether folding is enabled by the flags and the current (non-JSON) display mode.
+        auto shouldApplyFolding = [this]() -> bool { return foldSystems && !showAllSystems && !json; };
+
+        // Format a single system name, highlighting the local system with bold brackets
+        // and dimming the others.
+        auto formatSystemName = [&localSystem](const std::string & sys) -> std::string {
+            return sys == localSystem ? fmt(ANSI_BOLD "[%s]" ANSI_NORMAL, sys) : fmt(ANSI_FAINT "%s" ANSI_NORMAL, sys);
+        };
+
+        // Build the folded display label for a set of systems, e.g. "{[x86_64-linux],aarch64-linux}"
+        // where the local system is bracketed/bold and the rest are dim. Systems are shown in
+        // reverse alphabetical order (x86_64-linux before aarch64-linux).
+        auto createFoldedDisplay = [&formatSystemName](const std::vector<std::string> & systems) -> std::string {
+            std::vector<std::string> display;
+            display.reserve(systems.size());
+            for (const auto & sys : systems) {
+                display.push_back(formatSystemName(sys));
+            }
+            return fmt("{%s}", concatStringsSep(",", display));
+        };
+
+        // Return the system names of the given symbols, sorted in reverse alphabetical order.
+        // Pure: does not mutate the input.
+        auto sortedSystemNames = [&state](const std::vector<Symbol> & attrs) -> std::vector<std::string> {
+            std::vector<std::string> result;
+            result.reserve(attrs.size());
+            for (const auto & sym : attrs) {
+                result.push_back(std::string(state->symbols[sym]));
+            }
+            std::sort(result.begin(), result.end(), std::greater<>{}); // reverse alphabetical
+            return result;
+        };
 
         std::function<bool(eval_cache::AttrCursor & visitor, const AttrPath & attrPath, const Symbol & attr)>
             hasContent;
@@ -1275,27 +1324,71 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                 auto recurse = [&]() {
                     if (!json)
                         logger->cout("%s", headerPrefix);
+
+                    // Collect attributes with content
                     std::vector<Symbol> attrs;
-                    for (const auto & attr : visitor.getAttrs()) {
+                    const auto allAttrs = visitor.getAttrs();
+                    attrs.reserve(allAttrs.size());
+                    for (const auto & attr : allAttrs) {
                         if (hasContent(visitor, attrPath, attr))
                             attrs.push_back(attr);
                     }
 
-                    for (const auto & [last, attr] : markLast(attrs)) {
-                        const auto & attrName = state->symbols[attr];
-                        auto visitor2 = visitor.getAttr(attrName);
+                    // System folding: consolidate multiple system nodes under a system-category
+                    // root into a single display node. Only fold when there is more than one
+                    // system, so single-system output is unchanged.
+                    const bool applyFolding = shouldApplyFolding() && isSystemCategory(attrPathS) && attrs.size() > 1;
+
+                    if (applyFolding) {
+                        // Systems to show in the folded label (reverse alphabetical order).
+                        const auto categorySystems = sortedSystemNames(attrs);
+
+                        // Choose which system to actually descend into: prefer the local system
+                        // (so the deeper "non-local systems are omitted" rule shows real content
+                        // rather than "omitted"); fall back to the first system otherwise.
+                        Symbol chosenAttr = attrs.front();
+                        for (const auto & attr : attrs) {
+                            if (std::string(state->symbols[attr]) == localSystem) {
+                                chosenAttr = attr;
+                                break;
+                            }
+                        }
+                        const auto & chosenName = state->symbols[chosenAttr];
+
+                        auto visitor2 = visitor.getAttr(chosenName);
                         auto attrPath2(attrPath);
-                        attrPath2.push_back(attr);
+                        attrPath2.push_back(chosenAttr);
+
                         auto j2 = visit(
                             *visitor2,
                             attrPath2,
                             fmt(ANSI_GREEN "%s%s" ANSI_NORMAL ANSI_BOLD "%s" ANSI_NORMAL,
                                 nextPrefix,
-                                last ? treeLast : treeConn,
-                                attrName),
-                            nextPrefix + (last ? treeNull : treeLine));
+                                treeLast,
+                                createFoldedDisplay(categorySystems)),
+                            nextPrefix + treeNull);
+                        // Folding is disabled in JSON mode (see shouldApplyFolding), so this
+                        // branch is never taken when emitting JSON; keep the guard defensive.
                         if (json)
-                            j.emplace(attrName, std::move(j2));
+                            j.emplace(chosenName, std::move(j2));
+                    } else {
+                        for (const auto & [last, attr] : markLast(attrs)) {
+                            const auto & attrName = state->symbols[attr];
+                            auto visitor2 = visitor.getAttr(attrName);
+                            auto attrPath2(attrPath);
+                            attrPath2.push_back(attr);
+
+                            auto j2 = visit(
+                                *visitor2,
+                                attrPath2,
+                                fmt(ANSI_GREEN "%s%s" ANSI_NORMAL ANSI_BOLD "%s" ANSI_NORMAL,
+                                    nextPrefix,
+                                    last ? treeLast : treeConn,
+                                    attrName),
+                                nextPrefix + (last ? treeNull : treeLine));
+                            if (json)
+                                j.emplace(attrName, std::move(j2));
+                        }
                     }
                 };
 

--- a/tests/functional/flakes/show.sh
+++ b/tests/functional/flakes/show.sh
@@ -130,3 +130,121 @@ assert show_output.packages.${builtins.currentSystem}.not-a-derivation == {};
 true
 '
 
+# System folding tests
+# ============================================================
+#
+# These tests rely on `$system` being the host running the test. Folding
+# prefers the local system, so the asserted output depends on whether the host
+# system is among the ones advertised by the flake.
+
+# A flake advertising both x86_64-linux and aarch64-linux across the foldable
+# categories.
+cat >flake.nix <<EOF
+{
+  description = "System folding test";
+  outputs = inputs: {
+    packages.x86_64-linux.p1 = import ./simple.nix;
+    packages.aarch64-linux.p1 = import ./simple.nix;
+    apps.x86_64-linux.a1 = {
+      type = "app";
+      program = "\${./simple.nix}";
+    };
+    apps.aarch64-linux.a1 = {
+      type = "app";
+      program = "\${./simple.nix}";
+    };
+    checks.x86_64-linux.c1 = import ./simple.nix;
+    checks.aarch64-linux.c1 = import ./simple.nix;
+    devShells.x86_64-linux.default = import ./shell.nix;
+    devShells.aarch64-linux.default = import ./shell.nix;
+  };
+}
+EOF
+
+# Test 1: by default the two systems are folded into a single label that lists
+# both systems inside one pair of braces.
+nix flake show > show-output.txt
+grep -qE '\{[^}]*x86_64-linux[^}]*aarch64-linux[^}]*\}' show-output.txt
+
+# When the host system is one of the advertised systems, folding must descend
+# into the local system so its content is shown (not "omitted"). This is the
+# regression guard for the bug where the descended system was chosen by display
+# order rather than by locality.
+case "$system" in
+  x86_64-linux|aarch64-linux)
+    grepQuietInverse 'omitted' show-output.txt
+    ;;
+esac
+
+# Test 2: --no-system-folding shows each system as its own node (no braces).
+nix flake show --no-system-folding > show-output.txt
+# No folded braces: systems are not consolidated.
+grepQuietInverse '{' show-output.txt
+# Both systems appear. They are bold-wrapped node labels here, so they are
+# present as substrings.
+grep -q 'x86_64-linux' show-output.txt
+grep -q 'aarch64-linux' show-output.txt
+
+# Test 3: folding is disabled with --json and with --all-systems.
+nix flake show --json > show-output.json
+# shellcheck disable=SC2016
+nix eval --impure --expr '
+let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
+in
+assert show_output.packages ? x86_64-linux;
+assert show_output.packages ? aarch64-linux;
+assert show_output.apps ? x86_64-linux;
+assert show_output.apps ? aarch64-linux;
+true
+'
+
+nix flake show --all-systems > show-output.txt
+grepQuietInverse '{' show-output.txt
+grep -q 'x86_64-linux' show-output.txt
+grep -q 'aarch64-linux' show-output.txt
+
+# Test 4: a single system is not folded (no braces around a lone system).
+cat >flake.nix <<EOF
+{
+  description = "Single system test";
+  outputs = inputs: {
+    packages.$system.default = import ./simple.nix;
+    apps.$system.hello = {
+      type = "app";
+      program = "\${./simple.nix}";
+    };
+  };
+}
+EOF
+nix flake show > show-output.txt
+grepQuietInverse '{' show-output.txt
+grep -q "$system" show-output.txt
+
+# Test 5: empty system categories don't crash and produce no folded node.
+cat >flake.nix <<EOF
+{
+  description = "Empty categories test";
+  outputs = inputs: {
+    packages = {};
+    apps = {};
+    checks = {};
+    devShells = {};
+  };
+}
+EOF
+nix flake show > show-output.txt
+
+# Test 6: legacyPackages is never folded even with multiple systems.
+cat >flake.nix <<EOF
+{
+  description = "legacyPackages not folded";
+  outputs = inputs: {
+    legacyPackages.x86_64-linux.p1 = import ./simple.nix;
+    legacyPackages.aarch64-linux.p1 = import ./simple.nix;
+  };
+}
+EOF
+nix flake show --legacy > show-output.txt
+grepQuietInverse '{' show-output.txt
+grep -q 'x86_64-linux' show-output.txt
+grep -q 'aarch64-linux' show-output.txt


### PR DESCRIPTION
# Motivation

`nix flake show` clutters output with a wall of `omitted` lines for every non-local system. This PR folds the system level of `apps`, `checks`, `devShells`, and `packages` into a single node.

Closes #9011.

# Example

On an `x86_64-linux` host, before (or with `--no-system-folding`):

```
github:owner/repo
├───devShells
│   ├───aarch64-linux
│   │   └───default omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       └───default: development environment 'nix-shell-env'
└───packages
    ├───aarch64-linux
    │   └───hello omitted (use '--all-systems' to show)
    └───x86_64-linux
        └───hello: package 'hello-1.0'
```

After (default):

```
github:owner/repo
├───devShells
│   └───{[x86_64-linux],aarch64-linux}
│       └───default: development environment 'nix-shell-env'
└───packages
    └───{[x86_64-linux],aarch64-linux}
        └───hello: package 'hello-1.0'
```

The local system is highlighted with bold brackets; others are dimmed. The folded node descends into the local system so its content is shown.

Folding is disabled with `--no-system-folding`, `--json`, or `--all-systems`. Single-system categories are not folded.

Related: #6985 #9650 #8803
