### PR TITLE
Don't throw Interrupted from JSONLogger::write

### DIFF
--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -250,15 +250,15 @@ struct JSONLogger : Logger
 
     void write(const nlohmann::json & json)
     {
-        auto line =
-            (includeNixPrefix ? "@nix " : "") + json.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
+        auto line = (includeNixPrefix ? "@nix " : "")
+                    + json.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace) + "\n";
 
         /* Acquire a lock to prevent log messages from clobbering each
            other. */
         try {
             auto state(_state.lock());
             if (state->enabled)
-                writeLine(fd, line);
+                writeFullLogging(fd, line);
         } catch (...) {
             bool enabled = false;
             std::swap(_state.lock()->enabled, enabled);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

```console
$ nix --log-format internal-json eval nixpkgs#linux
@nix {"action":"msg","level":1,"msg":"\u001b[35;1mwarning:\u001b[0m unknown setting 'default-flake'"}
@nix {"action":"msg","level":1,"msg":"\u001b[35;1mwarning:\u001b[0m unknown setting 'environment'"}
```

Press Ctrl-C here before it gets any further, and:

```console
Nix crashed. This is a bug. Please report this at https://github.com/NixOS/nix/issues with the following information included:

Exception: nix::Interrupted: error: interrupted by the user
```

<details>
<summary>Stack trace</summary>

```
#0  0x00007fff556052ac in __pthread_kill_implementation () from /nix/store/99al6q9wd3jg1qs43fvmllx7vakazm8x-glibc-2.42-51/lib/libc.so.6
#1  0x00007fff555ac5b8 in raise () from /nix/store/99al6q9wd3jg1qs43fvmllx7vakazm8x-glibc-2.42-51/lib/libc.so.6
#2  0x00007fff55595d38 in abort () from /nix/store/99al6q9wd3jg1qs43fvmllx7vakazm8x-glibc-2.42-51/lib/libc.so.6
#3  0x00005555aeeb4d08 in nix::(anonymous namespace)::onTerminate() [clone .lto_priv.0] ()
#4  0x00007fff5585704c in __cxxabiv1::__terminate(void (*)()) ()
   from /nix/store/biihsjk1ndvj6sf06wv5rai9v4jsnzba-gcc-15.2.0-lib/lib/libstdc++.so.6
#5  0x00007fff5584e49c in std::terminate() () from /nix/store/biihsjk1ndvj6sf06wv5rai9v4jsnzba-gcc-15.2.0-lib/lib/libstdc++.so.6
#6  0x00007fff55857440 in __cxa_rethrow () from /nix/store/biihsjk1ndvj6sf06wv5rai9v4jsnzba-gcc-15.2.0-lib/lib/libstdc++.so.6
#7  0x00007fff5656f9ec in nix::ignoreExceptionExceptInterrupt(nix::Verbosity) ()
   from /nix/store/m4s7czgh9d0ff85h1i0j0brg757fd77f-nix-util-2.33.3/lib/libnixutil.so.2.33.3
#8  0x00007fff565f8db4 in nix::JSONLogger::write(nlohmann::json_abi_v3_12_0::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_12_0::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> >, void> const&) ()
   from /nix/store/m4s7czgh9d0ff85h1i0j0brg757fd77f-nix-util-2.33.3/lib/libnixutil.so.2.33.3
#9  0x00007fff565f9a84 in nix::JSONLogger::logEI(nix::ErrorInfo const&) ()
   from /nix/store/m4s7czgh9d0ff85h1i0j0brg757fd77f-nix-util-2.33.3/lib/libnixutil.so.2.33.3
#10 0x00007fff55b20ecc in nix::handleExceptions(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()>) () from /nix/store/01vp6fqxjcvrfw0ygrzjv4flxprcp590-nix-main-2.33.3/lib/libnixmain.so.2.33.3
#11 0x00005555aee81a68 in main ()
```
</details>

This happens more "normally" when https://github.com/maralorn/nix-output-monitor wrapping a `nix --log-format internal-json` is interrupted.

## Context

#14687 assumes loggers don't throw `Interrupted`. That wasn't true for `JSONLogger`.

Fix it here by generalizing 054be5025762c5e1c7e853c4fa5d7eed8da1727f, generalizing `writeToStderr` to `writeFullLogging`.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
