### PR TITLE
builtins.getFlake: Support path values

### DIFF
--- a/doc/manual/rl-next/getflake-path.md
+++ b/doc/manual/rl-next/getflake-path.md
@@ -1,0 +1,6 @@
+---
+synopsis: "`builtins.getFlake` now supports path values"
+prs: [15290]
+---
+
+`builtins.getFlake` now accepts path values in addition to flakerefs, allowing you to write `builtins.getFlake ./subflake` instead of having to use ugly workarounds to construct a pure flakeref.

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -416,18 +416,14 @@ static LockFile readLockFile(const fetchers::Settings & fetchSettings, const Sou
                                      : LockFile();
 }
 
-/* Compute an in-memory lock file for the specified top-level flake,
-   and optionally write it to file, if the flake is writable. */
-LockedFlake
-lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef, const LockFlags & lockFlags)
+LockedFlake lockFlake(
+    const Settings & settings, EvalState & state, const FlakeRef & topRef, const LockFlags & lockFlags, Flake flake)
 {
     experimentalFeatureSettings.require(Xp::Flakes);
 
     auto useRegistries = lockFlags.useRegistries.value_or(settings.useRegistries);
     auto useRegistriesTop = useRegistries ? fetchers::UseRegistries::All : fetchers::UseRegistries::No;
     auto useRegistriesInputs = useRegistries ? fetchers::UseRegistries::Limited : fetchers::UseRegistries::No;
-
-    auto flake = getFlake(state, topRef, useRegistriesTop, {});
 
     if (lockFlags.applyNixConfig) {
         flake.config.apply(settings);
@@ -906,6 +902,22 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
         e.addTrace({}, "while updating the lock file of flake '%s'", flake.lockedRef.to_string());
         throw;
     }
+}
+
+LockedFlake
+lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef, const LockFlags & lockFlags)
+{
+    auto useRegistries = lockFlags.useRegistries.value_or(settings.useRegistries);
+    auto useRegistriesTop = useRegistries ? fetchers::UseRegistries::All : fetchers::UseRegistries::No;
+    return lockFlake(settings, state, topRef, lockFlags, getFlake(state, topRef, useRegistriesTop, {}));
+}
+
+LockedFlake
+lockFlake(const Settings & settings, EvalState & state, const SourcePath & flakeDir, const LockFlags & lockFlags)
+{
+    /* We need a fake flakeref to put in the `Flake` struct, but it's not used for anything. */
+    auto fakeRef = parseFlakeRef(state.fetchSettings, "flake:get-flake");
+    return lockFlake(settings, state, fakeRef, lockFlags, readFlake(state, fakeRef, fakeRef, fakeRef, flakeDir, {}));
 }
 
 static ref<SourceAccessor> makeInternalFS()

--- a/src/libflake/include/nix/flake/flake.hh
+++ b/src/libflake/include/nix/flake/flake.hh
@@ -214,8 +214,15 @@ struct LockFlags
     std::set<NonEmptyInputAttrPath> inputUpdates;
 };
 
+/*
+ * Compute an in-memory lock file for the specified top-level flake, and optionally write it to file, if the flake is
+ * writable.
+ */
 LockedFlake
 lockFlake(const Settings & settings, EvalState & state, const FlakeRef & flakeRef, const LockFlags & lockFlags);
+
+LockedFlake
+lockFlake(const Settings & settings, EvalState & state, const SourcePath & flakeDir, const LockFlags & lockFlags);
 
 void callFlake(EvalState & state, const LockedFlake & lockedFlake, Value & v);
 

--- a/tests/functional/flakes/common.sh
+++ b/tests/functional/flakes/common.sh
@@ -32,6 +32,8 @@ writeSimpleFlake() {
     baseName = builtins.baseNameOf ./.;
 
     root = ./.;
+
+    number = 123;
   };
 }
 EOF

--- a/tests/functional/flakes/get-flake.sh
+++ b/tests/functional/flakes/get-flake.sh
@@ -9,12 +9,18 @@ cat > "$flake1Dir/subflake/flake.nix" <<EOF
 {
   outputs = { self }:
     let
+      # Bad, legacy way of getting a flake from an input.
       parentFlake = builtins.getFlake (builtins.flakeRefToString { type = "path"; path = self.sourceInfo.outPath; narHash = self.narHash; });
+      # Better way using a path value.
+      parentFlake2 = builtins.getFlake ./..;
     in {
       x = parentFlake.number;
+      y = parentFlake2.number;
     };
 }
 EOF
 git -C "$flake1Dir" add subflake/flake.nix
 
 [[ $(nix eval "$flake1Dir/subflake#x") = 123 ]]
+
+[[ $(nix eval "$flake1Dir/subflake#y") = 123 ]]

--- a/tests/functional/flakes/get-flake.sh
+++ b/tests/functional/flakes/get-flake.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+source ./common.sh
+
+createFlake1
+
+mkdir -p "$flake1Dir/subflake"
+cat > "$flake1Dir/subflake/flake.nix" <<EOF
+{
+  outputs = { self }:
+    let
+      parentFlake = builtins.getFlake (builtins.flakeRefToString { type = "path"; path = self.sourceInfo.outPath; narHash = self.narHash; });
+    in {
+      x = parentFlake.number;
+    };
+}
+EOF
+git -C "$flake1Dir" add subflake/flake.nix
+
+[[ $(nix eval "$flake1Dir/subflake#x") = 123 ]]

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -34,6 +34,7 @@ suites += {
     'source-paths.sh',
     'old-lockfiles.sh',
     'trace-ifd.sh',
+    'get-flake.sh',
   ],
   'workdir' : meson.current_source_dir(),
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This allows getting a subflake from the current source tree by doing
```nix
builtins.getFlake ./..
```
instead of the hacky 
```
builtins.getFlake (builtins.flakeRefToString { type = "path"; path = self.sourceInfo.outPath; narHash = self.narHash; });
```

Based on https://github.com/DeterminateSystems/nix-src/pull/338 and part of https://github.com/DeterminateSystems/nix-src/pull/337.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
