### PR TITLE
fix: Propagate self-attrs to originalRef in lock file entries (#15350)

### DIFF
--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -723,6 +723,13 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
                             auto inputFlake = getInputFlake(
                                 *input.ref, inputIsOverride ? fetchers::UseRegistries::All : useRegistriesInputs);
 
+                        
+                            for (auto & [name, value] : inputFlake.selfAttrs) {
+                                if (ref.input.attrs.count(name) == 0) {
+                                    ref.input.attrs.insert_or_assign(name, value);
+                                }
+                            }
+
                             auto childNode =
                                 make_ref<LockedNode>(inputFlake.lockedRef, ref, true, overriddenParentPath);
 


### PR DESCRIPTION
When a flake declares `inputs.self.lfs = true`, `getFlake()` correctly
discovers this and refetches with LFS enabled. However, the `originalRef`
stored in the lock file entry did not include these self-attrs,
causing narHash mismatches when the consuming flake's input URL
didn't explicitly specify `&lfs=1`.

This commit propagates self-attrs (lfs, submodules) discovered from
the dependency's flake.nix to the originalRef before creating the
LockedNode. This ensures:

1. The lock file accurately reflects the dependency's fetch requirements
2. Re-locking correctly detects changes in self-attrs
3. narHash is always computed against the correct (LFS-enabled) tree

Fixes #15350