### PR TITLE
sqlite: use close_v2 API

### DIFF
--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -115,7 +115,7 @@ SQLite::SQLite(const std::filesystem::path & path, Settings && settings)
 SQLite::~SQLite()
 {
     try {
-        if (db && sqlite3_close(db) != SQLITE_OK)
+        if (db && sqlite3_close_v2(db) != SQLITE_OK)
             SQLiteError::throw_(db, "closing database");
     } catch (...) {
         ignoreExceptionInDestructor();


### PR DESCRIPTION
sqlite3_close_v2() defers closing if prepared statements are still active, making it safer to call from destructors. This avoids potential issues when the database is closed while queries are still in flight.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Nix on Windows

Without this fix, the Windows build of Nix crashes when the SQLite destructor is called.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
