### PR TITLE
types: remove Path* typedefs

### DIFF
--- a/src/libexpr-c/nix_api_external.cc
+++ b/src/libexpr-c/nix_api_external.cc
@@ -153,7 +153,7 @@ public:
         bool location,
         nix::XMLWriter & doc,
         nix::NixStringContext & context,
-        nix::PathSet & drvsSeen,
+        nix::StringSet & drvsSeen,
         const nix::PosIdx pos) const override
     {
         if (!desc.printValueAsXML) {

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -368,7 +368,7 @@ EvalState::EvalState(
 
 EvalState::~EvalState() {}
 
-void EvalState::allowPathLegacy(const Path & path)
+void EvalState::allowPathLegacy(const std::string & path)
 {
     if (auto rootFS2 = rootFS.dynamic_pointer_cast<AllowListSourceAccessor>())
         rootFS2->allowPrefix(CanonPath(path));

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -268,7 +268,7 @@ struct EvalSettings : Config
           See [Using the `eval-profiler`](@docroot@/advanced-topics/eval-profiler.md).
         )"};
 
-    Setting<Path> evalProfileFile{
+    Setting<std::filesystem::path> evalProfileFile{
         this,
         "nix.profile",
         "eval-profile-file",

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -548,7 +548,7 @@ public:
     /**
      * Variant which accepts relative paths too.
      */
-    SourcePath rootPath(PathView path);
+    SourcePath rootPath(std::string_view path);
 
     /**
      * Return a `SourcePath` that refers to `path` in the store.
@@ -565,7 +565,7 @@ public:
      * Only for restrict eval: pure eval just whitelist store paths,
      * never arbitrary paths.
      */
-    void allowPathLegacy(const Path & path);
+    void allowPathLegacy(const std::string & path);
 
     /**
      * Allow access to a store path. Note that this gets remapped to

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -155,7 +155,7 @@ public:
         bool location,
         XMLWriter & doc,
         NixStringContext & context,
-        PathSet & drvsSeen,
+        StringSet & drvsSeen,
         const PosIdx pos) const;
 
     virtual ~ExternalValueBase() {};

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -422,6 +422,7 @@ path_start
                 .pos = state->positions[CUR_POS]
             });
         });
+
         /* Absolute paths are always interpreted relative to the
            root filesystem accessor, rather than the accessor of the
            current Nix expression. */
@@ -463,7 +464,7 @@ path_start
             .pos = state->positions[CUR_POS]
         });
     });
-    Path path(getHome().string() + std::string($1.p + 1, $1.l - 1));
+    auto path(getHome().string() + std::string($1.p + 1, $1.l - 1));
     $$ = state->exprs.add<ExprPath>(state->exprs.alloc, state->rootFS, path);
   }
   ;

--- a/src/libexpr/paths.cc
+++ b/src/libexpr/paths.cc
@@ -10,7 +10,7 @@ SourcePath EvalState::rootPath(CanonPath path)
     return {rootFS, std::move(path)};
 }
 
