### PR TITLE
flake: show attribute path on error "not an app definition"

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1410,7 +1410,9 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                             description = aDescription->getString();
                     }
                     if (!aType || aType->getString() != "app")
-                        state->error<EvalError>("not an app definition").debugThrow();
+                        state->error<EvalError>("not an app definition: %s", concatStringsSep(".", attrPathS))
+                            .debugThrow();
+                    // }
                     if (json) {
                         j.emplace("type", "app");
                         if (description)


### PR DESCRIPTION
Makes error `not an app definition` show the offending attribute path.

## Motivation

Currently, flake outputs' `apps` sub-attributes trigger an error `not an app definition` when the value does not conform to expectations.
This error message however so far has not clarified what attribute triggered the error.

## Context

I further looked for similar errors also lacking context, but could not find any in my (brief) search.
