### PR TITLE
fix: daemon crash when Unix socket path exceeds sun_path limit

### DIFF
--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -8,6 +8,7 @@
 #else
 #  include <sys/socket.h>
 #  include <sys/un.h>
+#  include <sys/wait.h>
 #  include "nix/util/processes.hh"
 #endif
 #include <unistd.h>
@@ -88,7 +89,19 @@ bindConnectProcHelper(std::string_view operationName, auto && operation, Socket 
             }
         });
         pipe.writeSide.close();
+        // If drainFD throws, Pid::~Pid() still runs before
+        // release(), and may crash in a SIGCHLD auto-reaping
+        // context (see below). Unlikely since the pipe has data.
         auto errNo = string2Int<int>(chomp(drainFD(pipe.readSide.get())));
+        // The child has written its result and will now exit.
+        // Release the Pid to avoid Pid::~Pid() trying to kill/wait it,
+        // which crashes when a SIGCHLD handler (e.g. in nix daemon)
+        // has already reaped the child.
+        pid_t childPid = pid.release();
+        // Best-effort reap to avoid zombies; may get ECHILD if a
+        // SIGCHLD handler already reaped it, which is fine.
+        while (waitpid(childPid, nullptr, 0) == -1 && errno == EINTR)
+            ;
         if (!errNo || *errNo == -1)
             throw Error("cannot %s to socket at '%s'", operationName, path);
         else if (*errNo > 0) {


### PR DESCRIPTION
bindConnectProcHelper forks a helper child to work around long socket paths. In the daemon, a SIGCHLD handler races with the helper's Pid destructor, crashing the process.

This can occur on macOS where sun_path is shorter and /private/tmp is longer than on Linux. The Nix build sandbox can produce paths long enough to trigger it.

Release the Pid after reading the result and do a best-effort waitpid instead.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

fix bug
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

   I would have preferred to remove the auto reaping from the daemon
   accept loop, harmonizing these process "environments" but that's a
   somewhat larger change that should be considered on its own.
   This PR is a low risk change.
   - See https://github.com/NixOS/nix/issues/15394


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
