### PR TITLE
libstore: extract `ProfileDirsOptions` from `Settings`

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -325,7 +325,7 @@ void MixProfile::updateProfile(Store & store, const BuiltPaths & buildables)
 
 MixDefaultProfile::MixDefaultProfile()
 {
-    profile = getDefaultProfile().string();
+    profile = getDefaultProfile(settings.getProfileDirsOptions()).string();
 }
 
 static constexpr auto environmentVariablesCategory = "Options that change environment variables";

--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -71,8 +71,9 @@ Strings EvalSettings::getDefaultNixPath()
     };
 
     add(std::filesystem::path{getNixDefExpr()} / "channels");
-    add(rootChannelsDir() / "nixpkgs", "nixpkgs");
-    add(rootChannelsDir());
+    auto profilesDirOpts = settings.getProfileDirsOptions();
+    add(rootChannelsDir(profilesDirOpts) / "nixpkgs", "nixpkgs");
+    add(rootChannelsDir(profilesDirOpts));
 
     return res;
 }

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -1,4 +1,5 @@
 #include "nix/store/globals.hh"
+#include "nix/store/profiles.hh"
 #include "nix/util/config-impl.hh"
 #include "nix/util/config-global.hh"
 #include "nix/util/current-process.hh"
@@ -292,6 +293,14 @@ const ExternalBuilder * Settings::findExternalDerivationBuilderIfSupported(const
         it != externalBuilders.get().end())
         return &*it;
     return nullptr;
+}
+
+ProfileDirsOptions Settings::getProfileDirsOptions() const
+{
+    return {
+        .nixStateDir = nixStateDir,
+        .useXDGBaseDirectories = useXDGBaseDirectories,
+    };
 }
 
 std::string nixVersion = PACKAGE_VERSION;

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -15,6 +15,8 @@
 
 namespace nix {
 
+struct ProfileDirsOptions;
+
 struct LogFileSettings : public virtual Config
 {
     /**
@@ -398,6 +400,11 @@ public:
      * derivation, or else returns a null pointer.
      */
     const ExternalBuilder * findExternalDerivationBuilderIfSupported(const Derivation & drv);
+
+    /**
+     * Get the options needed for profile directory functions.
+     */
+    ProfileDirsOptions getProfileDirsOptions() const;
 };
 
 // FIXME: don't use a global variable.

--- a/src/libstore/include/nix/store/profiles.hh
+++ b/src/libstore/include/nix/store/profiles.hh
@@ -209,32 +209,38 @@ void lockProfile(PathLocks & lock, const std::filesystem::path & profile);
  */
 std::string optimisticLockProfile(const std::filesystem::path & profile);
 
+struct ProfileDirsOptions
+{
+    const std::filesystem::path & nixStateDir;
+    bool useXDGBaseDirectories;
+};
+
 /**
  * Create and return the path to a directory suitable for storing the user’s
  * profiles.
  */
-std::filesystem::path profilesDir();
+std::filesystem::path profilesDir(ProfileDirsOptions opts);
 
 /**
  * Return the path to the profile directory for root (but don't try creating it)
  */
-std::filesystem::path rootProfilesDir();
+std::filesystem::path rootProfilesDir(ProfileDirsOptions opts);
 
 /**
  * Create and return the path to the file used for storing the users's channels
  */
-std::filesystem::path defaultChannelsDir();
+std::filesystem::path defaultChannelsDir(ProfileDirsOptions opts);
 
 /**
  * Return the path to the channel directory for root (but don't try creating it)
  */
-std::filesystem::path rootChannelsDir();
+std::filesystem::path rootChannelsDir(ProfileDirsOptions opts);
 
 /**
  * Resolve the default profile (~/.nix-profile by default,
  * $XDG_STATE_HOME/nix/profile if XDG Base Directory Support is enabled),
  * and create if doesn't exist
  */
-std::filesystem::path getDefaultProfile();
+std::filesystem::path getDefaultProfile(ProfileDirsOptions opts);
 
 } // namespace nix

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -291,31 +291,32 @@ std::string optimisticLockProfile(const std::filesystem::path & profile)
     return pathExists(profile) ? readLink(profile).string() : "";
 }
 
-std::filesystem::path profilesDir()
+std::filesystem::path profilesDir(ProfileDirsOptions settings)
 {
-    auto profileRoot = isRootUser() ? rootProfilesDir() : std::filesystem::path{createNixStateDir()} / "profiles";
+    auto profileRoot =
+        isRootUser() ? rootProfilesDir(settings) : std::filesystem::path{createNixStateDir()} / "profiles";
     createDirs(profileRoot);
     return profileRoot;
 }
 
