### PR TITLE
libstore: use Windows known folders API for `LocalFSStore::storeDir`

### DIFF
--- a/src/libstore-test-support/include/nix/store/tests/https-store.hh
+++ b/src/libstore-test-support/include/nix/store/tests/https-store.hh
@@ -43,7 +43,7 @@ class TestHttpBinaryCacheStoreConfig : public HttpBinaryCacheStoreConfig
 {
 public:
     TestHttpBinaryCacheStoreConfig(ParsedURL url, const Store::Config::Params & params)
-        : StoreConfig(params)
+        : StoreConfig(params, FilePathType::Unix)
         , HttpBinaryCacheStoreConfig(url, params)
     {
     }

--- a/src/libstore-tests/dummy-store.cc
+++ b/src/libstore-tests/dummy-store.cc
@@ -27,6 +27,34 @@ public:
     }
 };
 
+TEST(DummyStore, storeDir_default)
+{
+    DummyStoreConfig config{{}};
+    EXPECT_EQ(config.storeDir, "/nix/store");
+}
+
+TEST(DummyStore, storeDir_absolutePath)
+{
+    DummyStoreConfig config{{{"store", "/my/store"}}};
+    EXPECT_EQ(config.storeDir, "/my/store");
+}
+
+TEST(DummyStore, storeDir_canonicalized)
+{
+    DummyStoreConfig config{{{"store", "/my//store/../store"}}};
+    EXPECT_EQ(config.storeDir, "/my/store");
+}
+
+TEST(DummyStore, storeDir_relativePath_rejected)
+{
+    EXPECT_THROW((DummyStoreConfig{{{"store", "my/store"}}}), UsageError);
+}
+
+TEST(DummyStore, storeDir_empty_rejected)
+{
+    EXPECT_THROW((DummyStoreConfig{{{"store", ""}}}), UsageError);
+}
+
 TEST(DummyStore, realisation_read)
 {
     initLibStore(/*loadConfig=*/false);

--- a/src/libstore-tests/http-binary-cache-store.cc
+++ b/src/libstore-tests/http-binary-cache-store.cc
@@ -9,6 +9,17 @@ namespace nix {
 
 using Authority = ParsedURL::Authority;
 
+TEST(HttpBinaryCacheStore, storeDir_absolutePath)
+{
+    HttpBinaryCacheStoreConfig config{parseURL("https://example.com"), {{"store", "/my/store"}}};
+    EXPECT_EQ(config.storeDir, "/my/store");
+}
+
+TEST(HttpBinaryCacheStore, storeDir_relativePath_rejected)
+{
+    EXPECT_THROW(HttpBinaryCacheStoreConfig(parseURL("https://example.com"), {{"store", "my/store"}}), UsageError);
+}
+
 TEST(HttpBinaryCacheStore, constructConfig)
 {
     HttpBinaryCacheStoreConfig config{

--- a/src/libstore-tests/legacy-ssh-store.cc
+++ b/src/libstore-tests/legacy-ssh-store.cc
@@ -4,6 +4,20 @@
 
 namespace nix {
 
+TEST(LegacySSHStore, storeDir_absolutePath)
+{
+    LegacySSHStoreConfig config{
+        ParsedURL::Authority::parse("localhost"),
+        {{"store", "/my/store"}},
+    };
+    EXPECT_EQ(config.storeDir, "/my/store");
+}
+
+TEST(LegacySSHStore, storeDir_relativePath_rejected)
+{
+    EXPECT_THROW(LegacySSHStoreConfig(ParsedURL::Authority::parse("localhost"), {{"store", "my/store"}}), UsageError);
+}
+
 TEST(LegacySSHStore, constructConfig)
 {
     LegacySSHStoreConfig config(

--- a/src/libstore-tests/local-binary-cache-store.cc
+++ b/src/libstore-tests/local-binary-cache-store.cc
@@ -4,6 +4,18 @@
 
 namespace nix {
 
+TEST(LocalBinaryCacheStore, storeDir_absolutePath)
+{
+    LocalBinaryCacheStoreConfig config{std::filesystem::path("/foo/bar/baz"), {{"store", "/my/store"}}};
+    EXPECT_EQ(config.storeDir, "/my/store");
+}
+
+TEST(LocalBinaryCacheStore, storeDir_relativePath_rejected)
+{
+    EXPECT_THROW(
+        LocalBinaryCacheStoreConfig(std::filesystem::path("/foo/bar/baz"), {{"store", "my/store"}}), UsageError);
+}
+
 TEST(LocalBinaryCacheStore, constructConfig)
 {
     LocalBinaryCacheStoreConfig config{std::filesystem::path("/foo/bar/baz"), {}};

--- a/src/libstore-tests/local-store.cc
+++ b/src/libstore-tests/local-store.cc
@@ -10,6 +10,30 @@
 
 namespace nix {
 
+TEST(LocalStore, storeDir_absolutePath)
+{
+    std::filesystem::path storeDir =
+#ifdef _WIN32
+        "C:\\";
+#else
+        "/";
+#endif
+    storeDir /= "nix";
+    storeDir /= "store";
+    LocalStoreConfig config{"", {{"store", storeDir.string()}}};
+    EXPECT_EQ(config.storeDir, storeDir.string());
+}
+
+TEST(LocalStore, storeDir_relativePath_rejected)
+{
+    EXPECT_THROW(LocalStoreConfig("", {{"store", (std::filesystem::path{"nix"} / "store").string()}}), UsageError);
+}
+
+TEST(LocalStore, storeDir_empty_rejected)
+{
+    EXPECT_THROW(LocalStoreConfig("", {{"store", ""}}), UsageError);
+}
+
 TEST(LocalStore, constructConfig_rootQueryParam)
 {
 #ifdef _WIN32

--- a/src/libstore-tests/ssh-store.cc
+++ b/src/libstore-tests/ssh-store.cc
@@ -6,6 +6,20 @@
 
 namespace nix {
 
+TEST(SSHStore, storeDir_absolutePath)
+{
+    SSHStoreConfig config{
+        ParsedURL::Authority::parse("localhost"),
+        {{"store", "/my/store"}},
+    };
+    EXPECT_EQ(config.storeDir, "/my/store");
+}
+
+TEST(SSHStore, storeDir_relativePath_rejected)
+{
+    EXPECT_THROW(SSHStoreConfig(ParsedURL::Authority::parse("localhost"), {{"store", "my/store"}}), UsageError);
+}
+
 TEST(SSHStore, constructConfig)
 {
     SSHStoreConfig config{
@@ -29,6 +43,27 @@ TEST(SSHStore, constructConfig)
     EXPECT_EQ(config.getReference().render(/*withParams=*/true), "ssh-ng://me@localhost:2222?remote-program=foo%20bar");
     config.resetOverridden();
     EXPECT_EQ(config.getReference().render(/*withParams=*/true), "ssh-ng://me@localhost:2222");
+}
+
+TEST(MountedSSHStore, storeDir_absolutePath)
+{
+    std::filesystem::path storeDir =
+#ifdef _WIN32
+        "C:\\";
+#else
+        "/";
+#endif
+    storeDir /= "nix";
+    storeDir /= "store";
+    MountedSSHStoreConfig config{{.host = "localhost"}, {{"store", storeDir.string()}}};
+    EXPECT_EQ(config.storeDir, storeDir.string());
+}
+
+TEST(MountedSSHStore, storeDir_relativePath_rejected)
+{
+    EXPECT_THROW(
+        MountedSSHStoreConfig({.host = "localhost"}, {{"store", (std::filesystem::path{"nix"} / "store").string()}}),
+        UsageError);
 }
 
 TEST(MountedSSHStore, constructConfig)

--- a/src/libstore-tests/uds-remote-store.cc
+++ b/src/libstore-tests/uds-remote-store.cc
@@ -4,6 +4,25 @@
 
 namespace nix {
 
+TEST(UDSRemoteStore, storeDir_absolutePath)
+{
+    std::filesystem::path storeDir =
+#ifdef _WIN32
+        "C:\\";
+#else
+        "/";
+#endif
+    storeDir /= "nix";
+    storeDir /= "store";
+    UDSRemoteStoreConfig config{"", {{"store", storeDir.string()}}};
+    EXPECT_EQ(config.storeDir, storeDir.string());
+}
+
+TEST(UDSRemoteStore, storeDir_relativePath_rejected)
+{
+    EXPECT_THROW(UDSRemoteStoreConfig("", {{"store", (std::filesystem::path{"nix"} / "store").string()}}), UsageError);
+}
+
 TEST(UDSRemoteStore, constructConfig)
 {
     UDSRemoteStoreConfig config{"/tmp/socket", {}};

--- a/src/libstore/common-ssh-store-config.cc
+++ b/src/libstore/common-ssh-store-config.cc
@@ -4,7 +4,7 @@
 namespace nix {
 
 CommonSSHStoreConfig::CommonSSHStoreConfig(const ParsedURL::Authority & authority, const Params & params)
-    : StoreConfig(params)
+    : StoreConfig(params, FilePathType::Unix)
     , authority(authority)
 {
 }

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -21,7 +21,7 @@ StringSet HttpBinaryCacheStoreConfig::uriSchemes()
 }
 
 HttpBinaryCacheStoreConfig::HttpBinaryCacheStoreConfig(ParsedURL _cacheUri, const Params & params)
-    : StoreConfig(params)
+    : StoreConfig(params, FilePathType::Unix)
     , BinaryCacheStoreConfig(params)
     , cacheUri(std::move(_cacheUri))
 {

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -16,7 +16,10 @@ class RemoteFSAccessor;
 
 struct BinaryCacheStoreConfig : virtual StoreConfig
 {
-    using StoreConfig::StoreConfig;
+    BinaryCacheStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Unix)
+    {
+    }
 
     Setting<CompressionAlgo> compression{
         this,

--- a/src/libstore/include/nix/store/common-ssh-store-config.hh
+++ b/src/libstore/include/nix/store/common-ssh-store-config.hh
@@ -10,7 +10,10 @@ class SSHMaster;
 
 struct CommonSSHStoreConfig : virtual StoreConfig
 {
-    using StoreConfig::StoreConfig;
+    CommonSSHStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Unix)
+    {
+    }
 
     CommonSSHStoreConfig(const ParsedURL::Authority & authority, const Params & params);
 

--- a/src/libstore/include/nix/store/dummy-store.hh
+++ b/src/libstore/include/nix/store/dummy-store.hh
@@ -13,7 +13,7 @@ struct DummyStore;
 struct DummyStoreConfig : public std::enable_shared_from_this<DummyStoreConfig>, virtual StoreConfig
 {
     DummyStoreConfig(const Params & params)
-        : StoreConfig(params)
+        : StoreConfig(params, FilePathType::Unix)
     {
         // Disable caching since this a temporary in-memory store.
         pathInfoCacheSize = 0;

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -14,7 +14,11 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
                                     virtual Store::Config,
                                     BinaryCacheStoreConfig
 {
-    using BinaryCacheStoreConfig::BinaryCacheStoreConfig;
+    HttpBinaryCacheStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Unix)
+        , BinaryCacheStoreConfig(params)
+    {
+    }
 
     HttpBinaryCacheStoreConfig(ParsedURL cacheUri, const Store::Config::Params & params);
 

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -12,7 +12,11 @@ namespace nix {
 
 struct LegacySSHStoreConfig : std::enable_shared_from_this<LegacySSHStoreConfig>, virtual CommonSSHStoreConfig
 {
-    using CommonSSHStoreConfig::CommonSSHStoreConfig;
+    LegacySSHStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Unix)
+        , CommonSSHStoreConfig(params)
+    {
+    }
 
     LegacySSHStoreConfig(const ParsedURL::Authority & authority, const Params & params);
 

--- a/src/libstore/include/nix/store/local-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/local-binary-cache-store.hh
@@ -6,7 +6,11 @@ struct LocalBinaryCacheStoreConfig : std::enable_shared_from_this<LocalBinaryCac
                                      virtual Store::Config,
                                      BinaryCacheStoreConfig
 {
-    using BinaryCacheStoreConfig::BinaryCacheStoreConfig;
+    LocalBinaryCacheStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Unix)
+        , BinaryCacheStoreConfig(params)
+    {
+    }
 
     /**
      * @param binaryCacheDir `file://` is a short-hand for `file:///`

--- a/src/libstore/include/nix/store/local-fs-store.hh
+++ b/src/libstore/include/nix/store/local-fs-store.hh
@@ -22,7 +22,10 @@ private:
     }
 
 public:
-    using StoreConfig::StoreConfig;
+    LocalFSStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Native)
+    {
+    }
 
     /**
      * Used to override the `root` settings. Can't be done via modifying

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -13,7 +13,7 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
     }
 
     LocalOverlayStoreConfig(const std::filesystem::path & path, const Params & params)
-        : StoreConfig(params)
+        : StoreConfig(params, FilePathType::Native)
         , LocalFSStoreConfig(path, params)
         , LocalStoreConfig(path, params)
     {

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -80,7 +80,11 @@ struct LocalStoreConfig : std::enable_shared_from_this<LocalStoreConfig>,
                           virtual LocalFSStoreConfig,
                           virtual LocalBuildStoreConfig
 {
-    using LocalFSStoreConfig::LocalFSStoreConfig;
+    LocalStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Native)
+        , LocalFSStoreConfig(params)
+    {
+    }
 
     LocalStoreConfig(const std::filesystem::path & path, const Params & params);
 

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -23,7 +23,10 @@ class RemoteFSAccessor;
 
 struct RemoteStoreConfig : virtual StoreConfig
 {
-    using StoreConfig::StoreConfig;
+    RemoteStoreConfig(const Params & params, FilePathType pathType)
+        : StoreConfig(params, pathType)
+    {
+    }
 
     Setting<int> maxConnections{
         this, 1, "max-connections", "Maximum number of concurrent connections to the Nix daemon."};

--- a/src/libstore/include/nix/store/s3-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/s3-binary-cache-store.hh
@@ -9,7 +9,11 @@ namespace nix {
 
 struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
 {
-    using HttpBinaryCacheStoreConfig::HttpBinaryCacheStoreConfig;
+    S3BinaryCacheStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Unix)
+        , HttpBinaryCacheStoreConfig(params)
+    {
+    }
 
     S3BinaryCacheStoreConfig(ParsedURL cacheUri, const Params & params);
 

--- a/src/libstore/include/nix/store/ssh-store.hh
+++ b/src/libstore/include/nix/store/ssh-store.hh
@@ -12,8 +12,12 @@ struct SSHStoreConfig : std::enable_shared_from_this<SSHStoreConfig>,
                         virtual RemoteStoreConfig,
                         virtual CommonSSHStoreConfig
 {
-    using CommonSSHStoreConfig::CommonSSHStoreConfig;
-    using RemoteStoreConfig::RemoteStoreConfig;
+    SSHStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Unix)
+        , RemoteStoreConfig(params, FilePathType::Unix)
+        , CommonSSHStoreConfig(params)
+    {
+    }
 
     SSHStoreConfig(const ParsedURL::Authority & authority, const Params & params);
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -73,58 +73,126 @@ struct MissingPaths
 };
 
 /**
- * A setting for the Nix store directory. Automatically canonicalises the
- * path and rejects the empty string. Stored as `std::string` because
- * store directory are valid file paths on *some* OS, but not neccessarily the OS of this build of Nix.
- *
- * (For example, consider `SSHStore` from Linux to Windows, or vice versa, the foreign path will not be a valid
- * `std::filesystem::path`.)
- */
-class StoreDirSetting : public BaseSetting<std::string>
-{
-public:
-    StoreDirSetting(
-        Config * options,
-        const std::string & def,
-        const std::string & name,
-        const std::string & description,
-        const StringSet & aliases = {});
-
-    std::string parse(const std::string & str) const override;
-
-    void operator=(const std::string & v)
-    {
-        this->assign(v);
-    }
-};
-
-/**
  * Need to make this a separate class so I can get the right
  * initialization order in the constructor for `StoreConfig`.
  */
 struct StoreConfigBase : Config
 {
-    using Config::Config;
-
-private:
+protected:
 
     /**
-     * Compute the default Nix store directory from environment variables
-     * (`NIX_STORE_DIR`, `NIX_STORE`) or the compile-time default.
+     * This data type is only used for `StoreConfigBase` constructor's
+     * `pathType` parameter. This documentation will describe what it means in
+     * that one context.
+     *
+     * This enum determines how the default (logical) store path for the store
+     * is chosen, if no explicit setting was given. There are two different ways
+     * to default this setting. `Native` is appropriate for any store which is a
+     * `LocalFSStore`, and `Unix` is appropriate for any store which is *not* a
+     * `LocalFSStore`.
+     *
+     * Because this information is needed when constructing `StoreConfigBase`,
+     * we cannot use a virtual method in a directed class (like `LocalFSStore`)
+     * so instead we add this argument to `StoreConfigBase` in order to make the
+     * choice in a non-vtable/inheritance-based way.
      */
-    static std::string getDefaultNixStoreDir();
+    enum struct FilePathType {
+        /**
+         * Unix-style path (e.g., `/nix/store`)
+         *
+         * Unix paths use forward slashes, and do not have any root "drive" or
+         * other such notion.
+         *
+         * When the store dir is defaulted this way, we do not care what OS we
+         * are on. The default path is canonicalized, removing any `..`
+         * lexically.
+         *
+         * This is used for store implementations that do not use the host file
+         * system, like `DummyStore` which is entirely in-memory and portable,
+         * or remote stores which refer to some *other* computer's file system.
+         *
+         * The default store path used in this case is morally a `CanonPath`.
+         *
+         * The default store path in this case is a hard-coded constant,
+         * `NIX_STORE_DIR`, which is probably `/nix/store`.
+         *
+         * @todo At some point we will have to adjust this further, to support
+         * the case of Unix SSHing to Windows.
+         */
+        Unix,
+
+        /**
+         * Native path for the current platform. On Unix this is a Unix Path,
+         * and on Windows, it is a Windows path.
+         *
+         * This is used for store implementations that do use the local file
+         * system as part of their interface (not just as an implementation
+         * detail). Concretely, that is all stores that inherit from
+         * `LocalFSStore`.
+         *
+         * Those stores advertise that the store objects are on disk, and the
+         * logical store directory path (at least after one enters the
+         * appropriate chroot / other similar mechanism) is the literal
+         * directory those store objects are contained with. As such, the store
+         * directory path must be something that is supported by the OS's native
+         * file system (or inside the chroot / other similar mechanism, if
+         * needed).
+         *
+         * The default store path used in this case is morally a
+         * `std::filesystem::path`.
+         *
+         * The default store path in this case depends on the platform:
+         *
+         * - On Unix, is based on a hard-coded constant, `NIX_STORE_DIR`, which
+         * is probably `/nix/store`.
+         *
+         * - On Windows, it is based on `%PROGRAMDATA%\nix\store`.
+         *
+         * In both cases, the default path is canonicalized, removing any `..`
+         * lexically.
+         */
+        Native,
+    };
 
 public:
 
-    StoreDirSetting storeDir_{
-        this,
-        getDefaultNixStoreDir(),
-        "store",
-        R"(
-          Logical location of the Nix store, usually
-          `/nix/store`. Note that you can only copy store paths
-          between stores if they have the same `store` setting.
-        )"};
+    /**
+     * A setting for the Nix store directory. Automatically canonicalises the
+     * path and rejects the empty string. Stored as `std::string` because
+     * store directory are valid file paths on *some* OS, but not neccessarily the OS of this build of Nix.
+     *
+     * (For example, consider `SSHStore` from Linux to Windows, or vice versa, the foreign path will not be a valid
+     * `std::filesystem::path`.)
+     */
+    class StoreDirSetting : public BaseSetting<std::string>
+    {
+        friend StoreConfigBase;
+
+        FilePathType pathType;
+
+        /**
+         * Compute the default Nix store directory from environment variables
+         * (`NIX_STORE_DIR`, `NIX_STORE`) or the compile-time default.
+         *
+         * @param pathType Whether to return a Unix-style or native path. Different
+         * stores will use different types for the default store path.
+         */
+        StoreDirSetting(Config * options, FilePathType pathType);
+
+        std::string parse(const std::string & str) const override;
+
+        void operator=(const std::string & v)
+        {
+            this->assign(v);
+        }
+    };
+
+    StoreDirSetting storeDir_;
+
+    /**
+     * @pathType see FilePathType
+     */
+    StoreConfigBase(const StoreReference::Params & params, FilePathType pathType);
 };
 
 /**
@@ -163,7 +231,7 @@ struct StoreConfig : public StoreConfigBase, public StoreDirConfig
 {
     using Params = StoreReference::Params;
 
-    StoreConfig(const Params & params);
+    StoreConfig(const Params & params, FilePathType pathType);
 
     StoreConfig() = delete;
 

--- a/src/libstore/include/nix/store/uds-remote-store.hh
+++ b/src/libstore/include/nix/store/uds-remote-store.hh
@@ -11,9 +11,6 @@ struct UDSRemoteStoreConfig : std::enable_shared_from_this<UDSRemoteStoreConfig>
                               virtual LocalFSStoreConfig,
                               virtual RemoteStoreConfig
 {
-    using LocalFSStoreConfig::LocalFSStoreConfig;
-    using RemoteStoreConfig::RemoteStoreConfig;
-
     UDSRemoteStoreConfig(const std::filesystem::path & path, const Params & params);
 
     UDSRemoteStoreConfig(const Params & params);

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -19,7 +19,7 @@
 namespace nix {
 
 LegacySSHStoreConfig::LegacySSHStoreConfig(const ParsedURL::Authority & authority, const Params & params)
-    : StoreConfig(params)
+    : StoreConfig(params, FilePathType::Unix)
     , CommonSSHStoreConfig(authority, params)
 {
 }

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -27,7 +27,7 @@ static std::filesystem::path checkBinaryCachePath(const std::filesystem::path & 
 
 LocalBinaryCacheStoreConfig::LocalBinaryCacheStoreConfig(
     const std::filesystem::path & binaryCacheDir, const StoreReference::Params & params)
-    : Store::Config{params}
+    : Store::Config{params, FilePathType::Unix}
     , BinaryCacheStoreConfig{params}
     , binaryCacheDir(binaryCacheDir)
 {

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -19,7 +19,7 @@ std::filesystem::path LocalFSStoreConfig::getDefaultLogDir()
 }
 
 LocalFSStoreConfig::LocalFSStoreConfig(const std::filesystem::path & rootDir, const Params & params)
-    : StoreConfig(params)
+    : StoreConfig(params, FilePathType::Native)
     /* Default `?root` from `rootDir` if non set
      * NOTE: We would like to just do rootDir.set(...), which would take care of
      * all normalization and error checking for us. Unfortunately we cannot do

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -57,7 +57,7 @@
 namespace nix {
 
 LocalStoreConfig::LocalStoreConfig(const std::filesystem::path & path, const Params & params)
-    : StoreConfig(params)
+    : StoreConfig(params, FilePathType::Native)
     , LocalFSStoreConfig(path, params)
 {
 }

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -417,7 +417,7 @@ StringSet S3BinaryCacheStoreConfig::uriSchemes()
 }
 
 S3BinaryCacheStoreConfig::S3BinaryCacheStoreConfig(ParsedURL cacheUri_, const Params & params)
-    : StoreConfig(params)
+    : StoreConfig(params, FilePathType::Unix)
     , HttpBinaryCacheStoreConfig(std::move(cacheUri_), params)
 {
     assert(cacheUri.query.empty());

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -12,8 +12,8 @@
 namespace nix {
 
 SSHStoreConfig::SSHStoreConfig(const ParsedURL::Authority & authority, const Params & params)
-    : Store::Config{params}
-    , RemoteStore::Config{params}
+    : Store::Config{params, FilePathType::Unix}
+    , RemoteStore::Config{params, FilePathType::Unix}
     , CommonSSHStoreConfig{authority, params}
 {
 }
@@ -89,8 +89,8 @@ protected:
 };
 
 MountedSSHStoreConfig::MountedSSHStoreConfig(StringMap params)
-    : StoreConfig(params)
-    , RemoteStoreConfig(params)
+    : StoreConfig(params, FilePathType::Native)
+    , RemoteStoreConfig(params, FilePathType::Native)
     , CommonSSHStoreConfig(params)
     , SSHStoreConfig(params)
     , LocalFSStoreConfig(params)
@@ -98,8 +98,8 @@ MountedSSHStoreConfig::MountedSSHStoreConfig(StringMap params)
 }
 
 MountedSSHStoreConfig::MountedSSHStoreConfig(const ParsedURL::Authority & authority, StringMap params)
-    : StoreConfig(params)
-    , RemoteStoreConfig(params)
+    : StoreConfig(params, FilePathType::Native)
+    , RemoteStoreConfig(params, FilePathType::Native)
     , CommonSSHStoreConfig(authority, params)
     , SSHStoreConfig(authority, params)
     , LocalFSStoreConfig(params)

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -28,43 +28,90 @@
 
 #include "nix/util/strings.hh"
 
+#ifdef _WIN32
+#  include "nix/util/windows-known-folders.hh"
+#endif
+
 using json = nlohmann::json;
 
 namespace nix {
 
-std::string StoreConfigBase::getDefaultNixStoreDir()
+static std::string canonStoreDir(std::string path)
 {
-    return
-#ifndef _WIN32
-        canonPath
-#endif
-        (getEnvNonEmpty("NIX_STORE_DIR").value_or(getEnvNonEmpty("NIX_STORE").value_or(NIX_STORE_DIR)))
-#ifndef _WIN32
-            .string()
-#endif
-            ;
+    if (path.empty() || path[0] != '/')
+        throw UsageError("store directory path \"%s\" is not an absolute path", path);
+    return CanonPath(std::move(path)).abs();
 }
 
-StoreDirSetting::StoreDirSetting(
-    Config * options,
-    const std::string & def,
-    const std::string & name,
-    const std::string & description,
-    const StringSet & aliases)
-    : BaseSetting<std::string>(def, true, name, description, aliases)
+static std::string canonStoreDir(std::filesystem::path path)
+{
+    if (!path.is_absolute())
+        throw UsageError("store directory path %s is not an absolute path", PathFmt(path));
+    return canonPath(std::move(path)).string();
+}
+
+StoreConfigBase::StoreDirSetting::StoreDirSetting(Config * options, FilePathType pathType)
+    : BaseSetting<std::string>(
+          [pathType]() -> std::string {
+              auto envOverrides = getEnvOsNonEmpty(OS_STR("NIX_STORE_DIR")).or_else([] {
+                  return getEnvOsNonEmpty(OS_STR("NIX_STORE"));
+              });
+
+              switch (pathType) {
+              case FilePathType::Unix:
+                  return canonStoreDir(
+                      envOverrides.transform([](auto && s) { return os_string_to_string(std::move(s)); })
+                          .value_or(NIX_STORE_DIR));
+
+              case FilePathType::Native:
+                  return canonStoreDir(
+                      envOverrides.transform([](auto && s) { return std::filesystem::path(std::move(s)); })
+                          .or_else([]() -> std::optional<std::filesystem::path> {
+#ifdef _WIN32
+                              return windows::known_folders::getProgramData() / "nix" / "store";
+#else
+                              return std::filesystem::path{NIX_STORE_DIR};
+#endif
+                          })
+                          .value());
+              }
+              assert(false);
+          }(),
+          true,
+          "store",
+          R"(
+            Logical location of the Nix store, usually
+            `/nix/store`. Note that you can only copy store paths
+            between stores if they have the same `store` setting.
+          )",
+          {})
+    , pathType(pathType)
 {
     options->addSetting(this);
 }
 
-std::string StoreDirSetting::parse(const std::string & str) const
+std::string StoreConfigBase::StoreDirSetting::parse(const std::string & str) const
 {
     if (str.empty())
         throw UsageError("setting '%s' is a path and paths cannot be empty", name);
-    return canonPath(str).string();
+
+    switch (pathType) {
+    case FilePathType::Unix:
+        return canonStoreDir(str);
+    case FilePathType::Native:
+        return canonStoreDir(std::filesystem::path(str));
+    }
+    assert(false);
 }
 
-StoreConfig::StoreConfig(const Params & params)
-    : StoreConfigBase(params)
+StoreConfigBase::StoreConfigBase(const StoreReference::Params & params, FilePathType pathType)
+    : Config(params)
+    , storeDir_{this, pathType}
+{
+}
+
+StoreConfig::StoreConfig(const Params & params, FilePathType pathType)
+    : StoreConfigBase(params, pathType)
     , StoreDirConfig{storeDir_}
 {
 }

--- a/src/libstore/uds-remote-store.cc
+++ b/src/libstore/uds-remote-store.cc
@@ -20,9 +20,9 @@
 namespace nix {
 
 UDSRemoteStoreConfig::UDSRemoteStoreConfig(const std::filesystem::path & path, const StoreReference::Params & params)
-    : Store::Config{params}
+    : Store::Config{params, FilePathType::Native}
     , LocalFSStore::Config{params}
-    , RemoteStore::Config{params}
+    , RemoteStore::Config{params, FilePathType::Native}
     , path{path.empty() ? settings.nixDaemonSocketFile : path}
 {
 }


### PR DESCRIPTION
## Motivation

On Windows the compile-time path constants (`NIX_CONF_DIR`, `NIX_STATE_DIR`,
`NIX_LOG_DIR`) are meaningless because the install drive varies, so this resolves
them at runtime via `FOLDERID_ProgramData` through the existing known-folders API.
A new `FilePathType` enum on `StoreConfigBase` lets each store declare whether its
default store directory is a Unix-style canonical path (remote/HTTP/S3) or a native
OS path (local/UDS), and `getDefaultNixStoreDir` branches accordingly.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
