### PR TITLE
`PathLocks` allow to fail on Wine

### DIFF
--- a/src/libutil/windows/include/nix/util/meson.build
+++ b/src/libutil/windows/include/nix/util/meson.build
@@ -5,5 +5,6 @@ include_dirs += include_directories('../..')
 headers += files(
   'signals-impl.hh',
   'windows-async-pipe.hh',
+  'windows-environment.hh',
   'windows-known-folders.hh',
 )

--- a/src/libutil/windows/include/nix/util/windows-environment.hh
+++ b/src/libutil/windows/include/nix/util/windows-environment.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+///@file
+
+namespace nix::windows {
+
+/**
+ * Check if the current process is running under Wine.
+ */
+bool isWine();
+
+} // namespace nix::windows

--- a/src/libutil/windows/meson.build
+++ b/src/libutil/windows/meson.build
@@ -11,6 +11,7 @@ sources += files(
   'processes.cc',
   'users.cc',
   'windows-async-pipe.cc',
+  'windows-environment.cc',
   'windows-error.cc',
 )
 

--- a/src/libutil/windows/windows-environment.cc
+++ b/src/libutil/windows/windows-environment.cc
@@ -1,0 +1,14 @@
+#include "nix/util/windows-environment.hh"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+namespace nix::windows {
+
+bool isWine()
+{
+    HMODULE hntdll = GetModuleHandle("ntdll.dll");
+    return GetProcAddress(hntdll, "wine_get_version") != nullptr;
+}
+
+} // namespace nix::windows


### PR DESCRIPTION
## Motivation

It needs functionality Wine doesn't implement yet. So let's just have a wine-only warn-and-keep-going.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
