### PR TITLE
libflake: allow underscores at start of flake input names

### DIFF
--- a/src/libfetchers/indirect.cc
+++ b/src/libfetchers/indirect.cc
@@ -5,7 +5,7 @@
 
 namespace nix::fetchers {
 
-std::regex flakeRegex("[a-zA-Z][a-zA-Z0-9_-]*", std::regex::ECMAScript);
+std::regex flakeRegex("[a-zA-Z_][a-zA-Z0-9_-]*", std::regex::ECMAScript);
 
 struct IndirectInputScheme : InputScheme
 {

--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -10,6 +10,7 @@
 #include "nix/util/configuration.hh"
 #include "nix/util/error.hh"
 #include "nix/util/experimental-features.hh"
+#include "nix/flake/lockfile.hh"
 
 namespace nix {
 
@@ -148,6 +149,16 @@ INSTANTIATE_TEST_SUITE_P(
             .description = "basic_indirect",
         },
         InputFromURLTestCase{
+            .url = "_foo",
+            .attrs =
+                {
+                    {"id", Attr("_foo")},
+                    {"type", Attr("indirect")},
+                },
+            .description = "underscore_prefixed_flake_id",
+            .expectedUrl = "flake:_foo",
+        },
+        InputFromURLTestCase{
             .url = "flake:nixpkgs/branch",
             .attrs =
                 {
@@ -281,6 +292,18 @@ TEST(to_string, doesntReencodeUrl)
     auto expected = "http://localhost:8181/test/%2B3d.tar.gz";
 
     ASSERT_EQ(unparsed, expected);
+}
+
+TEST(parseInputAttrPath, underscorePrefixed)
+{
+    auto path = flake::parseInputAttrPath("_foo");
+    ASSERT_EQ(path.size(), 1);
+    ASSERT_EQ(path[0], "_foo");
+
+    auto path2 = flake::parseInputAttrPath("_foo/nested");
+    ASSERT_EQ(path2.size(), 2);
+    ASSERT_EQ(path2[0], "_foo");
+    ASSERT_EQ(path2[1], "nested");
 }
 
 } // namespace nix

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -121,7 +121,7 @@ std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragment
     bool allowMissing = false,
     bool isFlake = true);
 
-const static std::string flakeIdRegexS = "[a-zA-Z][a-zA-Z0-9_-]*";
+const static std::string flakeIdRegexS = "[a-zA-Z_][a-zA-Z0-9_-]*";
 extern std::regex flakeIdRegex;
 
 } // namespace nix


### PR DESCRIPTION
## Motivation

The flake ID regex `[a-zA-Z][a-zA-Z0-9_-]*` rejected identifiers starting with underscores even though the Nix lexer accepts them (`[a-zA-Z_][a-zA-Z0-9_'-]*`). This broke real-world inputs like `_1password-shell-plugins`. The same pattern existed in both `flakeIdRegexS` and the local `flakeRegex` in `IndirectInputScheme`.

Single quotes are intentionally left out of the flake ID regex since they get percent-encoded in URL contexts (`foo'bar` becomes `flake:foo%27bar`), making them impractical for flake references.

## Context

- Fixes #9674

For single quotes, I'm not sure if leaving them out is best, it'd be nice to get confirmation on that :)

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
