### PR TITLE
libflake: fix assertion crash when malformed URL falls through to path scheme

### DIFF
--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -283,4 +283,18 @@ TEST(to_string, doesntReencodeUrl)
     ASSERT_EQ(unparsed, expected);
 }
 
+TEST(parseFlakeRef, malformedGithubUrlDoesNotCrash)
+{
+    experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
+
+    fetchers::Settings fetchSettings;
+
+    // Using ref= instead of rev= with a github: URL should produce an
+    // error, not an assertion failure in renderAuthorityAndPath
+    // (https://github.com/NixOS/nix/issues/15196).
+    EXPECT_THROW(
+        parseFlakeRef(fetchSettings, "github:nixos/nixpkgs/nixpkgs.git?ref=aead170c1a49253ebfa5027010dfd89a77b73ca4"),
+        Error);
+}
+
 } // namespace nix

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -205,7 +205,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
         fetchSettings,
         {
             .scheme = "path",
-            .authority = ParsedURL::Authority{},
+            .authority = isAbsolute(path) ? std::optional{ParsedURL::Authority{}} : std::nullopt,
             .path = splitString<std::vector<std::string>>(path, "/"),
             .query = query,
             .fragment = fragment,


### PR DESCRIPTION
## Motivation

When a URL like `github:nixos/nixpkgs/nixpkgs.git?ref=<hash>` (using `ref` instead of `rev`) failed the github input scheme, it fell through to `parsePathFlakeRefWithFragment` which constructed a `path:` `ParsedURL` with an empty authority but a relative path. This violated [RFC 3986 section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3) (authority present requires path starting with `/`), causing an assertion failure in `renderAuthorityAndPath` when `PathInputScheme` tried to format the URL for an error message.

This commit only sets the authority on absolute paths. Relative paths get `std::nullopt` for authority, which is the correct representation per the URL spec.

## Context

- Fixes #15196
- Fixes #14830

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
