### PR TITLE
Decouple the file object sinks for different purposes

### DIFF
--- a/src/libfetchers-tests/git-utils.cc
+++ b/src/libfetchers-tests/git-utils.cc
@@ -1,4 +1,5 @@
 #include "nix/fetchers/git-utils.hh"
+#include "nix/util/merkle-files.hh"
 #include "nix/util/file-system.hh"
 #include <gmock/gmock.h>
 #include <git2/global.h>
@@ -8,7 +9,6 @@
 #include <git2/object.h>
 #include <git2/tag.h>
 #include <gtest/gtest.h>
-#include "nix/util/fs-sink.hh"
 #include "nix/util/serialise.hh"
 
 #include <git2/blob.h>
@@ -50,47 +50,82 @@ public:
         return GitRepo::openRepo(tmpDir, {.create = true});
     }
 
+    ref<GitRepoPool> openWriterPool()
+    {
+        return GitRepoPool::create(tmpDir, {.create = true});
+    }
+
     std::string getRepoName() const
     {
         return tmpDir.filename().string();
     }
 };
 
-void writeString(CreateRegularFileSink & fileSink, std::string contents, bool executable)
+merkle::TreeEntry writeString(merkle::FileSinkBuilder & store, std::string contents, bool executable = false)
 {
-    if (executable)
-        fileSink.isExecutable();
-    fileSink.preallocateContents(contents.size());
-    fileSink(contents);
+    auto sink = store.makeRegularFileSink();
+    (*sink)(contents);
+    return merkle::TreeEntry{
+        executable ? merkle::Mode::Executable : merkle::Mode::Regular,
+        std::move(*sink).flush(),
+    };
 }
 
 TEST_F(GitUtilsTest, sink_basic)
 {
     auto repo = openRepo();
-    auto sink = repo->getFileSystemObjectSink();
+    auto pool = openWriterPool();
 
-    // TODO/Question: It seems a little odd that we use the tarball-like convention of requiring a top-level directory
-    // here
-    //                The sync method does not document this behavior, should probably renamed because it's not very
-    //                general, and I can't imagine that "non-conventional" archives or any other source to be handled by
-    //                this sink.
+    // Build tree bottom-up using insertChild
+    // hello file
+    auto hello = writeString(*pool, "hello world");
 
-    sink->createDirectory(CanonPath("foo-1.1"));
+    // bye file
+    auto bye = writeString(*pool, "thanks for all the fish");
 
-    sink->createRegularFile(CanonPath("foo-1.1/hello"), [](CreateRegularFileSink & fileSink) {
-        writeString(fileSink, "hello world", false);
-    });
-    sink->createRegularFile(CanonPath("foo-1.1/bye"), [](CreateRegularFileSink & fileSink) {
-        writeString(fileSink, "thanks for all the fish", false);
-    });
-    sink->createSymlink(CanonPath("foo-1.1/bye-link"), "bye");
-    sink->createDirectory(CanonPath("foo-1.1/empty"));
-    sink->createDirectory(CanonPath("foo-1.1/links"));
-    sink->createHardlink(CanonPath("foo-1.1/links/foo"), CanonPath("foo-1.1/hello"));
+    // bye-link symlink
+    auto byeLink = pool->makeSymlink("bye");
 
-    // sink->createHardlink("foo-1.1/links/foo-2", CanonPath("foo-1.1/hello"));
+    // Flush blobs/symlinks so directory sinks can reference them.
+    pool->flushAndSetAllowDependentCreation(true);
 
-    auto result = repo->dereferenceSingletonDirectory(sink->flush());
+    // empty directory
+    auto empty = [&] {
+        auto emptyDir = pool->makeDirectorySink();
+        return merkle::TreeEntry{merkle::Mode::Directory, std::move(*emptyDir).flush()};
+    }();
+
+    // links/foo file
+    auto linksFoo = writeString(*pool, "hello world");
+
+    // links directory
+    auto links = [&] {
+        auto linksDir = pool->makeDirectorySink();
+        linksDir->insertChild("foo", linksFoo);
+        return merkle::TreeEntry{merkle::Mode::Directory, std::move(*linksDir).flush()};
+    }();
+
+    // foo-1.1 directory (contains hello, bye, bye-link, empty, links)
+    auto foo = [&] {
+        auto fooDir = pool->makeDirectorySink();
+        fooDir->insertChild("hello", hello);
+        fooDir->insertChild("bye", bye);
+        fooDir->insertChild("bye-link", byeLink);
+        fooDir->insertChild("empty", empty);
+        fooDir->insertChild("links", links);
+        return merkle::TreeEntry{merkle::Mode::Directory, std::move(*fooDir).flush()};
+    }();
+
+    // root directory (contains foo-1.1)
+    auto rootHash = [&] {
+        auto rootDir = pool->makeDirectorySink();
+        rootDir->insertChild("foo-1.1", foo);
+        return std::move(*rootDir).flush();
+    }();
+
+    pool->flushAndSetAllowDependentCreation(false);
+
+    auto result = repo->dereferenceSingletonDirectory(rootHash);
     auto accessor = repo->getAccessor(result, {}, getRepoName());
     auto entries = accessor->readDirectory(CanonPath::root);
     ASSERT_EQ(entries.size(), 5u);
@@ -99,29 +134,7 @@ TEST_F(GitUtilsTest, sink_basic)
     ASSERT_EQ(accessor->readLink(CanonPath("bye-link")), "bye");
     ASSERT_EQ(accessor->readDirectory(CanonPath("empty")).size(), 0u);
     ASSERT_EQ(accessor->readFile(CanonPath("links/foo")), "hello world");
-};
-
-TEST_F(GitUtilsTest, sink_hardlink)
-{
-    auto repo = openRepo();
-    auto sink = repo->getFileSystemObjectSink();
-
-    sink->createDirectory(CanonPath("foo-1.1"));
-
-    sink->createRegularFile(CanonPath("foo-1.1/hello"), [](CreateRegularFileSink & fileSink) {
-        writeString(fileSink, "hello world", false);
-    });
-
-    try {
-        sink->createHardlink(CanonPath("foo-1.1/link"), CanonPath("hello"));
-        sink->flush();
-        FAIL() << "Expected an exception";
-    } catch (const nix::Error & e) {
-        ASSERT_THAT(e.msg(), testing::HasSubstr("does not exist"));
-        ASSERT_THAT(e.msg(), testing::HasSubstr("/hello"));
-        ASSERT_THAT(e.msg(), testing::HasSubstr("foo-1.1/link"));
-    }
-};
+}
 
 TEST_F(GitUtilsTest, peel_reference)
 {

--- a/src/libfetchers-tests/merkle-tar-adapter.cc
+++ b/src/libfetchers-tests/merkle-tar-adapter.cc
@@ -1,0 +1,563 @@
+#include "nix/fetchers/git-utils.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/serialise.hh"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <rapidcheck/gtest.h>
+
+#include <git2/global.h>
+#include <git2/repository.h>
+
+namespace nix {
+
+class MerkleTarAdapterTest : public ::testing::Test
+{
+    std::unique_ptr<AutoDelete> delTmpDir;
+
+protected:
+    std::filesystem::path tmpDir;
+
+public:
+    void SetUp() override
+    {
+        tmpDir = createTempDir();
+        delTmpDir = std::make_unique<AutoDelete>(tmpDir, true);
+
+        git_libgit2_init();
+        git_repository * repo = nullptr;
+        auto r = git_repository_init(&repo, tmpDir.string().c_str(), 0);
+        ASSERT_EQ(r, 0);
+        git_repository_free(repo);
+    }
+
+    void TearDown() override
+    {
+        delTmpDir.reset();
+    }
+
+    ref<GitRepo> openRepo()
+    {
+        return GitRepo::openRepo(tmpDir, {.create = true});
+    }
+
+    ref<GitRepoPool> openWriterPool()
+    {
+        return GitRepoPool::create(tmpDir, {.create = true});
+    }
+
+    std::string getRepoName() const
+    {
+        return tmpDir.filename().string();
+    }
+};
+
+TEST_F(MerkleTarAdapterTest, empty_archive_throws)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    EXPECT_THROW(tarSink->flush(), Error);
+}
+
+TEST_F(MerkleTarAdapterTest, single_file_at_root)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath::root, false, [](Sink & sink) { sink("hello world"); });
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Regular);
+
+    // Wrap in a directory to verify content via accessor
+    pool->flushAndSetAllowDependentCreation(true);
+    auto dirSink = pool->makeDirectorySink();
+    dirSink->insertChild("file", result);
+    auto dirHash = std::move(*dirSink).flush();
+
+    pool->flushAndSetAllowDependentCreation(false);
+    auto accessor = repo->getAccessor(dirHash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("file")), "hello world");
+}
+
+TEST_F(MerkleTarAdapterTest, single_executable_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("script.sh"), true, [](Sink & sink) { sink("#!/bin/bash\necho hello"); });
+
+    auto result = tarSink->flush();
+
+    pool->flushAndSetAllowDependentCreation(false);
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("script.sh")), "#!/bin/bash\necho hello");
+}
+
+TEST_F(MerkleTarAdapterTest, single_symlink)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath::root, "target");
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Symlink);
+
+    // Wrap in a directory to verify content via accessor
+    pool->flushAndSetAllowDependentCreation(true);
+    auto dirSink = pool->makeDirectorySink();
+    dirSink->insertChild("link", result);
+    auto dirHash = std::move(*dirSink).flush();
+
+    pool->flushAndSetAllowDependentCreation(false);
+    auto accessor = repo->getAccessor(dirHash, {}, getRepoName());
+    ASSERT_EQ(accessor->readLink(CanonPath("link")), "target");
+}
+
+TEST_F(MerkleTarAdapterTest, empty_directory)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath::root);
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Directory);
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    auto entries = accessor->readDirectory(CanonPath::root);
+    ASSERT_EQ(entries.size(), 0u);
+}
+
+TEST_F(MerkleTarAdapterTest, nested_empty_directories)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath("a/b/c"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readDirectory(CanonPath("a")).size(), 1u);
+    ASSERT_EQ(accessor->readDirectory(CanonPath("a/b")).size(), 1u);
+    ASSERT_EQ(accessor->readDirectory(CanonPath("a/b/c")).size(), 0u);
+}
+
+TEST_F(MerkleTarAdapterTest, directory_with_files)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("hello.txt"), false, [](Sink & sink) { sink("hello world"); });
+    tarSink->createRegularFile(CanonPath("bye.txt"), false, [](Sink & sink) { sink("goodbye"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    auto entries = accessor->readDirectory(CanonPath::root);
+    ASSERT_EQ(entries.size(), 2u);
+    ASSERT_EQ(accessor->readFile(CanonPath("hello.txt")), "hello world");
+    ASSERT_EQ(accessor->readFile(CanonPath("bye.txt")), "goodbye");
+}
+
+TEST_F(MerkleTarAdapterTest, nested_directory_with_files)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("a/b/file.txt"), false, [](Sink & sink) { sink("nested content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("a/b/file.txt")), "nested content");
+}
+
+TEST_F(MerkleTarAdapterTest, mixed_content)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("regular file"); });
+    tarSink->createRegularFile(CanonPath("script.sh"), true, [](Sink & sink) { sink("#!/bin/bash"); });
+    tarSink->createSymlink(CanonPath("link"), "file.txt");
+    tarSink->createDirectory(CanonPath("empty"));
+    tarSink->createRegularFile(CanonPath("subdir/nested.txt"), false, [](Sink & sink) { sink("nested"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    auto entries = accessor->readDirectory(CanonPath::root);
+    ASSERT_EQ(entries.size(), 5u);
+    ASSERT_EQ(accessor->readFile(CanonPath("file.txt")), "regular file");
+    ASSERT_EQ(accessor->readFile(CanonPath("script.sh")), "#!/bin/bash");
+    ASSERT_EQ(accessor->readLink(CanonPath("link")), "file.txt");
+    ASSERT_EQ(accessor->readDirectory(CanonPath("empty")).size(), 0u);
+    ASSERT_EQ(accessor->readFile(CanonPath("subdir/nested.txt")), "nested");
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_target_not_found)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createHardlink(CanonPath("link"), CanonPath("nonexistent"));
+
+    EXPECT_THAT([&]() { tarSink->flush(); }, ::testing::ThrowsMessage<Error>(::testing::HasSubstr("not found")));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("original.txt"), false, [](Sink & sink) { sink("shared content"); });
+    tarSink->createHardlink(CanonPath("link.txt"), CanonPath("original.txt"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("original.txt")), "shared content");
+    ASSERT_EQ(accessor->readFile(CanonPath("link.txt")), "shared content");
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_executable)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("script.sh"), true, [](Sink & sink) { sink("#!/bin/bash"); });
+    tarSink->createHardlink(CanonPath("script-link.sh"), CanonPath("script.sh"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("script.sh")), "#!/bin/bash");
+    ASSERT_EQ(accessor->readFile(CanonPath("script-link.sh")), "#!/bin/bash");
+}
+
+TEST_F(MerkleTarAdapterTest, multiple_hardlinks_same_target)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("original"), false, [](Sink & sink) { sink("content"); });
+    tarSink->createHardlink(CanonPath("link1"), CanonPath("original"));
+    tarSink->createHardlink(CanonPath("link2"), CanonPath("original"));
+    tarSink->createHardlink(CanonPath("link3"), CanonPath("original"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("original")), "content");
+    ASSERT_EQ(accessor->readFile(CanonPath("link1")), "content");
+    ASSERT_EQ(accessor->readFile(CanonPath("link2")), "content");
+    ASSERT_EQ(accessor->readFile(CanonPath("link3")), "content");
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_directory_fails)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath("dir"));
+    tarSink->createHardlink(CanonPath("link"), CanonPath("dir"));
+
+    EXPECT_THAT([&]() { tarSink->flush(); }, ::testing::ThrowsMessage<Error>(::testing::HasSubstr("directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, child_of_file_fails)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("content"); });
+
+    EXPECT_THAT(
+        [&]() { tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("x"); }); },
+        ::testing::ThrowsMessage<Error>(::testing::HasSubstr("not a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, child_of_symlink_fails)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Symlink points to a valid directory, but we still can't create children under the symlink path
+    tarSink->createDirectory(CanonPath("target"));
+    tarSink->createSymlink(CanonPath("foo"), "target");
+
+    EXPECT_THAT(
+        [&]() { tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("x"); }); },
+        ::testing::ThrowsMessage<Error>(::testing::HasSubstr("not a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, explicit_directory_replaces_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Create a file at "foo"
+    tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("content"); });
+    // Explicitly replace it with a directory
+    tarSink->createDirectory(CanonPath("foo"));
+    // Now we can create children
+    tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("child content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("foo/bar")), "child content");
+}
+
+TEST_F(MerkleTarAdapterTest, large_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Create a file larger than the buffering threshold (1 MiB)
+    std::string largeContent(2 * 1024 * 1024, 'x');
+
+    tarSink->createRegularFile(CanonPath("large.bin"), false, [&](Sink & sink) { sink(largeContent); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("large.bin")), largeContent);
+}
+
+TEST_F(MerkleTarAdapterTest, many_files)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    constexpr int numFiles = 100;
+    for (int i = 0; i < numFiles; i++) {
+        auto path = CanonPath("file" + std::to_string(i) + ".txt");
+        auto content = "content " + std::to_string(i);
+        tarSink->createRegularFile(path, false, [&](Sink & sink) { sink(content); });
+    }
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    auto entries = accessor->readDirectory(CanonPath::root);
+    ASSERT_EQ(entries.size(), static_cast<size_t>(numFiles));
+
+    for (int i = 0; i < numFiles; i++) {
+        auto path = CanonPath("file" + std::to_string(i) + ".txt");
+        auto expectedContent = "content " + std::to_string(i);
+        ASSERT_EQ(accessor->readFile(path), expectedContent);
+    }
+}
+
+TEST_F(MerkleTarAdapterTest, deep_nesting)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(
+        CanonPath("a/b/c/d/e/f/g/h/file.txt"), false, [](Sink & sink) { sink("deeply nested"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("a/b/c/d/e/f/g/h/file.txt")), "deeply nested");
+}
+
+TEST_F(MerkleTarAdapterTest, directory_with_symlink_and_empty_subdir)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("content"); });
+    tarSink->createSymlink(CanonPath("link"), "file.txt");
+    tarSink->createDirectory(CanonPath("empty"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("file.txt")), "content");
+    ASSERT_EQ(accessor->readLink(CanonPath("link")), "file.txt");
+    ASSERT_EQ(accessor->readDirectory(CanonPath("empty")).size(), 0u);
+}
+
+// Tests for "last wins" tar semantics - when a path appears multiple times,
+// the last entry should win.
+
+TEST_F(MerkleTarAdapterTest, last_wins_file_overwrites_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("first content"); });
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("second content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("file.txt")), "second content");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_file_overwrites_symlink)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath("entry"), "some-target");
+    tarSink->createRegularFile(CanonPath("entry"), false, [](Sink & sink) { sink("file content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("entry")), "file content");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_symlink_overwrites_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("entry"), false, [](Sink & sink) { sink("file content"); });
+    tarSink->createSymlink(CanonPath("entry"), "new-target");
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readLink(CanonPath("entry")), "new-target");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_symlink_overwrites_symlink)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath("link"), "first-target");
+    tarSink->createSymlink(CanonPath("link"), "second-target");
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readLink(CanonPath("link")), "second-target");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_executable_changes)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("script"), false, [](Sink & sink) { sink("content"); });
+    tarSink->createRegularFile(CanonPath("script"), true, [](Sink & sink) { sink("content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    // The file should be executable now (mode change)
+    // We can verify content is there; checking executable bit would need different API
+    ASSERT_EQ(accessor->readFile(CanonPath("script")), "content");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_nested_file_overwrites)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("a/b/file.txt"), false, [](Sink & sink) { sink("first"); });
+    tarSink->createRegularFile(CanonPath("a/b/file.txt"), false, [](Sink & sink) { sink("second"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("a/b/file.txt")), "second");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_at_root)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath::root, "first-target");
+    tarSink->createSymlink(CanonPath::root, "second-target");
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Symlink);
+
+    // Wrap to verify
+    pool->flushAndSetAllowDependentCreation(true);
+    auto dirSink = pool->makeDirectorySink();
+    dirSink->insertChild("link", result);
+    auto dirHash = std::move(*dirSink).flush();
+
+    pool->flushAndSetAllowDependentCreation(false);
+    auto accessor = repo->getAccessor(dirHash, {}, getRepoName());
+    ASSERT_EQ(accessor->readLink(CanonPath("link")), "second-target");
+}
+
+// Property-based test: last entry for each path wins
+RC_GTEST_FIXTURE_PROP(MerkleTarAdapterTest, last_wins_property, ())
+{
+    // Generate a list of (path, content) pairs where paths may repeat
+    auto pathNames = *rc::gen::container<std::vector<std::string>>(
+        rc::gen::element(std::string("a"), std::string("b"), std::string("c")));
+
+    RC_PRE(!pathNames.empty());
+
+    auto entries = *rc::gen::container<std::vector<std::pair<std::string, std::string>>>(
+        rc::gen::pair(rc::gen::elementOf(pathNames), rc::gen::arbitrary<std::string>()));
+
+    RC_PRE(!entries.empty());
+
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Track what the final content should be for each path
+    std::map<std::string, std::string> expected;
+
+    for (auto & [path, content] : entries) {
+        tarSink->createRegularFile(CanonPath(path), false, [&](Sink & sink) { sink(content); });
+        expected[path] = content; // Last write wins
+    }
+
+    auto result = tarSink->flush();
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+
+    // Verify each path has its expected final content
+    for (auto & [path, content] : expected) {
+        RC_ASSERT(accessor->readFile(CanonPath(path)) == content);
+    }
+}
+
+} // namespace nix

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -43,6 +43,7 @@ sources = files(
   'git-utils.cc',
   'git.cc',
   'input.cc',
+  'merkle-tar-adapter.cc',
   'nix_api_fetchers.cc',
   'public-key.cc',
 )

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -485,15 +485,17 @@ void InputScheme::clone(
 
     Activity act(*logger, lvlTalkative, actUnknown, fmt("copying '%s' to %s...", input2.to_string(), PathFmt(destDir)));
 
-    auto dirFd = openDirectory(destDir.parent_path(), FinalSymlink::Follow);
-    if (!dirFd)
-        throw SysError("opening parent directory of %s", PathFmt(destDir));
-    RestoreSink sink{
-        RestoreSink::DirFdParent{OsFilename{destDir.filename()}},
-        std::move(dirFd),
-        /*startFsync=*/false,
-    };
-    copyRecursive(*accessor, CanonPath::root, sink, CanonPath::root);
+    /* This is used with an arbitrary user-given path (just `nix flake
+       clone` currently) and so we better follow any symlinks. */
+    auto absPath = std::filesystem::absolute(destDir);
+    auto parentPath = absPath.parent_path();
+
+    auto parentDirFd = openDirectory(parentPath, FinalSymlink::Follow);
+    if (!parentDirFd)
+        throw NativeSysError("opening directory %s", PathFmt(parentPath));
+
+    RestoreSink sink{parentDirFd.get(), absPath.filename(), /*startFsync=*/false};
+    copyRecursive(*accessor, CanonPath::root, sink);
 }
 
 std::optional<ExperimentalFeature> InputScheme::experimentalFeature() const

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -485,8 +485,14 @@ void InputScheme::clone(
 
     Activity act(*logger, lvlTalkative, actUnknown, fmt("copying '%s' to %s...", input2.to_string(), PathFmt(destDir)));
 
-    RestoreSink sink(/*startFsync=*/false);
-    sink.dstPath = destDir;
+    auto dirFd = openDirectory(destDir.parent_path(), FinalSymlink::Follow);
+    if (!dirFd)
+        throw SysError("opening parent directory of %s", PathFmt(destDir));
+    RestoreSink sink{
+        RestoreSink::DirFdParent{OsFilename{destDir.filename()}},
+        std::move(dirFd),
+        /*startFsync=*/false,
+    };
     copyRecursive(*accessor, CanonPath::root, sink, CanonPath::root);
 }
 

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1060,10 +1060,15 @@ struct GitRepoHandle
 {
     std::variant<Pool<GitRepoImpl>::Handle, ref<GitRepoImpl>> inner;
 
-    GitRepoImpl & operator*() {
+    GitRepoImpl & operator*()
+    {
         return std::visit([](auto & h) -> GitRepoImpl & { return *h; }, inner);
     }
-    GitRepoImpl * operator->() { return &**this; }
+
+    GitRepoImpl * operator->()
+    {
+        return &**this;
+    }
 };
 
 struct GitRegularFileSinkImpl : merkle::RegularFileSinkWithFlush
@@ -1188,9 +1193,8 @@ ref<merkle::DirectorySinkWithFlush> GitRepoImpl::makeDirectorySink()
 
 ref<merkle::RegularFileSinkWithFlush> GitRepoImpl::makeRegularFileSink()
 {
-    return make_ref<GitRegularFileSinkImpl>([self = ref<GitRepoImpl>(shared_from_this())]() -> GitRepoHandle {
-        return {self};
-    });
+    return make_ref<GitRegularFileSinkImpl>(
+        [self = ref<GitRepoImpl>(shared_from_this())]() -> GitRepoHandle { return {self}; });
 }
 
 ref<GitSourceAccessor> GitRepoImpl::getRawAccessor(const Hash & rev, const GitAccessorOptions & options)
@@ -1397,7 +1401,6 @@ struct GitRepoPoolImpl : GitRepoPool
 
         return done.size();
     }
-
 };
 
 ref<GitRepoPool> GitRepoPool::create(const std::filesystem::path & path, GitRepo::Options options)

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -253,6 +253,8 @@ static void initRepoAtomically(std::filesystem::path & path, GitRepo::Options op
     delTmpDir.cancel();
 }
 
+struct GitDirectorySinkImpl;
+
 struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 {
     /** Location of the repository on disk. */
@@ -263,7 +265,8 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
     /**
      * libgit2 repository. Note that new objects are not written to disk,
      * because we are using a mempack backend. For writing to disk, see
-     * `flush()`, which is also called by `GitFileSystemObjectSink::sync()`.
+     * `flush()`, which is also called by `flush()` on the various merkle file
+     * interfaces.
      */
     Repository repo;
 
@@ -382,78 +385,8 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         checkInterrupt();
     }
 
-    /**
-     * Return a connection pool for this repo. Useful for
-     * multithreaded access.
-     */
-    Pool<GitRepoImpl> getPool()
-    {
-        // TODO: as an optimization, it would be nice to include `this` in the pool.
-        return Pool<GitRepoImpl>(std::numeric_limits<size_t>::max(), [this]() -> ref<GitRepoImpl> {
-            auto repo = make_ref<GitRepoImpl>(path, options);
-
-            /* Monkey-patching the pack backend to only read the pack directory
-               once. Otherwise it will do a readdir for each added oid when it's
-               not found and that translates to ~6 syscalls. Since we are never
-               writing pack files until flushing we can force the odb backend to
-               read the directory just once. It's very convenient that the vtable is
-               semi-public interface and is up for grabs.
-
-               This is purely an optimization for our use-case with a tarball cache.
-               libgit2 calls refresh() if the backend provides it when an oid isn't found.
-               We are only writing objects to a mempack (it has higher priority) and there isn't
-               a realistic use-case where a previously missing object would appear from thin air
-               on the disk (unless another process happens to be unpacking a similar tarball to
-               the cache at the same time, but that's a very unrealistic scenario).
-            */
-            if (auto * backend = repo->packBackend)
-                backend->refresh = nullptr;
-
-            return repo;
-        });
-    }
-
-    uint64_t getRevCount(const Hash & rev) override
-    {
-        boost::concurrent_flat_set<git_oid, std::hash<git_oid>> done;
-
-        auto startCommit = peelObject<Commit>(lookupObject(*this, hashToOID(rev)).get(), GIT_OBJECT_COMMIT);
-        auto startOid = *git_commit_id(startCommit.get());
-        done.insert(startOid);
-
-        auto repoPool(getPool());
-
-        ThreadPool pool;
-
-        auto process = [&done, &pool, &repoPool](this const auto & process, const git_oid & oid) -> void {
-            auto repo(repoPool.get());
-
-            auto _commit = lookupObject(*repo, oid, GIT_OBJECT_COMMIT);
-            auto commit = (const git_commit *) &*_commit;
-
-            for (auto n : std::views::iota(0U, git_commit_parentcount(commit))) {
-                auto parentOid = git_commit_parent_id(commit, n);
-                if (!parentOid) {
-                    throw Error(
-                        "Failed to retrieve the parent of Git commit '%s': %s. "
-                        "This may be due to an incomplete repository history. "
-                        "To resolve this, either enable the shallow parameter in your flake URL (?shallow=1) "
-                        "or add set the shallow parameter to true in builtins.fetchGit, "
-                        "or fetch the complete history for this branch.",
-                        *git_commit_id(commit),
-                        git_error_last()->message);
-                }
-                if (done.insert(*parentOid))
-                    pool.enqueue(std::bind(process, *parentOid));
-            }
-        };
-
-        pool.enqueue(std::bind(process, startOid));
-
-        pool.process();
-
-        return done.size();
-    }
+    ref<merkle::DirectorySinkWithFlush> makeDirectorySink() override;
+    ref<merkle::RegularFileSinkWithFlush> makeRegularFileSink() override;
 
     uint64_t getLastModified(const Hash & rev) override
     {
@@ -624,8 +557,6 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
     ref<SourceAccessor>
     getAccessor(const WorkdirInfo & wd, const GitAccessorOptions & options, MakeNotAllowedError e) override;
-
-    ref<GitFileSystemObjectSink> getFileSystemObjectSink() override;
 
     void fetch(const std::string & url, const std::string & refspec, bool shallow) override
     {
@@ -1119,300 +1050,148 @@ struct GitExportIgnoreSourceAccessor : CachingFilteringSourceAccessor
     }
 };
 
-struct GitFileSystemObjectSinkImpl : GitFileSystemObjectSink
+/**
+ * A handle to a `GitRepoImpl` that is either borrowed from a pool
+ * (independent phase) or references a single shared repo (dependent
+ * phase). The pool handle, if any, is returned to the pool on
+ * destruction.
+ */
+struct GitRepoHandle
 {
-    ref<GitRepoImpl> repo;
+    std::variant<Pool<GitRepoImpl>::Handle, ref<GitRepoImpl>> inner;
 
-    Pool<GitRepoImpl> repoPool;
+    GitRepoImpl & operator*() {
+        return std::visit([](auto & h) -> GitRepoImpl & { return *h; }, inner);
+    }
+    GitRepoImpl * operator->() { return &**this; }
+};
 
-    unsigned int concurrency = std::min(std::thread::hardware_concurrency(), 10U);
+struct GitRegularFileSinkImpl : merkle::RegularFileSinkWithFlush
+{
+    using WriteStream = std::unique_ptr<git_writestream, decltype([](git_writestream * stream) {
+                                            if (stream)
+                                                stream->free(stream);
+                                        })>;
 
-    ThreadPool workers{concurrency};
+    std::function<GitRepoHandle()> getRepo;
 
-    /** Total file contents in flight. */
-    std::atomic<size_t> totalBufSize{0};
+    /**
+     * Writer acquired lazily. Only set when we have a stream (large file).
+     */
+    std::optional<GitRepoHandle> writer;
 
-    static constexpr std::size_t maxBufSize = 16 * 1024 * 1024;
+    /**
+     * In-memory buffer for small files.
+     */
+    std::string contents;
 
-    GitFileSystemObjectSinkImpl(ref<GitRepoImpl> repo)
-        : repo(repo)
-        , repoPool(repo->getPool())
+    /**
+     * Stream for large files. Only created when contents exceeds maxBufferSize.
+     */
+    WriteStream stream;
+
+    /**
+     * Maximum file size that gets buffered in memory before flushing to a
+     * git_writestream backed by a temporary objects/streamed_git2_* file.
+     * We should avoid that for common cases, since creating (and deleting)
+     * a temporary file for each blob is expensive.
+     */
+    static constexpr std::size_t maxBufferSize = 1024 * 1024; /* 1 MiB */
+
+    GitRegularFileSinkImpl(std::function<GitRepoHandle()> getRepo)
+        : getRepo(std::move(getRepo))
     {
     }
 
-    ~GitFileSystemObjectSinkImpl()
+    void writeToStream(git_writestream & stream, std::string_view data)
     {
-        // Make sure the worker threads are destroyed before any state
-        // they're referring to.
-        workers.shutdown();
+        if (stream.write(&stream, data.data(), data.size()))
+            throw GitError("writing to blob stream");
     }
 
-    struct Child;
-
-    /// A directory to be written as a Git tree.
-    struct Directory
+    void operator()(std::string_view data) override
     {
-        std::map<std::string, Child> children;
-        std::optional<git_oid> oid;
-
-        Child & lookup(const CanonPath & path)
-        {
-            assert(!path.isRoot());
-            auto parent = path.parent();
-            auto cur = this;
-            for (auto & name : *parent) {
-                auto i = cur->children.find(std::string(name));
-                if (i == cur->children.end())
-                    throw Error("path '%s' does not exist", path);
-                auto dir = std::get_if<Directory>(&i->second.file);
-                if (!dir)
-                    throw Error("path '%s' has a non-directory parent", path);
-                cur = dir;
-            }
-
-            auto i = cur->children.find(std::string(*path.baseName()));
-            if (i == cur->children.end())
-                throw Error("path '%s' does not exist", path);
-            return i->second;
-        }
-    };
-
-    size_t nextId = 0; // for Child.id
-
-    struct Child
-    {
-        git_filemode_t mode;
-        std::variant<Directory, git_oid> file;
-
-        /// Sequential numbering of the file in the tarball. This is
-        /// used to make sure we only import the latest version of a
-        /// path.
-        size_t id{0};
-    };
-
-    struct State
-    {
-        Directory root;
-    };
-
-    Sync<State> _state;
-
-    void addNode(State & state, const CanonPath & path, Child && child)
-    {
-        assert(!path.isRoot());
-        auto parent = path.parent();
-
-        Directory * cur = &state.root;
-
-        for (auto & i : *parent) {
-            auto child = std::get_if<Directory>(
-                &cur->children.emplace(std::string(i), Child{GIT_FILEMODE_TREE, {Directory()}}).first->second.file);
-            assert(child);
-            cur = child;
+        /* Already in slow path. Just write to the stream. */
+        if (stream) {
+            writeToStream(*stream, data);
+            return;
         }
 
-        std::string name(*path.baseName());
-
-        if (auto prev = cur->children.find(name); prev == cur->children.end() || prev->second.id < child.id)
-            cur->children.insert_or_assign(name, std::move(child));
+        contents += data;
+        if (contents.size() > maxBufferSize) {
+            /* Lazily acquire a writer and create the stream. */
+            writer.emplace(getRepo());
+            git_writestream * streamRaw = nullptr;
+            if (git_blob_create_from_stream(&streamRaw, **writer, nullptr))
+                throw GitError("creating blob stream");
+            stream = WriteStream{streamRaw};
+            writeToStream(*stream, contents);
+            contents.clear();
+        }
     }
 
-    void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func) override
+    Hash flush() && override
     {
-        checkInterrupt();
+        git_oid oid;
 
-        /* Multithreaded blob writing. We read the incoming file data into memory and asynchronously write it to a Git
-           blob object. However, to avoid unbounded memory usage, if the amount of data in flight exceeds a threshold,
-           we switch to writing directly to a Git write stream. */
-
-        using WriteStream = std::unique_ptr<::git_writestream, decltype([](::git_writestream * stream) {
-                                                if (stream)
-                                                    stream->free(stream);
-                                            })>;
-
-        struct CRF : CreateRegularFileSink
-        {
-            CanonPath path;
-            GitFileSystemObjectSinkImpl & parent;
-            WriteStream stream;
-            std::optional<decltype(parent.repoPool)::Handle> repo;
-
-            std::string contents;
-            bool executable = false;
-
-            CRF(CanonPath path, GitFileSystemObjectSinkImpl & parent)
-                : path(std::move(path))
-                , parent(parent)
-            {
-            }
-
-            ~CRF()
-            {
-                parent.totalBufSize -= contents.size();
-            }
-
-            void operator()(std::string_view data) override
-            {
-                if (!stream) {
-                    contents.append(data);
-                    parent.totalBufSize += data.size();
-
-                    if (parent.totalBufSize > parent.maxBufSize) {
-                        repo.emplace(parent.repoPool.get());
-
-                        if (git_blob_create_from_stream(Setter(stream), **repo, nullptr))
-                            throw GitError("creating a blob stream object");
-
-                        if (stream->write(stream.get(), contents.data(), contents.size()))
-                            throw GitError("writing a blob for tarball member '%s'", path);
-
-                        parent.totalBufSize -= contents.size();
-                        contents.clear();
-                    }
-                } else {
-                    if (stream->write(stream.get(), data.data(), data.size()))
-                        throw GitError("writing a blob for tarball member '%s'", path);
-                }
-            }
-
-            void isExecutable() override
-            {
-                executable = true;
-            }
-        };
-
-        auto crf = std::make_shared<CRF>(path, *this);
-
-        func(*crf);
-
-        auto id = nextId++;
-
-        if (crf->stream) {
-            /* Finish the slow path by creating the blob object synchronously.
-               Call .release(), since git_blob_create_from_stream_commit
+        if (stream) {
+            /* Large file: finalize the stream we created earlier. */
+            assert(writer);
+            /* Call .release(), since git_blob_create_from_stream_commit
                acquires ownership and frees the stream. */
-            git_oid oid;
-            if (git_blob_create_from_stream_commit(&oid, crf->stream.release()))
-                throw GitError("creating a blob object for '%s'", path);
-            addNode(
-                *_state.lock(),
-                crf->path,
-                Child{crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB, oid, id});
-            return;
+            if (git_blob_create_from_stream_commit(&oid, stream.release()))
+                throw GitError("finalizing blob stream");
+            writer.reset();
+        } else {
+            /* Small file: get a repo and create blob from buffer. */
+            auto handle = getRepo();
+            if (git_blob_create_from_buffer(&oid, *handle, contents.data(), contents.size()))
+                throw GitError("creating blob from buffer");
         }
 
-        /* Fast path: create the blob object in a separate thread. */
-        workers.enqueue([this, crf{std::move(crf)}, id]() {
-            auto repo(repoPool.get());
-
-            git_oid oid;
-            if (git_blob_create_from_buffer(&oid, *repo, crf->contents.data(), crf->contents.size()))
-                throw GitError("creating a blob object for '%s' from in-memory buffer", crf->path);
-
-            addNode(
-                *_state.lock(),
-                crf->path,
-                Child{crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB, oid, id});
-        });
-    }
-
-    void createDirectory(const CanonPath & path) override
-    {
-        if (path.isRoot())
-            return;
-        auto state(_state.lock());
-        addNode(*state, path, {GIT_FILEMODE_TREE, Directory()});
-    }
-
-    void createSymlink(const CanonPath & path, const std::string & target) override
-    {
-        workers.enqueue([this, path, target]() {
-            auto repo(repoPool.get());
-
-            git_oid oid;
-            if (git_blob_create_from_buffer(&oid, *repo, target.c_str(), target.size()))
-                throw GitError("creating a blob object for tarball symlink member '%s'", path);
-
-            auto state(_state.lock());
-            addNode(*state, path, Child{GIT_FILEMODE_LINK, oid});
-        });
-    }
-
-    std::map<CanonPath, CanonPath> hardLinks;
-
-    void createHardlink(const CanonPath & path, const CanonPath & target) override
-    {
-        hardLinks.insert_or_assign(path, target);
-    }
-
-    Hash flush() override
-    {
-        workers.process();
-
-        /* Create hard links. */
-        {
-            auto state(_state.lock());
-            for (auto & [path, target] : hardLinks) {
-                if (target.isRoot())
-                    continue;
-                try {
-                    auto child = state->root.lookup(target);
-                    auto oid = std::get_if<git_oid>(&child.file);
-                    if (!oid)
-                        throw Error("cannot create a hard link to a directory");
-                    addNode(*state, path, {child.mode, *oid});
-                } catch (Error & e) {
-                    e.addTrace(nullptr, "while creating a hard link from '%s' to '%s'", path, target);
-                    throw;
-                }
-            }
-        }
-
-        // Flush all repo objects to disk.
-        {
-            auto repos = repoPool.clear();
-            ThreadPool workers{repos.size()};
-            for (auto & repo : repos)
-                workers.enqueue([repo]() { repo->flush(); });
-            workers.process();
-        }
-
-        // Write the Git trees to disk. Would be nice to have this multithreaded too, but that's hard because a tree
-        // can't refer to an object that hasn't been written yet. Also it doesn't make a big difference for performance.
-        auto repo(repoPool.get());
-
-        [&](this const auto & visit, Directory & node) -> void {
-            checkInterrupt();
-
-            // Write the child directories.
-            for (auto & child : node.children)
-                if (auto dir = std::get_if<Directory>(&child.second.file))
-                    visit(*dir);
-
-            // Write this directory.
-            git_treebuilder * b;
-            if (git_treebuilder_new(&b, *repo, nullptr))
-                throw GitError("creating a tree builder");
-            TreeBuilder builder(b);
-
-            for (auto & [name, child] : node.children) {
-                auto oid_p = std::get_if<git_oid>(&child.file);
-                auto oid = oid_p ? *oid_p : std::get<Directory>(child.file).oid.value();
-                if (git_treebuilder_insert(nullptr, builder.get(), name.c_str(), &oid, child.mode))
-                    throw GitError("adding a file to a tree builder");
-            }
-
-            git_oid oid;
-            if (git_treebuilder_write(&oid, builder.get()))
-                throw GitError("creating a tree object");
-            node.oid = oid;
-        }(_state.lock()->root);
-
-        repo->flush();
-
-        return toHash(_state.lock()->root.oid.value());
+        return toHash(oid);
     }
 };
