### PR TITLE
Fix NarInfoDiskCache::queryCacheRaw on 32 bit platforms

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -5230,7 +5230,7 @@ void EvalState::createBaseEnv(const EvalSettings & evalSettings)
         });
 
     if (!settings.pureEval) {
-        v.mkInt(time(0));
+        v.mkInt(time(nullptr));
     }
     addConstant(
         "__currentTime",

--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -60,7 +60,7 @@ struct CacheImpl : Cache
     void upsert(const Key & key, const Attrs & value) override
     {
         _state.lock()
-            ->upsert.use()(key.first)(attrsToJSON(key.second).dump())(attrsToJSON(value).dump())(time(0))
+            ->upsert.use()(key.first)(attrsToJSON(key.second).dump())(attrsToJSON(value).dump())(time(nullptr))
             .exec();
     }
 
@@ -99,7 +99,7 @@ struct CacheImpl : Cache
         debug("using cache entry '%s:%s' -> '%s'", key.first, keyJSON, valueJSON);
 
         return Result{
-            .expired = settings.tarballTtl.get() == 0 || timestamp + settings.tarballTtl < time(0),
+            .expired = settings.tarballTtl.get() == 0 || timestamp + settings.tarballTtl < time(nullptr),
             .value = jsonToAttrs(nlohmann::json::parse(valueJSON)),
         };
     }

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -126,7 +126,7 @@ static std::optional<std::string> readHeadCached(const Settings & settings, cons
     std::filesystem::path cacheDir = getCachePath(actualUrl, shallow);
     std::filesystem::path headRefFile = cacheDir / "HEAD";
 
-    time_t now = time(0);
+    time_t now = time(nullptr);
     auto st = maybeStat(headRefFile);
     std::optional<std::string> cachedRef;
     if (st) {
@@ -830,7 +830,7 @@ struct GitInputScheme : InputScheme
             auto localRefFile = ref.compare(0, 5, "refs/") == 0 ? cacheDir / ref : cacheDir / "refs/heads" / ref;
 
             bool doFetch = false;
-            time_t now = time(0);
+            time_t now = time(nullptr);
 
             /* If a rev was specified, we need to fetch if it's not in the
                repo. */

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -616,7 +616,7 @@ Goal::Co DerivationBuildingGoal::buildWithHook(
     fds.insert(hook->builderOut.readSide.get());
     worker.childStarted(shared_from_this(), fds, false, false);
 
-    buildResult.startTime = time(0); // inexact
+    buildResult.startTime = time(nullptr); // inexact
 
     auto msg =
         fmt(buildMode == bmRepair  ? "repairing outputs of '%s'"
@@ -709,7 +709,7 @@ Goal::Co DerivationBuildingGoal::buildWithHook(
     debug("build hook for '%s' finished", worker.store.printStorePath(drvPath));
 
     buildResult.timesBuilt++;
-    buildResult.stopTime = time(0);
+    buildResult.stopTime = time(nullptr);
 
     /* So the child is gone now. */
     worker.childTerminated(this);

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -209,7 +209,7 @@ void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning);
 template<typename T, typename F>
 T retrySQLite(F && fun)
 {
-    time_t nextWarning = time(0) + 1;
+    time_t nextWarning = time(nullptr) + 1;
 
     while (true) {
         try {

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -688,7 +688,7 @@ uint64_t LocalStore::addValidPath(State & state, const ValidPathInfo & info)
 
     state.stmts->RegisterValidPath
         .use()(printStorePath(info.path))(info.narHash.to_string(HashFormat::Base16, true))(
-            info.registrationTime == 0 ? time(0) : info.registrationTime)(
+            info.registrationTime == 0 ? time(nullptr) : info.registrationTime)(
             info.deriver ? printStorePath(*info.deriver) : "",
             (bool) info.deriver)(info.narSize, info.narSize != 0)(info.ultimate ? 1 : 0, info.ultimate)(
             concatStringsSep(" ", Signature::toStrings(info.sigs)),

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -142,7 +142,7 @@ struct NarInfoDiskCacheImpl : NarInfoDiskCache
 
         /* Periodically purge expired entries from the database. */
         retrySQLite<void>([&]() {
-            auto now = time(0);
+            auto now = time(nullptr);
 
             SQLiteStmt queryLastPurge(state->db, "select value from LastPurge");
             auto queryLastPurge_(queryLastPurge.use());
@@ -221,7 +221,7 @@ public:
             };
 
             {
-                auto r(state->insertCache.use()(uri)(time(0))(storeDir) (wantMassQuery) (priority));
+                auto r(state->insertCache.use()(uri)(time(nullptr))(storeDir) (wantMassQuery) (priority));
                 if (!r.next()) {
                     unreachable();
                 }
@@ -255,7 +255,7 @@ public:
 
                 auto & cache(getCache(*state, uri));
 
-                auto now = time(0);
+                auto now = time(nullptr);
 
                 auto queryNAR(
                     state->queryNAR.use()(cache.id)(hashPart) (now - settings.ttlNegative)(now - settings.ttlPositive));
@@ -296,7 +296,7 @@ public:
 
                 auto & cache(getCache(*state, uri));
 
-                auto now = time(0);
+                auto now = time(nullptr);
 
                 auto queryRealisation(state->queryRealisation.use()(cache.id)(id.to_string())(
                     now - settings.ttlNegative)(now - settings.ttlPositive));
@@ -342,11 +342,11 @@ public:
                         HashFormat::Nix32, true))(info->narSize)(concatStringsSep(" ", info->shortRefs()))(
                         info->deriver ? std::string(info->deriver->to_string()) : "",
                         (bool) info->deriver)(concatStringsSep(" ", Signature::toStrings(info->sigs)))(
-                        renderContentAddress(info->ca))(time(0))
+                        renderContentAddress(info->ca))(time(nullptr))
                     .exec();
 
             } else {
-                state->insertMissingNAR.use()(cache.id)(hashPart) (time(0)).exec();
+                state->insertMissingNAR.use()(cache.id)(hashPart) (time(nullptr)).exec();
             }
         });
     }
@@ -359,7 +359,8 @@ public:
             auto & cache(getCache(*state, uri));
 
             state->insertRealisation
-                .use()(cache.id)(realisation.id.to_string())(static_cast<nlohmann::json>(realisation).dump())(time(0))
+                .use()(cache.id)(realisation.id.to_string())(static_cast<nlohmann::json>(realisation).dump())(
+                    time(nullptr))
                 .exec();
         });
     }
