### PR TITLE
Enable static LLVM/libc++ & Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -430,7 +430,6 @@
                 {
                   # These attributes go right into `packages.<system>`.
                   "${pkgName}" = nixpkgsFor.${system}.native.nixComponents2.${pkgName};
-                  "${pkgName}-static" = nixpkgsFor.${system}.native.pkgsStatic.nixComponents2.${pkgName};
                   "${pkgName}-llvm" = nixpkgsFor.${system}.native.pkgsLLVM.nixComponents2.${pkgName};
                 }
                 // flatMapAttrs (lib.genAttrs stdenvs (_: { })) (
@@ -440,6 +439,9 @@
                     # These attributes go right into `packages.<system>`.
                     "${pkgName}-${stdenvName}" =
                       nixpkgsFor.${system}.nativeForStdenv.${stdenvName}.nixComponents2.${pkgName};
+
+                    "${pkgName}-${stdenvName}-static" =
+                      nixpkgsFor.${system}.nativeForStdenv.${stdenvName}.pkgsStatic.nixComponents2.${pkgName};
                   }
                 )
               )
@@ -454,6 +456,9 @@
                       "${pkgName}-${crossSystem}" = nixpkgsFor.${system}.cross.${crossSystem}.nixComponents2.${pkgName};
                     }
                 )
+                // {
+                  "${pkgName}-static" = nixpkgsFor.${system}.native.pkgsStatic.nixComponents2.${pkgName};
+                }
               )
             )
         // lib.optionalAttrs (self.hydraJobs.rustInstaller ? ${system}) {

--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -80,6 +80,13 @@ endif
 # Darwin ld doesn't like "X.Y.ZpreABCD+W"
 nix_soversion = meson.project_version().split('+')[0].split('pre')[0]
 
+# Clang does not support prelinking on static builds
+if cxx.get_id() == 'clang' and get_option('default_library') == 'static'
+  prelink = false
+else
+  prelink = true
+endif
+
 subdir('assert-fail')
 subdir('asan-options')
 if not meson.is_subproject()

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -163,6 +163,25 @@ let
     mesonCheckFlags = prevAttrs.mesonCheckFlags or [ ] ++ [
       "--print-errorlogs"
     ];
