### PR TITLE
[UX] Improve untrusted user warning message

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -272,7 +272,7 @@ struct ClientSettings
                     else
                         warn(
                             "ignoring untrusted substituter '%s', you are not a trusted user.\n"
-                            "Run `man nix.conf` for more information on the `substituters` configuration option.",
+                            "Run `man nix.conf` for more information on the 'substituters' and 'trusted-users' configuration options.",
                             s);
                 }
                 res = std::move(subs);
@@ -302,7 +302,9 @@ struct ClientSettings
                     ;
                 else
                     warn(
-                        "ignoring the client-specified setting '%s', because it is a restricted setting and you are not a trusted user",
+                        "ignoring the client-specified setting '%s', because it is a restricted setting and you are not a trusted user.\n"
+                        "Run `man nix.conf` for more information on the '%s' and 'trusted-users' configuration options.",
+                        name,
                         name);
             } catch (UsageError & e) {
                 warn(e.what());

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -68,6 +68,11 @@ struct AuthorizationSettings : Config
           You can also specify groups by prefixing names with `@`.
           For instance, `@wheel` means all users in the `wheel` group.
 
+          This is only respected when set in a nix.conf that is already trusted, such as /etc/nix/nix.conf.
+          Setting this in the local nix.conf in an untrusted user's home will have no effect.
+
+          Often, it is better to add a privileged setting directly to /etc/nix/nix.conf (such as `extra-substituters`) rather than to add your username to `trusted-users`.
+
           > **Warning**
           >
           > Adding a user to `trusted-users` is essentially equivalent to giving that user root access to the system.


### PR DESCRIPTION
Based on user feedback mentioned in the linked issue, more information about how to resolve an untrusted user issue should be provided in the warning message.

Resolves #8248

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This resolves a popular UX issue.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#8248

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
