### PR TITLE
feat(nix): add shortname to bundle bundler arg

### DIFF
--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -18,6 +18,7 @@ struct CmdBundle : InstallableValueCommand
     {
         addFlag({
             .longName = "bundler",
+            .shortName = 'B',
             .description = fmt("Use a custom bundler instead of the default (`%s`).", bundler),
             .labels = {"flake-url"},
             .handler = {&bundler},


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

I have done what I have said I would do @tomberek.

## Motivation

Short name for bundler. 


## Context
There is an typing bundlers issue where there is no short name when you chain bundlers you have to do --bundler for each one which takes time out of development, so this simplifies it to `-B` therefore saving time.

### Alternatives

No shortname (would be bad for time to type out and doesn't save time)
`-b` for the shortname.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
