### PR TITLE
Windows: unit test fixes and skips

### DIFF
--- a/src/libexpr-tests/error_traces.cc
+++ b/src/libexpr-tests/error_traces.cc
@@ -317,6 +317,10 @@ TEST_F(ErrorTraceTest, toFile) {}
 
 TEST_F(ErrorTraceTest, filterSource)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     ASSERT_TRACE2(
         "filterSource [] []",
         TypeError,

--- a/src/libexpr-tests/nix_api_expr.cc
+++ b/src/libexpr-tests/nix_api_expr.cc
@@ -16,6 +16,10 @@ namespace nixC {
 
 TEST_F(nix_api_expr_test, nix_eval_state_lookup_path)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     auto tmpDir = nix::createTempDir();
     auto delTmpDir = std::make_unique<nix::AutoDelete>(tmpDir, true);
     auto nixpkgs = tmpDir / "pkgs";
@@ -75,6 +79,10 @@ TEST_F(nix_api_expr_test, nix_expr_eval_add_numbers)
 
 TEST_F(nix_api_expr_test, nix_expr_eval_drv)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     auto expr = R"(derivation { name = "myname"; builder = "mybuilder"; system = "mysystem"; })";
     nix_expr_eval_from_string(nullptr, state, expr, ".", value);
     ASSERT_EQ(NIX_TYPE_ATTRS, nix_get_type(nullptr, value));
@@ -104,6 +112,10 @@ TEST_F(nix_api_expr_test, nix_expr_eval_drv)
 
 TEST_F(nix_api_expr_test, nix_build_drv)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     auto expr = R"(derivation { name = "myname";
                                 system = builtins.currentSystem;
                                 builder = "/bin/sh";
@@ -159,6 +171,10 @@ TEST_F(nix_api_expr_test, nix_expr_realise_context_bad_value)
 
 TEST_F(nix_api_expr_test, nix_expr_realise_context_bad_build)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     auto expr = R"(
         derivation { name = "letsbuild";
             system = builtins.currentSystem;
@@ -176,6 +192,10 @@ TEST_F(nix_api_expr_test, nix_expr_realise_context_bad_build)
 
 TEST_F(nix_api_expr_test, nix_expr_realise_context)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     // TODO (ca-derivations): add a content-addressing derivation output, which produces a placeholder
     auto expr = R"(
         ''

--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -156,12 +156,20 @@ TEST_F(PrimOpTest, placeholder)
 
 TEST_F(PrimOpTest, baseNameOf)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     auto v = eval("builtins.baseNameOf /some/path");
     ASSERT_THAT(v, IsStringEq("path"));
 }
 
 TEST_F(PrimOpTest, dirOf)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     auto v = eval("builtins.dirOf /some/path");
     ASSERT_THAT(v, IsPathEq("/some"));
 }
@@ -664,7 +672,7 @@ INSTANTIATE_TEST_SUITE_P(
         CASE(R"({ outPath = "foo"; })", "foo")
 // this is broken on cygwin because canonPath("//./test", false) returns //./test
 // FIXME: don't use canonPath
-#ifndef __CYGWIN__
+#if !defined(__CYGWIN__) && !defined(_WIN32)
             ,
         CASE(R"(./test)", "/test")
 #endif

--- a/src/libexpr-tests/value/print.cc
+++ b/src/libexpr-tests/value/print.cc
@@ -355,7 +355,18 @@ TEST_F(ValuePrintingTests, ansiColorsPath)
     Value v;
     v.mkPath(state.rootPath(CanonPath("puppy")), state.mem);
 
-    test(v, ANSI_GREEN "/puppy" ANSI_NORMAL, PrintOptions{.ansiColors = true});
+    test(v,
+         ANSI_GREEN
+#ifdef _WIN32
+        "C:\\"
+#else
+        "/"
+#endif
+         "puppy"
+         ANSI_NORMAL,
+         PrintOptions {
+             .ansiColors = true
+         });
 }
 
 TEST_F(ValuePrintingTests, ansiColorsNull)

--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -11,6 +11,12 @@
 #include "nix/util/error.hh"
 #include "nix/util/experimental-features.hh"
 
+#ifndef _WIN32
+#define BASE_PATH "/foo/bar"
+#else
+#define BASE_PATH "C:/foo/bar"
+#endif
+
 namespace nix {
 
 /* ----------- tests for flake/flakeref.hh --------------------------------------------------*/
@@ -22,38 +28,38 @@ TEST(parseFlakeRef, path)
     fetchers::Settings fetchSettings;
 
     {
-        auto s = "/foo/bar";
+        auto s = BASE_PATH;
         auto flakeref = parseFlakeRef(fetchSettings, s);
-        ASSERT_EQ(flakeref.to_string(), "path:/foo/bar");
+        ASSERT_EQ(flakeref.to_string(), "path:" BASE_PATH);
     }
 
     {
-        auto s = "/foo/bar?revCount=123&rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        auto s = BASE_PATH "?revCount=123&rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         auto flakeref = parseFlakeRef(fetchSettings, s);
-        ASSERT_EQ(flakeref.to_string(), "path:/foo/bar?rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&revCount=123");
+        ASSERT_EQ(flakeref.to_string(), "path:" BASE_PATH "?rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&revCount=123");
     }
 
     {
-        auto s = "/foo/bar?xyzzy=123";
+        auto s = BASE_PATH "?xyzzy=123";
         EXPECT_THROW(parseFlakeRef(fetchSettings, s), Error);
     }
 
     {
-        auto s = "/foo/bar#bla";
+        auto s = BASE_PATH "#bla";
         EXPECT_THROW(parseFlakeRef(fetchSettings, s), Error);
     }
 
     {
-        auto s = "/foo/bar#bla";
+        auto s = BASE_PATH "#bla";
         auto [flakeref, fragment] = parseFlakeRefWithFragment(fetchSettings, s);
-        ASSERT_EQ(flakeref.to_string(), "path:/foo/bar");
+        ASSERT_EQ(flakeref.to_string(), "path:" BASE_PATH);
         ASSERT_EQ(fragment, "bla");
     }
 
     {
-        auto s = "/foo/bar?revCount=123#bla";
+        auto s = BASE_PATH "?revCount=123#bla";
         auto [flakeref, fragment] = parseFlakeRefWithFragment(fetchSettings, s);
-        ASSERT_EQ(flakeref.to_string(), "path:/foo/bar?revCount=123");
+        ASSERT_EQ(flakeref.to_string(), "path:" BASE_PATH "?revCount=123");
         ASSERT_EQ(fragment, "bla");
     }
 

--- a/src/libflake-tests/nix_api_flake.cc
+++ b/src/libflake-tests/nix_api_flake.cc
@@ -17,6 +17,10 @@ namespace nixC {
 
 TEST_F(nix_api_store_test, nix_api_init_getFlake_exists)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     nix_libstore_init(ctx);
     assert_ctx_ok();
     nix_libexpr_init(ctx);

--- a/src/libstore-test-support/include/nix/store/tests/nix_api_store.hh
+++ b/src/libstore-test-support/include/nix/store/tests/nix_api_store.hh
@@ -44,7 +44,7 @@ protected:
         auto tmpl = nix::defaultTempDir() / "tests_nix-store.";
         for (size_t i = 0; true; ++i) {
             nixDir = tmpl.string() + std::to_string(i);
-            if (std::filesystem::create_directory(nixDir))
+            if (std::filesystem::create_directories(nixDir))
                 break;
         }
 #else

--- a/src/libstore-tests/data/store-reference/local_shorthand_2_windows.txt
+++ b/src/libstore-tests/data/store-reference/local_shorthand_2_windows.txt
@@ -1,0 +1,1 @@
+Z:\foo\bar\baz?trusted=true

--- a/src/libstore-tests/machines.cc
+++ b/src/libstore-tests/machines.cc
@@ -189,6 +189,10 @@ TEST(machines, getMachinesWithCorrectFileReference)
 
 TEST(machines, getMachinesWithCorrectFileReferenceToEmptyFile)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     std::filesystem::path path = "/dev/null";
     ASSERT_TRUE(std::filesystem::exists(path));
 
@@ -198,6 +202,10 @@ TEST(machines, getMachinesWithCorrectFileReferenceToEmptyFile)
 
 TEST(machines, getMachinesWithIncorrectFileReference)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     auto path = std::filesystem::weakly_canonical("/not/a/file");
     ASSERT_TRUE(!std::filesystem::exists(path));
     auto actual = Machine::parseConfig({}, "@" + path.string());

--- a/src/libstore-tests/nar-info-disk-cache.cc
+++ b/src/libstore-tests/nar-info-disk-cache.cc
@@ -10,6 +10,10 @@ namespace nix {
 
 TEST(NarInfoDiskCacheImpl, create_and_read)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     // This is a large single test to avoid some setup overhead.
 
     int prio = 12345;

--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -25,6 +25,10 @@ TEST_F(nix_api_util_context, nix_libstore_init)
 
 TEST_F(nix_api_store_test, nix_store_get_uri)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     std::string str;
     auto ret = nix_store_get_uri(ctx, store, OBSERVE_STRING(str));
     ASSERT_EQ(NIX_OK, ret);
@@ -39,6 +43,10 @@ TEST_F(nix_api_store_test, nix_store_get_uri)
 
 TEST_F(nix_api_util_context, nix_store_get_storedir_default)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     nix_libstore_init(ctx);
     Store * store = nix_store_open(ctx, nullptr, nullptr);
     assert_ctx_ok();
@@ -57,6 +65,10 @@ TEST_F(nix_api_util_context, nix_store_get_storedir_default)
 
 TEST_F(nix_api_store_test, nix_store_get_storedir)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     std::string str;
     auto ret = nix_store_get_storedir(ctx, store, OBSERVE_STRING(str));
     assert_ctx_ok();
@@ -74,6 +86,10 @@ TEST_F(nix_api_store_test, InvalidPathFails)
 
 TEST_F(nix_api_store_test, ReturnsValidStorePath)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     StorePath * result = nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str());
     ASSERT_NE(result, nullptr);
     ASSERT_STREQ("name", result->path.name().data());
@@ -83,6 +99,10 @@ TEST_F(nix_api_store_test, ReturnsValidStorePath)
 
 TEST_F(nix_api_store_test, SetsLastErrCodeToNixOk)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     StorePath * path = nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str());
     ASSERT_EQ(nix_err_code(ctx), NIX_OK);
     nix_store_path_free(path);
@@ -90,6 +110,10 @@ TEST_F(nix_api_store_test, SetsLastErrCodeToNixOk)
 
 TEST_F(nix_api_store_test, DoesNotCrashWhenContextIsNull)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     StorePath * path = nullptr;
     ASSERT_NO_THROW(path = nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str()));
     nix_store_path_free(path);
@@ -161,6 +185,10 @@ TEST_F(nix_api_store_test, nix_store_create_from_parts_invalid_name)
 
 TEST_F(nix_api_store_test, get_version)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     std::string str;
     auto ret = nix_store_get_version(ctx, store, OBSERVE_STRING(str));
     ASSERT_EQ(NIX_OK, ret);
@@ -192,6 +220,10 @@ TEST_F(nix_api_util_context, nix_store_open_invalid)
 
 TEST_F(nix_api_store_test, nix_store_is_valid_path_not_in_store)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     StorePath * path = nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str());
     ASSERT_EQ(false, nix_store_is_valid_path(ctx, store, path));
     nix_store_path_free(path);
