### PR TITLE
tests: quote `PATH` in external-builders test heredoc

### DIFF
--- a/tests/functional/external-builders.sh
+++ b/tests/functional/external-builders.sh
@@ -23,7 +23,7 @@ external_builder="$TEST_ROOT/external-builder.sh"
 cat > "$external_builder" <<EOF
 #! $SHELL -e
 
-PATH=$PATH
+PATH=${PATH@Q}
 
 [[ "\$1" = bla ]]
 


### PR DESCRIPTION
## Motivation

The external-builders test expands $PATH into a heredoc without quotes,
so any PATH entry containing spaces (e.g. "Application Support/carapace")
causes bash to parse the line as a command instead of an assignment. This
breaks the test on any macOS system with such entries.

## Context

I was testing out #15244 on my Mac and noticed the `external-builders` test failing due to this. The `PATH` env variable on my Mac does have a space, thanks to the `Application Support` directory.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
