### PR TITLE
Warn when parsing a base64 string with extraneous data or the wrong amount of padding

### DIFF
--- a/src/libutil/base-n.cc
+++ b/src/libutil/base-n.cc
@@ -88,24 +88,73 @@ std::string base64::decode(std::string_view s)
     // Some sequences are missing the padding consisting of up to two '='.
     //                    vvv
     res.reserve((s.size() + 2) / 4 * 3);
-    unsigned int d = 0, bits = 0;
+    unsigned int d = 0, bits = 0, char_count = 0, padding_count = 0;
+    size_t padding_idx[2] = {SIZE_MAX, SIZE_MAX};
+    size_t i = 0, parse_finished_at = 0;
 
-    for (char c : s) {
-        if (c == '=')
-            break;
+    for (; i < s.size(); i++) {
+        char c = s[i];
         if (c == '\n')
             continue;
+        if (padding_count > 0 && c != '=')
+            break;
+        if (c == '=') {
+            padding_idx[padding_count] = i;
+            padding_count += 1;
+            if (padding_count >= 2)
+                break;
+        } else {
+            char digit = base64DecodeChars[(unsigned char) c];
+            if (digit == npos)
+                throw FormatError("invalid character in Base64 string: '%c'", c);
+            char_count += 1;
 
-        char digit = base64DecodeChars[(unsigned char) c];
-        if (digit == npos)
-            throw FormatError("invalid character in Base64 string: '%c'", c);
-
-        bits += 6;
-        d = d << 6 | digit;
-        if (bits >= 8) {
-            res.push_back(d >> (bits - 8) & 0xff);
-            bits -= 8;
+            bits += 6;
+            d = d << 6 | digit;
+            if (bits >= 8) {
+                res.push_back(d >> (bits - 8) & 0xff);
+                d &= ~(0xff << (bits - 8));
+                bits -= 8;
+            }
         }
+    }
+
+    unsigned int trailing_count = char_count % 4;
+    unsigned int expected_padding;
+    switch (trailing_count) {
+    case 0:
+        expected_padding = 0;
+        break;
+    case 1:
+        throw FormatError("invalid Base64 string");
+    case 2:
+    case 3:
+        expected_padding = 4 - trailing_count;
+        break;
+    default:
+        // impossible; the result of anything % 4 is always 0,1,2, or 3
+        assert(false);
+        break;
+    }
+
+    if (padding_count <= expected_padding) {
+        parse_finished_at = i + 1;
+    } else {
+        parse_finished_at = padding_idx[expected_padding];
+        assert(parse_finished_at != SIZE_MAX);
+    }
+
+    auto hash_part = s.substr(0, parse_finished_at);
+
+    if (d != 0)
+        warn("Hash '%s' has non-zero padding bits", hash_part);
+
+    if (padding_count < expected_padding)
+        warn("Hash '%s' is missing '=' padding", hash_part);
+
+    if (parse_finished_at < s.size()) {
+        auto extraneous_part = s.substr(parse_finished_at);
+        warn("Hash '%s' has extraneous data: '%s'", hash_part, extraneous_part);
     }
 
     return res;


### PR DESCRIPTION
See #6414

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

```
$ nix hash convert --from sri --to base16 'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD============ currently nix will accept arbitrary data after an ='

0000000000000000000000000000000000000000000000000000000000000000
```

And a hash can appear to "change"

```
$ nix hash convert --from sri --to sri sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD=

sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=

$ nix build --expr 'derivation { name = "demo"; builder = "/bin/sh"; args = [ "-c" "echo > $out" ]; system = "x86_64-linux"; outputHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD=";}'

error: hash mismatch in fixed-output derivation '/nix/store/b60sr8vmbjb8302s6xksxpyg8142k0zm-demo.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs=
```

This threw me for a loop the first time I ran into it, I thought I was experiencing memory corruption.

## Context

#6414

These would be errors rather than warnings, but backwards compatibility doesn't allow that. I considered adding an option for that, but I wanted to get a relatively simple PR out first.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
