### PR TITLE
Add nix_store_build_paths to libstore-c

### DIFF
--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -146,7 +146,26 @@ nix_err nix_store_real_path(
     nix_c_context * context, Store * store, StorePath * path, nix_get_string_callback callback, void * user_data);
 
 // nix_err nix_store_ensure(Store*, const char*);
-// nix_err nix_store_build_paths(Store*);
+/**
+ * @breif Builds a series of opaque Nix store paths
+ *
+ * Blocking, calls the callback per num_store_paths once each path is built.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] store Nix Store reference
+ * @param[in] store_paths Pointer to the store paths
+ * @param[in] num_store_paths Number of elements in store_paths
+ * @param[in] callback called for each built output
+ * @return NIX_OF if the paths are valid, actual build results are provided to the callback in JSON form.
+ */
+nix_err nix_store_build_paths(
+    nix_c_context * context,
+    Store * store,
+    const StorePath ** store_paths,
+    unsigned int num_store_paths,
+    void (*callback)(void * userdata, const char * path, const char * result),
+    void * userdata);
+
 /**
  * @brief Realise a Nix store path
  *


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Provides a more flexible way to build paths, `nix_store_build_paths` can take opaque paths. That means they're not a `.drv` file, that makes this useful for fetching paths which have no `.drv` associated with it.

## Context

Upstream `nix_store_build_paths` from https://github.com/DeterminateSystems/nix-src/pull/210 & sliced out of #14031

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
