### PR TITLE
Filesystem error improvements

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -710,7 +710,7 @@ void NixRepl::loadFlake(const std::string & flakeRefS)
     try {
         cwd = std::filesystem::current_path();
     } catch (std::filesystem::filesystem_error & e) {
-        throw SysError("cannot determine current working directory");
+        throw SystemError(e.code(), "cannot determine current working directory");
     }
 
     auto flakeRef = parseFlakeRef(fetchSettings, flakeRefS, cwd.string(), true);

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -247,7 +247,8 @@ static void initRepoAtomically(std::filesystem::path & path, GitRepo::Options op
             || e.code() == std::errc::directory_not_empty) {
             return;
         } else
-            throw SysError("moving temporary git repository from %s to %s", PathFmt(tmpDir), PathFmt(path));
+            throw SystemError(
+                e.code(), "moving temporary git repository from %s to %s", PathFmt(tmpDir), PathFmt(path));
     }
     // we successfully moved the repository, so the temporary directory no longer exists.
     delTmpDir.cancel();

--- a/src/libstore/builtins/unpack-channel.cc
+++ b/src/libstore/builtins/unpack-channel.cc
@@ -36,8 +36,8 @@ static void builtinUnpackChannel(const BuiltinBuilderContext & ctx)
     auto target = out / channelName;
     try {
         std::filesystem::rename(fileName, target);
-    } catch (std::filesystem::filesystem_error &) {
-        throw SysError("failed to rename %1% to %2%", fileName, target.string());
+    } catch (std::filesystem::filesystem_error & e) {
+        throw SystemError(e.code(), "failed to rename %1% to %2%", fileName, target.string());
     }
 }
 

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -272,7 +272,7 @@ void LocalStore::findRoots(const Path & path, std::filesystem::file_type type, R
             || e.code() == std::errc::not_a_directory)
             printInfo("cannot read potential root '%1%'", path);
         else
-            throw;
+            throw SystemError(e.code(), "finding GC roots in '%1%'", path);
     }
 
     catch (SystemError & e) {

--- a/src/libstore/local-gc.cc
+++ b/src/libstore/local-gc.cc
@@ -35,7 +35,7 @@ static void readProcLink(const std::filesystem::path & file, UncheckedRoots & ro
         if (e.code() == std::errc::no_such_file_or_directory || e.code() == std::errc::permission_denied
             || e.code() == std::errc::no_such_process)
             return;
-        throw;
+        throw SystemError(e.code(), "reading symlink '%s'", PathFmt(file));
     }
     if (buf.is_absolute())
         roots[buf.string()].emplace(file.string());

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -111,8 +111,8 @@ static std::vector<std::string> expandBuilderLines(const std::string & builders)
                 std::string text;
                 try {
                     text = readFile(path);
-                } catch (const SysError & e) {
-                    if (e.errNo != ENOENT)
+                } catch (const SystemError & e) {
+                    if (!e.is(std::errc::no_such_file_or_directory))
                         throw;
                     debug("cannot find machines file '%s'", path);
                     continue;

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -202,14 +202,13 @@ void LocalStore::optimisePath_(
                    full.  When that happens, it's fine to ignore it: we
                    just effectively disable deduplication of this
                    file.
-                   TODO: Get rid of errno, use error code.
                    */
-                printInfo("cannot link %s to '%s': %s", PathFmt(linkPath), path, strerror(errno));
+                printInfo("cannot link %s to '%s': %s", PathFmt(linkPath), path, e.code().message());
                 return;
             }
 
             else
-                throw;
+                throw SystemError(e.code(), "creating hard link from %1% to %2%", PathFmt(linkPath), path);
         }
     }
 
@@ -250,7 +249,7 @@ void LocalStore::optimisePath_(
                 printInfo("%1% has maximum number of links", PathFmt(linkPath));
             return;
         }
-        throw;
+        throw SystemError(e.code(), "creating hard link from %1% to %2%", PathFmt(linkPath), PathFmt(tempLink));
     }
 
     /* Atomically replace the old file with the new hard link. */
@@ -271,7 +270,7 @@ void LocalStore::optimisePath_(
             debug("%s has reached maximum number of links", PathFmt(linkPath));
             return;
         }
-        throw;
+        throw SystemError(e.code(), "renaming %1% to %2%", PathFmt(tempLink), path);
     }
 
     stats.filesLinked++;

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -103,7 +103,7 @@ static void removeFile(const std::filesystem::path & path)
     try {
         std::filesystem::remove(path);
     } catch (std::filesystem::filesystem_error & e) {
-        throw SysError("removing file %1%", PathFmt(path));
+        throw SystemError(e.code(), "removing file %1%", PathFmt(path));
     }
 }
 
