### PR TITLE
registry: fix symlinked flake registry files broken by convert-end-exes

### DIFF
--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -153,7 +153,7 @@ static std::shared_ptr<Registry> getGlobalRegistry(const Settings & settings, St
                         store2->addPermRoot(storePath, (getCacheDir() / "flake-registry.json").string());
                     return {store.requireStoreObjectAccessor(storePath)};
                 } else {
-                    return SourcePath{makeFSSourceAccessor(path)}.resolveSymlinks();
+                    return SourcePath{getFSSourceAccessor(), CanonPath{path}}.resolveSymlinks();
                 }
             }(),
             Registry::Global);

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -222,6 +222,12 @@ nix store gc
 nix registry list --flake-registry "file://$registry" --refresh | grepQuiet flake3
 mv "$registry.tmp" "$registry"
 
+# A symlinked registry file should work even when the symlink target is
+# an absolute path. The source accessor needs to be rooted at `/` for this.
+ln -sfn "$registry" "$TEST_ROOT/registry-symlink.json"
+nix registry list --flake-registry "$TEST_ROOT/registry-symlink.json" | grepQuiet flake1
+rm "$TEST_ROOT/registry-symlink.json"
+
 # Ensure that locking ignores the user registry.
 mkdir -p "$TEST_HOME/.config/nix"
 ln -sfn "$registry" "$TEST_HOME/.config/nix/registry.json"


### PR DESCRIPTION
## Motivation

This commit reverts to using `getFSSourceAccessor()` so absolute symlink targets resolve correctly, since `makeFSSourceAccessor(path)` roots the accessor at `path` and can't follow symlinks that escape it.

## Context

- This is a follow-up to https://github.com/NixOS/nix/pull/15311#discussion_r2836005511

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
