### PR TITLE
Introduce `Source::drainInto` with explicit length

### DIFF
--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -135,18 +135,7 @@ static void parseContents(CreateRegularFileSink & sink, Source & source)
         return;
     }
 
-    uint64_t left = size;
-    std::array<char, 65536> buf;
-
-    while (left) {
-        checkInterrupt();
-        auto n = buf.size();
-        if ((uint64_t) n > left)
-            n = left;
-        source(buf.data(), n);
-        sink({buf.data(), n});
-        left -= n;
-    }
+    source.drainInto(sink, size);
 
     readPadding(size, source);
 }

--- a/src/libutil/git.cc
+++ b/src/libutil/git.cc
@@ -68,17 +68,7 @@ void parseBlob(
 
             crf.preallocateContents(size);
 
-            unsigned long long left = size;
-            std::string buf;
-            buf.reserve(65536);
-
-            while (left) {
-                checkInterrupt();
-                buf.resize(std::min((unsigned long long) buf.capacity(), left));
-                source(buf);
-                crf(buf);
-                left -= buf.size();
-            }
+            source.drainInto(crf, size);
         });
     };
 

--- a/src/libutil/include/nix/util/serialise.hh
+++ b/src/libutil/include/nix/util/serialise.hh
@@ -96,7 +96,19 @@ struct Source
         return true;
     }
 
+    /**
+     * Read the rest of this `Source` into `sink`.
+     */
     void drainInto(Sink & sink);
+
+    /**
+     * Read exactly 'len' bytes and write them to 'sink'.
+     *
+     * Virtual in anticipation that some `Source` implementations, like
+     * `FdSource` may eventually be able to provide more performant
+     * implementations of this function.
+     */
+    virtual void drainInto(Sink & sink, uint64_t len);
 
     std::string drain();
 

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -7,6 +7,7 @@
 
 #include <cstring>
 #include <cerrno>
+#include <limits>
 #include <memory>
 
 #include <boost/coroutine2/coroutine.hpp>
@@ -101,6 +102,20 @@ void Source::drainInto(Sink & sink)
         } catch (EndOfFile &) {
             break;
         }
+    }
+}
+
+void Source::drainInto(Sink & sink, uint64_t len)
+{
+    std::array<char, 65536> buf;
+    while (len) {
+        checkInterrupt();
+        // Until std::saturate_cast is available (C++26)
+        auto lenTrunc = static_cast<size_t>(std::min<uint64_t>(len, std::numeric_limits<size_t>::max()));
+        auto n = read(buf.data(), std::min(lenTrunc, buf.size()));
+        sink({buf.data(), n});
+        assert(n <= len);
+        len -= n;
     }
 }
 


### PR DESCRIPTION
## Motivation

This is used to deduplicate two spots in the code:

- `git::parseBlob`

- `parseContents` in `archive.cc`

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
