### PR TITLE
Set `NIX_SHELL_PACKAGES` in nix shell

### DIFF
--- a/src/nix/env.cc
+++ b/src/nix/env.cc
@@ -1,6 +1,7 @@
 #include <queue>
 
 #include <boost/unordered/unordered_flat_set.hpp>
+#include <boost/algorithm/string/join.hpp>
 
 #include "nix/cmd/command.hh"
 #include "nix/expr/eval.hh"
@@ -78,9 +79,8 @@ struct CmdShell : InstallablesCommand, MixEnvironment
         for (auto & path : outPaths)
             todo.push(path);
 
-        setEnviron();
-
         std::vector<std::string> pathAdditions;
+        std::vector<std::string> packageNames;
 
         while (!todo.empty()) {
             auto path = todo.front();
@@ -100,7 +100,16 @@ struct CmdShell : InstallablesCommand, MixEnvironment
                 for (auto & p : tokenizeString<Paths>(state->storeFS->readFile(propPath)))
                     todo.push(store->parseStorePath(p));
             }
+
+            packageNames.push_back(std::string(path.name()));
         }
+
+        auto existingPackagesVar = getEnvOs(OS_STR("NIX_SHELL_PACKAGES")).value_or(OS_STR(""));
+        if (!existingPackagesVar.empty())
+            packageNames.push_back(existingPackagesVar);
+        setVars["NIX_SHELL_PACKAGES"] = boost::algorithm::join(packageNames, " ");
+
+        setEnviron();
 
         // TODO: split losslessly; empty means .
         auto unixPath = ExecutablePath::load();

--- a/tests/functional/shell.sh
+++ b/tests/functional/shell.sh
@@ -41,6 +41,7 @@ sed -i \
   -e '/^TMPDIR=\/var\/folders\/.*/d' \
   -e '/^__CF_USER_TEXT_ENCODING=.*$/d' \
   -e '/^__LLVM_PROFILE_RT_INIT_ONCE=.*$/d' \
+  -e '/^NIX_SHELL_PACKAGES=.*$/d' \
   "$TEST_ROOT/expected-env" "$TEST_ROOT/actual-env"
 sort "$TEST_ROOT/expected-env" > "$TEST_ROOT/expected-env.sorted"
 sort "$TEST_ROOT/actual-env" > "$TEST_ROOT/actual-env.sorted"


### PR DESCRIPTION
Opting not to also set `IN_NIX_SHELL` to provide a way to differentiate between the different kinds of nix shells.

Nested nix shells will pick up the prior shell's package names as well.

Resolves #6677

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is a popular requested feature.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#6677

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