@@ -323,8 +323,6 @@ std::filesystem::path getDefaultProfile(ProfileDirsOptions settings)
         auto linkDir = profileLink.parent_path();
         return absPath(readLink(profileLink), &linkDir);
     } catch (Error &) {
-        return profileLink;
-    } catch (std::filesystem::filesystem_error &) {
         return profileLink;
     }
 }

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -319,7 +319,7 @@ TEST(chmodIfNeeded, works)
 
 TEST(chmodIfNeeded, nonexistent)
 {
-    ASSERT_THROW(chmodIfNeeded("/schnitzel/darmstadt/pommes", 0755), SysError);
+    ASSERT_THROW(chmodIfNeeded("/schnitzel/darmstadt/pommes", 0755), SystemError);
 }
 
 /* ----------------------------------------------------------------------------
@@ -340,7 +340,7 @@ TEST(DirectoryIterator, works)
 
 TEST(DirectoryIterator, nonexistent)
 {
-    ASSERT_THROW(DirectoryIterator("/schnitzel/darmstadt/pommes"), SysError);
+    ASSERT_THROW(DirectoryIterator("/schnitzel/darmstadt/pommes"), SystemError);
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -75,7 +75,7 @@ namespace linux {
  *
  * @see https://man7.org/linux/man-pages/man2/openat2.2.html
  * @see https://man7.org/linux/man-pages/man2/open_how.2type.html
-v*
+ *
  * @param flags O_* flags
  * @param mode Mode for O_{CREAT,TMPFILE}
  * @param resolve RESOLVE_* flags

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -189,21 +189,19 @@ Path readLink(const Path & path);
  */
 std::filesystem::path readLink(const std::filesystem::path & path);
 
