### PR TITLE
upload-release: disable containerd image store to preserve gzip layer compression

### DIFF
--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -39,6 +39,17 @@ jobs:
           role-to-assume: "arn:aws:iam::080433136561:role/nix-release"
           role-session-name: nix-release-oidc-${{ github.run_id }}
           aws-region: eu-west-1
+      - name: Disable containerd image store
+        run: |
+          # Docker 28+ defaults to the containerd image store, which
+          # pushes layers uncompressed instead of gzip. OCI clients
+          # that only support gzip (e.g. go-containerregistry) fail
+          # with "gzip: invalid header". Disabling the containerd
+          # snapshotter restores the classic storage driver, which
+          # preserves gzip-compressed layers through the
+          # `docker load` / `docker push` pipeline.
+          echo '{"features":{"containerd-snapshotter":false}}' | sudo tee /etc/docker/daemon.json > /dev/null
+          sudo systemctl restart docker
       - name: Login to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:


### PR DESCRIPTION
## Motivation

Docker 28+ defaults to the containerd image store, which pushes layers uncompressed instead of gzip. The GHA runner image updated Docker to 29.x (actions/runner-images#13633), causing the `nixos/nix:2.33.3` image to balloon from 138 MB to 505 MB, with all 70 layers pushed as `application/vnd.docker.image.rootfs.diff.tar` instead of `.tar.gzip`. OCI clients that only support gzip (e.g. `go-containerregistry`, used by Concourse CI) fail with "gzip: invalid header".

This commit disables the containerd snapshotter in the release workflow before any Docker operations, restoring the classic storage driver that preserves gzip compression through the `docker load` / `docker push` pipeline.

## Context

- Fixes #15246

The Docker 29.x update to the containerd image store appears to have changed how `docker push` handles layer compression, as there's a similar breaking change in push behavior being tracked in moby/moby#51532. I ran a [before/after comparison](https://github.com/amaanq/nix/actions/runs/22074631759/job/63786942108#step:7:1) on an `ubuntu-24.04` runner with Docker 29.x, which confirms the fix, that is, pushing the same Hydra-built `nix:2.33.3` tarball goes from 505 MB uncompressed (`diff.tar`) to 138 MB gzip (`diff.tar.gzip`).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
