### PR TITLE
Error on invalid URL param in github fetcher

### DIFF
--- a/doc/manual/rl-next/github-fetcher-param-validation.md
+++ b/doc/manual/rl-next/github-fetcher-param-validation.md
@@ -1,0 +1,7 @@
+---
+synopsis: GitHub fetcher now validates URL parameters
+prs: [15331]
+issues: [15304]
+---
+
+The `github:` fetcher now validates URL parameters, and will error if an invalid parameter like `tag` is provided.

--- a/src/libfetchers-tests/input.cc
+++ b/src/libfetchers-tests/input.cc
@@ -1,8 +1,12 @@
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/fetchers/attrs.hh"
 #include "nix/fetchers/fetchers.hh"
+#include "nix/fetchers/fetch-settings.hh"
+#include "nix/util/tests/gmock-matchers.hh"
+#include "nix/util/url.hh"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <string>
 
@@ -57,5 +61,19 @@ INSTANTIATE_TEST_SUITE_P(
                 },
         }),
     [](const ::testing::TestParamInfo<InputFromAttrsTestCase> & info) { return info.param.description; });
+
+namespace fetchers {
+
+class GitHubInputTest : public ::testing::Test
+{};
+
+TEST_F(GitHubInputTest, throwOnInvalidURLParam)
+{
+    EXPECT_THAT(
+        []() { Input::fromURL(fetchers::Settings{}, "github:a/b?tag=foo"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("tag")));
+}
+
+} // namespace fetchers
 
 } // namespace nix


### PR DESCRIPTION
Resolves #15304

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

It is easy for people to make the mistake of including a `tag` parameter when they want to fetch a tag from a github URL. Currently, Nix will just ignore it and fall back to fetching the default branch, with no error printed, which is highly undesirable.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#15304

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
