### PR TITLE
Add --preserve-cwd option to nix develop

### DIFF
--- a/doc/manual/rl-next/develop-preserve-cwd.md
+++ b/doc/manual/rl-next/develop-preserve-cwd.md
@@ -1,0 +1,7 @@
+---
+synopsis: New flag --preserve-cwd to nix develop
+prs: [15337]
+issues: [7361]
+---
+
+This addresses issues where `nix develop --phase` is running against a flake in the Nix store and/or a flake registry. By default, the working directory will be changed to the flake root before running the requested phase, which can break `--unpack` when it tries to write to a read-only filesystem. `--preserve-cwd` will run the phase without changing directory to the flake root.

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -512,6 +512,7 @@ struct CmdDevelop : Common, MixEnvironment
 {
     std::vector<std::string> command;
     std::optional<std::string> phase;
+    bool preserveCwd = false;
 
     CmdDevelop()
     {
@@ -536,7 +537,8 @@ struct CmdDevelop : Common, MixEnvironment
 
         addFlag({
             .longName = "unpack",
-            .description = "Run the `unpack` phase.",
+            .description =
+                "Run the `unpack` phase. By default this will unpack in the flake root. See `--preserve-cwd`.",
             .handler = {&phase, {"unpack"}},
         });
 
@@ -568,6 +570,13 @@ struct CmdDevelop : Common, MixEnvironment
             .longName = "installcheck",
             .description = "Run the `installcheck` phase.",
             .handler = {&phase, {"installCheck"}},
+        });
+
+        addFlag({
+            .longName = "preserve-cwd",
+            .description =
+                "Don't cd to the flake root when using `--phase`. Useful when using `--unpack` with a flake in the Nix store / flake registry.",
+            .handler = {&preserveCwd, true},
         });
     }
 
@@ -692,7 +701,7 @@ struct CmdDevelop : Common, MixEnvironment
                                               : Strings{shell.filename().string(), "--rcfile", rcFilePath};
 
         // Need to chdir since phases assume in flake directory
-        if (phase) {
+        if (phase && !preserveCwd) {
             // chdir if installable is a flake of type git+file or path
             auto installableFlake = installable.dynamic_pointer_cast<InstallableFlake>();
             if (installableFlake) {


### PR DESCRIPTION
Resolves #7361

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

`nix develop nixpkgs#hello --unpack` trying to unpack into the flake root (the nix store) is unintuitive, and results in a read-only error.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#7361
#3976
#4176

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