+
+struct GitDirectorySinkImpl : merkle::DirectorySinkWithFlush
+{
+    TreeBuilder builder;
+
+    GitDirectorySinkImpl(GitRepoImpl & repo)
+    {
+        git_treebuilder * b;
+        if (git_treebuilder_new(&b, repo, nullptr))
+            throw GitError("creating a tree builder");
+        builder = TreeBuilder(b);
+    }
+
+    void insertChild(std::string_view name, merkle::TreeEntry entry) override
+    {
+        auto oid = hashToOID(entry.hash);
+        git_treebuilder_insert(
+            nullptr, builder.get(), std::string(name).c_str(), &oid, static_cast<git_filemode_t>(entry.mode));
+    }
+
+    Hash flush() && override
+    {
+        git_oid oid;
+        if (git_treebuilder_write(&oid, builder.get()))
+            throw GitError("creating a tree object");
+        return toHash(oid);
+    }
+};
+
+ref<merkle::DirectorySinkWithFlush> GitRepoImpl::makeDirectorySink()
+{
+    return make_ref<GitDirectorySinkImpl>(*this);
+}
+
+ref<merkle::RegularFileSinkWithFlush> GitRepoImpl::makeRegularFileSink()
+{
+    return make_ref<GitRegularFileSinkImpl>([self = ref<GitRepoImpl>(shared_from_this())]() -> GitRepoHandle {
+        return {self};
+    });
+}
 
 ref<GitSourceAccessor> GitRepoImpl::getRawAccessor(const Hash & rev, const GitAccessorOptions & options)
 {
@@ -1448,9 +1227,182 @@ ref<SourceAccessor> GitRepoImpl::getAccessor(
     return fileAccessor;
 }
 
-ref<GitFileSystemObjectSink> GitRepoImpl::getFileSystemObjectSink()
+/**
+ * A pool of `GitRepoImpl` instances for parallel merkle object writing.
+ *
+ * libgit2 repositories are not thread-safe, so concurrent writes
+ * require separate repository handles. This pool manages those handles.
+ *
+ * When `disablePackRefresh` is true. Monkey-patch, the pack backend to
+ * only read the pack directory once. Otherwise it will do a readdir for
+ * each added oid when it's not found and that translates to ~6
+ * syscalls. Since we are never writing pack files until flushing we can
+ * force the odb backend to read the directory just once. It's very
+ * convenient that the vtable is semi-public interface and is up for
+ * grabs.
+ *
+ * This is purely an optimization for when we are writing independent
+ * data concurrently. For example, when we are only writing blobs to the
+ * git repo. Blobs are leaf nodes which cannot reference other objects,
+ * and so there is far less need for synchronisation.
+ *
+ * `flushAndSetAllowDependentCreation(true)` flushes all idle pool
+ * members to disk, reinitializes the directory repo handle so it can
+ * see the newly written packfiles, and clears the flag so that
+ * subsequently created pool members get the normal `refresh` behavior.
+ *
+ * This comes up in our use-case of the tarball cache. We write all the
+ * files from the tarball to git, and only then write the directories.
+ * When writing files, libgit2 calls refresh() if the backend provides
+ * it when an oid isn't found. We are only writing objects to a mempack
+ * (it has higher priority) and there isn't a realistic use-case where a
+ * previously missing object would appear from thin air on the disk
+ * (unless another process happens to be unpacking a similar tarball to
+ * the cache at the same time, but that's a very unrealistic scenario).
+ * After we're done writing the files, we call
+ * `flushAndSetAllowDependentCreation(true)` and write the directories
+ * to a single dedicated repo handle (`singleRepo`).
+ */
+struct GitRepoPoolImpl : GitRepoPool
 {
-    return make_ref<GitFileSystemObjectSinkImpl>(ref<GitRepoImpl>(shared_from_this()));
+    std::filesystem::path path;
+    GitRepo::Options options;
+
+    /**
+     * When true, new pool members have `refresh` disabled on their
+     * pack backend. Cleared by `flushAndSetAllowDependentCreation(true)`.
+     */
+    bool disablePackRefresh = true;
+
+    Pool<GitRepoImpl> pool;
+
+    /**
+     * Single repo handle used when `flushAndSetAllowDependentCreation(true)`.
+     * All sinks share this handle, avoiding per-sink pool overhead and
+     * extra packfile flushes. Only initialized once dependent creation
+     * is allowed.
+     */
+    std::shared_ptr<GitRepoImpl> singleRepo;
+
+    GitRepoHandle getRepo()
+    {
+        if (singleRepo)
+            return {ref<GitRepoImpl>(singleRepo)};
+        return {pool.get()};
+    }
+
+    GitRepoPoolImpl(const std::filesystem::path & path, GitRepo::Options options)
+        : path(path)
+        , options(options)
+        , pool(std::numeric_limits<size_t>::max(), [this]() -> ref<GitRepoImpl> {
+            auto repo = make_ref<GitRepoImpl>(this->path, this->options);
+
+            if (disablePackRefresh) {
+                /* Null out the pack backend's refresh callback so that
+                   libgit2 only reads the pack directory once (on first
+                   use) instead of re-scanning on every cache miss.
+                   The vtable is semi-public interface in libgit2.
+
+                   @see GitRepoPoolImpl for context on why we do this.
+                 */
+                if (auto * backend = repo->packBackend)
+                    backend->refresh = nullptr;
+            }
+
+            return repo;
+        })
+    {
+    }
+
+    void flushAndSetAllowDependentCreation(bool allow) override
+    {
+        auto repos = pool.clear();
+        ThreadPool workers{repos.size()};
+        for (auto & repo : repos)
+            workers.enqueue([repo]() { repo->flush(); });
+        workers.process();
+
+        if (allow) {
+            // Initialize singleRepo so it can see packfiles just written.
+            singleRepo = make_ref<GitRepoImpl>(path, options);
+        } else {
+            // Flush the directory repo's mempack to disk.
+            if (singleRepo)
+                singleRepo->flush();
+            singleRepo.reset();
+        }
+
+        disablePackRefresh = !allow;
+    }
+
+    ref<merkle::DirectorySinkWithFlush> makeDirectorySink() override
+    {
+        assert(singleRepo);
+        return singleRepo->makeDirectorySink();
+    }
+
+    ref<merkle::RegularFileSinkWithFlush> makeRegularFileSink() override
+    {
+        if (singleRepo)
+            return singleRepo->makeRegularFileSink();
+        return make_ref<GitRegularFileSinkImpl>([this]() { return getRepo(); });
+    }
+
+    merkle::TreeEntry makeSymlink(const std::string & target) override
+    {
+        auto handle = getRepo();
+        git_oid oid;
+        if (git_blob_create_from_buffer(&oid, *handle, target.data(), target.size()))
+            throw GitError("creating a blob object for symlink");
+        return merkle::TreeEntry{merkle::Mode::Symlink, toHash(oid)};
+    }
+
+    uint64_t getRevCount(const Hash & rev) override
+    {
+        boost::concurrent_flat_set<git_oid, std::hash<git_oid>> done;
+
+        auto startRepo = pool.get();
+        auto startCommit = peelObject<Commit>(lookupObject(*startRepo, hashToOID(rev)).get(), GIT_OBJECT_COMMIT);
+        auto startOid = *git_commit_id(startCommit.get());
+        done.insert(startOid);
+
+        ThreadPool threadPool;
+
+        auto process = [&done, &threadPool, &pool = pool](this const auto & process, const git_oid & oid) -> void {
+            auto repo(pool.get());
+
+            auto _commit = lookupObject(*repo, oid, GIT_OBJECT_COMMIT);
+            auto commit = (const git_commit *) &*_commit;
+
+            for (auto n : std::views::iota(0U, git_commit_parentcount(commit))) {
+                auto parentOid = git_commit_parent_id(commit, n);
+                if (!parentOid) {
+                    throw Error(
+                        "Failed to retrieve the parent of Git commit '%s': %s. "
+                        "This may be due to an incomplete repository history. "
+                        "To resolve this, either enable the shallow parameter in your flake URL (?shallow=1) "
+                        "or add set the shallow parameter to true in builtins.fetchGit, "
+                        "or fetch the complete history for this branch.",
+                        *git_commit_id(commit),
+                        git_error_last()->message);
+                }
+                if (done.insert(*parentOid))
+                    threadPool.enqueue(std::bind(process, *parentOid));
+            }
+        };
+
+        threadPool.enqueue(std::bind(process, startOid));
+
+        threadPool.process();
+
+        return done.size();
+    }
+
+};
+
+ref<GitRepoPool> GitRepoPool::create(const std::filesystem::path & path, GitRepo::Options options)
+{
+    return make_ref<GitRepoPoolImpl>(path, options);
 }
 
 std::vector<std::tuple<GitRepoImpl::Submodule, Hash>> GitRepoImpl::getSubmodules(const Hash & rev, bool exportIgnore)
@@ -1489,14 +1441,22 @@ std::vector<std::tuple<GitRepoImpl::Submodule, Hash>> GitRepoImpl::getSubmodules
 
 namespace fetchers {
 
+static std::filesystem::path tarballCacheDir()
+{
+    static auto repoDir = std::filesystem::path(getCacheDir()) / "tarball-cache-v2";
+    return repoDir;
+}
+
+static constexpr GitRepo::Options tarballCacheOptions{.create = true, .bare = true, .packfilesOnly = true};
+
 ref<GitRepo> Settings::getTarballCache() const
 {
-    /* v1: Had either only loose objects or thin packfiles referring to loose objects
-     * v2: Must have only packfiles with no loose objects. Should get repacked periodically
-     * for optimal packfiles.
-     */
-    static auto repoDir = std::filesystem::path(getCacheDir()) / "tarball-cache-v2";
-    return GitRepo::openRepo(repoDir, {.create = true, .bare = true, .packfilesOnly = true});
+    return GitRepo::openRepo(tarballCacheDir(), tarballCacheOptions);
+}
+
+ref<GitRepoPool> Settings::getTarballWriterPool() const
+{
+    return GitRepoPool::create(tarballCacheDir(), tarballCacheOptions);
 }
 
 } // namespace fetchers

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -733,7 +733,7 @@ struct GitInputScheme : InputScheme
         Activity act(
             *logger, lvlChatty, actUnknown, fmt("getting Git revision count of '%s'", repoInfo.locationToArg()));
 
-        auto revCount = GitRepo::openRepo(repoDir, {})->getRevCount(rev);
+        auto revCount = GitRepoPool::create(repoDir, {})->getRevCount(rev);
 
         cache->upsert(key, Attrs{{"revCount", revCount}});
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -9,6 +9,7 @@
 #include "nix/fetchers/tarball.hh"
 #include "nix/util/tarfile.hh"
 #include "nix/fetchers/git-utils.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
 
 #include <optional>
 #include <nlohmann/json.hpp>
@@ -307,14 +308,15 @@ struct GitArchiveInputScheme : InputScheme
 
         TarArchive archive{*source};
         auto tarballCache = settings.getTarballCache();
-        auto parseSink = tarballCache->getFileSystemObjectSink();
+        auto writerPool = settings.getTarballWriterPool();
+        auto parseSink = merkle::makeTarSink(*writerPool);
         auto lastModified = unpackTarfileToSink(archive, *parseSink);
         auto tree = parseSink->flush();
 
         act.reset();
 
         TarballInfo tarballInfo{
-            .treeHash = tarballCache->dereferenceSingletonDirectory(tree), .lastModified = lastModified};
+            .treeHash = tarballCache->dereferenceSingletonDirectory(tree.hash), .lastModified = lastModified};
 
         cache->upsert(treeHashKey, Attrs{{"treeHash", tarballInfo.treeHash.gitRev()}});
         cache->upsert(lastModifiedKey, Attrs{{"lastModified", (uint64_t) tarballInfo.lastModified}});

--- a/src/libfetchers/include/nix/fetchers/fetch-settings.hh
+++ b/src/libfetchers/include/nix/fetchers/fetch-settings.hh
@@ -14,8 +14,9 @@
 namespace nix {
 
 struct GitRepo;
+struct GitRepoPool;
 
-}
+} // namespace nix
 
 namespace nix::fetchers {
 
@@ -151,6 +152,8 @@ struct Settings : public Config
     ref<Cache> getCache() const;
 
     ref<GitRepo> getTarballCache() const;
+
+    ref<GitRepoPool> getTarballWriterPool() const;
 
 private:
     mutable Sync<std::shared_ptr<Cache>> _cache;

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "nix/fetchers/filtering-source-accessor.hh"
-#include "nix/util/fs-sink.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
 
 namespace nix {
 
@@ -9,18 +9,6 @@ namespace fetchers {
 struct PublicKey;
 struct Settings;
 } // namespace fetchers
-
-/**
- * A sink that writes into a Git repository. Note that nothing may be written
- * until `flush()` is called.
- */
-struct GitFileSystemObjectSink : ExtendedFileSystemObjectSink
-{
-    /**
-     * Flush builder and return a final Git hash.
-     */
-    virtual Hash flush() = 0;
-};
 
 struct GitAccessorOptions
 {
@@ -30,7 +18,7 @@ struct GitAccessorOptions
 
 struct GitRepo
 {
-    virtual ~GitRepo() {}
+    virtual ~GitRepo() = default;
 
     struct Options
     {
@@ -40,8 +28,6 @@ struct GitRepo
     };
 
     static ref<GitRepo> openRepo(const std::filesystem::path & path, Options options);
-
-    virtual uint64_t getRevCount(const Hash & rev) = 0;
 
     virtual uint64_t getLastModified(const Hash & rev) = 0;
 
@@ -107,9 +93,10 @@ struct GitRepo
     virtual ref<SourceAccessor> getAccessor(
         const WorkdirInfo & wd, const GitAccessorOptions & options, MakeNotAllowedError makeNotAllowedError) = 0;
 
-    virtual ref<GitFileSystemObjectSink> getFileSystemObjectSink() = 0;
-
     virtual void flush() = 0;
+
+    virtual ref<merkle::DirectorySinkWithFlush> makeDirectorySink() = 0;
+    virtual ref<merkle::RegularFileSinkWithFlush> makeRegularFileSink() = 0;
 
     virtual void fetch(const std::string & url, const std::string & refspec, bool shallow) = 0;
 
@@ -131,6 +118,15 @@ struct GitRepo
      * Otherwise, return the passed ID unchanged.
      */
     virtual Hash dereferenceSingletonDirectory(const Hash & oid) = 0;
+};
+
+struct GitRepoPool : merkle::FileSinkBuilder
+{
+    virtual ~GitRepoPool() = default;
+
+    static ref<GitRepoPool> create(const std::filesystem::path & path, GitRepo::Options options);
+
+    virtual uint64_t getRevCount(const Hash & rev) = 0;
 };
 
 // A helper to ensure that the `git_*_free` functions get called.

--- a/src/libfetchers/include/nix/fetchers/merkle-tar-adapter.hh
+++ b/src/libfetchers/include/nix/fetchers/merkle-tar-adapter.hh
@@ -1,0 +1,77 @@
+#pragma once
+///@file
+
+#include "nix/util/merkle-files.hh"
+#include "nix/util/ref.hh"
+#include "nix/util/tarfile.hh"
+
+namespace nix::merkle {
+
+/**
+ * A merkle regular file sink that can be flushed to get the content hash.
+ */
+struct RegularFileSinkWithFlush : virtual Sink
+{
+    /**
+     * Flush and return the hash of the blob.
+     */
+    virtual Hash flush() && = 0;
+};
+
+/**
+ * A merkle directory sink that can be flushed to get the tree hash.
+ */
+struct DirectorySinkWithFlush : merkle::DirectorySink
+{
+    /**
+     * Flush the directory and return its tree hash.
+     */
+    virtual Hash flush() && = 0;
+};
+
+/**
+ * Interface for creating merkle file system object sinks.
+ *
+ * By returning sinks rather than taking callbacks, we allow starting
+ * and finishing sink-based creation in an asynchronous manner. This is
+ * crucial to being able to adapt messy providers of file system object
+ * data (like tarballs) to this interface.
+ */
+struct FileSinkBuilder
+{
+    virtual ~FileSinkBuilder() = default;
+
+    virtual ref<DirectorySinkWithFlush> makeDirectorySink() = 0;
+    virtual ref<RegularFileSinkWithFlush> makeRegularFileSink() = 0;
+    virtual merkle::TreeEntry makeSymlink(const std::string & target) = 0;
+
+    /**
+     * Flush all pending writes to persistent storage, and set whether
+     * subsequently created sinks may reference objects produced by
+     * previously created (and completed) sinks.
+     *
+     * When @p allow is false, the builder may apply optimizations
+     * that assume sinks are write-independent.
+     *
+     * When @p allow is true, those optimizations are disabled so that
+     * new sinks can look up objects written by earlier ones.
+     */
+    virtual void flushAndSetAllowDependentCreation(bool allow) = 0;
+};
+
+/**
+ * Adapter that implements TarSink by building a merkle tree.
+ */
+struct TarAdapter : TarSink
+{
+    virtual merkle::TreeEntry flush() = 0;
+};
+
+/**
+ * Create a TarSink that builds a merkle tree from path-based tar entries.
+ *
+ * @param store Factory for creating merkle sinks
+ */
+ref<TarAdapter> makeTarSink(FileSinkBuilder & store);
+
+} // namespace nix::merkle

--- a/src/libfetchers/include/nix/fetchers/meson.build
+++ b/src/libfetchers/include/nix/fetchers/meson.build
@@ -10,6 +10,7 @@ headers = files(
   'git-lfs-fetch.hh',
   'git-utils.hh',
   'input-cache.hh',
+  'merkle-tar-adapter.hh',
   'registry.hh',
   'tarball.hh',
 )

--- a/src/libfetchers/merkle-tar-adapter.cc
+++ b/src/libfetchers/merkle-tar-adapter.cc
@@ -1,0 +1,256 @@
+#include "nix/fetchers/merkle-tar-adapter.hh"
+#include "nix/util/thread-pool.hh"
+#include "nix/util/util.hh"
+
+#include <map>
+#include <optional>
+#include <set>
+#include <variant>
+
+namespace nix {
+
+/**
+ * Entry types in the flat path map.
+ */
+
+/**
+ * A file whose content is still being written to a sink.
+ * Will be flushed in Phase 1 and converted to CompletedFile.
+ */
+struct PendingFile
+{
+    ref<merkle::RegularFileSinkWithFlush> sink;
+    merkle::Mode mode;
+};
+
+/**
+ * A file or symlink that has been flushed and has a hash.
+ *
+ * @note Symlinks are not asynchronously sunk to the store, but always written
+ * in one go, because they are presumed to be short.
+ */
+struct CompletedFile
+{
+    Hash hash;
+    merkle::Mode mode;
+};
+
+/**
+ * Hardlinks store the target path and are resolved during flush.
+ */
+struct PendingHardlink
+{
+    CanonPath target;
+};
+
+/**
+ * Marks a directory entry. Content determined by children.
+ */
+struct DirectoryMarker
+{};
+
+using Entry = std::variant<PendingFile, CompletedFile, PendingHardlink, DirectoryMarker>;
+
+/**
+ * Simple tar adapter using a flat path map.
+ *
+ * 1. During tar parsing, builds a flat map of CanonPath -> Entry
+ * 2. At flush time:
+ *    a. Flush all file sinks in parallel
+ *    b. Build directories bottom-up (children before parents)
+ */
+struct TarAdapterImpl : merkle::TarAdapter
+{
+    merkle::FileSinkBuilder & store;
+
+    /**
+     * Flat map from path to entry.
+     * Includes explicit files, symlinks, and directories.
+     * Parent directories are created implicitly when adding children.
+     */
+    std::map<CanonPath, Entry> entries;
+
+    TarAdapterImpl(merkle::FileSinkBuilder & store)
+        : store(store)
+    {
+    }
+
+    /**
+     * Ensure all ancestor directories exist in the map.
+     * Throws if an ancestor already exists as a non-directory.
+     */
+    void ensureParentDirs(const CanonPath & path)
+    {
+        for (auto ancestor = path.parent(); ancestor; ancestor = ancestor->parent()) {
+            auto [it, inserted] = entries.try_emplace(*ancestor, DirectoryMarker{});
+            if (!inserted && !std::holds_alternative<DirectoryMarker>(it->second)) {
+                throw Error("cannot create '%s': ancestor '%s' is not a directory", path, *ancestor);
+            }
+        }
+        // Ensure root is a directory if we have any non-root paths
+        if (!path.isRoot()) {
+            auto [it, inserted] = entries.try_emplace(CanonPath::root, DirectoryMarker{});
+            if (!inserted && !std::holds_alternative<DirectoryMarker>(it->second)) {
+                throw Error("cannot create '%s': root is not a directory", path);
+            }
+        }
+    }
+
+    void createDirectory(const CanonPath & path) override
+    {
+        ensureParentDirs(path);
+        entries.insert_or_assign(path, DirectoryMarker{});
+    }
+
+    void createRegularFile(const CanonPath & path, bool isExecutable, fun<void(Sink &)> callback) override
+    {
+        auto sink = store.makeRegularFileSink();
+        callback(*sink);
+
+        auto mode = isExecutable ? merkle::Mode::Executable : merkle::Mode::Regular;
+        ensureParentDirs(path);
+        entries.insert_or_assign(path, PendingFile{sink, mode});
+    }
+
+    void createSymlink(const CanonPath & path, const std::string & target) override
+    {
+        auto entry = store.makeSymlink(target);
+        ensureParentDirs(path);
+        entries.insert_or_assign(path, CompletedFile{entry.hash, entry.mode});
+    }
+
+    void createHardlink(const CanonPath & path, const CanonPath & target) override
+    {
+        ensureParentDirs(path);
+        entries.insert_or_assign(path, PendingHardlink{target});
+    }
+
+    merkle::TreeEntry flush() override
+    {
+        if (entries.empty())
+            throw Error("tar archive is empty");
+
+        // Phase 1: Flush all PendingFile sinks in parallel, collect hardlink paths
+        std::set<const CanonPath *> pendingHardlinks;
+        {
+            ThreadPool pool;
+            for (auto & [path, entry] : entries) {
+                if (std::holds_alternative<PendingFile>(entry)) {
+                    pool.enqueue([&entry]() {
+                        auto & file = std::get<PendingFile>(entry);
+                        Hash hash = std::move(*file.sink).flush();
+                        entry = CompletedFile{hash, file.mode};
+                    });
+                } else if (std::holds_alternative<PendingHardlink>(entry)) {
+                    pendingHardlinks.insert(&path);
+                }
+            }
+            pool.process();
+        }
+
+        // Phase 2: Resolve hardlinks, loop until all resolved (handles chains)
+        while (!pendingHardlinks.empty()) {
+            std::set<const CanonPath *> stillPending;
+            for (auto * pathPtr : pendingHardlinks) {
+                auto & entry = entries.at(*pathPtr);
+                auto * linkP = std::get_if<PendingHardlink>(&entry);
+                assert(linkP);
+                auto & link = *linkP;
+                auto targetIt = entries.find(link.target);
+                if (targetIt == entries.end()) {
+                    throw Error("hardlink target '%s' not found", link.target);
+                }
+                std::visit(
+                    overloaded{
+                        [&](CompletedFile & file) { entry = file; },
+                        [&](PendingFile &) { assert(false); },
+                        [&](PendingHardlink &) { stillPending.insert(pathPtr); },
+                        [&](DirectoryMarker &) { throw Error("hardlink target '%s' is a directory", link.target); },
+                    },
+                    targetIt->second);
+            }
+            if (stillPending.size() == pendingHardlinks.size()) {
+                throw Error("hardlink cycle detected");
+            }
+            pendingHardlinks = std::move(stillPending);
+        }
+
+        // Persist all blob/symlink writes and enable cross-sink
+        // visibility so that directory sinks created below can
+        // reference objects written during Phase 1.
+        store.flushAndSetAllowDependentCreation(true);
+
+        // Special case: single non-directory entry at root
+        if (entries.size() == 1) {
+            auto & [path, entry] = *entries.begin();
+            if (auto * file = std::get_if<CompletedFile>(&entry)) {
+                store.flushAndSetAllowDependentCreation(false);
+                return {file->mode, file->hash};
+            }
+            // Must be an empty directory
+            auto dirSink = store.makeDirectorySink();
+            auto hash = std::move(*dirSink).flush();
+            store.flushAndSetAllowDependentCreation(false);
+            return {merkle::Mode::Directory, hash};
+        }
+
+        // Phase 3: Build directories bottom-up (children before parents).
+        // CanonPath sorts parents before children, so reverse iteration
+        // gives us the right order.
+        // All pointers below refer into `entries`, which is a stable std::map.
+        std::map<const CanonPath *, std::vector<std::pair<const CanonPath *, Entry *>>> children;
+
+        const CanonPath * rootPtr = nullptr;
+
+        for (auto & [path, entry] : entries) {
+            if (path.isRoot()) {
+                rootPtr = &path;
+            } else {
+                auto parent = path.parent();
+                const CanonPath * parentPtr = &entries.find(parent ? *parent : CanonPath::root)->first;
+                children[parentPtr].emplace_back(&path, &entry);
+            }
+        }
+
+        std::map<const CanonPath *, Hash> dirHashes;
+
+        for (auto it = entries.rbegin(); it != entries.rend(); ++it) {
+            if (!std::holds_alternative<DirectoryMarker>(it->second))
+                continue;
+
+            const CanonPath * pathPtr = &it->first;
+            auto dirSink = store.makeDirectorySink();
+
+            auto childIt = children.find(pathPtr);
+            if (childIt != children.end()) {
+                for (auto & [childPtr, childEntry] : childIt->second) {
+                    auto name = childPtr->baseName().value();
+
+                    if (auto * file = std::get_if<CompletedFile>(childEntry)) {
+                        dirSink->insertChild(name, {file->mode, file->hash});
+                    } else if (std::holds_alternative<DirectoryMarker>(*childEntry)) {
+                        dirSink->insertChild(name, {merkle::Mode::Directory, dirHashes.at(childPtr)});
+                    }
+                }
+            }
+
+            dirHashes.emplace(pathPtr, std::move(*dirSink).flush());
+        }
+
+        store.flushAndSetAllowDependentCreation(false);
+
+        assert(rootPtr);
+        return {merkle::Mode::Directory, dirHashes.at(rootPtr)};
+    }
+};
+
+} // namespace nix
+
+namespace nix::merkle {
+
+ref<TarAdapter> makeTarSink(FileSinkBuilder & store)
+{
+    return make_ref<nix::TarAdapterImpl>(store);
+}
+
+} // namespace nix::merkle

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -47,6 +47,7 @@ sources = files(
   'indirect.cc',
   'input-cache.cc',
   'mercurial.cc',
+  'merkle-tar-adapter.cc',
   'path.cc',
   'registry.cc',
   'tarball.cc',

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -8,6 +8,7 @@
 #include "nix/util/types.hh"
 #include "nix/store/store-api.hh"
 #include "nix/fetchers/git-utils.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
 #include "nix/fetchers/fetch-settings.hh"
 
 namespace nix::fetchers {
@@ -188,7 +189,8 @@ static DownloadTarballResult downloadTarball_(
     })
                                                                                     : TarArchive{*source};
     auto tarballCache = settings.getTarballCache();
-    auto parseSink = tarballCache->getFileSystemObjectSink();
+    auto writerPool = settings.getTarballWriterPool();
+    auto parseSink = merkle::makeTarSink(*writerPool);
     auto lastModified = unpackTarfileToSink(archive, *parseSink);
     auto tree = parseSink->flush();
 
@@ -204,7 +206,7 @@ static DownloadTarballResult downloadTarball_(
         infoAttrs = cached->value;
     } else {
         infoAttrs.insert_or_assign("etag", res->etag);
-        infoAttrs.insert_or_assign("treeHash", tarballCache->dereferenceSingletonDirectory(tree).gitRev());
+        infoAttrs.insert_or_assign("treeHash", tarballCache->dereferenceSingletonDirectory(tree.hash).gitRev());
         infoAttrs.insert_or_assign("lastModified", uint64_t(lastModified));
         if (res->immutableUrl)
             infoAttrs.insert_or_assign("immutableUrl", *res->immutableUrl);

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -59,9 +59,10 @@ static void builtinFetchurl(const BuiltinBuilderContext & ctx)
             decompressor->finish();
         });
 
-        if (unpack)
-            restorePath(storePath, *source);
-        else
+        if (unpack) {
+            std::filesystem::path p{storePath};
+            restorePath(p.parent_path(), p.filename(), *source);
+        } else
             writeFile(storePath, *source);
 
         auto executable = ctx.drv.env.find("executable");

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -71,8 +71,7 @@ class WholeStoreViewAccessor : public SourceAccessor
 public:
     WholeStoreViewAccessor()
     {
-        MemorySink sink{rootPathAccessor};
-        sink.createDirectory(CanonPath::root);
+        rootPathAccessor.root = MemorySourceAccessor::File{MemorySourceAccessor::File::Directory{}};
     }
 
     void addObject(std::string_view baseName, ref<MemorySourceAccessor> accessor)
@@ -208,7 +207,9 @@ struct DummyStoreImpl : DummyStore
             throw Error("checking signatures is not supported for '%s' store", config->getHumanReadableURI());
 
         auto accessor = make_ref<MemorySourceAccessor>();
-        MemorySink tempSink{*accessor};
+        MemorySink tempSink{[&](MemorySourceAccessor::File file) -> MemorySourceAccessor::File & {
+            return accessor->root.emplace(std::move(file));
+        }};
         parseDump(tempSink, source);
         auto path = info.path;
 
@@ -250,19 +251,18 @@ struct DummyStoreImpl : DummyStore
         auto temp = make_ref<MemorySourceAccessor>();
 
         {
-            MemorySink tempSink{*temp};
+            MemorySink tempSink{[&](MemorySourceAccessor::File file) -> MemorySourceAccessor::File & {
+                return temp->root.emplace(std::move(file));
+            }};
 
             // TODO factor this out into `restorePath`, same todo on it.
             switch (dumpMethod) {
             case FileSerialisationMethod::NixArchive:
                 parseDump(tempSink, source);
                 break;
-            case FileSerialisationMethod::Flat: {
-                // Replace root dir with file so next part succeeds.
-                temp->root = MemorySourceAccessor::File::Regular{};
-                tempSink.createRegularFile(CanonPath::root, [&](auto & sink) { source.drainInto(sink); });
+            case FileSerialisationMethod::Flat:
+                tempSink.createRegularFile(false, [&](auto & sink) { source.drainInto(sink); });
                 break;
-            }
             }
         }
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1306,7 +1306,7 @@ std::pair<std::filesystem::path, AutoCloseFD> LocalStore::createTempDirInStore()
            the GC between createTempDir() and when we acquire a lock on it.
            We'll repeat until 'tmpDir' exists and we've locked it.
            Make the directory accessible only to the current user. */
-        tmpDirFn = createTempDir(std::filesystem::path{config->realStoreDir.get()}, "tmp", /*mode=*/0700);
+        tmpDirFn = createTempDir(config->realStoreDir.get(), "tmp", /*mode=*/0700);
         tmpDirFd = openDirectory(tmpDirFn, FinalSymlink::DontFollow);
         if (!tmpDirFd) {
             continue;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1056,7 +1056,11 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
 
                 TeeSource wrapperSource{source, hashSink};
 
-                restorePath(realPath, wrapperSource, config->getLocalSettings().fsyncStorePaths);
+                restorePath(
+                    realPath.parent_path(),
+                    realPath.filename(),
+                    wrapperSource,
+                    config->getLocalSettings().fsyncStorePaths);
 
                 auto hashResult = hashSink.finish();
 
@@ -1208,7 +1212,7 @@ StorePath LocalStore::addToStoreFromDump(
         delTempDir = std::make_unique<AutoDelete>(tempDir);
         tempPath = tempDir / "x";
 
-        restorePath(tempPath.string(), bothSource, dumpMethod, localSettings.fsyncStorePaths);
+        restorePath(tempDir, "x", bothSource, dumpMethod, localSettings.fsyncStorePaths);
 
         dumpBuffer.reset();
         dump = {};
@@ -1252,7 +1256,12 @@ StorePath LocalStore::addToStoreFromDump(
                 switch (fim) {
                 case FileIngestionMethod::Flat:
                 case FileIngestionMethod::NixArchive:
-                    restorePath(realPath, dumpSource, (FileSerialisationMethod) fim, localSettings.fsyncStorePaths);
+                    restorePath(
+                        realPath.parent_path(),
+                        realPath.filename(),
+                        dumpSource,
+                        (FileSerialisationMethod) fim,
+                        localSettings.fsyncStorePaths);
                     break;
                 case FileIngestionMethod::Git:
                     // doesn't correspond to serialization method, so

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -3,6 +3,7 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/signals.hh"
 #include "nix/store/store-api.hh"
+#include "nix/util/file-system-at.hh"
 
 #if NIX_SUPPORT_ACL
 #  include <sys/xattr.h>

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1,5 +1,6 @@
 #include "nix/store/build/derivation-builder.hh"
 #include "nix/util/file-system-at.hh"
+#include "nix/util/os-filename.hh"
 #include "nix/util/file-system.hh"
 #include "nix/store/local-store.hh"
 #include "nix/util/processes.hh"
@@ -396,7 +397,7 @@ protected:
      * @param Name must not contain more than one path segment and none of them must be `..`, `.`
      * Otherwise this function throws an Error.
      */
-    void writeBuilderFile(const std::string & name, std::string_view contents);
+    void writeBuilderFile(const OsFilename & name, std::string_view contents);
 
     /**
      * Arguments passed to runChild().
@@ -1094,7 +1095,7 @@ void DerivationBuilderImpl::initEnv()
 
     /* Add extra files, similar to `finalEnv` */
     for (const auto & [fileName, value] : desugaredEnv.extraFiles) {
-        writeBuilderFile(fileName, rewriteStrings(value, inputRewrites));
+        writeBuilderFile(OsFilename{std::filesystem::path(fileName)}, rewriteStrings(value, inputRewrites));
     }
 
     /* For convenience, set an environment pointing to the top build
@@ -1266,16 +1267,11 @@ void DerivationBuilderImpl::chownToBuilder(int fd, const std::filesystem::path &
         throw SysError("cannot change ownership of file %1%", PathFmt(path));
 }
 
-void DerivationBuilderImpl::writeBuilderFile(const std::string & name, std::string_view contents)
+void DerivationBuilderImpl::writeBuilderFile(const OsFilename & name, std::string_view contents)
 {
-    /* Path must be the same after normalisation. This is an additional sanity check in addition to
-       existing parsing checks for non-structured attrs exportReferencesGraph. In practice we only expect
-       a single path component without any `..`, `.` components. */
-    auto relPath = std::filesystem::path(name);
-    assert(relPath == relPath.filename());
-    AutoCloseFD fd = openFileEnsureBeneathNoSymlinks(
-        tmpDirFd.get(), relPath, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL, 0666);
-    auto path = tmpDir / relPath; /* This is used only for error messages. */
+    AutoCloseFD fd =
+        openFileEnsureBeneathNoSymlinks(tmpDirFd.get(), name, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL, 0666);
+    auto path = tmpDir / name.path(); /* This is used only for error messages. */
     if (!fd)
         throw SysError("creating file %s", PathFmt(path));
     writeFile(fd.get(), contents);

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1269,8 +1269,8 @@ void DerivationBuilderImpl::chownToBuilder(int fd, const std::filesystem::path &
 
 void DerivationBuilderImpl::writeBuilderFile(const OsFilename & name, std::string_view contents)
 {
-    AutoCloseFD fd =
-        openFileEnsureBeneathNoSymlinks(tmpDirFd.get(), name, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL, 0666);
+    AutoCloseFD fd = openFileEnsureBeneathNoSymlinks(
+        tmpDirFd.get(), name, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL, 0666);
     auto path = tmpDir / name.path(); /* This is used only for error messages. */
     if (!fd)
         throw SysError("creating file %s", PathFmt(path));
@@ -1639,10 +1639,12 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                     dumpPath(actualPath, rsink);
                     rsink.flush();
                 });
-                std::filesystem::path tmpPath = actualPath.native() + ".tmp";
-                restorePath(tmpPath, *source);
+                auto tmpName = actualPath.filename();
+                tmpName += ".tmp";
+                auto parentDir = actualPath.parent_path();
+                restorePath(parentDir, tmpName, *source);
                 deletePath(actualPath);
-                movePath(tmpPath, actualPath);
+                movePath(parentDir / tmpName, actualPath);
 
                 /* FIXME: set proper permissions in restorePath() so
                    we don't have to do another traversal. */
@@ -1760,7 +1762,11 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                serialisation/deserialisation. TODO: Use copyRecursive here and
                make use of reflinking. */
             auto source = sinkToSource([&](Sink & nextSink) { dumpPath(actualPath, nextSink); });
-            restorePath(tmpOutput, *source, store.config->getLocalSettings().fsyncStorePaths);
+            restorePath(
+                tmpOutput.parent_path(),
+                tmpOutput.filename(),
+                *source,
+                store.config->getLocalSettings().fsyncStorePaths);
             /* This makes it slightly harder to make sense of the control flow. The rule
                of thumb is that actualPath points to the current location of the stuff
                that we'll end up registering. */

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1271,10 +1271,11 @@ void DerivationBuilderImpl::writeBuilderFile(const std::string & name, std::stri
     /* Path must be the same after normalisation. This is an additional sanity check in addition to
        existing parsing checks for non-structured attrs exportReferencesGraph. In practice we only expect
        a single path component without any `..`, `.` components. */
-    auto relPath = CanonPath::fromFilename(name);
+    auto relPath = std::filesystem::path(name);
+    assert(relPath == relPath.filename());
     AutoCloseFD fd = openFileEnsureBeneathNoSymlinks(
         tmpDirFd.get(), relPath, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL, 0666);
-    auto path = tmpDir / relPath.rel(); /* This is used only for error messages. */
+    auto path = tmpDir / relPath; /* This is used only for error messages. */
     if (!fd)
         throw SysError("creating file %s", PathFmt(path));
     writeFile(fd.get(), contents);

--- a/src/libutil-test-support/include/nix/util/tests/gmock-matchers.hh
+++ b/src/libutil-test-support/include/nix/util/tests/gmock-matchers.hh
@@ -66,4 +66,19 @@ inline auto ThrowsSysError(int expected)
     return ::testing::Throws<SysError>(::testing::Field(&SysError::errNo, expected));
 }
 
+#ifdef _WIN32
+/**
+ * Matches a callable that throws `WinError` whose `lastError` equals `expected`.
+ *
+ * Example:
+ *
+ *     EXPECT_THAT([&]{ openFile("nope"); }, ThrowsWinError(ERROR_FILE_NOT_FOUND));
+ */
+inline auto ThrowsWinError(DWORD expected)
+{
+    return ::testing::Throws<windows::WinError>(::testing::Field(&windows::WinError::lastError, expected));
+}
+
+#endif
+
 } // namespace nix::testing

--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -301,7 +301,7 @@ TEST(BufferedSourceReadLine, BufferExhaustedThenEof)
 TEST(WriteFull, RespectsAllowInterrupts)
 {
 #ifdef _WIN32
-    GTEST_SKIP() << "Broken on Windows";
+    GTEST_SKIP() << "Interrupt support on Windows not expected to work";
 #endif
     Pipe pipe;
     pipe.create();

--- a/src/libutil-tests/file-system-at.cc
+++ b/src/libutil-tests/file-system-at.cc
@@ -5,6 +5,9 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/fs-sink.hh"
 #include "nix/util/tests/gmock-matchers.hh"
+#ifdef _WIN32
+#  include "nix/util/windows-environment.hh"
+#endif
 
 namespace nix {
 
@@ -14,9 +17,6 @@ namespace nix {
 
 TEST(readLinkAt, works)
 {
-#ifdef _WIN32
-    GTEST_SKIP() << "Broken on Windows";
-#endif
     std::filesystem::path tmpDir = nix::createTempDir();
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
@@ -35,7 +35,16 @@ TEST(readLinkAt, works)
         RestoreSink sink(/*startFsync=*/false);
         sink.dstPath = tmpDir;
         sink.dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
-        sink.createSymlink(CanonPath("link"), "target");
+        try {
+            sink.createSymlink(CanonPath("link"), "target");
+        } catch (SystemError &) {
+#ifdef _WIN32
+            // It works in @ericson2314's local wine build, but not in the Nix sandbox
+            if (windows::isWine())
+                GTEST_SKIP() << "symlink creation not supported in Wine only on some file systems";
+#endif
+            throw;
+        }
         sink.createSymlink(CanonPath("relative"), "../relative/path");
         sink.createSymlink(CanonPath("absolute"), "/absolute/path");
         try {
@@ -57,22 +66,22 @@ TEST(readLinkAt, works)
 
     auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
 
-    EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("link")), OS_STR("target"));
-    EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("relative")), OS_STR("../relative/path"));
-    EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("absolute")), OS_STR("/absolute/path"));
+    EXPECT_EQ(readLinkAt(dirFd.get(), std::filesystem::path("link")), OS_STR("target"));
+    EXPECT_EQ(readLinkAt(dirFd.get(), std::filesystem::path("relative")), OS_STR("../relative/path"));
+    EXPECT_EQ(readLinkAt(dirFd.get(), std::filesystem::path("absolute")), OS_STR("/absolute/path"));
     if (hasLongSymlinks) {
-        EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("medium")), string_to_os_string(mediumTarget));
-        EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("long")), string_to_os_string(longTarget));
+        EXPECT_EQ(readLinkAt(dirFd.get(), std::filesystem::path("medium")), string_to_os_string(mediumTarget));
+        EXPECT_EQ(readLinkAt(dirFd.get(), std::filesystem::path("long")), string_to_os_string(longTarget));
     }
-    EXPECT_EQ(readLinkAt(dirFd.get(), CanonPath("a/b/link")), OS_STR("nested_target"));
+    EXPECT_EQ(readLinkAt(dirFd.get(), std::filesystem::path("a/b/link")), OS_STR("nested_target"));
 
     auto subDirFd = openDirectory(tmpDir / "a", FinalSymlink::Follow);
-    EXPECT_EQ(readLinkAt(subDirFd.get(), CanonPath("b/link")), OS_STR("nested_target"));
+    EXPECT_EQ(readLinkAt(subDirFd.get(), std::filesystem::path("b/link")), OS_STR("nested_target"));
 
     // Test error cases - expect SystemError on both platforms
-    EXPECT_THROW(readLinkAt(dirFd.get(), CanonPath("regular")), SystemError);
-    EXPECT_THROW(readLinkAt(dirFd.get(), CanonPath("dir")), SystemError);
-    EXPECT_THROW(readLinkAt(dirFd.get(), CanonPath("nonexistent")), SystemError);
+    EXPECT_THROW(readLinkAt(dirFd.get(), std::filesystem::path("regular")), SystemError);
+    EXPECT_THROW(readLinkAt(dirFd.get(), std::filesystem::path("dir")), SystemError);
+    EXPECT_THROW(readLinkAt(dirFd.get(), std::filesystem::path("nonexistent")), SystemError);
 }
 
 /* ----------------------------------------------------------------------------
@@ -81,9 +90,6 @@ TEST(readLinkAt, works)
 
 TEST(openFileEnsureBeneathNoSymlinks, works)
 {
-#ifdef _WIN32
-    GTEST_SKIP() << "Broken on Windows";
-#endif
     std::filesystem::path tmpDir = nix::createTempDir();
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
@@ -95,7 +101,16 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
         sink.createDirectory(CanonPath("c"));
         sink.createDirectory(CanonPath("c/d"));
         sink.createRegularFile(CanonPath("c/d/regular"), [](CreateRegularFileSink & crf) { crf("some contents"); });
-        sink.createSymlink(CanonPath("a/absolute_symlink"), tmpDir.string());
+        try {
+            sink.createSymlink(CanonPath("a/absolute_symlink"), tmpDir.string());
+        } catch (SystemError &) {
+#ifdef _WIN32
+            // It works in @ericson2314's local wine build, but not in the Nix sandbox
+            if (windows::isWine())
+                GTEST_SKIP() << "symlink creation not supported in Wine only on some file systems";
+#endif
+            throw;
+        }
         sink.createSymlink(CanonPath("a/relative_symlink"), "../.");
         sink.createSymlink(CanonPath("a/broken_symlink"), "./nonexistent");
         sink.createDirectory(CanonPath("a/b"), [](FileSystemObjectSink & dirSink, const CanonPath & relPath) {
@@ -124,7 +139,7 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
        `.errNo`. */
     auto check = [](std::string_view what, AutoCloseFD fd) {
         if (!fd)
-            throw SysError("openFileEnsureBeneathNoSymlinks: %s", what);
+            throw NativeSysError("openFileEnsureBeneathNoSymlinks: %s", what);
         return fd;
     };
 
