### PR TITLE
libutil: replace string-based Path with std::filesystem::path across core libraries

### DIFF
--- a/src/libcmd/include/nix/cmd/repl-interacter.hh
+++ b/src/libcmd/include/nix/cmd/repl-interacter.hh
@@ -3,6 +3,7 @@
 
 #include "nix/util/finally.hh"
 #include "nix/util/types.hh"
+#include <filesystem>
 #include <functional>
 #include <string>
 
@@ -36,10 +37,10 @@ public:
 
 class ReadlineLikeInteracter : public virtual ReplInteracter
 {
-    std::string historyFile;
+    std::filesystem::path historyFile;
 public:
-    ReadlineLikeInteracter(std::string historyFile)
-        : historyFile(historyFile)
+    ReadlineLikeInteracter(std::filesystem::path historyFile)
+        : historyFile(std::move(historyFile))
     {
     }
 

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -157,7 +157,7 @@ MixFlakeOptions::MixFlakeOptions()
         .category = category,
         .labels = {"flake-lock-path"},
         .handler = {[&](std::string lockFilePath) {
-            lockFlags.referenceLockFilePath = {getFSSourceAccessor(), CanonPath(absPath(lockFilePath))};
+            lockFlags.referenceLockFilePath = {getFSSourceAccessor(), CanonPath(absPath(lockFilePath).string())};
         }},
         .completer = completePath,
     });

