### PR TITLE
Flake eval cache fixes

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -56,6 +56,9 @@ struct AttrDb
         SQLiteStmt insertAttributeWithContext;
         SQLiteStmt queryAttribute;
         SQLiteStmt queryAttributes;
+        SQLiteStmt upsertAttribute;
+        SQLiteStmt insertAttributeIfNotExists;
+        SQLiteStmt deleteMissingChildren;
         std::unique_ptr<SQLiteTxn> txn;
     };
 
@@ -89,6 +92,17 @@ struct AttrDb
             state->db, "select rowid, type, value, context from Attributes where parent = ? and name = ?");
 
         state->queryAttributes.create(state->db, "select name from Attributes where parent = ?");
+
+        state->upsertAttribute.create(
+            state->db,
+            "insert into Attributes(parent, name, type, value) values (?, ?, ?, ?) "
+            "on conflict(parent, name) do update set type = excluded.type, value = excluded.value "
+            "returning rowid");
+
+        state->insertAttributeIfNotExists.create(
+            state->db, "insert or ignore into Attributes(parent, name, type, value) values (?, ?, ?, ?)");
+
+        state->deleteMissingChildren.create(state->db, "delete from Attributes where parent = ? and type = 3");
 
         state->txn = std::make_unique<SQLiteTxn>(state->db);
     }
@@ -124,13 +138,17 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::FullAttrs) (0, false).exec();
-
-            AttrId rowId = state->db.getLastInsertedRowId();
+            // Seal the attribute names: we now know the complete set.
+            auto upsertAttribute(
+                state->upsertAttribute.use()(key.first)(symbols[key.second])(AttrType::FullAttrs) (0, false));
+            upsertAttribute.next();
+            auto rowId = (AttrId) upsertAttribute.getInt(0);
             assert(rowId);
+            state->deleteMissingChildren.use()(rowId).exec();
 
+            // Insert children as placeholders, but don't replace existing entries
             for (auto & attr : attrs)
-                state->insertAttribute.use()(rowId)(symbols[attr])(AttrType::Placeholder) (0, false).exec();
+                state->insertAttributeIfNotExists.use()(rowId)(symbols[attr])(AttrType::Placeholder) (0, false).exec();
 
             return rowId;
         });

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -407,9 +407,13 @@ Value & AttrCursor::forceValue()
     }
 
     if (root->db && (!cachedValue || std::get_if<placeholder_t>(&cachedValue->second))) {
-        if (v.type() == nString)
-            cachedValue = {root->db->setString(getKey(), v.string_view(), v.context()), string_t{v.string_view(), {}}};
-        else if (v.type() == nPath) {
+        if (v.type() == nString) {
+            NixStringContext context;
+            copyContext(v, context);
+            cachedValue = {
+                root->db->setString(getKey(), v.string_view(), v.context()),
+                string_t{v.string_view(), std::move(context)}};
+        } else if (v.type() == nPath) {
             auto path = v.path().path;
             cachedValue = {root->db->setString(getKey(), path.abs()), string_t{path.abs(), {}}};
         } else if (v.type() == nBool)

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -58,6 +58,9 @@ struct AttrDb
         SQLiteStmt insertAttributeWithContext;
         SQLiteStmt queryAttribute;
         SQLiteStmt queryAttributes;
+        SQLiteStmt upsertAttribute;
+        SQLiteStmt insertAttributeIfNotExists;
+        SQLiteStmt deleteMissingChildren;
         std::unique_ptr<SQLiteTxn> txn;
     };
 
@@ -91,6 +94,17 @@ struct AttrDb
             state->db, "select rowid, type, value, context from Attributes where parent = ? and name = ?");
 
         state->queryAttributes.create(state->db, "select name from Attributes where parent = ?");