@@ -133,7 +148,7 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
             path,
             openFileEnsureBeneathNoSymlinks(
                 dirFd.get(),
-                CanonPath(path),
+                std::filesystem::path(path),
 #ifdef _WIN32
                 FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
                 0
@@ -149,7 +164,7 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
             path,
             openFileEnsureBeneathNoSymlinks(
                 dirFd.get(),
-                CanonPath(path),
+                std::filesystem::path(path),
 #ifdef _WIN32
                 FILE_READ_ATTRIBUTES | SYNCHRONIZE,
                 FILE_DIRECTORY_FILE
@@ -163,10 +178,13 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
 #if defined(__linux__)
     auto openReadDirPath = [&](std::string_view path) -> AutoCloseFD {
         return check(
-            path, openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath(path), O_PATH | O_DIRECTORY | O_CLOEXEC, 0));
+            path,
+            openFileEnsureBeneathNoSymlinks(
+                dirFd.get(), std::filesystem::path(path), O_PATH | O_DIRECTORY | O_CLOEXEC, 0));
     };
     auto openPath = [&](std::string_view path) -> AutoCloseFD {
-        return check(path, openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath(path), O_PATH | O_CLOEXEC, 0));
+        return check(
+            path, openFileEnsureBeneathNoSymlinks(dirFd.get(), std::filesystem::path(path), O_PATH | O_CLOEXEC, 0));
     };
 #endif
 
@@ -175,7 +193,7 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
             path,
             openFileEnsureBeneathNoSymlinks(
                 dirFd.get(),
-                CanonPath(path),
+                std::filesystem::path(path),
 #ifdef _WIN32
                 FILE_WRITE_DATA | SYNCHRONIZE,
                 0,
@@ -188,6 +206,9 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
     };
 
     using nix::testing::ThrowsSysError;
+#ifdef _WIN32
+    using nix::testing::ThrowsWinError;
+#endif
 
     // Symlinks in the path (any position) are rejected.
     EXPECT_THROW(openRead("a/absolute_symlink"), SymlinkNotAllowed);
@@ -234,10 +255,31 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
 #endif
     EXPECT_THROW(openCreateExclusive("a/absolute_symlink/broken_symlink"), SymlinkNotAllowed);
 
-    // Non-symlink failure modes: errno must survive.
-    EXPECT_THAT([&] { openRead("c/d/regular/a"); }, ThrowsSysError(ENOTDIR));
-    EXPECT_THAT([&] { openReadDir("c/d/regular"); }, ThrowsSysError(ENOTDIR));
-    EXPECT_THAT([&] { openRead("c/d/nonexistent"); }, ThrowsSysError(ENOENT));
+    // Non-symlink failure modes: error codes must survive.
+    EXPECT_THAT(
+        [&] { openRead("c/d/regular/a"); },
+#ifdef _WIN32
+        ThrowsWinError(ERROR_DIRECTORY)
+#else
+        ThrowsSysError(ENOTDIR)
+#endif
+    );
+    EXPECT_THAT(
+        [&] { openReadDir("c/d/regular"); },
+#ifdef _WIN32
+        ThrowsWinError(ERROR_DIRECTORY)
+#else
+        ThrowsSysError(ENOTDIR)
+#endif
+    );
+    EXPECT_THAT(
+        [&] { openRead("c/d/nonexistent"); },
+#ifdef _WIN32
+        ThrowsWinError(ERROR_FILE_NOT_FOUND)
+#else
+        ThrowsSysError(ENOENT)
+#endif
+    );
 
     // Happy paths.
     EXPECT_TRUE(openRead("c/d/regular"));
@@ -275,14 +317,19 @@ TEST(openFileEnsureBeneathNoSymlinksDeathTest, rejectsONofollow)
        owns symlink policy. Verify the assert fires for every flag
        combination that includes `O_NOFOLLOW`. */
     EXPECT_DEATH(
-        openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_RDONLY | O_NOFOLLOW, 0), "O_NOFOLLOW");
+        openFileEnsureBeneathNoSymlinks(dirFd.get(), std::filesystem::path("file"), O_RDONLY | O_NOFOLLOW, 0),
+        "O_NOFOLLOW");
     EXPECT_DEATH(
-        openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_RDONLY | O_DIRECTORY | O_NOFOLLOW, 0),
+        openFileEnsureBeneathNoSymlinks(
+            dirFd.get(), std::filesystem::path("file"), O_RDONLY | O_DIRECTORY | O_NOFOLLOW, 0),
         "O_NOFOLLOW");
 #  if defined(__linux__)
-    EXPECT_DEATH(openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_PATH | O_NOFOLLOW, 0), "O_NOFOLLOW");
     EXPECT_DEATH(
-        openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_PATH | O_DIRECTORY | O_NOFOLLOW, 0),
+        openFileEnsureBeneathNoSymlinks(dirFd.get(), std::filesystem::path("file"), O_PATH | O_NOFOLLOW, 0),
+        "O_NOFOLLOW");
+    EXPECT_DEATH(
+        openFileEnsureBeneathNoSymlinks(
+            dirFd.get(), std::filesystem::path("file"), O_PATH | O_DIRECTORY | O_NOFOLLOW, 0),
         "O_NOFOLLOW");
 #  endif
 }

--- a/src/libutil-tests/file-system-at.cc
+++ b/src/libutil-tests/file-system-at.cc
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <system_error>
+
 #include "nix/util/file-system-at.hh"
 #include "nix/util/file-system.hh"
 #include "nix/util/fs-sink.hh"
@@ -31,10 +33,42 @@ TEST(readLinkAt, works)
     std::string longTarget(maxPathLength - 1, 'y');
 
     bool hasLongSymlinks = true;
+    auto testDir = tmpDir / "root";
     {
-        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
+        auto parentFd = openDirectory(tmpDir, FinalSymlink::Follow);
+
+        // Create entire test structure through a single RestoreSink
+        RestoreSink sink{parentFd.get(), "root", /*startFsync=*/false};
         try {
-            sink.createSymlink(CanonPath("link"), "target");
+            sink.createDirectory([&](FileSystemObjectSink::OnDirectory & root) {
+                root.createChild("link", [](FileSystemObjectSink & s) { s.createSymlink("target"); });
+                root.createChild("relative", [](FileSystemObjectSink & s) { s.createSymlink("../relative/path"); });
+                root.createChild("absolute", [](FileSystemObjectSink & s) { s.createSymlink("/absolute/path"); });
+                try {
+                    root.createChild("medium", [&](FileSystemObjectSink & s) { s.createSymlink(mediumTarget); });
+                    root.createChild("long", [&](FileSystemObjectSink & s) { s.createSymlink(longTarget); });
+                } catch (SystemError & e) {
+                    if (e.is(std::errc::filename_too_long)) {
+                        hasLongSymlinks = false;
+                    } else {
+                        throw;
+                    }
+            }
+            root.createChild("a", [](FileSystemObjectSink & s) {
+                s.createDirectory([](FileSystemObjectSink::OnDirectory & a) {
+                    a.createChild("b", [](FileSystemObjectSink & s) {
+                        s.createDirectory([](FileSystemObjectSink::OnDirectory & b) {
+                            b.createChild("link", [](FileSystemObjectSink & s) { s.createSymlink("nested_target"); });
+                        });
+                    });
+                });
+            });
+            root.createChild("regular", [](FileSystemObjectSink & s) {
+                s.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile &) {});
+            });
+            root.createChild(
+                "dir", [](FileSystemObjectSink & s) { s.createDirectory([](FileSystemObjectSink::OnDirectory &) {}); });
+        });
         } catch (SystemError &) {
 #ifdef _WIN32
             // It works in @ericson2314's local wine build, but not in the Nix sandbox
@@ -43,26 +77,9 @@ TEST(readLinkAt, works)
 #endif
             throw;
         }
-        sink.createSymlink(CanonPath("relative"), "../relative/path");
-        sink.createSymlink(CanonPath("absolute"), "/absolute/path");
-        try {
-            sink.createSymlink(CanonPath("medium"), mediumTarget);
-            sink.createSymlink(CanonPath("long"), longTarget);
-        } catch (SystemError & e) {
-            if (e.is(std::errc::filename_too_long)) {
-                hasLongSymlinks = false;
-            } else {
-                throw;
-            }
-        }
-        sink.createDirectory(CanonPath("a"));
-        sink.createDirectory(CanonPath("a/b"));
-        sink.createSymlink(CanonPath("a/b/link"), "nested_target");
-        sink.createRegularFile(CanonPath("regular"), [](CreateRegularFileSink &) {});
-        sink.createDirectory(CanonPath("dir"));
     }
 
-    auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+    auto dirFd = openDirectory(testDir, FinalSymlink::Follow);
 
     EXPECT_EQ(readLinkAt(dirFd.get(), std::filesystem::path("link")), OS_STR("target"));
     EXPECT_EQ(readLinkAt(dirFd.get(), std::filesystem::path("relative")), OS_STR("../relative/path"));
@@ -73,7 +90,7 @@ TEST(readLinkAt, works)
     }
     EXPECT_EQ(readLinkAt(dirFd.get(), std::filesystem::path("a/b/link")), OS_STR("nested_target"));
 
-    auto subDirFd = openDirectory(tmpDir / "a", FinalSymlink::Follow);
+    auto subDirFd = openDirectory(testDir / "a", FinalSymlink::Follow);
     EXPECT_EQ(readLinkAt(subDirFd.get(), std::filesystem::path("b/link")), OS_STR("nested_target"));
 
     // Test error cases - expect SystemError on both platforms
