### PR TITLE
fix(EvalState): Use make_shared for enable_shared_from_this compatibi…

### DIFF
--- a/src/libexpr-c/nix_api_expr.cc
+++ b/src/libexpr-c/nix_api_expr.cc
@@ -185,7 +185,9 @@ EvalState * nix_eval_state_build(nix_c_context * context, nix_eval_state_builder
             return EvalState{
                 .fetchSettings = std::move(builder->fetchSettings),
                 .settings = std::move(builder->settings),
-                .state = nix::EvalState(builder->lookupPath, builder->store, self->fetchSettings, self->settings),
+                .statePtr = std::make_shared<nix::EvalState>(
+                    builder->lookupPath, builder->store, self->fetchSettings, self->settings),
+                .state = *self->statePtr,
             };
         });
     }

--- a/src/libexpr-c/nix_api_expr_internal.h
+++ b/src/libexpr-c/nix_api_expr_internal.h
@@ -24,7 +24,8 @@ struct EvalState
 {
     nix::fetchers::Settings fetchSettings;
     nix::EvalSettings settings;
-    nix::EvalState state;
+    std::shared_ptr<nix::EvalState> statePtr;
+    nix::EvalState & state;
 };
 
 struct BindingsBuilder

--- a/src/libexpr-tests/dynamic-attrs-bench.cc
+++ b/src/libexpr-tests/dynamic-attrs-bench.cc
@@ -37,7 +37,8 @@ static void BM_EvalDynamicAttrs(benchmark::State & state)
         EvalSettings evalSettings{readOnlyMode};
         evalSettings.nixPath = {};
 
-        EvalState st({}, store, fetchSettings, evalSettings, nullptr);
+        auto stPtr = std::make_shared<EvalState>(LookupPath{}, store, fetchSettings, evalSettings, nullptr);
+        auto & st = *stPtr;
         Expr * expr = st.parseExprFromString(exprStr, st.rootPath(CanonPath::root));
 
         Value v;

--- a/src/libexpr-tests/get-drvs-bench.cc
+++ b/src/libexpr-tests/get-drvs-bench.cc
@@ -16,7 +16,8 @@ struct GetDerivationsEnv
     fetchers::Settings fetchSettings{};
     bool readOnlyMode = true;
     EvalSettings evalSettings{readOnlyMode};
-    EvalState state;
+    std::shared_ptr<EvalState> statePtr;
+    EvalState & state;
 
     Bindings * autoArgs = nullptr;
     Value attrsValue;
@@ -27,7 +28,8 @@ struct GetDerivationsEnv
             settings.nixPath = {};
             return settings;
         }())
