### PR TITLE
Fix SSH connection sharing

### DIFF
--- a/src/libstore/include/nix/store/ssh.hh
+++ b/src/libstore/include/nix/store/ssh.hh
@@ -39,7 +39,7 @@ private:
 
     Sync<State> state_;
 
-    void addCommonSSHOpts(Strings & args);
+    void addCommonSSHOpts(Strings & args, Path socketPath);
     bool isMasterRunning(Path socketPath);
 
 #ifndef _WIN32 // TODO re-enable on Windows, once we can start processes.

--- a/src/libstore/include/nix/store/ssh.hh
+++ b/src/libstore/include/nix/store/ssh.hh
@@ -40,7 +40,7 @@ private:
     Sync<State> state_;
 
     void addCommonSSHOpts(Strings & args);
-    bool isMasterRunning();
+    bool isMasterRunning(Path socketPath);
 
 #ifndef _WIN32 // TODO re-enable on Windows, once we can start processes.
     Path startMaster();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

I originally stumbled upon this issue in the SSH code while tinkering with the DeterminateSystems/nix-src fork. I ran into an issue with the `-oLocalCommand` ssh trick introduced in https://github.com/NixOS/nix/pull/8018. But unlike https://github.com/NixOS/nix/issues/8329 and https://github.com/NixOS/nix/issues/10645 this didn't cause a hang where Nix is waiting for `-oLocalCommand=echo started` but instead was *not* consuming the `started` line.

```console
$ nix build --eval-store auto --store ssh-ng://store.example?max-connections=2
error: cannot open connection to remote store 'ssh-ng://store.example': error: protocol mismatch, got 'started
oixd
```

My general SSH setup is similar to the one in https://github.com/NixOS/nix/issues/10645. I'm using `ControlMaster=yes` and `ControlPath ~/.ssh/control-%r@%h:%p` and I think that the issue may be related.

I've started to look into the SSH-related code in Nix and found some things that didn't seem right to me.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

I'm not sure about the original intentions in the SSHMaster connection sharing code. But I'm convinced that we should *never* use a ControlMaster from a user's `.ssh/config`. The lifetime of these connections isn't managed by the nix itself, and any attempt to check for these is inherently racy as the connection could be closed at any time (e.g. when ControlPersist expires).

There was a follow-up bugfix PR https://github.com/NixOS/nix/pull/8349 that tried to fix a regression caused in https://github.com/NixOS/nix/pull/8018 by introducing the `SSHMaster::isMasterRunning`. I don't understand what this function is supposed to do. There are two kinds of control masters we need to have in mind here. The ones created by Nix itself when `SSHMaster::useMaster` is `true` and the ones created implicitly by SSH when, e.g. `ControlMaster yes` is specified in `.ssh/config`. The code in its current form uses `SSHMaster::isMasterRunning` for both and confuses them in some places.

I've refactored the code to *always* specify the `-S` option, either providing the ControlPath explicitly or passing `none` to suppress connection sharing entirely.

`SSHMaster::addCommonSSHOpts` and `SSHMaster::isMasterRunning` now take an explicit `path` argument to prevent them from seeing the `ControlPath` from `.ssh/config`.  

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
