### PR TITLE
LocalStore: stop creating outdated profiles symlink

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -144,10 +144,7 @@ LocalStore::LocalStore(ref<const Config> config)
     auto gcRootsDir = config->stateDir.get() / "gcroots";
     const auto & localSettings = config->getLocalSettings();
     const auto & gcSettings = localSettings.getGCSettings();
-    if (!pathExists(gcRootsDir)) {
-        createDirs(gcRootsDir);
-        replaceSymlink(profilesDir, gcRootsDir / "profiles");
-    }
+    createDirs(gcRootsDir);
 
     for (auto & perUserDir : {profilesDir / "per-user", gcRootsDir / "per-user"}) {
         createDirs(perUserDir);


### PR DESCRIPTION
This was done in 97990235454f0aa19b793c74c8f7fd8b7da3001b but accidentally reverted during a merge.
