### PR TITLE
fix(libexpr-c): pass valid EvalState to primop callback

### DIFF
--- a/doc/manual/rl-next/fix-primop-eval-state.md
+++ b/doc/manual/rl-next/fix-primop-eval-state.md
@@ -1,0 +1,10 @@
+---
+synopsis: "C API: Fix `EvalState` pointer passed to primop callbacks"
+prs: [15300, 15383]
+---
+
+The `EvalState *` passed to C API primop callbacks was incorrectly pointing to
+the internal `nix::EvalState` rather than the C API wrapper struct. This caused
+a segfault when the callback used the pointer with C API functions such as
+`nix_alloc_value()`. The same issue affected `printValueAsJSON` and
+`printValueAsXML` callbacks on external values.

--- a/src/libexpr-c/nix_api_expr.cc
+++ b/src/libexpr-c/nix_api_expr.cc
@@ -181,15 +181,13 @@ EvalState * nix_eval_state_build(nix_c_context * context, nix_eval_state_builder
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        return unsafe_new_with_self<EvalState>([&](auto * self) {
-            return EvalState{
-                .fetchSettings = std::move(builder->fetchSettings),
-                .settings = std::move(builder->settings),
-                .statePtr = std::make_shared<nix::EvalState>(
-                    builder->lookupPath, builder->store, self->fetchSettings, self->settings),
-                .state = *self->statePtr,
-            };
-        });
+        auto fetchSettings = std::make_unique<nix::fetchers::Settings>(std::move(builder->fetchSettings));
+        auto settings = std::make_unique<nix::EvalSettings>(std::move(builder->settings));
+        auto ownedState =
+            std::make_shared<nix::EvalState>(builder->lookupPath, builder->store, *fetchSettings, *settings);
+        auto & stateRef = *ownedState;
+        void * p = ::operator new(sizeof(EvalState), static_cast<std::align_val_t>(alignof(EvalState)));
+        return new (p) EvalState{stateRef, std::move(fetchSettings), std::move(settings), std::move(ownedState)};
     }
     NIXC_CATCH_ERRS_NULL
 }

--- a/src/libexpr-c/nix_api_expr_internal.h
+++ b/src/libexpr-c/nix_api_expr_internal.h
@@ -1,6 +1,8 @@
 #ifndef NIX_API_EXPR_INTERNAL_H
 #define NIX_API_EXPR_INTERNAL_H
 
+#include <memory>
+
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/expr/eval.hh"
 #include "nix/expr/eval-settings.hh"
@@ -22,10 +24,11 @@ struct nix_eval_state_builder
 
 struct EvalState
 {
-    nix::fetchers::Settings fetchSettings;
-    nix::EvalSettings settings;
-    std::shared_ptr<nix::EvalState> statePtr;
     nix::EvalState & state;
+    // Owned resources; null for temporary wrappers created in C API callbacks.
+    std::unique_ptr<nix::fetchers::Settings> ownedFetchSettings;
+    std::unique_ptr<nix::EvalSettings> ownedSettings;
+    std::shared_ptr<nix::EvalState> ownedState;
 };
 
 struct BindingsBuilder

--- a/src/libexpr-c/nix_api_external.cc
+++ b/src/libexpr-c/nix_api_external.cc
@@ -137,7 +137,8 @@ public:
         }
         nix_string_context ctx{context};
         nix_string_return res{""};
-        desc.printValueAsJSON(v, (EvalState *) &state, strict, &ctx, copyToStore, &res);
+        EvalState wrapper{state};
+        desc.printValueAsJSON(v, &wrapper, strict, &ctx, copyToStore, &res);
         if (res.str.empty()) {
             return nix::ExternalValueBase::printValueAsJSON(state, strict, context, copyToStore);
         }
@@ -160,15 +161,9 @@ public:
             return nix::ExternalValueBase::printValueAsXML(state, strict, location, doc, context, drvsSeen, pos);
         }
         nix_string_context ctx{context};
+        EvalState wrapper{state};
         desc.printValueAsXML(
-            v,
-            (EvalState *) &state,
-            strict,
-            location,
-            &doc,
-            &ctx,
-            &drvsSeen,
-            *reinterpret_cast<const uint32_t *>(&pos));
+            v, &wrapper, strict, location, &doc, &ctx, &drvsSeen, *reinterpret_cast<const uint32_t *>(&pos));
     }
 
     virtual ~NixCExternalValue() override {};

--- a/src/libexpr-c/nix_api_external.h
+++ b/src/libexpr-c/nix_api_external.h
@@ -145,6 +145,7 @@ typedef struct NixCExternalValueDesc
      * Optional, the default is to throw an error
      * @todo The mechanisms for this call are incomplete. There are no C
      *       bindings to work with XML, pathsets and positions.
+     *       This callback also has no test coverage.
      * @param[in] self the void* passed to nix_create_external_value
      * @param[in] state The evaluator state
      * @param[in] strict boolean Whether to force the value before printing