+
+        state->upsertAttribute.create(
+            state->db,
+            "insert into Attributes(parent, name, type, value) values (?, ?, ?, ?) "
+            "on conflict(parent, name) do update set type = excluded.type, value = excluded.value "
+            "returning rowid");
+
+        state->insertAttributeIfNotExists.create(
+            state->db, "insert or ignore into Attributes(parent, name, type, value) values (?, ?, ?, ?)");
+
+        state->deleteMissingChildren.create(state->db, "delete from Attributes where parent = ? and type = 3");
 
         state->txn = std::make_unique<SQLiteTxn>(state->db);
     }
@@ -126,18 +140,20 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()
-                .apply(key.first)
-                .apply(symbols[key.second])
-                .apply(AttrType::FullAttrs)
-                .apply(0, false)
-                .exec();
-
-            AttrId rowId = state->db.getLastInsertedRowId();
+            // Seal the attribute names: we now know the complete set.
+            auto upsertAttribute(state->upsertAttribute.use()
+                                     .apply(key.first)
+                                     .apply(symbols[key.second])
+                                     .apply(AttrType::FullAttrs)
+                                     .apply(0, false));
+            upsertAttribute.next();
+            auto rowId = (AttrId) upsertAttribute.getInt(0);
             assert(rowId);
+            state->deleteMissingChildren.use().apply(rowId).exec();
 
+            // Insert children as placeholders, but don't replace existing entries
             for (auto & attr : attrs)
