### PR TITLE
Relative url tests

### DIFF
--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -755,6 +755,39 @@ INSTANTIATE_TEST_SUITE_P(
         },
         ParseURLRelativeParam{
             .base = "https://www.example.org/path/index.html?a\%20b=5\%206&x\%20y=34#frag",
+            .relative = "#",
+            .expected =
+                ParsedURL{
+                    .scheme = "https",
+                    .authority =
+                        Authority{
+                            .hostType = HostType::Name,
+                            .host = "www.example.org",
+                        },
+                    .path = {"", "path", "index.html"},
+                    .query = {{"a b", "5 6"}, {"x y", "34"}},
+                    .fragment = "",
+                },
+            .description = "emptyFragmentRelative",
+        },
+        ParseURLRelativeParam{
+            .base = "https://www.example.org/path/index.html?a\%20b=5\%206&x\%20y=34#frag",
+            .relative = "?",
+            .expected =
+                ParsedURL{
+                    .scheme = "https",
+                    .authority =
+                        Authority{
+                            .hostType = HostType::Name,
+                            .host = "www.example.org",
+                        },
+                    .path = {"", "path", "index.html"},
+                    .query = {},
+                },
+            .description = "emptyQueryRelative",
+        },
+        ParseURLRelativeParam{
+            .base = "https://www.example.org/path/index.html?a\%20b=5\%206&x\%20y=34#frag",
             .relative = "?asdf\%20qwer=1\%202\%203",
             .expected =
                 ParsedURL{


### PR DESCRIPTION
## Motivation

More organized tests, and then two more tests

## Context

Pulled out from #15353

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
