### PR TITLE
libutil: Drop superflous .string() in pathExists and pathAccessible

### DIFF
--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -262,13 +262,13 @@ std::optional<PosixStat> maybeLstat(const std::filesystem::path & path)
 
 bool pathExists(const std::filesystem::path & path)
 {
-    return maybeLstat(path.string()).has_value();
+    return maybeLstat(path).has_value();
 }
 
 bool pathAccessible(const std::filesystem::path & path)
 {
     try {
-        return pathExists(path.string());
+        return pathExists(path);
     } catch (SystemError & e) {
         // swallow EPERM
         if (e.is(std::errc::operation_not_permitted))


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

libutil: Drop superflous .string() in pathExists and pathAccessible. The underlying functions
already take a `std::filesystem::path` now.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
