### PR TITLE
fix(tests): use glob instead of regex in nix-shell test

### DIFF
--- a/tests/functional/nix-shell.sh
+++ b/tests/functional/nix-shell.sh
@@ -39,8 +39,8 @@ testTmpDir=$(pwd)/nix-shell
 mkdir -p "$testTmpDir"
 # shellcheck disable=SC2016
 output=$(TMPDIR="$testTmpDir" nix-shell --pure "$shellDotNix" -A shellDrv --run 'echo $NIX_BUILD_TOP')
-[[ "$output" =~ ${testTmpDir}.* ]] || {
-    echo "expected $output =~ ${testTmpDir}.*" >&2
+[[ "$output" == "${testTmpDir}"/* ]] || {
+    echo "expected $output == ${testTmpDir}/*" >&2
     exit 1
 }
 


### PR DESCRIPTION
The `NIX_BUILD_TOP` test used regex matching with an unquoted path variable. When the path contains `+` (or other regex operators), the test fails because `+` is interpreted as a quantifier rather than a literal character. Glob matching handles these characters correctly.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I use worktree directories with a `+` in them.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
