### PR TITLE
libstore: inline `getMachines` into call sites

### DIFF
--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -367,7 +367,7 @@ void Worker::run(const Goals & _topGoals)
         if (!children.empty() || !waitingForAWhile.empty())
             waitForInput();
         else if (awake.empty() && 0U == settings.maxBuildJobs) {
-            if (getMachines().empty())
+            if (Machine::parseConfig({nix::settings.thisSystem}, nix::settings.getWorkerSettings().builders).empty())
                 throw Error(
                     "Unable to start any build; either increase '--max-jobs' or enable remote builds.\n"
                     "\n"

--- a/src/libstore/include/nix/store/machines.hh
+++ b/src/libstore/include/nix/store/machines.hh
@@ -79,11 +79,4 @@ struct Machine
     static Machines parseConfig(const StringSet & defaultSystems, const std::string & config);
 };
 
-/**
- * Parse machines from the global config
- *
- * @todo Remove, globals are bad.
- */
-Machines getMachines();
-
 } // namespace nix

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -207,9 +207,4 @@ Machines Machine::parseConfig(const StringSet & defaultSystems, const std::strin
     return parseBuilderLines(defaultSystems, builderLines);
 }
 
-Machines getMachines()
-{
-    return Machine::parseConfig({settings.thisSystem}, settings.getWorkerSettings().builders);
-}
-
 } // namespace nix

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -94,7 +94,7 @@ static int main_build_remote(int argc, char ** argv)
         std::shared_ptr<Store> sshStore;
         AutoCloseFD bestSlotLock;
 
-        auto machines = getMachines();
+        auto machines = Machine::parseConfig({settings.thisSystem}, settings.getWorkerSettings().builders);
         debug("got %d remote builders", machines.size());
 
         if (machines.empty()) {


### PR DESCRIPTION
## Motivation

This commit removes the `getMachines` free function and inlines `Machine::parseConfig({settings.thisSystem}, settings.getWorkerSettings().builders)` at its two call sites in `worker.cc` and `build-remote.cc`. The wrapper just forwarded to `Machine::parseConfig` with global settings, so inlining it removes an unnecessary layer of indirection and makes the global dependency explicit at each call site.

## Context

Progress on #5638

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
