### PR TITLE
configuration: make `AbsolutePath` a wrapper type

### DIFF
--- a/src/libstore-tests/local-overlay-store.cc
+++ b/src/libstore-tests/local-overlay-store.cc
@@ -21,7 +21,7 @@ TEST(LocalOverlayStore, constructConfig_rootQueryParam)
         },
     };
 
-    EXPECT_EQ(config.rootDir.get(), std::optional{std::string{root}});
+    EXPECT_EQ(config.rootDir.get(), std::optional<AbsolutePath>{std::string{root}});
 }
 
 TEST(LocalOverlayStore, constructConfig_rootPath)
@@ -33,7 +33,7 @@ TEST(LocalOverlayStore, constructConfig_rootPath)
 #endif
     LocalOverlayStoreConfig config{std::string{root}, {}};
 
-    EXPECT_EQ(config.rootDir.get(), std::optional{std::string{root}});
+    EXPECT_EQ(config.rootDir.get(), std::optional<AbsolutePath>{std::string{root}});
 }
 
 TEST(LocalOverlayStore, upperLayer_notOverridden)

--- a/src/libstore-tests/local-store.cc
+++ b/src/libstore-tests/local-store.cc
@@ -27,7 +27,7 @@ TEST(LocalStore, constructConfig_rootQueryParam)
         },
     };
 
-    EXPECT_EQ(config.rootDir.get(), std::optional{std::string{root}});
+    EXPECT_EQ(config.rootDir.get(), std::optional<AbsolutePath>{std::string{root}});
 }
 
 TEST(LocalStore, constructConfig_rootPath)
@@ -39,7 +39,7 @@ TEST(LocalStore, constructConfig_rootPath)
 #endif
     LocalStoreConfig config{std::string{root}, {}};
 
-    EXPECT_EQ(config.rootDir.get(), std::optional{std::string{root}});
+    EXPECT_EQ(config.rootDir.get(), std::optional<AbsolutePath>{std::string{root}});
 }
 
 TEST(LocalStore, constructConfig_to_string)

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -556,6 +556,8 @@ struct curlFileTransfer : public FileTransfer
                 curl_easy_setopt(req, CURLOPT_SEEKDATA, this);
             }
 
+            /* Note: libcurl copies string arguments, so temporaries from
+               .string().c_str() are safe. See the comment near CURLOPT_SSLKEY below. */
             if (auto & caFile = fileTransfer.settings.caFile.get())
                 curl_easy_setopt(req, CURLOPT_CAINFO, caFile->string().c_str());
 

--- a/src/libstore/include/nix/store/local-settings.hh
+++ b/src/libstore/include/nix/store/local-settings.hh
@@ -528,7 +528,7 @@ public:
      * Get the diff hook path if run-diff-hook is enabled.
      * @return Pointer to path if enabled, nullptr otherwise.
      */
-    const std::filesystem::path * getDiffHook() const
+    const AbsolutePath * getDiffHook() const
     {
         if (!runDiffHook.get()) {
             return nullptr;

--- a/src/libutil/include/nix/util/configuration.hh
+++ b/src/libutil/include/nix/util/configuration.hh
@@ -224,35 +224,90 @@ protected:
  *
  * Constructors assert that the path is absolute.
  */
-struct AbsolutePath : std::filesystem::path
+struct AbsolutePath
 {
-    using path::operator=;
-
-    AbsolutePath(const std::filesystem::path & p)
-        : path(p)
+    AbsolutePath(std::filesystem::path p)
+        : _path(std::move(p))
     {
-        assert(is_absolute());
-    }
-
-    AbsolutePath(std::filesystem::path && p)
-        : path(std::move(p))
-    {
-        assert(is_absolute());
+        assert(_path.is_absolute());
     }
 
     AbsolutePath(const char * s)
-        : path(s)
+        : _path(s)
     {
-        assert(is_absolute());
+        assert(_path.is_absolute());
     }
 
 #ifdef _WIN32
     AbsolutePath(const wchar_t * s)
-        : path(s)
+        : _path(s)
     {
-        assert(is_absolute());
+        assert(_path.is_absolute());
     }
 #endif
+
+    const std::filesystem::path & path() const
+    {
+        return _path;
+    }
+
+    operator const std::filesystem::path &() const
+    {
+        return _path;
+    }
+
+    std::string string() const
+    {
+        return _path.string();
+    }
+
+    const auto & native() const
+    {
+        return _path.native();
+    }
+
+    const std::filesystem::path::value_type * c_str() const
+    {
+        return _path.c_str();
+    }
+
+    bool empty() const
+    {
+        return _path.empty();
+    }
+
+    std::filesystem::path operator/(const std::filesystem::path & rhs) const
+    {
+        return _path / rhs;
+    }
+
+    bool operator==(const AbsolutePath & rhs) const
+    {
+        return _path == rhs._path;
+    }
+
+    bool operator==(const std::filesystem::path & rhs) const
+    {
+        return _path == rhs;
+    }
+
+    bool operator==(const std::string & rhs) const
+    {
+        return _path == rhs;
+    }
+
+    auto operator<=>(const AbsolutePath & rhs) const
+    {
+        return _path <=> rhs._path;
+    }
+
+    friend std::ostream & operator<<(std::ostream & os, const AbsolutePath & p)
+    {
+        return os << p._path.string();
+    }
+
+private:
+    std::filesystem::path _path;
 };
 
 template<>
@@ -419,6 +474,46 @@ public:
     void operator=(const T & v)
     {
         this->assign(v);
+    }
+};
+
+/**
+ * `AbsolutePath` wraps `std::filesystem::path`, so implicit conversion
+ * from `Setting<AbsolutePath>` to `const path &` requires two
+ * user-defined conversions (`Setting` -> `AbsolutePath` -> `path`),
+ * which C++ does not allow in a single implicit conversion sequence.
+ * This specialization provides a direct conversion operator.
+ *
+ * See https://en.cppreference.com/w/cpp/language/implicit_conversion.html
+ */
+template<>
+class Setting<AbsolutePath> : public BaseSetting<AbsolutePath>
+{
+public:
+    using BaseSetting<AbsolutePath>::BaseSetting;
+    using BaseSetting<AbsolutePath>::operator=;
+
+    Setting(
+        Config * options,
+        const AbsolutePath & def,
+        const std::string & name,
+        const std::string & description,
+        const StringSet & aliases = {},
+        const bool documentDefault = true,
+        std::optional<ExperimentalFeature> experimentalFeature = std::nullopt)
+        : BaseSetting<AbsolutePath>(def, documentDefault, name, description, aliases, std::move(experimentalFeature))
+    {
+        options->addSetting(this);
+    }
+
+    void operator=(const AbsolutePath & v)
+    {
+        this->assign(v);
+    }
+
+    operator const std::filesystem::path &() const
+    {
+        return this->value.path();
     }
 };
 


### PR DESCRIPTION
## Motivation

Public inheritance from `std::filesystem::path` lets `AbsolutePath`
silently slice down to a plain path when passed by value, so this commit changes
`AbsolutePath` to use a `path` field instead, which is easier to reason about and prevents that.

## Context

- Followup to #15354

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
