### PR TITLE
Get rid of `SysError` and `WinError` derived classes

### DIFF
--- a/src/libutil-tests/unix/file-system-at.cc
+++ b/src/libutil-tests/unix/file-system-at.cc
@@ -47,16 +47,16 @@ TEST(fchmodatTryNoFollow, works)
     /* Check that symlinks are not followed and targets are not changed. */
 
     EXPECT_NO_THROW(
-        try { fchmodatTryNoFollow(dirFd.get(), CanonPath("filelink"), 0777); } catch (SysError & e) {
-            if (e.errNo != EOPNOTSUPP)
+        try { fchmodatTryNoFollow(dirFd.get(), CanonPath("filelink"), 0777); } catch (SystemError & e) {
+            if (!e.is(std::errc::operation_not_supported))
                 throw;
         });
     ASSERT_EQ(stat((tmpDir / "file").c_str(), &st), 0);
     EXPECT_EQ(st.st_mode & 0777, 0644);
 
     EXPECT_NO_THROW(
-        try { fchmodatTryNoFollow(dirFd.get(), CanonPath("dirlink"), 0777); } catch (SysError & e) {
-            if (e.errNo != EOPNOTSUPP)
+        try { fchmodatTryNoFollow(dirFd.get(), CanonPath("dirlink"), 0777); } catch (SystemError & e) {
+            if (!e.is(std::errc::operation_not_supported))
                 throw;
         });
     ASSERT_EQ(stat((tmpDir / "dir").c_str(), &st), 0);
@@ -110,14 +110,14 @@ TEST(fchmodatTryNoFollow, fallbackWithoutProc)
 
             try {
                 fchmodatTryNoFollow(dirFd.get(), CanonPath("file"), 0600);
-            } catch (SysError & e) {
+            } catch (SystemError & e) {
                 _exit(1);
             }
 
             try {
                 fchmodatTryNoFollow(dirFd.get(), CanonPath("link"), 0777);
-            } catch (SysError & e) {
-                if (e.errNo == EOPNOTSUPP)
+            } catch (SystemError & e) {
+                if (e.is(std::errc::operation_not_supported))
                     _exit(0); /* Success. */
             }
 

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -97,7 +97,7 @@ namespace unix {
  * AT_SYMLINK_NOFOLLOW, since it's the best we can do without failing.
  *
  * @pre path.isRoot() is false
- * @throws SysError if any operation fails
+ * @throws SystemError if any operation fails
  */
 void fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t mode);
 

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -199,7 +199,7 @@ std::filesystem::path readLink(const std::filesystem::path & path);
  *
  * @note this function will clobber `errno` (Unix) / "last error"
  * (Windows), so care must be used to get those error codes, then call
- * this, then build a `SysError` / `WinError` with the saved error code.
+ * this, then build a `SystemError` with the saved error code.
  */
 std::filesystem::path descriptorToPath(Descriptor fd);
 

--- a/src/libutil/linux/linux-namespaces.cc
+++ b/src/libutil/linux/linux-namespaces.cc
@@ -40,7 +40,7 @@ bool userNamespacesSupported()
 
             auto r = pid.wait();
             assert(!r);
-        } catch (SysError & e) {
+        } catch (SystemError & e) {
             debug("user namespaces do not work on this system: %s", e.msg());
             return false;
         }
@@ -77,7 +77,7 @@ bool mountAndPidNamespacesSupported()
                 return false;
             }
 
-        } catch (SysError & e) {
+        } catch (SystemError & e) {
             debug("mount namespaces do not work on this system: %s", e.msg());
             return false;
         }

--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -78,8 +78,8 @@ bindConnectProcHelper(std::string_view operationName, auto && operation, Socket 
                 if (operation(fd, psaddr, sizeof(addr)) == -1)
                     throw SysError("cannot %s to socket at '%s'", operationName, path);
                 writeFull(pipe.writeSide.get(), "0\n");
-            } catch (SysError & e) {
-                writeFull(pipe.writeSide.get(), fmt("%d\n", e.errNo));
+            } catch (SystemError & e) {
+                writeFull(pipe.writeSide.get(), fmt("%d\n", e.ec().value()));
             } catch (...) {
                 writeFull(pipe.writeSide.get(), "-1\n");
             }

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -188,7 +188,7 @@ void unix::closeExtraFDs()
             }
         }
         return;