-#ifdef _WIN32
-namespace windows {
-
 /**
- * Get the path associated with a file handle.
+ * Get the path associated with a file descriptor.
  *
  * @note One MUST only use this for error handling, because it creates
  * TOCTOU issues. We don't mind if error messages point to out of date
  * paths (that is a rather trivial TOCTOU --- the error message is best
  * effort) but for anything else we do.
+ *
+ * @note this function will clobber `errno` (Unix) / "last error"
+ * (Windows), so care must be used to get those error codes, then call
+ * this, then build a `SysError` / `WinError` with the saved error code.
  */
-std::filesystem::path handleToPath(Descriptor handle);
-
-} // namespace windows
-#endif
+std::filesystem::path descriptorToPath(Descriptor fd);
 
 /**
  * Open a `Descriptor` with read-only access to the given directory.

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -170,7 +170,7 @@ SourceAccessor::DirEntries PosixSourceAccessor::readDirectory(const CanonPath & 
                 if (e.code() == std::errc::permission_denied || e.code() == std::errc::operation_not_permitted)
                     return std::nullopt;
                 else
-                    throw;
+                    throw SystemError(e.code(), "getting status of '%s'", PathFmt(entry.path()));
             }
         }();
         res.emplace(entry.path().filename().string(), type);

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -49,7 +49,8 @@ void readFull(int fd, char * buf, size_t count)
                 pollFD(fd, POLLIN);
                 continue;
             }
-            throw SysError("reading from file");
+            auto savedErrno = errno;
+            throw SysError(savedErrno, "reading from file %s", PathFmt(descriptorToPath(fd)));
         }
         if (res == 0)
             throw EndOfFile("unexpected end-of-file");
@@ -72,7 +73,8 @@ void writeFull(int fd, std::string_view s, bool allowInterrupts)
                 pollFD(fd, POLLOUT);
                 continue;
             }
-            throw SysError("writing to file");
+            auto savedErrno = errno;
+            throw SysError(savedErrno, "writing to file %s", PathFmt(descriptorToPath(fd)));
         }
         if (res > 0)
             s.remove_prefix(res);
@@ -95,8 +97,10 @@ std::string readLine(int fd, bool eofOk, char terminator)
                 pollFD(fd, POLLIN);
                 continue;
             }
-            default:
-                throw SysError("reading a line");
+            default: {
+                auto savedErrno = errno;
+                throw SysError(savedErrno, "reading a line from %s", PathFmt(descriptorToPath(fd)));
+            }
             }
         } else if (rd == 0) {
             if (eofOk)

--- a/src/libutil/unix/meson.build
+++ b/src/libutil/unix/meson.build
@@ -8,6 +8,12 @@ configdata_unix.set(
   description : 'Optionally used for changing the files and symlinks.',
 )
 
+configdata_unix.set(
+  'HAVE_F_GETPATH',
+  cxx.has_header_symbol('fcntl.h', 'F_GETPATH').to_int(),
+  description : 'Optionally used for getting the path of a file descriptor (macOS).',
+)
+
 # Check for each of these functions, and create a define like `#define
 # HAVE_CLOSE_RANGE 1`.
 check_funcs_unix = [

--- a/src/libutil/windows/file-descriptor.cc
+++ b/src/libutil/windows/file-descriptor.cc
@@ -45,9 +45,9 @@ void writeFull(HANDLE handle, std::string_view s, bool allowInterrupts)
             checkInterrupt();
         DWORD res;
         if (!WriteFile(handle, s.data(), s.size(), &res, NULL)) {
-            // Do this because `handleToPath` will overwrite the last error.
+            // Do this because `descriptorToPath` will overwrite the last error.
             auto lastError = GetLastError();
-            auto path = handleToPath(handle);
+            auto path = descriptorToPath(handle);
             throw WinError(lastError, "writing to file %d:%s", handle, PathFmt(path));
         }
         if (res > 0)

--- a/src/libutil/windows/file-system-at.cc
+++ b/src/libutil/windows/file-system-at.cc
@@ -156,13 +156,13 @@ OsString readSymlinkTarget(HANDLE linkHandle)
     size_t path_buf_offset = offsetof(ReparseDataBuffer, SymbolicLinkReparseBuffer.PathBuffer[0]);
 
     if (out < path_buf_offset) {
-        auto fullPath = handleToPath(linkHandle);
+        auto fullPath = descriptorToPath(linkHandle);
         throw WinError(
             DWORD{ERROR_REPARSE_TAG_INVALID}, "invalid reparse data for %d:%s", linkHandle, PathFmt(fullPath));
     }
 
     if (reparse->ReparseTag != IO_REPARSE_TAG_SYMLINK) {
-        auto fullPath = handleToPath(linkHandle);
+        auto fullPath = descriptorToPath(linkHandle);
         throw WinError(DWORD{ERROR_REPARSE_TAG_INVALID}, "not a symlink: %d:%s", linkHandle, PathFmt(fullPath));
     }
 
@@ -179,7 +179,7 @@ OsString readSymlinkTarget(HANDLE linkHandle)
     }
 
     if (path_buf_offset + name_offset + name_length > out) {
-        auto fullPath = handleToPath(linkHandle);
+        auto fullPath = descriptorToPath(linkHandle);
         throw WinError(
             DWORD{ERROR_REPARSE_TAG_INVALID}, "invalid symlink data for %d:%s", linkHandle, PathFmt(fullPath));
     }

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -83,7 +83,7 @@ void deletePath(const std::filesystem::path & path, uint64_t & bytesFreed)
     deletePath(path);
 }
 
-std::filesystem::path windows::handleToPath(HANDLE handle)
+std::filesystem::path descriptorToPath(Descriptor handle)
 {
     std::vector<wchar_t> buf(0x100);
     DWORD dw = GetFinalPathNameByHandleW(handle, buf.data(), buf.size(), FILE_NAME_OPENED);

--- a/src/nix/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix/nix-collect-garbage/nix-collect-garbage.cc
@@ -43,8 +43,8 @@ void removeOldGenerations(std::filesystem::path dir)
             std::string link;
             try {
                 link = readLink(path);
-            } catch (std::filesystem::filesystem_error & e) {
-                if (e.code() == std::errc::no_such_file_or_directory)
+            } catch (SystemError & e) {
+                if (e.is(std::errc::no_such_file_or_directory))
                     continue;
                 throw;
             }

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -1419,7 +1419,6 @@ static int main_nix_env(int argc, char ** argv)
                 replaceSymlink(defaultChannelsDir(profilesDirOpts), nixExprPath / "channels");
                 if (!isRootUser())
                     replaceSymlink(rootChannelsDir(profilesDirOpts), nixExprPath / "channels_root");
-            } catch (std::filesystem::filesystem_error &) {
             } catch (Error &) {
             }
         }


### PR DESCRIPTION
## Motivation

File system error improvements

- Make `descriptorToPath` cross-platform (renamed from `windows::handleToPath`). Uses `/proc/self/fd` on Linux and `F_GETPATH` on macOS. Add `HAVE_F_GETPATH` meson check.

  This is based on 7226a116a0bbc1f304d8160615525cb0aeb46096, which was removed in 479c356510dcdcb43f16c7483a48ff3308c6dd2b, but is now introduced more judiciously.

- Unix error messages in `readFull`, `writeFull`, `readLine` now include file paths via `descriptorToPath`.

- Convert `std::filesystem::filesystem_error` to `SystemError`

  Wrappers like `readLink`, `createDirs`, `DirectoryIterator`, etc. now catch `std::filesystem::filesystem_error` and rethrow as `SystemError` with the error code preserved. This ensures consistent exception types throughout the codebase.

  Call sites that previously caught `filesystem_error` and rethrew with `throw;` now throw `SystemError(e.code(), ...)` instead.

  Some call sites can stop catching `filesystem_error` at all, because they only call the wrapped functions.

- Rework `SystemError` constructors to auto-append error message

  The public `SystemError(std::error_code, ...)` constructor now automatically appends `errorCode.message()` to the error message. A protected constructor takes an explicit error message string for subclasses.

  `SysError` delegates to the protected constructor with `strerror(errNo)`. `WinError` delegates with `renderError(lastError)` (now static).

  This removes the need to manually append `e.code().message()` at call sites when converting `filesystem_error` to `SystemError`.

- Use perfect forwarding (`Args &&...` with `std::forward`) consistently in `BaseError`, `SystemError`, `SysError`, and `WinError` constructors.

## Context

Possibly fixes #11376

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