@@ -91,14 +108,44 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
     std::filesystem::path tmpDir = nix::createTempDir();
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
+    auto testDir = tmpDir / "root";
     {
-        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
-        sink.createDirectory(CanonPath("a"));
-        sink.createDirectory(CanonPath("c"));
-        sink.createDirectory(CanonPath("c/d"));
-        sink.createRegularFile(CanonPath("c/d/regular"), [](CreateRegularFileSink & crf) { crf("some contents"); });
+        auto parentFd = openDirectory(tmpDir, FinalSymlink::Follow);
+
+        // Create entire test structure through a single RestoreSink
+        RestoreSink sink{parentFd.get(), "root", /*startFsync=*/false};
         try {
-            sink.createSymlink(CanonPath("a/absolute_symlink"), tmpDir.string());
+            sink.createDirectory([&](FileSystemObjectSink::OnDirectory & root) {
+                root.createChild("a", [&](FileSystemObjectSink & s) {
+                    s.createDirectory([&](FileSystemObjectSink::OnDirectory & a) {
+                        a.createChild(
+                            "absolute_symlink", [&](FileSystemObjectSink & s) { s.createSymlink(testDir.string()); });
+                        a.createChild("relative_symlink", [](FileSystemObjectSink & s) { s.createSymlink("../."); });
+                        a.createChild(
+                            "broken_symlink", [](FileSystemObjectSink & s) { s.createSymlink("./nonexistent"); });
+                        a.createChild("b", [](FileSystemObjectSink & s) {
+                            s.createDirectory([](FileSystemObjectSink::OnDirectory & b) {
+                                b.createChild("d", [](FileSystemObjectSink & s) {
+                                    s.createDirectory([](FileSystemObjectSink::OnDirectory &) {});
+                                });
+                                b.createChild("c", [](FileSystemObjectSink & s) { s.createSymlink("./d"); });
+                            });
+                        });
+                    });
+                });
+                root.createChild("c", [](FileSystemObjectSink & s) {
+                    s.createDirectory([](FileSystemObjectSink::OnDirectory & c) {
+                        c.createChild("d", [](FileSystemObjectSink & s) {
+                            s.createDirectory([](FileSystemObjectSink::OnDirectory & d) {
+                                d.createChild("regular", [](FileSystemObjectSink & s) {
+                                    s.createRegularFile(
+                                        false, [](FileSystemObjectSink::OnRegularFile & crf) { crf("some contents"); });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
         } catch (SystemError &) {
 #ifdef _WIN32
             // It works in @ericson2314's local wine build, but not in the Nix sandbox
@@ -107,25 +154,39 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
 #endif
             throw;
         }
-        sink.createSymlink(CanonPath("a/relative_symlink"), "../.");
-        sink.createSymlink(CanonPath("a/broken_symlink"), "./nonexistent");
-        sink.createDirectory(CanonPath("a/b"), [](FileSystemObjectSink & dirSink, const CanonPath & relPath) {
-            dirSink.createDirectory(CanonPath("d"));
-            dirSink.createSymlink(CanonPath("c"), "./d");
         });
-        EXPECT_THROW(sink.createDirectory(CanonPath("a/b/c/e")), SymlinkNotAllowed);
-        // Test that symlinks in intermediate path are detected during nested operations
-        EXPECT_THROW(
-            sink.createDirectory(
-                CanonPath("a/b/c/f"), [](FileSystemObjectSink & dirSink, const CanonPath & relPath) {}),
-            SymlinkNotAllowed);
-        EXPECT_THROW(
-            sink.createRegularFile(
-                CanonPath("a/b/c/regular"), [](CreateRegularFileSink & crf) { crf("some contents"); }),
-            SymlinkNotAllowed);
+
+        // Test that creating at an existing path fails
+        // a/b/c already exists (as a symlink), so trying to create there should fail
+        {
+            auto abDir = openDirectory(testDir / "a" / "b", FinalSymlink::Follow);
+            bool threw = false;
+            try {
+                RestoreSink sink{abDir.get(), "c", /*startFsync=*/false};
+                sink.createDirectory([](FileSystemObjectSink::OnDirectory &) {});
+            } catch (const SystemError & e) {
+                threw = true;
+                EXPECT_TRUE(e.is(std::errc::file_exists));
+            }
+            EXPECT_TRUE(threw) << "Expected SystemError to be thrown";
+        }
+
+        // a/b/d already exists (as a directory), so trying to create there should fail
+        {
+            auto abDir = openDirectory(testDir / "a" / "b", FinalSymlink::Follow);
+            bool threw = false;
+            try {
+                RestoreSink sink{abDir.get(), "d", /*startFsync=*/false};
+                sink.createDirectory([](FileSystemObjectSink::OnDirectory &) {});
+            } catch (const SystemError & e) {
+                threw = true;
+                EXPECT_TRUE(e.is(std::errc::file_exists));
+            }
+            EXPECT_TRUE(threw) << "Expected SystemError to be thrown";
+        }
     }
 
-    auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+    auto dirFd = openDirectory(testDir, FinalSymlink::Follow);
 
     /* Helpers that wrap `openFileEnsureBeneathNoSymlinks` to throw
        `SysError` on null-fd failure. This way every failure is an
@@ -300,18 +361,25 @@ TEST(openFileEnsureBeneathNoSymlinksDeathTest, rejectsONofollow)
     std::filesystem::path tmpDir = nix::createTempDir();
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
+    auto testDir = tmpDir / "root";
     {
-        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
-        sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink & crf) {});
+        auto parentFd = openDirectory(tmpDir, FinalSymlink::Follow);
+        RestoreSink sink{parentFd.get(), "root", /*startFsync=*/false};
+        sink.createDirectory([](FileSystemObjectSink::OnDirectory & root) {
+            root.createChild("file", [](FileSystemObjectSink & s) {
+                s.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile &) {});
+            });
+        });
     }
 
-    auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+    auto dirFd = openDirectory(testDir, FinalSymlink::Follow);
 
     /* The function asserts that callers don't pass `O_NOFOLLOW` — it
        owns symlink policy. Verify the assert fires for every flag
        combination that includes `O_NOFOLLOW`. */
     EXPECT_DEATH(
-        openFileEnsureBeneathNoSymlinks(dirFd.get(), std::filesystem::path("file"), O_RDONLY | O_NOFOLLOW, 0),
+        openFileEnsureBeneathNoSymlinks(
+            dirFd.get(), std::filesystem::path("file"), O_RDONLY | O_NOFOLLOW, 0),
         "O_NOFOLLOW");
     EXPECT_DEATH(
         openFileEnsureBeneathNoSymlinks(
@@ -319,7 +387,8 @@ TEST(openFileEnsureBeneathNoSymlinksDeathTest, rejectsONofollow)
         "O_NOFOLLOW");
 #  if defined(__linux__)
     EXPECT_DEATH(
-        openFileEnsureBeneathNoSymlinks(dirFd.get(), std::filesystem::path("file"), O_PATH | O_NOFOLLOW, 0),
+        openFileEnsureBeneathNoSymlinks(
+            dirFd.get(), std::filesystem::path("file"), O_PATH | O_NOFOLLOW, 0),
         "O_NOFOLLOW");
     EXPECT_DEATH(
         openFileEnsureBeneathNoSymlinks(

--- a/src/libutil-tests/file-system-at.cc
+++ b/src/libutil-tests/file-system-at.cc
@@ -32,9 +32,7 @@ TEST(readLinkAt, works)
 
     bool hasLongSymlinks = true;
     {
-        RestoreSink sink(/*startFsync=*/false);
-        sink.dstPath = tmpDir;
-        sink.dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
         try {
             sink.createSymlink(CanonPath("link"), "target");
         } catch (SystemError &) {
@@ -94,9 +92,7 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
     {
-        RestoreSink sink(/*startFsync=*/false);
-        sink.dstPath = tmpDir;
-        sink.dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
         sink.createDirectory(CanonPath("a"));
         sink.createDirectory(CanonPath("c"));
         sink.createDirectory(CanonPath("c/d"));
@@ -305,9 +301,7 @@ TEST(openFileEnsureBeneathNoSymlinksDeathTest, rejectsONofollow)
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
     {
-        RestoreSink sink(/*startFsync=*/false);
-        sink.dstPath = tmpDir;
-        sink.dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
         sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink & crf) {});
     }
 

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -279,7 +279,7 @@ TEST(chmodIfNeeded, works)
 #ifdef _WIN32
     // Windows doesn't support Unix-style permission bits - lstat always
     // returns the same mode regardless of what chmod sets.
-    GTEST_SKIP() << "Broken on Windows";
+    GTEST_SKIP() << "chmod on Windows not expected to work";
 #endif
     auto [autoClose_, tmpFile] = nix::createTempFile();
     auto deleteTmpFile = AutoDelete(tmpFile);

--- a/src/libutil-tests/git.cc
+++ b/src/libutil-tests/git.cc
@@ -7,6 +7,23 @@
 
 namespace nix {
 
+/**
+ * Test implementation of merkle::DirectorySink that captures entries.
+ */
+struct TestDirectorySink : merkle::DirectorySink
+{
+    git::Tree entries;
+
+    void insertChild(std::string_view name, merkle::TreeEntry entry) override
+    {
+        auto name2 = std::string{name};
+        if (entry.mode == merkle::Mode::Directory)
+            name2 += '/';
+        entries.insert_or_assign(name2, std::move(entry));
+    }
+};
+
+
 class GitTest : public CharacterizationTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "git";
@@ -74,14 +91,28 @@ TEST_F(GitTest, blob_read)
     readTest("hello-world-blob.bin", [&](const auto & encoded) {
         StringSource in{encoded};
         StringSink out;
-        RegularFileSink out2{out};
         ASSERT_EQ(parseObjectType(in, mockXpSettings), ObjectType::Blob);
-        parseBlob(out2, CanonPath::root, in, BlobMode::Regular, mockXpSettings);
+        auto size = parseBlob(in, mockXpSettings);
+        in.drainInto(out, size);
 
         auto expected = readFile(goldenMaster("hello-world.bin"));
 
         ASSERT_EQ(out.s, expected);
     });
+}
+
+TEST_F(GitTest, blob_read_large_size)
+{
+    // Test that parseBlob handles sizes larger than INT_MAX (2^31 - 1)
+    // This verifies that a bad overflowing number parser isn't used.
+    uint64_t largeSize = 5000000000ULL; // ~5 GB, larger than INT_MAX
+    std::string blobHeader = std::to_string(largeSize);
+    blobHeader.push_back('\0'); // null terminator expected by parseBlob
+
+    StringSource in{blobHeader};
+    auto size = git::parseBlob(in, mockXpSettings);
+
+    ASSERT_EQ(size, largeSize);
 }
 
 TEST_F(GitTest, blob_write)
@@ -181,23 +212,11 @@ static auto mkTreeReadTest(HashAlgorithm hashAlgo, git::Tree tree, const Experim
     using namespace git;
     return [hashAlgo, tree, mockXpSettings](const auto & encoded) {
         StringSource in{encoded};
-        NullFileSystemObjectSink out;
-        Tree got;
+        TestDirectorySink out;
         ASSERT_EQ(parseObjectType(in, mockXpSettings), ObjectType::Tree);
-        parseTree(
-            out,
-            CanonPath::root,
-            in,
-            hashAlgo,
-            [&](auto & name, auto entry) {
-                auto name2 = std::string{name.rel()};
-                if (entry.mode == Mode::Directory)
-                    name2 += '/';
-                got.insert_or_assign(name2, std::move(entry));
-            },
-            mockXpSettings);
+        parseTree(out, in, hashAlgo, mockXpSettings);
 
-        ASSERT_EQ(got, tree);
+        ASSERT_EQ(out.entries, tree);
     };
 }
 
@@ -245,6 +264,7 @@ TEST_F(GitTest, both_roundrip)
     for (const auto hashAlgo : {HashAlgorithm::SHA1, HashAlgorithm::SHA256}) {
         std::map<Hash, std::string> cas;
 
+        // Dump phase: serialize files to git objects in cas
         fun<DumpHook> dumpHook = [&](const SourcePath & path) {
             StringSink s;
             HashSink hashSink{hashAlgo};
@@ -260,32 +280,58 @@ TEST_F(GitTest, both_roundrip)
 
         auto root = dumpHook(SourcePath{files});
 
+        // Parse phase: deserialize git objects back to files
         auto files2 = make_ref<MemorySourceAccessor>();
 
-        MemorySink sinkFiles2{*files2};
+        // Recursive function to parse a git object into a File
+        std::function<MemorySourceAccessor::File(merkle::TreeEntry)> parseToFile;
 
-        std::function<void(const CanonPath, const Hash &, BlobMode)> mkSinkHook;
-        mkSinkHook = [&](auto prefix, auto & hash, auto blobMode) {
-            StringSource in{cas[hash]};
-            parse(
-                sinkFiles2,
-                prefix,
-                in,
-                blobMode,
-                hashAlgo,
-                [&](const CanonPath & name, const auto & entry) {
-                    mkSinkHook(
-                        prefix / name,
-                        entry.hash,
-                        // N.B. this cast would not be acceptable in real
-                        // code, because it would make an assert reachable,
-                        // but it should harmless in this test.
-                        static_cast<BlobMode>(entry.mode));
-                },
-                mockXpSettings);
+        // DirectorySink that recursively parses children
+        struct RecursiveDirSink : merkle::DirectorySink
+        {
+            std::function<MemorySourceAccessor::File(merkle::TreeEntry)> & parseToFile;
+            MemorySourceAccessor::File::Directory dir;
+
+            RecursiveDirSink(std::function<MemorySourceAccessor::File(merkle::TreeEntry)> & parseToFile)
+                : parseToFile(parseToFile)
+            {
+            }
+
+            void insertChild(std::string_view name, merkle::TreeEntry entry) override
+            {
+                dir.entries.insert_or_assign(std::string{name}, parseToFile(entry));
+            }
         };
 
-        mkSinkHook(CanonPath::root, root.hash, BlobMode::Regular);
+        parseToFile = [&](merkle::TreeEntry entry) -> MemorySourceAccessor::File {
+            StringSource in{cas[entry.hash]};
+            auto type = parseObjectType(in, mockXpSettings);
+
+            switch (type) {
+            case ObjectType::Blob: {
+                StringSink content;
+                auto size = parseBlob(in, mockXpSettings);
+                in.drainInto(content, size);
+                if (entry.mode == merkle::Mode::Symlink) {
+                    return MemorySourceAccessor::File::Symlink{std::move(content.s)};
+                } else {
+                    return MemorySourceAccessor::File::Regular{
+                        .executable = entry.mode == merkle::Mode::Executable,
+                        .contents = std::move(content.s),
+                    };
+                }
+            }
+            case ObjectType::Tree: {
+                RecursiveDirSink dirSink{parseToFile};
+                parseTree(dirSink, in, hashAlgo, mockXpSettings);
+                return std::move(dirSink.dir);
+            }
+            default:
+                assert(false);
+            }
+        };
+
+        files2->root = parseToFile(root);
 
         EXPECT_EQ(files->root, files2->root);
     }

--- a/src/libutil-tests/git.cc
+++ b/src/libutil-tests/git.cc
@@ -23,7 +23,6 @@ struct TestDirectorySink : merkle::DirectorySink
     }
 };
 
-
 class GitTest : public CharacterizationTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "git";

--- a/src/libutil-tests/memory-source-accessor.cc
+++ b/src/libutil-tests/memory-source-accessor.cc
@@ -1,10 +1,12 @@
 #include "nix/util/memory-source-accessor.hh"
+#include "nix/util/file-system-at.hh"
 #include "nix/util/tests/json-characterization.hh"
 #include "nix/util/tests/gmock-matchers.hh"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <string_view>
 
 namespace nix {
@@ -73,17 +75,20 @@ class MemorySourceAccessorTestErrors : public ::testing::Test
 {
 protected:
     ref<MemorySourceAccessor> accessor = make_ref<MemorySourceAccessor>();
-    MemorySink sink{*accessor};
+    MemorySink sink{[&](MemorySourceAccessor::File file) -> MemorySourceAccessor::File & {
+        return accessor->root.emplace(std::move(file));
+    }};
 
     void SetUp() override
     {
         accessor->setPathDisplay("somepath");
-        sink.createDirectory(CanonPath::root);
     }
 };
 
 TEST_F(MemorySourceAccessorTestErrors, readFileNotFound)
 {
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory &) {});
+
     EXPECT_THAT(
         [&] { accessor->readFile(CanonPath("nonexistent")); },
         ThrowsMessage<FileNotFound>(
@@ -92,7 +97,11 @@ TEST_F(MemorySourceAccessorTestErrors, readFileNotFound)
 
 TEST_F(MemorySourceAccessorTestErrors, readFileNotARegularFile)
 {
-    sink.createDirectory(CanonPath("subdir"));
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory & dir) {
+        dir.createChild("subdir", [](FileSystemObjectSink & child) {
+            child.createDirectory([](FileSystemObjectSink::OnDirectory &) {});
+        });
+    });
 
     EXPECT_THAT(
         [&] { accessor->readFile(CanonPath("subdir")); },
@@ -102,6 +111,8 @@ TEST_F(MemorySourceAccessorTestErrors, readFileNotARegularFile)
 
 TEST_F(MemorySourceAccessorTestErrors, readDirectoryNotFound)
 {
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory &) {});
+
     EXPECT_THAT(
         [&] { accessor->readDirectory(CanonPath("nonexistent")); },
         ThrowsMessage<FileNotFound>(
@@ -110,7 +121,11 @@ TEST_F(MemorySourceAccessorTestErrors, readDirectoryNotFound)
 
 TEST_F(MemorySourceAccessorTestErrors, readDirectoryNotADirectory)
 {
-    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory & dir) {
+        dir.createChild("file", [](FileSystemObjectSink & child) {
+            child.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile &) {});
+        });
+    });
 
     EXPECT_THAT(
         [&] { accessor->readDirectory(CanonPath("file")); },
@@ -120,6 +135,8 @@ TEST_F(MemorySourceAccessorTestErrors, readDirectoryNotADirectory)
 
 TEST_F(MemorySourceAccessorTestErrors, readLinkNotFound)
 {
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory &) {});
+
     EXPECT_THAT(
         [&] { accessor->readLink(CanonPath("nonexistent")); },
         ThrowsMessage<FileNotFound>(
@@ -128,7 +145,11 @@ TEST_F(MemorySourceAccessorTestErrors, readLinkNotFound)
 
 TEST_F(MemorySourceAccessorTestErrors, readLinkNotASymlink)
 {
-    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory & dir) {
+        dir.createChild("file", [](FileSystemObjectSink & child) {
+            child.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile &) {});
+        });
+    });
 
     EXPECT_THAT(
         [&] { accessor->readLink(CanonPath("file")); },
@@ -138,7 +159,11 @@ TEST_F(MemorySourceAccessorTestErrors, readLinkNotASymlink)
 
 TEST_F(MemorySourceAccessorTestErrors, addFileParentNotDirectory)
 {
-    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory & dir) {
+        dir.createChild("file", [](FileSystemObjectSink & child) {
+            child.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile &) {});
+        });
+    });
 
     EXPECT_THAT(
         [&] { accessor->addFile(CanonPath("file/child"), "contents"); },
@@ -149,7 +174,11 @@ TEST_F(MemorySourceAccessorTestErrors, addFileParentNotDirectory)
 
 TEST_F(MemorySourceAccessorTestErrors, addFileNotARegularFile)
 {
-    sink.createDirectory(CanonPath("subdir"));
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory & dir) {
+        dir.createChild("subdir", [](FileSystemObjectSink & child) {
+            child.createDirectory([](FileSystemObjectSink::OnDirectory &) {});
+        });
+    });
 
     EXPECT_THAT(
         [&] { accessor->addFile(CanonPath("subdir"), "contents"); },
@@ -157,95 +186,44 @@ TEST_F(MemorySourceAccessorTestErrors, addFileNotARegularFile)
             AllOf(HasSubstrIgnoreANSIMatcher("somepath/subdir"), HasSubstrIgnoreANSIMatcher("is not a regular file"))));
 }
 
-TEST_F(MemorySourceAccessorTestErrors, createDirectoryParentNotDirectory)
-{
-    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
-
-    EXPECT_THAT(
-        [&] { sink.createDirectory(CanonPath("file/child")); },
-        ThrowsMessage<Error>(AllOf(
-            HasSubstrIgnoreANSIMatcher("somepath/file/child"),
-            HasSubstrIgnoreANSIMatcher("file 'somepath/file' is not a directory"))));
-}
-
-TEST_F(MemorySourceAccessorTestErrors, createDirectoryNotADirectory)
-{
-    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
-
-    EXPECT_THAT(
-        [&] { sink.createDirectory(CanonPath("file")); },
-        ThrowsMessage<NotADirectory>(
-            AllOf(HasSubstrIgnoreANSIMatcher("somepath/file"), HasSubstrIgnoreANSIMatcher("is not a directory"))));
-}
-
-TEST_F(MemorySourceAccessorTestErrors, createRegularFileParentNotDirectory)
-{
-    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
-
-    EXPECT_THAT(
-        [&] { sink.createRegularFile(CanonPath("file/child"), [](CreateRegularFileSink &) {}); },
-        ThrowsMessage<Error>(AllOf(
-            HasSubstrIgnoreANSIMatcher("somepath/file/child"),
-            HasSubstrIgnoreANSIMatcher("file 'somepath/file' is not a directory"))));
-}
-
-TEST_F(MemorySourceAccessorTestErrors, createRegularFileNotARegularFile)
-{
-    sink.createDirectory(CanonPath("subdir"));
-
-    EXPECT_THAT(
-        [&] { sink.createRegularFile(CanonPath("subdir"), [](CreateRegularFileSink &) {}); },
-        ThrowsMessage<NotARegularFile>(
-            AllOf(HasSubstrIgnoreANSIMatcher("somepath/subdir"), HasSubstrIgnoreANSIMatcher("is not a regular file"))));
-}
-
-TEST_F(MemorySourceAccessorTestErrors, createSymlinkParentNotDirectory)
-{
-    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
-
-    EXPECT_THAT(
-        [&] { sink.createSymlink(CanonPath("file/child"), "target"); },
-        ThrowsMessage<Error>(AllOf(
-            HasSubstrIgnoreANSIMatcher("somepath/file/child"),
-            HasSubstrIgnoreANSIMatcher("file 'somepath/file' is not a directory"))));
-}
-
-TEST_F(MemorySourceAccessorTestErrors, createSymlinkNotASymlink)
-{
-    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
-
-    EXPECT_THAT(
-        [&] { sink.createSymlink(CanonPath("file"), "target"); },
-        ThrowsMessage<NotASymlink>(
-            AllOf(HasSubstrIgnoreANSIMatcher("somepath/file"), HasSubstrIgnoreANSIMatcher("is not a symbolic link"))));
-}
-
 TEST_F(MemorySourceAccessorTestErrors, pathExistsThroughRegularFile)
 {
-    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory & dir) {
+        dir.createChild("file", [](FileSystemObjectSink & s) {
+            s.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile &) {});
+        });
+    });
     EXPECT_FALSE(accessor->pathExists(CanonPath("file/child")));
 }
 
 TEST_F(MemorySourceAccessorTestErrors, maybeLstatThroughRegularFile)
 {
-    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory & dir) {
+        dir.createChild("file", [](FileSystemObjectSink & s) {
+            s.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile &) {});
+        });
+    });
     EXPECT_FALSE(accessor->maybeLstat(CanonPath("file/child")));
 }
 
 TEST_F(MemorySourceAccessorTestErrors, pathExistsThroughSymlink)
 {
-    sink.createSymlink(CanonPath("link"), "target");
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory & dir) {
+        dir.createChild("link", [](FileSystemObjectSink & s) { s.createSymlink("target"); });
+    });
     EXPECT_THAT(
         [&] { accessor->pathExists(CanonPath("link/child")); },
         ThrowsMessage<SymlinkNotAllowed>(
             AllOf(HasSubstrIgnoreANSIMatcher("somepath/link"), HasSubstrIgnoreANSIMatcher("is a symlink"))));
 }
 
-TEST_F(MemorySourceAccessorTestErrors, createFileThroughSymlink)
+TEST_F(MemorySourceAccessorTestErrors, addFileThroughSymlink)
 {
-    sink.createSymlink(CanonPath("link"), "target");
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory & dir) {
+        dir.createChild("link", [](FileSystemObjectSink & s) { s.createSymlink("target"); });
+    });
     EXPECT_THAT(
-        [&] { sink.createRegularFile(CanonPath("link/child"), [](CreateRegularFileSink &) {}); },
+        [&] { accessor->addFile(CanonPath("link/child"), "contents"); },
         ThrowsMessage<SymlinkNotAllowed>(
             AllOf(HasSubstrIgnoreANSIMatcher("somepath/link"), HasSubstrIgnoreANSIMatcher("is a symlink"))));
 }

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -81,6 +81,7 @@ sources = files(
   'nar-listing.cc',
   'nix_api_util.cc',
   'nix_api_util_internal.cc',
+  'os-filename.cc',
   'pool.cc',
   'position.cc',
   'processes.cc',

--- a/src/libutil-tests/os-filename.cc
+++ b/src/libutil-tests/os-filename.cc
@@ -1,0 +1,85 @@
+#include "nix/util/os-filename.hh"
+
+#include <gtest/gtest.h>
+
+namespace nix {
+
+TEST(OsFilename, validFilenames)
+{
+    // Simple filename
+    OsFilename f1("foo");
+    ASSERT_EQ(f1.path(), "foo");
+
+    // Filename with extension
+    OsFilename f2("bar.txt");
+    ASSERT_EQ(f2.path(), "bar.txt");
+
+    // Filename with multiple dots
+    OsFilename f3("file.tar.gz");
+    ASSERT_EQ(f3.path(), "file.tar.gz");
+
+    // Filename starting with dot (hidden file)
+    OsFilename f4(".hidden");
+    ASSERT_EQ(f4.path(), ".hidden");
+}
+
+TEST(OsFilename, equality)
+{
+    OsFilename a("foo");
+    OsFilename b("foo");
+    OsFilename c("bar");
+
+    ASSERT_EQ(a, b);
+    ASSERT_NE(a, c);
+}
+
+TEST(OsFilename, implicitConversion)
+{
+    OsFilename f("test.txt");
+    std::filesystem::path p = f;
+    ASSERT_EQ(p, "test.txt");
+}
+
+#ifndef NDEBUG
+// These tests only work in debug builds where asserts are enabled
+
+TEST(OsFilename, emptyFails)
+{
+    ASSERT_DEATH(OsFilename(""), "cannot be empty");
+}
+
+TEST(OsFilename, dotFails)
+{
+    ASSERT_DEATH(OsFilename("."), "cannot be '\\.'");
+}
+
+TEST(OsFilename, dotDotFails)
+{
+    ASSERT_DEATH(OsFilename(".."), "cannot be '\\.\\.'");
+}
+
+TEST(OsFilename, absolutePathFails)
+{
+    ASSERT_DEATH(OsFilename("/foo"), "cannot have a root path");
+}
+
+TEST(OsFilename, relativePathWithDirFails)
+{
+    ASSERT_DEATH(OsFilename("foo/bar"), "cannot have a parent path");
+}
+
+#  ifdef _WIN32
+TEST(OsFilename, windowsDriveLetterFails)
+{
+    ASSERT_DEATH(OsFilename("C:\\foo"), "cannot have a root path");
+}
+
+TEST(OsFilename, windowsBackslashFails)
+{
+    ASSERT_DEATH(OsFilename("foo\\bar"), "cannot have a parent path");
+}
+#  endif
+
+#endif // NDEBUG
+
+} // namespace nix

--- a/src/libutil-tests/source-accessor.cc
+++ b/src/libutil-tests/source-accessor.cc
@@ -1,5 +1,6 @@
 #include "nix/util/fs-sink.hh"
 #include "nix/util/file-system.hh"
+#include "nix/util/file-system-at.hh"
 #include "nix/util/processes.hh"
 
 #include <gtest/gtest.h>
@@ -91,25 +92,41 @@ TEST_F(FSSourceAccessorTest, works)
 #ifdef _WIN32
     GTEST_SKIP() << "Broken on Windows";
 #endif
-    {
-        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
-        sink.createDirectory(CanonPath("subdir"));
-        sink.createRegularFile(CanonPath("file1"), [](CreateRegularFileSink & crf) { crf("content1"); });
-        sink.createRegularFile(CanonPath("subdir/file2"), [](CreateRegularFileSink & crf) { crf("content2"); });
-        sink.createSymlink(CanonPath("rootlink"), "target");
-        sink.createDirectory(CanonPath("a"));
-        sink.createSymlink(CanonPath("a/dirlink"), "../subdir");
-    }
+    auto parentFd = openDirectory(tmpDir, FinalSymlink::Follow);
 
-    EXPECT_THAT(makeFSSourceAccessor(tmpDir / "file1"), HasContents(CanonPath::root, "content1"));
-    EXPECT_THAT(makeFSSourceAccessor(tmpDir / "rootlink"), HasSymlink(CanonPath::root, "target"));
+    // Create entire test structure through a single RestoreSink
+    RestoreSink sink{parentFd.get(), "root", /*startFsync=*/false};
+    sink.createDirectory([](FileSystemObjectSink::OnDirectory & root) {
+        root.createChild("file1", [](FileSystemObjectSink & s) {
+            s.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile & crf) { crf("content1"); });
+        });
+        root.createChild("subdir", [](FileSystemObjectSink & s) {
+            s.createDirectory([](FileSystemObjectSink::OnDirectory & subdir) {
+                subdir.createChild("file2", [](FileSystemObjectSink & s) {
+                    s.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile & crf) { crf("content2"); });
+                });
+            });
+        });
+        root.createChild("rootlink", [](FileSystemObjectSink & s) { s.createSymlink("target"); });
+        root.createChild("a", [](FileSystemObjectSink & s) {
+            s.createDirectory([](FileSystemObjectSink::OnDirectory & a) {
+                a.createChild("dirlink", [](FileSystemObjectSink & s) { s.createSymlink("../subdir"); });
+            });
+        });
+    });
+
+    auto testDir = tmpDir / "root";
+
+    EXPECT_THAT(makeFSSourceAccessor(testDir / "file1"), HasContents(CanonPath::root, "content1"));
+    EXPECT_THAT(makeFSSourceAccessor(testDir / "rootlink"), HasSymlink(CanonPath::root, "target"));
     EXPECT_THAT(
-        makeFSSourceAccessor(tmpDir),
+        makeFSSourceAccessor(testDir),
         HasDirectory(CanonPath::root, std::set<std::string>{"file1", "subdir", "rootlink", "a"}));
-    EXPECT_THAT(makeFSSourceAccessor(tmpDir / "subdir"), HasDirectory(CanonPath::root, std::set<std::string>{"file2"}));
+    EXPECT_THAT(
+        makeFSSourceAccessor(testDir / "subdir"), HasDirectory(CanonPath::root, std::set<std::string>{"file2"}));
 
     {
-        auto accessor = makeFSSourceAccessor(tmpDir);
+        auto accessor = makeFSSourceAccessor(testDir);
         EXPECT_THAT(accessor, HasContents(CanonPath("file1"), "content1"));
         EXPECT_THAT(accessor, HasContents(CanonPath("subdir/file2"), "content2"));
 
@@ -123,11 +140,11 @@ TEST_F(FSSourceAccessorTest, works)
     }
 
     {
-        EXPECT_THROW(makeFSSourceAccessor(tmpDir / "nonexistent"), SystemError);
+        EXPECT_THROW(makeFSSourceAccessor(testDir / "nonexistent"), SystemError);
     }
 
     {
-        auto accessor = makeFSSourceAccessor(tmpDir, true);
+        auto accessor = makeFSSourceAccessor(testDir, true);
         EXPECT_EQ(accessor->getLastModified(), 0);
         accessor->maybeLstat(CanonPath("file1"));
         EXPECT_GT(accessor->getLastModified(), 0);
@@ -141,32 +158,19 @@ TEST_F(FSSourceAccessorTest, works)
 TEST_F(FSSourceAccessorTest, RestoreSinkRegularFileAtRoot)
 {
     auto filePath = tmpDir / "rootfile";
-    {
-        RestoreSink sink{
-            RestoreSink::DirFdParent{OsFilename{std::filesystem::path("rootfile")}},
-            openDirectory(tmpDir, FinalSymlink::Follow),
-            /*startFsync=*/false,
-        };
-        sink.createRegularFile(CanonPath::root, [](CreateRegularFileSink & crf) { crf("root content"); });
-    }
+    auto parentFd = openDirectory(tmpDir, FinalSymlink::Follow);
+    RestoreSink sink{parentFd.get(), "rootfile", /*startFsync=*/false};
+    sink.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile & crf) { crf("root content"); });
 
     EXPECT_THAT(makeFSSourceAccessor(filePath), HasContents(CanonPath::root, "root content"));
 }
 
 TEST_F(FSSourceAccessorTest, RestoreSinkSymlinkAtRoot)
 {
-#ifdef _WIN32
-    GTEST_SKIP() << "symlinks have some problems under Wine";
-#endif
-    auto linkPath = tmpDir / "rootlink";
-    {
-        RestoreSink sink{
-            RestoreSink::DirFdParent{OsFilename{std::filesystem::path("rootlink")}},
-            openDirectory(tmpDir, FinalSymlink::Follow),
-            /*startFsync=*/false,
-        };
-        sink.createSymlink(CanonPath::root, "symlink_target");
-    }
+    auto linkPath = tmpDir / "rootlink2";
+    auto parentFd = openDirectory(tmpDir, FinalSymlink::Follow);
+    RestoreSink sink{parentFd.get(), "rootlink2", /*startFsync=*/false};
+    sink.createSymlink("symlink_target");
 
     EXPECT_THAT(makeFSSourceAccessor(linkPath), HasSymlink(CanonPath::root, "symlink_target"));
 }

--- a/src/libutil-tests/source-accessor.cc
+++ b/src/libutil-tests/source-accessor.cc
@@ -92,11 +92,7 @@ TEST_F(FSSourceAccessorTest, works)
     GTEST_SKIP() << "Broken on Windows";
 #endif
     {
-        RestoreSink sink(false);
-        sink.dstPath = tmpDir;
-#ifndef _WIN32
-        sink.dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
-#endif
+        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
         sink.createDirectory(CanonPath("subdir"));
         sink.createRegularFile(CanonPath("file1"), [](CreateRegularFileSink & crf) { crf("content1"); });
         sink.createRegularFile(CanonPath("subdir/file2"), [](CreateRegularFileSink & crf) { crf("content2"); });
@@ -146,9 +142,11 @@ TEST_F(FSSourceAccessorTest, RestoreSinkRegularFileAtRoot)
 {
     auto filePath = tmpDir / "rootfile";
     {
-        RestoreSink sink(false);
-        sink.dstPath = filePath;
-        // No dirFd set - this tests the !dirFd path
+        RestoreSink sink{
+            RestoreSink::DirFdParent{OsFilename{std::filesystem::path("rootfile")}},
+            openDirectory(tmpDir, FinalSymlink::Follow),
+            /*startFsync=*/false,
+        };
         sink.createRegularFile(CanonPath::root, [](CreateRegularFileSink & crf) { crf("root content"); });
     }
 
@@ -162,9 +160,11 @@ TEST_F(FSSourceAccessorTest, RestoreSinkSymlinkAtRoot)
 #endif
     auto linkPath = tmpDir / "rootlink";
     {
-        RestoreSink sink(false);
-        sink.dstPath = linkPath;
-        // No dirFd set - this tests the !dirFd path
+        RestoreSink sink{
+            RestoreSink::DirFdParent{OsFilename{std::filesystem::path("rootlink")}},
+            openDirectory(tmpDir, FinalSymlink::Follow),
+            /*startFsync=*/false,
+        };
         sink.createSymlink(CanonPath::root, "symlink_target");
     }
 

--- a/src/libutil-tests/unix/file-system-at.cc
+++ b/src/libutil-tests/unix/file-system-at.cc
@@ -26,18 +26,27 @@ TEST(fchmodatTryNoFollow, works)
     std::filesystem::path tmpDir = nix::createTempDir();
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
+    auto testDir = tmpDir / "root";
     {
-        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
-        sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink & crf) {});
-        sink.createDirectory(CanonPath("dir"));
-        sink.createSymlink(CanonPath("filelink"), "file");
-        sink.createSymlink(CanonPath("dirlink"), "dir");
+        auto parentFd = openDirectory(tmpDir, FinalSymlink::Follow);
+
+        // Create entire test structure through a single RestoreSink
+        RestoreSink sink{parentFd.get(), "root", /*startFsync=*/false};
+        sink.createDirectory([](FileSystemObjectSink::OnDirectory & root) {
+            root.createChild("file", [](FileSystemObjectSink & s) {
+                s.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile &) {});
+            });
+            root.createChild(
+                "dir", [](FileSystemObjectSink & s) { s.createDirectory([](FileSystemObjectSink::OnDirectory &) {}); });
+            root.createChild("filelink", [](FileSystemObjectSink & s) { s.createSymlink("file"); });
+            root.createChild("dirlink", [](FileSystemObjectSink & s) { s.createSymlink("dir"); });
+        });
     }
 
-    ASSERT_NO_THROW(chmod(tmpDir / "file", 0644));
-    ASSERT_NO_THROW(chmod(tmpDir / "dir", 0755));
+    ASSERT_NO_THROW(chmod(testDir / "file", 0644));
+    ASSERT_NO_THROW(chmod(testDir / "dir", 0755));
 
-    auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+    auto dirFd = openDirectory(testDir, FinalSymlink::Follow);
     ASSERT_TRUE(dirFd);
 
     struct ::stat st;
@@ -81,21 +90,21 @@ TEST(fchmodatTryNoFollow, works)
     };
 
     expectSymlinkChmod("filelink", 0777);
-    ASSERT_EQ(stat((tmpDir / "file").c_str(), &st), 0);
+    ASSERT_EQ(stat((testDir / "file").c_str(), &st), 0);
     EXPECT_EQ(st.st_mode & 0777, 0644);
 
     expectSymlinkChmod("dirlink", 0777);
-    ASSERT_EQ(stat((tmpDir / "dir").c_str(), &st), 0);
+    ASSERT_EQ(stat((testDir / "dir").c_str(), &st), 0);
     EXPECT_EQ(st.st_mode & 0777, 0755);
 
     /* Check fchmodatTryNoFollow works on regular files and directories. */
 
     EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), std::filesystem::path("file"), 0600));
-    ASSERT_EQ(stat((tmpDir / "file").c_str(), &st), 0);
+    ASSERT_EQ(stat((testDir / "file").c_str(), &st), 0);
     EXPECT_EQ(st.st_mode & 0777, 0600);
 
     EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), std::filesystem::path("dir"), 0700));
-    ASSERT_EQ(stat((tmpDir / "dir").c_str(), &st), 0);
+    ASSERT_EQ(stat((testDir / "dir").c_str(), &st), 0);
     EXPECT_EQ(st.st_mode & 0777, 0700);
 
     EXPECT_THAT(
@@ -114,13 +123,21 @@ TEST(fchmodatTryNoFollow, fallbackWithoutProc)
     std::filesystem::path tmpDir = nix::createTempDir();
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
+    auto testDir = tmpDir / "root";
     {
-        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
-        sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink & crf) {});
-        sink.createSymlink(CanonPath("link"), "file");
+        auto parentFd = openDirectory(tmpDir, FinalSymlink::Follow);
+
+        // Create entire test structure through a single RestoreSink
+        RestoreSink sink{parentFd.get(), "root", /*startFsync=*/false};
+        sink.createDirectory([](FileSystemObjectSink::OnDirectory & root) {
+            root.createChild("file", [](FileSystemObjectSink & s) {
+                s.createRegularFile(false, [](FileSystemObjectSink::OnRegularFile &) {});
+            });
+            root.createChild("link", [](FileSystemObjectSink & s) { s.createSymlink("file"); });
+        });
     }
 
-    ASSERT_NO_THROW(chmod(tmpDir / "file", 0644));
+    ASSERT_NO_THROW(chmod(testDir / "file", 0644));
 
     Pid pid = startProcess(
         [&] {
@@ -133,7 +150,7 @@ TEST(fchmodatTryNoFollow, fallbackWithoutProc)
             if (mount("tmpfs", "/proc", "tmpfs", 0, 0) == -1)
                 _exit(2);
 
-            auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+            auto dirFd = openDirectory(testDir, FinalSymlink::Follow);
             if (!dirFd)
                 _exit(3);
 
@@ -161,7 +178,7 @@ TEST(fchmodatTryNoFollow, fallbackWithoutProc)
     EXPECT_EQ(WEXITSTATUS(status), 0);
 
     struct ::stat st;
-    ASSERT_EQ(stat((tmpDir / "file").c_str(), &st), 0);
+    ASSERT_EQ(stat((testDir / "file").c_str(), &st), 0);
     EXPECT_EQ(st.st_mode & 0777, 0600);
 }
 #endif

--- a/src/libutil-tests/unix/file-system-at.cc
+++ b/src/libutil-tests/unix/file-system-at.cc
@@ -68,14 +68,15 @@ TEST(fchmodatTryNoFollow, works)
        property we actually care about. */
     auto expectSymlinkChmod = [&](std::string_view path, mode_t mode) {
 #if defined(__linux__)
-        EXPECT_THAT([&] { fchmodatTryNoFollow(dirFd.get(), CanonPath(path), mode); }, ThrowsSysError(EOPNOTSUPP));
+        EXPECT_THAT(
+            [&] { fchmodatTryNoFollow(dirFd.get(), std::filesystem::path(path), mode); }, ThrowsSysError(EOPNOTSUPP));
 #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) \
     || defined(__DragonFly__)
-        EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), CanonPath(path), mode));
+        EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), std::filesystem::path(path), mode));
 #else
         GTEST_LOG_(WARNING) << "unknown platform: chmod-on-symlink behaviour is not verified for this OS";
         try {
-            fchmodatTryNoFollow(dirFd.get(), CanonPath(path), mode);
+            fchmodatTryNoFollow(dirFd.get(), std::filesystem::path(path), mode);
         } catch (SysError &) {
         }
 #endif
@@ -91,15 +92,16 @@ TEST(fchmodatTryNoFollow, works)
 
     /* Check fchmodatTryNoFollow works on regular files and directories. */
 
-    EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), CanonPath("file"), 0600));
+    EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), std::filesystem::path("file"), 0600));
     ASSERT_EQ(stat((tmpDir / "file").c_str(), &st), 0);
     EXPECT_EQ(st.st_mode & 0777, 0600);
 
-    EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), CanonPath("dir"), 0700));
+    EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), std::filesystem::path("dir"), 0700));
     ASSERT_EQ(stat((tmpDir / "dir").c_str(), &st), 0);
     EXPECT_EQ(st.st_mode & 0777, 0700);
 
-    EXPECT_THAT([&] { fchmodatTryNoFollow(dirFd.get(), CanonPath("nonexistent"), 0600); }, ThrowsSysError(ENOENT));
+    EXPECT_THAT(
+        [&] { fchmodatTryNoFollow(dirFd.get(), std::filesystem::path("nonexistent"), 0600); }, ThrowsSysError(ENOENT));
 }
 
 #ifdef __linux__
