### PR TITLE
LocalStore: stop creating outdated profiles symlink

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -358,7 +358,6 @@ dockerTools.buildLayeredImageWithNixDb {
 
   extraCommands = ''
     rm -rf nix-support
-    ln -s /nix/var/nix/profiles nix/var/nix/gcroots/profiles
   '';
   fakeRootCommands = ''
     chmod 1777 tmp

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -144,10 +144,7 @@ LocalStore::LocalStore(ref<const Config> config)
     Path gcRootsDir = config->stateDir + "/gcroots";
     const auto & localSettings = config->getLocalSettings();
     const auto & gcSettings = localSettings.getGCSettings();
-    if (!pathExists(gcRootsDir)) {
-        createDirs(gcRootsDir);
-        replaceSymlink(profilesDir, gcRootsDir + "/profiles");
-    }
+    createDirs(gcRootsDir);
 
     for (auto & perUserDir : {profilesDir + "/per-user", gcRootsDir + "/per-user"}) {
         createDirs(perUserDir);


### PR DESCRIPTION
The GC already knows where profiles are via stateDir, so the profiles symlink in gcroots is unnecessary. Always create gcRootsDir unconditionally instead of gating on its existence.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Symlinks pose some issues on Windows and I don't see a reason to get this one to work because it's outdated.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
