### PR TITLE
libutil: More robust check for NIX_UBSAN_ENABLED

### DIFF
--- a/nix-meson-build-support/common/asan-options/meson.build
+++ b/nix-meson-build-support/common/asan-options/meson.build
@@ -9,9 +9,3 @@ endif
 if 'address' in get_option('b_sanitize')
   deps_other += declare_dependency(sources : 'asan-options.cc')
 endif
-
-if 'undefined' in get_option('b_sanitize')
-  add_project_arguments('-DNIX_UBSAN_ENABLED=1', language : 'cpp')
-else
-  add_project_arguments('-DNIX_UBSAN_ENABLED=0', language : 'cpp')
-endif

--- a/src/libutil/include/nix/util/error.hh
+++ b/src/libutil/include/nix/util/error.hh
@@ -17,6 +17,7 @@
 
 #include "nix/util/suggestions.hh"
 #include "nix/util/fmt.hh"
+#include "nix/util/config.hh"
 
 #include <cstring>
 #include <list>
@@ -350,7 +351,7 @@ int handleExceptions(const std::string & programName, std::function<void()> fun)
  */
 [[gnu::noinline, gnu::cold, noreturn]] void unreachable(std::source_location loc = std::source_location::current());
 
-#if NIX_UBSAN_ENABLED == 1
+#if NIX_UBSAN_ENABLED
 /* When building with sanitizers, also enable expensive unreachable checks. In
    optimised builds this explicitly invokes UB with std::unreachable for better
    optimisations. */

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -2,7 +2,12 @@
 
 include_dirs = [ include_directories('../..') ]
 
-headers = files(
+config_pub_h = configure_file(
+  configuration : configdata_pub,
+  output : 'config.hh',
+)
+
+headers = [ config_pub_h ] + files(
   'abstract-setting-to-json.hh',
   'alignment.hh',
   'ansicolor.hh',

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -16,7 +16,8 @@ cxx = meson.get_compiler('cpp')
 
 subdir('nix-meson-build-support/deps-lists')
 
-configdata = configuration_data()
+configdata_pub = configuration_data()
+configdata_priv = configuration_data()
 
 deps_private_maybe_subproject = []
 deps_public_maybe_subproject = []
@@ -34,8 +35,14 @@ check_funcs = [
 foreach funcspec : check_funcs
   define_name = 'HAVE_' + funcspec[0].underscorify().to_upper()
   define_value = cxx.has_function(funcspec[0]).to_int()
-  configdata.set(define_name, define_value, description : funcspec[1])
+  configdata_priv.set(define_name, define_value, description : funcspec[1])
 endforeach
+
+configdata_pub.set(
+  'NIX_UBSAN_ENABLED',
+  ('undefined' in get_option('b_sanitize')).to_int(),
+  description : 'Whether nix has been built with UBSan enabled',
+)
 
 subdir('nix-meson-build-support/libatomic')
 
@@ -104,7 +111,7 @@ cpuid = dependency(
   version : '>= 0.7.0',
   required : cpuid_required,
 )
-configdata.set('HAVE_LIBCPUID', cpuid.found().to_int())
+configdata_priv.set('HAVE_LIBCPUID', cpuid.found().to_int())
 deps_private += cpuid
 
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
@@ -113,7 +120,7 @@ deps_public += nlohmann_json
 cxx = meson.get_compiler('cpp')
 
 config_priv_h = configure_file(
-  configuration : configdata,
+  configuration : configdata_priv,
   output : 'util-config-private.hh',
 )
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

In https://github.com/NixOS/nix/commit/3df91bea6270b01045ebaa54275a4a3f4aca437d I forgot that the header
might get included out-of-tree with -Wundef. Let's make this a public
config option for libutil as it can affect function bodies in headers.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
