### PR TITLE
Improve formatting of various errors and warnings

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -400,7 +400,7 @@ void completeFlakeRefWithFragment(
             }
         }
     } catch (Error & e) {
-        warn(e.msg());
+        logWarning(e.info());
     }
 }
 

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -51,7 +51,7 @@ DownloadFileResult downloadFile(
         res = getFileTransfer()->download(request);
     } catch (FileTransferError & e) {
         if (cached) {
-            warn("%s; using cached version", e.msg());
+            warn("%s; using cached version", e.message());
             return useCached();
         } else
             throw;

--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -48,7 +48,7 @@ MixCommonArgs::MixCommonArgs(const std::string & programName)
                 globalConfig.set(name, value);
             } catch (UsageError & e) {
                 if (!getRoot().completions)
-                    warn(e.what());
+                    logWarning(e.info());
             }
         }},
         .completer =

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -305,7 +305,7 @@ struct ClientSettings
                         "ignoring the client-specified setting '%s', because it is a restricted setting and you are not a trusted user",
                         name);
             } catch (UsageError & e) {
-                warn(e.what());
+                logWarning(e.info());
             }
         }
     }

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -221,6 +221,8 @@ struct curlFileTransfer : public FileTransfer
             done = true;
             try {
                 std::rethrow_exception(ex);
+            } catch (FileTransferError & e) {
+                /* Already descriptive enough. */
             } catch (nix::Error & e) {
                 /* Add more context to the error message. */
                 e.addTrace({}, "during %s of '%s'", Uncolored(request.noun()), request.uri.to_string());
@@ -628,7 +630,7 @@ struct curlFileTransfer : public FileTransfer
 
             debug(
                 "finished %s of '%s'; curl status = %d, HTTP status = %d, body = %d bytes, duration = %.2f s",
-                request.noun(),
+                Uncolored(request.noun()),
                 request.uri,
                 code,
                 httpStatus,
@@ -723,14 +725,14 @@ struct curlFileTransfer : public FileTransfer
                                                                                        Interrupted,
                                                                                        std::move(response),
                                                                                        "%s of '%s' was interrupted",
-                                                                                       request.noun(),
+                                                                                       Uncolored(request.noun()),
                                                                                        request.uri)
                            : httpStatus != 0
                                ? FileTransferError(
                                      err,
                                      std::move(response),
                                      "unable to %s '%s': HTTP error %d%s",
-                                     request.verb(),
+                                     Uncolored(request.verb()),
                                      request.uri,
                                      httpStatus,
                                      code == CURLE_OK ? "" : fmt(" (curl error: %s)", curl_easy_strerror(code)))
@@ -738,7 +740,7 @@ struct curlFileTransfer : public FileTransfer
                                      err,
                                      std::move(response),
                                      "unable to %s '%s': %s (%d) %s",
-                                     request.verb(),
+                                     Uncolored(request.verb()),
                                      request.uri,
                                      curl_easy_strerror(code),
                                      code,
@@ -753,10 +755,24 @@ struct curlFileTransfer : public FileTransfer
                     int ms = retryTimeMs
                              * std::pow(
                                  2.0f, attempt - 1 + std::uniform_real_distribution<>(0.0, 0.5)(fileTransfer.mt19937));
-                    if (writtenToSink)
-                        warn("%s; retrying from offset %d in %d ms", exc.what(), writtenToSink, ms);
-                    else
-                        warn("%s; retrying in %d ms", exc.what(), ms);
+
+                    if (writtenToSink) {
+                        warn(
+                            "%s; retrying from offset %d in %d ms (attempt %d/%d)",
+                            exc.message(),
+                            writtenToSink,
+                            ms,
+                            attempt,
+                            fileTransfer.settings.tries);
+                    } else {
+                        warn(
+                            "%s; retrying in %d ms (attempt %d/%d)",
+                            exc.message(),
+                            ms,
+                            attempt,
+                            fileTransfer.settings.tries);
+                    }
+
                     errorSink.reset();
                     embargo = std::chrono::steady_clock::now() + std::chrono::milliseconds(ms);
                     try {
@@ -937,7 +953,7 @@ struct curlFileTransfer : public FileTransfer
             }
 
             for (auto & item : incoming) {
-                debug("starting %s of %s", item->request.noun(), item->request.uri);
+                debug("starting %s of '%s'", Uncolored(item->request.noun()), item->request.uri);
                 item->init();
                 curl_multi_add_handle(curlm.get(), item->req);
                 item->active = true;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1407,7 +1407,7 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
                 if (isValidPath(i))
                     logError(e.info());
                 else
-                    warn(e.msg());
+                    logWarning(e.info());
                 errors = true;
             }
         }

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1201,7 +1201,7 @@ static Derivation readDerivationCommon(Store & store, const StorePath & drvPath,
 
         return parseDerivation(store, std::move(contents), Derivation::nameFromPath(drvPath));
     } catch (FormatError & e) {
-        throw Error("error parsing derivation '%s': %s", store.printStorePath(drvPath), e.msg());
+        throw Error("error parsing derivation '%s': %s", store.printStorePath(drvPath), e.message());
     }
 }
 

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -676,9 +676,10 @@ struct CmdDevelop : Common, MixEnvironment
 
         // Override SHELL with the one chosen for this environment.
         // This is to make sure the system shell doesn't leak into the build environment.
-        setEnv("SHELL", shell.string().c_str());
-        // https://github.com/NixOS/nix/issues/5873
-        script += fmt("SHELL=%s\n", PathFmt(shell));
+        setEnvOs(OS_STR("SHELL"), shell.c_str());
+        /* See: https://github.com/NixOS/nix/issues/5873
+           Format via .string() and not PathFmt intentionally. */
+        script += fmt("SHELL=\"%s\"\n", shell.string());
         if (foundInteractive)
             script += fmt("PATH=\"%s${PATH:+:$PATH}\"\n", std::filesystem::path(shell).parent_path().string());
         writeFull(rcFileFd.get(), script);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Removes unnecessary `error: warning:` prefixes by using .message() and not .msg(). Also includes attempt counts in the filetransfer warnings. Removes a redundant trace from the filetransfer errors with FileTransferError (which is already descriptive enough) and contains the same information basically.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
