### PR TITLE
Create two wrappers for `unlink`

### DIFF
--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -80,8 +80,7 @@ createLinks(State & state, const std::filesystem::path & srcDir, const std::file
                     auto target = canonPath(dstFile, true);
                     if (!S_ISDIR(lstat(target).st_mode))
                         throw Error("collision between %1% and non-directory %2%", PathFmt(srcFile), PathFmt(target));
-                    if (unlink(dstFile.c_str()) == -1)
-                        throw SysError("unlinking %1%", PathFmt(dstFile));
+                    unlink(dstFile);
                     if (mkdir(
                             dstFile.c_str()
 #ifndef _WIN32 // TODO abstract mkdir perms for Windows
@@ -108,8 +107,7 @@ createLinks(State & state, const std::filesystem::path & srcDir, const std::file
                         throw BuildEnvFileConflictError(readLink(dstFile), srcFile, priority);
                     if (prevPriority < priority)
                         continue;
-                    if (unlink(dstFile.c_str()) == -1)
-                        throw SysError("unlinking %1%", PathFmt(dstFile));
+                    unlink(dstFile);
                 } else if (S_ISDIR(dstSt.st_mode))
                     throw Error("collision between non-directory '%1%' and directory '%2%'", srcFile, dstFile);
             }

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -57,7 +57,7 @@ void LocalStore::createTempRootsFile()
         if (pathExists(fnTempRoots))
             /* It *must* be stale, since there can be no two
                processes with the same pid. */
-            unlink(fnTempRoots.string().c_str());
+            tryUnlink(fnTempRoots);
 
         *fdTempRoots = openLockFile(fnTempRoots, true);
 
@@ -190,7 +190,7 @@ void LocalStore::findTempRoots(Roots & tempRoots, bool censor)
            we don't care about its temporary roots. */
         if (lockFile(fd.get(), ltWrite, false)) {
             printInfo("removing stale temporary roots file %1%", PathFmt(path));
-            unlink(path.string().c_str());
+            tryUnlink(path);
             writeFull(fd.get(), "d");
             continue;
         }
@@ -247,7 +247,7 @@ void LocalStore::findRoots(const std::filesystem::path & path, std::filesystem::
                 if (!pathExists(target)) {
                     if (isInDir(path, config->stateDir.get() / gcRootsDir / "auto")) {
                         printInfo("removing stale link from %1% to %2%", PathFmt(path), PathFmt(target));
-                        unlink(path.string().c_str());
+                        tryUnlink(path);
                     }
                 } else {
                     if (!std::filesystem::is_symlink(target))
@@ -782,8 +782,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
 
             printMsg(lvlTalkative, "deleting unused link %1%", PathFmt(path));
 
-            if (unlink(path.string().c_str()) == -1)
-                throw SysError("deleting %1%", PathFmt(path));
+            unlink(path);
 
             /* Do not account for deleted file here. Rely on deletePath()
                accounting.  */

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -450,7 +450,7 @@ LocalStore::~LocalStore()
         auto fdTempRoots(_fdTempRoots.lock());
         if (*fdTempRoots) {
             fdTempRoots->close();
-            unlink(fnTempRoots.string().c_str());
+            tryUnlink(fnTempRoots);
         }
     } catch (...) {
         ignoreExceptionInDestructor();

--- a/src/libstore/unix/pathlocks.cc
+++ b/src/libstore/unix/pathlocks.cc
@@ -31,9 +31,9 @@ void deleteLockFile(const std::filesystem::path & path, Descriptor desc)
        races.  Write a (meaningless) token to the file to indicate to
        other processes waiting on this lock that the lock is stale
        (deleted). */
-    unlink(path.c_str());
+    tryUnlink(path);
     writeFull(desc, "d");
-    /* Note that the result of unlink() is ignored; removing the lock
+    /* We just try to unlink don't care if it fails; removing the lock
        file is an optimisation, not a necessity. */
 }
 

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -458,6 +458,20 @@ bool chmodIfNeeded(const std::filesystem::path & path, mode_t mode, mode_t mask 
 void chmod(const std::filesystem::path & path, mode_t mode);
 
 /**
+ * Remove a file, throwing an exception on error.
+ *
+ * @param path Path to the file to remove.
+ */
+void unlink(const std::filesystem::path & path);
+
+/**
+ * Try to remove a file, ignoring errors.
+ *
+ * @param path Path to the file to try to remove.
+ */
+void tryUnlink(const std::filesystem::path & path);
+
+/**
  * @brief A directory iterator that can be used to iterate over the
  * contents of a directory. It is similar to std::filesystem::directory_iterator
  * but throws NixError on failure instead of std::filesystem::filesystem_error.

--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -105,12 +105,7 @@ bindConnectProcHelper(std::string_view operationName, auto && operation, Socket 
 
 void bind(Socket fd, const std::filesystem::path & path)
 {
-#ifdef _WIN32
-    _wunlink
-#else
-    unlink
-#endif
-        (path.c_str());
+    tryUnlink(path);
 
     bindConnectProcHelper("bind", ::bind, fd, path.string());
 }

--- a/src/nix/nix-channel/nix-channel.cc
+++ b/src/nix/nix-channel/nix-channel.cc
@@ -192,8 +192,7 @@ static void update(const StringSet & channelNames)
     if (lstat(nixDefExpr.c_str(), &st) == 0) {
         if (S_ISLNK(st.st_mode))
             // old-skool ~/.nix-defexpr
-            if (unlink(nixDefExpr.c_str()) == -1)
-                throw SysError("unlinking %1%", PathFmt(nixDefExpr));
+            unlink(nixDefExpr);
     } else if (errno != ENOENT) {
         throw SysError("getting status of %1%", PathFmt(nixDefExpr));
     }


### PR DESCRIPTION
See b9ef088e80fb9c138b94b208341b6a652a488e88 for why `std::filesystem::remove` was no good.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
