### PR TITLE
Add `SysError`/`WinError` constructors that take a `HintFmt`-producing function

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -425,7 +425,7 @@ path_start
         /* Absolute paths are always interpreted relative to the
            root filesystem accessor, rather than the accessor of the
            current Nix expression. */
-        Path path(canonPath(literal));
+        auto path = canonPath(literal).string();
         /* add back in the trailing '/' to the first segment */
         if (literal.size() > 1 && literal.back() == '/')
           path += '/';
@@ -442,7 +442,7 @@ path_start
         });
 
         auto basePath = std::filesystem::path(state->basePath.path.abs());
-        Path path(absPath(literal, &basePath).string());
+        auto path = absPath(literal, &basePath).string();
         /* add back in the trailing '/' to the first segment */
         if (literal.size() > 1 && literal.back() == '/')
           path += '/';

--- a/src/libutil/windows/current-process.cc
+++ b/src/libutil/windows/current-process.cc
@@ -16,8 +16,7 @@ std::chrono::microseconds getCpuUserTime()
     FILETIME userTime;
 
     if (!GetProcessTimes(GetCurrentProcess(), &creationTime, &exitTime, &kernelTime, &userTime)) {
-        auto lastError = GetLastError();
-        throw windows::WinError(lastError, "failed to get CPU time");
+        throw windows::WinError("failed to get CPU time");
     }
 
     ULARGE_INTEGER uLargeInt;


### PR DESCRIPTION
## Motivation

This allows capturing `errno`/`GetLastError()` before constructing the error message. Useful when the error message construction itself might clobber the error code (e.g., calling `descriptorToPath()`).

Also fix the Windows build

## Context

Usage:
```
throw NativeSysError([&] { return HintFmt("msg %s", foo()); });
```

The error code is captured when the exception is constructed, then the lambda is called to produce the `HintFmt`.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
