### PR TITLE
repl: fix history truncation of long lines

### DIFF
--- a/src/libcmd/repl-interacter.cc
+++ b/src/libcmd/repl-interacter.cc
@@ -22,6 +22,7 @@ extern "C" {
 #include "nix/util/finally.hh"
 #include "nix/cmd/repl-interacter.hh"
 #include "nix/util/file-system.hh"
+#include "nix/util/serialise.hh"
 #include "nix/cmd/repl.hh"
 #include "nix/util/environment-variables.hh"
 
@@ -124,8 +125,27 @@ ReadlineLikeInteracter::Guard ReadlineLikeInteracter::init(detail::ReplCompleter
     }
 #if !USE_READLINE
     el_hist_size = 1000;
-#endif
+    // editline's read_history uses a fixed 256-byte buffer (SCREEN_INC),
+    // which silently splits lines longer than 255 characters into separate
+    // history entries. Read the file ourselves to avoid the length limit.
+    auto fd = openFileReadonly(historyFile);
+    if (!fd) {
+        NativeSysError err("opening file %s", PathFmt(historyFile));
+        if (!err.is(std::errc::no_such_file_or_directory) && !err.is(std::errc::not_a_directory))
+            logWarning(err.info());
+    } else {
+        try {
+            FdSource source(fd.get());
+            while (true)
+                add_history(source.readLine().c_str());
+        } catch (EndOfFile &) {
+        } catch (SystemError & e) {
+            logWarning(e.info());
+        }
+    }
+#else
     read_history(historyFile.string().c_str());
+#endif
     auto oldRepl = curRepl;
     curRepl = repl;
     Guard restoreRepl([oldRepl] { curRepl = oldRepl; });

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -227,7 +227,7 @@ std::string readFile(const std::filesystem::path & path)
 {
     auto fd = openFileReadonly(path);
     if (!fd)
-        throw NativeSysError("opening file %1%", PathFmt(path));
+        throw NativeSysError("opening file %s", PathFmt(path));
     return readFile(fd.get());
 }
 


### PR DESCRIPTION
## Motivation

Editline's `read_history` uses `fgets(buf, 256, fp)` internally, splitting
any line longer than 255 characters into multiple history entries. This
commit bypasses it with `std::getline` and `add_history` calls, which
handle arbitrary lengths. GNU readline's `read_history` has no such limit
and is left as-is, and `write_history` already writes full lines via
`fprintf` so it needs no change either.

## Context

- Fixes #15162

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
