### PR TITLE
Revert "libstore: replace unlink() with std::filesystem::remove()"

### DIFF
--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -80,11 +80,8 @@ createLinks(State & state, const std::filesystem::path & srcDir, const std::file
                     auto target = canonPath(dstFile, true);
                     if (!S_ISDIR(lstat(target).st_mode))
                         throw Error("collision between %1% and non-directory %2%", PathFmt(srcFile), PathFmt(target));
-                    try {
-                        std::filesystem::remove(dstFile);
-                    } catch (std::filesystem::filesystem_error & e) {
-                        throw SystemError(e.code(), "unlinking %s", PathFmt(dstFile));
-                    }
+                    if (unlink(dstFile.c_str()) == -1)
+                        throw SysError("unlinking %1%", PathFmt(dstFile));
                     if (mkdir(
                             dstFile.c_str()
 #ifndef _WIN32 // TODO abstract mkdir perms for Windows
@@ -111,11 +108,8 @@ createLinks(State & state, const std::filesystem::path & srcDir, const std::file
                         throw BuildEnvFileConflictError(readLink(dstFile), srcFile, priority);
                     if (prevPriority < priority)
                         continue;
-                    try {
-                        std::filesystem::remove(dstFile);
-                    } catch (std::filesystem::filesystem_error & e) {
-                        throw SystemError(e.code(), "unlinking %s", PathFmt(dstFile));
-                    }
+                    if (unlink(dstFile.c_str()) == -1)
+                        throw SysError("unlinking %1%", PathFmt(dstFile));
                 } else if (S_ISDIR(dstSt.st_mode))
                     throw Error("collision between non-directory '%1%' and directory '%2%'", srcFile, dstFile);
             }

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -450,9 +450,7 @@ LocalStore::~LocalStore()
         auto fdTempRoots(_fdTempRoots.lock());
         if (*fdTempRoots) {
             fdTempRoots->close();
-            /* The error code of std::filesystem::remove() is intentionally ignored. */
-            std::error_code ec;
-            std::filesystem::remove(fnTempRoots, ec);
+            unlink(fnTempRoots.string().c_str());
         }
     } catch (...) {
         ignoreExceptionInDestructor();

--- a/src/libstore/unix/pathlocks.cc
+++ b/src/libstore/unix/pathlocks.cc
@@ -31,12 +31,10 @@ void deleteLockFile(const std::filesystem::path & path, Descriptor desc)
        races.  Write a (meaningless) token to the file to indicate to
        other processes waiting on this lock that the lock is stale
        (deleted). */
-    std::error_code ec;
-    std::filesystem::remove(path, ec);
+    unlink(path.c_str());
     writeFull(desc, "d");
-    /* Note that the error code of std::filesystem::remove() is
-       intentionally ignored; removing the lock file is an optimisation,
-       not a necessity. */
+    /* Note that the result of unlink() is ignored; removing the lock
+       file is an optimisation, not a necessity. */
 }
 
 bool lockFile(Descriptor desc, LockType lockType, bool wait)

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -587,8 +587,7 @@ AutoCloseFD createAnonymousTempFile()
     if (!fd2)
         throw SysError("creating temporary file %s", PathFmt(path));
     fd = std::move(fd2);
-    std::error_code ec;
-    std::filesystem::remove(path, ec); /* We only care about the file descriptor. */
+    unlink(requireCString(path)); /* We only care about the file descriptor. */
 #endif
 
     return fd;

--- a/src/nix/nix-channel/nix-channel.cc
+++ b/src/nix/nix-channel/nix-channel.cc
@@ -192,11 +192,8 @@ static void update(const StringSet & channelNames)
     if (lstat(nixDefExpr.c_str(), &st) == 0) {
         if (S_ISLNK(st.st_mode))
             // old-skool ~/.nix-defexpr
-            try {
-                std::filesystem::remove(nixDefExpr);
-            } catch (std::filesystem::filesystem_error & e) {
-                throw SystemError(e.code(), "unlinking %s", PathFmt(nixDefExpr));
-            }
+            if (unlink(nixDefExpr.c_str()) == -1)
+                throw SysError("unlinking %1%", PathFmt(nixDefExpr));
     } else if (errno != ENOENT) {
         throw SysError("getting status of %1%", PathFmt(nixDefExpr));
     }


### PR DESCRIPTION
This reverts commit b8caabe25f3565d74ef75e2ed8163ac1d5377cd8.

`std::filesystem::remove` will actually do a `rmdir` for directories. Per https://en.cppreference.com/w/cpp/filesystem/remove.html :

> The file or empty directory identified by the path p is deleted as if
> by the POSIX remove. Symlinks are not followed (symlink is removed,
> not its target).

See
https://pubs.opengroup.org/onlinepubs/9699919799/functions/remove.html

This is a behavior change that we can't be sure is fine, so let's revert for now. We can do an unlink wrapper later to avoid the `.string()`.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