@@ -140,13 +142,13 @@ TEST(fchmodatTryNoFollow, fallbackWithoutProc)
                 _exit(3);
 
             try {
-                fchmodatTryNoFollow(dirFd.get(), CanonPath("file"), 0600);
+                fchmodatTryNoFollow(dirFd.get(), std::filesystem::path("file"), 0600);
             } catch (SysError & e) {
                 _exit(4);
             }
 
             try {
-                fchmodatTryNoFollow(dirFd.get(), CanonPath("link"), 0777);
+                fchmodatTryNoFollow(dirFd.get(), std::filesystem::path("link"), 0777);
             } catch (SysError & e) {
                 if (e.errNo == EOPNOTSUPP)
                     _exit(0); /* Success. */

--- a/src/libutil-tests/unix/file-system-at.cc
+++ b/src/libutil-tests/unix/file-system-at.cc
@@ -27,9 +27,7 @@ TEST(fchmodatTryNoFollow, works)
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
     {
-        RestoreSink sink(/*startFsync=*/false);
-        sink.dstPath = tmpDir;
-        sink.dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
         sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink & crf) {});
         sink.createDirectory(CanonPath("dir"));
         sink.createSymlink(CanonPath("filelink"), "file");
@@ -117,9 +115,7 @@ TEST(fchmodatTryNoFollow, fallbackWithoutProc)
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
     {
-        RestoreSink sink(/*startFsync=*/false);
-        sink.dstPath = tmpDir;
-        sink.dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+        RestoreSink sink{RestoreSink::DirFdRoot{}, openDirectory(tmpDir, FinalSymlink::Follow), /*startFsync=*/false};
         sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink & crf) {});
         sink.createSymlink(CanonPath("link"), "file");
     }

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -1,5 +1,4 @@
 #include <cerrno>
-#include <fcntl.h>
 #include <map>
 
 #include <strings.h> // for strcasecmp
@@ -7,10 +6,11 @@
 #include "nix/util/archive.hh"
 #include "nix/util/alignment.hh"
 #include "nix/util/config-global.hh"
-#include "nix/util/posix-source-accessor.hh"
-#include "nix/util/source-path.hh"
 #include "nix/util/file-system.hh"
+#include "nix/util/fs-sink.hh"
+#include "nix/util/posix-source-accessor.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/source-path.hh"
 
 namespace nix {
 
@@ -123,7 +123,7 @@ static SerialisationError badArchive(std::string_view s, const Args &... args)
     return SerialisationError("bad archive: " + s, args...);
 }
 
-static void parseContents(CreateRegularFileSink & sink, Source & source)
+static void parseContents(FileSystemObjectSink::OnRegularFile & sink, Source & source)
 {
     uint64_t size = readLongLong(source);
 
@@ -147,7 +147,7 @@ struct CaseInsensitiveCompare
     }
 };
 