-        , state({}, store, fetchSettings, evalSettings, nullptr)
+        , statePtr(std::make_shared<EvalState>(LookupPath{}, store, fetchSettings, evalSettings, nullptr))
+        , state(*statePtr)
     {
         autoArgs = state.buildBindings(0).finish();
 

--- a/src/libexpr-tests/regex-cache-bench.cc
+++ b/src/libexpr-tests/regex-cache-bench.cc
@@ -27,7 +27,8 @@ static void BM_EvalManyBuiltinsMatchSameRegex(benchmark::State & state)
         EvalSettings evalSettings{readOnlyMode};
         evalSettings.nixPath = {};
 
-        EvalState st({}, store, fetchSettings, evalSettings, nullptr);
+        auto stPtr = std::make_shared<EvalState>(LookupPath{}, store, fetchSettings, evalSettings, nullptr);
+        auto & st = *stPtr;
         Expr * expr = st.parseExprFromString(std::string(exprStr), st.rootPath(CanonPath::root));
 
         Value v;

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -247,11 +247,12 @@ static void showHelp(std::vector<std::string> subcommand, NixArgs & toplevel)
 
     evalSettings.restrictEval = true;
     evalSettings.pureEval = true;
-    EvalState state(
-        {},
+    auto statePtr = std::make_shared<EvalState>(
+        LookupPath{},
         openStore(StoreReference{.variant = StoreReference::Specified{.scheme = "dummy"}}),
         fetchSettings,
         evalSettings);
+    auto & state = *statePtr;
 
     auto vGenerateManpage = state.allocValue();
     state.eval(
@@ -454,11 +455,12 @@ void mainWrapped(int argc, char ** argv)
             Xp::FetchTree,
         };
         evalSettings.pureEval = false;
-        EvalState state(
-            {},
+        auto statePtr = std::make_shared<EvalState>(
+            LookupPath{},
             openStore(StoreReference{.variant = StoreReference::Specified{.scheme = "dummy"}}),
             fetchSettings,
             evalSettings);
+        auto & state = *statePtr;
         auto builtinsJson = nlohmann::json::object();
         for (auto & builtinPtr : state.getBuiltins().attrs()->lexicographicOrder(state.symbols)) {
             auto & builtin = *builtinPtr;

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -315,7 +315,7 @@ static void main_nix_build(int argc, char ** argv)
     auto store = openStore();
     auto evalStore = myArgs.evalStoreUrl ? openStore(StoreReference{*myArgs.evalStoreUrl}) : store;
 
-    auto state = std::make_unique<EvalState>(myArgs.lookupPath, evalStore, fetchSettings, evalSettings, store);
+    auto state = std::make_shared<EvalState>(myArgs.lookupPath, evalStore, fetchSettings, evalSettings, store);
     state->repair = myArgs.repair;
     if (myArgs.repair)
         buildMode = bmRepair;

--- a/src/nix/nix-instantiate/nix-instantiate.cc
+++ b/src/nix/nix-instantiate/nix-instantiate.cc
@@ -169,7 +169,7 @@ static int main_nix_instantiate(int argc, char ** argv)
         auto store = openStore();
         auto evalStore = myArgs.evalStoreUrl ? openStore(StoreReference{*myArgs.evalStoreUrl}) : store;
 
-        auto state = std::make_unique<EvalState>(myArgs.lookupPath, evalStore, fetchSettings, evalSettings, store);
+        auto state = std::make_shared<EvalState>(myArgs.lookupPath, evalStore, fetchSettings, evalSettings, store);
         state->repair = myArgs.repair;
 
         Bindings & autoArgs = *myArgs.getAutoArgs(*state);

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -203,7 +203,7 @@ static int main_nix_prefetch_url(int argc, char ** argv)
         setLogFormat("bar");
 
         auto store = openStore();
-        auto state = std::make_unique<EvalState>(myArgs.lookupPath, store, fetchSettings, evalSettings);
+        auto state = std::make_shared<EvalState>(myArgs.lookupPath, store, fetchSettings, evalSettings);
 
         Bindings & autoArgs = *myArgs.getAutoArgs(*state);
 

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -182,7 +182,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         auto req = FileTransferRequest(parseURL(upgradeSettings.storePathUrl.get()));
         auto res = getFileTransfer()->download(req);
 
-        auto state = std::make_unique<EvalState>(LookupPath{}, store, fetchSettings, evalSettings);
+        auto state = std::make_shared<EvalState>(LookupPath{}, store, fetchSettings, evalSettings);
         auto v = state->allocValue();
         state->eval(state->parseExprFromString(res.data, state->rootPath(CanonPath("/no-such-path"))), *v);
         Bindings & bindings = Bindings::emptyBindings;


### PR DESCRIPTION
…lity

EvalState inherits from enable_shared_from_this (added in b4c24a29 for debugRepl), but was being stack-allocated or created with make_unique in several places. This causes bad_weak_ptr errors when shared_from_this is called.

Convert all EvalState allocations to use make_shared.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Might fix a crash.
Brings debugger support in the old CLI closer if anyone's interested.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Was needed at some point in my eval cache work.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
