### PR TITLE
libexpr: Make Boehm allocation cache thread_local

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -228,10 +228,6 @@ static Symbol getName(const AttrName & name, EvalState & state, Env & env)
 static constexpr size_t BASE_ENV_SIZE = 128;
 
 EvalMemory::EvalMemory()
-#if NIX_USE_BOEHMGC
-    : valueAllocCache(std::allocate_shared<void *>(traceable_allocator<void *>(), nullptr))
-    , env1AllocCache(std::allocate_shared<void *>(traceable_allocator<void *>(), nullptr))
-#endif
 {
     assertGCInitialized();
 }

--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -30,6 +30,11 @@ inline void * EvalMemory::allocBytes(size_t n)
 Value * EvalMemory::allocValue()
 {
 #if NIX_USE_BOEHMGC
+    /* Allocation cache for GC'd Value objects. Boehm GC is already a global resource, so thread_local is
+       a natural solution. Multiple EvalState instances on the same thread will reuse the same cache. */
+    static thread_local std::shared_ptr<void *> valueAllocCache{
+        std::allocate_shared<void *>(traceable_allocator<void *>(), nullptr)};
+
     /* We use the boehm batch allocator to speed up allocations of Values (of which there are many).
        GC_malloc_many returns a linked list of objects of the given size, where the first word
        of each object is also the pointer to the next object in the list. This also means that we
@@ -63,6 +68,10 @@ Env & EvalMemory::allocEnv(size_t size)
 
 #if NIX_USE_BOEHMGC
     if (size == 1) {
+        /* Allocation cache for size-1 Env objects. Boehm GC is already a global resource, so thread_local is
+           a natural solution. Multiple EvalState instances on the same thread will reuse the same cache. */
+        static thread_local std::shared_ptr<void *> env1AllocCache{
+            std::allocate_shared<void *>(traceable_allocator<void *>(), nullptr)};
         /* see allocValue for explanations. */
         if (!*env1AllocCache) {
             *env1AllocCache = GC_malloc_many(sizeof(Env) + sizeof(Value *));

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -305,18 +305,6 @@ struct StaticEvalSymbols
 
 class EvalMemory
 {
-#if NIX_USE_BOEHMGC
-    /**
-     * Allocation cache for GC'd Value objects.
-     */
-    std::shared_ptr<void *> valueAllocCache;
-
-    /**
-     * Allocation cache for size-1 Env objects.
-     */
-    std::shared_ptr<void *> env1AllocCache;
-#endif
-
 public:
     struct Statistics
     {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This seems quite natural to me, since boehm is necessarily a global resource. I still think that it would be best if we don't make it a requirement to only have a single instance of EvalState per thread, but specifically for this use-case thread_local is a perfect fit.

Same as in https://github.com/DeterminateSystems/nix-src/commit/6eafc52b7a2157ac1ccfc8d1105465c7d96187a7.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
