### PR TITLE
libstore: extract `NarInfoDiskCacheSettings` from `Settings`

### DIFF
--- a/src/libstore-tests/nar-info-disk-cache.cc
+++ b/src/libstore-tests/nar-info-disk-cache.cc
@@ -25,7 +25,8 @@ TEST(NarInfoDiskCacheImpl, create_and_read)
     SQLiteStmt getIds;
 
     {
-        auto cache = getTestNarInfoDiskCache(dbPath.string());
+        auto cache = NarInfoDiskCache::getTest(
+            settings.getNarInfoDiskCacheSettings(), {.useWAL = settings.useSQLiteWAL}, dbPath.string());
 
         // Set up "background noise" and check that different caches receive different ids
         {
@@ -74,7 +75,8 @@ TEST(NarInfoDiskCacheImpl, create_and_read)
     {
         // We can't clear the in-memory cache, so we use a new cache object. This is
         // more realistic anyway.
-        auto cache2 = getTestNarInfoDiskCache(dbPath.string());
+        auto cache2 = NarInfoDiskCache::getTest(
+            settings.getNarInfoDiskCacheSettings(), {.useWAL = settings.useSQLiteWAL}, dbPath.string());
 
         {
             auto r = cache2->upToDateCacheExists("http://foo");

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -2,8 +2,10 @@
 #include "nix/store/filetransfer.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/nar-info-disk-cache.hh"
+#include "nix/store/sqlite.hh"
 #include "nix/util/callback.hh"
 #include "nix/store/store-registration.hh"
+#include "nix/store/globals.hh"
 
 namespace nix {
 
@@ -64,7 +66,7 @@ HttpBinaryCacheStore::HttpBinaryCacheStore(ref<Config> config, ref<FileTransfer>
     , fileTransfer{fileTransfer}
     , config{config}
 {
-    diskCache = getNarInfoDiskCache();
+    diskCache = NarInfoDiskCache::get(settings.getNarInfoDiskCacheSettings(), {.useWAL = settings.useSQLiteWAL});
 }
 
 void HttpBinaryCacheStore::init()

--- a/src/libstore/include/nix/store/nar-info-disk-cache.hh
+++ b/src/libstore/include/nix/store/nar-info-disk-cache.hh
@@ -7,9 +7,20 @@
 
 namespace nix {
 
-class NarInfoDiskCache
+struct SQLiteSettings;
+struct NarInfoDiskCacheSettings;
+
+struct NarInfoDiskCache
 {
-public:
+    using Settings = NarInfoDiskCacheSettings;
+
+    const Settings & settings;
+
+    NarInfoDiskCache(const Settings & settings)
+        : settings(settings)
+    {
+    }
+
     typedef enum { oValid, oInvalid, oUnknown } Outcome;
 
     virtual ~NarInfoDiskCache() {}
@@ -35,14 +46,20 @@ public:
     virtual void upsertAbsentRealisation(const std::string & uri, const DrvOutput & id) = 0;
     virtual std::pair<Outcome, std::shared_ptr<Realisation>>
     lookupRealisation(const std::string & uri, const DrvOutput & id) = 0;
+
+    /**
+     * Return a singleton cache object that can be used concurrently by
+     * multiple threads.
+     *
+     * @note the parameters are only used to initialize this the first time this is called.
+     * In subsequent calls, these arguments are ignored.
+     *
+     * @todo Probably should instead create a memo table so multiple settings -> multiple instances,
+     * but this is not yet a problem in practice.
+     */
+    static ref<NarInfoDiskCache> get(const Settings & settings, SQLiteSettings);
+
+    static ref<NarInfoDiskCache> getTest(const Settings & settings, SQLiteSettings, Path dbPath);
 };
-
-/**
- * Return a singleton cache object that can be used concurrently by
- * multiple threads.
- */
-ref<NarInfoDiskCache> getNarInfoDiskCache();
-
-ref<NarInfoDiskCache> getTestNarInfoDiskCache(Path dbPath);
 
 } // namespace nix

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -33,6 +33,12 @@ enum class SQLiteOpenMode {
     Immutable,
 };
 
+struct SQLiteSettings
+{
+    SQLiteOpenMode mode = SQLiteOpenMode::Normal;
+    bool useWAL;
+};
+
 /**
  * RAII wrapper to close a SQLite database automatically.
  */
@@ -42,11 +48,7 @@ struct SQLite
 
     SQLite() {}
 
-    struct Settings
-    {
-        SQLiteOpenMode mode = SQLiteOpenMode::Normal;
-        bool useWAL;
-    };
+    using Settings = SQLiteSettings;
 
     SQLite(const std::filesystem::path & path, Settings && settings);
     SQLite(const SQLite & from) = delete;

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -40,7 +40,8 @@ struct BasicDerivation;
 struct Derivation;
 
 struct SourceAccessor;
-class NarInfoDiskCache;
+struct NarInfoDiskCache;
+struct NarInfoDiskCacheSettings;
 class Store;
 
 typedef std::map<std::string, StorePath> OutputPathMap;
@@ -300,7 +301,7 @@ protected:
          * Whether the value is valid as a cache entry. The path may not
          * exist.
          */
-        bool isKnownNow();
+        bool isKnownNow(const NarInfoDiskCacheSettings & settings);
 
         /**
          * Past tense, because a path can only be assumed to exists when

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -566,8 +566,8 @@ void mainWrapped(int argc, char ** argv)
 
     if (args.refresh) {
         fetchSettings.tarballTtl = 0;
-        settings.ttlNegativeNarInfoCache = 0;
-        settings.ttlPositiveNarInfoCache = 0;
+        settings.getNarInfoDiskCacheSettings().ttlNegative = 0;
+        settings.getNarInfoDiskCacheSettings().ttlPositive = 0;
     }
 
     if (args.command->second->forceImpureByDefault() && !evalSettings.pureEval.overridden) {


### PR DESCRIPTION
## Motivation

This commit moves `ttlNegativeNarInfoCache` and `ttlPositiveNarInfoCache` into a dedicated `NarInfoDiskCacheSettings` struct that `Settings` privately inherits from, following the same pattern as `LocalSettings`, `LogFileSettings`, and `WorkerSettings`.

`NarInfoDiskCache` now takes explicit `NarInfoDiskCacheSettings` and `SQLiteSettings` in its constructor instead of reading from the global. The singleton `getNarInfoDiskCache()` is replaced with a `NarInfoDiskCache::get()` static method that accepts these settings, though they are only used on the first call (subsequent calls return the cached instance regardless of arguments).

## Context

Progress on #5638

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
