### PR TITLE
libstore: guard against empty archive in unpack paths

### DIFF
--- a/src/libstore/builtins/unpack-channel.cc
+++ b/src/libstore/builtins/unpack-channel.cc
@@ -27,6 +27,8 @@ static void builtinUnpackChannel(const BuiltinBuilderContext & ctx)
     size_t fileCount;
     std::string fileName;
     auto entries = DirectoryIterator{out};
+    if (entries == DirectoryIterator{})
+        throw Error("channel tarball '%s' is empty", src);
     fileName = entries->path().string();
     fileCount = std::distance(entries.begin(), entries.end());
 

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -131,6 +131,8 @@ std::tuple<StorePath, Hash> prefetchFile(
             unpackTarfile(tmpFile, unpacked);
 
             auto entries = DirectoryIterator{unpacked};
+            if (entries == DirectoryIterator{})
+                throw Error("archive '%s' is empty", url.to_string());
             /* If the archive unpacks to a single file/directory, then use
                that as the top-level. */
             tmpFile = entries->path();

--- a/tests/functional/tarball.sh
+++ b/tests/functional/tarball.sh
@@ -112,3 +112,7 @@ path="$(nix flake prefetch --refresh --json "tarball+file://$TEST_ROOT/tar.tar" 
 [[ $(cat "$path/a/b/xyzzy") = xyzzy ]]
 [[ $(cat "$path/a/b/foo") = foo ]]
 [[ $(cat "$path/bla") = abc ]]
+
+# Test that unpacking an empty file does not segfault (see https://github.com/NixOS/nix/issues/15116).
+touch "$TEST_ROOT/empty"
+expectStderr 1 nix store prefetch-file --unpack "file://$TEST_ROOT/empty" | grepQuiet "archive.*is empty"


### PR DESCRIPTION
## Motivation

`DirectoryIterator` is dereferenced without an end check, which segfaults when unpacking an empty or zero-sized archive. This commit adds an emptiness check before the dereference in both `prefetchFile` and `builtinUnpackChannel`, throwing a descriptive error instead.

## Context

- Fixes #15116

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
