### PR TITLE
libutil: Add dupDescriptor function

### DIFF
--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -285,6 +285,14 @@ public:
     void startFsync() const;
 };
 
+/**
+ * Duplicate a file descriptor.
+ *
+ * Returns a new file descriptor that refers to the same open file
+ * description as the original.
+ */
+AutoCloseFD dupDescriptor(Descriptor fd);
+
 class Pipe
 {
 public:

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -56,6 +56,14 @@ size_t write(Descriptor fd, std::span<const std::byte> buffer, bool allowInterru
     return static_cast<size_t>(n);
 }
 
+AutoCloseFD dupDescriptor(Descriptor fd)
+{
+    int newFd = fcntl(fd, F_DUPFD_CLOEXEC, 0);
+    if (newFd == -1)
+        throw SysError("duplicating file descriptor");
+    return AutoCloseFD{newFd};
+}
+
 //////////////////////////////////////////////////////////////////////
 
 void Pipe::create()

--- a/src/libutil/windows/file-descriptor.cc
+++ b/src/libutil/windows/file-descriptor.cc
@@ -68,6 +68,15 @@ size_t write(Descriptor fd, std::span<const std::byte> buffer, bool allowInterru
     return static_cast<size_t>(n);
 }
 
+AutoCloseFD dupDescriptor(Descriptor fd)
+{
+    HANDLE newHandle;
+    if (!DuplicateHandle(GetCurrentProcess(), fd, GetCurrentProcess(), &newHandle, 0, FALSE, DUPLICATE_SAME_ACCESS)) {
+        throw WinError("duplicating handle");
+    }
+    return AutoCloseFD{newHandle};
+}
+
 //////////////////////////////////////////////////////////////////////
 
 void Pipe::create()


### PR DESCRIPTION
## Motivation

Add a cross-platform function for duplicating file descriptors:
- Unix: uses fcntl(F_DUPFD_CLOEXEC)
- Windows: uses DuplicateHandle

This is useful when code needs to take ownership of a borrowed descriptor.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