-std::filesystem::path rootProfilesDir()
+std::filesystem::path rootProfilesDir(ProfileDirsOptions settings)
 {
-    return std::filesystem::path{settings.nixStateDir} / "profiles/per-user/root";
+    return settings.nixStateDir / "profiles/per-user/root";
 }
 
-std::filesystem::path getDefaultProfile()
+std::filesystem::path getDefaultProfile(ProfileDirsOptions settings)
 {
     std::filesystem::path profileLink = settings.useXDGBaseDirectories
                                             ? std::filesystem::path{createNixStateDir()} / "profile"
                                             : std::filesystem::path{getHome()} / ".nix-profile";
     try {
-        auto profile = profilesDir() / "profile";
+        auto profile = profilesDir(settings) / "profile";
         if (!pathExists(profileLink)) {
             replaceSymlink(profile, profileLink);
         }
         // Backwards compatibility measure: Make root's profile available as
         // `.../default` as it's what NixOS and most of the init scripts expect
-        auto globalProfileLink = std::filesystem::path{settings.nixStateDir} / "profiles" / "default";
+        auto globalProfileLink = settings.nixStateDir / "profiles" / "default";
         if (isRootUser() && !pathExists(globalProfileLink)) {
             replaceSymlink(profile, globalProfileLink);
         }
@@ -328,14 +329,14 @@ std::filesystem::path getDefaultProfile()
     }
 }
 
-std::filesystem::path defaultChannelsDir()
+std::filesystem::path defaultChannelsDir(ProfileDirsOptions settings)
 {
-    return profilesDir() / "channels";
+    return profilesDir(settings) / "channels";
 }
 
-std::filesystem::path rootChannelsDir()
+std::filesystem::path rootChannelsDir(ProfileDirsOptions settings)
 {
-    return rootProfilesDir() / "channels";
+    return rootProfilesDir(settings) / "channels";
 }
 
 } // namespace nix

--- a/src/nix/nix-channel/nix-channel.cc
+++ b/src/nix/nix-channel/nix-channel.cc
@@ -192,7 +192,7 @@ static int main_nix_channel(int argc, char ** argv)
         nixDefExpr = getNixDefExpr();
 
         // Figure out the name of the channels profile.
-        profile = profilesDir() + "/channels";
+        profile = profilesDir(settings.getProfileDirsOptions()) + "/channels";
         createDirs(dirOf(profile));
 
         enum { cNone, cAdd, cRemove, cList, cUpdate, cListGenerations, cRollback } cmd = cNone;

--- a/src/nix/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix/nix-collect-garbage/nix-collect-garbage.cc
@@ -88,10 +88,11 @@ static int main_nix_collect_garbage(int argc, char ** argv)
         });
 
         if (removeOld) {
+            auto profilesDirOpts = settings.getProfileDirsOptions();
             std::set<std::filesystem::path> dirsToClean = {
-                profilesDir(),
+                profilesDir(profilesDirOpts),
                 std::filesystem::path{settings.nixStateDir} / "profiles",
-                getDefaultProfile().parent_path(),
+                getDefaultProfile(profilesDirOpts).parent_path(),
             };
             for (auto & dir : dirsToClean)
                 removeOldGenerations(dir);

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -1414,10 +1414,11 @@ static int main_nix_env(int argc, char ** argv)
 
         if (!pathExists(nixExprPath)) {
             try {
+                auto profilesDirOpts = settings.getProfileDirsOptions();
                 createDirs(nixExprPath);
-                replaceSymlink(defaultChannelsDir(), nixExprPath / "channels");
+                replaceSymlink(defaultChannelsDir(profilesDirOpts), nixExprPath / "channels");
                 if (!isRootUser())
-                    replaceSymlink(rootChannelsDir(), nixExprPath / "channels_root");
+                    replaceSymlink(rootChannelsDir(profilesDirOpts), nixExprPath / "channels_root");
             } catch (std::filesystem::filesystem_error &) {
             } catch (Error &) {
             }
@@ -1524,7 +1525,7 @@ static int main_nix_env(int argc, char ** argv)
             globals.profile = getEnv("NIX_PROFILE").value_or("");
 
         if (globals.profile == "")
-            globals.profile = getDefaultProfile().string();
+            globals.profile = getDefaultProfile(settings.getProfileDirsOptions()).string();
 
         op(globals, std::move(opFlags), std::move(opArgs));
 


### PR DESCRIPTION
## Motivation

This commit moves `nixStateDir` and `useXDGBaseDirectories` into a dedicated `ProfileDirsOptions` struct and threads it through the profile directory functions (`profilesDir`, `rootProfilesDir`, `defaultChannelsDir`, `rootChannelsDir`, `getDefaultProfile`) so they no longer read from the global `Settings` object directly. This follows the same pattern as `LocalSettings`, `WorkerSettings`, and `NarInfoDiskCacheSettings`.

## Context

Progress on #5638

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
