### PR TITLE
libstore: remove `Settings::nixStore` in favor of `StoreConfigBase::getDefaultNixStoreDir`

### DIFF
--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -756,7 +756,7 @@ TEST_F(PrimOpTest, langVersion)
 TEST_F(PrimOpTest, storeDir)
 {
     auto v = eval("builtins.storeDir");
-    ASSERT_THAT(v, IsStringEq(settings.nixStore));
+    ASSERT_THAT(v, IsStringEq(state.store->storeDir));
 }
 
 TEST_F(PrimOpTest, nixVersion)

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -3,6 +3,7 @@
 #include "nix/util/executable-path.hh"
 #include "nix/main/shared.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/store-open.hh"
 #include "nix/store/gc-store.hh"
 #include "nix/main/loggers.hh"
 #include "nix/main/progress-bar.hh"
@@ -331,7 +332,8 @@ void printVersion(const std::string & programName)
         std::cout << "System configuration file: " << nixConfFile() << "\n";
         std::cout << "User configuration files: "
                   << os_string_to_string(ExecutablePath{.directories = nixUserConfFiles()}.render()) << "\n";
-        std::cout << "Store directory: " << settings.nixStore << "\n";
+        std::cout << "Store directory: " << resolveStoreConfig(StoreReference{settings.storeUri.get()})->storeDir
+                  << "\n";
         std::cout << "State directory: " << settings.nixStateDir << "\n";
     }
     throw Exit();

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -83,14 +83,7 @@ Settings settings;
 static GlobalConfig::Register rSettings(&settings);
 
 Settings::Settings()
-    : nixStore(
-#ifndef _WIN32
-          // On Windows `/nix/store` is not a canonical path, but we dont'
-          // want to deal with that yet.
-          canonPath
-#endif
-          (getEnvNonEmpty("NIX_STORE_DIR").value_or(getEnvNonEmpty("NIX_STORE").value_or(NIX_STORE_DIR))))
-    , nixStateDir(canonPath(getEnvNonEmpty("NIX_STATE_DIR").value_or(NIX_STATE_DIR)))
+    : nixStateDir(canonPath(getEnvNonEmpty("NIX_STATE_DIR").value_or(NIX_STATE_DIR)))
     , nixDaemonSocketFile(canonPath(getEnvOsNonEmpty(OS_STR("NIX_DAEMON_SOCKET_PATH"))
                                         .transform([](auto && s) { return std::filesystem::path(s); })
                                         .value_or(nixStateDir / DEFAULT_SOCKET_PATH)))

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -159,11 +159,6 @@ public:
     static unsigned int getDefaultCores();
 
     /**
-     * The directory where we store sources and derived files.
-     */
-    Path nixStore;
-
-    /**
      * The directory where state is stored.
      */
     std::filesystem::path nixStateDir;

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -83,8 +83,8 @@ struct StoreConfigBase : Config
 private:
 
     /**
-     * An indirection so that we don't need to refer to global settings
-     * in headers.
+     * Compute the default Nix store directory from environment variables
+     * (`NIX_STORE_DIR`, `NIX_STORE`) or the compile-time default.
      */
     static Path getDefaultNixStoreDir();
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -18,6 +18,10 @@
 // `addMultipleToStore`.
 #include "nix/store/worker-protocol.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/environment-variables.hh"
+#include "nix/util/file-system.hh"
+
+#include "store-config-private.hh"
 
 #include <filesystem>
 #include <nlohmann/json.hpp>
@@ -30,7 +34,11 @@ namespace nix {
 
 Path StoreConfigBase::getDefaultNixStoreDir()
 {
-    return settings.nixStore;
+    return
+#ifndef _WIN32
+        canonPath
+#endif
+        (getEnvNonEmpty("NIX_STORE_DIR").value_or(getEnvNonEmpty("NIX_STORE").value_or(NIX_STORE_DIR)));
 }
 
 StoreConfig::StoreConfig(const Params & params)

--- a/src/perl/lib/Nix/Store.xs
+++ b/src/perl/lib/Nix/Store.xs
@@ -424,4 +424,4 @@ StoreWrapper::addTempRoot(char * storePath)
 
 SV * getStoreDir()
     PPCODE:
-        XPUSHs(sv_2mortal(newSVpv(settings.nixStore.c_str(), 0)));
+        XPUSHs(sv_2mortal(newSVpv(resolveStoreConfig(StoreReference{settings.storeUri.get()})->storeDir.c_str(), 0)));


### PR DESCRIPTION
## Motivation

This commit removes the `nixStore` member from `Settings` and instead computes the default Nix store directory directly in `StoreConfigBase::getDefaultNixStoreDir()` from env vars (`NIX_STORE_DIR`, `NIX_STORE`) or the compile-time default. The method is made public so callers that previously reached through the global `settings.nixStore` can use it instead.

## Context

Progress on #5638

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
