### PR TITLE
Emit basic dry run message for garbage collection

### DIFF
--- a/src/libmain/include/nix/main/shared.hh
+++ b/src/libmain/include/nix/main/shared.hh
@@ -89,19 +89,7 @@ extern volatile ::sig_atomic_t blockInt;
 
 struct GCResults;
 
-struct PrintFreed
-{
-    bool show;
-    const GCResults & results;
-
-    PrintFreed(bool show, const GCResults & results)
-        : show(show)
-        , results(results)
-    {
-    }
-
-    ~PrintFreed();
-};
+void printFreed(bool dryRun, const GCResults & results);
 
 #ifndef _WIN32
 /**

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -391,9 +391,12 @@ RunPager::~RunPager()
     }
 }
 
-PrintFreed::~PrintFreed()
+void printFreed(bool dryRun, const GCResults & results)
 {
-    if (show)
+    /* bytesFreed cannot be reliably computed without actually deleting store paths because of hardlinking. */
+    if (dryRun)
+        std::cout << fmt("%d store paths would be deleted\n", results.paths.size());
+    else
         std::cout << fmt("%d store paths deleted, %s freed\n", results.paths.size(), renderSize(results.bytesFreed));
 }
 

--- a/src/libstore/include/nix/store/gc-store.hh
+++ b/src/libstore/include/nix/store/gc-store.hh
@@ -69,8 +69,7 @@ struct GCResults
     PathSet paths;
 
     /**
-     * For `gcReturnDead`, `gcDeleteDead` and `gcDeleteSpecific`, the
-     * number of bytes that would be or was freed.
+     * For `gcDeleteDead` and `gcDeleteSpecific`, the number of bytes that were freed.
      */
     uint64_t bytesFreed = 0;
 };

--- a/src/nix/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix/nix-collect-garbage/nix-collect-garbage.cc
@@ -1,5 +1,6 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/error.hh"
 #include "nix/store/store-open.hh"
 #include "nix/store/store-cast.hh"
 #include "nix/store/gc-store.hh"
@@ -87,6 +88,9 @@ static int main_nix_collect_garbage(int argc, char ** argv)
             return true;
         });
 
+        if (options.maxFreed != std::numeric_limits<uint64_t>::max() && dryRun)
+            throw UsageError("options --max-freed and --dry-run cannot be combined");
+
         if (removeOld) {
             std::set<std::filesystem::path> dirsToClean = {
                 profilesDir(),
@@ -97,15 +101,12 @@ static int main_nix_collect_garbage(int argc, char ** argv)
                 removeOldGenerations(dir);
         }
 
-        // Run the actual garbage collector.
-        if (!dryRun) {
-            auto store = openStore();
-            auto & gcStore = require<GcStore>(*store);
-            options.action = GCOptions::gcDeleteDead;
-            GCResults results;
-            PrintFreed freed(true, results);
-            gcStore.collectGarbage(options, results);
-        }
+        auto store = openStore();
+        auto & gcStore = require<GcStore>(*store);
+        options.action = dryRun ? GCOptions::gcReturnDead : GCOptions::gcDeleteDead;
+        GCResults results;
+        Finally printer([&] { printFreed(dryRun, results); });
+        gcStore.collectGarbage(options, results);
 
         return 0;
     }

--- a/src/nix/store-delete.cc
+++ b/src/nix/store-delete.cc
@@ -40,7 +40,7 @@ struct CmdStoreDelete : StorePathsCommand
             options.pathsToDelete.insert(path);
 
         GCResults results;
-        PrintFreed freed(true, results);
+        Finally printer([&] { printFreed(false, results); });
         gcStore.collectGarbage(options, results);
     }
 };

--- a/src/nix/store-gc.cc
+++ b/src/nix/store-gc.cc
@@ -4,6 +4,8 @@
 #include "nix/store/store-api.hh"
 #include "nix/store/store-cast.hh"
 #include "nix/store/gc-store.hh"
+#include "nix/util/error.hh"
+#include "nix/util/logging.hh"
 
 using namespace nix;
 
@@ -15,7 +17,7 @@ struct CmdStoreGC : StoreCommand, MixDryRun
     {
         addFlag({
             .longName = "max",
-            .description = "Stop after freeing *n* bytes of disk space.",
+            .description = "Stop after freeing *n* bytes of disk space. Cannot be combined with --dry-run.",
             .labels = {"n"},
             .handler = {&options.maxFreed},
         });
@@ -35,11 +37,14 @@ struct CmdStoreGC : StoreCommand, MixDryRun
 
     void run(ref<Store> store) override
     {
+        if (options.maxFreed != std::numeric_limits<uint64_t>::max() && dryRun)
+            throw UsageError("options --max and --dry-run cannot be combined");
+
         auto & gcStore = require<GcStore>(*store);
 
         options.action = dryRun ? GCOptions::gcReturnDead : GCOptions::gcDeleteDead;
         GCResults results;
-        PrintFreed freed(options.action == GCOptions::gcDeleteDead, results);
+        Finally printer([&] { printFreed(dryRun, results); });
         gcStore.collectGarbage(options, results);
     }
 };


### PR DESCRIPTION
nix store gc: prints number of paths that would be freed, but not bytes
nix-collect-garbage: ditto
nix-store --gc: retains current behavior

It would be very non-trivial to also compute the bytes that would be freed, due to hardlinking in the store.

Also adds checking for incompatible mixing of dry-run and max-freed options.

Resolves #5704

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

A very basic output (path count) is better than the current behavior (no output / no-op). The current behavior is kind of dangerous because a user may take the empty output of `--dry-run` at face value, and assume running without it will not delete anything (or will delete less than it actually will, if combined with `--delete-old`).

## Context

#5704

https://github.com/NixOS/nix/pull/5705

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