-    } catch (SysError &) {
+    } catch (SystemError &) {
     }
 #endif
 

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -186,9 +186,9 @@ static void _deletePath(
         if ((st.st_mode & PERM_MASK) != PERM_MASK)
             try {
                 unix::fchmodatTryNoFollow(parentfd, CanonPath(name), st.st_mode | PERM_MASK);
-            } catch (SysError & e) {
+            } catch (SystemError & e) {
                 e.addTrace({}, "while making directory %1% accessible for deletion", PathFmt(path));
-                if (e.errNo == EOPNOTSUPP)
+                if (e.is(std::errc::operation_not_supported))
                     e.addTrace({}, "%1% is now a symlink, expected directory", PathFmt(path));
                 throw;
             }

--- a/src/libutil/unix/include/nix/util/monitor-fd.hh
+++ b/src/libutil/unix/include/nix/util/monitor-fd.hh
@@ -60,7 +60,7 @@ inline void MonitorFdHup::runThread(int watchFd, int notifyFd)
 {
     int kqResult = kqueue();
     if (kqResult < 0) {
-        throw SysError("MonitorFdHup kqueue");
+        throw SystemError::fromPosix("MonitorFdHup kqueue");
     }
     AutoCloseFD kq{kqResult};
 
@@ -78,14 +78,14 @@ inline void MonitorFdHup::runThread(int watchFd, int notifyFd)
 
     int result = kevent(kq.get(), kevs.data(), kevs.size(), nullptr, 0, nullptr);
     if (result < 0) {
-        throw SysError("MonitorFdHup kevent add");
+        throw SystemError::fromPosix("MonitorFdHup kevent add");
     }
 
     while (true) {
         struct kevent event;
         int numEvents = kevent(kq.get(), nullptr, 0, &event, 1, nullptr);
         if (numEvents < 0) {
-            throw SysError("MonitorFdHup kevent watch");
+            throw SystemError::fromPosix("MonitorFdHup kevent watch");
         }
 
         if (numEvents > 0 && (event.flags & EV_EOF)) {
@@ -112,7 +112,7 @@ inline void MonitorFdHup::runThread(int watchFd, int notifyFd)
             if (errno == EINTR || errno == EAGAIN) {
                 continue;
             } else {
-                throw SysError("in MonitorFdHup poll()");
+                throw SystemError::fromPosix("in MonitorFdHup poll()");
             }
         }
 

--- a/src/libutil/unix/users.cc
+++ b/src/libutil/unix/users.cc
@@ -39,7 +39,7 @@ std::filesystem::path getHome()
                 auto st = maybeStat(homeDir->c_str());
                 if (st && st->st_uid != geteuid())
                     unownedUserHomeDir.swap(homeDir);
-            } catch (SysError & e) {
+            } catch (SystemError & e) {
                 warn(
                     "couldn't stat $HOME ('%s') for reason other than not existing, falling back to the one defined in the 'passwd' file: %s",
                     *homeDir,

--- a/src/libutil/windows/current-process.cc
+++ b/src/libutil/windows/current-process.cc
@@ -8,6 +8,8 @@
 
 namespace nix {
 
+using namespace nix::windows;
+
 std::chrono::microseconds getCpuUserTime()
 {
     FILETIME creationTime;
@@ -17,7 +19,7 @@ std::chrono::microseconds getCpuUserTime()
 
     if (!GetProcessTimes(GetCurrentProcess(), &creationTime, &exitTime, &kernelTime, &userTime)) {
         auto lastError = GetLastError();
-        throw windows::WinError(lastError, "failed to get CPU time");
+        throw WinError(lastError, "failed to get CPU time");
     }
 
     ULARGE_INTEGER uLargeInt;

--- a/src/libutil/windows/known-folders.cc
+++ b/src/libutil/windows/known-folders.cc
@@ -8,8 +8,6 @@
 
 namespace nix::windows::known_folders {
 
-using namespace nix::windows;
-
 static std::filesystem::path getKnownFolder(REFKNOWNFOLDERID rfid)
 {
     PWSTR str = nullptr;

--- a/src/libutil/windows/windows-error.cc
+++ b/src/libutil/windows/windows-error.cc
@@ -6,9 +6,9 @@
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
 
-namespace nix::windows {
+namespace nix {
 
-std::string WinError::renderError(DWORD lastError)
+std::string SystemError::renderWindowsError(DWORD lastError)
 {
     LPSTR errorText = NULL;
 
@@ -32,5 +32,5 @@ std::string WinError::renderError(DWORD lastError)
     return fmt("CODE=%d", lastError);
 }
 
-} // namespace nix::windows
+} // namespace nix
 #endif

--- a/src/nix/man-pages.cc
+++ b/src/nix/man-pages.cc
@@ -17,7 +17,7 @@ void showManPage(const std::string & name)
     setEnv("MANPATH", (getNixManDir().string() + ":").c_str());
     execlp("man", "man", name.c_str(), nullptr);
     if (errno == ENOENT) {
-        // Not SysError because we don't want to suffix the errno, aka No such file or directory.
+        // Not SystemError because we don't want to suffix the errno, aka No such file or directory.
         throw Error(
             "The '%1%' command was not found, but it is needed for '%2%' and some other '%3%' commands' help text. Perhaps you could install the '%1%' command?",
             "man",


### PR DESCRIPTION
## Motivation

All we need is `SystemError`, and the various ways to construct it can be done with static methods that are more informative. Catching the derived classes was a footgun that is now impossible, because one can only has `SystemError` to catch.

I did however make `SysError` and `WinError` top-level function wrappers in order to avoid churn in the vast majority of call sites.

## Context

Depends on #15283

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
