### PR TITLE
libstore: structured diagnostics for local build rejection

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -279,7 +279,7 @@ bool Settings::isWSL1()
 #endif
 }
 
-const ExternalBuilder * Settings::findExternalDerivationBuilderIfSupported(const Derivation & drv)
+const ExternalBuilder * LocalSettings::findExternalDerivationBuilderIfSupported(const Derivation & drv)
 {
     if (auto it = std::ranges::find_if(
             externalBuilders.get(), [&](const auto & handler) { return handler.systems.contains(drv.platform); });
@@ -429,17 +429,17 @@ unsigned int MaxBuildJobsSetting::parse(const std::string & str) const
 }
 
 template<>
-Settings::ExternalBuilders BaseSetting<Settings::ExternalBuilders>::parse(const std::string & str) const
+LocalSettings::ExternalBuilders BaseSetting<LocalSettings::ExternalBuilders>::parse(const std::string & str) const
 {
     try {
-        return nlohmann::json::parse(str).template get<Settings::ExternalBuilders>();
+        return nlohmann::json::parse(str).template get<LocalSettings::ExternalBuilders>();
     } catch (std::exception & e) {
         throw UsageError("parsing setting '%s': %s", name, e.what());
     }
 }
 
 template<>
-std::string BaseSetting<Settings::ExternalBuilders>::to_string() const
+std::string BaseSetting<LocalSettings::ExternalBuilders>::to_string() const
 {
     return nlohmann::json(value).dump();
 }

--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
@@ -64,6 +64,12 @@ private:
 
     std::string key() override;
 
+    struct LocalBuildCapability
+    {
+        LocalStore & localStore;
+        const ExternalBuilder * externalBuilder;
+    };
+
     /**
      * The states.
      */
@@ -75,12 +81,11 @@ private:
         DerivationOptions<StorePath> drvOptions,
         PathLocks outputLocks);
     Co buildLocally(
-        LocalStore & localStore,
+        LocalBuildCapability localBuildCap,
         StorePathSet inputPaths,
         std::map<std::string, InitialOutput> initialOutputs,
         DerivationOptions<StorePath> drvOptions,
-        PathLocks outputLocks,
-        const ExternalBuilder * externalBuilder);
+        PathLocks outputLocks);
 
     /**
      * Is the build hook willing to perform the build?

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -104,8 +104,6 @@ public:
 
     Settings();
 
-    using ExternalBuilders = std::vector<ExternalBuilder>;
-
     /**
      * Get the local store settings.
      */
@@ -409,12 +407,6 @@ public:
           Default is 0, which disables the warning.
           Set it to 1 to warn on all paths.
         )"};
-
-    /**
-     * Finds the first external derivation builder that supports this
-     * derivation, or else returns a null pointer.
-     */
-    const ExternalBuilder * findExternalDerivationBuilderIfSupported(const Derivation & drv);
 
     /**
      * Get the options needed for profile directory functions.

--- a/src/libstore/include/nix/store/local-settings.hh
+++ b/src/libstore/include/nix/store/local-settings.hh
@@ -707,6 +707,12 @@ public:
         //        Current system: 'aarch64-darwin' with features {apple-virt, benchmark, big-parallel, nixos-test}
         // Xp::ExternalBuilders
     };
+
+    /**
+     * Finds the first external derivation builder that supports this
+     * derivation, or else returns a null pointer.
+     */
+    const ExternalBuilder * findExternalDerivationBuilderIfSupported(const Derivation & drv);
 };
 
 } // namespace nix

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -282,3 +282,14 @@ if isDaemonNewer "2.34pre" && canUseSandbox; then
     # Error messages should not be empty (end with just "failed:")
     <<<"$out" grepQuietInverse -E "^error:.*failed: *$"
 fi
+
+# https://github.com/NixOS/nix/issues/14883
+# When max-jobs=0 and no remote builders, the error should say
+# "local builds are disabled" instead of the misleading
+# "required system or feature not available".
+if isDaemonNewer "2.34pre"; then
+    expectStderr 1 nix build --impure --max-jobs 0 --expr \
+      'derivation { name = "test-maxjobs"; builder = "/bin/sh"; args = ["-c" "exit 0"]; system = builtins.currentSystem; }' \
+      --no-link \
+      | grepQuiet "local builds are disabled"
+fi


### PR DESCRIPTION
## Motivation

When `max-jobs = 0` and no remote builders are available, Nix reported
"required system or feature not available" even though the system and
features matched fine. The `canBuildLocally` lambda returned a plain
`bool`, conflating a configuration knob (`max-jobs = 0`) with actual
incompatibility (wrong platform, missing features). It also short-circuited
on the first failing check, so a user with both a platform mismatch and
missing features would only see one of the two.

This commit replaces the bool with a `LocalBuildRejection` struct whose
`WrongLocalStore` variant collects all applicable failures into
`badPlatform`, `missingFeatures`, and an orthogonal `maxJobsZero` flag.
Platform mismatch and missing features now produce separate error
paragraphs, and all applicable reasons appear in a single message.

The local-build capability check also now returns
`std::variant<LocalBuildCapability, LocalBuildRejection>`, bundling
the `LocalStore &` and optional `ExternalBuilder *` together.

## Context

- Fixes #14883

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
