### PR TITLE
libutil: treat EIO as EOF in `readLine`

### DIFF
--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -6,6 +6,11 @@
 
 #include <cstring>
 
+#ifndef _WIN32
+#  include <fcntl.h>
+#  include <stdlib.h>
+#endif
+
 namespace nix {
 
 // BufferedSource with configurable small buffer for precise boundary testing.
@@ -112,6 +117,55 @@ TEST(ReadLine, LineWithNullBytes)
             "b",
             3));
 }
+
+#ifndef _WIN32
+TEST(ReadLine, TreatsEioAsEof)
+{
+    // Open a pty master. When the slave side is closed (or never opened),
+    // reading from the master returns EIO, which readLine should treat as EOF.
+    int master = posix_openpt(O_RDWR | O_NOCTTY);
+    ASSERT_NE(master, -1);
+    ASSERT_EQ(grantpt(master), 0);
+    ASSERT_EQ(unlockpt(master), 0);
+
+    // Open and immediately close the slave to trigger EIO on the master.
+    int slave = open(ptsname(master), O_RDWR | O_NOCTTY);
+    ASSERT_NE(slave, -1);
+    close(slave);
+
+    // With eofOk=true, readLine should return empty string (treating EIO as EOF).
+    EXPECT_EQ(readLine(master, /*eofOk=*/true), "");
+
+    // With eofOk=false, readLine should throw EndOfFile.
+    EXPECT_THROW(readLine(master), EndOfFile);
+
+    close(master);
+}
+
+// macOS (BSD) discards buffered pty data on slave close and returns normal
+// EOF (0) instead of EIO, so partial data never reaches the master.
+#  ifdef __linux__
+TEST(ReadLine, PartialLineBeforeEio)
+{
+    int master = posix_openpt(O_RDWR | O_NOCTTY);
+    ASSERT_NE(master, -1);
+    ASSERT_EQ(grantpt(master), 0);
+    ASSERT_EQ(unlockpt(master), 0);
+
+    int slave = open(ptsname(master), O_RDWR | O_NOCTTY);
+    ASSERT_NE(slave, -1);
+
+    // Write a partial line (no terminator) from the slave, then close it.
+    ASSERT_EQ(::write(slave, "partial", 7), 7);
+    close(slave);
+
+    // readLine should return the partial data when eofOk=true.
+    EXPECT_EQ(readLine(master, /*eofOk=*/true), "partial");
+
+    close(master);
+}
+#  endif
+#endif
 
 TEST(BufferedSourceReadLine, ReadsLinesFromPipe)
 {


### PR DESCRIPTION
## Motivation

Reading from a pty master returns `EIO` once the slave side closes, however, `readLine` lets it propagate as an uncaught `SysError`, which causes spurious build failures in gvisor and similar sandboxed environments where pty teardown races differently. This commit catches `EIO` inside the read lambda and maps it to a zero-length read, reusing the existing EOF path.	

## Context

When pty support was first added in #2878, EIO was handled at the call site, but a later refactor moved reading to the generic `readLine` which didn't carry the handling over, though muxable-pipe.cc still has it.

Note that the test is skipped on macOS, because macOS returns EOF with 0 immediately and discards all buffered data ([ref](https://developer.apple.com/forums/thread/663632)). 

- Fixes #15181

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
