### PR TITLE
Remove path setting

### DIFF
--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -412,7 +412,7 @@ ref<DummyStoreConfig> adl_serializer<ref<DummyStore::Config>>::from_json(const j
 {
     auto & obj = getObject(json);
     auto cfg = make_ref<DummyStore::Config>(DummyStore::Config::Params{});
-    const_cast<PathSetting &>(cfg->storeDir_).set(getString(valueAt(obj, "store")));
+    cfg->storeDir_.set(getString(valueAt(obj, "store")));
     cfg->readOnly = true;
     return cfg;
 }

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -73,6 +73,32 @@ struct MissingPaths
 };
 
 /**
+ * A setting for the Nix store directory. Automatically canonicalises the
+ * path and rejects the empty string. Stored as `std::string` because
+ * store directory are valid file paths on *some* OS, but not neccessarily the OS of this build of Nix.
+ *
+ * (For example, consider `SSHStore` from Linux to Windows, or vice versa, the foreign path will not be a valid
+ * `std::filesystem::path`.)
+ */
+class StoreDirSetting : public BaseSetting<std::string>
+{
+public:
+    StoreDirSetting(
+        Config * options,
+        const std::string & def,
+        const std::string & name,
+        const std::string & description,
+        const StringSet & aliases = {});
+
+    std::string parse(const std::string & str) const override;
+
+    void operator=(const std::string & v)
+    {
+        this->assign(v);
+    }
+};
+
+/**
  * Need to make this a separate class so I can get the right
  * initialization order in the constructor for `StoreConfig`.
  */
@@ -86,11 +112,11 @@ private:
      * Compute the default Nix store directory from environment variables
      * (`NIX_STORE_DIR`, `NIX_STORE`) or the compile-time default.
      */
-    static Path getDefaultNixStoreDir();
+    static std::string getDefaultNixStoreDir();
 
 public:
 
-    const PathSetting storeDir_{
+    StoreDirSetting storeDir_{
         this,
         getDefaultNixStoreDir(),
         "store",

--- a/src/libstore/include/nix/store/store-dir-config.hh
+++ b/src/libstore/include/nix/store/store-dir-config.hh
@@ -29,7 +29,7 @@ MakeError(BadStorePathName, BadStorePath);
  */
 struct StoreDirConfig
 {
-    const Path & storeDir;
+    const std::string & storeDir;
 
     // pure methods
 

--- a/src/libutil/configuration.cc
+++ b/src/libutil/configuration.cc
@@ -514,22 +514,6 @@ template class BaseSetting<std::filesystem::path>;
 template class BaseSetting<std::optional<std::filesystem::path>>;
 template class BaseSetting<std::optional<std::string>>;
 
-PathSetting::PathSetting(
-    Config * options,
-    const Path & def,
-    const std::string & name,
-    const std::string & description,
-    const StringSet & aliases)
-    : BaseSetting<Path>(def, true, name, description, aliases)
-{
-    options->addSetting(this);
-}
-
-Path PathSetting::parse(const std::string & str) const
-{
-    return parsePath(*this, str).string();
-}
-
 bool ExperimentalFeatureSettings::isEnabled(const ExperimentalFeature & feature) const
 {
     auto & f = experimentalFeatures.get();

--- a/src/libutil/include/nix/util/configuration.hh
+++ b/src/libutil/include/nix/util/configuration.hh
@@ -379,37 +379,6 @@ public:
     }
 };
 
-/**
- * A special setting for Paths. These are automatically canonicalised
- * (e.g. "/foo//bar/" becomes "/foo/bar").
- *
- * It is mandatory to specify a path; i.e. the empty string is not
- * permitted.
- */
-class PathSetting : public BaseSetting<Path>
-{
-public:
-
-    PathSetting(
-        Config * options,
-        const Path & def,
-        const std::string & name,
-        const std::string & description,
-        const StringSet & aliases = {});
-
-    Path parse(const std::string & str) const override;
-
-    Path operator+(const char * p) const
-    {
-        return value + p;
-    }
-
-    void operator=(const Path & v)
-    {
-        this->assign(v);
-    }
-};
-
 struct ExperimentalFeatureSettings : Config
 {
 


### PR DESCRIPTION
## Motivation

This PR removes the unused `OptionalPathSetting` and replaces `PathSetting` with `StoreDirSetting`.

## Context

- Pulled out from #15354

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