--- a/src/libcmd/repl-interacter.cc
+++ b/src/libcmd/repl-interacter.cc
@@ -118,7 +118,7 @@ ReadlineLikeInteracter::Guard ReadlineLikeInteracter::init(detail::ReplCompleter
     // Allow nix-repl specific settings in .inputrc
     rl_readline_name = "nix-repl";
     try {
-        createDirs(dirOf(historyFile));
+        createDirs(historyFile.parent_path());
     } catch (SystemError & e) {
         logWarning(e.info());
     }

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 
 #include "nix/util/error.hh"
 #include "nix/cmd/repl-interacter.hh"
@@ -141,7 +142,7 @@ NixRepl::NixRepl(
     , getValues(getValues)
     , staticEnv(new StaticEnv(nullptr, state->staticBaseEnv))
     , runNixPtr{runNix}
-    , interacter(make_unique<ReadlineLikeInteracter>((getDataDir() / "repl-history").string()))
+    , interacter(std::make_unique<ReadlineLikeInteracter>(getDataDir() / "repl-history"))
 {
 }
 

--- a/src/libexpr/eval-error.cc
+++ b/src/libexpr/eval-error.cc
@@ -1,8 +1,15 @@
 #include "nix/expr/eval-error.hh"
 #include "nix/expr/eval.hh"
 #include "nix/expr/value.hh"
+#include "nix/store/store-api.hh"
 
 namespace nix {
+
+InvalidPathError::InvalidPathError(EvalState & state, const StorePath & path)
+    : CloneableError(state, "path '%s' is not valid", path.to_string())
+    , path{path}
+{
+}
 
 template<class T>
 EvalErrorBuilder<T> & EvalErrorBuilder<T>::withExitStatus(unsigned int exitStatus)

--- a/src/libexpr/include/nix/expr/eval-error.hh
+++ b/src/libexpr/include/nix/expr/eval-error.hh
@@ -2,6 +2,7 @@
 
 #include "nix/util/error.hh"
 #include "nix/util/pos-idx.hh"
+#include "nix/store/path.hh"
 
 namespace nix {
 
@@ -81,12 +82,9 @@ MakeError(RecoverableEvalError, EvalBaseError);
 struct InvalidPathError : public CloneableError<InvalidPathError, EvalError>
 {
 public:
-    Path path;
+    StorePath path;
 
-    InvalidPathError(EvalState & state, const Path & path)
-        : CloneableError(state, "path '%s' is not valid", path)
-    {
-    }
+    InvalidPathError(EvalState & state, const StorePath & path);
 };
 
 /**

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -388,7 +388,8 @@ path_start
         });
     }
 
-    Path path(absPath(literal, state->basePath.path.abs()));
+    auto basePath = std::filesystem::path(state->basePath.path.abs());
+    Path path(absPath(literal, &basePath).string());
     /* add back in the trailing '/' to the first segment */
     if (literal.size() > 1 && literal.back() == '/')
       path += '/';

--- a/src/libexpr/paths.cc
+++ b/src/libexpr/paths.cc
@@ -12,7 +12,7 @@ SourcePath EvalState::rootPath(CanonPath path)
 
 SourcePath EvalState::rootPath(PathView path)
 {
-    return {rootFS, CanonPath(absPath(path))};
+    return {rootFS, CanonPath(absPath(path).string())};
 }
 
 SourcePath EvalState::storePath(const StorePath & path)

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -75,7 +75,7 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
     for (auto & c : context) {
         auto ensureValid = [&](const StorePath & p) {
             if (!store->isValidPath(p))
-                error<InvalidPathError>(store->printStorePath(p)).debugThrow();
+                error<InvalidPathError>(p).debugThrow();
         };
         std::visit(
             overloaded{
@@ -504,7 +504,7 @@ void prim_exec(EvalState & state, const PosIdx pos, Value ** args, Value & v)
     try {
         auto _ = state.realiseContext(context); // FIXME: Handle CA derivations
     } catch (InvalidPathError & e) {
-        state.error<EvalError>("cannot execute '%1%', since path '%2%' is not valid", program, e.path)
+        state.error<EvalError>("cannot execute '%1%', since store path '%2%' is not valid", program, e.path.to_string())
             .atPos(pos)
             .debugThrow();
     }
@@ -1934,7 +1934,7 @@ static void prim_storePath(EvalState & state, const PosIdx pos, Value ** args, V
        directly in the store.  The latter condition is necessary so
        e.g. nix-push does the right thing. */
     if (!state.store->isStorePath(path.abs()))
-        path = CanonPath(canonPath(path.abs(), true));
+        path = CanonPath(canonPath(path.abs(), true).string());
     if (!state.store->isInStore(path.abs()))
         state.error<EvalError>("path '%1%' is not in the Nix store", path).atPos(pos).debugThrow();
     auto path2 = state.store->toStorePath(path.abs()).first;
@@ -2155,7 +2155,7 @@ static void prim_findFile(EvalState & state, const PosIdx pos, Value ** args, Va
             auto rewrites = state.realiseContext(context);
             path = rewriteStrings(std::move(path), rewrites);
         } catch (InvalidPathError & e) {
-            state.error<EvalError>("cannot find '%1%', since path '%2%' is not valid", path, e.path)
+            state.error<EvalError>("cannot find '%1%', since path '%2%' is not valid", path, e.path.to_string())
                 .atPos(pos)
                 .debugThrow();
         }

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -161,7 +161,7 @@ bool Input::isFinal() const
     return maybeGetBoolAttr(attrs, "__final").value_or(false);
 }
 
-std::optional<std::string> Input::isRelative() const
+std::optional<std::filesystem::path> Input::isRelative() const
 {
     assert(scheme);
     return scheme->isRelative(*this);

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -699,7 +699,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
             .program = "git",
             .args{
                 OS_STR("-c"),
-                string_to_os_string("gpg.ssh.allowedSignersFile=" + allowedSignersFile),
+                OS_STR("gpg.ssh.allowedSignersFile=") + allowedSignersFile.native(),
                 OS_STR("-C"),
                 path.native(),
                 OS_STR("verify-commit"),

--- a/src/libfetchers/include/nix/fetchers/fetchers.hh
+++ b/src/libfetchers/include/nix/fetchers/fetchers.hh
@@ -86,7 +86,7 @@ public:
      * Only for relative path flakes, i.e. 'path:./foo', returns the
      * relative path, i.e. './foo'.
      */
-    std::optional<std::string> isRelative() const;
+    std::optional<std::filesystem::path> isRelative() const;
 
     /**
      * Return whether this is a "final" input, meaning that fetching
@@ -263,7 +263,7 @@ struct InputScheme
         return false;
     }
 
-    virtual std::optional<std::string> isRelative(const Input & input) const
+    virtual std::optional<std::filesystem::path> isRelative(const Input & input) const
     {
         return std::nullopt;
     }

--- a/src/libfetchers/include/nix/fetchers/tarball.hh
+++ b/src/libfetchers/include/nix/fetchers/tarball.hh
@@ -6,6 +6,7 @@
 #include "nix/store/path.hh"
 #include "nix/util/ref.hh"
 #include "nix/util/types.hh"
+#include "nix/util/url.hh"
 
 namespace nix {
 class Store;
@@ -27,7 +28,7 @@ struct DownloadFileResult
 DownloadFileResult downloadFile(
     Store & store,
     const Settings & settings,
-    const std::string & url,
+    const VerbatimURL & url,
     const std::string & name,
     const Headers & headers = {});
 

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -114,10 +114,10 @@ struct PathInputScheme : InputScheme
         writeFile(getAbsPath(input) / path.rel(), contents);
     }
 
-    std::optional<std::string> isRelative(const Input & input) const override
+    std::optional<std::filesystem::path> isRelative(const Input & input) const override
     {
-        auto path = getStrAttr(input.attrs, "path");
-        if (isAbsolute(path))
+        std::filesystem::path path = getStrAttr(input.attrs, "path");
+        if (path.is_absolute())
             return std::nullopt;
         else
             return path;
@@ -130,9 +130,9 @@ struct PathInputScheme : InputScheme
 
     std::filesystem::path getAbsPath(const Input & input) const
     {
-        auto path = getStrAttr(input.attrs, "path");
+        std::filesystem::path path = getStrAttr(input.attrs, "path");
 
-        if (isAbsolute(path))
+        if (path.is_absolute())
             return canonPath(path);
 
         throw Error("cannot fetch input '%s' because it uses a relative path", input.to_string());

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -147,13 +147,14 @@ static std::shared_ptr<Registry> getGlobalRegistry(const Settings & settings, St
         return Registry::read(
             settings,
             [&] -> SourcePath {
-                if (!isAbsolute(path)) {
+                std::filesystem::path fsPath{path};
+                if (!fsPath.is_absolute()) {
                     auto storePath = downloadFile(store, settings, path, "flake-registry.json").storePath;
                     if (auto store2 = dynamic_cast<LocalFSStore *>(&store))
                         store2->addPermRoot(storePath, (getCacheDir() / "flake-registry.json").string());
                     return {store.requireStoreObjectAccessor(storePath)};
                 } else {
-                    return SourcePath{getFSSourceAccessor(), CanonPath{path}}.resolveSymlinks();
+                    return SourcePath{getFSSourceAccessor(), CanonPath{fsPath.string()}}.resolveSymlinks();
                 }
             }(),
             Registry::Global);

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -15,7 +15,7 @@ namespace nix::fetchers {
 DownloadFileResult downloadFile(
     Store & store,
     const Settings & settings,
-    const std::string & url,
+    const VerbatimURL & url,
     const std::string & name,
     const Headers & headers)
 {
@@ -24,7 +24,7 @@ DownloadFileResult downloadFile(
     Cache::Key key{
         "file",
         {{
-            {"url", url},
+            {"url", url.to_string()},
             {"name", name},
         }}};
 
@@ -42,7 +42,7 @@ DownloadFileResult downloadFile(
     if (cached && !cached->expired)
         return useCached();
 
-    FileTransferRequest request(VerbatimURL{url});
+    FileTransferRequest request(url);
     request.headers = headers;
     if (cached)
         request.expectedETag = getStrAttr(cached->value, "etag");
@@ -179,7 +179,7 @@ static DownloadTarballResult downloadTarball_(
         auto [fdTemp, path] = createTempFile("nix-zipfile");
         cleanupTemp.cancel();
         cleanupTemp = {path};
-        debug("downloading '%s' into '%s'...", url, path);
+        debug("downloading '%s' into %s...", url, PathFmt(path));
         {
             FdSink sink(fdTemp.get());
             source->drainInto(sink);

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -596,7 +596,7 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
                         if (auto relativePath = input.ref->input.isRelative()) {
                             return SourcePath{
                                 overriddenSourcePath.accessor,
-                                CanonPath(*relativePath, overriddenSourcePath.path.parent().value())};
+                                CanonPath(relativePath->string(), overriddenSourcePath.path.parent().value())};
                         } else
                             return std::nullopt;
                     };

--- a/src/libstore-test-support/include/nix/store/tests/nix_api_store.hh
+++ b/src/libstore-test-support/include/nix/store/tests/nix_api_store.hh
@@ -50,8 +50,7 @@ protected:
 #else
         // resolve any symlinks in i.e. on macOS /tmp -> /private/tmp
         // because this is not allowed for a nix store.
-        auto tmpl =
-            nix::absPath(std::filesystem::path(nix::defaultTempDir()) / "tests_nix-store.XXXXXX", std::nullopt, true);
+        auto tmpl = nix::absPath(nix::defaultTempDir() / "tests_nix-store.XXXXXX", nullptr, true);
         nixDir = mkdtemp((char *) tmpl.c_str());
 #endif
 

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -28,7 +28,7 @@ BinaryCacheStore::BinaryCacheStore(Config & config)
     : config{config}
 {
     if (config.secretKeyFile != "")
-        signers.push_back(std::make_unique<LocalSigner>(SecretKey{readFile(config.secretKeyFile)}));
+        signers.push_back(std::make_unique<LocalSigner>(SecretKey{readFile(config.secretKeyFile.get())}));
 
     if (config.secretKeyFiles != "") {
         std::stringstream ss(config.secretKeyFiles);

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1178,15 +1178,15 @@ LogFile::LogFile(Store & store, const StorePath & drvPath, const LogFileSettings
 
     auto baseName = std::string(baseNameOf(store.printStorePath(drvPath)));
 
-    Path logDir;
+    std::filesystem::path logDir;
     if (auto localStore = dynamic_cast<LocalStore *>(&store))
-        logDir = localStore->config->logDir;
+        logDir = localStore->config->logDir.get();
     else
-        logDir = logSettings.nixLogDir.string();
-    Path dir = fmt("%s/%s/%s/", logDir, LocalFSStore::drvsLogDir, baseName.substr(0, 2));
+        logDir = logSettings.nixLogDir;
+    auto dir = logDir / LocalFSStore::drvsLogDir / baseName.substr(0, 2);
     createDirs(dir);
 
-    Path logFileName = fmt("%s/%s%s", dir, baseName.substr(2), logSettings.compressLog ? ".bz2" : "");
+    auto logFileName = dir / (baseName.substr(2) + (logSettings.compressLog ? ".bz2" : ""));
 
     fd = openNewFileForWrite(
         logFileName,
@@ -1196,7 +1196,7 @@ LogFile::LogFile(Store & store, const StorePath & drvPath, const LogFileSettings
             .followSymlinksOnTruncate = true, /* FIXME: Probably shouldn't follow symlinks. */
         });
     if (!fd)
-        throw SysError("creating log file '%1%'", logFileName);
+        throw SysError("creating log file %1%", PathFmt(logFileName));
 
     fileSink = std::make_shared<FdSink>(fd.get());
 

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -78,9 +78,9 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
                 } else if (S_ISLNK(dstSt.st_mode)) {
                     auto target = canonPath(dstFile, true);
                     if (!S_ISDIR(lstat(target).st_mode))
-                        throw Error("collision between '%1%' and non-directory '%2%'", srcFile, target);
+                        throw Error("collision between %1% and non-directory %2%", PathFmt(srcFile), PathFmt(target));
                     if (unlink(dstFile.c_str()) == -1)
-                        throw SysError("unlinking '%1%'", dstFile);
+                        throw SysError("unlinking %1%", PathFmt(dstFile));
                     if (mkdir(
                             dstFile.c_str()
 #ifndef _WIN32 // TODO abstract mkdir perms for Windows
@@ -108,7 +108,7 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
                     if (prevPriority < priority)
                         continue;
                     if (unlink(dstFile.c_str()) == -1)
-                        throw SysError("unlinking '%1%'", dstFile);
+                        throw SysError("unlinking %1%", PathFmt(dstFile));
                 } else if (S_ISDIR(dstSt.st_mode))
                     throw Error("collision between non-directory '%1%' and directory '%2%'", srcFile, dstFile);
             }

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -15,7 +15,7 @@ static void builtinFetchurl(const BuiltinBuilderContext & ctx)
        pass a pointer to the data. */
     if (ctx.netrcData != "") {
         fileTransferSettings.netrcFile = "netrc";
-        writeFile(fileTransferSettings.netrcFile, ctx.netrcData, 0600);
+        writeFile(fileTransferSettings.netrcFile.get(), ctx.netrcData, 0600);
     }
 
     fileTransferSettings.caFile = "ca-certificates.crt";

--- a/src/libstore/include/nix/store/local-fs-store.hh
+++ b/src/libstore/include/nix/store/local-fs-store.hh
@@ -10,7 +10,8 @@ namespace nix {
 struct LocalFSStoreConfig : virtual StoreConfig
 {
 private:
-    static OptionalPathSetting makeRootDirSetting(LocalFSStoreConfig & self, std::optional<Path> defaultValue)
+    static Setting<std::optional<std::filesystem::path>>
+    makeRootDirSetting(LocalFSStoreConfig & self, std::optional<Path> defaultValue)
     {
         return {
             &self,
@@ -32,7 +33,7 @@ public:
      */
     LocalFSStoreConfig(PathView path, const Params & params);
 
-    OptionalPathSetting rootDir = makeRootDirSetting(*this, std::nullopt);
+    Setting<std::optional<std::filesystem::path>> rootDir = makeRootDirSetting(*this, std::nullopt);
 
 private:
 
@@ -50,19 +51,19 @@ private:
 
 public:
 
-    PathSetting stateDir{
+    Setting<std::filesystem::path> stateDir{
         this,
         rootDir.get() ? *rootDir.get() + "/nix/var/nix" : getDefaultStateDir(),
         "state",
         "Directory where Nix stores state."};
 
-    PathSetting logDir{
+    Setting<std::filesystem::path> logDir{
         this,
         rootDir.get() ? *rootDir.get() + "/nix/var/log/nix" : getDefaultLogDir(),
         "log",
         "directory where Nix stores log files."};
 
-    PathSetting realStoreDir{
+    Setting<std::filesystem::path> realStoreDir{
         this, rootDir.get() ? *rootDir.get() + "/nix/store" : storeDir, "real", "Physical path of the Nix store."};
 };
 
@@ -77,7 +78,7 @@ struct alignas(8) /* Work around ASAN failures on i686-linux. */
 
     inline static std::string operationName = "Local Filesystem Store";
 
-    const static std::string drvsLogDir;
+    const static std::filesystem::path drvsLogDir;
 
     LocalFSStore(const Config & params);
 
@@ -100,7 +101,7 @@ struct alignas(8) /* Work around ASAN failures on i686-linux. */
      */
     virtual Path addPermRoot(const StorePath & storePath, const Path & gcRoot) = 0;
 
-    virtual Path getRealStoreDir()
+    virtual std::filesystem::path getRealStoreDir()
     {
         return config.realStoreDir;
     }

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -31,7 +31,7 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
           Must be used as OverlayFS lower layer for this store's store dir.
         )"};
 
-    PathSetting upperLayer{
+    const Setting<std::filesystem::path> upperLayer{
         (StoreConfig *) this,
         "",
         "upper-layer",
@@ -53,7 +53,7 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
           default, but can be disabled if needed.
         )"};
 
-    Setting<std::filesystem::path> remountHook{
+    const Setting<std::filesystem::path> remountHook{
         (StoreConfig *) this,
         "",
         "remount-hook",

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -228,12 +228,12 @@ private:
 
 public:
 
-    const Path dbDir;
-    const Path linksDir;
-    const Path reservedPath;
-    const Path schemaPath;
-    const Path tempRootsDir;
-    const Path fnTempRoots;
+    const std::filesystem::path dbDir;
+    const std::filesystem::path linksDir;
+    const std::filesystem::path reservedPath;
+    const std::filesystem::path schemaPath;
+    const std::filesystem::path tempRootsDir;
+    const std::filesystem::path fnTempRoots;
 
 private:
 
@@ -492,9 +492,13 @@ private:
     typedef boost::unordered_flat_set<ino_t> InodeHash;
 
     InodeHash loadInodeHash();
-    Strings readDirectoryIgnoringInodes(const Path & path, const InodeHash & inodeHash);
-    void
-    optimisePath_(Activity * act, OptimiseStats & stats, const Path & path, InodeHash & inodeHash, RepairFlag repair);
+    Strings readDirectoryIgnoringInodes(const std::filesystem::path & path, const InodeHash & inodeHash);
+    void optimisePath_(
+        Activity * act,
+        OptimiseStats & stats,
+        const std::filesystem::path & path,
+        InodeHash & inodeHash,
+        RepairFlag repair);
 
     // Internal versions that are not wrapped in retry_sqlite.
     bool isValidPath_(State & state, const StorePath & path);

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -335,7 +335,7 @@ public:
     /**
      * Follow symlinks until we end up with a path in the Nix store.
      */
-    Path followLinksToStore(std::string_view path) const;
+    std::filesystem::path followLinksToStore(std::string_view path) const;
 
     /**
      * Same as followLinksToStore(), but apply toStorePath() to the

--- a/src/libstore/indirect-root-store.cc
+++ b/src/libstore/indirect-root-store.cc
@@ -5,7 +5,7 @@ namespace nix {
 void IndirectRootStore::makeSymlink(const Path & link, const Path & target)
 {
     /* Create directories up to `gcRoot'. */
-    createDirs(dirOf(link));
+    createDirs(std::filesystem::path(link).parent_path());
 
     /* Create the new symlink. */
     Path tempLink = fmt("%1%.tmp-%2%-%3%", link, getpid(), rand());
@@ -33,7 +33,7 @@ Path IndirectRootStore::addPermRoot(const StorePath & storePath, const Path & _g
 
     /* Don't clobber the link if it already exists and doesn't
        point to the Nix store. */
-    if (pathExists(gcRoot) && (!std::filesystem::is_symlink(gcRoot) || !isInStore(readLink(gcRoot))))
+    if (pathExists(gcRoot) && (!std::filesystem::is_symlink(gcRoot) || !isInStore(readLink(gcRoot).string())))
         throw Error("cannot create symlink '%1%'; already exists", gcRoot);
 
     makeSymlink(gcRoot, printStorePath(storePath));

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -112,7 +112,7 @@ std::shared_ptr<SourceAccessor> LocalFSStore::getFSAccessor(const StorePath & pa
     return std::make_shared<PosixSourceAccessor>(std::move(absPath));
 }
 
-const std::string LocalFSStore::drvsLogDir = "drvs";
+const std::filesystem::path LocalFSStore::drvsLogDir = "drvs";
 
 std::optional<std::string> LocalFSStore::getBuildLogExact(const StorePath & path)
 {
@@ -120,10 +120,10 @@ std::optional<std::string> LocalFSStore::getBuildLogExact(const StorePath & path
 
     for (int j = 0; j < 2; j++) {
 
-        Path logPath =
-            j == 0 ? fmt("%s/%s/%s/%s", config.logDir.get(), drvsLogDir, baseName.substr(0, 2), baseName.substr(2))
-                   : fmt("%s/%s/%s", config.logDir.get(), drvsLogDir, baseName);
-        Path logBz2Path = logPath + ".bz2";
+        auto logPath = config.logDir.get()
+                       / (j == 0 ? drvsLogDir / baseName.substr(0, 2) / baseName.substr(2) : drvsLogDir / baseName);
+        auto logBz2Path = logPath;
+        logBz2Path += ".bz2";
 
         if (pathExists(logPath))
             return readFile(logPath);

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -36,7 +36,7 @@ StoreReference LocalOverlayStoreConfig::getReference() const
 
 Path LocalOverlayStoreConfig::toUpperPath(const StorePath & path) const
 {
-    return upperLayer + "/" + path.to_string();
+    return (upperLayer.get() / path.to_string()).string();
 }
 
 LocalOverlayStore::LocalOverlayStore(ref<const Config> config)
@@ -50,7 +50,7 @@ LocalOverlayStore::LocalOverlayStore(ref<const Config> config)
         std::smatch match;
         std::string mountInfo;
         auto mounts = readFile(std::filesystem::path{"/proc/self/mounts"});
-        auto regex = std::regex(R"((^|\n)overlay )" + config->realStoreDir.get() + R"( .*(\n|$))");
+        auto regex = std::regex(R"((^|\n)overlay )" + config->realStoreDir.get().string() + R"( .*(\n|$))");
 
         // Mount points can be stacked, so there might be multiple matching entries.
         // Loop until the last match, which will be the current state of the mount point.
@@ -59,16 +59,16 @@ LocalOverlayStore::LocalOverlayStore(ref<const Config> config)
             mounts = match.suffix();
         }
 
-        auto checkOption = [&](std::string option, std::string value) {
-            return std::regex_search(mountInfo, std::regex("\\b" + option + "=" + value + "( |,)"));
+        auto checkOption = [&](std::string_view option, const std::filesystem::path & value) {
+            return std::regex_search(mountInfo, std::regex("\\b" + option + "=" + value.string() + "( |,)"));
         };
 
         auto expectedLowerDir = lowerStore->config.realStoreDir.get();
-        if (!checkOption("lowerdir", expectedLowerDir) || !checkOption("upperdir", config->upperLayer)) {
-            debug("expected lowerdir: %s", expectedLowerDir);
-            debug("expected upperdir: %s", config->upperLayer);
+        if (!checkOption("lowerdir", expectedLowerDir) || !checkOption("upperdir", config->upperLayer.get())) {
+            debug("expected lowerdir: %s", PathFmt(lowerStore->config.realStoreDir.get()));
+            debug("expected upperdir: %s", PathFmt(config->upperLayer.get()));
             debug("actual mount: %s", mountInfo);
-            throw Error("overlay filesystem '%s' mounted incorrectly", config->realStoreDir.get());
+            throw Error("overlay filesystem %s mounted incorrectly", PathFmt(config->realStoreDir.get()));
         }
     }
 }
@@ -282,9 +282,9 @@ void LocalOverlayStore::remountIfNecessary()
         return;
 
     if (config->remountHook.get().empty()) {
-        warn("'%s' needs remounting, set remount-hook to do this automatically", config->realStoreDir.get());
+        warn("%s needs remounting, set remount-hook to do this automatically", PathFmt(config->realStoreDir.get()));
     } else {
-        runProgram(config->remountHook, false, {string_to_os_string(config->realStoreDir.get())});
+        runProgram(config->remountHook.get(), false, {config->realStoreDir.get().native()});
     }
 
     _remountRequired = false;

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -84,12 +84,12 @@ struct NarInfoDiskCacheImpl : NarInfoDiskCache
     NarInfoDiskCacheImpl(
         const Settings & settings,
         SQLiteSettings sqliteSettings,
-        Path dbPath = (getCacheDir() / "binary-cache-v7.sqlite").string())
+        std::filesystem::path dbPath = getCacheDir() / "binary-cache-v7.sqlite")
         : NarInfoDiskCache{settings}
     {
         auto state(_state.lock());
 
-        createDirs(dirOf(dbPath));
+        createDirs(dbPath.parent_path());
 
         state->db = SQLite(dbPath, SQLite::Settings{sqliteSettings});
 

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -53,7 +53,7 @@ struct RestrictedStore : public virtual IndirectRootStore, public virtual GcStor
     {
     }
 
-    Path getRealStoreDir() override
+    std::filesystem::path getRealStoreDir() override
     {
         return next->config->realStoreDir;
     }

--- a/src/libstore/store-dir-config.cc
+++ b/src/libstore/store-dir-config.cc
@@ -20,9 +20,9 @@ StorePath StoreDirConfig::parseStorePath(std::string_view path) const
         canonPath(std::string(path))
 #endif
         ;
-    if (dirOf(p) != storeDir)
-        throw BadStorePath("path '%s' is not in the Nix store", p);
-    return StorePath(baseNameOf(p));
+    if (p.parent_path() != storeDir)
+        throw BadStorePath("path %s is not in the Nix store", PathFmt(p));
+    return StorePath(p.filename().string());
 }
 
 std::optional<StorePath> StoreDirConfig::maybeParseStorePath(std::string_view path) const

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1298,7 +1298,7 @@ void DerivationBuilderImpl::runChild(RunChildArgs args)
 
         if (drv.isBuiltin() && drv.builder == "builtin:fetchurl") {
             try {
-                ctx.netrcData = readFile(fileTransferSettings.netrcFile);
+                ctx.netrcData = readFile(fileTransferSettings.netrcFile.get());
             } catch (SystemError &) {
             }
 

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -62,9 +62,10 @@ TEST(absPath, usesOptionalBasePathWhenGiven)
     OsChar _cwd[PATH_MAX + 1];
     OsChar * cwd = GET_CWD((OsChar *) &_cwd, PATH_MAX);
 
-    auto p = absPath(std::filesystem::path{""}.string(), std::filesystem::path{cwd}.string());
+    auto cwdPath = std::filesystem::path{cwd};
+    auto p = absPath("", &cwdPath);
 
-    ASSERT_EQ(p, std::filesystem::path{cwd}.string());
+    ASSERT_EQ(p, cwdPath);
 }
 
 TEST(absPath, isIdempotent)
@@ -120,30 +121,7 @@ TEST(canonPath, requiresAbsolutePath)
     ASSERT_ANY_THROW(canonPath("."sv));
     ASSERT_ANY_THROW(canonPath(".."sv));
     ASSERT_ANY_THROW(canonPath("../"sv));
-    ASSERT_DEATH({ canonPath(""sv); }, "path != \"\"");
-}
-
-/* ----------------------------------------------------------------------------
- * dirOf
- * --------------------------------------------------------------------------*/
-
-TEST(dirOf, returnsEmptyStringForRoot)
-{
-    auto p = dirOf("/");
-
-    ASSERT_EQ(p, "/");
-}
-
-TEST(dirOf, returnsFirstPathComponent)
-{
-    auto p1 = dirOf("/dir/");
-    ASSERT_EQ(p1, "/dir");
-    auto p2 = dirOf("/dir");
-    ASSERT_EQ(p2, "/");
-    auto p3 = dirOf("/dir/..");
-    ASSERT_EQ(p3, "/dir");
-    auto p4 = dirOf("/dir/../");
-    ASSERT_EQ(p4, "/dir/..");
+    ASSERT_DEATH({ canonPath(""sv); }, "!path.empty\\(\\)");
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -32,7 +32,7 @@ static ArchiveSettings archiveSettings;
 
 static GlobalConfig::Register rArchiveSettings(&archiveSettings);
 
-PathFilter defaultPathFilter = [](const Path &) { return true; };
+PathFilter defaultPathFilter = [](const std::string &) { return true; };
 
 void SourceAccessor::dumpPath(const CanonPath & path, Sink & sink, PathFilter & filter)
 {
@@ -101,14 +101,14 @@ void SourceAccessor::dumpPath(const CanonPath & path, Sink & sink, PathFilter & 
     }(path);
 }
 
-time_t dumpPathAndGetMtime(const Path & path, Sink & sink, PathFilter & filter)
+time_t dumpPathAndGetMtime(const std::filesystem::path & path, Sink & sink, PathFilter & filter)
 {
     auto path2 = PosixSourceAccessor::createAtRoot(path, /*trackLastModified=*/true);
     path2.dumpPath(sink, filter);
     return path2.accessor->getLastModified().value();
 }
 
-void dumpPath(const Path & path, Sink & sink, PathFilter & filter)
+void dumpPath(const std::filesystem::path & path, Sink & sink, PathFilter & filter)
 {
     dumpPathAndGetMtime(path, sink, filter);
 }
@@ -201,7 +201,7 @@ static void parse(FileSystemObjectSink & sink, Source & source, const CanonPath 
 
     else if (type == "directory") {
         sink.createDirectory(path, [&](FileSystemObjectSink & dirSink, const CanonPath & relDirPath) {
-            std::map<Path, int, CaseInsensitiveCompare> names;
+            std::map<std::string, int, CaseInsensitiveCompare> names;
 
             std::string prevName;
 

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -284,7 +284,7 @@ void RootArgs::parseCmdline(const Strings & _cmdline, bool allowShebang)
     // executable file, and it starts with "#!".
     Strings savedArgs;
     if (allowShebang) {
-        auto script = *cmdline.begin();
+        std::filesystem::path script = *cmdline.begin();
         try {
             std::ifstream stream(script);
             char shebang[3] = {0, 0, 0};
@@ -310,8 +310,8 @@ void RootArgs::parseCmdline(const Strings & _cmdline, bool allowShebang)
                 for (const auto & word : parseShebangContent(shebangContent)) {
                     cmdline.push_back(word);
                 }
-                cmdline.push_back(script);
-                commandBaseDir = dirOf(script);
+                cmdline.push_back(script.string());
+                commandBaseDir = script.parent_path();
                 for (auto pos = savedArgs.begin(); pos != savedArgs.end(); pos++)
                     cmdline.push_back(*pos);
             }

--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -120,9 +120,9 @@ void restoreProcessContext(bool restoreMounts)
 
 //////////////////////////////////////////////////////////////////////
 
-std::optional<Path> getSelfExe()
+std::optional<std::filesystem::path> getSelfExe()
 {
-    static auto cached = []() -> std::optional<Path> {
+    static auto cached = []() -> std::optional<std::filesystem::path> {
 #if defined(__linux__) || defined(__GNU__)
         return readLink(std::filesystem::path{"/proc/self/exe"});
 #elif defined(__APPLE__)

--- a/src/libutil/executable-path.cc
+++ b/src/libutil/executable-path.cc
@@ -55,7 +55,7 @@ void ExecutablePath::parseAppend(const OsString & path)
 
 OsString ExecutablePath::render() const
 {
-    std::vector<PathViewNG> path2;
+    std::vector<PathView> path2;
     path2.reserve(directories.size());
     for (auto & p : directories)
         path2.push_back(p.native());

--- a/src/libutil/file-content-address.cc
+++ b/src/libutil/file-content-address.cc
@@ -75,7 +75,7 @@ void dumpPath(const SourcePath & path, Sink & sink, FileSerialisationMethod meth
     }
 }
 
-void restorePath(const Path & path, Source & source, FileSerialisationMethod method, bool startFsync)
+void restorePath(const std::filesystem::path & path, Source & source, FileSerialisationMethod method, bool startFsync)
 {
     switch (method) {
     case FileSerialisationMethod::Flat:

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -369,7 +369,7 @@ Hash hashString(HashAlgorithm ha, std::string_view s, const ExperimentalFeatureS
     return hash;
 }
 
-Hash hashFile(HashAlgorithm ha, const Path & path)
+Hash hashFile(HashAlgorithm ha, const std::filesystem::path & path)
 {
     HashSink sink(ha);
     readFile(path, sink);

--- a/src/libutil/include/nix/util/archive.hh
+++ b/src/libutil/include/nix/util/archive.hh
@@ -55,12 +55,12 @@ namespace nix {
  *   `+` denotes string concatenation.
  * ```
  */
-void dumpPath(const Path & path, Sink & sink, PathFilter & filter = defaultPathFilter);
+void dumpPath(const std::filesystem::path & path, Sink & sink, PathFilter & filter = defaultPathFilter);
 
 /**
  * Same as dumpPath(), but returns the last modified date of the path.
  */
-time_t dumpPathAndGetMtime(const Path & path, Sink & sink, PathFilter & filter = defaultPathFilter);
+time_t dumpPathAndGetMtime(const std::filesystem::path & path, Sink & sink, PathFilter & filter = defaultPathFilter);
 
 /**
  * Dump an archive with a single file with these contents.

--- a/src/libutil/include/nix/util/current-process.hh
+++ b/src/libutil/include/nix/util/current-process.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include <filesystem>
 #include <optional>
 #include <chrono>
 
@@ -42,6 +43,6 @@ void restoreProcessContext(bool restoreMounts = true);
 /**
  * @return the path of the current executable.
  */
-std::optional<Path> getSelfExe();
+std::optional<std::filesystem::path> getSelfExe();
 
 } // namespace nix

--- a/src/libutil/include/nix/util/file-content-address.hh
+++ b/src/libutil/include/nix/util/file-content-address.hh
@@ -64,7 +64,8 @@ void dumpPath(
  *
  * \todo use an arbitrary `FileSystemObjectSink`.
  */
-void restorePath(const Path & path, Source & source, FileSerialisationMethod method, bool startFsync = false);
+void restorePath(
+    const std::filesystem::path & path, Source & source, FileSerialisationMethod method, bool startFsync = false);
 
 /**
  * Compute the hash of the given file system object according to the

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -42,24 +42,12 @@ struct Sink;
 struct Source;
 
 /**
- * Return whether the path denotes an absolute path.
- */
-bool isAbsolute(PathView path);
-
-/**
  * @return An absolutized path, resolving paths relative to the
  * specified directory, or the current directory otherwise.  The path
  * is also canonicalised.
  *
  * In the process of being deprecated for `std::filesystem::absolute`.
  */
-Path absPath(PathView path, std::optional<PathView> dir = {}, bool resolveSymlinks = false);
-
-inline Path absPath(const Path & path, std::optional<PathView> dir = {}, bool resolveSymlinks = false)
-{
-    return absPath(PathView{path}, dir, resolveSymlinks);
-}
-
 std::filesystem::path
 absPath(const std::filesystem::path & path, const std::filesystem::path * dir = nullptr, bool resolveSymlinks = false);
 
@@ -74,25 +62,7 @@ absPath(const std::filesystem::path & path, const std::filesystem::path * dir = 
  * false` case), and `std::filesystem::weakly_canonical` (for the
  * `resolveSymlinks = true` case).
  */
-Path canonPath(PathView path, bool resolveSymlinks = false);
-
-static inline Path canonPath(const Path & path, bool resolveSymlinks = false)
-{
-    return canonPath(PathView{path}, resolveSymlinks);
-}
-
 std::filesystem::path canonPath(const std::filesystem::path & path, bool resolveSymlinks = false);
-
-/**
- * @return The directory part of the given canonical path, i.e.,
- * everything before the final `/`.  If the path is the root or an
- * immediate child thereof (e.g., `/foo`), this means `/`
- * is returned.
- *
- * In the process of being deprecated for
- * `std::filesystem::path::parent_path`.
- */
-Path dirOf(const PathView path);
 
 /**
  * @return the base name of the given canonical path, i.e., everything
@@ -178,15 +148,6 @@ bool pathAccessible(const std::filesystem::path & path);
 /**
  * Read the contents (target) of a symbolic link.  The result is not
  * in any way canonicalised.
- *
- * In the process of being deprecated for
- * `std::filesystem::read_symlink`.
- */
-Path readLink(const Path & path);
-
-/**
- * Read the contents (target) of a symbolic link.  The result is not
- * in any way canonicalised.
  */
 std::filesystem::path readLink(const std::filesystem::path & path);
 
@@ -242,42 +203,30 @@ Descriptor openNewFileForWrite(const std::filesystem::path & path, mode_t mode, 
 /**
  * Read the contents of a file into a string.
  */
-std::string readFile(const Path & path);
 std::string readFile(const std::filesystem::path & path);
-void readFile(const Path & path, Sink & sink, bool memory_map = true);
+void readFile(const std::filesystem::path & path, Sink & sink, bool memory_map = true);
 
 enum struct FsSync { Yes, No };
 
 /**
  * Write a string to a file.
  */
-void writeFile(const Path & path, std::string_view s, mode_t mode = 0666, FsSync sync = FsSync::No);
+void writeFile(const std::filesystem::path & path, std::string_view s, mode_t mode = 0666, FsSync sync = FsSync::No);
 
-static inline void
-writeFile(const std::filesystem::path & path, std::string_view s, mode_t mode = 0666, FsSync sync = FsSync::No)
-{
-    return writeFile(path.string(), s, mode, sync);
-}
+void writeFile(const std::filesystem::path & path, Source & source, mode_t mode = 0666, FsSync sync = FsSync::No);
 
-void writeFile(const Path & path, Source & source, mode_t mode = 0666, FsSync sync = FsSync::No);
-
-static inline void
-writeFile(const std::filesystem::path & path, Source & source, mode_t mode = 0666, FsSync sync = FsSync::No)
-{
-    return writeFile(path.string(), source, mode, sync);
-}
-
-void writeFile(Descriptor fd, std::string_view s, FsSync sync = FsSync::No, const Path * origPath = nullptr);
+void writeFile(
+    Descriptor fd, std::string_view s, FsSync sync = FsSync::No, const std::filesystem::path * origPath = nullptr);
 
 /**
  * Flush a path's parent directory to disk.
  */
-void syncParent(const Path & path);
+void syncParent(const std::filesystem::path & path);
 
 /**
  * Flush a file or entire directory tree to disk.
  */
-void recursiveSync(const Path & path);
+void recursiveSync(const std::filesystem::path & path);
 
 /**
  * Delete a path; i.e., in the case of a directory, it is deleted
@@ -298,7 +247,7 @@ void createDirs(const std::filesystem::path & path);
 /**
  * Create a single directory.
  */
-void createDir(const Path & path, mode_t mode = 0755);
+void createDir(const std::filesystem::path & path, mode_t mode = 0755);
 
 /**
  * Set the access and modification times of the given path, not
@@ -328,17 +277,12 @@ void setWriteTime(const std::filesystem::path & path, const PosixStat & st);
  * Create a symlink.
  *
  */
-void createSymlink(const Path & target, const Path & link);
+void createSymlink(const std::filesystem::path & target, const std::filesystem::path & link);
 
 /**
  * Atomically create or replace a symlink.
  */
 void replaceSymlink(const std::filesystem::path & target, const std::filesystem::path & link);
-
-inline void replaceSymlink(const Path & target, const Path & link)
-{
-    return replaceSymlink(std::filesystem::path{target}, std::filesystem::path{link});
-}
 
 /**
  * Similar to 'renameFile', but fallback to a copy+remove if `src` and `dst`
@@ -347,7 +291,7 @@ inline void replaceSymlink(const Path & target, const Path & link)
  * Beware that this might not be atomic because of the copy that happens behind
  * the scenes
  */
-void moveFile(const Path & src, const Path & dst);
+void moveFile(const std::filesystem::path & src, const std::filesystem::path & dst);
 
 /**
  * Recursively copy the content of `oldPath` to `newPath`. If `andDelete` is
@@ -454,7 +398,7 @@ AutoCloseFD createAnonymousTempFile();
 /**
  * Create a temporary file, returning a file handle and its path.
  */
-std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix = "nix");
+std::pair<AutoCloseFD, std::filesystem::path> createTempFile(const std::filesystem::path & prefix = "nix");
 
 /**
  * Return `TMPDIR`, or the default temporary directory if unset or empty.
@@ -479,8 +423,10 @@ std::filesystem::path makeTempPath(const std::filesystem::path & root, const std
 
 /**
  * Used in various places.
+ *
+ * @todo type
  */
-typedef std::function<bool(const Path & path)> PathFilter;
+typedef std::function<bool(const std::string & path)> PathFilter;
 
 extern PathFilter defaultPathFilter;
 

--- a/src/libutil/include/nix/util/hash.hh
+++ b/src/libutil/include/nix/util/hash.hh
@@ -165,7 +165,7 @@ Hash hashString(
  *
  * (Metadata, such as the executable permission bit, is ignored.)
  */
-Hash hashFile(HashAlgorithm ha, const Path & path);
+Hash hashFile(HashAlgorithm ha, const std::filesystem::path & path);
 
 /**
  * The final hash and the number of bytes digested.

--- a/src/libutil/include/nix/util/unix-domain-socket.hh
+++ b/src/libutil/include/nix/util/unix-domain-socket.hh
@@ -19,12 +19,12 @@ AutoCloseFD createUnixDomainSocket();
 /**
  * Create a Unix domain socket in listen mode.
  */
-AutoCloseFD createUnixDomainSocket(const Path & path, mode_t mode);
+AutoCloseFD createUnixDomainSocket(const std::filesystem::path & path, mode_t mode);
 
 /**
  * Bind a Unix domain socket to a path.
  */
-void bind(Socket fd, const std::string & path);
+void bind(Socket fd, const std::filesystem::path & path);
 
 /**
  * Connect to a Unix domain socket.

--- a/src/libutil/linux/linux-namespaces.cc
+++ b/src/libutil/linux/linux-namespaces.cc
@@ -22,13 +22,13 @@ bool userNamespacesSupported()
             return false;
         }
 
-        Path maxUserNamespaces = "/proc/sys/user/max_user_namespaces";
+        std::filesystem::path maxUserNamespaces = "/proc/sys/user/max_user_namespaces";
         if (!pathExists(maxUserNamespaces) || trim(readFile(maxUserNamespaces)) == "0") {
             debug("user namespaces appear to be disabled; check '/proc/sys/user/max_user_namespaces'");
             return false;
         }
 
-        Path procSysKernelUnprivilegedUsernsClone = "/proc/sys/kernel/unprivileged_userns_clone";
+        std::filesystem::path procSysKernelUnprivilegedUsernsClone = "/proc/sys/kernel/unprivileged_userns_clone";
         if (pathExists(procSysKernelUnprivilegedUsernsClone)
             && trim(readFile(procSysKernelUnprivilegedUsernsClone)) == "0") {
             debug("user namespaces appear to be disabled; check '/proc/sys/kernel/unprivileged_userns_clone'");

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -69,14 +69,14 @@ bool PosixSourceAccessor::pathExists(const CanonPath & path)
     return nix::pathExists(makeAbsPath(path).string());
 }
 
-using Cache = boost::concurrent_flat_map<Path, std::optional<PosixStat>>;
+using Cache = boost::concurrent_flat_map<std::string, std::optional<PosixStat>>;
 static Cache cache;
 
 std::optional<PosixStat> PosixSourceAccessor::cachedLstat(const CanonPath & path)
 {
-    // Note: we convert std::filesystem::path to Path because the
+    // Note: we convert std::filesystem::path to std::string because the
     // former is not hashable on libc++.
-    Path absPath = makeAbsPath(path).string();
+    std::string absPath = makeAbsPath(path).string();
 
     if (auto res = getConcurrent(cache, absPath))
         return *res;

--- a/src/libutil/source-accessor.cc
+++ b/src/libutil/source-accessor.cc
@@ -112,7 +112,7 @@ CanonPath SourceAccessor::resolveSymlinks(const CanonPath & path, SymlinkResolut
                     if (!linksAllowed--)
                         throw Error("infinite symlink recursion in path '%s'", showPath(path));
                     auto target = readLink(res);
-                    if (isAbsolute(target)) {
+                    if (std::filesystem::path(target).is_absolute()) {
                         res = CanonPath::root;
                     } else {
                         res.pop();

--- a/src/libutil/unix/file-path.cc
+++ b/src/libutil/unix/file-path.cc
@@ -8,14 +8,9 @@
 
 namespace nix {
 
-std::optional<std::filesystem::path> maybePath(PathView path)
-{
-    return {path};
-}
-
 std::filesystem::path pathNG(PathView path)
 {
-    return path;
+    return {std::string{path}};
 }
 
 } // namespace nix

--- a/src/libutil/windows/file-path.cc
+++ b/src/libutil/windows/file-path.cc
@@ -9,7 +9,7 @@
 
 namespace nix {
 
-std::optional<std::filesystem::path> maybePath(PathView path)
+static std::optional<std::filesystem::path> maybePath(PathView path)
 {
     if (path.length() >= 3 && (('A' <= path[0] && path[0] <= 'Z') || ('a' <= path[0] && path[0] <= 'z'))
         && path[1] == ':' && WindowsPathTrait<char>::isPathSep(path[2])) {

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -596,7 +596,7 @@ struct CmdDevelop : Common, MixEnvironment
         if (verbosity >= lvlDebug)
             script += "set -x\n";
 
-        script += fmt("command rm -f '%s'\n", rcFilePath);
+        script += fmt("command rm -f '%s'\n", rcFilePath.string());
 
         if (phase) {
             if (!command.empty())

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -920,11 +920,11 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
                 else if (st.type == SourceAccessor::tRegular) {
                     auto contents = from2.readFile();
                     if (std::filesystem::exists(to_st)) {
-                        auto contents2 = readFile(to2.string());
+                        auto contents2 = readFile(to2);
                         if (contents != contents2) {
                             printError(
-                                "refusing to overwrite existing file '%s'\n please merge it manually with '%s'",
-                                to2.string(),
+                                "refusing to overwrite existing file %s\n please merge it manually with '%s'",
+                                PathFmt(to2),
                                 from2);
                             conflictedFiles.push_back(to2);
                         } else {
@@ -938,8 +938,8 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
                     if (std::filesystem::exists(to_st)) {
                         if (std::filesystem::read_symlink(to2) != target) {
                             printError(
-                                "refusing to overwrite existing file '%s'\n please merge it manually with '%s'",
-                                to2.string(),
+                                "refusing to overwrite existing file %s\n please merge it manually with '%s'",
+                                PathFmt(to2),
                                 from2);
                             conflictedFiles.push_back(to2);
                         } else {
@@ -947,7 +947,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
                         }
                         continue;
                     } else
-                        createSymlink(target, os_string_to_string(PathViewNG{to2}));
+                        createSymlink(target, to2);
                 } else
                     throw Error(
                         "path '%s' needs to be a symlink, file, or directory but instead is a %s",

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -654,7 +654,7 @@ static void main_nix_build(int argc, char ** argv)
                 escapeShellArgAlways(tmpDir.path().string()),
                 (pure ? "" : "p=$PATH; "),
                 (pure ? "" : "PATH=$PATH:$p; unset p; "),
-                escapeShellArgAlways(dirOf(*shell)),
+                escapeShellArgAlways(std::filesystem::path(*shell).parent_path().string()),
                 escapeShellArgAlways(*shell),
                 tzExport,
                 envCommand);

--- a/src/nix/nix-channel/nix-channel.cc
+++ b/src/nix/nix-channel/nix-channel.cc
@@ -148,8 +148,9 @@ static void update(const StringSet & channelNames)
                         OS_STR("--no-out-link"),
                         OS_STR("--expr"),
                         string_to_os_string(
-                            "import " + unpackChannelPath + "{ name = \"" + cname + "\"; channelName = \"" + name
-                            + "\"; src = builtins.storePath \"" + store->printStorePath(result.storePath) + "\"; }"),
+                            "import " + unpackChannelPath.string() + "{ name = \"" + cname + "\"; channelName = \""
+                            + name + "\"; src = builtins.storePath \"" + store->printStorePath(result.storePath)
+                            + "\"; }"),
                     });
                 unpacked = true;
             }

--- a/tests/functional/flakes/init.sh
+++ b/tests/functional/flakes/init.sh
@@ -78,7 +78,7 @@ echo a > "$flakeDir/a"
 createGitRepo "$flakeDir"
 echo b > "$flakeDir/a"
 pushd "$flakeDir"
-(! nix flake init) |& grep "refusing to overwrite existing file '$flakeDir/a'"
+(! nix flake init) |& grep "refusing to overwrite existing file \"$flakeDir/a\""
 popd
 git -C "$flakeDir" commit -a -m 'Changed'
 

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -68,7 +68,7 @@ testRepl () {
     echo "$replOutput" | grepInverse "error: Cannot run 'nix-shell'"
 
     expectStderr 1 nix repl "${testDir}/simple.nix" \
-      | grepQuiet -s "error: path '$testDir/simple.nix' is not a flake"
+      | grepQuiet -s "error: path \"$testDir/simple.nix\" is not a flake"
 }
 
 # Simple test, try building a drv


### PR DESCRIPTION
## Motivation

This takes the `std::filesystem::path` migration from the CLI layer into the core libraries (libutil, libstore, libexpr, libfetchers, libflake), converting function signatures, settings fields, and locals throughout `file-system.hh`, `archive.hh`, `configuration.hh`, and their implementations. `PathSetting` becomes `Setting<std::filesystem::path>` in `local-overlay-store.hh` and `local-store.hh` with `.get()` calls at use sites, and several `writeFile` overloads collapse now that the `Path`-based wrappers in `file-system.hh` are gone.


## Context

- This builds upon #15312

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