-static void parse(FileSystemObjectSink & sink, Source & source, const CanonPath & path)
+static void parse(FileSystemObjectSink & sink, Source & source)
 {
     auto getString = [&]() {
         checkInterrupt();
@@ -167,28 +167,27 @@ static void parse(FileSystemObjectSink & sink, Source & source, const CanonPath 
     auto type = getString();
 
     if (type == "regular") {
-        sink.createRegularFile(path, [&](auto & crf) {
-            auto tag = getString();
+        auto tag = getString();
 
-            if (tag == "executable") {
-                auto s2 = getString();
-                if (s2 != "")
-                    throw badArchive("executable marker has non-empty value");
-                crf.isExecutable();
-                tag = getString();
-            }
+        bool isExecutable = false;
+        if (tag == "executable") {
+            auto s2 = getString();
+            if (s2 != "")
+                throw badArchive("executable marker has non-empty value");
+            isExecutable = true;
+            tag = getString();
+        }
 
-            if (tag != "contents")
-                throw badArchive("expected tag 'contents', got '%s'", tag);
+        if (tag != "contents")
+            throw badArchive("expected tag 'contents', got '%s'", tag);
 
-            parseContents(crf, source);
+        sink.createRegularFile(isExecutable, [&](auto & crf) { parseContents(crf, source); });
 
-            expectTag(")");
-        });
+        expectTag(")");
     }
 
     else if (type == "directory") {
-        sink.createDirectory(path, [&](FileSystemObjectSink & dirSink, const CanonPath & relDirPath) {
+        sink.createDirectory([&](FileSystemObjectSink::OnDirectory & dirSink) {
             std::map<std::string, int, CaseInsensitiveCompare> names;
 
             std::string prevName;
@@ -231,7 +230,7 @@ static void parse(FileSystemObjectSink & sink, Source & source, const CanonPath 
 
                 expectTag("node");
 
-                parse(dirSink, source, relDirPath / name);
+                dirSink.createChild(name, [&](FileSystemObjectSink & childSink) { parse(childSink, source); });
 
                 expectTag(")");
             }
@@ -242,7 +241,7 @@ static void parse(FileSystemObjectSink & sink, Source & source, const CanonPath 
         expectTag("target");
 
         auto target = getString();
-        sink.createSymlink(path, target);
+        sink.createSymlink(target);
 
         expectTag(")");
     }
@@ -262,30 +261,17 @@ void parseDump(FileSystemObjectSink & sink, Source & source)
     }
     if (version != narVersionMagic1)
         throw badArchive("input doesn't look like a Nix archive");
-    parse(sink, source, CanonPath::root);
+    parse(sink, source);
 }
 
-void restorePath(const std::filesystem::path & path, Source & source, bool startFsync)
+void restorePath(
+    const std::filesystem::path & parentPath, const std::string & childName, Source & source, bool startFsync)
 {
-    if (path.empty())
-        throw Error("restore destination path is empty");
-    auto filename = path.filename();
-    if (filename == "." || filename == "..")
-        throw Error(
-            "restore destination '%s' ends in '%s', which is not a valid filename", path.string(), filename.string());
-    /* For bare relative paths like "out", parent_path() returns "".
-       Fall back to "." to pin the current working directory. */
-    auto parentPath = path.parent_path();
-    if (parentPath.empty())
-        parentPath = ".";
-    auto dirFd = openDirectory(parentPath, FinalSymlink::Follow);
-    if (!dirFd)
-        throw SysError("opening parent directory of %s", PathFmt(path));
-    RestoreSink sink{
-        RestoreSink::DirFdParent{OsFilename{filename}},
-        std::move(dirFd),
-        startFsync,
-    };
+    auto parentDir = openDirectory(parentPath, FinalSymlink::Follow);
+    if (!parentDir)
+        throw NativeSysError("opening directory %s", PathFmt(parentPath));
+
+    RestoreSink sink{parentDir.get(), childName, startFsync};
     parseDump(sink, source);
 }
 

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -267,8 +267,25 @@ void parseDump(FileSystemObjectSink & sink, Source & source)
 
 void restorePath(const std::filesystem::path & path, Source & source, bool startFsync)
 {
-    RestoreSink sink{startFsync};
-    sink.dstPath = path;
+    if (path.empty())
+        throw Error("restore destination path is empty");
+    auto filename = path.filename();
+    if (filename == "." || filename == "..")
+        throw Error(
+            "restore destination '%s' ends in '%s', which is not a valid filename", path.string(), filename.string());
+    /* For bare relative paths like "out", parent_path() returns "".
+       Fall back to "." to pin the current working directory. */
+    auto parentPath = path.parent_path();
+    if (parentPath.empty())
+        parentPath = ".";
+    auto dirFd = openDirectory(parentPath, FinalSymlink::Follow);
+    if (!dirFd)
+        throw SysError("opening parent directory of %s", PathFmt(path));
+    RestoreSink sink{
+        RestoreSink::DirFdParent{OsFilename{filename}},
+        std::move(dirFd),
+        startFsync,
+    };
     parseDump(sink, source);
 }
 

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -1,4 +1,5 @@
 #include <cerrno>
+#include <fcntl.h>
 #include <map>
 
 #include <strings.h> // for strcasecmp

--- a/src/libutil/canon-path.cc
+++ b/src/libutil/canon-path.cc
@@ -64,6 +64,16 @@ std::optional<CanonPath> CanonPath::parent() const
     return CanonPath(unchecked_t(), path.substr(0, std::max((size_t) 1, path.rfind('/'))));
 }
 
+std::optional<std::pair<CanonPath, std::string_view>> CanonPath::parentAndChild() const
+{
+    if (isRoot())
+        return std::nullopt;
+    auto slash = path.rfind('/');
+    return {
+        {CanonPath(unchecked_t(), path.substr(0, std::max((size_t) 1, slash))),
+         std::string_view{path}.substr(slash + 1)}};
+}
+
 void CanonPath::pop()
 {
     assert(!isRoot());

--- a/src/libutil/file-content-address.cc
+++ b/src/libutil/file-content-address.cc
@@ -75,14 +75,20 @@ void dumpPath(const SourcePath & path, Sink & sink, FileSerialisationMethod meth
     }
 }
 
-void restorePath(const std::filesystem::path & path, Source & source, FileSerialisationMethod method, bool startFsync)
+void restorePath(
+    const std::filesystem::path & parentPath,
+    const std::string & childName,
+    Source & source,
+    FileSerialisationMethod method,
+    bool startFsync)
 {
     switch (method) {
     case FileSerialisationMethod::Flat:
-        writeFile(path, source, 0666, startFsync ? FsSync::Yes : FsSync::No, FinalSymlink::DontFollow);
+        writeFile(
+            parentPath / childName, source, 0666, startFsync ? FsSync::Yes : FsSync::No, FinalSymlink::DontFollow);
         break;
     case FileSerialisationMethod::NixArchive:
-        restorePath(path, source, startFsync);
+        restorePath(parentPath, childName, source, startFsync);
         break;
     }
 }

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -1,9 +1,11 @@
 #include "nix/util/file-system.hh"
+#include "nix/util/file-system-at.hh"
 #include "nix/util/file-path.hh"
 #include "nix/util/file-path-impl.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/finally.hh"
 #include "nix/util/serialise.hh"
+#include "nix/util/source-accessor.hh"
 #include "nix/util/util.hh"
 
 #include <atomic>
@@ -215,11 +217,19 @@ bool pathAccessible(const std::filesystem::path & path)
 std::filesystem::path readLink(const std::filesystem::path & path)
 {
     checkInterrupt();
+#ifdef _WIN32
+    // libstdc++ doesn't implement std::filesystem::read_symlink on Windows yet
+    auto parentDir = openDirectory(path.parent_path(), FinalSymlink::Follow);
+    if (!parentDir)
+        throw NativeSysError("opening parent directory of %s", PathFmt(path));
+    return readLinkAt(parentDir.get(), path.filename());
+#else
     try {
         return std::filesystem::read_symlink(path);
     } catch (std::filesystem::filesystem_error & e) {
         throw SystemError(e.code(), "reading symbolic link %s", PathFmt(path));
     }
+#endif
 }
 
 std::string readFile(const std::filesystem::path & path)
@@ -541,10 +551,18 @@ std::filesystem::path makeTempPath(const std::filesystem::path & root, const std
 
 void createSymlink(const std::filesystem::path & target, const std::filesystem::path & link)
 {
+#ifdef _WIN32
+    // libstdc++ doesn't implement std::filesystem::create_symlink on Windows yet
+    auto parentDir = openDirectory(link.parent_path(), FinalSymlink::Follow);
+    if (!parentDir)
+        throw NativeSysError("opening parent directory of %s", PathFmt(link));
+    createUnknownSymlinkAt(parentDir.get(), link.filename(), target.native());
+#else
     std::error_code ec;
     std::filesystem::create_symlink(target, link, ec);
     if (ec)
-        throw SysError(ec.value(), "creating symlink %s -> %s", PathFmt(link), PathFmt(target));
+        throw SystemError(ec, "creating symlink %s -> %s", PathFmt(link), PathFmt(target));
+#endif
 }
 
 void replaceSymlink(const std::filesystem::path & target, const std::filesystem::path & link)
@@ -554,11 +572,11 @@ void replaceSymlink(const std::filesystem::path & target, const std::filesystem:
         tmp = tmp.lexically_normal();
 
         try {
-            std::filesystem::create_symlink(target, tmp);
-        } catch (std::filesystem::filesystem_error & e) {
-            if (e.code() == std::errc::file_exists)
+            createSymlink(target, tmp);
+        } catch (SystemError & e) {
+            if (e.is(std::errc::file_exists))
                 continue;
-            throw SystemError(e.code(), "creating symlink %1% -> %2%", PathFmt(tmp), PathFmt(target));
+            throw;
         }
 
         try {
@@ -628,15 +646,14 @@ void moveFile(const std::filesystem::path & oldName, const std::filesystem::path
         auto newPath = newName;
         // For the move to be as atomic as possible, copy to a temporary
         // directory
-        std::filesystem::path temp = createTempDir(os_string_to_string(PathView{newPath.parent_path()}), "rename-tmp");
+        std::filesystem::path temp = createTempDir(newPath.parent_path(), "rename-tmp");
         Finally removeTemp = [&]() { std::filesystem::remove(temp); };
         auto tempCopyTarget = temp / "copy-target";
         if (e.code().value() == EXDEV) {
             std::filesystem::remove(newPath);
             warn("can’t rename %s as %s, copying instead", PathFmt(oldName), PathFmt(newName));
             copyFile(oldPath, tempCopyTarget, true);
-            std::filesystem::rename(
-                os_string_to_string(PathView{tempCopyTarget}), os_string_to_string(PathView{newPath}));
+            std::filesystem::rename(tempCopyTarget, newPath);
         }
     }
 }

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -4,6 +4,7 @@
 #include "nix/util/config-global.hh"
 #include "nix/util/file-system-at.hh"
 #include "nix/util/fs-sink.hh"
+#include "nix/util/util.hh"
 
 #ifdef _WIN32
 #  include <fileapi.h>
@@ -62,74 +63,49 @@ static RestoreSinkSettings restoreSinkSettings;
 
 static GlobalConfig::Register r1(&restoreSinkSettings);
 
-static std::filesystem::path append(const std::filesystem::path & src, const CanonPath & path)
-{
-    auto dst = src;
-    if (!path.rel().empty())
-        dst /= path.rel();
-    return dst;
-}
-
 /**
  * Return a descriptor and single-component name suitable for
- * `*at` operations. The returned `CanonPath` is always a pure
+ * `*at` operations. The returned `OsFilename` is always a pure
  * name (no slashes). The `Descriptor` is the fd to use. The
  * `AutoCloseFD` keeps it alive when it was opened temporarily
  * (for multi-component paths); otherwise it is empty and the
- * `Descriptor` borrows from `dirFd`. When `dirFd` is not set,
- * temporarily opens the parent of `dstPath`.
+ * `Descriptor` borrows from `dirFd`.
  */
-static std::tuple<AutoCloseFD, Descriptor, CanonPath>
-getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, const CanonPath & path)
+static std::tuple<AutoCloseFD, Descriptor, OsFilename> getParentFdAndName(RestoreSink & sink, const CanonPath & path)
 {
-    if (dirFd != INVALID_DESCRIPTOR) {
-        /* dirFd is the root of the restore tree, which means we already created
-           a root directory, which means that path must be relative (i.e. not
-           root) within it. */
-        assert(!path.isRoot());
-        auto parent = path.parent();
-        if (parent->isRoot())
-            return {AutoCloseFD{}, dirFd, CanonPath::fromFilename(*path.baseName())};
-        auto parentFd = openFileEnsureBeneathNoSymlinks(
-            dirFd,
-            std::filesystem::path(parent->rel()),
-#ifdef _WIN32
-            FILE_READ_ATTRIBUTES | SYNCHRONIZE,
-            FILE_DIRECTORY_FILE
-#else
-            O_RDONLY | O_DIRECTORY | O_CLOEXEC,
-            0
-#endif
-        );
-        if (!parentFd)
-            throw SysError("opening parent directory of %s", PathFmt(append(dstPath, path)));
-        auto fd = parentFd.get();
-        return {std::move(parentFd), fd, CanonPath::fromFilename(*path.baseName())};
+    if (auto * parent = std::get_if<RestoreSink::DirFdParent>(&sink.dirFdKind)) {
+        /* dirFd is the parent directory. The root entry's name comes
+           from the variant. path must be root since we haven't
+           created the root directory yet. */
+        if (!path.isRoot())
+            throw Error("cannot create non-root path %s without a root directory", path);
+        return {AutoCloseFD{}, sink.dirFd.get(), parent->name};
     }
 
-    /* Without dirFd, we're creating the root entry itself, so path
-       must be root. If it's not, someone forgot to create the root
-       directory first. */
-    auto p = append(dstPath, path);
-    if (!path.isRoot())
-        throw Error("cannot create non-root path %s without a root directory", PathFmt(p));
-    if (p.empty())
-        throw Error("restore destination path is empty");
-    auto filename = p.filename();
-    if (filename == "." || filename == "..")
-        throw Error("restore destination %s ends in %s, which is not a valid filename", PathFmt(p), PathFmt(filename));
-    auto parentPath = p.parent_path();
-    /* Relative path with no directory component (e.g. "out") —
-       the parent is the current working directory. Open it so we
-       hold a stable reference in case something else in the process
-       changes the working directory mid-unpack. */
-    if (parentPath.empty())
-        parentPath = ".";
-    auto parentFd = openDirectory(parentPath, FinalSymlink::Follow);
+    /* dirFd is the root of the restore tree, so path must be
+       relative (i.e. not root) within it. */
+    assert(!path.isRoot());
+    auto parent = path.parent();
+    if (parent->isRoot())
+        return {AutoCloseFD{}, sink.dirFd.get(), OsFilename{std::filesystem::path(std::string{*path.baseName()})}};
+
+    /* Multi-component path: open intermediate directories to reach
+       the immediate parent. The returned AutoCloseFD keeps it alive. */
+    auto parentFd = openFileEnsureBeneathNoSymlinks(
+        sink.dirFd.get(),
+        std::filesystem::path(parent->rel()),
+#ifdef _WIN32
+        FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        FILE_DIRECTORY_FILE
+#else
+        O_RDONLY | O_DIRECTORY | O_CLOEXEC,
+        0
+#endif
+    );
     if (!parentFd)
-        throw NativeSysError("opening parent directory of %s", PathFmt(p));
+        throw SysError("opening parent directory of %s", PathFmt(descriptorToPath(sink.dirFd.get()) / path.rel()));
     auto fd = parentFd.get();
-    return {std::move(parentFd), fd, CanonPath::fromFilename(p.filename().string())};
+    return {std::move(parentFd), fd, OsFilename{std::filesystem::path(std::string{*path.baseName()})}};
 }
 
 void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallback callback)
@@ -141,11 +117,11 @@ void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallba
     }
 
     createDirectory(path);
-    assert(dirFd); // If that's not true the above call must have thrown an exception.
+    assert(
+        std::holds_alternative<DirFdRoot>(
+            dirFdKind)); // If that's not true the above call must have thrown an exception.
 
-    RestoreSink dirSink{startFsync};
-    dirSink.dstPath = append(dstPath, path);
-    dirSink.dirFd = openFileEnsureBeneathNoSymlinks(
+    auto subDirFd = openFileEnsureBeneathNoSymlinks(
         dirFd.get(),
         std::filesystem::path(path.rel()),
 #ifdef _WIN32
@@ -157,32 +133,39 @@ void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallba
 #endif
     );
 
-    if (!dirSink.dirFd)
-        throw SysError("opening directory %s", PathFmt(dirSink.dstPath));
+    if (!subDirFd)
+        throw SysError("opening directory %s", PathFmt(descriptorToPath(dirFd.get()) / path.rel()));
+
+    RestoreSink dirSink{DirFdRoot{}, std::move(subDirFd), startFsync};
 
     callback(dirSink, CanonPath::root);
 }
 
 void RestoreSink::createDirectory(const CanonPath & path)
 {
-    if (dirFd && path.isRoot())
-        throw Error("path %s already exists", PathFmt(append(dstPath, path)));
+    if (std::holds_alternative<DirFdRoot>(dirFdKind) && path.isRoot())
+        /* Trying to create a directory that we already have a file descriptor for. */
+        throw Error("path %s already exists", PathFmt(descriptorToPath(dirFd.get())));
 
-    auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
+    auto [_parentFd, fd, name] = getParentFdAndName(*this, path);
 
-    if (auto result = openDirectoryAt(fd, std::filesystem::path(name.rel()), true); !result) {
+    if (auto result = openDirectoryAt(fd, name, true); !result) {
         auto ec = result.error();
-        if (ec == std::errc::file_exists)
-            throw Error("path %s already exists", PathFmt(append(dstPath, path)));
-        throw SystemError(ec, "creating directory %s", PathFmt(append(dstPath, path)));
+        auto fullPath = descriptorToPath(fd) / name.path();
+        if (ec == std::errc::not_a_directory || ec == std::errc::too_many_symbolic_link_levels)
+            throw SymlinkNotAllowed(fullPath);
+        throw SystemError(ec, "creating directory %s", PathFmt(fullPath));
     }
 
-    if (!dirFd) {
-        /* Open directory for further *at operations relative to the sink root
-           directory. */
-        dirFd = openFileEnsureBeneathNoSymlinks(
+    if (std::holds_alternative<DirFdParent>(dirFdKind)) {
+        /* getParentFdAndName throws if path is not root when dirFdKind is Parent. */
+        assert(path.isRoot());
+        /* Open the newly created root directory for further *at operations.
+           Use a temp because `fd` borrows from `this->dirFd` and the
+           assignment would close it before the error message could use it. */
+        auto newDirFd = openFileEnsureBeneathNoSymlinks(
             fd,
-            std::filesystem::path(name.rel()),
+            name,
 #ifdef _WIN32
             FILE_READ_ATTRIBUTES | SYNCHRONIZE,
             FILE_DIRECTORY_FILE
@@ -191,8 +174,10 @@ void RestoreSink::createDirectory(const CanonPath & path)
             0
 #endif
         );
-        if (!dirFd)
-            throw NativeSysError("opening directory %s", PathFmt(append(dstPath, path)));
+        if (!newDirFd)
+            throw SysError("opening directory %s", PathFmt(descriptorToPath(fd) / name.path()));
+        dirFd = std::move(newDirFd);
+        dirFdKind = DirFdRoot{};
     }
 };
 
@@ -234,23 +219,23 @@ struct RestoreRegularFile : CreateRegularFileSink, FdSink
 
 void RestoreSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)
 {
-    auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
-    auto crf = RestoreRegularFile(
-        startFsync,
-        openFileEnsureBeneathNoSymlinks(
-            fd,
-            std::filesystem::path(name.rel()),
+    auto [_parentFd, parentDescriptor, name] = getParentFdAndName(*this, path);
+    auto fd = openFileEnsureBeneathNoSymlinks(
+        parentDescriptor,
+        name,
 #ifdef _WIN32
-            FILE_WRITE_DATA | SYNCHRONIZE,
-            0,
-            FILE_CREATE
+        FILE_WRITE_DATA | SYNCHRONIZE,
+        0,
+        FILE_CREATE
 #else
-            O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC,
-            0666
+        O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC,
+        0666
 #endif
-            ));
-    if (!crf.fd)
-        throw NativeSysError("creating file %s", PathFmt(append(dstPath, path)));
+    );
+    if (!fd)
+        throw NativeSysError("creating file %s", PathFmt(descriptorToPath(dirFd.get()) / path.rel()));
+
+    auto crf = RestoreRegularFile(startFsync, std::move(fd));
     func(crf);
     crf.flush();
 }
@@ -286,8 +271,8 @@ void RestoreRegularFile::preallocateContents(uint64_t len)
 
 void RestoreSink::createSymlink(const CanonPath & path, const std::string & target)
 {
-    auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
-    createUnknownSymlinkAt(fd, std::filesystem::path(name.rel()), string_to_os_string(target));
+    auto [_parentFd, fd, name] = getParentFdAndName(*this, path);
+    createUnknownSymlinkAt(fd, name, string_to_os_string(target));
 }
 
 void RegularFileSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -15,29 +15,28 @@
 
 namespace nix {
 
-void copyRecursive(SourceAccessor & accessor, const CanonPath & from, FileSystemObjectSink & sink, const CanonPath & to)
+void copyRecursive(SourceAccessor & accessor, const CanonPath & from, FileSystemObjectSink & sink)
 {
     auto stat = accessor.lstat(from);
 
     switch (stat.type) {
     case SourceAccessor::tSymlink: {
-        sink.createSymlink(to, accessor.readLink(from));
+        sink.createSymlink(accessor.readLink(from));
         break;
     }
 
     case SourceAccessor::tRegular: {
-        sink.createRegularFile(to, [&](CreateRegularFileSink & crf) {
-            if (stat.isExecutable)
-                crf.isExecutable();
+        sink.createRegularFile(stat.isExecutable, [&](FileSystemObjectSink::OnRegularFile & crf) {
             accessor.readFile(from, crf, [&](uint64_t size) { crf.preallocateContents(size); });
         });
         break;
     }
 
     case SourceAccessor::tDirectory: {
-        sink.createDirectory(to, [&](FileSystemObjectSink & dirSink, const CanonPath & relDirPath) {
+        sink.createDirectory([&](FileSystemObjectSink::OnDirectory & dirSink) {
             for (auto & [name, _] : accessor.readDirectory(from)) {
-                copyRecursive(accessor, from / name, dirSink, relDirPath / name);
+                dirSink.createChild(
+                    name, [&](FileSystemObjectSink & childSink) { copyRecursive(accessor, from / name, childSink); });
             }
         });
         break;
@@ -63,125 +62,43 @@ static RestoreSinkSettings restoreSinkSettings;
 
 static GlobalConfig::Register r1(&restoreSinkSettings);
 
-/**
- * Return a descriptor and single-component name suitable for
- * `*at` operations. The returned `OsFilename` is always a pure
- * name (no slashes). The `Descriptor` is the fd to use. The
- * `AutoCloseFD` keeps it alive when it was opened temporarily
- * (for multi-component paths); otherwise it is empty and the
- * `Descriptor` borrows from `dirFd`.
- */
-static std::tuple<AutoCloseFD, Descriptor, OsFilename> getParentFdAndName(RestoreSink & sink, const CanonPath & path)
+void RestoreSink::Directory::createChild(std::string_view name, ChildCreatedCallback callback)
 {
-    if (auto * parent = std::get_if<RestoreSink::DirFdParent>(&sink.dirFdKind)) {
-        /* dirFd is the parent directory. The root entry's name comes
-           from the variant. path must be root since we haven't
-           created the root directory yet. */
-        if (!path.isRoot())
-            throw Error("cannot create non-root path %s without a root directory", path);
-        return {AutoCloseFD{}, sink.dirFd.get(), parent->name};
-    }
-
-    /* dirFd is the root of the restore tree, so path must be
-       relative (i.e. not root) within it. */
-    assert(!path.isRoot());
-    auto parent = path.parent();
-    if (parent->isRoot())
-        return {AutoCloseFD{}, sink.dirFd.get(), OsFilename{std::filesystem::path(std::string{*path.baseName()})}};
-
-    /* Multi-component path: open intermediate directories to reach
-       the immediate parent. The returned AutoCloseFD keeps it alive. */
-    auto parentFd = openFileEnsureBeneathNoSymlinks(
-        sink.dirFd.get(),
-        std::filesystem::path(parent->rel()),
-#ifdef _WIN32
-        FILE_READ_ATTRIBUTES | SYNCHRONIZE,
-        FILE_DIRECTORY_FILE
-#else
-        O_RDONLY | O_DIRECTORY | O_CLOEXEC,
-        0
-#endif
-    );
-    if (!parentFd)
-        throw SysError("opening parent directory of %s", PathFmt(descriptorToPath(sink.dirFd.get()) / path.rel()));
-    auto fd = parentFd.get();
-    return {std::move(parentFd), fd, OsFilename{std::filesystem::path(std::string{*path.baseName()})}};
+    RestoreSink childSink{directory.get(), std::string{name}, startFsync};
+    callback(childSink);
 }
 
-void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallback callback)
+void RestoreSink::createDirectory(DirectoryCreatedCallback callback)
 {
-    if (path.isRoot()) {
-        createDirectory(path);
-        callback(*this, path);
-        return;
-    }
-
-    createDirectory(path);
-    assert(
-        std::holds_alternative<DirFdRoot>(
-            dirFdKind)); // If that's not true the above call must have thrown an exception.
-
-    auto subDirFd = openFileEnsureBeneathNoSymlinks(
-        dirFd.get(),
-        std::filesystem::path(path.rel()),
-#ifdef _WIN32
-        FILE_READ_ATTRIBUTES | SYNCHRONIZE,
-        FILE_DIRECTORY_FILE
-#else
-        O_RDONLY | O_DIRECTORY | O_CLOEXEC,
-        0
-#endif
-    );
-
-    if (!subDirFd)
-        throw SysError("opening directory %s", PathFmt(descriptorToPath(dirFd.get()) / path.rel()));
-
-    RestoreSink dirSink{DirFdRoot{}, std::move(subDirFd), startFsync};
-
-    callback(dirSink, CanonPath::root);
-}
-
-void RestoreSink::createDirectory(const CanonPath & path)
-{
-    if (std::holds_alternative<DirFdRoot>(dirFdKind) && path.isRoot())
-        /* Trying to create a directory that we already have a file descriptor for. */
-        throw Error("path %s already exists", PathFmt(descriptorToPath(dirFd.get())));
-
-    auto [_parentFd, fd, name] = getParentFdAndName(*this, path);
-
-    if (auto result = openDirectoryAt(fd, name, true); !result) {
+    if (auto result = openDirectoryAt(parentDir, name, true); !result) {
         auto ec = result.error();
-        auto fullPath = descriptorToPath(fd) / name.path();
+        auto fullPath = descriptorToPath(parentDir) / name;
+        // ENOTDIR or ELOOP means the path exists but is not a directory (e.g., it's a symlink)
         if (ec == std::errc::not_a_directory || ec == std::errc::too_many_symbolic_link_levels)
             throw SymlinkNotAllowed(fullPath);
         throw SystemError(ec, "creating directory %s", PathFmt(fullPath));
     }
 
-    if (std::holds_alternative<DirFdParent>(dirFdKind)) {
-        /* getParentFdAndName throws if path is not root when dirFdKind is Parent. */
-        assert(path.isRoot());
-        /* Open the newly created root directory for further *at operations.
-           Use a temp because `fd` borrows from `this->dirFd` and the
-           assignment would close it before the error message could use it. */
-        auto newDirFd = openFileEnsureBeneathNoSymlinks(
-            fd,
-            name,
+    auto dirFd = openFileEnsureBeneathNoSymlinks(
+        parentDir,
+        name,
 #ifdef _WIN32
-            FILE_READ_ATTRIBUTES | SYNCHRONIZE,
-            FILE_DIRECTORY_FILE
+        FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        FILE_DIRECTORY_FILE
 #else
-            O_RDONLY | O_DIRECTORY | O_CLOEXEC,
-            0
+        O_RDONLY | O_DIRECTORY | O_CLOEXEC,
+        0
 #endif
-        );
-        if (!newDirFd)
-            throw SysError("opening directory %s", PathFmt(descriptorToPath(fd) / name.path()));
-        dirFd = std::move(newDirFd);
-        dirFdKind = DirFdRoot{};
-    }
-};
+    );
+    if (!dirFd)
+        throw NativeSysError(
+            [&] { return HintFmt("opening directory %s", PathFmt(descriptorToPath(parentDir) / name)); });
 
-struct RestoreRegularFile : CreateRegularFileSink, FdSink
+    Directory dir{std::move(dirFd), startFsync};
+    callback(dir);
+}
+
+struct RestoreRegularFile : FileSystemObjectSink::OnRegularFile, FdSink
 {
     AutoCloseFD fd;
     bool startFsync = false;
@@ -213,19 +130,17 @@ struct RestoreRegularFile : CreateRegularFileSink, FdSink
             fd.startFsync();
     }
 
-    void isExecutable() override;
     void preallocateContents(uint64_t size) override;
 };
 
-void RestoreSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)
+void RestoreSink::createRegularFile(bool isExecutable, RegularFileCreatedCallback func)
 {
-    auto [_parentFd, parentDescriptor, name] = getParentFdAndName(*this, path);
     auto fd = openFileEnsureBeneathNoSymlinks(
-        parentDescriptor,
+        parentDir,
         name,
 #ifdef _WIN32
-        FILE_WRITE_DATA | SYNCHRONIZE,
-        0,
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_NON_DIRECTORY_FILE,
         FILE_CREATE
 #else
         O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC,
@@ -233,21 +148,19 @@ void RestoreSink::createRegularFile(const CanonPath & path, fun<void(CreateRegul
 #endif
     );
     if (!fd)
-        throw NativeSysError("creating file %s", PathFmt(descriptorToPath(dirFd.get()) / path.rel()));
+        throw NativeSysError([&] { return HintFmt("creating file %s", PathFmt(descriptorToPath(parentDir) / name)); });
 
     auto crf = RestoreRegularFile(startFsync, std::move(fd));
     func(crf);
     crf.flush();
-}
-
-void RestoreRegularFile::isExecutable()
-{
     // Windows doesn't have a notion of executable file permissions we
     // care about here, right?
 #ifndef _WIN32
-    auto st = nix::fstat(fd.get());
-    if (fchmod(fd.get(), st.st_mode | (S_IXUSR | S_IXGRP | S_IXOTH)) == -1)
-        throw SysError("fchmod");
+    if (isExecutable) {
+        auto st = nix::fstat(crf.fd.get());
+        if (fchmod(crf.fd.get(), st.st_mode | (S_IXUSR | S_IXGRP | S_IXOTH)) == -1)
+            throw SysError("fchmod");
+    }
 #endif
 }
 
@@ -269,15 +182,14 @@ void RestoreRegularFile::preallocateContents(uint64_t len)
 #endif
 }
 
-void RestoreSink::createSymlink(const CanonPath & path, const std::string & target)
+void RestoreSink::createSymlink(const std::string & target)
 {
-    auto [_parentFd, fd, name] = getParentFdAndName(*this, path);
-    createUnknownSymlinkAt(fd, name, string_to_os_string(target));
+    createUnknownSymlinkAt(parentDir, name, string_to_os_string(target));
 }
 
-void RegularFileSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)
+void RegularFileSink::createRegularFile(bool isExecutable, RegularFileCreatedCallback func)
 {
-    struct CRF : CreateRegularFileSink
+    struct CRF : OnRegularFile
     {
         RegularFileSink & back;
 
@@ -290,20 +202,30 @@ void RegularFileSink::createRegularFile(const CanonPath & path, fun<void(CreateR
         {
             back.sink(data);
         }
-
-        void isExecutable() override {}
     } crf{*this};
 
     func(crf);
 }
 
-void NullFileSystemObjectSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)
+void NullFileSystemObjectSink::createDirectory(DirectoryCreatedCallback func)
 {
-    struct : CreateRegularFileSink
+    struct : OnDirectory
+    {
+        void createChild(std::string_view, ChildCreatedCallback callback) override
+        {
+            NullFileSystemObjectSink childSink;
+            callback(childSink);
+        }
+    } dir;
+
+    func(dir);
+}
+
+void NullFileSystemObjectSink::createRegularFile(bool isExecutable, RegularFileCreatedCallback func)
+{
+    struct : OnRegularFile
     {
         void operator()(std::string_view data) override {}
-
-        void isExecutable() override {}
     } crf;
 
     crf.skipContents = true;

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -70,7 +70,6 @@ static std::filesystem::path append(const std::filesystem::path & src, const Can
     return dst;
 }
 
-#ifndef _WIN32
 /**
  * Return a descriptor and single-component name suitable for
  * `*at` operations. The returned `CanonPath` is always a pure
@@ -91,7 +90,17 @@ getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, cons
         auto parent = path.parent();
         if (parent->isRoot())
             return {AutoCloseFD{}, dirFd, CanonPath::fromFilename(*path.baseName())};
-        auto parentFd = openFileEnsureBeneathNoSymlinks(dirFd, *parent, O_RDONLY | O_DIRECTORY | O_CLOEXEC, 0);
+        auto parentFd = openFileEnsureBeneathNoSymlinks(
+            dirFd,
+            std::filesystem::path(parent->rel()),
+#ifdef _WIN32
+            FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+            FILE_DIRECTORY_FILE
+#else
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC,
+            0
+#endif
+        );
         if (!parentFd)
             throw SysError("opening parent directory of %s", PathFmt(append(dstPath, path)));
         auto fd = parentFd.get();
@@ -108,8 +117,7 @@ getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, cons
         throw Error("restore destination path is empty");
     auto filename = p.filename();
     if (filename == "." || filename == "..")
-        throw Error(
-            "restore destination '%s' ends in '%s', which is not a valid filename", p.native(), filename.native());
+        throw Error("restore destination %s ends in %s, which is not a valid filename", PathFmt(p), PathFmt(filename));
     auto parentPath = p.parent_path();
     /* Relative path with no directory component (e.g. "out") —
        the parent is the current working directory. Open it so we
@@ -117,13 +125,12 @@ getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, cons
        changes the working directory mid-unpack. */
     if (parentPath.empty())
         parentPath = ".";
-    AutoCloseFD parentFd{::open(parentPath.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC)};
+    auto parentFd = openDirectory(parentPath, FinalSymlink::Follow);
     if (!parentFd)
-        throw SysError("opening parent directory of %s", PathFmt(p));
+        throw NativeSysError("opening parent directory of %s", PathFmt(p));
     auto fd = parentFd.get();
-    return {std::move(parentFd), fd, CanonPath::fromFilename(p.filename().native())};
+    return {std::move(parentFd), fd, CanonPath::fromFilename(p.filename().string())};
 }
-#endif
 
 void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallback callback)
 {
@@ -140,7 +147,7 @@ void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallba
     dirSink.dstPath = append(dstPath, path);
     dirSink.dirFd = openFileEnsureBeneathNoSymlinks(
         dirFd.get(),
-        path,
+        std::filesystem::path(path.rel()),
 #ifdef _WIN32
         FILE_READ_ATTRIBUTES | SYNCHRONIZE,
         FILE_DIRECTORY_FILE
@@ -158,28 +165,35 @@ void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallba
 
 void RestoreSink::createDirectory(const CanonPath & path)
 {
-#ifndef _WIN32
     if (dirFd && path.isRoot())
-        /* Trying to create a directory that we already have a file descriptor for. */
         throw Error("path %s already exists", PathFmt(append(dstPath, path)));
 
     auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
 
-    if (::mkdirat(fd, name.rel_c_str(), 0777) == -1)
-        throw SysError("creating directory %s", PathFmt(append(dstPath, path)));
+    if (auto result = openDirectoryAt(fd, std::filesystem::path(name.rel()), true); !result) {
+        auto ec = result.error();
+        if (ec == std::errc::file_exists)
+            throw Error("path %s already exists", PathFmt(append(dstPath, path)));
+        throw SystemError(ec, "creating directory %s", PathFmt(append(dstPath, path)));
+    }
 
     if (!dirFd) {
         /* Open directory for further *at operations relative to the sink root
            directory. */
-        dirFd = openFileEnsureBeneathNoSymlinks(fd, name, O_RDONLY | O_DIRECTORY | O_CLOEXEC, 0);
-        if (!dirFd)
-            throw SysError("opening directory %s", PathFmt(append(dstPath, path)));
-    }
+        dirFd = openFileEnsureBeneathNoSymlinks(
+            fd,
+            std::filesystem::path(name.rel()),
+#ifdef _WIN32
+            FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+            FILE_DIRECTORY_FILE
 #else
-    auto p = append(dstPath, path);
-    if (!std::filesystem::create_directory(p))
-        throw Error("path '%s' already exists", p.string());
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC,
+            0
 #endif
+        );
+        if (!dirFd)
+            throw NativeSysError("opening directory %s", PathFmt(append(dstPath, path)));
+    }
 };
 
 struct RestoreRegularFile : CreateRegularFileSink, FdSink
@@ -220,29 +234,23 @@ struct RestoreRegularFile : CreateRegularFileSink, FdSink
 
 void RestoreSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)
 {
+    auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
     auto crf = RestoreRegularFile(
         startFsync,
+        openFileEnsureBeneathNoSymlinks(
+            fd,
+            std::filesystem::path(name.rel()),
 #ifdef _WIN32
-        CreateFileW(
-            append(dstPath, path).c_str(),
-            GENERIC_READ | GENERIC_WRITE,
-            FILE_SHARE_READ | FILE_SHARE_WRITE,
-            NULL,
-            CREATE_NEW,
-            FILE_ATTRIBUTE_NORMAL,
-            NULL)
+            FILE_WRITE_DATA | SYNCHRONIZE,
+            0,
+            FILE_CREATE
 #else
-        [&]() {
-            /* O_EXCL together with O_CREAT ensures symbolic links in the last
-               component are not followed. */
-            constexpr int flags = O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC;
-            auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
-            return openFileEnsureBeneathNoSymlinks(fd, name, flags, 0666);
-        }()
+            O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC,
+            0666
 #endif
-    );
+            ));
     if (!crf.fd)
-        throw NativeSysError("creating file %1%", PathFmt(append(dstPath, path)));
+        throw NativeSysError("creating file %s", PathFmt(append(dstPath, path)));
     func(crf);
     crf.flush();
 }
@@ -278,13 +286,8 @@ void RestoreRegularFile::preallocateContents(uint64_t len)
 
 void RestoreSink::createSymlink(const CanonPath & path, const std::string & target)
 {
-#ifndef _WIN32
     auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
-    if (::symlinkat(requireCString(target), fd, name.rel_c_str()) == -1)
-        throw SysError("creating symlink from %1% -> '%2%'", PathFmt(append(dstPath, path)), target);
-#else
-    nix::createSymlink(target, append(dstPath, path).string());
-#endif
+    createUnknownSymlinkAt(fd, std::filesystem::path(name.rel()), string_to_os_string(target));
 }
 
 void RegularFileSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)

--- a/src/libutil/git.cc
+++ b/src/libutil/git.cc
@@ -1,5 +1,6 @@
 #include <cerrno>
 #include <algorithm>
+#include <charconv>
 #include <regex>
 #include <strings.h> // for strcasecmp
 
@@ -9,24 +10,12 @@
 
 #include "nix/util/git.hh"
 #include "nix/util/serialise.hh"
+#include "nix/util/util.hh"
 
 namespace nix::git {
 
 using namespace nix;
 using namespace std::string_literals;
-
-std::optional<Mode> decodeMode(RawMode m)
-{
-    switch (m) {
-    case (RawMode) Mode::Directory:
-    case (RawMode) Mode::Executable:
-    case (RawMode) Mode::Regular:
-    case (RawMode) Mode::Symlink:
-        return (Mode) m;
-    default:
-        return std::nullopt;
-    }
-}
 
 static std::string getStringUntil(Source & source, char byte)
 {
@@ -48,78 +37,44 @@ static std::string getString(Source & source, int n)
     return v;
 }
 
-void parseBlob(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
+uint64_t parseBlob(Source & source, const ExperimentalFeatureSettings & xpSettings)
+{
+    xpSettings.require(Xp::GitHashing);
+
+    auto sizeStr = getStringUntil(source, 0);
+    uint64_t size;
+    auto [ptr, ec] = std::from_chars(sizeStr.data(), sizeStr.data() + sizeStr.size(), size);
+    if (ec != std::errc{})
+        throw Error("invalid blob size '%s'", sizeStr);
+    return size;
+}
+
+void parseTree(
+    merkle::DirectorySink & sink,
     Source & source,
-    BlobMode blobMode,
+    HashAlgorithm hashAlgo,
     const ExperimentalFeatureSettings & xpSettings)
 {
     xpSettings.require(Xp::GitHashing);
 
-    const unsigned long long size = std::stoi(getStringUntil(source, 0));
-
-    auto doRegularFile = [&](bool executable) {
-        sink.createRegularFile(sinkPath, [&](auto & crf) {
-            if (executable)
-                crf.isExecutable();
-
-            crf.preallocateContents(size);
-
-            source.drainInto(crf, size);
-        });
-    };
-
-    switch (blobMode) {
-
-    case BlobMode::Regular:
-        doRegularFile(false);
-        break;
-
-    case BlobMode::Executable:
-        doRegularFile(true);
-        break;
-
-    case BlobMode::Symlink: {
-        std::string target;
-        target.resize(size, '0');
-        target.reserve(size);
-        for (size_t n = 0; n < target.size();) {
-            checkInterrupt();
-            n += source.read(const_cast<char *>(target.c_str()) + n, target.size() - n);
-        }
-
-        sink.createSymlink(sinkPath, target);
-        break;
-    }
-
-    default:
-        assert(false);
-    }
-}
-
-void parseTree(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
-    Source & source,
-    HashAlgorithm hashAlgo,
-    fun<SinkHook> hook,
-    const ExperimentalFeatureSettings & xpSettings)
-{
-    const unsigned long long size = std::stoi(getStringUntil(source, 0));
-    unsigned long long left = size;
-
-    sink.createDirectory(sinkPath);
+    auto sizeStr = getStringUntil(source, 0);
+    uint64_t left;
+    auto [ptr, ec] = std::from_chars(sizeStr.data(), sizeStr.data() + sizeStr.size(), left);
+    if (ec != std::errc{})
+        throw Error("invalid tree size '%s'", sizeStr);
 
     while (left) {
         std::string perms = getStringUntil(source, ' ');
         left -= perms.size();
         left -= 1;
 
-        RawMode rawMode = std::stoi(perms, 0, 8);
+        RawMode rawMode;
+        auto [ptr, ec] = std::from_chars(perms.data(), perms.data() + perms.size(), rawMode, 8);
+        if (ec != std::errc{})
+            throw Error("invalid Git permission: %s", perms);
         auto modeOpt = decodeMode(rawMode);
         if (!modeOpt)
-            throw Error("Unknown Git permission: %o", rawMode);
+            throw Error("unknown Git permission: %o", rawMode);
         auto mode = std::move(*modeOpt);
 
         std::string name = getStringUntil(source, '\0');
@@ -137,12 +92,7 @@ void parseTree(
         Hash hash(hashAlgo);
         std::copy(hashs.begin(), hashs.end(), hash.hash);
 
-        hook(
-            CanonPath{name},
-            TreeEntry{
-                .mode = mode,
-                .hash = hash,
-            });
+        sink.insertChild(name, TreeEntry{.mode = mode, .hash = hash});
     }
 }
 
@@ -158,31 +108,6 @@ ObjectType parseObjectType(Source & source, const ExperimentalFeatureSettings & 
         return ObjectType::Tree;
     } else
         throw Error("input doesn't look like a Git object");
-}
-
-void parse(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
-    Source & source,
-    BlobMode rootModeIfBlob,
-    HashAlgorithm hashAlgo,
-    fun<SinkHook> hook,
-    const ExperimentalFeatureSettings & xpSettings)
-{
-    xpSettings.require(Xp::GitHashing);
-
-    auto type = parseObjectType(source, xpSettings);
-
-    switch (type) {
-    case ObjectType::Blob:
-        parseBlob(sink, sinkPath, source, rootModeIfBlob, xpSettings);
-        break;
-    case ObjectType::Tree:
-        parseTree(sink, sinkPath, source, hashAlgo, hook, xpSettings);
-        break;
-    default:
-        assert(false);
-    };
 }
 
 std::optional<Mode> convertMode(SourceAccessor::Type type)
@@ -203,29 +128,6 @@ std::optional<Mode> convertMode(SourceAccessor::Type type)
     default:
         unreachable();
     }
-}
-
-void restore(FileSystemObjectSink & sink, Source & source, HashAlgorithm hashAlgo, fun<RestoreHook> hook)
-{
-    parse(sink, CanonPath::root, source, BlobMode::Regular, hashAlgo, [&](CanonPath name, TreeEntry entry) {
-        auto [accessor, from] = hook(entry.hash);
-        auto stat = accessor->lstat(from);
-        auto gotOpt = convertMode(stat.type);
-        if (!gotOpt)
-            throw Error(
-                "file '%s' (git hash %s) has an unsupported type",
-                from,
-                entry.hash.to_string(HashFormat::Base16, false));
-        auto & got = *gotOpt;
-        if (got != entry.mode)
-            throw Error(
-                "git mode of file '%s' (git hash %s) is %o but expected %o",
-                from,
-                entry.hash.to_string(HashFormat::Base16, false),
-                (RawMode) got,
-                (RawMode) entry.mode);
-        copyRecursive(*accessor, from, sink, name);
-    });
 }
 
 void dumpBlobPrefix(uint64_t size, Sink & sink, const ExperimentalFeatureSettings & xpSettings)

--- a/src/libutil/include/nix/util/archive.hh
+++ b/src/libutil/include/nix/util/archive.hh
@@ -71,7 +71,8 @@ void dumpString(std::string_view s, Sink & sink);
 
 void parseDump(FileSystemObjectSink & sink, Source & source);
 
-void restorePath(const std::filesystem::path & path, Source & source, bool startFsync = false);
+void restorePath(
+    const std::filesystem::path & parentPath, const std::string & childName, Source & source, bool startFsync = false);
 
 /**
  * Read a NAR from 'source' and write it to 'sink'.

--- a/src/libutil/include/nix/util/canon-path.hh
+++ b/src/libutil/include/nix/util/canon-path.hh
@@ -244,6 +244,13 @@ public:
         return ((std::string_view) path).substr(path.rfind('/') + 1);
     }
 
+    /**
+     * Combination of `parent` and `baseName`.
+     *
+     * @note that because of the `std::string_view`, we are borrowing for the base name.
+     */
+    std::optional<std::pair<CanonPath, std::string_view>> parentAndChild() const;
+
     bool operator==(const CanonPath & x) const
     {
         return path == x.path;

--- a/src/libutil/include/nix/util/file-content-address.hh
+++ b/src/libutil/include/nix/util/file-content-address.hh
@@ -65,7 +65,11 @@ void dumpPath(
  * \todo use an arbitrary `FileSystemObjectSink`.
  */
 void restorePath(
-    const std::filesystem::path & path, Source & source, FileSerialisationMethod method, bool startFsync = false);
+    const std::filesystem::path & parentPath,
+    const std::string & childName,
+    Source & source,
+    FileSerialisationMethod method,
+    bool startFsync = false);
 
 /**
  * Compute the hash of the given file system object according to the

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -17,7 +17,6 @@
 #include "nix/util/error.hh"
 #include "nix/util/file-descriptor.hh"
 #include "nix/util/file-system.hh"
-#include "nix/util/source-accessor.hh"
 
 #include <boost/outcome.hpp>
 #include <optional>

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -14,10 +14,14 @@
  * issues.
  */
 
+#include "nix/util/error.hh"
 #include "nix/util/file-descriptor.hh"
 #include "nix/util/file-system.hh"
+#include "nix/util/source-accessor.hh"
 
+#include <boost/outcome.hpp>
 #include <optional>
+#include <system_error>
 
 #ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
@@ -26,6 +30,91 @@
 
 namespace nix {
 
+namespace outcome = BOOST_OUTCOME_V2_NAMESPACE;
+
+/**
+ * Read a symlink relative to a directory file descriptor.
+ *
+ * @pre `path` must be relative (not absolute).
+ *
+ * @throws SystemError on any I/O errors.
+ * @throws Interrupted if interrupted.
+ */
+OsString readLinkAt(Descriptor dirFd, const std::filesystem::path & path);
+
+/**
+ * Create a symlink to a file relative to a directory file descriptor.
+ *
+ * On Windows, creates a file symlink. On Unix, equivalent to symlinkat.
+ *
+ * @param dirFd Directory file descriptor
+ * @param path Relative path for the new symlink
+ * @param target The symlink target (what it points to)
+ *
+ * @pre `path` must be relative (not absolute).
+ *
+ * @throws SystemError on any I/O errors.
+ */
+void createFileSymlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target);
+
+/**
+ * Create a symlink to a directory relative to a directory file descriptor.
+ *
+ * On Windows, creates a directory symlink. On Unix, equivalent to symlinkat.
+ *
+ * @param dirFd Directory file descriptor
+ * @param path Relative path for the new symlink
+ * @param target The symlink target (what it points to)
+ *
+ * @pre `path` must be relative (not absolute).
+ *
+ * @throws SystemError on any I/O errors.
+ */
+void createDirectorySymlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target);
+
+/**
+ * Create a symlink relative to a directory file descriptor, detecting target type.
+ *
+ * On Windows, stats the target to determine whether to create a file or
+ * directory symlink. Falls back to file symlink if the target does not exist.
+ * On Unix, equivalent to symlinkat.
+ *
+ * @param dirFd Directory file descriptor
+ * @param path Relative path for the new symlink
+ * @param target The symlink target (what it points to)
+ *
+ * @pre `path` must be relative (not absolute).
+ *
+ * @throws SystemError on any I/O errors.
+ */
+void createUnknownSymlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target);
+
+/**
+ * Open or create a directory relative to a directory file descriptor.
+ *
+ * @param dirFd Directory file descriptor
+ * @param path Relative path to the directory
+ * @param create If true, create the directory and open it.
+ *               If false, open existing directory.
+ * @param mode File mode for the new directory (only used when `create` is true).
+ *             Unix only.
+ *
+ * @return File descriptor for the directory, or error code on failure.
+ *
+ * @pre `path` must be relative (not absolute).
+ *
+ * @note Does not follow symlinks - if path is a symlink, will fail to open.
+ */
+outcome::unchecked<AutoCloseFD, std::error_code> openDirectoryAt(
+    Descriptor dirFd,
+    const std::filesystem::path & path,
+    bool create = false
+#ifndef _WIN32
+    ,
+    mode_t mode = 0777
+#endif
+);
+
 /**
  * Get status of an open file/directory handle.
  *
@@ -33,8 +122,6 @@ namespace nix {
  * @throws SystemError on I/O errors.
  */
 PosixStat fstat(Descriptor fd);
-
-#ifndef _WIN32
 
 /**
  * Get status of a file relative to a directory file descriptor.
@@ -61,16 +148,6 @@ std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const std::filesystem::p
  */
 PosixStat fstatat(Descriptor dirFd, const std::filesystem::path & path);
 
-#endif
-
-/**
- * Read a symlink relative to a directory file descriptor.
- *
- * @throws SystemError on any I/O errors.
- * @throws Interrupted if interrupted.
- */
-OsString readLinkAt(Descriptor dirFd, const CanonPath & path);
-
 /**
  * Open a file relative to @p dirFd, ensuring the path stays beneath
  * @p dirFd and that no path component is a symlink (with the
@@ -86,6 +163,8 @@ OsString readLinkAt(Descriptor dirFd, const CanonPath & path);
  * @param desiredAccess (Windows) Windows `ACCESS_MASK`
  * @param createOptions (Windows) Windows create options
  * @param createDisposition (Windows) `FILE_OPEN`, `FILE_CREATE`, etc.
+ *
+ * @pre `path` must be relative (not absolute) and non-empty.
  *
  * @param flags (Unix) `O_*` flags (must not include `O_NOFOLLOW`)
  * @param mode (Unix) Mode for `O_{CREAT,TMPFILE}`
@@ -114,7 +193,7 @@ OsString readLinkAt(Descriptor dirFd, const CanonPath & path);
  */
 AutoCloseFD openFileEnsureBeneathNoSymlinks(
     Descriptor dirFd,
-    const CanonPath & path,
+    const std::filesystem::path & path,
 #ifdef _WIN32
     ACCESS_MASK desiredAccess,
     ULONG createOptions,
@@ -155,10 +234,10 @@ namespace unix {
  * @note When on linux without fchmodat2 support and without procfs mounted falls back to fchmodat without
  * AT_SYMLINK_NOFOLLOW, since it's the best we can do without failing.
  *
- * @pre path.isRoot() is false
+ * @pre `path` must be relative (not absolute) and non-empty.
  * @throws SysError if any operation fails
  */
-void fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t mode);
+void fchmodatTryNoFollow(Descriptor dirFd, const std::filesystem::path & path, mode_t mode);
 
 } // namespace unix
 #endif

--- a/src/libutil/include/nix/util/fs-sink.hh
+++ b/src/libutil/include/nix/util/fs-sink.hh
@@ -1,97 +1,135 @@
 #pragma once
 ///@file
 
+#include "nix/util/file-descriptor.hh"
 #include "nix/util/serialise.hh"
 #include "nix/util/source-accessor.hh"
-#include "nix/util/file-system.hh"
-#include "nix/util/os-filename.hh"
 
 namespace nix {
 
 /**
- * Actions on an open regular file in the process of creating it.
+ * A way to directly and recursively sink file system objects
  *
- * See `FileSystemObjectSink::createRegularFile`.
+ * This is a very well-restricted interface to recursively create file
+ * system objects "bottom up", and "one layer at a time". For example of
+ * some rules this enforces:
+ *
+ *  - Parent directories must be created before children.
+ *
+ *  - Child names must be picked before child contents (including file
+ *    type).
+ *
+ *  - Metadata like the executable bit on files must be chosen before
+ *    file concepts are streamed.
+ *
+ *  As such, this interface is very good for two tasks in particular:
+ *
+ *  - Parsing Nix Archives, as the NAR format exactly corresponds to
+ *    this. (You can think of this as a NAR Visitor.)
+ *
+ *  - Creating files on disk, as the above invariants give us the
+ *    opportunity to create files in a very controlled manner, avoiding
+ *    all sorts of security issues.
+ *
+ *  What this is *not* good for is:
+ *
+ *  - Unpacking unstructured file formats like tarballs. (See `TarSink`
+ *    for that.)
+ *
+ *  - Merkle formats/protocols that do not want to consume all layers at
+ *    once, but support more asynchronous and lazy IO. (See
+ *    `merkle::FileSinkBuilder` for that.)
  */
-struct CreateRegularFileSink : virtual Sink
-{
-    /**
-     * If set to true, the sink will not be called with the contents
-     * of the file. `preallocateContents()` will still be called to
-     * convey the file size. Useful for sinks that want to efficiently
-     * discard the contents of the file.
-     */
-    bool skipContents = false;
-
-    virtual void isExecutable() = 0;
-
-    /**
-     * An optimization. By default, do nothing.
-     */
-    virtual void preallocateContents(uint64_t size) {};
-};
-
 struct FileSystemObjectSink
 {
+
+    /**
+     * Actions on an open regular file in the process of creating it.
+     *
+     * See `FileSystemObjectSink::createRegularFile`.
+     */
+    struct OnRegularFile : virtual Sink
+    {
+        /**
+         * If set to true, the sink will not be called with the contents
+         * of the file. `preallocateContents()` will still be called to
+         * convey the file size. Useful for sinks that want to efficiently
+         * discard the contents of the file.
+         */
+        bool skipContents = false;
+
+        /**
+         * An optimization. By default, do nothing.
+         */
+        virtual void preallocateContents(uint64_t size) {};
+    };
+
+    /**
+     * Actions on an open directory in order to populate it with its
+     * children.
+     */
+    struct OnDirectory
+    {
+        virtual ~OnDirectory() = default;
+
+        using ChildCreatedCallback = fun<void(FileSystemObjectSink & fsoSink)>;
+
+        /**
+         * Create a child of this directory. The callback provides us with a
+         * `FileSystemObjectSink` we can think of as "pointing" to the
+         * location which we are to create something in, giving us our
+         * choices.
+         *
+         * @param fileName must not contain any `/` or null bytes. It should
+         * also not contain any `\` when Windows host filesystems aim to be
+         * supported.
+         */
+        virtual void createChild(std::string_view fileName, ChildCreatedCallback callback) = 0;
+    };
+
     virtual ~FileSystemObjectSink() = default;
 
-    virtual void createDirectory(const CanonPath & path) = 0;
-
-    using DirectoryCreatedCallback = fun<void(FileSystemObjectSink & dirSink, const CanonPath & dirRelPath)>;
+    using DirectoryCreatedCallback = fun<void(OnDirectory & dirSink)>;
 
     /**
      * Create a directory and invoke a callback with a pair of sink + CanonPath
      * of the created subdirectory relative to dirSink.
      *
-     * @note This allows for UNIX RestoreSink implementations to implement
+     * @note This allows for `RestoreSink` to implement
      * *at-style accessors that always keep an open file descriptor for the
      * freshly created directory. Use this when it's important to disallow any
      * intermediate path components from being symlinks.
      */
-    virtual void createDirectory(const CanonPath & path, DirectoryCreatedCallback callback)
-    {
-        createDirectory(path);
-        callback(*this, path);
-    }
+    virtual void createDirectory(DirectoryCreatedCallback callback) = 0;
+
+    using RegularFileCreatedCallback = fun<void(OnRegularFile & regFileSink)>;
 
     /**
      * This function in general is no re-entrant. Only one file can be
      * written at a time.
+     *
+     * @param isExecutable whether the file should be marked executable
      */
-    virtual void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)>) = 0;
+    virtual void createRegularFile(bool isExecutable, RegularFileCreatedCallback callback) = 0;
 
-    virtual void createSymlink(const CanonPath & path, const std::string & target) = 0;
-};
-
-/**
- * An extension of `FileSystemObjectSink` that supports file types
- * that are not supported by Nix's FSO model.
- */
-struct ExtendedFileSystemObjectSink : virtual FileSystemObjectSink
-{
-    /**
-     * Create a hard link. The target must be the path of a previously
-     * encountered file relative to the root of the FSO.
-     */
-    virtual void createHardlink(const CanonPath & path, const CanonPath & target) = 0;
+    virtual void createSymlink(const std::string & target) = 0;
 };
 
 /**
  * Recursively copy file system objects from the source into the sink.
  */
-void copyRecursive(
-    SourceAccessor & accessor, const CanonPath & sourcePath, FileSystemObjectSink & sink, const CanonPath & destPath);
+void copyRecursive(SourceAccessor & accessor, const CanonPath & sourcePath, FileSystemObjectSink & sink);
 
 /**
  * Ignore everything and do nothing
  */
 struct NullFileSystemObjectSink : FileSystemObjectSink
 {
-    void createDirectory(const CanonPath & path) override {}
+    void createDirectory(DirectoryCreatedCallback) override;
 
-    void createSymlink(const CanonPath & path, const std::string & target) override {}
+    void createSymlink(const std::string & target) override {}
 
-    void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)>) override;
+    void createRegularFile(bool isExecutable, RegularFileCreatedCallback) override;
 };
 
 /**
@@ -106,58 +144,48 @@ struct NullFileSystemObjectSink : FileSystemObjectSink
 struct RestoreSink : FileSystemObjectSink
 {
     /**
-     * `dirFd` is the parent directory of the entry to create.
-     * `name` is the single-component name of the root entry
-     * within that parent.
+     * This is a borrowed descriptor; the caller must ensure it remains valid
+     * for the lifetime of operations on this sink.
      */
-    struct DirFdParent
+    Descriptor parentDir;
+    /**
+     * Name of the child to create within the parent directory.
+     */
+    std::filesystem::path name;
+    bool startFsync = false;
+
+    /**
+     * Implementation of OnDirectory for RestoreSink.
+     */
+    struct Directory : OnDirectory
     {
-        OsFilename name;
+        AutoCloseFD directory;
+        bool startFsync;
+
+        Directory(AutoCloseFD directory, bool startFsync)
+            : directory{std::move(directory)}
+            , startFsync{startFsync}
+        {
+        }
+
+        void createChild(std::string_view name, ChildCreatedCallback callback) override;
     };
 
     /**
-     * `dirFd` is the root directory of the restore tree itself.
-     * Paths are relative within it.
+     * Construct a sink.
      */
-    struct DirFdRoot
-    {};
-
-    using DirFdKind = std::variant<DirFdRoot, DirFdParent>;
-
-    /**
-     * What `dirFd` refers to.
-     */
-    DirFdKind dirFdKind;
-
-    /**
-     * File descriptor used for `*at` operations. Interpretation
-     * depends on `dirFdKind`.
-     *
-     * This sink must *never* follow intermediate symlinks in case a
-     * file collision is encountered for various reasons like
-     * case-insensitivity or other types of normalization. Using
-     * appropriate `*at` system calls and traversing only one path
-     * component at a time ensures that writing is race-free and is not
-     * susceptible to symlink replacement.
-     */
-    AutoCloseFD dirFd;
-
-    bool startFsync = false;
-
-    RestoreSink(DirFdKind dirFdKind, AutoCloseFD dirFd, bool startFsync)
-        : dirFdKind{std::move(dirFdKind)}
-        , dirFd{std::move(dirFd)}
+    explicit RestoreSink(Descriptor parentDir, std::filesystem::path name, bool startFsync = false)
+        : parentDir{parentDir}
+        , name{std::move(name)}
         , startFsync{startFsync}
     {
     }
 
-    void createDirectory(const CanonPath & path) override;
+    void createDirectory(DirectoryCreatedCallback callback) override;
 
-    void createDirectory(const CanonPath & path, DirectoryCreatedCallback callback) override;
+    void createRegularFile(bool isExecutable, RegularFileCreatedCallback callback) override;
 
-    void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)>) override;
-
-    void createSymlink(const CanonPath & path, const std::string & target) override;
+    void createSymlink(const std::string & target) override;
 };
 
 /**
@@ -175,17 +203,17 @@ struct RegularFileSink : FileSystemObjectSink
     {
     }
 
-    void createDirectory(const CanonPath & path) override
+    void createDirectory(DirectoryCreatedCallback) override
     {
         regular = false;
     }
 
-    void createSymlink(const CanonPath & path, const std::string & target) override
+    void createSymlink(const std::string & target) override
     {
         regular = false;
     }
 
-    void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)>) override;
+    void createRegularFile(bool isExecutable, RegularFileCreatedCallback callback) override;
 };
 
 } // namespace nix

--- a/src/libutil/include/nix/util/fs-sink.hh
+++ b/src/libutil/include/nix/util/fs-sink.hh
@@ -4,6 +4,7 @@
 #include "nix/util/serialise.hh"
 #include "nix/util/source-accessor.hh"
 #include "nix/util/file-system.hh"
+#include "nix/util/os-filename.hh"
 
 namespace nix {
 
@@ -95,24 +96,58 @@ struct NullFileSystemObjectSink : FileSystemObjectSink
 
 /**
  * Write files at the given path
+ *
+ * This sink must *never* follow intermediate symlinks in case a file collision
+ * is encountered for various reasons like case-insensitivity or other types of
+ * normalization. Using appropriate *at system calls and traversing only one
+ * path component at a time ensures that writing is race-free and is not
+ * susceptible to symlink replacement.
  */
 struct RestoreSink : FileSystemObjectSink
 {
-    std::filesystem::path dstPath;
     /**
-     * File descriptor for the directory located at dstPath. Used for *at
-     * operations relative to this file descriptor. This sink must *never*
-     * follow intermediate symlinks (starting from dstPath) in case a file
-     * collision is encountered for various reasons like case-insensitivity or
-     * other types on normalization. using appropriate *at system calls and traversing
-     * only one path component at a time ensures that writing is race-free and is
-     * is not susceptible to symlink replacement.
+     * `dirFd` is the parent directory of the entry to create.
+     * `name` is the single-component name of the root entry
+     * within that parent.
+     */
+    struct DirFdParent
+    {
+        OsFilename name;
+    };
+
+    /**
+     * `dirFd` is the root directory of the restore tree itself.
+     * Paths are relative within it.
+     */
+    struct DirFdRoot
+    {};
+
+    using DirFdKind = std::variant<DirFdRoot, DirFdParent>;
+
+    /**
+     * What `dirFd` refers to.
+     */
+    DirFdKind dirFdKind;
+
+    /**
+     * File descriptor used for `*at` operations. Interpretation
+     * depends on `dirFdKind`.
+     *
+     * This sink must *never* follow intermediate symlinks in case a
+     * file collision is encountered for various reasons like
+     * case-insensitivity or other types of normalization. Using
+     * appropriate `*at` system calls and traversing only one path
+     * component at a time ensures that writing is race-free and is not
+     * susceptible to symlink replacement.
      */
     AutoCloseFD dirFd;
+
     bool startFsync = false;
 
-    explicit RestoreSink(bool startFsync)
-        : startFsync{startFsync}
+    RestoreSink(DirFdKind dirFdKind, AutoCloseFD dirFd, bool startFsync)
+        : dirFdKind{std::move(dirFdKind)}
+        , dirFd{std::move(dirFd)}
+        , startFsync{startFsync}
     {
     }
 

--- a/src/libutil/include/nix/util/git.hh
+++ b/src/libutil/include/nix/util/git.hh
@@ -10,6 +10,7 @@
 #include "nix/util/hash.hh"
 #include "nix/util/source-path.hh"
 #include "nix/util/fs-sink.hh"
+#include "nix/util/merkle-files.hh"
 
 namespace nix::git {
 
@@ -20,28 +21,10 @@ enum struct ObjectType {
     // Tag,
 };
 
-using RawMode = uint32_t;
-
-enum struct Mode : RawMode {
-    Directory = 0040000,
-    Regular = 0100644,
-    Executable = 0100755,
-    Symlink = 0120000,
-};
-
-std::optional<Mode> decodeMode(RawMode m);
-
-/**
- * An anonymous Git tree object entry (no name part).
- */
-struct TreeEntry
-{
-    Mode mode;
-    Hash hash;
-
-    bool operator==(const TreeEntry &) const = default;
-    auto operator<=>(const TreeEntry &) const = default;
-};
+// Backwards compatibility aliases
+using merkle::Mode;
+using merkle::TreeEntry;
+using nix::RawMode;
 
 /**
  * A Git tree object, fully decoded and stored in memory.
@@ -51,21 +34,10 @@ struct TreeEntry
  */
 using Tree = std::map<std::string, TreeEntry>;
 
-/**
- * Callback for processing a child hash with `parse`
- *
- * The function should
- *
- * 1. Obtain the file system objects denoted by `gitHash`
- *
- * 2. Ensure they match `mode`
- *
- * 3. Feed them into the same sink `parse` was called with
- *
- * Implementations may seek to memoize resources (bandwidth, storage,
- * etc.) for the same Git hash.
- */
-using SinkHook = void(const CanonPath & name, TreeEntry entry);
+inline std::optional<Mode> decodeMode(RawMode m)
+{
+    return merkle::decodeMode(m);
+}
 
 /**
  * Parse the "blob " or "tree " prefix.
@@ -76,72 +48,26 @@ ObjectType
 parseObjectType(Source & source, const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
 
 /**
- * These 3 modes are represented by blob objects.
+ * Read the size of the blob
  *
- * Sometimes we need this information to disambiguate how a blob is
- * being used to better match our own "file system object" data model.
+ * The caller should then call `Source::drainInto` or similar with that
+ * size.
  */
-enum struct BlobMode : RawMode {
-    Regular = static_cast<RawMode>(Mode::Regular),
-    Executable = static_cast<RawMode>(Mode::Executable),
-    Symlink = static_cast<RawMode>(Mode::Symlink),
-};
-
-void parseBlob(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
-    Source & source,
-    BlobMode blobMode,
-    const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
+uint64_t parseBlob(Source & source, const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
 
 /**
  * @param hashAlgo must be `HashAlgo::SHA1` or `HashAlgo::SHA256` for now.
  */
 void parseTree(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
+    merkle::DirectorySink & sink,
     Source & source,
     HashAlgorithm hashAlgo,
-    fun<SinkHook> hook,
     const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
 
 /**
- * Helper putting the previous three `parse*` functions together.
- *
- * @param rootModeIfBlob How to interpret a root blob, for which there is no
- * disambiguating dir entry to answer that questino. If the root it not
- * a blob, this is ignored.
- *
- * @param hashAlgo must be `HashAlgo::SHA1` or `HashAlgo::SHA256` for now.
- */
-void parse(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
-    Source & source,
-    BlobMode rootModeIfBlob,
-    HashAlgorithm hashAlgo,
-    fun<SinkHook> hook,
-    const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
-
-/**
- * Assists with writing a `SinkHook` step (2).
+ * Convert a `SourceAccessor::Type` to a `Mode`.
  */
 std::optional<Mode> convertMode(SourceAccessor::Type type);
-
-/**
- * Simplified version of `SinkHook` for `restore`.
- *
- * Given a `Hash`, return a `SourceAccessor` and `CanonPath` pointing to
- * the file system object with that path.
- */
-using RestoreHook = SourcePath(Hash);
-
-/**
- * Wrapper around `parse` and `RestoreSink`
- *
- * @param hashAlgo must be `HashAlgo::SHA1` or `HashAlgo::SHA256` for now.
- */
-void restore(FileSystemObjectSink & sink, Source & source, HashAlgorithm hashAlgo, fun<RestoreHook> hook);
 
 /**
  * Dumps a single file to a sink

--- a/src/libutil/include/nix/util/memory-source-accessor.hh
+++ b/src/libutil/include/nix/util/memory-source-accessor.hh
@@ -144,22 +144,35 @@ struct MemorySourceAccessor : virtual SourceAccessor
 };
 
 /**
- * Write to a `MemorySourceAccessor` at the given path
+ * Write to a `MemorySourceAccessor::File`
  */
 struct MemorySink : FileSystemObjectSink
 {
-    MemorySourceAccessor & dst;
+    using CreateRoot = fun<MemorySourceAccessor::File &(MemorySourceAccessor::File)>;
+    CreateRoot createRoot;
 
-    MemorySink(MemorySourceAccessor & dst)
-        : dst(dst)
+    MemorySink(CreateRoot createRoot)
+        : createRoot(std::move(createRoot))
     {
     }
 
-    void createDirectory(const CanonPath & path) override;
+    struct MemoryDirectory : OnDirectory
+    {
+        MemorySourceAccessor::File::Directory & dir;
 
-    void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)>) override;
+        MemoryDirectory(MemorySourceAccessor::File::Directory & dir)
+            : dir(dir)
+        {
+        }
 
-    void createSymlink(const CanonPath & path, const std::string & target) override;
+        void createChild(std::string_view name, ChildCreatedCallback callback) override;
+    };
+
+    void createDirectory(DirectoryCreatedCallback callback) override;
+
+    void createRegularFile(bool isExecutable, RegularFileCreatedCallback callback) override;
+
+    void createSymlink(const std::string & target) override;
 };
 
 template<>

--- a/src/libutil/include/nix/util/merkle-files.hh
+++ b/src/libutil/include/nix/util/merkle-files.hh
@@ -1,0 +1,68 @@
+#pragma once
+///@file
+
+#include <cstdint>
+#include <optional>
+
+#include "nix/util/hash.hh"
+#include "nix/util/serialise.hh"
+
+namespace nix {
+
+using RawMode = uint32_t;
+
+namespace merkle {
+
+/**
+ * The mode of a file in a content-addressed/merkle file system.
+ * These values match the Git file modes.
+ */
+enum struct Mode : RawMode {
+    Directory = 0040000,
+    Regular = 0100644,
+    Executable = 0100755,
+    Symlink = 0120000,
+};
+
+inline std::optional<Mode> decodeMode(RawMode m)
+{
+    switch (m) {
+    case (RawMode) Mode::Directory:
+    case (RawMode) Mode::Executable:
+    case (RawMode) Mode::Regular:
+    case (RawMode) Mode::Symlink:
+        return (Mode) m;
+    default:
+        return std::nullopt;
+    }
+}
+
+/**
+ * An entry in a content-addressed/merkle file system directory.
+ */
+struct TreeEntry
+{
+    Mode mode;
+    Hash hash;
+
+    bool operator==(const TreeEntry &) const = default;
+    auto operator<=>(const TreeEntry &) const = default;
+};
+
+/**
+ * A sink for building a shallow Merkle directory by inserting child
+ * entries --- they contain a hash but no data.
+ */
+struct DirectorySink
+{
+    virtual ~DirectorySink() = default;
+
+    /**
+     * Insert an existing object as a child of this directory.
+     */
+    virtual void insertChild(std::string_view name, TreeEntry entry) = 0;
+};
+
+} // namespace merkle
+
+} // namespace nix

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -65,6 +65,7 @@ headers = [ config_pub_h ] + files(
   'nar-accessor.hh',
   'nar-cache.hh',
   'nar-listing.hh',
+  'os-filename.hh',
   'os-string.hh',
   'pool.hh',
   'pos-idx.hh',

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -60,6 +60,7 @@ headers = [ config_pub_h ] + files(
   'logging.hh',
   'lru-cache.hh',
   'memory-source-accessor.hh',
+  'merkle-files.hh',
   'mounted-source-accessor.hh',
   'muxable-pipe.hh',
   'nar-accessor.hh',

--- a/src/libutil/include/nix/util/os-filename.hh
+++ b/src/libutil/include/nix/util/os-filename.hh
@@ -1,0 +1,56 @@
+#pragma once
+///@file
+
+#include <filesystem>
+
+namespace nix {
+
+/**
+ * A newtype around `std::filesystem::path` that asserts at construction
+ * time that the path is a single filename component.
+ *
+ * A valid `OsFilename`:
+ * - Has no root path or root name (no drive letter on Windows, no leading `/`)
+ * - Has no directory separators
+ * - Is not empty
+ * - Is not `.` or `..`
+ *
+ * This type is useful for APIs that expect a bare filename rather than
+ * a full path, providing compile-time documentation and runtime validation.
+ */
+class OsFilename
+{
+    std::filesystem::path name;
+
+    void validate() const;
+
+public:
+    /**
+     * Construct an `OsFilename` from a path, asserting that it is a
+     * single filename component.
+     */
+    explicit OsFilename(std::filesystem::path p)
+        : name(std::move(p))
+    {
+        validate();
+    }
+
+    const std::filesystem::path & path() const noexcept
+    {
+        return name;
+    }
+
+    /**
+     * Implicit conversion to `const std::filesystem::path &` for
+     * convenience when passing to APIs expecting a path.
+     */
+    operator const std::filesystem::path &() const noexcept
+    {
+        return name;
+    }
+
+    bool operator==(const OsFilename &) const = default;
+    auto operator<=>(const OsFilename &) const = default;
+};
+
+} // namespace nix

--- a/src/libutil/include/nix/util/pool.hh
+++ b/src/libutil/include/nix/util/pool.hh
@@ -64,10 +64,13 @@ private:
 
 public:
 
+    /**
+     * Note: `factory` cannot have a default argument because the
+     * default would be instantiated when Pool<R> is instantiated,
+     * requiring R to be default-constructible.
+     */
     Pool(
-        size_t max = std::numeric_limits<size_t>::max(),
-        const Factory & factory = []() { return make_ref<R>(); },
-        const Validator & validator = [](ref<R> r) { return true; })
+        size_t max, const Factory & factory, const Validator & validator = [](ref<R> r) { return true; })
         : factory(factory)
         , validator(validator)
     {

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -225,18 +225,12 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
  */
 ref<SourceAccessor> makeEmptySourceAccessor();
 
-/**
- * Exception thrown when accessing a filtered path (see
- * `FilteringSourceAccessor`).
- */
-MakeError(RestrictedPathError, Error);
-
 struct SymlinkNotAllowed final : public CloneableError<SymlinkNotAllowed, Error>
 {
-    CanonPath path;
+    std::variant<CanonPath, std::filesystem::path> path;
 
     SymlinkNotAllowed(CanonPath path)
-        : CloneableError("relative path '%s' points to a symlink, which is not allowed", path.rel())
+        : CloneableError(defaultMsg, path.abs())
         , path(std::move(path))
     {
     }
@@ -247,7 +241,29 @@ struct SymlinkNotAllowed final : public CloneableError<SymlinkNotAllowed, Error>
         , path(std::move(path))
     {
     }
+
+    SymlinkNotAllowed(std::filesystem::path path)
+        : CloneableError(defaultMsg, path.string())
+        , path(std::move(path))
+    {
+    }
+
+    template<typename... Args>
+    SymlinkNotAllowed(std::filesystem::path path, const std::string & fs, Args &&... args)
+        : CloneableError(fs, std::forward<Args>(args)...)
+        , path(std::move(path))
+    {
+    }
+
+private:
+    static inline const std::string defaultMsg = "path '%s' is a symlink, which is not allowed";
 };
+
+/**
+ * Exception thrown when accessing a filtered path (see
+ * `FilteringSourceAccessor`).
+ */
+MakeError(RestrictedPathError, Error);
 
 /**
  * Return an accessor for the root filesystem.

--- a/src/libutil/include/nix/util/tarfile.hh
+++ b/src/libutil/include/nix/util/tarfile.hh
@@ -1,8 +1,8 @@
 #pragma once
 ///@file
 
+#include "nix/util/canon-path.hh"
 #include "nix/util/serialise.hh"
-#include "nix/util/fs-sink.hh"
 #include <archive.h>
 
 namespace nix {
@@ -39,6 +39,33 @@ int getArchiveFilterCodeByName(const std::string & method);
 
 void unpackTarfile(const std::filesystem::path & tarFile, const std::filesystem::path & destDir);
 
-time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & parseSink);
+/**
+ * Sink for unpacking archives. Uses a path-based interface since
+ * archives can have entries in any order.
+ *
+ * Of the three file system object sinks we have currently (this,
+ * `FileSystemObjectSink`, and `merkle::FileSinkBuilder`), this one is by far
+ * the "messiest", imposing the least structure. It is this rather a
+ * footgun, and one should avoid implementing it directly as much as
+ * possible.
+ */
+struct TarSink
+{
+    virtual ~TarSink() = default;
+
+    virtual void createDirectory(const CanonPath & path) = 0;
+
+    virtual void createRegularFile(const CanonPath & path, bool isExecutable, fun<void(Sink &)> callback) = 0;
+
+    virtual void createSymlink(const CanonPath & path, const std::string & target) = 0;
+
+    /**
+     * Create a hard link. The target must be the path of a previously
+     * encountered file relative to the root.
+     */
+    virtual void createHardlink(const CanonPath & path, const CanonPath & target) = 0;
+};
+
+time_t unpackTarfileToSink(TarArchive & archive, TarSink & parseSink);
 
 } // namespace nix

--- a/src/libutil/include/nix/util/variant-wrapper.hh
+++ b/src/libutil/include/nix/util/variant-wrapper.hh
@@ -4,30 +4,50 @@
 // not used, but will be used by callers
 #include <variant>
 
+#define FORCE_DEFAULT_MOVE_CONSTRUCTORS(CLASS_NAME) \
+    CLASS_NAME(CLASS_NAME &&) = default;            \
+    CLASS_NAME & operator=(CLASS_NAME &&) = default;
+
 /**
  * Force the default versions of all constructors (copy, move, copy
  * assignment).
  */
 #define FORCE_DEFAULT_CONSTRUCTORS(CLASS_NAME)            \
+    FORCE_DEFAULT_MOVE_CONSTRUCTORS(CLASS_NAME)           \
+                                                          \
     CLASS_NAME(const CLASS_NAME &) = default;             \
     CLASS_NAME(CLASS_NAME &) = default;                   \
-    CLASS_NAME(CLASS_NAME &&) = default;                  \
                                                           \
     CLASS_NAME & operator=(const CLASS_NAME &) = default; \
     CLASS_NAME & operator=(CLASS_NAME &) = default;
 
 /**
- * Make a wrapper constructor. All args are forwarded to the
- * construction of the "raw" field. (Which we assume is the only one.)
+ * Forwarding constructor for wrapper types. All args are forwarded to
+ * the construction of the "raw" field.
  *
  * The moral equivalent of `using Raw::Raw;`
  */
-#define MAKE_WRAPPER_CONSTRUCTOR(CLASS_NAME)                                                                \
-    FORCE_DEFAULT_CONSTRUCTORS(CLASS_NAME)                                                                  \
-                                                                                                            \
+#define MAKE_WRAPPER_CONSTRUCTOR_RAW(CLASS_NAME)                                                            \
     template<typename... Args>                                                                              \
         requires(!(sizeof...(Args) == 1 && (std::is_same_v<std::remove_cvref_t<Args>, CLASS_NAME> && ...))) \
     CLASS_NAME(Args &&... arg)                                                                              \
         : raw(std::forward<Args>(arg)...)                                                                   \
     {                                                                                                       \
     }
+
+/**
+ * Make a wrapper constructor. Also defaults move constructor/assignment.
+ * Copy operations will be implicitly defaulted or deleted based on the
+ * Raw type.
+ */
+#define MAKE_WRAPPER_CONSTRUCTOR_MOVE_ONLY(CLASS_NAME) \
+    FORCE_DEFAULT_MOVE_CONSTRUCTORS(CLASS_NAME)        \
+    MAKE_WRAPPER_CONSTRUCTOR_RAW(CLASS_NAME)
+
+/**
+ * Like MAKE_WRAPPER_CONSTRUCTOR, but also explicitly defaults copy
+ * operations for copyable types.
+ */
+#define MAKE_WRAPPER_CONSTRUCTOR(CLASS_NAME) \
+    FORCE_DEFAULT_CONSTRUCTORS(CLASS_NAME)   \
+    MAKE_WRAPPER_CONSTRUCTOR_RAW(CLASS_NAME)

--- a/src/libutil/memory-source-accessor.cc
+++ b/src/libutil/memory-source-accessor.cc
@@ -179,23 +179,7 @@ SourcePath MemorySourceAccessor::addFile(CanonPath path, std::string && contents
 
 using File = MemorySourceAccessor::File;
 
-void MemorySink::createDirectory(const CanonPath & path)
-{
-    MemorySourceAccessor::File * f = nullptr;
-    try {
-        f = dst.open(path, File{File::Directory{}});
-        if (!f)
-            throw Error(
-                "directory '%s' cannot be created because some parent directories don't exist", dst.showPath(path));
-    } catch (SourceAccessorError & e) {
-        e.addTrace({}, "while creating directory '%s'", dst.showPath(path));
-        throw;
-    }
-    if (!std::holds_alternative<File::Directory>(f->raw))
-        throw NotADirectory("file '%s' is not a directory", dst.showPath(path));
-};
-
-struct CreateMemoryRegularFile : CreateRegularFileSink
+struct CreateMemoryRegularFile : FileSystemObjectSink::OnRegularFile
 {
     File::Regular & regularFile;
 
@@ -205,31 +189,32 @@ struct CreateMemoryRegularFile : CreateRegularFileSink
     }
 
     void operator()(std::string_view data) override;
-    void isExecutable() override;
     void preallocateContents(uint64_t size) override;
 };
 
-void MemorySink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)
+void MemorySink::MemoryDirectory::createChild(std::string_view name, ChildCreatedCallback callback)
 {
-    MemorySourceAccessor::File * f = nullptr;
-    try {
-        f = dst.open(path, File{File::Regular{}});
-        if (!f)
-            throw Error("file '%s' cannot be created because some parent directories don't exist", dst.showPath(path));
-    } catch (SourceAccessorError & e) {
-        e.addTrace({}, "while creating regular file '%s'", dst.showPath(path));
-        throw;
-    }
-    if (auto * rp = std::get_if<File::Regular>(&f->raw)) {
-        CreateMemoryRegularFile crf{*rp};
-        func(crf);
-    } else
-        throw NotARegularFile("file '%s' is not a regular file", dst.showPath(path));
+    MemorySink childSink{[&, name = std::string{name}](File file) -> File & {
+        auto [it, inserted] = dir.entries.insert_or_assign(name, std::move(file));
+        return it->second;
+    }};
+    callback(childSink);
 }
 
-void CreateMemoryRegularFile::isExecutable()
+void MemorySink::createDirectory(DirectoryCreatedCallback callback)
 {
-    regularFile.executable = true;
+    File & dst = createRoot(File{File::Directory{}});
+    MemoryDirectory dir{std::get<File::Directory>(dst.raw)};
+    callback(dir);
+}
+
+void MemorySink::createRegularFile(bool isExecutable, RegularFileCreatedCallback func)
+{
+    File & dst = createRoot(File{File::Regular{}});
+    auto & reg = std::get<File::Regular>(dst.raw);
+    reg.executable = isExecutable;
+    CreateMemoryRegularFile crf{reg};
+    func(crf);
 }
 
 void CreateMemoryRegularFile::preallocateContents(uint64_t len)
@@ -242,30 +227,16 @@ void CreateMemoryRegularFile::operator()(std::string_view data)
     regularFile.contents += data;
 }
 
-void MemorySink::createSymlink(const CanonPath & path, const std::string & target)
+void MemorySink::createSymlink(const std::string & target)
 {
-    MemorySourceAccessor::File * f = nullptr;
-    try {
-        f = dst.open(path, File{File::Symlink{}});
-        if (!f)
-            throw Error(
-                "symlink '%s' cannot be created because some parent directories don't exist", dst.showPath(path));
-    } catch (SourceAccessorError & e) {
-        e.addTrace({}, "while creating symlink '%s'", dst.showPath(path));
-        throw;
-    }
-    if (auto * s = std::get_if<File::Symlink>(&f->raw))
-        s->target = target;
-    else
-        throw NotASymlink("file '%s' is not a symbolic link", dst.showPath(path));
+    createRoot(File{File::Symlink{.target = target}});
 }
 
 ref<SourceAccessor> makeEmptySourceAccessor()
 {
     static auto empty = []() {
         auto empty = make_ref<MemorySourceAccessor>();
-        MemorySink sink{*empty};
-        sink.createDirectory(CanonPath::root);
+        empty->root = File{File::Directory{}};
         /* Don't forget to clear the display prefix, as the default constructed
            SourceAccessor has the «unknown» prefix. Since this accessor is supposed
            to mimic an empty root directory the prefix needs to be empty. */

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -161,6 +161,7 @@ sources = [ config_priv_h ] + files(
   'nar-accessor.cc',
   'nar-cache.cc',
   'nar-listing.cc',
+  'os-filename.cc',
   'pos-table.cc',
   'position.cc',
   'posix-source-accessor.cc',

--- a/src/libutil/nar-listing.cc
+++ b/src/libutil/nar-listing.cc
@@ -2,108 +2,114 @@
 #include "nix/util/archive.hh"
 #include "nix/util/error.hh"
 
-#include <stack>
-
 namespace nix {
 
 NarListing parseNarListing(Source & source)
 {
-    struct NarMemberConstructor : CreateRegularFileSink
-    {
-    private:
-
-        NarListing::Regular & regular;
-
-        uint64_t & pos;
-
-    public:
-
-        NarMemberConstructor(NarListing::Regular & reg, uint64_t & pos)
-            : regular(reg)
-            , pos(pos)
-        {
-        }
-
-        void isExecutable() override
-        {
-            regular.executable = true;
-        }
-
-        void preallocateContents(uint64_t size) override
-        {
-            regular.contents.fileSize = size;
-            regular.contents.narOffset = pos;
-        }
-
-        void operator()(std::string_view data) override {}
-    };
-
     struct NarIndexer : FileSystemObjectSink, Source
     {
         std::optional<NarListing> root;
         Source & source;
-
-        std::stack<NarListing *> parents;
-
         uint64_t pos = 0;
+
+        /**
+         * Pointer to where the next created member should be stored.
+         * For root, this points to `root`. For children, it points into
+         * the parent directory's entries map.
+         */
+        NarListing * currentDst = nullptr;
 
         NarIndexer(Source & source)
             : source(source)
         {
         }
 
-        NarListing & createMember(const CanonPath & path, NarListing member)
+        void createDirectory(DirectoryCreatedCallback callback) override
         {
-            size_t level = 0;
-            for (auto _ : path) {
-                (void) _;
-                ++level;
-            }
-
-            while (parents.size() > level)
-                parents.pop();
-
-            if (parents.empty()) {
-                root = std::move(member);
-                parents.push(&*root);
-                return *root;
+            if (currentDst) {
+                *currentDst = NarListing::Directory{};
             } else {
-                auto * parentDir = std::get_if<NarListing::Directory>(&parents.top()->raw);
-                if (!parentDir)
-                    throw Error("NAR file missing parent directory of path '%s'", path);
-                auto result = parentDir->entries.emplace(*path.baseName(), std::move(member));
-                parents.push(&result.first->second);
-                return result.first->second;
+                root = NarListing::Directory{};
+                currentDst = &*root;
             }
+
+            struct Dir : OnDirectory
+            {
+                NarIndexer & indexer;
+                NarListing::Directory & dir;
+
+                Dir(NarIndexer & indexer, NarListing::Directory & dir)
+                    : indexer(indexer)
+                    , dir(dir)
+                {
+                }
+
+                void createChild(std::string_view name, ChildCreatedCallback callback) override
+                {
+                    auto [it, inserted] = dir.entries.emplace(std::string{name}, NarListing{});
+                    auto oldDst = indexer.currentDst;
+                    indexer.currentDst = &it->second;
+
+                    callback(indexer);
+
+                    indexer.currentDst = oldDst;
+                }
+            } dir{*this, std::get<NarListing::Directory>(currentDst->raw)};
+
+            callback(dir);
         }
 
-        void createDirectory(const CanonPath & path) override
+        void createRegularFile(bool isExecutable, RegularFileCreatedCallback func) override
         {
-            createMember(path, NarListing::Directory{});
-        }
+            auto reg = NarListing::Regular{
+                .executable = isExecutable,
+                .contents =
+                    NarListingRegularFile{
+                        .fileSize = 0,
+                        .narOffset = pos,
+                    },
+            };
 
-        void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func) override
-        {
-            auto & nm = createMember(
-                path,
-                NarListing::Regular{
-                    .executable = false,
-                    .contents =
-                        NarListingRegularFile{
-                            .fileSize = 0,
-                            .narOffset = pos,
-                        },
-                });
-            /* We know the downcast will succeed because we just added this */
-            auto & reg = std::get<NarListing::Regular>(nm.raw);
-            NarMemberConstructor nmc{reg, pos};
-            nmc.skipContents = true; /* Don't care about contents. */
+            if (currentDst) {
+                *currentDst = std::move(reg);
+            } else {
+                root = std::move(reg);
+                currentDst = &*root;
+            }
+
+            auto & regRef = std::get<NarListing::Regular>(currentDst->raw);
+
+            struct NarMemberConstructor : OnRegularFile
+            {
+                NarListing::Regular & regular;
+                uint64_t & pos;
+
+                NarMemberConstructor(NarListing::Regular & reg, uint64_t & pos)
+                    : regular(reg)
+                    , pos(pos)
+                {
+                    skipContents = true; /* Don't care about contents. */
+                }
+
+                void preallocateContents(uint64_t size) override
+                {
+                    regular.contents.fileSize = size;
+                    regular.contents.narOffset = pos;
+                }
+
+                void operator()(std::string_view data) override {}
+            } nmc{regRef, pos};
+
             func(nmc);
         }
 
-        void createSymlink(const CanonPath & path, const std::string & target) override
+        void createSymlink(const std::string & target) override
         {
-            createMember(path, NarListing::Symlink{.target = target});
+            if (currentDst) {
+                *currentDst = NarListing::Symlink{.target = target};
+            } else {
+                root = NarListing::Symlink{.target = target};
+            }
         }
 
         size_t read(char * data, size_t len) override

--- a/src/libutil/os-filename.cc
+++ b/src/libutil/os-filename.cc
@@ -1,0 +1,17 @@
+#include "nix/util/os-filename.hh"
+
+#include <cassert>
+
+namespace nix {
+
+void OsFilename::validate() const
+{
+    assert(!name.empty() && "OsFilename cannot be empty");
+    assert(!name.has_root_path() && "OsFilename cannot have a root path");
+    assert(!name.has_parent_path() && "OsFilename cannot have a parent path");
+    assert(name.filename() == name && "OsFilename must be a single filename");
+    assert(name != "." && "OsFilename cannot be '.'");
+    assert(name != ".." && "OsFilename cannot be '..'");
+}
+
+} // namespace nix

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -293,12 +293,24 @@ std::optional<std::filesystem::path> PosixSourceAccessor::getPhysicalPath(const 
 
 void PosixSourceAccessor::assertNoSymlinks(CanonPath path)
 {
+#ifdef _WIN32
+    /* On Windows, iterate from root outward so we detect symlinks before
+       trying to access paths beyond them (which would fail with INVALID_NAME). */
+    CanonPath current = CanonPath::root;
+    for (auto & component : path) {
+        current = current / component;
+        auto st = cachedLstat(current);
+        if (st && S_ISLNK(st->st_mode))
+            throw SymlinkNotAllowed(std::filesystem::path(current.rel()), "path '%s' is a symlink", showPath(current));
+    }
+#else
     while (!path.isRoot()) {
         auto st = cachedLstat(path);
         if (st && S_ISLNK(st->st_mode))
-            throw SymlinkNotAllowed(path, "path '%s' is a symlink", showPath(path));
+            throw SymlinkNotAllowed(std::filesystem::path(path.rel()), "path '%s' is a symlink", showPath(path));
         path.pop();
     }
+#endif
 }
 
 ref<SourceAccessor> getFSSourceAccessor()
@@ -375,7 +387,7 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackL
             mtime = st.st_mtime;
         }
 
-        auto linkTarget = readLinkAt(parentFd.get(), relPath);
+        auto linkTarget = readLinkAt(parentFd.get(), root.filename());
         return make_ref<SymlinkSourceAccessor>(std::move(linkTarget), std::move(root), trackLastModified, mtime);
     }
 

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -343,8 +343,10 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackL
                 , mtime(mtime)
                 , fsPath(std::move(fsPath_))
             {
-                MemorySink sink{*this};
-                sink.createSymlink(CanonPath::root, target);
+                MemorySink sink{[&](MemorySourceAccessor::File file) -> MemorySourceAccessor::File & {
+                    return root.emplace(std::move(file));
+                }};
+                sink.createSymlink(target);
                 displayPrefix = fsPath.native();
             }
 

--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -166,7 +166,7 @@ void unpackTarfile(const std::filesystem::path & tarFile, const std::filesystem:
     extract_archive(archive, destDir);
 }
 
-time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & parseSink)
+time_t unpackTarfileToSink(TarArchive & archive, TarSink & parseSink)
 {
     time_t lastModified = 0;
 
@@ -203,10 +203,8 @@ time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & 
             break;
 
         case AE_IFREG: {
-            parseSink.createRegularFile(cpath, [&](auto & crf) {
-                if (archive_entry_mode(entry) & S_IXUSR)
-                    crf.isExecutable();
-
+            bool isExecutable = archive_entry_mode(entry) & S_IXUSR;
+            parseSink.createRegularFile(cpath, isExecutable, [&](auto & crf) {
                 while (true) {
                     auto n = archive_read_data(archive.archive, buf.data(), buf.size());
                     if (n < 0)

--- a/src/libutil/unix/file-system-at.cc
+++ b/src/libutil/unix/file-system-at.cc
@@ -23,6 +23,8 @@
 #  define HAVE_FCHMODAT2 0
 #endif
 
+#include "util-unix-config-private.hh"
+
 namespace nix {
 
 #ifdef __linux__
@@ -57,22 +59,23 @@ std::optional<AutoCloseFD> openat2(Descriptor dirFd, const char * path, uint64_t
 
 #endif
 
-void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t mode)
+void unix::fchmodatTryNoFollow(Descriptor dirFd, const std::filesystem::path & path, mode_t mode)
 {
-    assert(!path.isRoot());
+    assert(path.is_relative());
+    assert(!path.empty());
 
 #if HAVE_FCHMODAT2
     /* Cache whether fchmodat2 is not supported. */
     static std::atomic_flag fchmodat2Unsupported{};
     if (!fchmodat2Unsupported.test()) {
         /* Try with fchmodat2 first. */
-        auto res = ::syscall(__NR_fchmodat2, dirFd, path.rel_c_str(), mode, AT_SYMLINK_NOFOLLOW);
+        auto res = ::syscall(__NR_fchmodat2, dirFd, path.c_str(), mode, AT_SYMLINK_NOFOLLOW);
         /* Cache that the syscall is not supported. */
         if (res < 0) {
             if (errno == ENOSYS)
                 fchmodat2Unsupported.test_and_set();
             else {
-                throw SysError([&] { return HintFmt("fchmodat2 %s", PathFmt(descriptorToPath(dirFd) / path.rel())); });
+                throw SysError([&] { return HintFmt("fchmodat2 %s", PathFmt(descriptorToPath(dirFd) / path)); });
             }
         } else
             return;
@@ -80,12 +83,12 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
 #endif
 
 #ifdef __linux__
-    AutoCloseFD pathFd = ::openat(dirFd, path.rel_c_str(), O_PATH | O_NOFOLLOW | O_CLOEXEC);
+    AutoCloseFD pathFd = ::openat(dirFd, path.c_str(), O_PATH | O_NOFOLLOW | O_CLOEXEC);
     if (!pathFd) {
         throw SysError([&] {
             return HintFmt(
                 "opening %s to get an O_PATH file descriptor (fchmodat2 is unsupported)",
-                PathFmt(descriptorToPath(dirFd) / path.rel()));
+                PathFmt(descriptorToPath(dirFd) / path));
         });
     }
 
@@ -94,11 +97,11 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
     auto st = fstat(pathFd.get());
 
     if (S_ISLNK(st.st_mode))
-        throw SysError(EOPNOTSUPP, "can't change mode of symlink %s", PathFmt(descriptorToPath(dirFd) / path.rel()));
+        throw SysError(EOPNOTSUPP, "can't change mode of symlink %s", PathFmt(descriptorToPath(dirFd) / path));
 
     static std::atomic_flag dontHaveProc{};
     if (!dontHaveProc.test()) {
-        static const CanonPath selfProcFd = CanonPath("/proc/self/fd");
+        static const std::filesystem::path selfProcFd = "/proc/self/fd";
 
         auto selfProcFdPath = selfProcFd / std::to_string(pathFd.get());
         if (int res = ::chmod(selfProcFdPath.c_str(), mode); res == -1) {
@@ -106,7 +109,7 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
                 dontHaveProc.test_and_set();
             else {
                 throw SysError([&] {
-                    return HintFmt("chmod %s (%s)", selfProcFdPath, PathFmt(descriptorToPath(dirFd) / path.rel()));
+                    return HintFmt("chmod %s (%s)", PathFmt(selfProcFdPath), PathFmt(descriptorToPath(dirFd) / path));
                 });
             }
         } else
@@ -119,7 +122,7 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
 
     int res = ::fchmodat(
         dirFd,
-        path.rel_c_str(),
+        path.c_str(),
         mode,
 #if defined(AT_SYMLINK_NOFOLLOW) && !defined(__linux__)
         AT_SYMLINK_NOFOLLOW
@@ -136,23 +139,22 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
     );
 
     if (res == -1) {
-        throw SysError([&] { return HintFmt("fchmodat %s", PathFmt(descriptorToPath(dirFd) / path.rel())); });
+        throw SysError([&] { return HintFmt("fchmodat %s", PathFmt(descriptorToPath(dirFd) / path)); });
     }
 }
 
 static AutoCloseFD
-openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & path, int flags, mode_t mode)
+openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const std::filesystem::path & path, int flags, mode_t mode)
 {
     AutoCloseFD parentFd;
-    auto nrComponents = std::ranges::distance(path);
-    assert(nrComponents >= 1);
-    auto components = std::views::take(path, nrComponents - 1); /* Everything but last component */
+    auto components = std::vector<std::filesystem::path>(path.begin(), path.end());
+    assert(!components.empty());
     auto getParentFd = [&]() { return parentFd ? parentFd.get() : dirFd; };
 
     /* This rather convoluted loop is necessary to avoid TOCTOU when validating that
        no inner path component is a symlink. */
-    for (auto it = components.begin(); it != components.end(); ++it) {
-        auto component = std::string(*it);                        /* Copy into a string to make NUL terminated. */
+    for (size_t i = 0; i + 1 < components.size(); ++i) {
+        auto component = components[i].string();
         assert(component != ".." && !component.starts_with('/')); /* In case invariant is broken somehow.. */
 
         AutoCloseFD parentFd2 = ::openat(
@@ -168,11 +170,10 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
         );
 
         if (!parentFd2) {
-            /* Construct the CanonPath for error message. */
-            auto path2 = std::ranges::fold_left(components.begin(), ++it, CanonPath::root, [](auto lhs, auto rhs) {
-                lhs.push(rhs);
-                return lhs;
-            });
+            /* Construct path up to failed component for error message. */
+            std::filesystem::path path2;
+            for (size_t j = 0; j <= i; ++j)
+                path2 /= components[j];
 
             if (errno == ENOTDIR) /* Path component might be a symlink. */ {
                 /* Does not follow final symlink. We know `component` is a
@@ -191,7 +192,7 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
         parentFd = std::move(parentFd2);
     }
 
-    auto lastComponent = std::string(path.baseName().value());
+    auto & lastComponent = components.back();
     AutoCloseFD res = ::openat(getParentFd(), lastComponent.c_str(), flags | O_NOFOLLOW, mode);
 
     if (!res) {
@@ -221,18 +222,16 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
     return res;
 }
 
-AutoCloseFD openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & path, int flags, mode_t mode)
+AutoCloseFD
+openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const std::filesystem::path & path, int flags, mode_t mode)
 {
-    /* Just in case the invariant is somehow broken. */
-    assert(!path.rel().starts_with('/'));
-    assert(!path.isRoot());
+    assert(path.is_relative());
+    assert(!path.empty());
 
     /* We don't want callers of this function to think about the presence or
        absence of `O_NOFOLLOW`. "ensure beneath no symlinks" is in the name, so
        we want them to trust us to handle it instead. */
     assert(!(flags & O_NOFOLLOW));
-
-    /* See doxygen in `file-system-at.hh` for why we reject this. */
 
 #if HAVE_OPENAT2
     /* Two things are being fixed here:
@@ -256,7 +255,7 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & 
     auto flagsAdj = (flags & O_PATH) && !(flags & O_DIRECTORY) ? flags | O_NOFOLLOW : flags;
 
     if (auto maybeFd = linux::openat2(
-            dirFd, path.rel_c_str(), flagsAdj, static_cast<uint64_t>(mode), RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)) {
+            dirFd, path.c_str(), flagsAdj, static_cast<uint64_t>(mode), RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)) {
         if (!*maybeFd && errno == ELOOP)
             throw SymlinkNotAllowed(path);
         return std::move(*maybeFd);
@@ -266,21 +265,64 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & 
     return openFileEnsureBeneathNoSymlinksIterative(dirFd, path, flags, mode);
 }
 
-OsString readLinkAt(Descriptor dirFd, const CanonPath & path)
+OsString readLinkAt(Descriptor dirFd, const std::filesystem::path & path)
 {
-    assert(!path.isRoot());
-    assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
+    assert(path.is_relative());
+    assert(!path.empty());
     std::vector<char> buf;
     for (ssize_t bufSize = PATH_MAX / 4; true; bufSize += bufSize / 2) {
         checkInterrupt();
         buf.resize(bufSize);
-        ssize_t rlSize = ::readlinkat(dirFd, path.rel_c_str(), buf.data(), bufSize);
+        ssize_t rlSize = ::readlinkat(dirFd, path.c_str(), buf.data(), bufSize);
         if (rlSize == -1) {
             throw SysError(
-                [&] { return HintFmt("reading symbolic link %1%", PathFmt(descriptorToPath(dirFd) / path.rel())); });
+                [&] { return HintFmt("reading symbolic link %1%", PathFmt(descriptorToPath(dirFd) / path)); });
         } else if (rlSize < bufSize)
             return {buf.data(), static_cast<std::size_t>(rlSize)};
     }
+}
+
+static void symlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+    if (::symlinkat(target.c_str(), dirFd, path.c_str()) == -1) {
+        throw SysError(
+            [&] { return HintFmt("creating symlink %1% -> %2%", PathFmt(descriptorToPath(dirFd) / path), target); });
+    }
+}
+
+void createFileSymlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target)
+{
+    symlinkAt(dirFd, path, target);
+}
+
+void createDirectorySymlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target)
+{
+    symlinkAt(dirFd, path, target);
+}
+
+void createUnknownSymlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target)
+{
+    symlinkAt(dirFd, path, target);
+}
+
+outcome::unchecked<AutoCloseFD, std::error_code>
+openDirectoryAt(Descriptor dirFd, const std::filesystem::path & path, bool create, mode_t mode)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+    if (create) {
+        if (::mkdirat(dirFd, path.c_str(), mode) == -1) {
+            return outcome::failure(std::error_code(errno, std::system_category()));
+        }
+    }
+    // Use O_NOFOLLOW to avoid following symlinks - if path is a symlink, this will fail with ENOTDIR
+    int fd = ::openat(dirFd, path.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (fd == -1) {
+        return outcome::failure(std::error_code(errno, std::system_category()));
+    }
+    return AutoCloseFD{fd};
 }
 
 PosixStat fstat(Descriptor fd)

--- a/src/libutil/unix/file-system-at.cc
+++ b/src/libutil/unix/file-system-at.cc
@@ -219,12 +219,14 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const std::filesystem
        are asking for a path reference, and interior symlinks are
        already guarded by the component-by-component walk above. */
 
+
     return res;
 }
 
 AutoCloseFD
 openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const std::filesystem::path & path, int flags, mode_t mode)
 {
+    /* Just in case the invariant is somehow broken. */
     assert(path.is_relative());
     assert(!path.empty());
 
@@ -232,6 +234,8 @@ openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const std::filesystem::path & 
        absence of `O_NOFOLLOW`. "ensure beneath no symlinks" is in the name, so
        we want them to trust us to handle it instead. */
     assert(!(flags & O_NOFOLLOW));
+
+    /* See doxygen in `file-system-at.hh` for why we reject this. */
 
 #if HAVE_OPENAT2
     /* Two things are being fixed here:

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -203,7 +203,7 @@ static void _deletePath(
         const auto PERM_MASK = S_IRUSR | S_IWUSR | S_IXUSR;
         if ((st.st_mode & PERM_MASK) != PERM_MASK)
             try {
-                unix::fchmodatTryNoFollow(parentfd, name, st.st_mode | PERM_MASK);
+                unix::fchmodatTryNoFollow(parentfd, std::filesystem::path(name.rel()), st.st_mode | PERM_MASK);
             } catch (SysError & e) {
                 e.addTrace({}, "while making directory %1% accessible for deletion", PathFmt(path));
                 if (e.errNo == EOPNOTSUPP)
@@ -251,7 +251,9 @@ static void _deletePath(const std::filesystem::path & path, uint64_t & bytesFree
     auto parentDirPath = path.parent_path();
     assert(parentDirPath != path);
 
-    AutoCloseFD dirfd = openDirectory(parentDirPath);
+    /* It's ok to follow symlinks in the parent since we only need to
+       ensure that there's no TOCTOU when traversing inside the path. */
+    AutoCloseFD dirfd = openDirectory(parentDirPath, FinalSymlink::Follow);
     if (!dirfd) {
         if (errno == ENOENT)
             return;

--- a/src/libutil/windows/file-system-at.cc
+++ b/src/libutil/windows/file-system-at.cc
@@ -277,8 +277,8 @@ bool isReparsePoint(HANDLE handle)
 
 OsString readLinkAt(Descriptor dirFd, const std::filesystem::path & path)
 {
-    auto linkHandle = windows::openSymlinkAt(dirFd, path);
-    return windows::readSymlinkTarget(linkHandle.get());
+    auto linkHandle = openSymlinkAt(dirFd, path);
+    return readSymlinkTarget(linkHandle.get());
 }
 
 void createFileSymlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target)

--- a/src/libutil/windows/file-system-at.cc
+++ b/src/libutil/windows/file-system-at.cc
@@ -3,9 +3,13 @@
 #include "nix/util/signals.hh"
 #include "nix/util/file-path.hh"
 #include "nix/util/source-accessor.hh"
+#include "nix/util/util.hh"
+#include "nix/util/windows-environment.hh"
+
+#include <boost/outcome.hpp>
+#include <span>
 
 #include <fileapi.h>
-#include <error.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <winioctl.h>
@@ -17,6 +21,8 @@ namespace windows {
 
 namespace {
 
+namespace outcome = BOOST_OUTCOME_V2_NAMESPACE;
+
 /**
  * Open a file/directory relative to a directory handle using NtCreateFile.
  *
@@ -25,9 +31,9 @@ namespace {
  * @param desiredAccess Access rights requested
  * @param createOptions NT create options flags
  * @param createDisposition FILE_OPEN, FILE_CREATE, etc.
- * @return Handle to the opened file/directory (caller must close)
+ * @return Handle to the opened file/directory, or NTSTATUS on error
  */
-AutoCloseFD ntOpenAt(
+outcome::unchecked<AutoCloseFD, NTSTATUS> maybeNtOpenAt(
     Descriptor dirFd,
     std::wstring_view pathComponent,
     ACCESS_MASK desiredAccess,
@@ -68,10 +74,23 @@ AutoCloseFD ntOpenAt(
     );
 
     if (status != 0)
-        throw WinError(
-            RtlNtStatusToDosError(status), "opening %s relative to directory handle", PathFmt(pathComponent));
+        return outcome::failure(status);
 
     return AutoCloseFD{h};
+}
+
+AutoCloseFD ntOpenAt(
+    Descriptor dirFd,
+    std::wstring_view pathComponent,
+    ACCESS_MASK desiredAccess,
+    ULONG createOptions,
+    ULONG createDisposition = FILE_OPEN)
+{
+    auto result = maybeNtOpenAt(dirFd, pathComponent, desiredAccess, createOptions, createDisposition);
+    if (!result)
+        throw WinError(
+            RtlNtStatusToDosError(result.error()), "opening %s relative to directory handle", PathFmt(pathComponent));
+    return std::move(result.value());
 }
 
 /**
@@ -81,13 +100,13 @@ AutoCloseFD ntOpenAt(
  * @param path Relative path to the symlink
  * @return Handle to the symlink
  */
-AutoCloseFD openSymlinkAt(Descriptor dirFd, const CanonPath & path)
+AutoCloseFD openSymlinkAt(Descriptor dirFd, const std::filesystem::path & path)
 {
-    assert(!path.isRoot());
-    assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
+    assert(path.is_relative());
+    assert(!path.empty());
 
-    std::wstring wpath = string_to_os_string(path.rel());
-    return ntOpenAt(dirFd, wpath, FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+    auto wpath = path.lexically_normal().make_preferred();
+    return ntOpenAt(dirFd, wpath.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
 }
 
 /**
@@ -190,6 +209,54 @@ OsString readSymlinkTarget(HANDLE linkHandle)
 }
 
 /**
+ * Write symlink target to an open file handle using reparse point.
+ *
+ * @param handle Open file handle (must have GENERIC_WRITE access)
+ * @param target The symlink target (what it points to)
+ */
+void writeSymlinkTarget(HANDLE handle, const std::filesystem::path & target)
+{
+    /* Build the reparse data buffer for a symbolic link.
+       Layout: SubstituteName and PrintName stored consecutively in PathBuffer.
+       We use the same string for both. */
+    size_t targetBytes = target.native().size() * sizeof(wchar_t);
+    size_t bufSize = offsetof(ReparseDataBuffer, SymbolicLinkReparseBuffer.PathBuffer) + targetBytes * 2;
+    std::vector<uint8_t> buf(bufSize, 0);
+
+    auto * reparse = reinterpret_cast<ReparseDataBuffer *>(buf.data());
+    reparse->ReparseTag = IO_REPARSE_TAG_SYMLINK;
+    reparse->ReparseDataLength =
+        static_cast<unsigned short>(bufSize - offsetof(ReparseDataBuffer, SymbolicLinkReparseBuffer));
+    reparse->Reserved = 0;
+
+    auto & symlink = reparse->SymbolicLinkReparseBuffer;
+    /* SubstituteName comes first */
+    symlink.SubstituteNameOffset = 0;
+    symlink.SubstituteNameLength = static_cast<unsigned short>(targetBytes);
+    /* PrintName follows SubstituteName */
+    symlink.PrintNameOffset = static_cast<unsigned short>(targetBytes);
+    symlink.PrintNameLength = static_cast<unsigned short>(targetBytes);
+    /* SYMLINK_FLAG_RELATIVE = 1 for relative symlinks, 0 for absolute */
+    symlink.Flags = target.is_relative() ? 1 : 0;
+
+    /* Copy target into PathBuffer twice (SubstituteName and PrintName) */
+    memcpy(symlink.PathBuffer, target.c_str(), targetBytes);
+    memcpy(reinterpret_cast<char *>(symlink.PathBuffer) + targetBytes, target.c_str(), targetBytes);
+
+    DWORD bytesReturned;
+    if (!DeviceIoControl(
+            handle,
+            FSCTL_SET_REPARSE_POINT,
+            buf.data(),
+            static_cast<DWORD>(bufSize),
+            nullptr,
+            0,
+            &bytesReturned,
+            nullptr))
+        throw WinError("setting reparse point for symlink");
+}
+
+/**
  * Check if a handle refers to a reparse point (e.g., symlink).
  *
  * @param handle Open file/directory handle
@@ -207,6 +274,103 @@ bool isReparsePoint(HANDLE handle)
 } // anonymous namespace
 
 } // namespace windows
+
+OsString readLinkAt(Descriptor dirFd, const std::filesystem::path & path)
+{
+    auto linkHandle = windows::openSymlinkAt(dirFd, path);
+    return windows::readSymlinkTarget(linkHandle.get());
+}
+
+void createFileSymlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+
+    auto wpath = path.lexically_normal().make_preferred();
+
+    /* Create the file that will become the symlink */
+    auto handle = windows::ntOpenAt(
+        dirFd, wpath.c_str(), GENERIC_WRITE | DELETE, FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT, FILE_CREATE);
+
+    windows::writeSymlinkTarget(handle.get(), target);
+}
+
+void createDirectorySymlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+
+    auto wpath = path.lexically_normal().make_preferred();
+
+    /* Create the directory that will become the symlink */
+    auto handle = windows::ntOpenAt(
+        dirFd, wpath.c_str(), GENERIC_WRITE | DELETE, FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT, FILE_CREATE);
+
+    windows::writeSymlinkTarget(handle.get(), target);
+}
+
+void createUnknownSymlinkAt(Descriptor dirFd, const std::filesystem::path & path, const OsString & target)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+
+    std::filesystem::path targetPath(target);
+    bool isDirectory = false;
+
+    if (targetPath.is_absolute()) {
+        /* For absolute targets, use std::filesystem::status directly */
+        std::error_code ec;
+        auto status = std::filesystem::status(targetPath, ec);
+        isDirectory = !ec && std::filesystem::is_directory(status);
+    } else {
+        /* For relative targets, the target is relative to the symlink's parent directory.
+           Open the parent directory first, then try to open the target relative to it. */
+        Descriptor parentFd = dirFd;
+        AutoCloseFD parentFdOwned;
+
+        auto parentPath = path.parent_path();
+        if (!parentPath.empty()) {
+            /* Open the parent directory of the symlink */
+            auto wparent = parentPath.lexically_normal().make_preferred();
+            parentFdOwned = windows::ntOpenAt(dirFd, wparent.c_str(), FILE_TRAVERSE | SYNCHRONIZE, FILE_DIRECTORY_FILE);
+            parentFd = parentFdOwned.get();
+        }
+
+        /* Try to open the target as a directory and verify with fstat. */
+        auto result = windows::maybeNtOpenAt(
+            parentFd, targetPath.make_preferred().wstring(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_DIRECTORY_FILE);
+        if (result) {
+            auto st = fstat(result.value().get());
+            isDirectory = S_ISDIR(st.st_mode);
+        }
+    }
+
+    if (isDirectory)
+        createDirectorySymlinkAt(dirFd, path, target);
+    else
+        createFileSymlinkAt(dirFd, path, target);
+}
+
+outcome::unchecked<AutoCloseFD, std::error_code>
+openDirectoryAt(Descriptor dirFd, const std::filesystem::path & path, bool create)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+
+    auto wpath = path.lexically_normal().make_preferred();
+
+    // Use FILE_OPEN_REPARSE_POINT to avoid following symlinks
+    auto result = windows::maybeNtOpenAt(
+        dirFd,
+        wpath.c_str(),
+        FILE_TRAVERSE | SYNCHRONIZE,
+        FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
+        create ? FILE_CREATE : FILE_OPEN);
+    if (result)
+        return std::move(result.value());
+
+    return outcome::failure(std::error_code(RtlNtStatusToDosError(result.error()), std::system_category()));
+}
 
 PosixStat fstat(Descriptor fd)
 {
@@ -228,28 +392,62 @@ PosixStat fstat(Descriptor fd)
     return st;
 }
 
-AutoCloseFD openFileEnsureBeneathNoSymlinks(
-    Descriptor dirFd, const CanonPath & path, ACCESS_MASK desiredAccess, ULONG createOptions, ULONG createDisposition)
+PosixStat fstatat(Descriptor dirFd, const std::filesystem::path & path)
 {
-    assert(!path.isRoot());
-    assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
+    assert(path.is_relative());
+    assert(!path.empty());
+
+    auto wpath = path.lexically_normal().make_preferred();
+
+    /* Open the file without following symlinks */
+    auto handle = windows::ntOpenAt(dirFd, wpath.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+
+    return fstat(handle.get());
+}
+
+std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const std::filesystem::path & path)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+
+    auto wpath = path.lexically_normal().make_preferred();
+
+    auto result =
+        windows::maybeNtOpenAt(dirFd, wpath.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+    if (result)
+        return fstat(result.value().get());
+
+    auto lastError = RtlNtStatusToDosError(result.error());
+    if (lastError == ERROR_FILE_NOT_FOUND || lastError == ERROR_PATH_NOT_FOUND)
+        return std::nullopt;
+    throw windows::WinError(lastError, "getting status of %s", PathFmt(descriptorToPath(dirFd) / path));
+}
+
+AutoCloseFD openFileEnsureBeneathNoSymlinks(
+    Descriptor dirFd,
+    const std::filesystem::path & path,
+    ACCESS_MASK desiredAccess,
+    ULONG createOptions,
+    ULONG createDisposition)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
 
     AutoCloseFD parentFd;
-    auto nrComponents = std::ranges::distance(path);
-    assert(nrComponents >= 1);
-    auto components = std::views::take(path, nrComponents - 1); /* Everything but last component */
+    auto components = std::vector<std::filesystem::path>(path.begin(), path.end());
+    assert(!components.empty());
     auto getParentFd = [&]() { return parentFd ? parentFd.get() : dirFd; };
 
-    /* Helper to construct CanonPath from components up to (and including) the given iterator */
-    auto pathUpTo = [&](auto it) {
-        return std::ranges::fold_left(components.begin(), it, CanonPath::root, [](auto lhs, auto rhs) {
-            lhs.push(rhs);
-            return lhs;
-        });
+    /* Helper to construct path from components up to (and including) the given index */
+    auto pathUpTo = [&](size_t idx) {
+        std::filesystem::path result;
+        for (size_t i = 0; i <= idx; ++i)
+            result /= components[i];
+        return result;
     };
 
     /* Helper to check if a component is a symlink and throw SymlinkNotAllowed if so */
-    auto throwIfSymlink = [&](std::wstring_view component, const CanonPath & pathForError) {
+    auto throwIfSymlink = [&](std::wstring_view component, const std::filesystem::path & pathForError) {
         try {
             auto testHandle = windows::ntOpenAt(
                 getParentFd(), component, FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
@@ -264,64 +462,90 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
 
     /* Iterate through each path component to ensure no symlinks in intermediate directories.
      * This prevents TOCTOU issues by opening each component relative to the parent. */
-    for (auto it = components.begin(); it != components.end(); ++it) {
-        std::wstring wcomponent = string_to_os_string(std::string(*it));
+    for (size_t i = 0; i + 1 < components.size(); ++i) {
+        const auto & wcomponent = components[i].native();
 
         /* Open directory without following symlinks */
-        AutoCloseFD parentFd2;
-        try {
-            parentFd2 = windows::ntOpenAt(
-                getParentFd(),
-                wcomponent,
-                FILE_TRAVERSE | SYNCHRONIZE,                  // Just need traversal rights
-                FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT // Open directory, don't follow symlinks
-            );
-        } catch (windows::WinError & e) {
-            /* Check if this is because it's a symlink */
-            if (e.lastError == ERROR_CANT_ACCESS_FILE || e.lastError == ERROR_ACCESS_DENIED) {
-                throwIfSymlink(wcomponent, pathUpTo(std::next(it)));
+        auto result = windows::maybeNtOpenAt(
+            getParentFd(),
+            wcomponent,
+            FILE_TRAVERSE | SYNCHRONIZE,                  // Just need traversal rights
+            FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT // Open directory, don't follow symlinks
+        );
+        if (!result) {
+            auto lastError = RtlNtStatusToDosError(result.error());
+            /* Check if this is because it's a symlink - these errors can indicate
+               we tried to traverse through a symlink or open a symlink as a directory */
+            if (lastError == ERROR_CANT_ACCESS_FILE || lastError == ERROR_ACCESS_DENIED
+                || lastError == ERROR_INVALID_NAME || lastError == ERROR_DIRECTORY) {
+                throwIfSymlink(wcomponent, pathUpTo(i));
             }
-            throw;
+            /* ERROR_DIRECTORY means the component is not a directory (e.g., it's a file).
+               Return invalid handle to indicate the path doesn't exist.
+               Set the Win32 error so the caller can inspect it. */
+            if (lastError == ERROR_DIRECTORY || lastError == ERROR_FILE_NOT_FOUND
+                || lastError == ERROR_PATH_NOT_FOUND) {
+                SetLastError(lastError);
+                return AutoCloseFD{};
+            }
+            throw windows::WinError(lastError, "opening directory component '%s'", PathFmt(pathUpTo(i)));
         }
 
         /* Check if what we opened is actually a symlink */
-        if (windows::isReparsePoint(parentFd2.get())) {
-            throw SymlinkNotAllowed(pathUpTo(std::next(it)));
+        if (windows::isReparsePoint(result.value().get())) {
+            throw SymlinkNotAllowed(pathUpTo(i));
         }
 
-        parentFd = std::move(parentFd2);
+        parentFd = std::move(result.value());
     }
 
     /* Now open the final component with requested flags */
-    std::wstring finalComponent = string_to_os_string(std::string(path.baseName().value()));
+    const auto & finalComponent = components.back().native();
 
-    AutoCloseFD finalHandle;
-    try {
-        finalHandle = windows::ntOpenAt(
-            getParentFd(),
-            finalComponent,
-            desiredAccess,
-            createOptions | FILE_OPEN_REPARSE_POINT, // Don't follow symlinks on final component either
-            createDisposition);
-    } catch (windows::WinError & e) {
-        /* Check if final component is a symlink when we requested to not follow it */
-        if (e.lastError == ERROR_CANT_ACCESS_FILE) {
+    auto finalResult = windows::maybeNtOpenAt(
+        getParentFd(),
+        finalComponent,
+        desiredAccess,
+        createOptions | FILE_OPEN_REPARSE_POINT, // Don't follow symlinks on final component either
+        createDisposition);
+    if (!finalResult) {
+        auto lastError = RtlNtStatusToDosError(finalResult.error());
+        /* Check if final component is a symlink when we requested to not follow it. */
+        if (lastError == ERROR_CANT_ACCESS_FILE || lastError == ERROR_INVALID_NAME) {
             throwIfSymlink(finalComponent, path);
         }
-        throw;
+        /* We suspect Wine incorrectly returns ERROR_DIRECTORY when opening a
+           directory symlink with FILE_OPEN_REPARSE_POINT | FILE_DIRECTORY_FILE,
+           as if it doesn't realize the reparse point itself is directory-typed.
+           Real Windows probably opens it successfully and hits the
+           isReparsePoint check below instead. Not yet verified on real Windows.
+
+           This is Claude's guess, but @Ericson3214 found it plausible enough of
+           a Wine bug to go ahead and do it. This keeps the unit tests passing in
+           Wine now, and if they fail on real Windows (without taking this
+           branch), then we'll update the code and this comment accordingly. On
+           the other hand, if they don't fail, then we'll avoid this bogus
+           "directory is actually symlink" stuff on real Windows where it
+           counts, and we'll have the evidence we need to submit a Wine bug.
+         */
+        if (lastError == ERROR_DIRECTORY && windows::isWine()) {
+            throwIfSymlink(finalComponent, path);
+        }
+        /* Return invalid handle for ENOENT/EEXIST style errors, or when trying to
+           open a non-directory as a directory (ERROR_DIRECTORY).
+           Set the Win32 error so the caller can inspect it. */
+        if (lastError == ERROR_FILE_NOT_FOUND || lastError == ERROR_FILE_EXISTS || lastError == ERROR_DIRECTORY) {
+            SetLastError(lastError);
+            return AutoCloseFD{};
+        }
+        throw windows::WinError(lastError, "opening file '%s'", PathFmt(path));
     }
 
     /* Final check: did we accidentally open a symlink? */
-    if (windows::isReparsePoint(finalHandle.get()))
+    if (windows::isReparsePoint(finalResult.value().get()))
         throw SymlinkNotAllowed(path);
 
-    return finalHandle;
-}
-
-OsString readLinkAt(Descriptor dirFd, const CanonPath & path)
-{
-    AutoCloseFD linkHandle(windows::openSymlinkAt(dirFd, path));
-    return windows::readSymlinkTarget(linkHandle.get());
+    return std::move(finalResult.value());
 }
 
 } // namespace nix

--- a/src/nix/cat.cc
+++ b/src/nix/cat.cc
@@ -84,19 +84,48 @@ struct CmdCatNar : StoreCommand, MixCat
 
         struct CatRegularFileSink : NullFileSystemObjectSink
         {
-            CanonPath neededPath = CanonPath::root;
-            bool found = false;
+            CanonPath currentPath;
+            CanonPath neededPath;
+            bool & found;
 
-            void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> crf) override
+            CatRegularFileSink(CanonPath currentPath, CanonPath neededPath, bool & found)
+                : currentPath(std::move(currentPath))
+                , neededPath(std::move(neededPath))
+                , found(found)
             {
-                struct : CreateRegularFileSink, FdSink
+            }
+
+            void createDirectory(DirectoryCreatedCallback callback) override
+            {
+                struct Dir : OnDirectory
                 {
-                    void isExecutable() override {}
+                    CatRegularFileSink & parent;
+
+                    Dir(CatRegularFileSink & parent)
+                        : parent(parent)
+                    {
+                    }
+
+                    void createChild(std::string_view name, ChildCreatedCallback callback) override
+                    {
+                        CatRegularFileSink childSink{
+                            parent.currentPath / std::string{name}, parent.neededPath, parent.found};
+                        callback(childSink);
+                    }
+                } dir{*this};
+
+                callback(dir);
+            }
+
+            void createRegularFile(bool isExecutable, RegularFileCreatedCallback crf) override
+            {
+                struct CRF : OnRegularFile, FdSink
+                {
                 } crfSink;
 
                 crfSink.fd = INVALID_DESCRIPTOR;
 
-                if (path == neededPath) {
+                if (currentPath == neededPath) {
                     logger->stop();
                     crfSink.skipContents = false;
                     crfSink.fd = getStandardOutput();
@@ -107,13 +136,14 @@ struct CmdCatNar : StoreCommand, MixCat
 
                 crf(crfSink);
             }
-        } sink;
+        };
 
-        sink.neededPath = CanonPath(path);
+        bool found = false;
+        CatRegularFileSink sink{CanonPath::root, CanonPath(path), found};
         /* NOTE: We still parse the whole file to validate that it's a correct NAR. */
         parseDump(sink, source);
 
-        if (!sink.found)
+        if (!found)
             throw Error("NAR does not contain regular file '%1%'", path);
     }
 };

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -113,7 +113,7 @@ struct CmdHashBase : Command
                 auto sourcePath = makeSourcePath();
                 fun<git::DumpHook> hook = [&](const SourcePath & path) -> git::TreeEntry {
                     auto hashSink = makeSink();
-                    auto mode = dump(path, *hashSink, hook);
+                    auto mode = git::dump(path, *hashSink, hook);
                     auto hash = hashSink->finish().hash;
                     return {
                         .mode = mode,

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -759,7 +759,8 @@ static void opRestore(Strings opFlags, Strings opArgs)
         throw UsageError("only one argument allowed");
 
     FdSource source(STDIN_FILENO);
-    restorePath(*opArgs.begin(), source);
+    auto path = std::filesystem::absolute(*opArgs.begin());
+    restorePath(path.parent_path(), path.filename(), source);
 }
 
 static void opExport(Strings opFlags, Strings opArgs)

--- a/tests/functional/nars.sh
+++ b/tests/functional/nars.sh
@@ -11,18 +11,18 @@ rm -rf "$TEST_ROOT/out"
 expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet "NAR directory is not sorted"
 
 # Check that nix-store --restore fails if the output already exists.
-expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'creating directory ".*/out": File exists'
+expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'path ".*/out" already exists'
 
 rm -rf "$TEST_ROOT/out"
 echo foo > "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'creating directory ".*/out": File exists'
+expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'path ".*/out" already exists'
 
 rm -rf "$TEST_ROOT/out"
 ln -s "$TEST_ROOT/out2" "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'creating directory ".*/out": File exists'
+expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'path ".*/out" already exists'
 
 mkdir -p "$TEST_ROOT/out2"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'creating directory ".*/out": File exists'
+expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'path ".*/out" already exists'
 
 # The same, but for a regular file.
 nix-store --dump ./nars.sh > "$TEST_ROOT/tmp.nar"
@@ -56,14 +56,14 @@ rm -rf "$TEST_ROOT/out"
 # must already exist, which conflicts with --restore creating
 # something new.
 rm -rf "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet "ends in '\.'.*not a valid filename"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet 'ends in "\.".*not a valid filename'
 
 # Destination with trailing `/..` should fail.
 rm -rf "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out/.." < "$TEST_ROOT/tmp.nar" | grepQuiet "ends in '\.\.'.*not a valid filename"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/.." < "$TEST_ROOT/tmp.nar" | grepQuiet 'ends in "\.\.".*not a valid filename'
 
 # Empty destination should fail.
-expectStderr 1 nix-store --restore "" < "$TEST_ROOT/tmp.nar" | grepQuiet "destination path is empty"
+expectStderr 1 nix-store --restore "" < "$TEST_ROOT/tmp.nar" | grepQuiet 'destination path is empty'
 
 # The same, but for a symlink.
 ln -sfn foo "$TEST_ROOT/symlink"
@@ -93,7 +93,7 @@ rm -rf "$TEST_ROOT/out"
 
 # Trailing `/.` — same baseline as above (currently fails).
 rm -rf "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet "ends in '\.'.*not a valid filename"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet 'ends in "\.".*not a valid filename'
 
 # Check whether restoring and dumping a NAR that contains case
 # collisions is round-tripping, even on a case-insensitive system.
@@ -122,7 +122,7 @@ expectStderr 1 nix-store "${opts[@]}" --dump "$TEST_ROOT/case" > /dev/null
 
 # Trailing `/.` — same baseline as above (currently fails).
 rm -rf "$TEST_ROOT/case"
-expectStderr 1 nix-store "${opts[@]}" --restore "$TEST_ROOT/case/." < case.nar | grepQuiet "ends in '\.'.*not a valid filename"
+expectStderr 1 nix-store "${opts[@]}" --restore "$TEST_ROOT/case/." < case.nar | grepQuiet 'ends in "\.".*not a valid filename'
 
 # Detect NARs that have a directory entry that after case-hacking
 # collides with another entry (e.g. a directory containing 'Test',


### PR DESCRIPTION
## Motivation

We were trying to do too much with one interface. Now, we instead have three interfaces:

- `FileSystemObjectSink`
- `merkle::FileSinkBuilder`
- `TarSink`

See the Doxygen on each one for details.

What this allows is the following changes:

- `FileSystemObjectSink` can become much more restrictive. In particular, it only needs to support what is needed for parsing NARs now, and is a very tightly-aligned visitor.

  These new invariants make it much easier to implement correctly, which will be very useful for `RestoreSink` -- the host OS filesystem implementation --- in subsequent PRs.

  We can --- actually are forced! --- to simplify a bunch of tests accordingly, in some cases deleting tests for failure modes that are no longer possible. The reason for this is that we simply are not creating entire paths at once anymore --- there's no `SymlinkNotAllowed` errors in this situation because we hit an `EEXIST` trying to create the parent directory before we try to traverse anything.

- The git repo implementation becomes *much* simpler, no longer bending over backwards to support tarballs. It is now just concerned with libgit2 FFI, and presents a very natural interface for a git repo.

- The tarball -> Merkle code that makes the tarball cache for fetchers work is instead factored out into its own file, decoupled from the libgit2 internals and the libarchive internals. (This would be `merkle::TarAdapter`.) It is hopefully less scary now, and does some directory parallelism.

  Also it is unit tested very comprehensively, including a property test. This more than makes up for the `FileSystemObjectSink` tests that were deleted when that interface was locked down.

## Context

Additionally:

- Pure visitor interfaces (`merkle::DirectorySink`, `merkle::TreeEntry`, `merkle::Mode`) are now in libutil's `merkle-files.hh`, while the sink builder factory (`merkle::FileSinkBuilder`) and flushable sinks (`merkle::RegularFileSinkWithFlush`, `merkle::DirectorySinkWithFlush`) are in libfetchers' `merkle-tar-adapter.hh`.

- Finally delete some the dead `git` code. My thinking has changed with LLMs easily able to write stuff like this, and also the `libgit2` integration, as of this PR, now being more versatile.

- `RestoreSink` now takes `parentPath` and `childName` separately instead of a single `dstPath`. This avoids redundant `path.filename()` calls throughout the code and makes the API clearer about what's actually needed: a parent directory (with its file descriptor for `*at` operations, when possible) and the name of the child to create.

  This interface cleanup will be further taken advantage of in future PRs --- we'll just have the parent directory descriptor, not parent path.

- Similarly, `restorePath()` now takes `parentPath` and `childName` as separate arguments, pushing the path splitting to callers who already have this information available.

depends on #15403

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).

