### PR TITLE
libutil: Fix writeFull to respect allowInterrupts

### DIFF
--- a/src/libutil/file-descriptor.cc
+++ b/src/libutil/file-descriptor.cc
@@ -97,7 +97,7 @@ void writeFull(Descriptor fd, std::string_view s, bool allowInterrupts)
         if (allowInterrupts)
             checkInterrupt();
         auto res = retryOnBlock(fd, PollDirection::Out, [&]() {
-            return write(fd, {reinterpret_cast<const std::byte *>(s.data()), s.size()});
+            return write(fd, {reinterpret_cast<const std::byte *>(s.data()), s.size()}, allowInterrupts);
         });
         if (res > 0)
             s.remove_prefix(res);

--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -85,7 +85,7 @@ size_t read(Descriptor fd, std::span<std::byte> buffer);
  * @return The number of bytes actually written
  * @throws SystemError on failure
  */
-size_t write(Descriptor fd, std::span<const std::byte> buffer);
+size_t write(Descriptor fd, std::span<const std::byte> buffer, bool allowInterrupts);
 
 /**
  * Get the size of a file.

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -42,11 +42,12 @@ size_t readOffset(Descriptor fd, off_t offset, std::span<std::byte> buffer)
     return static_cast<size_t>(n);
 }
 
-size_t write(Descriptor fd, std::span<const std::byte> buffer)
+size_t write(Descriptor fd, std::span<const std::byte> buffer, bool allowInterrupts)
 {
     ssize_t n;
     do {
-        checkInterrupt();
+        if (allowInterrupts)
+            checkInterrupt();
         n = ::write(fd, buffer.data(), buffer.size());
     } while (n == -1 && errno == EINTR);
     if (n == -1)

--- a/src/libutil/windows/file-descriptor.cc
+++ b/src/libutil/windows/file-descriptor.cc
@@ -60,9 +60,10 @@ size_t readOffset(Descriptor fd, off_t offset, std::span<std::byte> buffer)
     return static_cast<size_t>(n);
 }
 
-size_t write(Descriptor fd, std::span<const std::byte> buffer)
+size_t write(Descriptor fd, std::span<const std::byte> buffer, bool allowInterrupts)
 {
-    checkInterrupt(); // For consistency with unix
+    if (allowInterrupts)
+        checkInterrupt(); // For consistency with unix
     DWORD n;
     if (!WriteFile(fd, buffer.data(), static_cast<DWORD>(buffer.size()), &n, NULL)) {
         auto lastError = GetLastError();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

c0e849b696e31644e0f50d7882dd3a03aed06e94 broke interrupt handling since `writeFull` started throwing `Interrupted` even when `allowInterrupts` was false. This would lead to exceptions leaking out when they must not (for example during progress bar shutdown).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