-                state->insertAttribute.use()
+                state->insertAttributeIfNotExists.use()
                     .apply(rowId)
                     .apply(symbols[attr])
                     .apply(AttrType::Placeholder)

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -461,9 +461,13 @@ Value & AttrCursor::forceValue()
     }
 
     if (root->db && (!cachedValue || std::get_if<placeholder_t>(&cachedValue->second))) {
-        if (v.type() == nString)
-            cachedValue = {root->db->setString(getKey(), v.string_view(), v.context()), string_t{v.string_view(), {}}};
-        else if (v.type() == nPath) {
+        if (v.type() == nString) {
+            NixStringContext context;
+            copyContext(v, context);
+            cachedValue = {
+                root->db->setString(getKey(), v.string_view(), v.context()),
+                string_t{v.string_view(), std::move(context)}};
+        } else if (v.type() == nPath) {
             auto path = v.path().path;
             cachedValue = {root->db->setString(getKey(), path.abs()), string_t{path.abs(), {}}};
         } else if (v.type() == nBool)

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -53,6 +53,10 @@ deps_other += boost
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 
+# eval-cache uses `INSERT ... RETURNING` which requires >= 3.35
+sqlite = dependency('sqlite3', 'sqlite', version : '>= 3.35')
+deps_private += sqlite
+
 bdw_gc_required = get_option('gc').disable_if(
   'address' in get_option('b_sanitize'),
   error_message : 'Building with Boehm GC and ASAN is not supported',

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -52,6 +52,10 @@ deps_other += boost
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 
+# eval-cache uses `INSERT ... RETURNING` which requires >= 3.35
+sqlite = dependency('sqlite3', 'sqlite', version : '>= 3.35')
+deps_private += sqlite
+
 bdw_gc_required = get_option('gc').disable_if(
   'address' in get_option('b_sanitize'),
   error_message : 'Building with Boehm GC and ASAN is not supported',

--- a/src/libexpr/package.nix
+++ b/src/libexpr/package.nix
@@ -13,6 +13,7 @@
   boost,
   boehmgc,
   nlohmann_json,
+  sqlite,
   toml11,
   libcpuid,
 
@@ -64,6 +65,7 @@ mkMesonLibrary (finalAttrs: {
   ];
 
   buildInputs = [
+    sqlite
     toml11
   ]
   ++ lib.optional stdenv.hostPlatform.isx86_64 libcpuid;

--- a/tests/functional/flakes/eval-cache.sh
+++ b/tests/functional/flakes/eval-cache.sh
@@ -4,6 +4,42 @@ source ./common.sh
 
 requireGit
 
+# Test basic caching: trace should only appear on first evaluation
+basicCacheDir="$TEST_ROOT/basic-cache-flake"
+createGitRepo "$basicCacheDir" ""
+cp "${config_nix}" "$basicCacheDir/"
+git -C "$basicCacheDir" add config.nix
+git -C "$basicCacheDir" commit -m "config.nix"
+
+cat >"$basicCacheDir/flake.nix" <<EOF
+{
+  description = "Basic cache test";
+  outputs = { self }: let inherit (import ./config.nix) mkDerivation; in {
+    # Assert pure-eval is enabled (builtins.currentSystem is unavailable in pure mode)
+    packages.$system.default = assert builtins ? currentSystem -> throw "pure-eval not enabled";
+      builtins.trace "basic-test-evaluating" (mkDerivation {
+        name = "cached-build";
+        buildCommand = "echo hello > \\\$out";
+      });
+  };
+}
+EOF
+
+git -C "$basicCacheDir" add flake.nix
+git -C "$basicCacheDir" commit -m "Init"
+
+clearCache
+
+# First build should show trace
+nix build --no-link "$basicCacheDir" 2>&1 | grepQuiet 'trace: basic-test-evaluating'
+
+# Second build should use cache, no trace output
+nix build --no-link "$basicCacheDir" 2>&1 | grepQuietInverse 'trace: basic-test-evaluating'
+
+# Third build should also use cache, no trace output
+nix build --no-link "$basicCacheDir" 2>&1 | grepQuietInverse 'trace: basic-test-evaluating'
+
+# Test edge cases with separate flake
 flake1Dir="$TEST_ROOT/eval-cache-flake"
 
 createGitRepo "$flake1Dir" ""

--- a/tests/functional/flakes/eval-cache.sh
+++ b/tests/functional/flakes/eval-cache.sh
@@ -4,6 +4,42 @@ source ./common.sh
 
 requireGit
 
+# Test basic caching: trace should only appear on first evaluation
+basicCacheDir="$TEST_ROOT/basic-cache-flake"
+createGitRepo "$basicCacheDir" ""
+cp "${config_nix}" "$basicCacheDir/"
+git -C "$basicCacheDir" add config.nix
+git -C "$basicCacheDir" commit -m "config.nix"
+
+cat >"$basicCacheDir/flake.nix" <<EOF
+{
+  description = "Basic cache test";
+  outputs = { self }: let inherit (import ./config.nix) mkDerivation; in {
+    # Assert pure-eval is enabled (builtins.currentSystem is unavailable in pure mode)
+    packages.$system.default = assert builtins ? currentSystem -> throw "pure-eval not enabled";
+      builtins.trace "basic-test-evaluating" (mkDerivation {
+        name = "cached-build";
+        buildCommand = "echo hello > \\\$out";
+      });
+  };
+}
+EOF
+
+git -C "$basicCacheDir" add flake.nix
+git -C "$basicCacheDir" commit -m "Init"
+
+clearBinaryCache
+
+# First build should show trace
+nix build --no-link "$basicCacheDir" 2>&1 | grepQuiet 'trace: basic-test-evaluating'
+
+# Second build should use cache, no trace output
+nix build --no-link "$basicCacheDir" 2>&1 | grepQuietInverse 'trace: basic-test-evaluating'
+
+# Third build should also use cache, no trace output
+nix build --no-link "$basicCacheDir" 2>&1 | grepQuietInverse 'trace: basic-test-evaluating'
+
+# Test edge cases with separate flake
 flake1Dir="$TEST_ROOT/eval-cache-flake"
 
 createGitRepo "$flake1Dir" ""


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Get fixes into the release.

This fixes a problem where the third instead of second eval come from cache.
I haven't reproduced the string context splitting problem outside of a unit test in my WIP eval cache work - I would prefer to spend time improving that work than producing a test case for this unimportant corner case.

## Context

- Part of STF "Investigate evaluator performance improvements"

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
