### PR TITLE
filetransfer: Use libcurl for Content-Encoding/Transfer-Encoding transparent decompression

### DIFF
--- a/doc/manual/rl-next/libcurl-content-encoding.md
+++ b/doc/manual/rl-next/libcurl-content-encoding.md
@@ -1,0 +1,10 @@
+---
+synopsis: Content-Encoding decompression is now handled by libcurl
+prs: [15336]
+issues: [14324]
+---
+
+Transparent decompression of HTTP downloads specifying `Content-Encoding` header now uses libcurl. This adds support for previously advertised, but not supported `deflate` encoding as well as deprecated `x-gzip` alias.
+Non-standard `xz`, `bzip2` encodings that were previously advertised are no longer supported, as they do not commonly appear in the wild and should not be sent by compliant servers.
+
+`br`, `zstd`, `gzip` continue to be supported. Distro packaging should ensure that the `libcurl` dependency is linked against required libraries to support these encodings. By default now the build system requires libcurl >= 8.17.0 which is not known to have issues around [pausing and decompression](https://github.com/curl/curl/issues/16280).

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -30,9 +30,19 @@ scope: {
         NIX_CFLAGS_COMPILE = "-DINITIAL_MARK_STACK_SIZE=1048576";
       });
 
-  curl = pkgs.curl.override {
-    http3Support = !pkgs.stdenv.hostPlatform.isWindows;
-  };
+  curl =
+    (pkgs.curl.override {
+      http3Support = !pkgs.stdenv.hostPlatform.isWindows;
+      # Make sure we enable all the dependencies for Content-Encoding/Transfer-Encoding decompression.
+      zstdSupport = true;
+      brotliSupport = true;
+      zlibSupport = true;
+    }).overrideAttrs
+      {
+        # TODO: Fix in nixpkgs. Static build with brotli is marked as broken, but it's not the case.
+        # Remove once https://github.com/NixOS/nixpkgs/pull/494111 lands in the 25.11 channel.
+        meta.broken = false;
+      };
 
   libblake3 = pkgs.libblake3.override {
     useTBB = !(stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isStatic);

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -115,17 +115,10 @@ boost = dependency(
 # put in `deps_other`.
 deps_other += boost
 
-curl = dependency('libcurl', 'curl', version : '>= 7.75.0')
-if curl.version().version_compare('>=8.16.0') and curl.version().version_compare(
-  '<8.17.0',
-)
-  # Out of precaution, avoid building with libcurl version that suffer from https://github.com/curl/curl/issues/19334.
-  error(
-    'curl @0@ has issues with write pausing, please use libcurl < 8.16 or >= 8.17, see https://github.com/curl/curl/issues/19334'.format(
-      curl.version(),
-    ),
-  )
-endif
+# This is quite new, but curl has a bunch of known issues with write pausing and decompression.
+# Please use libcurl >= 8.17. See https://github.com/curl/curl/issues/19334, https://github.com/curl/curl/issues/16280, https://github.com/curl/curl/issues/16955 if in doubt.
+# Patch out this check at your own risk.
+curl = dependency('libcurl', 'curl', version : '>= 8.17.0')
 
 deps_private += curl
 

--- a/tests/nixos/content-encoding.nix
+++ b/tests/nixos/content-encoding.nix
@@ -82,7 +82,7 @@ in
 
               # Serve .narinfo files with gzip encoding
               location ~ \.narinfo$ {
-                add_header Content-Encoding gzip;
+                add_header Content-Encoding x-gzip;
                 default_type "text/x-nix-narinfo";
               }
 
@@ -172,7 +172,7 @@ in
 
     # Check Content-Encoding headers on the download endpoint
     narinfo_headers = machine.succeed(f"curl -I http://localhost/cache/{narinfoHash}.narinfo 2>&1")
-    assert "content-encoding: gzip" in narinfo_headers.lower(), f"Expected 'content-encoding: gzip' for .narinfo file, but headers were: {narinfo_headers}"
+    assert "content-encoding: x-gzip" in narinfo_headers.lower(), f"Expected 'content-encoding: x-gzip' for .narinfo file, but headers were: {narinfo_headers}"
 
     ls_headers = machine.succeed(f"curl -I http://localhost/cache/{narinfoHash}.ls 2>&1")
     assert "content-encoding: gzip" in ls_headers.lower(), f"Expected 'content-encoding: gzip' for .ls file, but headers were: {ls_headers}"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Get rid of manual decompression entirely. We can support zstd, br,
deflate (which was broken previously) and gzip/x-gzip encodings via curl
without manual work on our side. This is the same approach that was taken by lix.

Also adds some tests for x-gzip support.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes https://github.com/NixOS/nix/issues/14324.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
