### PR TITLE
libexpr: Optimise `Value::type()`, `ValueStorage::getInternalType()`

### DIFF
--- a/nix-meson-build-support/common/asan-options/meson.build
+++ b/nix-meson-build-support/common/asan-options/meson.build
@@ -9,3 +9,9 @@ endif
 if 'address' in get_option('b_sanitize')
   deps_other += declare_dependency(sources : 'asan-options.cc')
 endif
+
+if 'undefined' in get_option('b_sanitize')
+  add_project_arguments('-DNIX_UBSAN_ENABLED=1', language : 'cpp')
+else
+  add_project_arguments('-DNIX_UBSAN_ENABLED=0', language : 'cpp')
+endif

--- a/src/libexpr-tests/value/value.cc
+++ b/src/libexpr-tests/value/value.cc
@@ -13,8 +13,7 @@ TEST_F(ValueTest, unsetValue)
 {
     Value unsetValue;
     ASSERT_EQ(false, unsetValue.isValid());
-    ASSERT_EQ(nThunk, unsetValue.type(true));
-    ASSERT_DEATH(unsetValue.type(), "");
+    ASSERT_EQ(nThunk, unsetValue.type</*invalidIsThunk=*/true>());
 }
 
 TEST_F(ValueTest, vInt)

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -466,7 +466,7 @@ void EvalState::addConstant(const std::string & name, Value * v, Constant info)
 
            We might know the type of a thunk in advance, so be allowed
            to just write it down in that case. */
-        if (auto gotType = v->type(true); gotType != nThunk)
+        if (auto gotType = v->type</*invalidIsThunk=*/true>(); gotType != nThunk)
             assert(info.type == gotType);
 
         /* Install value the base environment. */

--- a/src/libutil/include/nix/util/error.hh
+++ b/src/libutil/include/nix/util/error.hh
@@ -350,6 +350,15 @@ int handleExceptions(const std::string & programName, std::function<void()> fun)
  */
 [[gnu::noinline, gnu::cold, noreturn]] void unreachable(std::source_location loc = std::source_location::current());
 
+#if NIX_UBSAN_ENABLED == 1
+/* When building with sanitizers, also enable expensive unreachable checks. In
+   optimised builds this explicitly invokes UB with std::unreachable for better
+   optimisations. */
+#  define nixUnreachableWhenHardened ::nix::unreachable
+#else
+#  define nixUnreachableWhenHardened std::unreachable
+#endif
+
 #ifdef _WIN32
 
 namespace windows {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Using `nix::unreachable()` in `getInternalType()` and `type()` turns
out to be quite expensive and prevents inlining. Also `Value::type`
got compiled to a jump table which has a high overhead from indirect
jumps. Using an explicit lookup table turns out to be more efficient.

This does mean that we lose out on nice diagnostics from nix::unreachable
calls, but this code is probably one of the hottests functions in the whole
evaluator, so I think the tradeoff is worth it. The nixUnreachableWhenHardened
boils down to nix::unreachable when UBSan is enabled so we still have good
coverage there.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