--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -105,7 +105,8 @@ static void nix_c_primop_wrapper(
         nix_value * external_arg = new_nix_value(args[i], state.mem);
         external_args.push_back(external_arg);
     }
-    f(userdata, &ctx, (EvalState *) &state, external_args.data(), vTmpPtr);
+    EvalState wrapper{state};
+    f(userdata, &ctx, &wrapper, external_args.data(), vTmpPtr);
 
     if (ctx.last_err_code != NIX_OK) {
         if (ctx.last_err_code == NIX_ERR_RECOVERABLE) {

--- a/src/libexpr-tests/nix_api_expr.cc
+++ b/src/libexpr-tests/nix_api_expr.cc
@@ -476,6 +476,52 @@ TEST_F(nix_api_expr_test, nix_expr_primop_nix_err_key_conversion)
     nix_gc_decref(ctx, result);
 }
 
+static void
+primop_alloc_value(void * user_data, nix_c_context * context, EvalState * state, nix_value ** args, nix_value * ret)
+{
+    assert(context);
+    assert(state);
+
+    // Regression test: nix_c_primop_wrapper previously cast the inner
+    // nix::EvalState* directly to EvalState* (C wrapper). C API functions
+    // like nix_alloc_value() then accessed state->state at the wrong offset,
+    // causing a segfault.
+    nix_value * v = nix_alloc_value(context, state);
+    assert(v != nullptr);
+    nix_init_int(context, v, 42);
+    nix_copy_value(context, ret, v);
+    nix_gc_decref(nullptr, v);
+}
+
+TEST_F(nix_api_expr_test, nix_primop_can_use_state_in_callback)
+{
+    PrimOp * primop =
+        nix_alloc_primop(ctx, primop_alloc_value, 1, "allocValue", nullptr, "test alloc_value in callback", nullptr);
+    assert_ctx_ok();
+    nix_value * primopValue = nix_alloc_value(ctx, state);
+    assert_ctx_ok();
+    nix_init_primop(ctx, primopValue, primop);
+    assert_ctx_ok();
+
+    nix_value * dummy = nix_alloc_value(ctx, state);
+    assert_ctx_ok();
+    nix_init_int(ctx, dummy, 0);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    assert_ctx_ok();
+    nix_value_call(ctx, state, primopValue, dummy, result);
+    assert_ctx_ok();
+
+    auto r = nix_get_int(ctx, result);
+    ASSERT_EQ(42, r);
+
+    nix_gc_decref(ctx, dummy);
+    nix_gc_decref(ctx, result);
+    nix_gc_decref(ctx, primopValue);
+    nix_gc_decref(ctx, primop);
+}
+
 TEST_F(nix_api_expr_test, nix_value_call_multi_no_args)
 {
     nix_value * n = nix_alloc_value(ctx, state);

--- a/src/libexpr-tests/nix_api_external.cc
+++ b/src/libexpr-tests/nix_api_external.cc
@@ -66,4 +66,44 @@ TEST_F(nix_api_expr_test, nix_expr_eval_external)
     nix_state_free(stateFn);
 }
 
+static void print_value_as_json_using_state(
+    void * self, EvalState * state, bool strict, nix_string_context * c, bool copyToStore, nix_string_return * res)
+{
+    // Regression test: same cast bug as in nix_c_primop_wrapper (see primop_alloc_value).
+    nix_value * v = nix_alloc_value(nullptr, state);
+    assert(v != nullptr);
+    nix_gc_decref(nullptr, v);
+
+    nix_set_string_return(res, "42");
+}
+
+TEST_F(nix_api_expr_test, nix_external_printValueAsJSON_can_use_state)
+{
+    NixCExternalValueDesc desc{};
+    desc.print = [](void *, nix_printer *) {};
+    desc.showType = [](void *, nix_string_return *) {};
+    desc.typeOf = [](void *, nix_string_return *) {};
+    desc.printValueAsJSON = print_value_as_json_using_state;
+
+    ExternalValue * val = nix_create_external_value(ctx, &desc, nullptr);
+    assert_ctx_ok();
+    nix_init_external(ctx, value, val);
+    assert_ctx_ok();
+
+    nix_value * toJsonFn = nix_alloc_value(ctx, state);
+    nix_expr_eval_from_string(ctx, state, "builtins.toJSON", ".", toJsonFn);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    nix_value_call(ctx, state, toJsonFn, value, result);
+    assert_ctx_ok();
+
+    std::string json_str;
+    nix_get_string(ctx, result, OBSERVE_STRING(json_str));
+    ASSERT_EQ("42", json_str);
+
+    nix_gc_decref(ctx, result);
+    nix_gc_decref(ctx, toJsonFn);
+}
+
 } // namespace nixC


### PR DESCRIPTION
Due to an erroneous cast, the wrong pointer was passed to these callbacks, leading to a crash.

We now create a lightweight temporary EvalState wrapper on the stack in each callback bridge. This also eliminates the need for unsafe_new_with_self for EvalState construction.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This could be a more straightforward alternative to #15300

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
