### PR TITLE
Centralize I/O error handling and make read/write functions portable

### DIFF
--- a/src/libmain/unix/stack.cc
+++ b/src/libmain/unix/stack.cc
@@ -73,7 +73,7 @@ std::function<void(siginfo_t * info, void * ctx)> stackOverflowHandler(defaultSt
 void defaultStackOverflowHandler(siginfo_t * info, void * ctx)
 {
     char msg[] = "error: stack overflow (possible infinite recursion)\n";
-    [[gnu::unused]] auto res = write(2, msg, strlen(msg));
+    [[gnu::unused]] auto res = ::write(2, msg, strlen(msg));
     _exit(1); // maybe abort instead?
 }
 

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -422,13 +422,20 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
  */
 static void writeErr(std::string_view buf)
 {
+    Descriptor fd = getStandardError();
     while (!buf.empty()) {
-        auto n = write(STDERR_FILENO, buf.data(), buf.size());
+#ifdef _WIN32
+        DWORD n;
+        if (!WriteFile(fd, buf.data(), buf.size(), &n, NULL))
+            abort();
+#else
+        auto n = ::write(fd, buf.data(), buf.size());
         if (n < 0) {
             if (errno == EINTR)
                 continue;
             abort();
         }
+#endif
         buf = buf.substr(n);
     }
 }

--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -65,7 +65,7 @@ std::string readFile(Descriptor fd);
  * Platform-specific read into a buffer.
  *
  * Thin wrapper around ::read (Unix) or ReadFile (Windows).
- * Does NOT handle EINTR on Unix - caller must catch and retry if needed.
+ * Handles EINTR on Unix. Treats ERROR_BROKEN_PIPE as EOF on Windows.
  *
  * @param fd The file descriptor to read from
  * @param buffer The buffer to read into
@@ -73,6 +73,19 @@ std::string readFile(Descriptor fd);
  * @throws SystemError on failure
  */
 size_t read(Descriptor fd, std::span<std::byte> buffer);
+
+/**
+ * Platform-specific write from a buffer.
+ *
+ * Thin wrapper around ::write (Unix) or WriteFile (Windows).
+ * Handles EINTR on Unix.
+ *
+ * @param fd The file descriptor to write to
+ * @param buffer The buffer to write from
+ * @return The number of bytes actually written
+ * @throws SystemError on failure
+ */
+size_t write(Descriptor fd, std::span<const std::byte> buffer);
 
 /**
  * Get the size of a file.

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -190,24 +190,7 @@ bool BufferedSource::hasData()
 
 size_t FdSource::readUnbuffered(char * data, size_t len)
 {
-#ifdef _WIN32
-    DWORD n;
-    checkInterrupt();
-    if (!::ReadFile(fd, data, len, &n, NULL)) {
-        _good = false;
-        throw windows::WinError("ReadFile when FdSource::readUnbuffered");
-    }
-#else
-    ssize_t n;
-    do {
-        checkInterrupt();
-        n = ::read(fd, data, len);
-    } while (n == -1 && errno == EINTR);
-    if (n == -1) {
-        _good = false;
-        throw SysError("reading from file");
-    }
-#endif
+    auto n = nix::read(fd, {reinterpret_cast<std::byte *>(data), len});
     if (n == 0) {
         _good = false;
         throw EndOfFile(std::string(*endOfFileError));


### PR DESCRIPTION
## Motivation

- Improve existing `read` and `readOffset` wrappers:
  - Unix: Add `EINTR` retry handling and `checkInterrupt`
  - Windows: Handle `ERROR_BROKEN_PIPE` as EOF, add `checkInterrupt`

- Add `write` wrapper with same treatment (`EINTR` on Unix, `checkInterrupt`)

- Improve many `windows/file-descriptor.cc` error messages with `descriptorToPath`


- Move `readFull`, `readLine`, `writeFull` to common file, using the platform wrappers instead of duplicating platform-specific logic. These ones don't need any `EINTR` or interrupt checking either. They only have `EGAIN` checking as Unix-specific code, but this is a temp hack to be removed per #12688, so its fine that it goes in the platform-agnostic file for now.

- Add `retryOnBlock` helper to abstract `EAGAIN`/`EWOULDBLOCK` poll-and-retry logic (Unix only, needed for buildhook workaround #12688)

- Simplify `FdSource::readUnbuffered` to just call `nix::read`

- Remove now-dead `EINTR` handling from `drainFD` and `copyFdRange`

- `writeErr` better impl on Windows

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
