### PR TITLE
Introduce `CanonPath::fromFilename`

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1270,13 +1270,10 @@ void DerivationBuilderImpl::chownToBuilder(int fd, const std::filesystem::path &
 
 void DerivationBuilderImpl::writeBuilderFile(const std::string & name, std::string_view contents)
 {
-    auto relPath = CanonPath(name);
     /* Path must be the same after normalisation. This is an additional sanity check in addition to
        existing parsing checks for non-structured attrs exportReferencesGraph. In practice we only expect
        a single path component without any `..`, `.` components. */
-    if (relPath.rel() != name || std::ranges::distance(relPath) != 1)
-        throw Error("invalid file name for a builder file: '%s'", name);
-
+    auto relPath = CanonPath::fromFilename(name);
     AutoCloseFD fd = openFileEnsureBeneathNoSymlinks(
         tmpDirFd.get(), relPath, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL | O_NOFOLLOW, 0666);
     auto path = tmpDir / relPath.rel(); /* This is used only for error messages. */

--- a/src/libutil-tests/canon-path.cc
+++ b/src/libutil-tests/canon-path.cc
@@ -51,6 +51,19 @@ TEST(CanonPath, nullBytes)
     ASSERT_THROW(CanonPath(s, CanonPath::root), BadCanonPath);
 }
 
+TEST(CanonPath, fromFilename)
+{
+    ASSERT_THROW(CanonPath::fromFilename("."), BadCanonPath);
+    ASSERT_THROW(CanonPath::fromFilename(".."), BadCanonPath);
+    ASSERT_THROW(CanonPath::fromFilename(""), BadCanonPath);
+    ASSERT_THROW(CanonPath::fromFilename("/.."), BadCanonPath);
+    ASSERT_THROW(CanonPath::fromFilename("/."), BadCanonPath);
+    ASSERT_THROW(CanonPath::fromFilename("/abc"), BadCanonPath);
+    ASSERT_THROW(CanonPath::fromFilename("abc/d"), BadCanonPath);
+    ASSERT_THROW(CanonPath::fromFilename("/abc/d"), BadCanonPath);
+    ASSERT_EQ(CanonPath::fromFilename("abc").rel(), "abc");
+}
+
 TEST(CanonPath, from_existing)
 {
     CanonPath p0("foo//bar/");

--- a/src/libutil/canon-path.cc
+++ b/src/libutil/canon-path.cc
@@ -23,6 +23,16 @@ static void ensureNoNullBytes(std::string_view s)
     }
 }
 
+CanonPath CanonPath::fromFilename(std::string_view segment)
+{
+    auto res = CanonPath(segment);
+    /* Use existing canonicalisation logic for CanonPath to check that the segment
+       is already a valid filename. */
+    if (segment != res.rel() || std::ranges::distance(res) != 1)
+        throw BadCanonPath("invalid filename '%s'", segment);
+    return res;
+}
+
 CanonPath::CanonPath(std::string_view raw)
     : path(absPathPure(concatStrings("/", raw)))
 {

--- a/src/libutil/include/nix/util/canon-path.hh
+++ b/src/libutil/include/nix/util/canon-path.hh
@@ -62,7 +62,7 @@ public:
     struct unchecked_t
     {};
 
-    CanonPath(unchecked_t _, std::string path)
+    constexpr CanonPath(unchecked_t _, std::string path)
         : path(std::move(path))
     {
     }
@@ -73,6 +73,12 @@ public:
     CanonPath(const std::vector<std::string> & elems);
 
     static const CanonPath root;
+
+    /**
+     * Construct a CanonPath from a single path segment. The segment
+     * must not contain any slashes and must not be `.` or `..`.
+     */
+    static CanonPath fromFilename(std::string_view segment);
 
     /**
      * If `raw` starts with a slash, return


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

See docs for what it is. Use in `DerivationBuilderImpl::writeBuilderFile` and `deletePath`. Also adds `O_DIRECTORY` via `openDirectory` in `deletePath`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