@@ -370,7 +371,7 @@ public:
             auto state(_state.lock());
 
             auto & cache(getCache(*state, uri));
-            state->insertMissingRealisation.use()(cache.id)(id.to_string())(time(0)).exec();
+            state->insertMissingRealisation.use()(cache.id)(id.to_string())(time(nullptr)).exec();
         });
     }
 };

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -234,7 +234,7 @@ time_t parseOlderThanTimeSpec(std::string_view timeSpec)
     if (timeSpec.empty() || timeSpec[timeSpec.size() - 1] != 'd')
         throw UsageError("invalid number of days specifier '%1%', expected something like '14d'", timeSpec);
 
-    time_t curTime = time(0);
+    time_t curTime = time(nullptr);
     auto strDays = timeSpec.substr(0, timeSpec.size() - 1);
     auto days = string2Int<int>(strDays);
 

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -278,7 +278,7 @@ SQLiteTxn::~SQLiteTxn()
 
 void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning)
 {
-    time_t now = time(0);
+    time_t now = time(nullptr);
     if (now > nextWarning) {
         nextWarning = now + 10;
         logWarning({.msg = e.info().msg});

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -554,7 +554,7 @@ SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()
     debug("builder process for '%s' finished", store.printStorePath(drvPath));
 
     buildResult.timesBuilt++;
-    buildResult.stopTime = time(0);
+    buildResult.stopTime = time(nullptr);
 
     /* So the child is gone now. */
     miscMethods->childTerminated();
@@ -872,7 +872,7 @@ std::optional<Descriptor> DerivationBuilderImpl::startBuild()
     if (unlockpt(builderOut.get()))
         throw SysError("unlocking pseudoterminal");
 
-    buildResult.startTime = time(0);
+    buildResult.startTime = time(nullptr);
 
     /* Start a child process to build the derivation. */
     startChild();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Bug has existed for a long time, but was only recently surfaced by 6733f2e5ce38b7e3f64b9529cb95b4b40acfcf42. `time_t` was being implicitly promoted to unsigned. Apparently `time_t` is still 32 bit for `i686-linux` in nixpkgs.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes https://hydra.nixos.org/build/322992746/nixlog/1

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