@@ -199,6 +231,10 @@ TEST_F(nix_api_store_test, nix_store_is_valid_path_not_in_store)
 
 TEST_F(nix_api_store_test, nix_store_real_path)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     StorePath * path = nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str());
     std::string rp;
     auto ret = nix_store_real_path(ctx, store, path, OBSERVE_STRING(rp));
@@ -212,6 +248,10 @@ TEST_F(nix_api_store_test, nix_store_real_path)
 
 TEST_F(nix_api_util_context, nix_store_real_path_relocated)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     auto tmp = nix::createTempDir();
     auto storeRoot = (tmp / "store").string();
     auto stateDir = (tmp / "state").string();
@@ -251,6 +291,10 @@ TEST_F(nix_api_util_context, nix_store_real_path_relocated)
 
 TEST_F(nix_api_util_context, nix_store_real_path_binary_cache)
 {
+#ifdef _WIN32
+    GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+#endif
+
     Store * store =
         nix_store_open(ctx, nix::fmt("file://%s/binary-cache", nix::createTempDir().string()).c_str(), nullptr);
     assert_ctx_ok();

--- a/src/libstore-tests/store-reference.cc
+++ b/src/libstore-tests/store-reference.cc
@@ -77,7 +77,11 @@ static StoreReference localExample_2{
     .variant =
         StoreReference::Specified{
             .scheme = "local",
+#ifndef _WIN32
             .authority = "/foo/bar/baz",
+#else
+            .authority = "Z:\\foo\\bar\\baz",
+#endif
         },
     .params =
         {
@@ -98,7 +102,9 @@ static StoreReference localExample_3{
 
 URI_TEST(local_1, localExample_1)
 
+#ifndef _WIN32
 URI_TEST(local_2, localExample_2)
+#endif
 
 /* Test path with encoded spaces */
 URI_TEST(local_3, localExample_3)
@@ -108,7 +114,11 @@ URI_TEST_READ(local_3_no_percent, localExample_3)
 
 URI_TEST_READ(local_shorthand_1, localExample_1)
 
+#ifndef _WIN32
 URI_TEST_READ(local_shorthand_2, localExample_2)
+#else
+URI_TEST_READ(local_shorthand_2_windows, localExample_2)
+#endif
 
 URI_TEST(
     local_shorthand_3,

--- a/src/libutil-tests/compression.cc
+++ b/src/libutil-tests/compression.cc
@@ -3,6 +3,19 @@
 
 namespace nix {
 
+    /*
+    TODO: Something around exception handling is broken when running under Wine.
+    An EndOfFile is being thrown but not caught when decompressing a compression source.
+    */
+    static bool isWine() {
+#ifndef _WIN32
+        return false;
+#else
+        HMODULE hntdll = GetModuleHandle("ntdll.dll");
+        return GetProcAddress(hntdll, "wine_get_version");
+#endif
+    }
+
 /* ----------------------------------------------------------------------------
  * compress / decompress
  * --------------------------------------------------------------------------*/
@@ -36,6 +49,8 @@ TEST(decompress, decompressEmptyCompressed)
 
 TEST(decompress, decompressXzCompressed)
 {
+    if (isWine()) GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+
     auto method = "xz";
     auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
     auto o = decompress(method, compress(CompressionAlgo::xz, str));
@@ -45,6 +60,8 @@ TEST(decompress, decompressXzCompressed)
 
 TEST(decompress, decompressBzip2Compressed)
 {
+    if (isWine()) GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+
     auto method = "bzip2";
     auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
     auto o = decompress(method, compress(CompressionAlgo::bzip2, str));
@@ -63,6 +80,8 @@ TEST(decompress, decompressBrCompressed)
 
 TEST(decompress, decompressInvalidInputThrowsCompressionError)
 {
+    if (isWine()) GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+
     auto method = "bzip2";
     auto str = "this is a string that does not qualify as valid bzip2 data";
 
@@ -86,6 +105,8 @@ TEST(makeCompressionSink, noneSinkDoesNothingToInput)
 
 TEST(makeCompressionSink, compressAndDecompress)
 {
+    if (isWine()) GTEST_SKIP_("Broken on Windows"); // TODO: Fix
+
     StringSink strSink;
     auto inputString = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
     auto decompressionSink = makeDecompressionSink("bzip2", strSink);

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -294,7 +294,14 @@ TEST(makeParentCanonical, noParent)
 
 TEST(makeParentCanonical, root)
 {
-    ASSERT_EQ(makeParentCanonical("/"), "/");
+    auto rootPath =
+#ifndef _WIN32
+        "/"
+#else
+        "C:\\"
+#endif
+        ;
+    ASSERT_EQ(makeParentCanonical(rootPath), rootPath);
 }
 
 /* ----------------------------------------------------------------------------


### PR DESCRIPTION
@Ericson2314 I rebased these old commits because I saw you mention unit tests on Windows. From memory, this was enough to make units tests go green.

---

Fix test infrastructure for Windows and skip tests that don't pass yet (all with TODO comments to fix later).

- nix_api_store.hh: use create_directories (supports nested paths)
- compression.cc: add isWine() runtime detection; skip decompression tests under Wine only (exception handling broken in Wine)
- file-system.cc: fix makeParentCanonical root test for Windows path
- flakeref.cc: add BASE_PATH macro for platform-appropriate paths
- nix_api_flake.cc: skip getFlake test on Windows
- machines.cc: skip /dev/null and /not/a/file reference tests
- nar-info-disk-cache.cc: skip create_and_read on Windows
- nix_api_store.cc: skip 11 store API tests on Windows
- store-reference.cc: add Windows URI test variation with Z: paths; create local_shorthand_2_windows.txt test data
- error_traces.cc: skip filterSource on Windows
- nix_api_expr.cc: skip 5 drv/eval tests on Windows
- primops.cc: skip baseNameOf, dirOf on Windows; guard coercion test
- value/print.cc: fix ansiColorsPath for Windows root path

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
