### PR TITLE
Allow garbage-collecting a closure

### DIFF
--- a/doc/manual/rl-next/closure-gc.md
+++ b/doc/manual/rl-next/closure-gc.md
@@ -1,0 +1,9 @@
+---
+synopsis: "Added `--skip-alive` option to `nix store delete` for collecting garbage within a closure"
+issues: 7239
+prs: 15236
+---
+
+`nix store delete --recursive --skip-alive` can be used to collect garbage
+within a closure, in which case it will only collect the dead paths that are
+part of the closure of its arguments.

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -17,6 +17,7 @@
 #include "nix/util/args.hh"
 #include "nix/util/logging.hh"
 #include "nix/store/globals.hh"
+#include <variant>
 
 #ifndef _WIN32 // TODO need graceful async exit support on Windows?
 #  include "nix/util/monitor-fd.hh"
@@ -745,12 +746,26 @@ static void performOp(
     case WorkerProto::Op::CollectGarbage: {
         GCOptions options;
         options.action = WorkerProto::Serialise<GCOptions::GCAction>::read(*store, rconn);
-        options.pathsToDelete = WorkerProto::Serialise<StorePathSet>::read(*store, rconn);
+        if (rconn.version.features.contains(WorkerProto::featureDeleteDeadSpecific)) {
+            options.pathsToDelete = WorkerProto::Serialise<GCOptions::GCPaths>::read(*store, rconn);
+        } else {
+            auto paths = WorkerProto::Serialise<StorePathSet>::read(*store, rconn);
+            if (options.action != GCAction::gcDeleteSpecific && paths.empty())
+                options.pathsToDelete = GCOptions::WholeStore{};
+            else
+                options.pathsToDelete = paths;
+        }
         conn.from >> options.ignoreLiveness >> options.maxFreed;
         // obsolete fields
         readInt(conn.from);
         readInt(conn.from);
         readInt(conn.from);
+
+        if (options.action == GCAction::gcDeleteDead && std::holds_alternative<StorePathSet>(options.pathsToDelete)
+            && !conn.protoVersion.features.contains(WorkerProto::featureDeleteDeadSpecific)) {
+            throw Error(
+                "Garbage collecting specific paths requested but it is not supported by the negotiated protocol");
+        }
 
         GCResults results;
 

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -1,3 +1,4 @@
+#include "nix/store/gc-store.hh"
 #include "nix/store/local-gc.hh"
 #include "nix/store/local-settings.hh"
 #include "nix/store/local-store.hh"
@@ -22,6 +23,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <variant>
 #if HAVE_STATVFS
 #  include <sys/statvfs.h>
 #endif
@@ -360,6 +362,11 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
 
     boost::unordered_flat_set<StorePath, std::hash<StorePath>> roots, dead, alive;
 
+    /* Return early if nothing to delete */
+    if (std::holds_alternative<StorePathSet>(options.pathsToDelete)
+        && std::get<StorePathSet>(options.pathsToDelete).empty())
+        return;
+
     struct Shared
     {
         // The temp roots only store the hash part to make it easier to
@@ -577,7 +584,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
        via the referrers edges and optionally derivers and derivation
        output edges. If none of those paths are roots, then all
        visited paths are garbage and are deleted. */
-    auto deleteReferrersClosure = [&](const StorePath & start) {
+    auto maybeDeleteReferrersClosure = [&](const StorePath & start) {
         StorePathSet visited;
         std::queue<StorePath> todo;
 
@@ -634,7 +641,8 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 return markAlive();
             }
 
-            if (options.action == GCOptions::gcDeleteSpecific && !options.pathsToDelete.count(*path))
+            if (std::holds_alternative<StorePathSet>(options.pathsToDelete)
+                && !std::get<StorePathSet>(options.pathsToDelete).contains(*path))
                 return;
 
             {
@@ -694,50 +702,73 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
         }
     };
 
-    /* Either delete all garbage paths, or just the specified
-       paths (for gcDeleteSpecific). */
-    if (options.action == GCOptions::gcDeleteSpecific) {
+    try {
+        /* Either delete all garbage paths, or just the specified paths. */
+        std::visit(
+            overloaded{
+                [&](const StorePathSet & paths) {
+                    for (auto & i : paths) {
+                        switch (options.action) {
+                        case GCOptions::gcDeleteDead:
+                            printInfo("deleting garbage within specified paths...");
+                            break;
+                        case GCOptions::gcDeleteSpecific:
+                            printInfo("deleting specified paths...");
+                            break;
+                        case GCOptions::gcReturnDead:
+                        case GCOptions::gcReturnLive:
+                            printInfo("determining live/dead paths...");
+                        }
 
-        for (auto & i : options.pathsToDelete) {
-            deleteReferrersClosure(i);
-            if (!dead.count(i))
-                throw Error(
-                    "Cannot delete path '%1%' since it is still alive. "
-                    "To find out why, use: "
-                    "nix-store --query --roots and nix-store --query --referrers",
-                    printStorePath(i));
-        }
+                        maybeDeleteReferrersClosure(i);
 
-    } else if (options.maxFreed > 0) {
+                        if (options.action == GCOptions::gcDeleteSpecific && !dead.count(i))
+                            throw Error(
+                                "Cannot delete path '%1%' since it is still alive. "
+                                "To find out why, use: "
+                                "nix-store --query --roots and nix-store --query --referrers",
+                                printStorePath(i));
+                    }
+                },
+                [&](const GCOptions::WholeStore & _) {
+                    if (options.maxFreed == 0)
+                        return;
 
-        if (shouldDelete)
-            printInfo("deleting garbage...");
-        else
-            printInfo("determining live/dead paths...");
+                    switch (options.action) {
+                    case GCOptions::gcDeleteDead:
+                        printInfo("deleting garbage...");
+                        break;
+                    case GCOptions::gcDeleteSpecific:
+                        throw Error("Cannot delete the entire store");
+                    case GCOptions::gcReturnDead:
+                    case GCOptions::gcReturnLive:
+                        printInfo("determining live/dead paths...");
+                    }
 
-        try {
-            AutoCloseDir dir(opendir(config->realStoreDir.get().string().c_str()));
-            if (!dir)
-                throw SysError("opening directory %1%", PathFmt(config->realStoreDir.get()));
+                    AutoCloseDir dir(opendir(config->realStoreDir.get().string().c_str()));
+                    if (!dir)
+                        throw SysError("opening directory %1%", PathFmt(config->realStoreDir.get()));
 
-            /* Read the store and delete all paths that are invalid or
-               unreachable. We don't use readDirectory() here so that
-               GCing can start faster. */
-            auto linksName = linksDir.filename();
-            struct dirent * dirent;
-            while (errno = 0, dirent = readdir(dir.get())) {
-                checkInterrupt();
-                std::string name = dirent->d_name;
-                if (name == "." || name == ".." || name == linksName)
-                    continue;
+                    /* Read the store and delete all paths that are invalid or
+                    unreachable. We don't use readDirectory() here so that
+                    GCing can start faster. */
+                    auto linksName = linksDir.filename();
+                    struct dirent * dirent;
+                    while (errno = 0, dirent = readdir(dir.get())) {
+                        checkInterrupt();
+                        std::string name = dirent->d_name;
+                        if (name == "." || name == ".." || name == linksName)
+                            continue;
 
-                if (auto storePath = maybeParseStorePath(storeDir + "/" + name))
-                    deleteReferrersClosure(*storePath);
-                else
-                    deleteFromStore(name, false);
-            }
-        } catch (GCLimitReached & e) {
-        }
+                        if (auto storePath = maybeParseStorePath(storeDir + "/" + name))
+                            maybeDeleteReferrersClosure(*storePath);
+                        else
+                            deleteFromStore(name, false);
+                    }
+                },
+            },
+            options.pathsToDelete);
+    } catch (GCLimitReached & e) {
     }
 
     if (options.action == GCOptions::gcReturnLive) {

--- a/src/libstore/include/nix/store/gc-store.hh
+++ b/src/libstore/include/nix/store/gc-store.hh
@@ -39,6 +39,9 @@ struct GCOptions
     using GCAction = nix::GCAction;
     using enum GCAction;
 
+    struct WholeStore
+    {};
+
     GCAction action{gcDeleteDead};
 
     /**
@@ -50,9 +53,10 @@ struct GCOptions
     bool ignoreLiveness{false};
 
     /**
-     * For `gcDeleteSpecific`, the paths to delete.
+     * The paths from which to delete.
      */
-    StorePathSet pathsToDelete;
+    using GCPaths = std::variant<WholeStore, StorePathSet>;
+    GCPaths pathsToDelete;
 
     /**
      * Stop after at least `maxFreed` bytes have been freed.

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -6,6 +6,7 @@
 #include <compare>
 
 #include "nix/store/common-protocol.hh"
+#include "nix/store/gc-store.hh"
 
 namespace nix {
 
@@ -123,6 +124,11 @@ struct WorkerProto
      * using drvPath (store path) instead of the old hash-based JSON format.
      */
     static constexpr std::string_view featureRealisationWithPath = "realisation-with-path-not-hash";
+
+    /**
+     * Feature for garbage collecting a specific set of paths.
+     */
+    static constexpr std::string_view featureDeleteDeadSpecific = "delete-dead-specific";
 
     /**
      * A unidirectional read connection, to be used by the read half of the
@@ -339,6 +345,8 @@ template<>
 DECLARE_WORKER_SERIALISER(std::optional<std::chrono::microseconds>);
 template<>
 DECLARE_WORKER_SERIALISER(WorkerProto::ClientHandshakeInfo);
+template<>
+DECLARE_WORKER_SERIALISER(GCOptions::GCPaths);
 
 template<typename T>
 DECLARE_WORKER_SERIALISER(std::vector<T>);

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -1,3 +1,5 @@
+#include "nix/store/path.hh"
+#include "nix/store/store-api.hh"
 #include "nix/util/serialise.hh"
 #include "nix/util/util.hh"
 #include "nix/store/path-with-outputs.hh"
@@ -18,6 +20,7 @@
 #include "nix/store/filetransfer.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/socket.hh"
+#include <variant>
 
 #ifndef _WIN32
 #  include <sys/socket.h>
@@ -679,9 +682,26 @@ void RemoteStore::collectGarbage(const GCOptions & options, GCResults & results)
 {
     auto conn(getConnection());
 
-    conn->to << WorkerProto::Op::CollectGarbage;
-    WorkerProto::write(*this, *conn, options.action);
-    WorkerProto::write(*this, *conn, options.pathsToDelete);
+    if (conn->protoVersion.features.contains(WorkerProto::featureDeleteDeadSpecific)) {
+        conn->to << WorkerProto::Op::CollectGarbage;
+        WorkerProto::write(*this, *conn, options.action);
+        WorkerProto::write(*this, *conn, options.pathsToDelete);
+    } else {
+        auto paths = std::visit(
+            overloaded{
+                [&](const StorePathSet & paths) {
+                    if (options.action != GCOptions::gcDeleteSpecific)
+                        throw Error(
+                            "Your daemon version is too old to support garbage collecting a specific set of paths");
+                    return paths;
+                },
+                [](const GCOptions::WholeStore & _) { return StorePathSet{}; },
+            },
+            options.pathsToDelete);
+        conn->to << WorkerProto::Op::CollectGarbage;
+        WorkerProto::write(*this, *conn, options.action);
+        WorkerProto::write(*this, *conn, paths);
+    }
     conn->to << options.ignoreLiveness
              << options.maxFreed
              /* removed options */

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -1,3 +1,4 @@
+#include "nix/store/store-dir-config.hh"
 #include "nix/util/serialise.hh"
 #include "nix/store/path-with-outputs.hh"
 #include "nix/store/store-api.hh"
@@ -8,8 +9,10 @@
 #include "nix/store/worker-protocol-impl.hh"
 #include "nix/store/path-info.hh"
 #include "nix/util/json-utils.hh"
+#include "nix/util/util.hh"
 
 #include <chrono>
+#include <cstdint>
 #include <nlohmann/json.hpp>
 
 namespace nix {
@@ -25,6 +28,7 @@ const WorkerProto::Version WorkerProto::latest = {
             std::string{
                 WorkerProto::featureRealisationWithPath,
             },
+            std::string{WorkerProto::featureDeleteDeadSpecific},
         },
 };
 
@@ -527,6 +531,34 @@ void WorkerProto::Serialise<Realisation>::write(const StoreDirConfig & store, Wr
 {
     WorkerProto::write(store, conn, info.id);
     WorkerProto::write(store, conn, static_cast<const UnkeyedRealisation &>(info));
+}
+
+GCOptions::GCPaths WorkerProto::Serialise<GCOptions::GCPaths>::read(const StoreDirConfig & store, ReadConn conn)
+{
+    uint8_t wholeStore;
+    conn.from >> wholeStore;
+    switch (wholeStore) {
+    case 0:
+        return WorkerProto::Serialise<StorePathSet>::read(store, conn);
+    case 1:
+        return GCOptions::WholeStore{};
+    default:
+        throw Error("Invalid whole store indicator from remote");
+    }
+}
+
+void WorkerProto::Serialise<GCOptions::GCPaths>::write(
+    const StoreDirConfig & store, WriteConn conn, const GCOptions::GCPaths & gcPaths)
+{
+    std::visit(
+        overloaded{
+            [&](const StorePathSet paths) {
+                conn.to << uint8_t{0};
+                WorkerProto::write(store, conn, paths);
+            },
+            [&](const GCOptions::WholeStore & _) { conn.to << uint8_t{1}; },
+        },
+        gcPaths);
 }
 
 } // namespace nix

--- a/src/nix/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix/nix-collect-garbage/nix-collect-garbage.cc
@@ -100,6 +100,7 @@ static int main_nix_collect_garbage(int argc, char ** argv)
         auto store = openStore();
         auto & gcStore = require<GcStore>(*store);
         options.action = dryRun ? GCOptions::gcReturnDead : GCOptions::gcDeleteDead;
+        options.pathsToDelete = GCOptions::WholeStore{};
         GCResults results;
         Finally printer([&] { printFreed(dryRun, results); });
         gcStore.collectGarbage(options, results);

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -663,6 +663,7 @@ static void opGC(Strings opFlags, Strings opArgs)
     bool printRoots = false;
     GCOptions options;
     options.action = GCOptions::gcDeleteDead;
+    options.pathsToDelete = GCOptions::WholeStore{};
 
     GCResults results;
 
@@ -725,8 +726,10 @@ static void opDelete(Strings opFlags, Strings opArgs)
         else
             throw UsageError("unknown flag '%1%'", i);
 
+    StorePathSet paths;
     for (auto & i : opArgs)
-        options.pathsToDelete.insert(store->followLinksToStorePath(i));
+        paths.insert(store->followLinksToStorePath(i));
+    options.pathsToDelete = std::move(paths);
 
     auto & gcStore = require<GcStore>(*store);
 

--- a/src/nix/store-delete.cc
+++ b/src/nix/store-delete.cc
@@ -17,6 +17,13 @@ struct CmdStoreDelete : StorePathsCommand
             .description = "Do not check whether the paths are reachable from a root.",
             .handler = {&options.ignoreLiveness, true},
         });
+
+        addFlag({
+            .longName = "skip-alive",
+            .description =
+                "Do not emit errors when attempting to delete something that is still alive, useful with --recursive.",
+            .handler = {&options.action, GCOptions::gcDeleteDead},
+        });
     }
 
     std::string description() override
@@ -35,8 +42,10 @@ struct CmdStoreDelete : StorePathsCommand
     {
         auto & gcStore = require<GcStore>(*store);
 
+        StorePathSet paths;
         for (auto & path : storePaths)
-            options.pathsToDelete.insert(path);
+            paths.insert(path);
+        options.pathsToDelete = std::move(paths);
 
         GCResults results;
         Finally printer([&] { printFreed(false, results); });

--- a/src/nix/store-gc.cc
+++ b/src/nix/store-gc.cc
@@ -42,6 +42,7 @@ struct CmdStoreGC : StoreCommand, MixDryRun
         auto & gcStore = require<GcStore>(*store);
 
         options.action = dryRun ? GCOptions::gcReturnDead : GCOptions::gcDeleteDead;
+        options.pathsToDelete = GCOptions::WholeStore{};
         GCResults results;
         Finally printer([&] { printFreed(dryRun, results); });
         gcStore.collectGarbage(options, results);

--- a/tests/functional/gc-closure.sh
+++ b/tests/functional/gc-closure.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+TODO_NixOS
+
+nix_gc_closure() {
+    clearStore
+    nix build -f dependencies.nix input0_drv --out-link "$TEST_ROOT/gc-root"
+    input0=$(realpath "$TEST_ROOT/gc-root")
+    input1=$(nix build -f dependencies.nix input1_drv --no-link --print-out-paths)
+    input2=$(nix build -f dependencies.nix input2_drv --no-link --print-out-paths)
+    top=$(nix build -f dependencies.nix --no-link --print-out-paths)
+    somthing_else=$(nix store add-path ./dependencies.nix)
+
+    if isDaemonNewer "2.35pre"; then
+        # Check that nix store delete --recursive --skip-alive is best-effort (doesn't fail when some paths in the closure are alive)
+        nix store delete --recursive --skip-alive "$top"
+        [[ ! -e "$top" ]] || fail "top should have been deleted"
+        [[ -e "$input0" ]] || fail "input0 is a gc root, shouldn't have been deleted"
+        [[ ! -e "$input2" ]] || fail "input2 is not a gc root and is part of top's closure, it should have been deleted"
+        [[ -e "$input1" ]] || fail "input1 is not in the closure of top, it shouldn't have been deleted"
+        [[ -e "$somthing_else" ]] || fail "somthing_else is not in the closure of top, it shouldn't have been deleted"
+    else
+        expectStderr 1 nix store delete --recursive --skip-alive "$top" | grepQuiet "Your daemon version is too old to support garbage collecting a specific set of paths"
+    fi
+}
+
+nix_gc_closure

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -89,6 +89,7 @@ suites = [
       'hash-convert.sh',
       'hash-path.sh',
       'gc-non-blocking.sh',
+      'gc-closure.sh',
       'check.sh',
       'nix-shell.sh',
       'check-refs.sh',


### PR DESCRIPTION
Add option `--skip-alive` to `nix store delete`

`nix store delete --recursive --skip-alive` is morally equivalent to

```bash
for validPath in $(nix path-info --recursive foo); do
  nix store delete "$validPath" || true
done
```

~~Also adds utility function `nix dev-env-path` to facilitate use with devShells.~~ will be split off into separate PR

Resolves #7239

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is the most requested unresolved feature in Nix. (https://github.com/NixOS/nix/issues?q=is%3Aissue%20state%3Aopen%20sort%3Areactions-%2B1-desc)

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

https://github.com/NixOS/nix/issues/7239

Replaces https://github.com/NixOS/nix/pull/8417 because the author appears to have stopped working on it years ago.

This is a separate command to avoid the pitfall of `nix store gc $(getSomePaths)` resolving to `nix store gc`, which would unintentionally GC the entire store.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
