### PR TITLE
Add support for --all to nix build

### DIFF
--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -210,6 +210,7 @@ struct RawInstallablesCommand : virtual Args, SourceExprCommand
 private:
 
     std::vector<std::string> rawInstallables;
+    bool all = false;
 };
 
 /**


### PR DESCRIPTION
Resolves #7165

TODO:
- [ ] Add test
- [ ] Refactor common logic out of `completeFlakeRefWithFragment()` so we're not abusing a completion function
- [ ] Accept argument to `--all` which is the fragment to apply to the flakes, e.g. `.devShells` rather than just getting default completions

Is it OK to abuse RawInstallables as specifying flakes to build `--all` from? I think so, because normally a flake installable arg evaluates to `flake#.packages.<system>.default` so there is precedent for this.

By doing it this way, it automatically does the right thing for multiple out links.

## Motivation

This is a very popular requested feature.

## Context

This is a WIP POC that I will refine.

#7165

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
