### PR TITLE
libstore: inline `willBuildLocally` and `canBuildLocally` into call sites

### DIFF
--- a/src/libstore-tests/derivation-advanced-attrs.cc
+++ b/src/libstore-tests/derivation-advanced-attrs.cc
@@ -193,8 +193,6 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_defaults)
 
         EXPECT_EQ(options, advancedAttributes_defaults);
 
-        EXPECT_EQ(options.canBuildLocally(*this->store, got), false);
-        EXPECT_EQ(options.willBuildLocally(*this->store, got), false);
         EXPECT_EQ(options.substitutesAllowed(settings.getWorkerSettings()), true);
         EXPECT_EQ(options.useUidRange(got), false);
     });
@@ -335,8 +333,6 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs_d
 
         EXPECT_EQ(options, advancedAttributes_structuredAttrs_defaults);
 
-        EXPECT_EQ(options.canBuildLocally(*this->store, got), false);
-        EXPECT_EQ(options.willBuildLocally(*this->store, got), false);
         EXPECT_EQ(options.substitutesAllowed(settings.getWorkerSettings()), true);
         EXPECT_EQ(options.useUidRange(got), false);
     });
@@ -402,8 +398,6 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs)
 
         EXPECT_EQ(options, expected);
 
-        EXPECT_EQ(options.canBuildLocally(*this->store, got), false);
-        EXPECT_EQ(options.willBuildLocally(*this->store, got), false);
         EXPECT_EQ(options.substitutesAllowed(settings.getWorkerSettings()), false);
         EXPECT_EQ(options.useUidRange(got), true);
     });

--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -6,7 +6,6 @@
 #include "nix/store/store-api.hh"
 #include "nix/util/types.hh"
 #include "nix/util/util.hh"
-#include "nix/store/globals.hh"
 #include "nix/util/variant-wrapper.hh"
 
 #include <optional>
@@ -357,29 +356,6 @@ StringSet DerivationOptions<Input>::getRequiredSystemFeatures(const BasicDerivat
     if (!drv.type().hasKnownOutputPaths())
         res.insert("ca-derivations");
     return res;
-}
-
-template<typename Input>
-bool DerivationOptions<Input>::canBuildLocally(Store & localStore, const BasicDerivation & drv) const
-{
-    if (drv.platform != settings.thisSystem.get() && !settings.extraPlatforms.get().count(drv.platform)
-        && !drv.isBuiltin())
-        return false;
-
-    if (settings.getWorkerSettings().maxBuildJobs.get() == 0 && !drv.isBuiltin())
-        return false;
-
-    for (auto & feature : getRequiredSystemFeatures(drv))
-        if (!localStore.config.systemFeatures.get().count(feature))
-            return false;
-
-    return true;
-}
-
-template<typename Input>
-bool DerivationOptions<Input>::willBuildLocally(Store & localStore, const BasicDerivation & drv) const
-{
-    return preferLocalBuild && canBuildLocally(localStore, drv);
 }
 
 template<typename Input>

--- a/src/libstore/include/nix/store/derivation-options.hh
+++ b/src/libstore/include/nix/store/derivation-options.hh
@@ -14,7 +14,6 @@
 
 namespace nix {
 
-class Store;
 struct StoreDirConfig;
 struct BasicDerivation;
 struct StructuredAttrs;
@@ -183,16 +182,6 @@ struct DerivationOptions
      * `DerivationOptions` instead.
      */
     StringSet getRequiredSystemFeatures(const BasicDerivation & drv) const;
-
-    /**
-     * @param drv See note on `getRequiredSystemFeatures`
-     */
-    bool canBuildLocally(Store & localStore, const BasicDerivation & drv) const;
-
-    /**
-     * @param drv See note on `getRequiredSystemFeatures`
-     */
-    bool willBuildLocally(Store & localStore, const BasicDerivation & drv) const;
 
     bool substitutesAllowed(const WorkerSettings & workerSettings) const;
 


### PR DESCRIPTION
## Motivation

This commit inlines `DerivationOptions::willBuildLocally` and `DerivationOptions::canBuildLocally` into their sole call site in `DerivationBuildingGoal::tryToBuild`. The `canBuildLocally` logic is now a lambda capturing the surrounding context, and `willBuildLocally` is replaced by `drvOptions.preferLocalBuild && canBuildLocally`. The corresponding method declarations, implementations, and test assertions are removed.

## Context

Progress on #5638

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
