### PR TITLE
libstore-tests: Fix mTLS test for redirect, correctly propagate tries

### DIFF
--- a/src/libstore-test-support/https-store.cc
+++ b/src/libstore-test-support/https-store.cc
@@ -50,9 +50,11 @@ void HttpsBinaryCacheStoreTest::SetUp()
     // clang-format off
     openssl({"ecparam", "-genkey", "-name", "prime256v1", "-out", caKey.string()});
     openssl({"req", "-new", "-x509", "-days", "1", "-key", caKey.string(), "-out", caCert.string(), "-subj", "/CN=TestCA"});
+    auto serverExtFile = tmpDir / "server.ext";
+    writeFile(serverExtFile, "subjectAltName=DNS:localhost,IP:127.0.0.1");
     openssl({"ecparam", "-genkey", "-name", "prime256v1", "-out", serverKey.string()});
-    openssl({"req", "-new", "-key", serverKey.string(), "-out", (tmpDir / "server.csr").string(), "-subj", "/CN=localhost"});
-    openssl({"x509", "-req", "-in", (tmpDir / "server.csr").string(), "-CA", caCert.string(), "-CAkey", caKey.string(), "-CAcreateserial", "-out", serverCert.string(), "-days", "1"});
+    openssl({"req", "-new", "-key", serverKey.string(), "-out", (tmpDir / "server.csr").string(), "-subj", "/CN=localhost", "-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1"});
+    openssl({"x509", "-req", "-in", (tmpDir / "server.csr").string(), "-CA", caCert.string(), "-CAkey", caKey.string(), "-CAcreateserial", "-out", serverCert.string(), "-days", "1", "-extfile", serverExtFile.string()});
     openssl({"ecparam", "-genkey", "-name", "prime256v1", "-out", clientKey.string()});
     openssl({"req", "-new", "-key", clientKey.string(), "-out", (tmpDir / "client.csr").string(), "-subj", "/CN=TestClient"});
     openssl({"x509", "-req", "-in", (tmpDir / "client.csr").string(), "-CA", caCert.string(), "-CAkey", caKey.string(), "-CAcreateserial", "-out", clientCert.string(), "-days", "1"});

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -737,7 +737,7 @@ struct curlFileTransfer : public FileTransfer
                    download after a while. If we're writing to a
                    sink, we can only retry if the server supports
                    ranged requests. */
-                if (err == Transient && attempt < request.tries
+                if (err == Transient && attempt < fileTransfer.settings.tries
                     && (!this->request.dataCallback || writtenToSink == 0 || (acceptRanges && encoding.empty()))) {
                     int ms = retryTimeMs
                              * std::pow(

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -182,7 +182,6 @@ struct FileTransferRequest
     Headers headers;
     std::string expectedETag;
     HttpMethod method = HttpMethod::Get;
-    size_t tries = fileTransferSettings.tries;
     unsigned int baseRetryTimeMs = RETRY_TIME_MS_DEFAULT;
     ActivityId parentAct;
     bool decompress = true;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The fake cacert didn't have `subjectAltName` for `127.0.0.1`, so the test was failing for a different reason. Also `tries` setting wasn't being respected. There's no callsite specifying it in the request, so just use the one specified in the `FileTransferSettings` and remove the fields from the `FileTransferRequest`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
