### PR TITLE
Refactor Parsing Content Encoding Http Headers 

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -277,7 +277,7 @@ struct curlFileTransfer : public FileTransfer
                 result.urls.push_back(effectiveUriCStr);
         }
 
-        std::string parseContentEncoding(std::string_view contentEncoding)
+        static std::string parseContentEncoding(std::string_view contentEncoding)
         {
 
             if (contentEncoding.find(",") != std::string::npos) {


### PR DESCRIPTION
Support parsing following encodings in case-insensitive manner - 
gzip, x-gzip, compress, x-compress, br, zstd, bzip2, and identity

Throw Exception for Stacked/Unsupported encodings.

Based on conversation #15238 