+    # Fixes a problem with some package outputs.
+    # For some reason that is not clear, it is wanting to use libgcc_eh which is not available.
+    # Force this to be built with compiler-rt & libunwind over libgcc_eh works.
+    # Issue: https://github.com/NixOS/nixpkgs/issues/177129
+    env.NIX_CFLAGS_COMPILE = builtins.toString (
+      (prevAttrs.NIX_CFLAGS_COMPILE or [ ])
+      ++
+        lib.optionals
+          (
+            stdenv.cc.isClang
+            && stdenv.hostPlatform.isStatic
+            && stdenv.cc.libcxx != null
+            && stdenv.cc.libcxx.isLLVM
+          )
+          [
+            "-rtlib=compiler-rt"
+            "-unwindlib=libunwind"
+          ]
+    );
   };
 
   mesonBuildLayer = finalAttrs: prevAttrs: rec {

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -46,25 +46,82 @@ scope: {
 
   curl =
     (pkgs.curl.override {
+      inherit stdenv;
       http3Support = !pkgs.stdenv.hostPlatform.isWindows;
       # Make sure we enable all the dependencies for Content-Encoding/Transfer-Encoding decompression.
       zstdSupport = true;
       brotliSupport = true;
       zlibSupport = true;
+      # libpsl uses a data file needed at runtime, not useful for nix.
+      pslSupport = !stdenv.hostPlatform.isStatic;
+      idnSupport = !stdenv.hostPlatform.isStatic;
     }).overrideAttrs
-      {
+      (attrs: {
+        # For some reason that is not clear, it is wanting to use libgcc_eh which is not available.
+        # Force this to be built with compiler-rt & libunwind over libgcc_eh works.
+        # Issue: https://github.com/NixOS/nixpkgs/issues/177129
+        NIX_CFLAGS_COMPILE =
+          lib.optionals
+            (
+              stdenv.cc.isClang
+              && stdenv.hostPlatform.isStatic
+              && stdenv.cc.libcxx != null
+              && stdenv.cc.libcxx.isLLVM
+            )
+            [
+              "-rtlib=compiler-rt"
+              "-unwindlib=libunwind"
+            ];
+
+        buildInputs =
+          (attrs.buildInputs or [ ])
+          ++ lib.optional (
+            stdenv.cc.isClang
+            && stdenv.hostPlatform.isStatic
+            && stdenv.cc.libcxx != null
+            && stdenv.cc.libcxx.isLLVM
+          ) pkgs.llvmPackages.libunwind;
+
         # TODO: Fix in nixpkgs. Static build with brotli is marked as broken, but it's not the case.
         # Remove once https://github.com/NixOS/nixpkgs/pull/494111 lands in the 25.11 channel.
         meta.broken = false;
-      };
+      });
 
-  libblake3 = pkgs.libblake3.override {
-    useTBB = !(stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isStatic);
-  };
+  libblake3 =
+    (pkgs.libblake3.override {
+      inherit stdenv;
+      # Nixpkgs disables tbb on static
+      useTBB = !(stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isStatic);
+    })
+    # For some reason that is not clear, it is wanting to use libgcc_eh which is not available.
+    # Force this to be built with compiler-rt & libunwind over libgcc_eh works.
+    # Issue: https://github.com/NixOS/nixpkgs/issues/177129
+    .overrideAttrs
+      (
+        attrs:
+        lib.optionalAttrs
+          (
+            stdenv.cc.isClang
+            && stdenv.hostPlatform.isStatic
+            && stdenv.cc.libcxx != null
+            && stdenv.cc.libcxx.isLLVM
+          )
+          {
+            NIX_CFLAGS_COMPILE = [
+              "-rtlib=compiler-rt"
+              "-unwindlib=libunwind"
+            ];
+
+            buildInputs = [
+              pkgs.llvmPackages.libunwind
+            ];
+          }
+      );
 
   # TODO Hack until https://github.com/NixOS/nixpkgs/issues/45462 is fixed.
   boost =
     (pkgs.boost.override {
+      inherit stdenv;
       extraB2Args = [
         "--with-container"
         "--with-context"

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -110,7 +110,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
   cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -54,7 +54,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -50,7 +50,7 @@ this_library = library(
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326
   #       is available. See also ../libutil/build.meson
   link_args : linker_export_flags + [ '-lrapidcheck' ],
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -246,7 +246,7 @@ this_library = library(
   include_directories : include_dirs,
   link_args : linker_export_flags,
   link_whole : [ parser_library ],
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
   cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )

--- a/src/libfetchers-c/meson.build
+++ b/src/libfetchers-c/meson.build
@@ -57,7 +57,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -64,7 +64,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
   cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )

--- a/src/libflake-c/meson.build
+++ b/src/libflake-c/meson.build
@@ -57,7 +57,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -62,7 +62,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -49,7 +49,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -81,7 +81,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -52,7 +52,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -56,7 +56,7 @@ this_library = library(
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326
   #       is available. See also ../libutil/build.meson
   link_args : linker_export_flags + [ '-lrapidcheck' ],
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -387,7 +387,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
   cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -57,7 +57,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -47,7 +47,7 @@ this_library = library(
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326
   #       is available. See also ../libutil/build.meson
   link_args : linker_export_flags + [ '-lrapidcheck' ],
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
 )
 

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -221,7 +221,7 @@ this_library = library(
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,
-  prelink : true, # For C++ static initializers
+  prelink : prelink, # For C++ static initializers
   install : true,
   cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -2,6 +2,8 @@
 #include "nix/util/file-system-at.hh"
 #include "nix/util/signals.hh"
 
+#include <sys/syscall.h>
+
 #include <fcntl.h>
 #include <unistd.h>
 #include <span>

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   mkMesonExecutable,
+  llvmPackages,
 
   nix-store,
   nix-expr,
@@ -77,7 +78,13 @@ mkMesonExecutable (finalAttrs: {
     nix-main
     nix-cmd
   ]
-  ++ lib.optional withMimalloc mimalloc;
+  ++ lib.optional withMimalloc mimalloc
+  ++ lib.optional (
+    stdenv.cc.isClang
+    && stdenv.hostPlatform.isStatic
+    && stdenv.cc.libcxx != null
+    && stdenv.cc.libcxx.isLLVM
+  ) llvmPackages.libunwind;
 
   mesonFlags = [
     (lib.mesonEnable "mimalloc" withMimalloc)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

This should allow for Nix libraries to be statically linked on Darwin, the executables should still be linked to libSystem and any other system library. This also enables `nix-cli-libcxxStdenv-static`, `nix-cli-clangStdenv-static`, and more static packages. I don't have a Darwin machine so I can't test the Darwin side, but I can test the Linux side. So far, the new Linux builds mostly work. There's weird linker errors, hoping someone could look into why we're getting strange C++ linker errors.

## Context

Upstreaming of https://github.com/DeterminateSystems/nix-src/pull/323

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
