### PR TITLE
Remove suppport for not having `lchown`

### DIFF
--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -28,7 +28,7 @@ deps_public_maybe_subproject = [
 subdir('nix-meson-build-support/subprojects')
 subdir('nix-meson-build-support/big-objs')
 
-# Check for each of these functions, and create a define like `#define HAVE_LCHOWN 1`.
+# Check for each of these functions, and create a define like `#define HAVE_SYSCONF 1`.
 check_funcs = [
   'sysconf',
 ]

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -68,10 +68,8 @@ endif
 summary('can hardlink to symlink', can_link_symlink, bool_yn : true)
 configdata_priv.set('CAN_LINK_SYMLINK', can_link_symlink.to_int())
 
-# Check for each of these functions, and create a define like `#define HAVE_LCHOWN 1`.
+# Check for each of these functions, and create a define like `#define HAVE_POSIX_FALLOCATE 1`.
 check_funcs = [
-  # Optionally used for canonicalising files from the build
-  'lchown',
   'posix_fallocate',
   'statvfs',
 ]


### PR DESCRIPTION
## Motivation

Linux, macOS, and all 3 BSDs have it (according to man page google search), so let's just drop this.

## Context

Support for not having it was added in d03f0d411740aebd5b27e5a1ac57d8533843ff6b in 2006, things have changed in the last 20 years!

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
