### PR TITLE
libexpr-c: fix EvalState pointer passed to primop callbacks

### DIFF
--- a/doc/manual/rl-next/fix-primop-eval-state.md
+++ b/doc/manual/rl-next/fix-primop-eval-state.md
@@ -1,0 +1,15 @@
+---
+synopsis: "C API: Fix EvalState pointer passed to primop callbacks"
+issues: []
+prs: []
+---
+
+The `EvalState *` passed to C API primop callbacks was incorrectly pointing to
+the internal `nix::EvalState` rather than the C API wrapper struct. This caused
+a segfault when the callback used the pointer with C API functions such as
+`nix_alloc_value()`. The same issue affected `printValueAsJSON` and
+`printValueAsXML` callbacks on external values.
+
+The fix creates a proper non-owning `EvalState` wrapper for each callback
+invocation, which also works correctly for C plugins where the
+`nix::EvalState` was created by C++ code rather than the C API.

--- a/src/libexpr-c/nix_api_expr_internal.h
+++ b/src/libexpr-c/nix_api_expr_internal.h
@@ -28,6 +28,36 @@ struct EvalState
     nix::EvalState & state;
 };
 
+/**
+ * Create a non-owning EvalState wrapper around a nix::EvalState.
+ *
+ * Useful in primop callbacks and external-value methods where
+ * we receive a raw nix::EvalState& (e.g. from a C++ plugin)
+ * and need to hand a valid EvalState* to the C API callback.
+ * The returned wrapper must not outlive the referenced state.
+ *
+ * The fetchSettings and settings fields are default-initialized
+ * dummies; no C API function accesses them through EvalState*.
+ */
+struct EvalStateRef
+{
+    /// Backing storage for the EvalSettings::readOnlyMode reference.
+    /// EvalSettings takes bool& in its constructor; this field keeps
+    /// that reference valid.  The settings object itself is never
+    /// accessed — C API functions only use wrapper.state.
+    ///
+    /// We intentionally do NOT read inner.settings.readOnlyMode here
+    /// because the EvalSettings::readOnlyMode reference may dangle
+    /// after the builder that created it has been freed.
+    bool readOnlyMode = false;
+    EvalState wrapper;
+
+    EvalStateRef(nix::EvalState & inner)
+        : wrapper{.settings = nix::EvalSettings{readOnlyMode}, .statePtr = nullptr, .state = inner}
+    {
+    }
+};
+
 struct BindingsBuilder
 {
     nix::BindingsBuilder builder;

--- a/src/libexpr-c/nix_api_external.cc
+++ b/src/libexpr-c/nix_api_external.cc
@@ -137,7 +137,8 @@ public:
         }
         nix_string_context ctx{context};
         nix_string_return res{""};
-        desc.printValueAsJSON(v, (EvalState *) &state, strict, &ctx, copyToStore, &res);
+        EvalStateRef wrappedState(state);
+        desc.printValueAsJSON(v, &wrappedState.wrapper, strict, &ctx, copyToStore, &res);
         if (res.str.empty()) {
             return nix::ExternalValueBase::printValueAsJSON(state, strict, context, copyToStore);
         }
@@ -160,9 +161,10 @@ public:
             return nix::ExternalValueBase::printValueAsXML(state, strict, location, doc, context, drvsSeen, pos);
         }
         nix_string_context ctx{context};
+        EvalStateRef wrappedState(state);
         desc.printValueAsXML(
             v,
-            (EvalState *) &state,
+            &wrappedState.wrapper,
             strict,
             location,
             &doc,

--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -105,7 +105,8 @@ static void nix_c_primop_wrapper(
         nix_value * external_arg = new_nix_value(args[i], state.mem);
         external_args.push_back(external_arg);
     }
-    f(userdata, &ctx, (EvalState *) &state, external_args.data(), vTmpPtr);
+    EvalStateRef wrappedState(state);
+    f(userdata, &ctx, &wrappedState.wrapper, external_args.data(), vTmpPtr);
 
     if (ctx.last_err_code != NIX_OK) {
         if (ctx.last_err_code == NIX_ERR_RECOVERABLE) {

--- a/src/libexpr-tests/nix_api_expr.cc
+++ b/src/libexpr-tests/nix_api_expr.cc
@@ -619,4 +619,52 @@ TEST_F(nix_api_expr_test, nix_expr_thunk_re_evaluation_after_deployment)
     ASSERT_STREQ("vm-12345", result.c_str());
 }
 
+static void
+primop_alloc_value(void * user_data, nix_c_context * context, EvalState * state, nix_value ** args, nix_value * ret)
+{
+    assert(context);
+    assert(state);
+
+    // Allocate a new value using the EvalState* from the primop callback.
+    // This is a regression test: nix_c_primop_wrapper previously cast the inner
+    // nix::EvalState* directly to EvalState* (C wrapper), but the wrapper has
+    // additional fields before the inner member. C API functions like
+    // nix_alloc_value() then accessed state->state at the wrong offset,
+    // causing a segfault.
+    nix_value * newValue = nix_alloc_value(context, state);
+    assert(newValue != nullptr);
+    nix_init_int(context, newValue, 42);
+    nix_copy_value(context, ret, newValue);
+    nix_gc_decref(nullptr, newValue);
+}
+
+TEST_F(nix_api_expr_test, nix_primop_alloc_value_in_callback)
+{
+    PrimOp * primop =
+        nix_alloc_primop(ctx, primop_alloc_value, 1, "allocValue", nullptr, "test alloc_value in callback", nullptr);
+    assert_ctx_ok();
+    nix_value * primopValue = nix_alloc_value(ctx, state);
+    assert_ctx_ok();
+    nix_init_primop(ctx, primopValue, primop);
+    assert_ctx_ok();
+
+    nix_value * dummy = nix_alloc_value(ctx, state);
+    assert_ctx_ok();
+    nix_init_int(ctx, dummy, 0);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    assert_ctx_ok();
+    nix_value_call(ctx, state, primopValue, dummy, result);
+    assert_ctx_ok();
+
+    auto r = nix_get_int(ctx, result);
+    ASSERT_EQ(42, r);
+
+    nix_gc_decref(ctx, dummy);
+    nix_gc_decref(ctx, result);
+    nix_gc_decref(ctx, primopValue);
+    nix_gc_decref(ctx, primop);
+}
+
 } // namespace nixC


### PR DESCRIPTION
nix_c_primop_wrapper cast nix::EvalState& directly to the C API wrapper EvalState*, but the wrapper has fetchSettings and settings fields before the inner nix::EvalState member. C API functions like nix_alloc_value() then accessed state->state at the wrong offset, causing a segfault.

Use offsetof to recover the enclosing wrapper from the inner member. Same fix applied to NixCExternalValue::printValueAsJSON/printValueAsXML.
