### PR TITLE
libutil: return `std::filesystem::path` from XDG directory helpers

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -70,7 +70,7 @@ struct AttrDb
     {
         auto state(_state->lock());
 
-        auto cacheDir = std::filesystem::path(getCacheDir()) / "eval-cache-v6";
+        auto cacheDir = getCacheDir() / "eval-cache-v6";
         createDirs(cacheDir);
 
         auto dbPath = cacheDir / (fingerprint.to_string(HashFormat::Base16, false) + ".sqlite");

--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -70,7 +70,7 @@ Strings EvalSettings::getDefaultNixPath()
         }
     };
 
-    add(std::filesystem::path{getNixDefExpr()} / "channels");
+    add(getNixDefExpr() / "channels");
     auto profilesDirOpts = settings.getProfileDirsOptions();
     add(rootChannelsDir(profilesDirOpts) / "nixpkgs", "nixpkgs");
     add(rootChannelsDir(profilesDirOpts));

--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -44,8 +44,8 @@ struct CacheImpl : Cache
     {
         auto state(_state.lock());
 
-        auto dbPath = (getCacheDir() / "fetcher-cache-v4.sqlite").string();
-        createDirs(dirOf(dbPath));
+        auto dbPath = getCacheDir() / "fetcher-cache-v4.sqlite";
+        createDirs(dbPath.parent_path());
 
         state->db = SQLite(dbPath, {.useWAL = nix::settings.useSQLiteWAL});
         state->db.isCache();

--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -268,10 +268,10 @@ void Fetch::fetch(
         return;
     }
 
-    std::filesystem::path cacheDir = getCacheDir() / "git-lfs";
+    auto cacheDir = getCacheDir() / "git-lfs";
     std::string key = hashString(HashAlgorithm::SHA256, pointerFilePath.rel()).to_string(HashFormat::Base16, false)
                       + "/" + pointer->oid;
-    std::filesystem::path cachePath = cacheDir / key;
+    auto cachePath = cacheDir / key;
     if (pathExists(cachePath)) {
         debug("using cache entry %s -> %s", key, PathFmt(cachePath));
         sink(readFile(cachePath));

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -44,8 +44,9 @@ static bool isCacheFileWithinTtl(const Settings & settings, time_t now, const Po
 
 std::filesystem::path getCachePath(std::string_view key, bool shallow)
 {
-    return getCacheDir() / "gitv3"
-           / (hashString(HashAlgorithm::SHA256, key).to_string(HashFormat::Nix32, false) + (shallow ? "-shallow" : ""));
+    auto name =
+        hashString(HashAlgorithm::SHA256, key).to_string(HashFormat::Nix32, false) + (shallow ? "-shallow" : "");
+    return getCacheDir() / "gitv3" / std::move(name);
 }
 
 // Returns the name of the HEAD branch.

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -153,7 +153,7 @@ static std::shared_ptr<Registry> getGlobalRegistry(const Settings & settings, St
                         store2->addPermRoot(storePath, (getCacheDir() / "flake-registry.json").string());
                     return {store.requireStoreObjectAccessor(storePath)};
                 } else {
-                    return SourcePath{getFSSourceAccessor(), CanonPath{path}}.resolveSymlinks();
+                    return SourcePath{makeFSSourceAccessor(path)}.resolveSymlinks();
                 }
             }(),
             Registry::Global);

--- a/src/libflake/config.cc
+++ b/src/libflake/config.cc
@@ -31,7 +31,7 @@ namespace nix::flake {
 // setting name -> setting value -> allow or ignore.
 typedef std::map<std::string, std::map<std::string, bool>> TrustedList;
 
-std::filesystem::path trustedListPath()
+static std::filesystem::path trustedListPath()
 {
     return getDataDir() / "trusted-settings.json";
 }

--- a/src/libstore-tests/machines.cc
+++ b/src/libstore-tests/machines.cc
@@ -13,10 +13,6 @@ using testing::Eq;
 using testing::Field;
 using testing::SizeIs;
 
-namespace nix::fs {
-using namespace std::filesystem;
-}
-
 using namespace nix;
 
 TEST(machines, getMachinesWithEmptyBuilders)

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -293,8 +293,7 @@ std::string optimisticLockProfile(const std::filesystem::path & profile)
 
 std::filesystem::path profilesDir(ProfileDirsOptions settings)
 {
-    auto profileRoot =
-        isRootUser() ? rootProfilesDir(settings) : std::filesystem::path{createNixStateDir()} / "profiles";
+    auto profileRoot = isRootUser() ? rootProfilesDir(settings) : createNixStateDir() / "profiles";
     createDirs(profileRoot);
     return profileRoot;
 }
@@ -306,9 +305,8 @@ std::filesystem::path rootProfilesDir(ProfileDirsOptions settings)
 
 std::filesystem::path getDefaultProfile(ProfileDirsOptions settings)
 {
-    std::filesystem::path profileLink = settings.useXDGBaseDirectories
-                                            ? std::filesystem::path{createNixStateDir()} / "profile"
-                                            : std::filesystem::path{getHome()} / ".nix-profile";
+    std::filesystem::path profileLink =
+        settings.useXDGBaseDirectories ? createNixStateDir() / "profile" : getHome() / ".nix-profile";
     try {
         auto profile = profilesDir(settings) / "profile";
         if (!pathExists(profileLink)) {

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -98,7 +98,7 @@ void SSHMaster::addCommonSSHOpts(Strings & args)
         args.insert(args.end(), {"-i", keyFile});
     if (!sshPublicHostKey.empty()) {
         std::filesystem::path fileName = tmpDir->path() / "host-key";
-        writeFile(fileName.string(), authority.host + " " + sshPublicHostKey + "\n");
+        writeFile(fileName, authority.host + " " + sshPublicHostKey + "\n");
         args.insert(args.end(), {"-oUserKnownHostsFile=" + fileName.string()});
     }
     if (compress)

--- a/src/libstore/store-registration.cc
+++ b/src/libstore/store-registration.cc
@@ -42,17 +42,18 @@ ref<StoreConfig> resolveStoreConfig(StoreReference && storeURI)
                     /* If /nix doesn't exist, there is no daemon socket, and
                        we're not root, then automatically set up a chroot
                        store in ~/.local/share/nix/root. */
-                    auto chrootStore = getDataDir() + "/root";
+                    auto chrootStore = getDataDir() / "root";
                     if (!pathExists(chrootStore)) {
                         try {
                             createDirs(chrootStore);
                         } catch (SystemError & e) {
                             return make_ref<LocalStore::Config>(params);
                         }
-                        warn("'%s' does not exist, so Nix will use '%s' as a chroot store", stateDir, chrootStore);
+                        warn("%s does not exist, so Nix will use %s as a chroot store", stateDir, PathFmt(chrootStore));
                     } else
-                        debug("'%s' does not exist, so Nix will use '%s' as a chroot store", stateDir, chrootStore);
-                    return make_ref<LocalStore::Config>("local", chrootStore, params);
+                        debug(
+                            "%s does not exist, so Nix will use %s as a chroot store", stateDir, PathFmt(chrootStore));
+                    return make_ref<LocalStore::Config>("local", chrootStore.string(), params);
                 }
 #endif
                 else

--- a/src/libutil/executable-path.cc
+++ b/src/libutil/executable-path.cc
@@ -21,16 +21,22 @@ ExecutablePath ExecutablePath::load()
 
 ExecutablePath ExecutablePath::parse(const OsString & path)
 {
+    ExecutablePath ret;
+    ret.parseAppend(path);
+    return ret;
+}
+
+void ExecutablePath::parseAppend(const OsString & path)
+{
     auto strings = path.empty() ? (std::list<OsString>{})
                                 : basicSplitString<std::list<OsString>, OsChar>(path, path_var_separator);
 
-    std::vector<std::filesystem::path> ret;
-    ret.reserve(strings.size());
+    directories.reserve(directories.size() + strings.size());
 
     std::transform(
         std::make_move_iterator(strings.begin()),
         std::make_move_iterator(strings.end()),
-        std::back_inserter(ret),
+        std::back_inserter(directories),
         [](OsString && str) {
             return std::filesystem::path{
                 str.empty()
@@ -45,8 +51,6 @@ ExecutablePath ExecutablePath::parse(const OsString & path)
                     : std::move(str),
             };
         });
-
-    return {ret};
 }
 
 OsString ExecutablePath::render() const

--- a/src/libutil/include/nix/util/executable-path.hh
+++ b/src/libutil/include/nix/util/executable-path.hh
@@ -34,6 +34,12 @@ struct ExecutablePath
     static ExecutablePath parse(const OsString & path);
 
     /**
+     * Like `parse` but appends new entries to the end of an existing
+     * `ExecutablePath`.
+     */
+    void parseAppend(const OsString & path);
+
+    /**
      * Load the `PATH` environment variable and `parse` it.
      */
     static ExecutablePath load();

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -12,6 +12,7 @@
 #include "nix/util/file-descriptor.hh"
 #include "nix/util/file-path.hh"
 
+#include <filesystem>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>

--- a/src/libutil/include/nix/util/users.hh
+++ b/src/libutil/include/nix/util/users.hh
@@ -2,12 +2,11 @@
 ///@file
 
 #include <filesystem>
-
-#include "nix/util/types.hh"
-
 #ifndef _WIN32
 #  include <sys/types.h>
 #endif
+
+#include "nix/util/types.hh"
 
 namespace nix {
 

--- a/src/libutil/users.cc
+++ b/src/libutil/users.cc
@@ -1,6 +1,7 @@
 #include "nix/util/util.hh"
 #include "nix/util/users.hh"
 #include "nix/util/environment-variables.hh"
+#include "nix/util/executable-path.hh"
 #include "nix/util/file-system.hh"
 
 #ifndef _WIN32
@@ -13,7 +14,7 @@ namespace nix {
 
 std::filesystem::path getCacheDir()
 {
-    auto dir = getEnv("NIX_CACHE_HOME");
+    auto dir = getEnvOs(OS_STR("NIX_CACHE_HOME"));
     if (dir)
         return *dir;
 #ifndef _WIN32
@@ -25,7 +26,7 @@ std::filesystem::path getCacheDir()
 
 std::filesystem::path getConfigDir()
 {
-    auto dir = getEnv("NIX_CONFIG_HOME");
+    auto dir = getEnvOs(OS_STR("NIX_CONFIG_HOME"));
     if (dir)
         return *dir;
 #ifndef _WIN32
@@ -51,7 +52,7 @@ std::vector<std::filesystem::path> getConfigDirs()
 
 std::filesystem::path getDataDir()
 {
-    auto dir = getEnv("NIX_DATA_HOME");
+    auto dir = getEnvOs(OS_STR("NIX_DATA_HOME"));
     if (dir)
         return *dir;
 #ifndef _WIN32
@@ -63,7 +64,7 @@ std::filesystem::path getDataDir()
 
 std::filesystem::path getStateDir()
 {
-    auto dir = getEnv("NIX_STATE_HOME");
+    auto dir = getEnvOs(OS_STR("NIX_STATE_HOME"));
     if (dir)
         return *dir;
 #ifndef _WIN32
@@ -84,9 +85,10 @@ std::string expandTilde(std::string_view path)
 {
     // TODO: expand ~user ?
     auto tilde = path.substr(0, 2);
-    if (tilde == "~/" || tilde == "~")
-        return getHome().string() + std::string(path.substr(1));
-    else
+    if (tilde == "~/" || tilde == "~") {
+        auto suffix = path.size() >= 2 ? std::string(path.substr(2)) : std::string{};
+        return (getHome() / suffix).string();
+    } else
         return std::string(path);
 }
 

--- a/src/libutil/windows/users.cc
+++ b/src/libutil/windows/users.cc
@@ -37,9 +37,9 @@ std::string getUserName()
 std::filesystem::path getHome()
 {
     static std::filesystem::path homeDir = []() {
-        std::filesystem::path homeDir = getEnv("USERPROFILE").value_or("C:\\Users\\Default");
+        std::filesystem::path homeDir = getEnvOs(L"USERPROFILE").value_or(L"C:\\Users\\Default");
         assert(!homeDir.empty());
-        return canonPath(homeDir.string());
+        return std::filesystem::path{canonPath(homeDir.string())};
     }();
     return homeDir;
 }

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -7,10 +7,6 @@
 #include "nix/expr/eval-inline.hh"
 #include "nix/store/globals.hh"
 
-namespace nix::fs {
-using namespace std::filesystem;
-}
-
 using namespace nix;
 
 struct CmdBundle : InstallableValueCommand

--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -11,10 +11,6 @@
 #include "nix/util/executable-path.hh"
 #include "nix/store/globals.hh"
 
-namespace nix::fs {
-using namespace std::filesystem;
-}
-
 using namespace nix;
 
 namespace {

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -21,10 +21,6 @@
 
 #include "nix/util/strings.hh"
 
-namespace nix::fs {
-using namespace std::filesystem;
-}
-
 using namespace nix;
 
 struct DevelopSettings : Config

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -10,10 +10,6 @@
 
 using namespace nix;
 
-namespace nix::fs {
-using namespace std::filesystem;
-}
-
 struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
 {
     bool raw = false;

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -29,10 +29,6 @@
 // FIXME is this supposed to be private or not?
 #include "flake-command.hh"
 
-namespace nix::fs {
-using namespace std::filesystem;
-}
-
 using namespace nix;
 using namespace nix::flake;
 using json = nlohmann::json;

--- a/src/nix/nix-channel/nix-channel.cc
+++ b/src/nix/nix-channel/nix-channel.cc
@@ -188,11 +188,12 @@ static int main_nix_channel(int argc, char ** argv)
     {
         // Figure out the name of the `.nix-channels' file to use
         auto home = getHome();
-        channelsList = settings.useXDGBaseDirectories ? createNixStateDir() + "/channels" : home + "/.nix-channels";
+        channelsList =
+            settings.useXDGBaseDirectories ? (createNixStateDir() / "channels").string() : home + "/.nix-channels";
         nixDefExpr = getNixDefExpr();
 
         // Figure out the name of the channels profile.
-        profile = profilesDir(settings.getProfileDirsOptions()) + "/channels";
+        profile = (profilesDir(settings.getProfileDirsOptions()) / "channels").string();
         createDirs(dirOf(profile));
 
         enum { cNone, cAdd, cRemove, cList, cUpdate, cListGenerations, cRollback } cmd = cNone;

--- a/src/nix/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix/nix-collect-garbage/nix-collect-garbage.cc
@@ -13,10 +13,6 @@
 #include <iostream>
 #include <cerrno>
 
-namespace nix::fs {
-using namespace std::filesystem;
-}
-
 using namespace nix;
 
 std::string deleteOlderThan;

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -1294,7 +1294,7 @@ static void opSwitchProfile(Globals & globals, Strings opFlags, Strings opArgs)
     if (opArgs.size() != 1)
         throw UsageError("exactly one argument expected");
 
-    Path profile = absPath(opArgs.front());
+    auto profile = absPath(std::filesystem::path{opArgs.front()});
     auto profileLink = settings.useXDGBaseDirectories ? createNixStateDir() / "profile" : getHome() / ".nix-profile";
 
     switchLink(profileLink, profile);

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -24,10 +24,6 @@
 
 extern char ** environ __attribute__((weak));
 
-namespace nix::fs {
-using namespace std::filesystem;
-}
-
 using namespace nix;
 
 std::string chrootHelperName = "__run_in_chroot";


### PR DESCRIPTION

## Motivation

`getCacheDir`, `getConfigDir`, `getDataDir`, `getStateDir`, and related functions now return `std::filesystem::path` and use `getEnvOs` for native OS string handling, letting callsites replace string concatenation with `operator/` and drop the ad-hoc `namespace nix::fs` alias from six CLI files. `expandTilde` is fixed to strip both `~` and `/` before joining with `operator/` (an absolute right-hand operand silently replaces the left-hand side), and `ExecutablePath` gains `parseAppend` for incremental `PATH` construction.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