-SourcePath EvalState::rootPath(PathView path)
+SourcePath EvalState::rootPath(std::string_view path)
 {
     return {rootFS, CanonPath(absPath(path).string())};
 }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2827,7 +2827,7 @@ static void addPath(
 
         std::unique_ptr<PathFilter> filter;
         if (filterFun)
-            filter = std::make_unique<PathFilter>([&](const Path & p) {
+            filter = std::make_unique<PathFilter>([&](const std::string & p) {
                 auto p2 = CanonPath(p);
                 return state.callPathFilter(filterFun, {path.accessor, p2}, pos);
             });

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -21,7 +21,7 @@ static void printValueAsXML(
     Value & v,
     XMLWriter & doc,
     NixStringContext & context,
-    PathSet & drvsSeen,
+    StringSet & drvsSeen,
     const PosIdx pos);
 
 static void posToXML(EvalState & state, XMLAttrs & xmlAttrs, const Pos & pos)
@@ -39,7 +39,7 @@ static void showAttrs(
     const Bindings & attrs,
     XMLWriter & doc,
     NixStringContext & context,
-    PathSet & drvsSeen)
+    StringSet & drvsSeen)
 {
     StringSet names;
 
@@ -61,7 +61,7 @@ static void printValueAsXML(
     Value & v,
     XMLWriter & doc,
     NixStringContext & context,
-    PathSet & drvsSeen,
+    StringSet & drvsSeen,
     const PosIdx pos)
 {
     checkInterrupt();
@@ -99,7 +99,7 @@ static void printValueAsXML(
         if (state.isDerivation(v)) {
             XMLAttrs xmlAttrs;
 
-            Path drvPath;
+            std::string drvPath;
             if (auto a = v.attrs()->get(state.s.drvPath)) {
                 if (strict)
                     state.forceValue(*a->value, a->pos);
@@ -185,7 +185,7 @@ void ExternalValueBase::printValueAsXML(
     bool location,
     XMLWriter & doc,
     NixStringContext & context,
-    PathSet & drvsSeen,
+    StringSet & drvsSeen,
     const PosIdx pos) const
 {
     doc.writeEmptyElement("unevaluated");
@@ -202,7 +202,7 @@ void printValueAsXML(
 {
     XMLWriter doc(true, out);
     XMLOpenElement root(doc, "expr");
-    PathSet drvsSeen;
+    StringSet drvsSeen;
     printValueAsXML(state, strict, location, v, doc, context, drvsSeen, pos);
 }
 

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -635,7 +635,9 @@ struct GitInputScheme : InputScheme
 
         // Why are we checking for bare repository?
         // well if it's a bare repository we want to force a git fetch rather than copying the folder
-        auto isBareRepository = [](PathView path) { return pathExists(path) && !pathExists(path + "/.git"); };
+        auto isBareRepository = [](const std::filesystem::path & path) {
+            return pathExists(path) && !pathExists(path / ".git");
+        };
 
         // FIXME: here we turn a possibly relative path into an absolute path.
         // This allows relative git flake inputs to be resolved against the
@@ -647,7 +649,7 @@ struct GitInputScheme : InputScheme
         //
         auto maybeUrlFsPathForFileUrl =
             url.scheme == "file" ? std::make_optional(urlPathToPath(url.path)) : std::nullopt;
-        if (maybeUrlFsPathForFileUrl && !forceHttp && !isBareRepository(maybeUrlFsPathForFileUrl->string())) {
+        if (maybeUrlFsPathForFileUrl && !forceHttp && !isBareRepository(*maybeUrlFsPathForFileUrl)) {
             auto & path = *maybeUrlFsPathForFileUrl;
 
             if (!path.is_absolute()) {

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -245,7 +245,7 @@ struct MercurialInputScheme : InputScheme
 
                 auto actualPath = absPath(localPath);
 
-                PathFilter filter = [&](const Path & p) -> bool {
+                PathFilter filter = [&](const std::string & p) -> bool {
                     assert(hasPrefix(p, actualPath.string()));
                     std::string file(p, actualPath.string().size() + 1);
 

--- a/src/libflake-c/nix_api_flake.cc
+++ b/src/libflake-c/nix_api_flake.cc
@@ -62,7 +62,7 @@ nix_err nix_flake_reference_parse_flags_set_base_directory(
 {
     nix_clear_err(context);
     try {
-        flags->baseDirectory.emplace(nix::Path{std::string(baseDirectory, baseDirectoryLen)});
+        flags->baseDirectory.emplace(std::string(baseDirectory, baseDirectoryLen));
         return NIX_OK;
     }
     NIXC_CATCH_ERRS

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -50,8 +50,10 @@ struct FlakeRef
 
     /**
      * sub-path within the fetched input that represents this input
+     *
+     * @todo Should probably use `CanonPath` instead of `std::string`?
      */
-    Path subdir;
+    std::string subdir;
 
     bool operator==(const FlakeRef & other) const = default;
 
@@ -60,7 +62,7 @@ struct FlakeRef
         return std::tie(input, subdir) < std::tie(other.input, other.subdir);
     }
 
-    FlakeRef(fetchers::Input && input, const Path & subdir)
+    FlakeRef(fetchers::Input && input, const std::string & subdir)
         : input(std::move(input))
         , subdir(subdir)
     {

--- a/src/libstore-test-support/include/nix/store/tests/protocol.hh
+++ b/src/libstore-test-support/include/nix/store/tests/protocol.hh
@@ -21,14 +21,14 @@ class ProtoTest : public CharacterizationTest
     }
 
 public:
-    Path storeDir = "/nix/store";
+    std::string storeDir = "/nix/store";
     StoreDirConfig store{storeDir};
 
     /**
      * Golden test for `T` JSON reading
      */
     template<typename T>
-    void readJsonTest(PathView testStem, const T & expected)
+    void readJsonTest(std::string_view testStem, const T & expected)
     {
         nix::readJsonTest(*this, testStem, expected);
     }
@@ -37,7 +37,7 @@ public:
      * Golden test for `T` JSON write
      */
     template<typename T>
-    void writeJsonTest(PathView testStem, const T & decoded)
+    void writeJsonTest(std::string_view testStem, const T & decoded)
     {
         nix::writeJsonTest(*this, testStem, decoded);
     }
@@ -51,7 +51,7 @@ public:
      * Golden test for `T` reading
      */
     template<typename T>
-    void readProtoTest(PathView testStem, typename Proto::Version version, T expected)
+    void readProtoTest(std::string_view testStem, typename Proto::Version version, T expected)
     {
         CharacterizationTest::readTest(std::string{testStem + ".bin"}, [&](const auto & encoded) {
             T got = ({
@@ -72,7 +72,7 @@ public:
      * Golden test for `T` write
      */
     template<typename T>
-    void writeProtoTest(PathView testStem, typename Proto::Version version, const T & decoded)
+    void writeProtoTest(std::string_view testStem, typename Proto::Version version, const T & decoded)
     {
         CharacterizationTest::writeTest(std::string{testStem + ".bin"}, [&]() {
             StringSink to;

--- a/src/libstore-tests/common-protocol.cc
+++ b/src/libstore-tests/common-protocol.cc
@@ -21,7 +21,7 @@ public:
      * Golden test for `T` reading
      */
     template<typename T>
-    void readProtoTest(PathView testStem, const T & expected)
+    void readProtoTest(std::string_view testStem, const T & expected)
     {
         CharacterizationTest::readTest(std::string{testStem + ".bin"}, [&](const auto & encoded) {
             T got = ({
@@ -37,7 +37,7 @@ public:
      * Golden test for `T` write
      */
     template<typename T>
-    void writeProtoTest(PathView testStem, const T & decoded)
+    void writeProtoTest(std::string_view testStem, const T & decoded)
     {
         CharacterizationTest::writeTest(std::string{testStem + ".bin"}, [&]() -> std::string {
             StringSink to;

--- a/src/libstore-tests/derivation/external-formats.cc
+++ b/src/libstore-tests/derivation/external-formats.cc
@@ -23,17 +23,17 @@ TEST_F(DynDerivationTest, BadATerm_oldVersionDynDeps)
         FormatError);
 }
 
-#define MAKE_OUTPUT_JSON_TEST_P(FIXTURE)                                \
-    TEST_P(FIXTURE, from_json)                                          \
-    {                                                                   \
-        const auto & [name, expected] = GetParam();                     \
-        readJsonTest(Path{"output-"} + name, expected, mockXpSettings); \
-    }                                                                   \
-                                                                        \
-    TEST_P(FIXTURE, to_json)                                            \
-    {                                                                   \
-        const auto & [name, value] = GetParam();                        \
-        writeJsonTest("output-" + name, value);                         \
+#define MAKE_OUTPUT_JSON_TEST_P(FIXTURE)                                       \
+    TEST_P(FIXTURE, from_json)                                                 \
+    {                                                                          \
+        const auto & [name, expected] = GetParam();                            \
+        readJsonTest(std::string{"output-"} + name, expected, mockXpSettings); \
+    }                                                                          \
+                                                                               \
+    TEST_P(FIXTURE, to_json)                                                   \
+    {                                                                          \
+        const auto & [name, value] = GetParam();                               \
+        writeJsonTest(std::string{"output-"} + name, value);                   \
     }
 
 struct DerivationOutputJsonTest : DerivationTest,

--- a/src/libstore-tests/dummy-store.cc
+++ b/src/libstore-tests/dummy-store.cc
@@ -73,7 +73,7 @@ TEST_P(DummyStoreJsonTest, from_json)
     using namespace nlohmann;
     /* Cannot use `readJsonTest` because need to dereference the stores
        for equality. */
-    readTest(Path{name} + ".json", [&](const auto & encodedRaw) {
+    readTest(std::string{name} + ".json", [&](const auto & encodedRaw) {
         auto encoded = json::parse(encodedRaw);
         ref<DummyStore> decoded = adl_serializer<ref<DummyStore>>::from_json(encoded);
         ASSERT_EQ(*decoded, *expected);

--- a/src/libstore-tests/nar-info.cc
+++ b/src/libstore-tests/nar-info.cc
@@ -15,7 +15,7 @@ class NarInfoTestV1 : public CharacterizationTest, public LibStoreTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "nar-info" / "json-1";
 
-    std::filesystem::path goldenMaster(PathView testStem) const override
+    std::filesystem::path goldenMaster(std::string_view testStem) const override
     {
         return unitTestData / (testStem + ".json");
     }
@@ -25,7 +25,7 @@ class NarInfoTestV2 : public CharacterizationTest, public LibStoreTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "nar-info" / "json-2";
 
-    std::filesystem::path goldenMaster(PathView testStem) const override
+    std::filesystem::path goldenMaster(std::string_view testStem) const override
     {
         return unitTestData / (testStem + ".json");
     }

--- a/src/libstore-tests/path-info.cc
+++ b/src/libstore-tests/path-info.cc
@@ -14,7 +14,7 @@ class PathInfoTestV1 : public CharacterizationTest, public LibStoreTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "path-info" / "json-1";
 
-    std::filesystem::path goldenMaster(PathView testStem) const override
+    std::filesystem::path goldenMaster(std::string_view testStem) const override
     {
         return unitTestData / (testStem + ".json");
     }
@@ -24,7 +24,7 @@ class PathInfoTestV2 : public CharacterizationTest, public LibStoreTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "path-info" / "json-2";
 
-    std::filesystem::path goldenMaster(PathView testStem) const override
+    std::filesystem::path goldenMaster(std::string_view testStem) const override
     {
         return unitTestData / (testStem + ".json");
     }

--- a/src/libstore-tests/store-reference.cc
+++ b/src/libstore-tests/store-reference.cc
@@ -15,7 +15,7 @@ class StoreReferenceTest : public CharacterizationTest, public LibStoreTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "store-reference";
 
-    std::filesystem::path goldenMaster(PathView testStem) const override
+    std::filesystem::path goldenMaster(std::string_view testStem) const override
     {
         return unitTestData / (testStem + ".txt");
     }

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -163,7 +163,9 @@ Goal::Co DerivationBuildingGoal::gaveUpOnSubstitution(bool storeDerivation)
     /* Second, the input sources. */
     worker.store.computeFSClosure(drv->inputSrcs, inputPaths);
 
-    debug("added input paths %s", worker.store.showPaths(inputPaths));
+    debug("added input paths %s", concatMapStringsSep(", ", inputPaths, [&](auto & p) {
+              return "'" + worker.store.printStorePath(p) + "'";
+          }));
 
     /* Okay, try to build.  Note that here we don't wait for a build
        slot to become available, since we don't need one if there is a
@@ -397,7 +399,11 @@ Goal::Co DerivationBuildingGoal::tryToBuild(StorePathSet inputPaths)
 
         if (!outputLocks.lockPaths(lockFiles, "", false)) {
             Activity act(
-                *logger, lvlWarn, actBuildWaiting, fmt("waiting for lock on %s", Magenta(showPaths(lockFiles))));
+                *logger,
+                lvlWarn,
+                actBuildWaiting,
+                fmt("waiting for lock on %s",
+                    Magenta(concatMapStringsSep(", ", lockFiles, [](auto & p) { return "'" + p.string() + "'"; }))));
 
             /* Wait then try locking again, repeat until success (returned
                boolean is true). */

--- a/src/libstore/build/derivation-check.cc
+++ b/src/libstore/build/derivation-check.cc
@@ -14,9 +14,9 @@ void checkOutputs(
     const decltype(DerivationOptions<StorePath>::outputChecks) & outputChecks,
     const std::map<std::string, ValidPathInfo> & outputs)
 {
-    std::map<Path, const ValidPathInfo &> outputsByPath;
+    std::map<StorePath, const ValidPathInfo &> outputsByPath;
     for (auto & output : outputs)
-        outputsByPath.emplace(store.printStorePath(output.second.path), output.second);
+        outputsByPath.emplace(output.second.path, output.second);
 
     for (auto & pair : outputs) {
         // We can't use auto destructuring here because
@@ -69,7 +69,7 @@ void checkOutputs(
                 if (!pathsDone.insert(path).second)
                     continue;
 
-                auto i = outputsByPath.find(store.printStorePath(path));
+                auto i = outputsByPath.find(path);
                 if (i != outputsByPath.end()) {
                     closureSize += i->second.narSize;
                     for (auto & ref : i->second.references)

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -123,10 +123,10 @@ void buildProfile(const std::filesystem::path & out, Packages && pkgs)
 {
     State state;
 
-    PathSet done, postponed;
+    std::set<std::filesystem::path> done, postponed;
 
     auto addPkg = [&](const std::filesystem::path & pkgDir, int priority) {
-        if (!done.insert(pkgDir.string()).second)
+        if (!done.insert(pkgDir).second)
             return;
         createLinks(state, pkgDir, out, priority);
 
@@ -159,7 +159,7 @@ void buildProfile(const std::filesystem::path & out, Packages && pkgs)
      */
     auto priorityCounter = 1000;
     while (!postponed.empty()) {
-        PathSet pkgDirs;
+        std::set<std::filesystem::path> pkgDirs;
         postponed.swap(pkgDirs);
         for (const auto & pkgDir : pkgDirs)
             addPkg(pkgDir, priorityCounter++);

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -540,7 +540,8 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
        GCLimitReached if we've deleted enough garbage. */
     auto deleteFromStore = [&](std::string_view baseName, bool isKnownPath) {
         assert(!std::filesystem::path(baseName).is_absolute());
-        Path path = storeDir + "/" + std::string(baseName);
+        /* Using `std::string` since this is the logical store dir. Hopefully that is the right choice. */
+        std::string path = storeDir + "/" + std::string(baseName);
         auto realPath = config->realStoreDir.get() / std::string(baseName);
 
         /* There may be temp directories in the store that are still in use

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -120,7 +120,7 @@ Settings::Settings()
          }) {
         sandboxPaths.get().insert_or_assign(std::string{p}, ChrootPath{.source = std::string{p}});
     }
-    allowedImpureHostPrefixes = tokenizeString<StringSet>("/System/Library /usr/lib /dev /bin/sh");
+    allowedImpureHostPrefixes = std::set<std::filesystem::path>{"/System/Library", "/usr/lib", "/dev", "/bin/sh"};
 #endif
 }
 

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -39,13 +39,13 @@ struct BinaryCacheStoreConfig : virtual StoreConfig
           fetch debug info on demand
         )"};
 
-    Setting<std::filesystem::path> secretKeyFile{
+    Setting<AbsolutePath> secretKeyFile{
         this, "", "secret-key", "Path to the secret key used to sign the binary cache."};
 
     Setting<std::string> secretKeyFiles{
         this, "", "secret-keys", "List of comma-separated paths to the secret keys used to sign the binary cache."};
 
-    Setting<std::optional<std::filesystem::path>> localNarCache{
+    Setting<std::optional<AbsolutePath>> localNarCache{
         this,
         std::nullopt,
         "local-nar-cache",

--- a/src/libstore/include/nix/store/builtins.hh
+++ b/src/libstore/include/nix/store/builtins.hh
@@ -13,11 +13,11 @@ namespace nix {
 struct BuiltinBuilderContext
 {
     const BasicDerivation & drv;
-    std::map<std::string, Path> outputs;
+    std::map<std::string, std::string> outputs;
     std::string netrcData;
     std::string caFileData;
     Strings hashedMirrors;
-    Path tmpDirInSandbox;
+    std::filesystem::path tmpDirInSandbox;
 
 #if NIX_WITH_AWS_AUTH
     /**

--- a/src/libstore/include/nix/store/common-ssh-store-config.hh
+++ b/src/libstore/include/nix/store/common-ssh-store-config.hh
@@ -14,7 +14,7 @@ struct CommonSSHStoreConfig : virtual StoreConfig
 
     CommonSSHStoreConfig(const ParsedURL::Authority & authority, const Params & params);
 
-    Setting<std::filesystem::path> sshKey{
+    Setting<AbsolutePath> sshKey{
         this, "", "ssh-key", "Path to the SSH private key used to authenticate to the remote machine."};
 
     Setting<std::string> sshPublicHostKey{

--- a/src/libstore/include/nix/store/derivations.hh
+++ b/src/libstore/include/nix/store/derivations.hh
@@ -274,7 +274,10 @@ struct BasicDerivation
      */
     StorePathSet inputSrcs;
     std::string platform;
-    Path builder;
+    /**
+     * Probably should be an absolute path in the path format that `platform` uses
+     */
+    std::string builder;
     Strings args;
     /**
      * Must not contain the key `__json`, at least in order to serialize to ATerm.

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -95,7 +95,7 @@ public:
           Nix to use for downloads.
         )"};
 
-    Setting<std::filesystem::path> netrcFile{
+    Setting<AbsolutePath> netrcFile{
         this,
         nixConfDir() / "netrc",
         "netrc-file",
@@ -122,7 +122,7 @@ public:
           > `.netrc`.
         )"};
 
-    Setting<std::optional<std::filesystem::path>> caFile{
+    Setting<std::optional<AbsolutePath>> caFile{
         this,
         getDefaultSSLCertFile(),
         "ssl-cert-file",

--- a/src/libstore/include/nix/store/gc-store.hh
+++ b/src/libstore/include/nix/store/gc-store.hh
@@ -66,7 +66,7 @@ struct GCResults
      * Depending on the action, the GC roots, or the paths that would
      * be or have been deleted.
      */
-    PathSet paths;
+    StringSet paths;
 
     /**
      * For `gcDeleteDead` and `gcDeleteSpecific`, the number of bytes that were freed.

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -36,10 +36,10 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
           (e.g. `brotli`).
         )"};
 
-    Setting<std::optional<std::filesystem::path>> tlsCert{
+    Setting<std::optional<AbsolutePath>> tlsCert{
         this, std::nullopt, "tls-certificate", "Path to an optional TLS client certificate in PEM format."};
 
-    Setting<std::optional<std::filesystem::path>> tlsKey{
+    Setting<std::optional<AbsolutePath>> tlsKey{
         this, std::nullopt, "tls-private-key", "Path to an optional TLS client certificate private key in PEM format."};
 
     static const std::string name()

--- a/src/libstore/include/nix/store/local-fs-store.hh
+++ b/src/libstore/include/nix/store/local-fs-store.hh
@@ -10,8 +10,8 @@ namespace nix {
 struct LocalFSStoreConfig : virtual StoreConfig
 {
 private:
-    static Setting<std::optional<std::filesystem::path>>
-    makeRootDirSetting(LocalFSStoreConfig & self, std::optional<std::filesystem::path> defaultValue)
+    static Setting<std::optional<AbsolutePath>>
+    makeRootDirSetting(LocalFSStoreConfig & self, std::optional<AbsolutePath> defaultValue)
     {
         return {
             &self,
@@ -33,7 +33,7 @@ public:
      */
     LocalFSStoreConfig(const std::filesystem::path & path, const Params & params);
 
-    Setting<std::optional<std::filesystem::path>> rootDir = makeRootDirSetting(*this, std::nullopt);
+    Setting<std::optional<AbsolutePath>> rootDir = makeRootDirSetting(*this, std::nullopt);
 
 private:
 
@@ -51,21 +51,21 @@ private:
 
 public:
 
-    Setting<std::filesystem::path> stateDir{
+    Setting<AbsolutePath> stateDir{
         this,
         rootDir.get() ? *rootDir.get() / "nix" / "var" / "nix" : getDefaultStateDir(),
         "state",
         "Directory where Nix stores state.",
     };
 
-    Setting<std::filesystem::path> logDir{
+    Setting<AbsolutePath> logDir{
         this,
         rootDir.get() ? *rootDir.get() / "nix" / "var" / "log" / "nix" : getDefaultLogDir(),
         "log",
         "directory where Nix stores log files.",
     };
 
-    Setting<std::filesystem::path> realStoreDir{
+    Setting<AbsolutePath> realStoreDir{
         this,
         rootDir.get() ? *rootDir.get() / "nix" / "store" : std::filesystem::path{storeDir},
         "real",

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -31,7 +31,7 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
           Must be used as OverlayFS lower layer for this store's store dir.
         )"};
 
-    const Setting<std::filesystem::path> upperLayer{
+    const Setting<AbsolutePath> upperLayer{
         (StoreConfig *) this,
         "",
         "upper-layer",
@@ -53,7 +53,7 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
           default, but can be disabled if needed.
         )"};
 
-    const Setting<std::filesystem::path> remountHook{
+    const Setting<AbsolutePath> remountHook{
         (StoreConfig *) this,
         "",
         "remount-hook",

--- a/src/libstore/include/nix/store/local-settings.hh
+++ b/src/libstore/include/nix/store/local-settings.hh
@@ -439,7 +439,7 @@ struct LocalSettings : public virtual Config, public GCSettings, public AutoAllo
 #endif
 
 #if defined(__linux__) || defined(__FreeBSD__)
-    Setting<std::filesystem::path> sandboxBuildDir{
+    Setting<AbsolutePath> sandboxBuildDir{
         this,
         "/build",
         "sandbox-build-dir",
@@ -452,7 +452,7 @@ struct LocalSettings : public virtual Config, public GCSettings, public AutoAllo
         )"};
 #endif
 
-    Setting<std::optional<std::filesystem::path>> buildDir{
+    Setting<std::optional<AbsolutePath>> buildDir{
         this,
         std::nullopt,
         "build-dir",
@@ -462,7 +462,7 @@ struct LocalSettings : public virtual Config, public GCSettings, public AutoAllo
             See also the per-store [`build-dir`](@docroot@/store/types/local-store.md#store-local-store-build-dir) setting.
         )"};
 
-    Setting<PathSet> allowedImpureHostPrefixes{
+    Setting<std::set<std::filesystem::path>> allowedImpureHostPrefixes{
         this,
         {},
         "allowed-impure-host-deps",
@@ -490,7 +490,7 @@ struct LocalSettings : public virtual Config, public GCSettings, public AutoAllo
 
 private:
 
-    Setting<std::optional<std::filesystem::path>> diffHook{
+    Setting<std::optional<AbsolutePath>> diffHook{
         this,
         std::nullopt,
         "diff-hook",

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -40,7 +40,7 @@ private:
     /**
       Input for computing the build directory. See `getBuildDir()`.
      */
-    Setting<std::optional<std::filesystem::path>> buildDir{
+    Setting<std::optional<AbsolutePath>> buildDir{
         this,
         std::nullopt,
         "build-dir",
@@ -244,7 +244,7 @@ public:
     /**
      * Hack for build-remote.cc.
      */
-    PathSetNG locksHeld;
+    PathSet locksHeld;
 
     /**
      * Initialise the local store, upgrading the schema if
@@ -477,9 +477,6 @@ private:
     std::shared_ptr<const ValidPathInfo> queryPathInfoInternal(State & state, const StorePath & path);
 
     void updatePathInfo(State & state, const ValidPathInfo & info);
-
-    PathSet queryValidPathsOld();
-    ValidPathInfo queryPathInfoOld(const Path & path);
 
     void findRoots(const std::filesystem::path & path, std::filesystem::file_type type, Roots & roots);
 

--- a/src/libstore/include/nix/store/nar-info-disk-cache.hh
+++ b/src/libstore/include/nix/store/nar-info-disk-cache.hh
@@ -25,7 +25,8 @@ struct NarInfoDiskCache
 
     virtual ~NarInfoDiskCache() {}
 
-    virtual int createCache(const std::string & uri, const Path & storeDir, bool wantMassQuery, int priority) = 0;
+    virtual int
+    createCache(const std::string & uri, const std::string & storeDir, bool wantMassQuery, int priority) = 0;
 
     struct CacheInfo
     {

--- a/src/libstore/include/nix/store/path-references.hh
+++ b/src/libstore/include/nix/store/path-references.hh
@@ -10,7 +10,7 @@
 
 namespace nix {
 
-StorePathSet scanForReferences(Sink & toTee, const Path & path, const StorePathSet & refs);
+StorePathSet scanForReferences(Sink & toTee, const std::filesystem::path & path, const StorePathSet & refs);
 
 class PathRefScanSink : public RefScanSink
 {

--- a/src/libstore/include/nix/store/remote-fs-accessor.hh
+++ b/src/libstore/include/nix/store/remote-fs-accessor.hh
@@ -34,8 +34,7 @@ public:
      */
     std::shared_ptr<SourceAccessor> accessObject(const StorePath & path);
 
-    RemoteFSAccessor(
-        ref<Store> store, bool requireValidPath = true, std::optional<std::filesystem::path> cacheDir = {});
+    RemoteFSAccessor(ref<Store> store, bool requireValidPath = true, std::optional<AbsolutePath> cacheDir = {});
 
     std::optional<Stat> maybeLstat(const CanonPath & path) override;
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -1020,18 +1020,6 @@ void removeTempRoots();
 StorePath resolveDerivedPath(Store &, const SingleDerivedPath &, Store * evalStore = nullptr);
 OutputPathMap resolveDerivedPath(Store &, const DerivedPath::Built &, Store * evalStore = nullptr);
 
-/**
- * Display a set of paths in human-readable form (i.e., between quotes
- * and separated by commas).
- */
-std::string showPaths(const PathSet & paths);
-
-/**
- * Display a set of paths in human-readable form (i.e., between quotes
- * and separated by commas).
- */
-std::string showPaths(const std::set<std::filesystem::path> paths);
-
 std::optional<ValidPathInfo>
 decodeValidPathInfo(const Store & store, std::istream & str, std::optional<HashResult> hashGiven = std::nullopt);
 

--- a/src/libstore/include/nix/store/store-dir-config.hh
+++ b/src/libstore/include/nix/store/store-dir-config.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nix/store/path.hh"
+#include "nix/util/canon-path.hh"
 #include "nix/util/hash.hh"
 #include "nix/store/content-address.hh"
 #include "nix/util/configuration.hh"
@@ -44,21 +45,19 @@ struct StoreDirConfig
      *
      * \todo remove
      */
-    StorePathSet parseStorePathSet(const PathSet & paths) const;
+    StorePathSet parseStorePathSet(const StringSet & paths) const;
 
-    PathSet printStorePathSet(const StorePathSet & path) const;
+    StringSet printStorePathSet(const StorePathSet & path) const;
 
     /**
      * Display a set of paths in human-readable form (i.e., between quotes
      * and separated by commas).
      */
-    std::string showPaths(const StorePathSet & paths) const;
-
     /**
      * @return true if *path* is in the Nix store (but not the Nix
      * store itself).
      */
-    bool isInStore(PathView path) const;
+    bool isInStore(std::string_view path) const;
 
     /**
      * @return true if *path* is a store path, i.e. a direct child of the
@@ -70,7 +69,7 @@ struct StoreDirConfig
      * Split a path like `/nix/store/<hash>-<name>/<bla>` into
      * `/nix/store/<hash>-<name>` and `/<bla>`.
      */
-    std::pair<StorePath, Path> toStorePath(PathView path) const;
+    std::pair<StorePath, CanonPath> toStorePath(std::string_view path) const;
 
     /**
      * Constructs a unique store path name.

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -66,7 +66,7 @@ struct NarInfoDiskCacheImpl : NarInfoDiskCache
     struct Cache
     {
         int id;
-        Path storeDir;
+        std::string storeDir;
         bool wantMassQuery;
         int priority;
     };
@@ -200,7 +200,7 @@ private:
     }
 
 public:
-    int createCache(const std::string & uri, const Path & storeDir, bool wantMassQuery, int priority) override
+    int createCache(const std::string & uri, const std::string & storeDir, bool wantMassQuery, int priority) override
     {
         return retrySQLite<int>([&]() {
             auto state(_state.lock());

--- a/src/libstore/path-references.cc
+++ b/src/libstore/path-references.cc
@@ -47,7 +47,7 @@ StorePathSet PathRefScanSink::getResultPaths()
     return found;
 }
 
-StorePathSet scanForReferences(Sink & toTee, const Path & path, const StorePathSet & refs)
+StorePathSet scanForReferences(Sink & toTee, const std::filesystem::path & path, const StorePathSet & refs)
 {
     PathRefScanSink refsSink = PathRefScanSink::fromPaths(refs);
     TeeSink sink{refsSink, toTee};

--- a/src/libstore/remote-fs-accessor.cc
+++ b/src/libstore/remote-fs-accessor.cc
@@ -2,8 +2,7 @@
 
 namespace nix {
 
-RemoteFSAccessor::RemoteFSAccessor(
-    ref<Store> store, bool requireValidPath, std::optional<std::filesystem::path> cacheDir)
+RemoteFSAccessor::RemoteFSAccessor(ref<Store> store, bool requireValidPath, std::optional<AbsolutePath> cacheDir)
     : store(store)
     , narCache(cacheDir)
     , requireValidPath(requireValidPath)
@@ -15,7 +14,7 @@ std::pair<ref<SourceAccessor>, CanonPath> RemoteFSAccessor::fetch(const CanonPat
     auto [storePath, restPath] = store->toStorePath(store->storeDir + path.abs());
     if (requireValidPath && !store->isValidPath(storePath))
         throw InvalidPath("path '%1%' is not a valid store path", store->printStorePath(storePath));
-    return {ref{accessObject(storePath)}, CanonPath{restPath}};
+    return {ref{accessObject(storePath)}, restPath};
 }
 
 std::shared_ptr<SourceAccessor> RemoteFSAccessor::accessObject(const StorePath & storePath)

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -695,7 +695,7 @@ Roots RemoteStore::findRoots(bool censor)
     size_t count = readNum<size_t>(conn->from);
     Roots result;
     while (count--) {
-        Path link = readString(conn->from);
+        std::string link = readString(conn->from);
         result[WorkerProto::Serialise<StorePath>::read(*this, *conn)].emplace(link);
     }
     return result;
@@ -715,7 +715,7 @@ void RemoteStore::collectGarbage(const GCOptions & options, GCResults & results)
 
     conn.processStderr();
 
-    results.paths = readStrings<PathSet>(conn->from);
+    results.paths = readStrings<StringSet>(conn->from);
     results.bytesFreed = readLongLong(conn->from);
     readLongLong(conn->from); // obsolete
 

--- a/src/libstore/store-dir-config.cc
+++ b/src/libstore/store-dir-config.cc
@@ -39,7 +39,7 @@ bool StoreDirConfig::isStorePath(std::string_view path) const
     return (bool) maybeParseStorePath(path);
 }
 
-StorePathSet StoreDirConfig::parseStorePathSet(const PathSet & paths) const
+StorePathSet StoreDirConfig::parseStorePathSet(const StringSet & paths) const
 {
     StorePathSet res;
     for (auto & i : paths)
@@ -52,9 +52,9 @@ std::string StoreDirConfig::printStorePath(const StorePath & path) const
     return (storeDir + "/").append(path.to_string());
 }
 
-PathSet StoreDirConfig::printStorePathSet(const StorePathSet & paths) const
+StringSet StoreDirConfig::printStorePathSet(const StorePathSet & paths) const
 {
-    PathSet res;
+    StringSet res;
     for (auto & i : paths)
         res.insert(printStorePath(i));
     return res;

--- a/src/libstore/unix/build/darwin-derivation-builder.cc
+++ b/src/libstore/unix/build/darwin-derivation-builder.cc
@@ -67,7 +67,7 @@ struct DarwinDerivationBuilder : DerivationBuilderImpl
         if (useSandbox) {
 
             /* Lots and lots and lots of file functions freak out if they can't stat their full ancestry */
-            PathSet ancestry;
+            StringSet ancestry;
 
             /* We build the ancestry before adding all inputPaths to the store because we know they'll
                all have the same parents (the store), and there might be lots of inputs. This isn't

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -895,7 +895,7 @@ PathsInChroot DerivationBuilderImpl::getPathsInSandbox()
     }
     pathsInChroot[tmpDirInSandbox()] = {.source = tmpDir};
 
-    PathSet allowedPaths = localSettings.allowedImpureHostPrefixes;
+    auto allowedPaths = localSettings.allowedImpureHostPrefixes.get();
 
     /* This works like the above, except on a per-derivation level */
     auto impurePaths = drvOptions.impureHostDeps;

--- a/src/libutil-test-support/include/nix/util/tests/characterization.hh
+++ b/src/libutil-test-support/include/nix/util/tests/characterization.hh
@@ -28,7 +28,7 @@ struct CharacterizationTest : virtual ::testing::Test
      * While the "golden master" for this characterization test is
      * located. It should not be shared with any other test.
      */
-    virtual std::filesystem::path goldenMaster(PathView testStem) const = 0;
+    virtual std::filesystem::path goldenMaster(std::string_view testStem) const = 0;
 
     /**
      * Golden test for reading
@@ -36,7 +36,7 @@ struct CharacterizationTest : virtual ::testing::Test
      * @param test hook that takes the contents of the file and does the
      * actual work
      */
-    void readTest(PathView testStem, auto && test)
+    void readTest(std::string_view testStem, auto && test)
     {
         auto file = goldenMaster(testStem);
 
@@ -53,7 +53,7 @@ struct CharacterizationTest : virtual ::testing::Test
      * @param test hook that produces contents of the file and does the
      * actual work
      */
-    void writeTest(PathView testStem, auto && test, auto && readFile2, auto && writeFile2)
+    void writeTest(std::string_view testStem, auto && test, auto && readFile2, auto && writeFile2)
     {
         auto file = goldenMaster(testStem);
 
@@ -72,7 +72,7 @@ struct CharacterizationTest : virtual ::testing::Test
     /**
      * Specialize to `std::string`
      */
-    void writeTest(PathView testStem, auto && test)
+    void writeTest(std::string_view testStem, auto && test)
     {
         writeTest(
             testStem,

--- a/src/libutil-test-support/include/nix/util/tests/json-characterization.hh
+++ b/src/libutil-test-support/include/nix/util/tests/json-characterization.hh
@@ -16,10 +16,10 @@ namespace nix {
  * Golden test for JSON reading
  */
 template<typename T>
-void readJsonTest(CharacterizationTest & test, PathView testStem, const T & expected, auto... args)
+void readJsonTest(CharacterizationTest & test, std::string_view testStem, const T & expected, auto... args)
 {
     using namespace nlohmann;
-    test.readTest(Path{testStem} + ".json", [&](const auto & encodedRaw) {
+    test.readTest(std::string{testStem} + ".json", [&](const auto & encodedRaw) {
         auto encoded = json::parse(encodedRaw);
         T decoded = adl_serializer<T>::from_json(encoded, args...);
         ASSERT_EQ(decoded, expected);
@@ -30,11 +30,11 @@ void readJsonTest(CharacterizationTest & test, PathView testStem, const T & expe
  * Golden test for JSON writing
  */
 template<typename T>
-void writeJsonTest(CharacterizationTest & test, PathView testStem, const T & value)
+void writeJsonTest(CharacterizationTest & test, std::string_view testStem, const T & value)
 {
     using namespace nlohmann;
     test.writeTest(
-        Path{testStem} + ".json",
+        std::string{testStem} + ".json",
         [&]() -> json { return static_cast<json>(value); },
         [](const auto & file) { return json::parse(readFile(file)); },
         [](const auto & file, const auto & got) { return writeFile(file, got.dump(2) + "\n"); });
@@ -49,11 +49,11 @@ void writeJsonTest(CharacterizationTest & test, PathView testStem, const T & val
  * pointer), so we break the symmetry as the best remaining option.
  */
 template<typename T>
-void writeJsonTest(CharacterizationTest & test, PathView testStem, const ref<T> & value)
+void writeJsonTest(CharacterizationTest & test, std::string_view testStem, const ref<T> & value)
 {
     using namespace nlohmann;
     test.writeTest(
-        Path{testStem} + ".json",
+        std::string{testStem} + ".json",
         [&]() -> json { return static_cast<json>(*value); },
         [](const auto & file) { return json::parse(readFile(file)); },
         [](const auto & file, const auto & got) { return writeFile(file, got.dump(2) + "\n"); });
@@ -63,11 +63,11 @@ void writeJsonTest(CharacterizationTest & test, PathView testStem, const ref<T> 
  * Golden test in the middle of something
  */
 template<typename T>
-void checkpointJson(CharacterizationTest & test, PathView testStem, const T & got)
+void checkpointJson(CharacterizationTest & test, std::string_view testStem, const T & got)
 {
     using namespace nlohmann;
 
-    auto file = test.goldenMaster(Path{testStem} + ".json");
+    auto file = test.goldenMaster(std::string{testStem} + ".json");
 
     json gotJson = static_cast<json>(got);
 
@@ -88,11 +88,11 @@ void checkpointJson(CharacterizationTest & test, PathView testStem, const T & go
  * direction, but "`const T &` -> JSON" in the other direction.
  */
 template<typename T>
-void checkpointJson(CharacterizationTest & test, PathView testStem, const ref<T> & got)
+void checkpointJson(CharacterizationTest & test, std::string_view testStem, const ref<T> & got)
 {
     using namespace nlohmann;
 
-    auto file = test.goldenMaster(Path{testStem} + ".json");
+    auto file = test.goldenMaster(std::string{testStem} + ".json");
 
     json gotJson = static_cast<json>(*got);
 
@@ -121,7 +121,7 @@ struct JsonCharacterizationTest : virtual CharacterizationTest
      * @param test hook that takes the contents of the file and does the
      * actual work
      */
-    void readJsonTest(PathView testStem, const T & expected, auto... args)
+    void readJsonTest(std::string_view testStem, const T & expected, auto... args)
     {
         nix::readJsonTest(*this, testStem, expected, args...);
     }
@@ -132,12 +132,12 @@ struct JsonCharacterizationTest : virtual CharacterizationTest
      * @param test hook that produces contents of the file and does the
      * actual work
      */
-    void writeJsonTest(PathView testStem, const T & value)
+    void writeJsonTest(std::string_view testStem, const T & value)
     {
         nix::writeJsonTest(*this, testStem, value);
     }
 
-    void checkpointJson(PathView testStem, const T & value)
+    void checkpointJson(std::string_view testStem, const T & value)
     {
         nix::checkpointJson(*this, testStem, value);
     }

--- a/src/libutil-tests/memory-source-accessor.cc
+++ b/src/libutil-tests/memory-source-accessor.cc
@@ -248,7 +248,7 @@ TEST_P(MemorySourceAccessorJsonTest, from_json)
     auto & [name, expected] = GetParam();
     /* Cannot use `readJsonTest` because need to compare `root` field of
        the source accessors for equality. */
-    readTest(Path{name} + ".json", [&](const auto & encodedRaw) {
+    readTest(std::string{name} + ".json", [&](const auto & encodedRaw) {
         auto encoded = json::parse(encodedRaw);
         auto decoded = static_cast<MemorySourceAccessor>(encoded);
         ASSERT_EQ(decoded.root, expected.root);

--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -154,7 +154,7 @@ std::optional<std::filesystem::path> getSelfExe()
         // serialized to JSON and evaluated as a Nix string.
         path.pop_back();
 
-        return Path(path.begin(), path.end());
+        return std::string(path.begin(), path.end());
 #else
         return std::nullopt;
 #endif

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -701,8 +701,7 @@ void moveFile(const std::filesystem::path & oldName, const std::filesystem::path
         auto newPath = newName;
         // For the move to be as atomic as possible, copy to a temporary
         // directory
-        std::filesystem::path temp =
-            createTempDir(os_string_to_string(PathViewNG{newPath.parent_path()}), "rename-tmp");
+        std::filesystem::path temp = createTempDir(os_string_to_string(PathView{newPath.parent_path()}), "rename-tmp");
         Finally removeTemp = [&]() { std::filesystem::remove(temp); };
         auto tempCopyTarget = temp / "copy-target";
         if (e.code().value() == EXDEV) {
@@ -710,7 +709,7 @@ void moveFile(const std::filesystem::path & oldName, const std::filesystem::path
             warn("can’t rename %s as %s, copying instead", PathFmt(oldName), PathFmt(newName));
             copyFile(oldPath, tempCopyTarget, true);
             std::filesystem::rename(
-                os_string_to_string(PathViewNG{tempCopyTarget}), os_string_to_string(PathViewNG{newPath}));
+                os_string_to_string(PathView{tempCopyTarget}), os_string_to_string(PathView{newPath}));
         }
     }
 }

--- a/src/libutil/include/nix/util/config-impl.hh
+++ b/src/libutil/include/nix/util/config-impl.hh
@@ -136,7 +136,9 @@ DECLARE_CONFIG_SERIALISER(StringSet)
 DECLARE_CONFIG_SERIALISER(StringMap)
 DECLARE_CONFIG_SERIALISER(std::set<ExperimentalFeature>)
 DECLARE_CONFIG_SERIALISER(std::filesystem::path)
-DECLARE_CONFIG_SERIALISER(std::optional<std::filesystem::path>)
+DECLARE_CONFIG_SERIALISER(AbsolutePath)
+DECLARE_CONFIG_SERIALISER(std::set<std::filesystem::path>)
+DECLARE_CONFIG_SERIALISER(std::optional<AbsolutePath>)
 
 template<typename T>
 T BaseSetting<T>::parse(const std::string & str) const

--- a/src/libutil/include/nix/util/file-path.hh
+++ b/src/libutil/include/nix/util/file-path.hh
@@ -11,30 +11,26 @@ namespace nix {
 
 /**
  * Paths are just `std::filesystem::path`s.
- *
- * @todo drop `NG` suffix and replace the ones in `types.hh`.
  */
-typedef std::list<std::filesystem::path> PathsNG;
-typedef std::set<std::filesystem::path> PathSetNG;
+typedef std::list<std::filesystem::path> Paths;
+typedef std::set<std::filesystem::path> PathSet;
 
 /**
  * Stop gap until `std::filesystem::path_view` from P1030R6 exists in a
  * future C++ standard.
- *
- * @todo drop `NG` suffix and replace the one in `types.hh`.
  */
-struct PathViewNG : OsStringView
+struct PathView : OsStringView
 {
     using string_view = OsStringView;
 
     using string_view::string_view;
 
-    PathViewNG(const std::filesystem::path & path)
+    PathView(const std::filesystem::path & path)
         : OsStringView{path.native()}
     {
     }
 
-    PathViewNG(const OsString & path)
+    PathView(const OsString & path)
         : OsStringView{path}
     {
     }
@@ -52,7 +48,7 @@ struct PathViewNG : OsStringView
 
 std::optional<std::filesystem::path> maybePath(PathView path);
 
-std::filesystem::path pathNG(PathView path);
+std::filesystem::path toOwnedPath(PathView path);
 
 template<>
 struct json_avoids_null<std::filesystem::path> : std::true_type

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -357,7 +357,7 @@ public:
         return _path;
     }
 
-    PathViewNG view() const
+    PathView view() const
     {
         return _path;
     }
@@ -367,7 +367,7 @@ public:
         return _path;
     }
 
-    operator PathViewNG() const
+    operator PathView() const
     {
         return _path;
     }

--- a/src/libutil/include/nix/util/logging.hh
+++ b/src/libutil/include/nix/util/logging.hh
@@ -54,7 +54,7 @@ struct LoggerSettings : Config
           expression evaluation errors.
         )"};
 
-    Setting<std::optional<std::filesystem::path>> jsonLogPath{
+    Setting<std::optional<AbsolutePath>> jsonLogPath{
         this,
         {},
         "json-log-path",

--- a/src/libutil/include/nix/util/types.hh
+++ b/src/libutil/include/nix/util/types.hh
@@ -44,20 +44,6 @@ using StringPairs = StringMap;
  */
 using StringSet = std::set<std::string, std::less<>>;
 
-/**
- * Paths are just strings.
- */
-typedef std::string Path;
-typedef std::string_view PathView;
-typedef std::list<Path> Paths;
-
-/**
- * Alias to an ordered set of `Path`s. Uses transparent comparator.
- *
- * @see StringSet
- */
-using PathSet = std::set<Path, std::less<>>;
-
 typedef std::vector<std::pair<std::string, std::string>> Headers;
 
 /**

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -531,8 +531,8 @@ T readStrings(Source & source)
     return ss;
 }
 
-template Paths readStrings(Source & source);
-template PathSet readStrings(Source & source);
+template Strings readStrings(Source & source);
+template StringSet readStrings(Source & source);
 
 Error readError(Source & source)
 {

--- a/src/libutil/unix/file-path.cc
+++ b/src/libutil/unix/file-path.cc
@@ -8,7 +8,7 @@
 
 namespace nix {
 
-std::filesystem::path pathNG(PathView path)
+std::filesystem::path toOwnedPath(PathView path)
 {
     return {std::string{path}};
 }

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -124,7 +124,7 @@ void setWriteTime(
 }
 
 #ifdef __FreeBSD__
-#  define MOUNTEDPATHS_PARAM , std::set<Path> & mountedPaths
+#  define MOUNTEDPATHS_PARAM , std::set<std::filesystem::path> & mountedPaths
 #  define MOUNTEDPATHS_ARG , mountedPaths
 #else
 #  define MOUNTEDPATHS_PARAM
@@ -257,7 +257,7 @@ void deletePath(const std::filesystem::path & path, uint64_t & bytesFreed)
 {
     // Activity act(*logger, lvlDebug, "recursively deleting path '%1%'", path);
 #ifdef __FreeBSD__
-    std::set<Path> mountedPaths;
+    std::set<std::filesystem::path> mountedPaths;
     struct statfs * mntbuf;
     int count;
     if ((count = getmntinfo(&mntbuf, MNT_WAIT)) < 0) {

--- a/src/libutil/windows/file-path.cc
+++ b/src/libutil/windows/file-path.cc
@@ -13,26 +13,26 @@ std::optional<std::filesystem::path> maybePath(PathView path)
 {
     if (path.length() >= 3 && (('A' <= path[0] && path[0] <= 'Z') || ('a' <= path[0] && path[0] <= 'z'))
         && path[1] == ':' && WindowsPathTrait<char>::isPathSep(path[2])) {
-        std::filesystem::path::string_type sw = string_to_os_string(std::string{"\\\\?\\"} + path);
+        std::filesystem::path::string_type sw = std::wstring{L"\\\\?\\"} + std::wstring{path};
         std::replace(sw.begin(), sw.end(), '/', '\\');
         return sw;
     }
     if (path.length() >= 7 && path[0] == '\\' && path[1] == '\\' && (path[2] == '.' || path[2] == '?')
         && path[3] == '\\' && ('A' <= path[4] && path[4] <= 'Z') && path[5] == ':'
         && WindowsPathTrait<char>::isPathSep(path[6])) {
-        std::filesystem::path::string_type sw = string_to_os_string(path);
+        std::filesystem::path::string_type sw{path};
         std::replace(sw.begin(), sw.end(), '/', '\\');
         return sw;
     }
     return std::optional<std::filesystem::path::string_type>();
 }
 
-std::filesystem::path pathNG(PathView path)
+std::filesystem::path toOwnedPath(PathView path)
 {
     std::optional<std::filesystem::path::string_type> sw = maybePath(path);
     if (!sw) {
         // FIXME why are we not using the regular error handling?
-        std::cerr << "invalid path for WinAPI call [" << path << "]" << std::endl;
+        std::wcerr << L"invalid path for WinAPI call [" << path << L"]" << std::endl;
         _exit(111);
     }
     return *sw;

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -254,7 +254,7 @@ static int main_build_remote(int argc, char ** argv)
 
         std::cerr << "# accept\n" << storeUri << "\n";
 
-        auto inputs = readStrings<PathSet>(source);
+        auto inputs = readStrings<StringSet>(source);
         auto wantedOutputs = readStrings<StringSet>(source);
 
         AutoCloseFD uploadLock;

--- a/src/nix/cat.cc
+++ b/src/nix/cat.cc
@@ -48,7 +48,7 @@ struct CmdCatStore : StoreCommand, MixCat
     void run(ref<Store> store) override
     {
         auto [storePath, rest] = store->toStorePath(path);
-        cat(store->requireStoreObjectAccessor(storePath), CanonPath{rest});
+        cat(store->requireStoreObjectAccessor(storePath), rest);
     }
 };
 

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -438,7 +438,7 @@ struct Common : InstallableCommand, MixProfile
      * that's accessible from the interactive shell session.
      */
     void fixupStructuredAttrs(
-        PathViewNG::string_view ext,
+        PathView::string_view ext,
         const std::string & envVar,
         const std::string & content,
         StringMap & rewrites,

--- a/src/nix/env.cc
+++ b/src/nix/env.cc
@@ -97,7 +97,7 @@ struct CmdShell : InstallablesCommand, MixEnvironment
             auto propPath = state->storeFS->resolveSymlinks(
                 CanonPath(store->printStorePath(path)) / "nix-support" / "propagated-user-env-packages");
             if (auto st = state->storeFS->maybeLstat(propPath); st && st->type == SourceAccessor::tRegular) {
-                for (auto & p : tokenizeString<Paths>(state->storeFS->readFile(propPath)))
+                for (auto & p : tokenizeString<Strings>(state->storeFS->readFile(propPath)))
                     todo.push(store->parseStorePath(p));
             }
         }

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -120,7 +120,7 @@ struct CmdLsStore : StoreCommand, MixLs
     void run(ref<Store> store) override
     {
         auto [storePath, rest] = store->toStorePath(path);
-        list(store->requireStoreObjectAccessor(storePath), CanonPath{rest});
+        list(store->requireStoreObjectAccessor(storePath), rest);
     }
 };
 

--- a/src/nix/nix-copy-closure/nix-copy-closure.cc
+++ b/src/nix/nix-copy-closure/nix-copy-closure.cc
@@ -16,7 +16,7 @@ static int main_nix_copy_closure(int argc, char ** argv)
         auto dryRun = false;
         auto useSubstitutes = NoSubstitute;
         std::string sshHost;
-        PathSet storePaths;
+        StringSet storePaths;
 
         parseCmdLine(argc, argv, [&](Strings::iterator & arg, const Strings::iterator & end) {
             if (*arg == "--help")


### PR DESCRIPTION
## Motivation

We want to get rid of the unnecessary Path* typedefs. This commit replaces all usages with their underlying types, that being `std::string` for store paths, `std::filesystem::path` for filesystem paths, `StringSet for path sets, and `std::string_view` for non-owning references.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
