### PR TITLE
Decouple the merkle file sinks from git internals, and `FileSystemObjectSink`

### DIFF
--- a/src/libfetchers-tests/git-utils.cc
+++ b/src/libfetchers-tests/git-utils.cc
@@ -1,4 +1,5 @@
 #include "nix/fetchers/git-utils.hh"
+#include "nix/util/merkle-files.hh"
 #include "nix/util/file-system.hh"
 #include <gmock/gmock.h>
 #include <git2/global.h>
@@ -8,7 +9,6 @@
 #include <git2/object.h>
 #include <git2/tag.h>
 #include <gtest/gtest.h>
-#include "nix/util/fs-sink.hh"
 #include "nix/util/serialise.hh"
 #include "nix/fetchers/git-lfs-fetch.hh"
 
@@ -51,47 +51,77 @@ public:
         return GitRepo::openRepo(tmpDir, {.create = true});
     }
 
+    ref<GitRepoPool> openWriterPool()
+    {
+        return GitRepoPool::create(tmpDir, {.create = true});
+    }
+
     std::string getRepoName() const
     {
         return tmpDir.filename().string();
     }
 };
 
-void writeString(CreateRegularFileSink & fileSink, std::string contents, bool executable)
+merkle::TreeEntry writeString(merkle::FileSinkBuilder & store, std::string contents, bool executable = false)
 {
-    if (executable)
-        fileSink.isExecutable();
-    fileSink.preallocateContents(contents.size());
-    fileSink(contents);
+    auto sink = store.makeRegularFileSink();
+    (*sink)(contents);
+    return merkle::TreeEntry{
+        executable ? merkle::Mode::Executable : merkle::Mode::Regular,
+        std::move(*sink).flush(),
+    };
 }
 
 TEST_F(GitUtilsTest, sink_basic)
 {
     auto repo = openRepo();
-    auto sink = repo->getFileSystemObjectSink();
+    auto pool = openWriterPool();
 
-    // TODO/Question: It seems a little odd that we use the tarball-like convention of requiring a top-level directory
-    // here
-    //                The sync method does not document this behavior, should probably renamed because it's not very
-    //                general, and I can't imagine that "non-conventional" archives or any other source to be handled by
-    //                this sink.
+    // Build tree bottom-up using insertChild
+    // hello file
+    auto hello = writeString(*pool, "hello world");
 
-    sink->createDirectory(CanonPath("foo-1.1"));
+    // bye file
+    auto bye = writeString(*pool, "thanks for all the fish");
 
-    sink->createRegularFile(CanonPath("foo-1.1/hello"), [](CreateRegularFileSink & fileSink) {
-        writeString(fileSink, "hello world", false);
-    });
-    sink->createRegularFile(CanonPath("foo-1.1/bye"), [](CreateRegularFileSink & fileSink) {
-        writeString(fileSink, "thanks for all the fish", false);
-    });
-    sink->createSymlink(CanonPath("foo-1.1/bye-link"), "bye");
-    sink->createDirectory(CanonPath("foo-1.1/empty"));
-    sink->createDirectory(CanonPath("foo-1.1/links"));
-    sink->createHardlink(CanonPath("foo-1.1/links/foo"), CanonPath("foo-1.1/hello"));
+    // bye-link symlink
+    auto byeLink = pool->makeSymlink("bye");
 
-    // sink->createHardlink("foo-1.1/links/foo-2", CanonPath("foo-1.1/hello"));
+    // empty directory
+    auto empty = [&] {
+        auto emptyDir = pool->makeDirectorySink();
+        return merkle::TreeEntry{merkle::Mode::Directory, std::move(*emptyDir).flush()};
+    }();
 
-    auto result = repo->dereferenceSingletonDirectory(sink->flush());
+    // links/foo file
+    auto linksFoo = writeString(*pool, "hello world");
+
+    // links directory
+    auto links = [&] {
+        auto linksDir = pool->makeDirectorySink();
+        linksDir->insertChild("foo", linksFoo);
+        return merkle::TreeEntry{merkle::Mode::Directory, std::move(*linksDir).flush()};
+    }();
+
+    // foo-1.1 directory (contains hello, bye, bye-link, empty, links)
+    auto foo = [&] {
+        auto fooDir = pool->makeDirectorySink();
+        fooDir->insertChild("hello", hello);
+        fooDir->insertChild("bye", bye);
+        fooDir->insertChild("bye-link", byeLink);
+        fooDir->insertChild("empty", empty);
+        fooDir->insertChild("links", links);
+        return merkle::TreeEntry{merkle::Mode::Directory, std::move(*fooDir).flush()};
+    }();
+
+    // root directory (contains foo-1.1)
+    auto rootHash = [&] {
+        auto rootDir = pool->makeDirectorySink();
+        rootDir->insertChild("foo-1.1", foo);
+        return std::move(*rootDir).flush();
+    }();
+
+    auto result = repo->dereferenceSingletonDirectory(rootHash);
     auto accessor = repo->getAccessor(result, {}, getRepoName());
     auto entries = accessor->readDirectory(CanonPath::root);
     ASSERT_EQ(entries.size(), 5u);
@@ -100,29 +130,7 @@ TEST_F(GitUtilsTest, sink_basic)
     ASSERT_EQ(accessor->readLink(CanonPath("bye-link")), "bye");
     ASSERT_EQ(accessor->readDirectory(CanonPath("empty")).size(), 0u);
     ASSERT_EQ(accessor->readFile(CanonPath("links/foo")), "hello world");
-};
-
-TEST_F(GitUtilsTest, sink_hardlink)
-{
-    auto repo = openRepo();
-    auto sink = repo->getFileSystemObjectSink();
-
-    sink->createDirectory(CanonPath("foo-1.1"));
-
-    sink->createRegularFile(CanonPath("foo-1.1/hello"), [](CreateRegularFileSink & fileSink) {
-        writeString(fileSink, "hello world", false);
-    });
-
-    try {
-        sink->createHardlink(CanonPath("foo-1.1/link"), CanonPath("hello"));
-        sink->flush();
-        FAIL() << "Expected an exception";
-    } catch (const nix::Error & e) {
-        ASSERT_THAT(e.msg(), testing::HasSubstr("does not exist"));
-        ASSERT_THAT(e.msg(), testing::HasSubstr("/hello"));
-        ASSERT_THAT(e.msg(), testing::HasSubstr("foo-1.1/link"));
-    }
-};
+}
 
 TEST_F(GitUtilsTest, peel_reference)
 {

--- a/src/libfetchers-tests/git-utils.cc
+++ b/src/libfetchers-tests/git-utils.cc
@@ -1,4 +1,5 @@
 #include "nix/fetchers/git-utils.hh"
+#include "nix/util/merkle-files.hh"
 #include "nix/util/file-system.hh"
 #include "nix/util/tests/gmock-matchers.hh"
 
@@ -10,7 +11,6 @@
 #include <git2/object.h>
 #include <git2/tag.h>
 #include <gtest/gtest.h>
-#include "nix/util/fs-sink.hh"
 #include "nix/util/serialise.hh"
 
 #include <git2/blob.h>
@@ -44,47 +44,79 @@ public:
         return GitRepo::openRepo(tmpDir, {.create = false});
     }
 
+    ref<GitRepoPool> openWriterPool()
+    {
+        return GitRepoPool::create(tmpDir, {.create = true});
+    }
+
     std::string getRepoName() const
     {
         return tmpDir.filename().string();
     }
 };
 
-void writeString(CreateRegularFileSink & fileSink, std::string contents, bool executable)
+merkle::TreeEntry writeString(merkle::FileSinkBuilder & store, std::string contents, bool executable = false)
 {
-    if (executable)
-        fileSink.isExecutable();
-    fileSink.preallocateContents(contents.size());
-    fileSink(contents);
+    auto sink = store.makeRegularFileSink();
+    (*sink)(contents);
+    return merkle::TreeEntry{
+        executable ? merkle::Mode::Executable : merkle::Mode::Regular,
+        std::move(*sink).finalize(),
+    };
 }
 
 TEST_F(GitUtilsTest, sink_basic)
 {
     auto repo = openRepo();
-    auto sink = repo->getFileSystemObjectSink();
+    auto pool = openWriterPool();
 
-    // TODO/Question: It seems a little odd that we use the tarball-like convention of requiring a top-level directory
-    // here
-    //                The sync method does not document this behavior, should probably renamed because it's not very
-    //                general, and I can't imagine that "non-conventional" archives or any other source to be handled by
-    //                this sink.
+    // Build tree bottom-up using insertChild
+    // hello file
+    auto hello = writeString(*pool, "hello world");
 
-    sink->createDirectory(CanonPath("foo-1.1"));
+    // bye file
+    auto bye = writeString(*pool, "thanks for all the fish");
 
-    sink->createRegularFile(CanonPath("foo-1.1/hello"), [](CreateRegularFileSink & fileSink) {
-        writeString(fileSink, "hello world", false);
-    });
-    sink->createRegularFile(CanonPath("foo-1.1/bye"), [](CreateRegularFileSink & fileSink) {
-        writeString(fileSink, "thanks for all the fish", false);
-    });
-    sink->createSymlink(CanonPath("foo-1.1/bye-link"), "bye");
-    sink->createDirectory(CanonPath("foo-1.1/empty"));
-    sink->createDirectory(CanonPath("foo-1.1/links"));
-    sink->createHardlink(CanonPath("foo-1.1/links/foo"), CanonPath("foo-1.1/hello"));
+    // bye-link symlink
+    auto byeLink = pool->makeSymlink("bye");
 
-    // sink->createHardlink("foo-1.1/links/foo-2", CanonPath("foo-1.1/hello"));
+    // empty directory
+    auto empty = [&] {
+        auto emptyDir = pool->makeDirectorySink();
+        return merkle::TreeEntry{merkle::Mode::Directory, std::move(*emptyDir).finalize()};
+    }();
 
-    auto result = repo->dereferenceSingletonDirectory(sink->flush());
+    // links/foo file
+    auto linksFoo = writeString(*pool, "hello world");
+
+    // links directory
+    auto links = [&] {
+        auto linksDir = pool->makeDirectorySink();
+        linksDir->insertChild("foo", linksFoo);
+        return merkle::TreeEntry{merkle::Mode::Directory, std::move(*linksDir).finalize()};
+    }();
+
+    // foo-1.1 directory (contains hello, bye, bye-link, empty, links)
+    auto foo = [&] {
+        auto fooDir = pool->makeDirectorySink();
+        fooDir->insertChild("hello", hello);
+        fooDir->insertChild("bye", bye);
+        fooDir->insertChild("bye-link", byeLink);
+        fooDir->insertChild("empty", empty);
+        fooDir->insertChild("links", links);
+        return merkle::TreeEntry{merkle::Mode::Directory, std::move(*fooDir).finalize()};
+    }();
+
+    // root directory (contains foo-1.1)
+    auto rootHash = [&] {
+        auto rootDir = pool->makeDirectorySink();
+        rootDir->insertChild("foo-1.1", foo);
+        return std::move(*rootDir).finalize();
+    }();
+
+    pool->flush();
+
+    auto result = repo->dereferenceSingletonDirectory(rootHash);
     auto accessor = repo->getAccessor(result, {}, getRepoName());
 
     ASSERT_THAT(
@@ -104,213 +136,6 @@ TEST_F(GitUtilsTest, sink_basic)
     ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("bye-link"), "bye"));
     ASSERT_THAT(accessor, testing::HasDirectory(CanonPath("empty"), std::set<std::string>{}));
     ASSERT_THAT(accessor, testing::HasContents(CanonPath("links/foo"), "hello world"));
-};
-
-TEST_F(GitUtilsTest, sink_hardlink)
-{
-    auto repo = openRepo();
-    auto sink = repo->getFileSystemObjectSink();
-
-    sink->createDirectory(CanonPath("foo-1.1"));
-
-    sink->createRegularFile(CanonPath("foo-1.1/hello"), [](CreateRegularFileSink & fileSink) {
-        writeString(fileSink, "hello world", false);
-    });
-
-    try {
-        sink->createHardlink(CanonPath("foo-1.1/link"), CanonPath("hello"));
-        sink->flush();
-        FAIL() << "Expected an exception";
-    } catch (const nix::Error & e) {
-        ASSERT_THAT(e.msg(), ::testing::HasSubstr("does not exist"));
-        ASSERT_THAT(e.msg(), ::testing::HasSubstr("/hello"));
-        ASSERT_THAT(e.msg(), ::testing::HasSubstr("foo-1.1/link"));
-    }
-};
-
-TEST_F(GitUtilsTest, sink_no_parent_dir)
-{
-    ASSERT_THAT(
-        [&]() {
-            auto repo = openRepo();
-            auto sink = repo->getFileSystemObjectSink();
-
-            sink->createDirectory(CanonPath::root);
-
-            sink->createRegularFile(CanonPath("foo"), [](CreateRegularFileSink & fileSink) {
-                writeString(fileSink, "test", /*executable=*/false);
-            });
-
-            sink->createRegularFile(CanonPath("foo/bar"), [](CreateRegularFileSink & fileSink) {
-                writeString(fileSink, "boom", /*executable=*/false);
-            });
-
-            sink->flush();
-        },
-        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("parent of 'foo/bar' is not a directory")));
-}
-
-TEST_F(GitUtilsTest, sink_no_parent_dir_symlink)
-{
-    ASSERT_THAT(
-        [&]() {
-            auto repo = openRepo();
-            auto sink = repo->getFileSystemObjectSink();
-
-            sink->createDirectory(CanonPath::root);
-
-            sink->createRegularFile(CanonPath("foo"), [](CreateRegularFileSink & fileSink) {
-                writeString(fileSink, "test", /*executable=*/false);
-            });
-
-            sink->createSymlink(CanonPath("foo/bar"), "target");
-
-            sink->flush();
-        },
-        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("parent of 'foo/bar' is not a directory")));
-}
-
-TEST_F(GitUtilsTest, sink_no_parent_dir_hardlink)
-{
-    ASSERT_THAT(
-        [&]() {
-            auto repo = openRepo();
-            auto sink = repo->getFileSystemObjectSink();
-
-            sink->createDirectory(CanonPath::root);
-
-            sink->createRegularFile(CanonPath("foo"), [](CreateRegularFileSink & fileSink) {
-                writeString(fileSink, "test", /*executable=*/false);
-            });
-
-            sink->createHardlink(CanonPath("foo/bar"), CanonPath("foo"));
-
-            sink->flush();
-        },
-        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("parent of 'foo/bar' is not a directory")));
-}
-
-TEST_F(GitUtilsTest, sink_replacing_empty_directory)
-{
-    auto repo = openRepo();
-    auto sink = repo->getFileSystemObjectSink();
-
-    sink->createDirectory(CanonPath::root);
-    sink->createDirectory(CanonPath("foo"));
-    sink->createDirectory(CanonPath("foo/bar"));
-    /* Under tarball unpacking semantics, creating the same directories
-       (implicitly or explicitly) is fine. */
-    sink->createDirectory(CanonPath("foo/bar"));
-    sink->createDirectory(CanonPath("foo"));
-
-    sink->createRegularFile(CanonPath("foo/bar"), [](CreateRegularFileSink & fileSink) {
-        writeString(fileSink, "test", /*executable=*/false);
-    });
-
-    auto accessor = repo->getAccessor(sink->flush(), {}, getRepoName());
-
-    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath("foo"), std::set<std::string>{"bar"}));
-    ASSERT_THAT(accessor, testing::HasContents(CanonPath("foo/bar"), "test"));
-}
-
-TEST_F(GitUtilsTest, sink_replacing_non_empty_directory)
-{
-    ASSERT_THAT(
-        [&]() {
-            auto repo = openRepo();
-            auto sink = repo->getFileSystemObjectSink();
-
-            sink->createDirectory(CanonPath::root);
-            sink->createDirectory(CanonPath("foo"));
-            sink->createDirectory(CanonPath("foo/bar"));
-
-            /* This fails. libarchive (and other tarball unpackers) doesn't recursive unlink existing non-empty
-               directories.
-               https://github.com/libarchive/libarchive/blob/761652401fe35fca9744607a0cf0009afbf04f42/libarchive/archive_write_disk_posix.c#L3411-L3417
-             */
-
-            sink->createRegularFile(CanonPath("foo"), [](CreateRegularFileSink & fileSink) {
-                writeString(fileSink, "test", /*executable=*/false);
-            });
-
-            sink->flush();
-        },
-        ::testing::ThrowsMessage<Error>(
-            testing::HasSubstrIgnoreANSIMatcher("cannot create 'foo', conflicting non-empty directory")));
-}
-
-TEST_F(GitUtilsTest, sink_hardlink_to_directory)
-{
-    ASSERT_THAT(
-        [&]() {
-            auto repo = openRepo();
-            auto sink = repo->getFileSystemObjectSink();
-
-            sink->createDirectory(CanonPath::root);
-            sink->createDirectory(CanonPath("foo"));
-            sink->createHardlink(CanonPath("bar"), CanonPath("foo"));
-
-            sink->flush();
-        },
-        ::testing::ThrowsMessage<Error>(
-            testing::HasSubstrIgnoreANSIMatcher("cannot create a hard link to a directory")));
-}
-
-TEST_F(GitUtilsTest, sink_hardlink_to_directory_root)
-{
-    auto repo = openRepo();
-    auto sink = repo->getFileSystemObjectSink();
-
-    sink->createDirectory(CanonPath::root);
-    sink->createDirectory(CanonPath("foo"));
-    sink->createHardlink(CanonPath("bar"), CanonPath::root);
-
-    auto accessor = repo->getAccessor(sink->flush(), {}, getRepoName());
-
-    /* FIXME: Why does it behave this way? This seems like a bug. */
-    ASSERT_THAT(
-        accessor,
-        testing::HasDirectory(
-            CanonPath::root,
-            std::set<std::string>{
-                "foo",
-            }));
-}
-
-TEST_F(GitUtilsTest, sink_hardlink_to_self)
-{
-    /* Here we are more strict than libarchive, which only warns on cyclic hardlinks.
-       https://github.com/libarchive/libarchive/blob/761652401fe35fca9744607a0cf0009afbf04f42/libarchive/archive_write_disk_posix.c#L632-L641
-     */
-    ASSERT_THAT(
-        [&]() {
-            auto repo = openRepo();
-            auto sink = repo->getFileSystemObjectSink();
-
-            sink->createDirectory(CanonPath::root);
-            sink->createHardlink(CanonPath("foo"), CanonPath("foo"));
-
-            sink->flush();
-        },
-        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("/foo")));
-}
-
-TEST_F(GitUtilsTest, sink_non_directory_root)
-{
-    /* FIXME: Allow non-directory roots. GitFileSystemObjectSink is too tarball-brained. */
-    ASSERT_THAT(
-        [&]() {
-            auto repo = openRepo();
-            auto sink = repo->getFileSystemObjectSink();
-
-            sink->createRegularFile(CanonPath::root, [](CreateRegularFileSink & fileSink) {
-                writeString(fileSink, "test", /*executable=*/false);
-            });
-
-            sink->flush();
-        },
-        ::testing::ThrowsMessage<Error>(
-            testing::HasSubstrIgnoreANSIMatcher("cannot create a file at the root of the git repository")));
 }
 
 TEST_F(GitUtilsTest, peel_reference)

--- a/src/libfetchers-tests/merkle-tar-adapter.cc
+++ b/src/libfetchers-tests/merkle-tar-adapter.cc
@@ -1,0 +1,556 @@
+#include "nix/fetchers/git-utils.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/serialise.hh"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <rapidcheck/gtest.h>
+
+#include <git2/global.h>
+#include <git2/repository.h>
+
+namespace nix {
+
+class MerkleTarAdapterTest : public ::testing::Test
+{
+    std::unique_ptr<AutoDelete> delTmpDir;
+
+protected:
+    std::filesystem::path tmpDir;
+
+public:
+    void SetUp() override
+    {
+        tmpDir = createTempDir();
+        delTmpDir = std::make_unique<AutoDelete>(tmpDir, true);
+
+        git_libgit2_init();
+        git_repository * repo = nullptr;
+        auto r = git_repository_init(&repo, tmpDir.string().c_str(), 0);
+        ASSERT_EQ(r, 0);
+        git_repository_free(repo);
+    }
+
+    void TearDown() override
+    {
+        delTmpDir.reset();
+    }
+
+    ref<GitRepo> openRepo()
+    {
+        return GitRepo::openRepo(tmpDir, {.create = true});
+    }
+
+    ref<GitRepoPool> openWriterPool()
+    {
+        return GitRepoPool::create(tmpDir, {.create = true});
+    }
+
+    std::string getRepoName() const
+    {
+        return tmpDir.filename().string();
+    }
+};
+
+TEST_F(MerkleTarAdapterTest, empty_archive_throws)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    EXPECT_THROW(tarSink->flush(), Error);
+}
+
+TEST_F(MerkleTarAdapterTest, single_file_at_root)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath::root, false, [](Sink & sink) { sink("hello world"); });
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Regular);
+
+    // Wrap in a directory to verify content via accessor
+    auto dirSink = pool->makeDirectorySink();
+    dirSink->insertChild("file", result);
+    auto dirHash = std::move(*dirSink).flush();
+
+    auto accessor = repo->getAccessor(dirHash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("file")), "hello world");
+}
+
+TEST_F(MerkleTarAdapterTest, single_executable_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("script.sh"), true, [](Sink & sink) { sink("#!/bin/bash\necho hello"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("script.sh")), "#!/bin/bash\necho hello");
+}
+
+TEST_F(MerkleTarAdapterTest, single_symlink)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath::root, "target");
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Symlink);
+
+    // Wrap in a directory to verify content via accessor
+    auto dirSink = pool->makeDirectorySink();
+    dirSink->insertChild("link", result);
+    auto dirHash = std::move(*dirSink).flush();
+
+    auto accessor = repo->getAccessor(dirHash, {}, getRepoName());
+    ASSERT_EQ(accessor->readLink(CanonPath("link")), "target");
+}
+
+TEST_F(MerkleTarAdapterTest, empty_directory)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath::root);
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Directory);
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    auto entries = accessor->readDirectory(CanonPath::root);
+    ASSERT_EQ(entries.size(), 0u);
+}
+
+TEST_F(MerkleTarAdapterTest, nested_empty_directories)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath("a/b/c"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readDirectory(CanonPath("a")).size(), 1u);
+    ASSERT_EQ(accessor->readDirectory(CanonPath("a/b")).size(), 1u);
+    ASSERT_EQ(accessor->readDirectory(CanonPath("a/b/c")).size(), 0u);
+}
+
+TEST_F(MerkleTarAdapterTest, directory_with_files)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("hello.txt"), false, [](Sink & sink) { sink("hello world"); });
+    tarSink->createRegularFile(CanonPath("bye.txt"), false, [](Sink & sink) { sink("goodbye"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    auto entries = accessor->readDirectory(CanonPath::root);
+    ASSERT_EQ(entries.size(), 2u);
+    ASSERT_EQ(accessor->readFile(CanonPath("hello.txt")), "hello world");
+    ASSERT_EQ(accessor->readFile(CanonPath("bye.txt")), "goodbye");
+}
+
+TEST_F(MerkleTarAdapterTest, nested_directory_with_files)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("a/b/file.txt"), false, [](Sink & sink) { sink("nested content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("a/b/file.txt")), "nested content");
+}
+
+TEST_F(MerkleTarAdapterTest, mixed_content)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("regular file"); });
+    tarSink->createRegularFile(CanonPath("script.sh"), true, [](Sink & sink) { sink("#!/bin/bash"); });
+    tarSink->createSymlink(CanonPath("link"), "file.txt");
+    tarSink->createDirectory(CanonPath("empty"));
+    tarSink->createRegularFile(CanonPath("subdir/nested.txt"), false, [](Sink & sink) { sink("nested"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    auto entries = accessor->readDirectory(CanonPath::root);
+    ASSERT_EQ(entries.size(), 5u);
+    ASSERT_EQ(accessor->readFile(CanonPath("file.txt")), "regular file");
+    ASSERT_EQ(accessor->readFile(CanonPath("script.sh")), "#!/bin/bash");
+    ASSERT_EQ(accessor->readLink(CanonPath("link")), "file.txt");
+    ASSERT_EQ(accessor->readDirectory(CanonPath("empty")).size(), 0u);
+    ASSERT_EQ(accessor->readFile(CanonPath("subdir/nested.txt")), "nested");
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_target_not_found)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createHardlink(CanonPath("link"), CanonPath("nonexistent"));
+
+    EXPECT_THAT([&]() { tarSink->flush(); }, testing::ThrowsMessage<Error>(testing::HasSubstr("not found")));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("original.txt"), false, [](Sink & sink) { sink("shared content"); });
+    tarSink->createHardlink(CanonPath("link.txt"), CanonPath("original.txt"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("original.txt")), "shared content");
+    ASSERT_EQ(accessor->readFile(CanonPath("link.txt")), "shared content");
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_executable)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("script.sh"), true, [](Sink & sink) { sink("#!/bin/bash"); });
+    tarSink->createHardlink(CanonPath("script-link.sh"), CanonPath("script.sh"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("script.sh")), "#!/bin/bash");
+    ASSERT_EQ(accessor->readFile(CanonPath("script-link.sh")), "#!/bin/bash");
+}
+
+TEST_F(MerkleTarAdapterTest, multiple_hardlinks_same_target)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("original"), false, [](Sink & sink) { sink("content"); });
+    tarSink->createHardlink(CanonPath("link1"), CanonPath("original"));
+    tarSink->createHardlink(CanonPath("link2"), CanonPath("original"));
+    tarSink->createHardlink(CanonPath("link3"), CanonPath("original"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("original")), "content");
+    ASSERT_EQ(accessor->readFile(CanonPath("link1")), "content");
+    ASSERT_EQ(accessor->readFile(CanonPath("link2")), "content");
+    ASSERT_EQ(accessor->readFile(CanonPath("link3")), "content");
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_directory_fails)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath("dir"));
+    tarSink->createHardlink(CanonPath("link"), CanonPath("dir"));
+
+    EXPECT_THAT([&]() { tarSink->flush(); }, testing::ThrowsMessage<Error>(testing::HasSubstr("directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, child_of_file_fails)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("content"); });
+
+    EXPECT_THAT(
+        [&]() { tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("x"); }); },
+        testing::ThrowsMessage<Error>(testing::HasSubstr("not a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, child_of_symlink_fails)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Symlink points to a valid directory, but we still can't create children under the symlink path
+    tarSink->createDirectory(CanonPath("target"));
+    tarSink->createSymlink(CanonPath("foo"), "target");
+
+    EXPECT_THAT(
+        [&]() { tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("x"); }); },
+        testing::ThrowsMessage<Error>(testing::HasSubstr("not a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, explicit_directory_replaces_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Create a file at "foo"
+    tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("content"); });
+    // Explicitly replace it with a directory
+    tarSink->createDirectory(CanonPath("foo"));
+    // Now we can create children
+    tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("child content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("foo/bar")), "child content");
+}
+
+TEST_F(MerkleTarAdapterTest, large_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Create a file larger than the buffering threshold (1 MiB)
+    std::string largeContent(2 * 1024 * 1024, 'x');
+
+    tarSink->createRegularFile(CanonPath("large.bin"), false, [&](Sink & sink) { sink(largeContent); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("large.bin")), largeContent);
+}
+
+TEST_F(MerkleTarAdapterTest, many_files)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    constexpr int numFiles = 100;
+    for (int i = 0; i < numFiles; i++) {
+        auto path = CanonPath("file" + std::to_string(i) + ".txt");
+        auto content = "content " + std::to_string(i);
+        tarSink->createRegularFile(path, false, [&](Sink & sink) { sink(content); });
+    }
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    auto entries = accessor->readDirectory(CanonPath::root);
+    ASSERT_EQ(entries.size(), static_cast<size_t>(numFiles));
+
+    for (int i = 0; i < numFiles; i++) {
+        auto path = CanonPath("file" + std::to_string(i) + ".txt");
+        auto expectedContent = "content " + std::to_string(i);
+        ASSERT_EQ(accessor->readFile(path), expectedContent);
+    }
+}
+
+TEST_F(MerkleTarAdapterTest, deep_nesting)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(
+        CanonPath("a/b/c/d/e/f/g/h/file.txt"), false, [](Sink & sink) { sink("deeply nested"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("a/b/c/d/e/f/g/h/file.txt")), "deeply nested");
+}
+
+TEST_F(MerkleTarAdapterTest, directory_with_symlink_and_empty_subdir)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("content"); });
+    tarSink->createSymlink(CanonPath("link"), "file.txt");
+    tarSink->createDirectory(CanonPath("empty"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("file.txt")), "content");
+    ASSERT_EQ(accessor->readLink(CanonPath("link")), "file.txt");
+    ASSERT_EQ(accessor->readDirectory(CanonPath("empty")).size(), 0u);
+}
+
+// Tests for "last wins" tar semantics - when a path appears multiple times,
+// the last entry should win.
+
+TEST_F(MerkleTarAdapterTest, last_wins_file_overwrites_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("first content"); });
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("second content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("file.txt")), "second content");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_file_overwrites_symlink)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath("entry"), "some-target");
+    tarSink->createRegularFile(CanonPath("entry"), false, [](Sink & sink) { sink("file content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("entry")), "file content");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_symlink_overwrites_file)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("entry"), false, [](Sink & sink) { sink("file content"); });
+    tarSink->createSymlink(CanonPath("entry"), "new-target");
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readLink(CanonPath("entry")), "new-target");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_symlink_overwrites_symlink)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath("link"), "first-target");
+    tarSink->createSymlink(CanonPath("link"), "second-target");
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readLink(CanonPath("link")), "second-target");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_executable_changes)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("script"), false, [](Sink & sink) { sink("content"); });
+    tarSink->createRegularFile(CanonPath("script"), true, [](Sink & sink) { sink("content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    // The file should be executable now (mode change)
+    // We can verify content is there; checking executable bit would need different API
+    ASSERT_EQ(accessor->readFile(CanonPath("script")), "content");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_nested_file_overwrites)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("a/b/file.txt"), false, [](Sink & sink) { sink("first"); });
+    tarSink->createRegularFile(CanonPath("a/b/file.txt"), false, [](Sink & sink) { sink("second"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+    ASSERT_EQ(accessor->readFile(CanonPath("a/b/file.txt")), "second");
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_at_root)
+{
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath::root, "first-target");
+    tarSink->createSymlink(CanonPath::root, "second-target");
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Symlink);
+
+    // Wrap to verify
+    auto dirSink = pool->makeDirectorySink();
+    dirSink->insertChild("link", result);
+    auto dirHash = std::move(*dirSink).flush();
+
+    auto accessor = repo->getAccessor(dirHash, {}, getRepoName());
+    ASSERT_EQ(accessor->readLink(CanonPath("link")), "second-target");
+}
+
+// Property-based test: last entry for each path wins
+RC_GTEST_FIXTURE_PROP(MerkleTarAdapterTest, last_wins_property, ())
+{
+    // Generate a list of (path, content) pairs where paths may repeat
+    auto pathNames = *rc::gen::container<std::vector<std::string>>(
+        rc::gen::element(std::string("a"), std::string("b"), std::string("c")));
+
+    RC_PRE(!pathNames.empty());
+
+    auto entries = *rc::gen::container<std::vector<std::pair<std::string, std::string>>>(
+        rc::gen::pair(rc::gen::elementOf(pathNames), rc::gen::arbitrary<std::string>()));
+
+    RC_PRE(!entries.empty());
+
+    auto repo = openRepo();
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Track what the final content should be for each path
+    std::map<std::string, std::string> expected;
+
+    for (auto & [path, content] : entries) {
+        tarSink->createRegularFile(CanonPath(path), false, [&](Sink & sink) { sink(content); });
+        expected[path] = content; // Last write wins
+    }
+
+    auto result = tarSink->flush();
+    auto accessor = repo->getAccessor(result.hash, {}, getRepoName());
+
+    // Verify each path has its expected final content
+    for (auto & [path, content] : expected) {
+        RC_ASSERT(accessor->readFile(CanonPath(path)) == content);
+    }
+}
+
+} // namespace nix

--- a/src/libfetchers-tests/merkle-tar-adapter.cc
+++ b/src/libfetchers-tests/merkle-tar-adapter.cc
@@ -567,6 +567,25 @@ TEST_F(MerkleTarAdapterTest, large_file)
     ASSERT_THAT(accessor, testing::HasContents(CanonPath("large.bin"), largeContent));
 }
 
+TEST_F(MerkleTarAdapterTest, large_file_in_chunks)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Create a file larger than the buffering threshold (1 MiB)
+    std::string largeContent(2 * 1024 * 1024, 'x');
+
+    tarSink->createRegularFile(CanonPath("large.bin"), false, [&](Sink & sink) {
+        sink(largeContent);
+        sink(largeContent);
+    });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("large.bin"), largeContent + largeContent));
+}
+
 TEST_F(MerkleTarAdapterTest, replacing_empty_directory)
 {
     auto pool = openWriterPool();

--- a/src/libfetchers-tests/merkle-tar-adapter.cc
+++ b/src/libfetchers-tests/merkle-tar-adapter.cc
@@ -1,0 +1,834 @@
+#include "nix/fetchers/git-utils.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/memory-source-accessor.hh"
+#include "nix/util/serialise.hh"
+#include "nix/util/tests/capture-logging.hh"
+#include "nix/util/tests/gmock-matchers.hh"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <rapidcheck/gtest.h>
+
+namespace nix {
+
+class MerkleTarAdapterTest : public ::testing::Test
+{
+    AutoDelete delTmpDir;
+    std::shared_ptr<GitRepo> repo;
+
+protected:
+    std::filesystem::path tmpDir;
+
+public:
+    void SetUp() override
+    {
+        tmpDir = createTempDir() / "test-git-repo";
+        repo = GitRepo::openRepo(tmpDir, {.create = true});
+        delTmpDir = AutoDelete(tmpDir, true);
+    }
+
+    void TearDown() override
+    {
+        repo.reset();
+        delTmpDir.deletePath();
+    }
+
+    ref<merkle::FileSinkBuilder> openWriterPool()
+    {
+        /* TODO: Make this a parametrised test and have a mock in-memory content
+           addressed store othen than git. */
+        return GitRepoPool::create(tmpDir, {.create = false});
+    }
+
+    ref<SourceAccessor> getAccessor(const Hash & hash) const
+    {
+        return repo->getAccessor(hash, {}, tmpDir.filename().string());
+    }
+};
+
+TEST_F(MerkleTarAdapterTest, empty_archive)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    /* An archive with no entries unpacks to an empty directory:
+       `downloadTarball` cannot tell that the server answered "not modified"
+       until it has already unpacked the (empty) response, and then throws the
+       result away. */
+    std::optional<merkle::TreeEntry> result;
+    {
+        testing::CaptureLogging log;
+        result = tarSink->flush();
+        EXPECT_EQ(log.get(), "");
+    }
+    ASSERT_EQ(result->mode, merkle::Mode::Directory);
+
+    auto accessor = getAccessor(result->hash);
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath::root, std::set<std::string>{}));
+}
+
+TEST_F(MerkleTarAdapterTest, single_file_at_root)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath::root, false, [](Sink & sink) { sink("hello world"); });
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Regular);
+
+    // Wrap in a directory to verify content via accessor
+    auto dirSink = pool->makeDirectorySink();
+    dirSink->insertChild("file", result);
+    auto dirHash = std::move(*dirSink).finalize();
+
+    pool->flush();
+    auto accessor = getAccessor(dirHash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("file"), "hello world"));
+}
+
+TEST_F(MerkleTarAdapterTest, single_executable_file)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("script.sh"), true, [](Sink & sink) { sink("#!/bin/bash\necho hello"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("script.sh"), "#!/bin/bash\necho hello"));
+    ASSERT_TRUE(accessor->lstat(CanonPath("script.sh")).isExecutable);
+}
+
+TEST_F(MerkleTarAdapterTest, single_symlink)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath::root, "target");
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Symlink);
+
+    // Wrap in a directory to verify content via accessor
+    auto dirSink = pool->makeDirectorySink();
+    dirSink->insertChild("link", result);
+    auto dirHash = std::move(*dirSink).finalize();
+
+    pool->flush();
+    auto accessor = getAccessor(dirHash);
+    ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("link"), "target"));
+}
+
+TEST_F(MerkleTarAdapterTest, empty_directory)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath::root);
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Directory);
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath::root, std::set<std::string>{}));
+}
+
+TEST_F(MerkleTarAdapterTest, nested_empty_directories)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath("a/b/c"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath("a"), std::set<std::string>{"b"}));
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath("a/b"), std::set<std::string>{"c"}));
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath("a/b/c"), std::set<std::string>{}));
+}
+
+TEST_F(MerkleTarAdapterTest, directory_with_files)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("hello.txt"), false, [](Sink & sink) { sink("hello world"); });
+    tarSink->createRegularFile(CanonPath("bye.txt"), false, [](Sink & sink) { sink("goodbye"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath::root, std::set<std::string>{"hello.txt", "bye.txt"}));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("hello.txt"), "hello world"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("bye.txt"), "goodbye"));
+}
+
+TEST_F(MerkleTarAdapterTest, nested_directory_with_files)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("a/b/file.txt"), false, [](Sink & sink) { sink("nested content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("a/b/file.txt"), "nested content"));
+}
+
+TEST_F(MerkleTarAdapterTest, mixed_content)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("regular file"); });
+    tarSink->createRegularFile(CanonPath("script.sh"), true, [](Sink & sink) { sink("#!/bin/bash"); });
+    tarSink->createSymlink(CanonPath("link"), "file.txt");
+    tarSink->createDirectory(CanonPath("empty"));
+    tarSink->createRegularFile(CanonPath("subdir/nested.txt"), false, [](Sink & sink) { sink("nested"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(
+        accessor,
+        testing::HasDirectory(
+            CanonPath::root, std::set<std::string>{"file.txt", "script.sh", "link", "empty", "subdir"}));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("file.txt"), "regular file"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("script.sh"), "#!/bin/bash"));
+    ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("link"), "file.txt"));
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath("empty"), std::set<std::string>{}));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("subdir/nested.txt"), "nested"));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_target_not_found)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    EXPECT_THAT(
+        [&]() { tarSink->createHardlink(CanonPath("link"), CanonPath("nonexistent")); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("target does not exist")));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_file)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("original.txt"), false, [](Sink & sink) { sink("shared content"); });
+    tarSink->createHardlink(CanonPath("link.txt"), CanonPath("original.txt"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("original.txt"), "shared content"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("link.txt"), "shared content"));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_executable)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("script.sh"), true, [](Sink & sink) { sink("#!/bin/bash"); });
+    tarSink->createHardlink(CanonPath("script-link.sh"), CanonPath("script.sh"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("script.sh"), "#!/bin/bash"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("script-link.sh"), "#!/bin/bash"));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_symlink)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    /* `tar` allows this, and the result is two symlinks. */
+    tarSink->createSymlink(CanonPath("s"), "some-target");
+    tarSink->createHardlink(CanonPath("h"), CanonPath("s"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("s"), "some-target"));
+    ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("h"), "some-target"));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_symlink_replaced_by_a_file)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    /* Replacing one end with a different kind of thing is allowed, and
+       leaves the other end as it was. */
+    tarSink->createSymlink(CanonPath("s"), "some-target");
+    tarSink->createHardlink(CanonPath("h"), CanonPath("s"));
+
+    {
+        testing::CaptureLogging log;
+        tarSink->createRegularFile(CanonPath("s"), false, [](Sink & sink) { sink("no longer a symlink"); });
+        EXPECT_THAT(log.get(), testing::HasSubstrIgnoreANSIMatcher("the same file as '/h'"));
+    }
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("s"), "no longer a symlink"));
+    ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("h"), "some-target"));
+}
+
+TEST_F(MerkleTarAdapterTest, multiple_hardlinks_same_target)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("original"), false, [](Sink & sink) { sink("content"); });
+    tarSink->createHardlink(CanonPath("link1"), CanonPath("original"));
+    tarSink->createHardlink(CanonPath("link2"), CanonPath("original"));
+    tarSink->createHardlink(CanonPath("link3"), CanonPath("original"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("original"), "content"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("link1"), "content"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("link2"), "content"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("link3"), "content"));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_chain)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    /* A hard link may point at another hard link. This works because a
+       link takes over its target's hash slot as it is created, so a chain
+       collapses as it is built rather than needing to be followed. */
+    constexpr int chainLength = 500;
+
+    tarSink->createRegularFile(CanonPath("target"), false, [](Sink & sink) { sink("chained content"); });
+
+    /* link0 -> target, link1 -> link0, ... */
+    tarSink->createHardlink(CanonPath("link0"), CanonPath("target"));
+    for (int i = 1; i < chainLength; i++)
+        tarSink->createHardlink(CanonPath("link" + std::to_string(i)), CanonPath("link" + std::to_string(i - 1)));
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("target"), "chained content"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("link0"), "chained content"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("link" + std::to_string(chainLength - 1)), "chained content"));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_directory_fails)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath("dir"));
+
+    EXPECT_THAT(
+        [&]() { tarSink->createHardlink(CanonPath("link"), CanonPath("dir")); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("target is a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_root_fails)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath("foo"));
+
+    EXPECT_THAT(
+        [&]() { tarSink->createHardlink(CanonPath("bar"), CanonPath::root); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("target is a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_to_later_path_fails)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    /* The target has to be something the archive has already got to, so a
+       hard link cannot form a cycle either. (libarchive only warns about
+       a cyclic hard link; we reject it.) */
+    EXPECT_THAT(
+        [&]() { tarSink->createHardlink(CanonPath("foo"), CanonPath("later")); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("does not exist")));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_keeps_the_file_it_was_made_from)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    /* Replacing the target afterwards does not follow through to the link:
+       the link is to the file, not to the path. `tar` behaves this way
+       because it unlinks the old file rather than writing through it. */
+    tarSink->createRegularFile(CanonPath("target"), false, [](Sink & sink) { sink("old"); });
+    tarSink->createHardlink(CanonPath("link"), CanonPath("target"));
+
+    {
+        /* Warned about, because older versions of Nix resolved the link
+           against the replacement instead. */
+        testing::CaptureLogging log;
+        tarSink->createRegularFile(CanonPath("target"), false, [](Sink & sink) { sink("new"); });
+        EXPECT_THAT(log.get(), testing::HasSubstrIgnoreANSIMatcher("the same file as '/link'"));
+    }
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("target"), "new"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("link"), "old"));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_replaced_itself_keeps_the_target)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    /* The other way round from `hardlink_keeps_the_file_it_was_made_from`:
+       the link's own path is replaced, and the file it was made from is
+       untouched. Warned about for the same reason. */
+    tarSink->createRegularFile(CanonPath("target"), false, [](Sink & sink) { sink("original"); });
+    tarSink->createHardlink(CanonPath("link"), CanonPath("target"));
+
+    {
+        testing::CaptureLogging log;
+        tarSink->createRegularFile(CanonPath("link"), false, [](Sink & sink) { sink("replacement"); });
+        EXPECT_THAT(log.get(), testing::HasSubstrIgnoreANSIMatcher("the same file as '/target'"));
+    }
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("target"), "original"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("link"), "replacement"));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_replaced_names_all_the_other_paths)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("a"), false, [](Sink & sink) { sink("shared"); });
+    tarSink->createHardlink(CanonPath("b"), CanonPath("a"));
+    tarSink->createHardlink(CanonPath("c"), CanonPath("a"));
+
+    {
+        testing::CaptureLogging log;
+        tarSink->createRegularFile(CanonPath("a"), false, [](Sink & sink) { sink("replacement"); });
+        /* All of them, not just the one it was linked from. */
+        EXPECT_THAT(log.get(), testing::HasSubstrIgnoreANSIMatcher("'/b', '/c'"));
+    }
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("a"), "replacement"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("b"), "shared"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("c"), "shared"));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_warns_only_while_paths_are_still_shared)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("a"), false, [](Sink & sink) { sink("shared"); });
+    tarSink->createHardlink(CanonPath("b"), CanonPath("a"));
+
+    {
+        testing::CaptureLogging log;
+        tarSink->createRegularFile(CanonPath("a"), false, [](Sink & sink) { sink("first"); });
+        EXPECT_THAT(log.get(), testing::HasSubstrIgnoreANSIMatcher("the same file as"));
+    }
+
+    {
+        /* `b` is on its own now, so replacing it is unremarkable. */
+        testing::CaptureLogging log;
+        tarSink->createRegularFile(CanonPath("b"), false, [](Sink & sink) { sink("second"); });
+        EXPECT_THAT(log.get(), ::testing::Not(testing::HasSubstrIgnoreANSIMatcher("the same file as")));
+    }
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("a"), "first"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("b"), "second"));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_failure_says_what_it_was_doing)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("content"); });
+
+    /* The error itself is about `foo/bar`; the trace says why we were
+       creating it. */
+    EXPECT_THAT(
+        [&]() { tarSink->createHardlink(CanonPath("foo/bar"), CanonPath("foo")); },
+        ::testing::ThrowsMessage<Error>(::testing::AllOf(
+            testing::HasSubstrIgnoreANSIMatcher("parent of '/foo/bar' is not a directory"),
+            testing::HasSubstrIgnoreANSIMatcher("while creating a hard link from '/foo/bar' to '/foo'"))));
+}
+
+TEST_F(MerkleTarAdapterTest, child_of_file_fails)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("content"); });
+
+    EXPECT_THAT(
+        [&]() { tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("x"); }); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("not a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, symlink_child_of_file_fails)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("content"); });
+
+    EXPECT_THAT(
+        [&]() { tarSink->createSymlink(CanonPath("foo/bar"), "target"); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("not a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, hardlink_child_of_file_fails)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("content"); });
+
+    EXPECT_THAT(
+        [&]() { tarSink->createHardlink(CanonPath("foo/bar"), CanonPath("foo")); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("not a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, child_of_symlink_fails)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Symlink points to a valid directory, but we still can't create children under the symlink path
+    tarSink->createDirectory(CanonPath("target"));
+    tarSink->createSymlink(CanonPath("foo"), "target");
+
+    EXPECT_THAT(
+        [&]() { tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("x"); }); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("not a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, explicit_directory_replaces_file)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Create a file at "foo"
+    tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("content"); });
+    // Explicitly replace it with a directory
+    tarSink->createDirectory(CanonPath("foo"));
+    // Now we can create children
+    tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("child content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("foo/bar"), "child content"));
+}
+
+TEST_F(MerkleTarAdapterTest, large_file)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Create a file larger than the buffering threshold (1 MiB)
+    std::string largeContent(2 * 1024 * 1024, 'x');
+
+    tarSink->createRegularFile(CanonPath("large.bin"), false, [&](Sink & sink) { sink(largeContent); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("large.bin"), largeContent));
+}
+
+TEST_F(MerkleTarAdapterTest, replacing_empty_directory)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath("foo"));
+    tarSink->createDirectory(CanonPath("foo/bar"));
+    /* Under tarball unpacking semantics, creating the same directories
+       (implicitly or explicitly) is fine. */
+    tarSink->createDirectory(CanonPath("foo/bar"));
+    tarSink->createDirectory(CanonPath("foo"));
+
+    tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("test"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath("foo"), std::set<std::string>{"bar"}));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("foo/bar"), "test"));
+}
+
+TEST_F(MerkleTarAdapterTest, replacing_non_empty_directory_fails)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath("foo"));
+    tarSink->createDirectory(CanonPath("foo/bar"));
+
+    /* This fails. libarchive (and other tarball unpackers) doesn't recursively unlink existing non-empty
+       directories.
+       https://github.com/libarchive/libarchive/blob/761652401fe35fca9744607a0cf0009afbf04f42/libarchive/archive_write_disk_posix.c#L3411-L3417
+     */
+    EXPECT_THAT(
+        [&]() { tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("test"); }); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("conflicting non-empty directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, replacing_non_empty_directory_with_symlink_fails)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createDirectory(CanonPath("foo"));
+    tarSink->createRegularFile(CanonPath("foo/bar"), false, [](Sink & sink) { sink("test"); });
+
+    EXPECT_THAT(
+        [&]() { tarSink->createSymlink(CanonPath("foo"), "target"); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("conflicting non-empty directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, child_of_hardlink_fails)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("foo"), false, [](Sink & sink) { sink("test"); });
+    tarSink->createHardlink(CanonPath("bar"), CanonPath("foo"));
+
+    EXPECT_THAT(
+        [&]() { tarSink->createRegularFile(CanonPath("bar/baz"), false, [](Sink & sink) { sink("x"); }); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("not a directory")));
+}
+
+TEST_F(MerkleTarAdapterTest, many_files)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    constexpr int numFiles = 100;
+    for (int i = 0; i < numFiles; i++) {
+        auto path = CanonPath("file" + std::to_string(i) + ".txt");
+        auto content = "content " + std::to_string(i);
+        tarSink->createRegularFile(path, false, [&](Sink & sink) { sink(content); });
+    }
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    auto entries = accessor->readDirectory(CanonPath::root);
+    ASSERT_EQ(entries.size(), static_cast<size_t>(numFiles));
+
+    for (int i = 0; i < numFiles; i++) {
+        auto path = CanonPath("file" + std::to_string(i) + ".txt");
+        auto expectedContent = "content " + std::to_string(i);
+        ASSERT_THAT(accessor, testing::HasContents(path, expectedContent));
+    }
+}
+
+TEST_F(MerkleTarAdapterTest, deep_nesting)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(
+        CanonPath("a/b/c/d/e/f/g/h/file.txt"), false, [](Sink & sink) { sink("deeply nested"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("a/b/c/d/e/f/g/h/file.txt"), "deeply nested"));
+}
+
+TEST_F(MerkleTarAdapterTest, directory_with_symlink_and_empty_subdir)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("content"); });
+    tarSink->createSymlink(CanonPath("link"), "file.txt");
+    tarSink->createDirectory(CanonPath("empty"));
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("file.txt"), "content"));
+    ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("link"), "file.txt"));
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath("empty"), std::set<std::string>{}));
+}
+
+// Tests for "last wins" tar semantics - when a path appears multiple times,
+// the last entry should win.
+
+TEST_F(MerkleTarAdapterTest, last_wins_file_overwrites_file)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("first content"); });
+    tarSink->createRegularFile(CanonPath("file.txt"), false, [](Sink & sink) { sink("second content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("file.txt"), "second content"));
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_file_overwrites_symlink)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath("entry"), "some-target");
+    tarSink->createRegularFile(CanonPath("entry"), false, [](Sink & sink) { sink("file content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("entry"), "file content"));
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_symlink_overwrites_file)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("entry"), false, [](Sink & sink) { sink("file content"); });
+    tarSink->createSymlink(CanonPath("entry"), "new-target");
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("entry"), "new-target"));
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_symlink_overwrites_symlink)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath("link"), "first-target");
+    tarSink->createSymlink(CanonPath("link"), "second-target");
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("link"), "second-target"));
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_executable_changes)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("script"), false, [](Sink & sink) { sink("content"); });
+    tarSink->createRegularFile(CanonPath("script"), true, [](Sink & sink) { sink("content"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    // The file should be executable now (mode change)
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("script"), "content"));
+    ASSERT_TRUE(accessor->lstat(CanonPath("script")).isExecutable);
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_nested_file_overwrites)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createRegularFile(CanonPath("a/b/file.txt"), false, [](Sink & sink) { sink("first"); });
+    tarSink->createRegularFile(CanonPath("a/b/file.txt"), false, [](Sink & sink) { sink("second"); });
+
+    auto result = tarSink->flush();
+
+    auto accessor = getAccessor(result.hash);
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("a/b/file.txt"), "second"));
+}
+
+TEST_F(MerkleTarAdapterTest, last_wins_at_root)
+{
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    tarSink->createSymlink(CanonPath::root, "first-target");
+    tarSink->createSymlink(CanonPath::root, "second-target");
+
+    auto result = tarSink->flush();
+    ASSERT_EQ(result.mode, merkle::Mode::Symlink);
+
+    // Wrap to verify
+    auto dirSink = pool->makeDirectorySink();
+    dirSink->insertChild("link", result);
+    auto dirHash = std::move(*dirSink).finalize();
+
+    pool->flush();
+    auto accessor = getAccessor(dirHash);
+    ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("link"), "second-target"));
+}
+
+// Property-based test: last entry for each path wins
+RC_GTEST_FIXTURE_PROP(MerkleTarAdapterTest, last_wins_property, ())
+{
+    // Generate a list of (path, content) pairs where paths may repeat
+    auto pathNames = *rc::gen::container<std::vector<std::string>>(
+        rc::gen::element(std::string("a"), std::string("b"), std::string("c")));
+
+    RC_PRE(!pathNames.empty());
+
+    auto entries = *rc::gen::container<std::vector<std::pair<std::string, std::string>>>(
+        rc::gen::pair(rc::gen::elementOf(pathNames), rc::gen::arbitrary<std::string>()));
+
+    RC_PRE(!entries.empty());
+
+    auto pool = openWriterPool();
+    auto tarSink = merkle::makeTarSink(*pool);
+
+    // Track what the final content should be for each path
+    std::map<std::string, std::string> expected;
+
+    for (auto & [path, content] : entries) {
+        tarSink->createRegularFile(CanonPath(path), false, [&](Sink & sink) { sink(content); });
+        expected[path] = content; // Last write wins
+    }
+
+    auto result = tarSink->flush();
+    auto accessor = getAccessor(result.hash);
+
+    // Verify each path has its expected final content
+    for (auto & [path, content] : expected) {
+        RC_ASSERT(accessor->readFile(CanonPath(path)) == content);
+    }
+}
+
+} // namespace nix

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -43,6 +43,7 @@ sources = files(
   'git-utils.cc',
   'git.cc',
   'input.cc',
+  'merkle-tar-adapter.cc',
   'nix_api_fetchers.cc',
   'public-key.cc',
 )

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -48,6 +48,7 @@ sources = files(
   'git-utils.cc',
   'git.cc',
   'input.cc',
+  'merkle-tar-adapter.cc',
   'nix_api_fetchers.cc',
   'public-key.cc',
 )

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -265,7 +265,8 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
     /**
      * libgit2 repository. Note that new objects are not written to disk,
      * because we are using a mempack backend. For writing to disk, see
-     * `flush()`, which is also called by `GitFileSystemObjectSink::sync()`.
+     * `flush()`, which is also called by `flush()` on the various merkle file
+     * interfaces.
      */
     Repository repo;
 
@@ -382,79 +383,6 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
             throw GitError("resetting git mempack backend");
 
         checkInterrupt();
-    }
-
-    /**
-     * Return a connection pool for this repo. Useful for
-     * multithreaded access.
-     */
-    Pool<GitRepoImpl> getPool()
-    {
-        // TODO: as an optimization, it would be nice to include `this` in the pool.
-        return Pool<GitRepoImpl>(std::numeric_limits<size_t>::max(), [this]() -> ref<GitRepoImpl> {
-            auto repo = make_ref<GitRepoImpl>(path, options);
-
-            /* Monkey-patching the pack backend to only read the pack directory
-               once. Otherwise it will do a readdir for each added oid when it's
-               not found and that translates to ~6 syscalls. Since we are never
-               writing pack files until flushing we can force the odb backend to
-               read the directory just once. It's very convenient that the vtable is
-               semi-public interface and is up for grabs.
-
-               This is purely an optimization for our use-case with a tarball cache.
-               libgit2 calls refresh() if the backend provides it when an oid isn't found.
-               We are only writing objects to a mempack (it has higher priority) and there isn't
-               a realistic use-case where a previously missing object would appear from thin air
-               on the disk (unless another process happens to be unpacking a similar tarball to
-               the cache at the same time, but that's a very unrealistic scenario).
-            */
-            if (auto * backend = repo->packBackend)
-                backend->refresh = nullptr;
-
-            return repo;
-        });
-    }
-
-    uint64_t getRevCount(const Hash & rev) override
-    {
-        boost::concurrent_flat_set<git_oid, std::hash<git_oid>> done;
-
-        auto startCommit = peelObject<Commit>(lookupObject(*this, hashToOID(rev)).get(), GIT_OBJECT_COMMIT);
-        auto startOid = *git_commit_id(startCommit.get());
-        done.insert(startOid);
-
-        auto repoPool(getPool());
-
-        ThreadPool pool;
-
-        auto process = [&done, &pool, &repoPool](this const auto & process, const git_oid & oid) -> void {
-            auto repo(repoPool.get());
-
-            auto _commit = lookupObject(*repo, oid, GIT_OBJECT_COMMIT);
-            auto commit = (const git_commit *) &*_commit;
-
-            for (auto n : std::views::iota(0U, git_commit_parentcount(commit))) {
-                auto parentOid = git_commit_parent_id(commit, n);
-                if (!parentOid) {
-                    throw Error(
-                        "Failed to retrieve the parent of Git commit '%s': %s. "
-                        "This may be due to an incomplete repository history. "
-                        "To resolve this, either enable the shallow parameter in your flake URL (?shallow=1) "
-                        "or add set the shallow parameter to true in builtins.fetchGit, "
-                        "or fetch the complete history for this branch.",
-                        *git_commit_id(commit),
-                        git_error_last()->message);
-                }
-                if (done.insert(*parentOid))
-                    pool.enqueue(std::bind(process, *parentOid));
-            }
-        };
-
-        pool.enqueue(std::bind(process, startOid));
-
-        pool.process();
-
-        return done.size();
     }
 
     uint64_t getLastModified(const Hash & rev) override
@@ -626,8 +554,6 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
     ref<SourceAccessor>
     getAccessor(const WorkdirInfo & wd, const GitAccessorOptions & options, MakeNotAllowedError e) override;
-
-    ref<GitFileSystemObjectSink> getFileSystemObjectSink() override;
 
     void fetch(const std::string & url, const std::string & refspec, bool shallow) override
     {
@@ -1116,298 +1042,132 @@ struct GitExportIgnoreSourceAccessor : CachingFilteringSourceAccessor
     }
 };
 
-struct GitFileSystemObjectSinkImpl : GitFileSystemObjectSink
+struct GitRegularFileSinkImpl : merkle::RegularFileSinkWithFlush
 {
-    ref<GitRepoImpl> repo;
+    using WriteStream = std::unique_ptr<git_writestream, decltype([](git_writestream * stream) {
+                                            if (stream)
+                                                stream->free(stream);
+                                        })>;
 
-    Pool<GitRepoImpl> repoPool;
+    Pool<GitRepoImpl> & writerPool;
 
-    unsigned int concurrency = std::min(std::thread::hardware_concurrency(), 10U);
+    /**
+     * Writer acquired from the pool. Only set when we have a stream (large file).
+     */
+    std::optional<Pool<GitRepoImpl>::Handle> writer;
 
-    ThreadPool workers{concurrency};
+    /**
+     * In-memory buffer for small files.
+     */
+    std::string contents;
 
-    /** Total file contents in flight. */
-    std::atomic<size_t> totalBufSize{0};
+    /**
+     * Stream for large files. Only created when contents exceeds maxBufferSize.
+     */
+    WriteStream stream;
 
-    static constexpr std::size_t maxBufSize = 16 * 1024 * 1024;
+    /**
+     * Maximum file size that gets buffered in memory before flushing to a
+     * git_writestream backed by a temporary objects/streamed_git2_* file.
+     * We should avoid that for common cases, since creating (and deleting)
+     * a temporary file for each blob is expensive.
+     */
+    static constexpr std::size_t maxBufferSize = 1024 * 1024; /* 1 MiB */
 
-    GitFileSystemObjectSinkImpl(ref<GitRepoImpl> repo)
-        : repo(repo)
-        , repoPool(repo->getPool())
+    GitRegularFileSinkImpl(Pool<GitRepoImpl> & writerPool)
+        : writerPool(writerPool)
     {
     }
 
-    ~GitFileSystemObjectSinkImpl()
+    void writeToStream(git_writestream & stream, std::string_view data)
     {
-        // Make sure the worker threads are destroyed before any state
-        // they're referring to.
-        workers.shutdown();
+        if (stream.write(&stream, data.data(), data.size()))
+            throw GitError("writing to blob stream");
     }
 
-    struct Child;
-
-    /// A directory to be written as a Git tree.
-    struct Directory
+    void operator()(std::string_view data) override
     {
-        std::map<std::string, Child> children;
-        std::optional<git_oid> oid;
-
-        Child & lookup(const CanonPath & path)
-        {
-            assert(!path.isRoot());
-            auto parent = path.parent();
-            auto cur = this;
-            for (auto & name : *parent) {
-                auto i = cur->children.find(std::string(name));
-                if (i == cur->children.end())
-                    throw Error("path '%s' does not exist", path);
-                auto dir = std::get_if<Directory>(&i->second.file);
-                if (!dir)
-                    throw Error("path '%s' has a non-directory parent", path);
-                cur = dir;
-            }
-
-            auto i = cur->children.find(std::string(*path.baseName()));
-            if (i == cur->children.end())
-                throw Error("path '%s' does not exist", path);
-            return i->second;
-        }
-    };
-
-    size_t nextId = 0; // for Child.id
-
-    struct Child
-    {
-        git_filemode_t mode;
-        std::variant<Directory, git_oid> file;
-
-        /// Sequential numbering of the file in the tarball. This is
-        /// used to make sure we only import the latest version of a
-        /// path.
-        size_t id{0};
-    };
-
-    struct State
-    {
-        Directory root;
-    };
-
-    Sync<State> _state;
-
-    void addNode(State & state, const CanonPath & path, Child && child)
-    {
-        assert(!path.isRoot());
-        auto parent = path.parent();
-
-        Directory * cur = &state.root;
-
-        for (auto & i : *parent) {
-            auto child = std::get_if<Directory>(
-                &cur->children.emplace(std::string(i), Child{GIT_FILEMODE_TREE, {Directory()}}).first->second.file);
-            assert(child);
-            cur = child;
+        /* Already in slow path. Just write to the stream. */
+        if (stream) {
+            writeToStream(*stream, data);
+            return;
         }
 
-        std::string name(*path.baseName());
-
-        if (auto prev = cur->children.find(name); prev == cur->children.end() || prev->second.id < child.id)
-            cur->children.insert_or_assign(name, std::move(child));
+        contents += data;
+        if (contents.size() > maxBufferSize) {
+            /* Lazily acquire a writer and create the stream. */
+            writer.emplace(writerPool.get());
+            git_writestream * streamRaw = nullptr;
+            if (git_blob_create_from_stream(&streamRaw, **writer, nullptr))
+                throw GitError("creating blob stream");
+            stream = WriteStream{streamRaw};
+            writeToStream(*stream, contents);
+            contents.clear();
+        }
     }
 
-    void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func) override
+    Hash flush() && override
     {
-        checkInterrupt();
+        git_oid oid;
 
-        /* Multithreaded blob writing. We read the incoming file data into memory and asynchronously write it to a Git
-           blob object. However, to avoid unbounded memory usage, if the amount of data in flight exceeds a threshold,
-           we switch to writing directly to a Git write stream. */
-
-        using WriteStream = std::unique_ptr<::git_writestream, decltype([](::git_writestream * stream) {
-                                                if (stream)
-                                                    stream->free(stream);
-                                            })>;
-
-        struct CRF : CreateRegularFileSink
-        {
-            CanonPath path;
-            GitFileSystemObjectSinkImpl & parent;
-            WriteStream stream;
-            std::optional<decltype(parent.repoPool)::Handle> repo;
-
-            std::string contents;
-            bool executable = false;
-
-            CRF(CanonPath path, GitFileSystemObjectSinkImpl & parent)
-                : path(std::move(path))
-                , parent(parent)
-            {
-            }
-
-            ~CRF()
-            {
-                parent.totalBufSize -= contents.size();
-            }
-
-            void operator()(std::string_view data) override
-            {
-                if (!stream) {
-                    contents.append(data);
-                    parent.totalBufSize += data.size();
-
-                    if (parent.totalBufSize > parent.maxBufSize) {
-                        repo.emplace(parent.repoPool.get());
-
-                        if (git_blob_create_from_stream(Setter(stream), **repo, nullptr))
-                            throw GitError("creating a blob stream object");
-
-                        if (stream->write(stream.get(), contents.data(), contents.size()))
-                            throw GitError("writing a blob for tarball member '%s'", path);
-
-                        parent.totalBufSize -= contents.size();
-                        contents.clear();
-                    }
-                } else {
-                    if (stream->write(stream.get(), data.data(), data.size()))
-                        throw GitError("writing a blob for tarball member '%s'", path);
-                }
-            }
-
-            void isExecutable() override
-            {
-                executable = true;
-            }
-        };
-
-        auto crf = std::make_shared<CRF>(path, *this);
-
-        func(*crf);
-
-        auto id = nextId++;
-
-        if (crf->stream) {
-            /* Finish the slow path by creating the blob object synchronously.
-               Call .release(), since git_blob_create_from_stream_commit
+        if (stream) {
+            /* Large file: finalize the stream we created earlier. */
+            assert(writer);
+            /* Call .release(), since git_blob_create_from_stream_commit
                acquires ownership and frees the stream. */
-            git_oid oid;
-            if (git_blob_create_from_stream_commit(&oid, crf->stream.release()))
-                throw GitError("creating a blob object for '%s'", path);
-            addNode(
-                *_state.lock(),
-                crf->path,
-                Child{crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB, oid, id});
-            return;
+            if (git_blob_create_from_stream_commit(&oid, stream.release()))
+                throw GitError("finalizing blob stream");
+            /* Can return this writer to the pool too, now that the stream
+               is closed. */
+            writer.reset();
+        } else {
+            /* Small file: get a writer from the pool and create blob from buffer. */
+            auto handle = writerPool.get();
+            if (git_blob_create_from_buffer(&oid, *handle, contents.data(), contents.size()))
+                throw GitError("creating blob from buffer");
         }
 
-        /* Fast path: create the blob object in a separate thread. */
-        workers.enqueue([this, crf{std::move(crf)}, id]() {
-            auto repo(repoPool.get());
+        return toHash(oid);
+    }
+};
 
-            git_oid oid;
-            if (git_blob_create_from_buffer(&oid, *repo, crf->contents.data(), crf->contents.size()))
-                throw GitError("creating a blob object for '%s' from in-memory buffer", crf->path);
+struct GitDirectorySinkImpl : merkle::DirectorySinkWithFlush
+{
+    Pool<GitRepoImpl> & pool;
 
-            addNode(
-                *_state.lock(),
-                crf->path,
-                Child{crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB, oid, id});
-        });
+    TreeBuilder builder;
+
+    Pool<GitRepoImpl>::Handle handle;
+
+    GitDirectorySinkImpl(Pool<GitRepoImpl> & pool)
+        : pool(pool)
+        , handle(pool.get())
+    {
+        git_treebuilder * b;
+        if (git_treebuilder_new(&b, *handle, nullptr))
+            throw GitError("creating a tree builder");
+        builder = TreeBuilder(b);
     }
 
-    void createDirectory(const CanonPath & path) override
+    git_oid writeTree()
     {
-        if (path.isRoot())
-            return;
-        auto state(_state.lock());
-        addNode(*state, path, {GIT_FILEMODE_TREE, Directory()});
+        git_oid oid;
+        if (git_treebuilder_write(&oid, builder.get()))
+            throw GitError("creating a tree object");
+        return oid;
     }
 
-    void createSymlink(const CanonPath & path, const std::string & target) override
+    void insertChild(std::string_view name, merkle::TreeEntry entry) override
     {
-        workers.enqueue([this, path, target]() {
-            auto repo(repoPool.get());
-
-            git_oid oid;
-            if (git_blob_create_from_buffer(&oid, *repo, target.c_str(), target.size()))
-                throw GitError("creating a blob object for tarball symlink member '%s'", path);
-
-            auto state(_state.lock());
-            addNode(*state, path, Child{GIT_FILEMODE_LINK, oid});
-        });
+        auto oid = hashToOID(entry.hash);
+        git_treebuilder_insert(
+            nullptr, builder.get(), std::string(name).c_str(), &oid, static_cast<git_filemode_t>(entry.mode));
     }
 
-    std::map<CanonPath, CanonPath> hardLinks;
-
-    void createHardlink(const CanonPath & path, const CanonPath & target) override
+    Hash flush() && override
     {
-        hardLinks.insert_or_assign(path, target);
-    }
-
-    Hash flush() override
-    {
-        workers.process();
-
-        /* Create hard links. */
-        {
-            auto state(_state.lock());
-            for (auto & [path, target] : hardLinks) {
-                if (target.isRoot())
-                    continue;
-                try {
-                    auto child = state->root.lookup(target);
-                    auto oid = std::get_if<git_oid>(&child.file);
-                    if (!oid)
-                        throw Error("cannot create a hard link to a directory");
-                    addNode(*state, path, {child.mode, *oid});
-                } catch (Error & e) {
-                    e.addTrace(nullptr, "while creating a hard link from '%s' to '%s'", path, target);
-                    throw;
-                }
-            }
-        }
-
-        // Flush all repo objects to disk.
-        {
-            auto repos = repoPool.clear();
-            ThreadPool workers{repos.size()};
-            for (auto & repo : repos)
-                workers.enqueue([repo]() { repo->flush(); });
-            workers.process();
-        }
-
-        // Write the Git trees to disk. Would be nice to have this multithreaded too, but that's hard because a tree
-        // can't refer to an object that hasn't been written yet. Also it doesn't make a big difference for performance.
-        auto repo(repoPool.get());
-
-        [&](this const auto & visit, Directory & node) -> void {
-            checkInterrupt();
-
-            // Write the child directories.
-            for (auto & child : node.children)
-                if (auto dir = std::get_if<Directory>(&child.second.file))
-                    visit(*dir);
-
-            // Write this directory.
-            git_treebuilder * b;
-            if (git_treebuilder_new(&b, *repo, nullptr))
-                throw GitError("creating a tree builder");
-            TreeBuilder builder(b);
-
-            for (auto & [name, child] : node.children) {
-                auto oid_p = std::get_if<git_oid>(&child.file);
-                auto oid = oid_p ? *oid_p : std::get<Directory>(child.file).oid.value();
-                if (git_treebuilder_insert(nullptr, builder.get(), name.c_str(), &oid, child.mode))
-                    throw GitError("adding a file to a tree builder");
-            }
-
-            git_oid oid;
-            if (git_treebuilder_write(&oid, builder.get()))
-                throw GitError("creating a tree object");
-            node.oid = oid;
-        }(_state.lock()->root);
-
-        repo->flush();
-
-        return toHash(_state.lock()->root.oid.value());
+        auto oid = writeTree();
+        return toHash(oid);
     }
 };
 
@@ -1445,9 +1205,152 @@ ref<SourceAccessor> GitRepoImpl::getAccessor(
     return fileAccessor;
 }
 
-ref<GitFileSystemObjectSink> GitRepoImpl::getFileSystemObjectSink()
+/**
+ * A pool of `GitRepoImpl` instances for parallel merkle object writing.
+ *
+ * libgit2 repositories are not thread-safe, so concurrent writes
+ * require separate repository handles. This pool manages those handles.
+ *
+ * When `disablePackRefresh` is true. Monkey-patch, the pack backend to
+ * only read the pack directory once. Otherwise it will do a readdir for
+ * each added oid when it's not found and that translates to ~6
+ * syscalls. Since we are never writing pack files until flushing we can
+ * force the odb backend to read the directory just once. It's very
+ * convenient that the vtable is semi-public interface and is up for
+ * grabs.
+ *
+ * This is an purely optimization for when we are writing independent
+ * data concurrently. For example, when we are only writing blobs to the
+ * git repo. Blobs are leaf notes which cannot referene other objects,
+ * and so there is far less need for synchronisation.
+ *
+ * `flushAndSetAllowDependentCreation(true)` discards all idle pool
+ * members and clears the flag, so that subsequently created members get
+ * the new `refresh` behavior and can discover packfiles written by
+ * other members.
+ *
+ * This comes up in our use-case of the tarball cache. We write all the
+ * files from the tarball to git, and only then write the directories.
+ * When writing files, libgit2 calls refresh() if the backend provides
+ * it when an oid isn't found. We are only writing objects to a mempack
+ * (it has higher priority) and there isn't a realistic use-case where a
+ * previously missing object would appear from thin air on the disk
+ * (unless another process happens to be unpacking a similar tarball to
+ * the cache at the same time, but that's a very unrealistic scenario).
+ * After we're done writing the files, we call
+ * `flushAndSetAllowDependentCreation(true)` and write the directories.
+ */
+struct GitRepoPoolImpl : GitRepoPool
 {
-    return make_ref<GitFileSystemObjectSinkImpl>(ref<GitRepoImpl>(shared_from_this()));
+    std::filesystem::path path;
+    GitRepo::Options options;
+
+    /**
+     * When true, new pool members have `refresh` disabled on their
+     * pack backend. Cleared by `flushAndSetAllowDependentCreation(true)`.
+     */
+    bool disablePackRefresh = true;
+
+    Pool<GitRepoImpl> pool;
+
+    GitRepoPoolImpl(const std::filesystem::path & path, GitRepo::Options options)
+        : path(path)
+        , options(options)
+        , pool(std::numeric_limits<size_t>::max(), [this]() -> ref<GitRepoImpl> {
+            auto repo = make_ref<GitRepoImpl>(this->path, this->options);
+
+            if (disablePackRefresh) {
+                /* Null out the pack backend's refresh callback so that
+                   libgit2 only reads the pack directory once (on first
+                   use) instead of re-scanning on every cache miss.
+                   The vtable is semi-public interface in libgit2.
+
+                   @see GitRepoPoolImpl for context on why we do this.
+                 */
+                if (auto * backend = repo->packBackend)
+                    backend->refresh = nullptr;
+            }
+
+            return repo;
+        })
+    {
+    }
+
+    void flushAndSetAllowDependentCreation(bool allow) override
+    {
+        auto repos = pool.clear();
+        ThreadPool workers{repos.size()};
+        for (auto & repo : repos)
+            workers.enqueue([repo]() { repo->flush(); });
+        workers.process();
+        disablePackRefresh = !allow;
+    }
+
+    ref<merkle::DirectorySinkWithFlush> makeDirectorySink() override
+    {
+        return make_ref<GitDirectorySinkImpl>(pool);
+    }
+
+    ref<merkle::RegularFileSinkWithFlush> makeRegularFileSink() override
+    {
+        return make_ref<GitRegularFileSinkImpl>(pool);
+    }
+
+    merkle::TreeEntry makeSymlink(const std::string & target) override
+    {
+        auto handle = pool.get();
+        git_oid oid;
+        if (git_blob_create_from_buffer(&oid, *handle, target.data(), target.size()))
+            throw GitError("creating a blob object for symlink");
+        return merkle::TreeEntry{merkle::Mode::Symlink, toHash(oid)};
+    }
+
+    uint64_t getRevCount(const Hash & rev) override
+    {
+        boost::concurrent_flat_set<git_oid, std::hash<git_oid>> done;
+
+        auto startRepo = pool.get();
+        auto startCommit = peelObject<Commit>(lookupObject(*startRepo, hashToOID(rev)).get(), GIT_OBJECT_COMMIT);
+        auto startOid = *git_commit_id(startCommit.get());
+        done.insert(startOid);
+
+        ThreadPool threadPool;
+
+        auto process = [&done, &threadPool, this](this const auto & process, const git_oid & oid) -> void {
+            auto repo(pool.get());
+
+            auto _commit = lookupObject(*repo, oid, GIT_OBJECT_COMMIT);
+            auto commit = (const git_commit *) &*_commit;
+
+            for (auto n : std::views::iota(0U, git_commit_parentcount(commit))) {
+                auto parentOid = git_commit_parent_id(commit, n);
+                if (!parentOid) {
+                    throw Error(
+                        "Failed to retrieve the parent of Git commit '%s': %s. "
+                        "This may be due to an incomplete repository history. "
+                        "To resolve this, either enable the shallow parameter in your flake URL (?shallow=1) "
+                        "or add set the shallow parameter to true in builtins.fetchGit, "
+                        "or fetch the complete history for this branch.",
+                        *git_commit_id(commit),
+                        git_error_last()->message);
+                }
+                if (done.insert(*parentOid))
+                    threadPool.enqueue(std::bind(process, *parentOid));
+            }
+        };
+
+        threadPool.enqueue(std::bind(process, startOid));
+
+        threadPool.process();
+
+        return done.size();
+    }
+
+};
+
+ref<GitRepoPool> GitRepoPool::create(const std::filesystem::path & path, GitRepo::Options options)
+{
+    return make_ref<GitRepoPoolImpl>(path, options);
 }
 
 std::vector<std::tuple<GitRepoImpl::Submodule, Hash>> GitRepoImpl::getSubmodules(const Hash & rev, bool exportIgnore)
@@ -1486,14 +1389,22 @@ std::vector<std::tuple<GitRepoImpl::Submodule, Hash>> GitRepoImpl::getSubmodules
 
 namespace fetchers {
 
+static std::filesystem::path tarballCacheDir()
+{
+    static auto repoDir = std::filesystem::path(getCacheDir()) / "tarball-cache-v2";
+    return repoDir;
+}
+
+static constexpr GitRepo::Options tarballCacheOptions{.create = true, .bare = true, .packfilesOnly = true};
+
 ref<GitRepo> Settings::getTarballCache() const
 {
-    /* v1: Had either only loose objects or thin packfiles referring to loose objects
-     * v2: Must have only packfiles with no loose objects. Should get repacked periodically
-     * for optimal packfiles.
-     */
-    static auto repoDir = std::filesystem::path(getCacheDir()) / "tarball-cache-v2";
-    return GitRepo::openRepo(repoDir, {.create = true, .bare = true, .packfilesOnly = true});
+    return GitRepo::openRepo(tarballCacheDir(), tarballCacheOptions);
+}
+
+ref<GitRepoPool> Settings::getTarballWriterPool() const
+{
+    return GitRepoPool::create(tarballCacheDir(), tarballCacheOptions);
 }
 
 } // namespace fetchers

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -331,7 +331,8 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
     /**
      * libgit2 repository. Note that new objects are not written to disk,
      * because we are using a mempack backend. For writing to disk, see
-     * `flush()`, which is also called by `GitFileSystemObjectSink::sync()`.
+     * `flush()`, which is also called by `flush()` on the various merkle file
+     * interfaces.
      */
     Repository repo;
 
@@ -346,6 +347,23 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
      * Owned by `repo`.
      */
     git_odb_backend * packBackend = nullptr;
+
+    /**
+     * Read the pack directory only the once, when this repo was created
+     * (`git_odb_backend_pack` does that), rather than re-scanning it
+     * whenever an object is not found --- which costs about six syscalls
+     * per miss.
+     *
+     * Done by nulling out the backend's `refresh` callback; the vtable is
+     * semi-public interface in libgit2.
+     *
+     * @see GitRepoPoolImpl for when this is safe.
+     */
+    void readPackDirOnlyOnce()
+    {
+        if (packBackend)
+            packBackend->refresh = nullptr;
+    }
 
     GitRepoImpl(std::filesystem::path _path, Options _options)
         : path(std::move(_path))
@@ -508,77 +526,8 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         checkInterrupt();
     }
 
-    /**
-     * Return a connection pool for this repo. Useful for
-     * multithreaded access.
-     */
-    Pool<GitRepoImpl> getPool()
-    {
-        return Pool<GitRepoImpl>(std::numeric_limits<size_t>::max(), [this]() -> ref<GitRepoImpl> {
-            auto repo = make_ref<GitRepoImpl>(path, options);
-
-            /* Monkey-patching the pack backend to only read the pack directory
-               once. Otherwise it will do a readdir for each added oid when it's
-               not found and that translates to ~6 syscalls. Since we are never
-               writing pack files until flushing we can force the odb backend to
-               read the directory just once. It's very convenient that the vtable is
-               semi-public interface and is up for grabs.
-
-               This is purely an optimization for our use-case with a tarball cache.
-               libgit2 calls refresh() if the backend provides it when an oid isn't found.
-               We are only writing objects to a mempack (it has higher priority) and there isn't
-               a realistic use-case where a previously missing object would appear from thin air
-               on the disk (unless another process happens to be unpacking a similar tarball to
-               the cache at the same time, but that's a very unrealistic scenario).
-            */
-            if (auto * backend = repo->packBackend)
-                backend->refresh = nullptr;
-
-            return repo;
-        });
-    }
-
-    uint64_t getRevCount(const Hash & rev) override
-    {
-        boost::concurrent_flat_set<git_oid, std::hash<git_oid>> done;
-
-        auto startCommit = peelObject<Commit>(lookupObject(*this, hashToOID(rev)).get(), GIT_OBJECT_COMMIT);
-        auto startOid = *git_commit_id(startCommit.get());
-        done.insert(startOid);
-
-        auto repoPool(getPool());
-
-        ThreadPool pool;
-
-        auto process = [&done, &pool, &repoPool](this const auto & process, const git_oid & oid) -> void {
-            auto repo(repoPool.get());
-
-            auto _commit = lookupObject(*repo, oid, GIT_OBJECT_COMMIT);
-            auto commit = (const git_commit *) &*_commit;
-
-            for (auto n : std::views::iota(0U, git_commit_parentcount(commit))) {
-                auto parentOid = git_commit_parent_id(commit, n);
-                if (!parentOid) {
-                    throw Error(
-                        "Failed to retrieve the parent of Git commit '%s': %s. "
-                        "This may be due to an incomplete repository history. "
-                        "To resolve this, either enable the shallow parameter in your flake URL (?shallow=1) "
-                        "or add set the shallow parameter to true in builtins.fetchGit, "
-                        "or fetch the complete history for this branch.",
-                        *git_commit_id(commit),
-                        git_error_last()->message);
-                }
-                if (done.insert(*parentOid))
-                    pool.enqueue(std::bind(process, *parentOid));
-            }
-        };
-
-        pool.enqueue(std::bind(process, startOid));
-
-        pool.process();
-
-        return done.size();
-    }
+    std::unique_ptr<merkle::DirectorySinkWithFinalize> makeDirectorySink() override;
+    std::unique_ptr<merkle::RegularFileSinkWithFinalize> makeRegularFileSink() override;
 
     uint64_t getLastModified(const Hash & rev) override
     {
@@ -766,8 +715,6 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
     ref<SourceAccessor>
     getAccessor(const WorkdirInfo & wd, const GitAccessorOptions & options, MakeNotAllowedError e) override;
-
-    ref<GitFileSystemObjectSink> getFileSystemObjectSink() override;
 
     void fetch(const std::string & url, const std::string & refspec, bool shallow) override
     {
@@ -1263,356 +1210,174 @@ public:
     }
 };
 
-void GitFileSystemObjectSink::anchor() {}
-
 namespace {
 
-struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
+/**
+ * A handle to a `GitRepoImpl` that is either borrowed from a pool
+ * (independent phase) or references a single shared repo (dependent
+ * phase). The pool handle, if any, is returned to the pool on
+ * destruction.
+ */
+struct GitRepoHandle
 {
-    ref<GitRepoImpl> repo;
+    /**
+     * Borrowed from the pool, or simply a shared reference to a repo with no
+     * interaction with any pool. Kept only to hold on to the repo; use `repo`
+     * to get at it.
+     */
+    std::variant<Pool<GitRepoImpl>::Handle, ref<GitRepoImpl>> owner;
 
-    Pool<GitRepoImpl> repoPool;
+    GitRepoImpl * repo;
 
-    unsigned int concurrency = std::min(std::thread::hardware_concurrency(), 10U);
+    GitRepoHandle(Pool<GitRepoImpl>::Handle handle)
+        : owner(std::move(handle))
+        , repo(&*std::get<Pool<GitRepoImpl>::Handle>(owner))
+    {
+    }
 
-    ThreadPool workers{concurrency};
+    GitRepoHandle(ref<GitRepoImpl> repo)
+        : owner(repo)
+        , repo(repo.get())
+    {
+    }
+
+    GitRepoImpl & operator*() const
+    {
+        return *repo;
+    }
+
+    GitRepoImpl * operator->() const
+    {
+        return repo;
+    }
+};
+
+struct GitRegularFileSinkImpl : merkle::RegularFileSinkWithFinalize
+{
+    using WriteStream = std::unique_ptr<git_writestream, decltype([](git_writestream * stream) {
+                                            if (stream)
+                                                stream->free(stream);
+                                        })>;
+
+    std::function<GitRepoHandle()> getRepo;
 
     /**
-     * If repo has a non-null packBackend, this has a copy of the refresh function
-     * from the backend virtual table. This is needed to restore it after we've flushed
-     * the sink. We modify it to avoid unnecessary I/O on non-existent oids.
+     * Writer acquired lazily. Only set when we have a stream (large file).
      */
-    decltype(::git_odb_backend::refresh) packfileOdbRefresh = nullptr;
+    std::optional<GitRepoHandle> writer;
 
-    /** Total file contents in flight. */
-    std::atomic<size_t> totalBufSize{0};
+    /**
+     * In-memory buffer for small files.
+     */
+    std::string contents;
 
-    static constexpr std::size_t maxBufSize = 16 * 1024 * 1024;
+    /**
+     * Stream for large files. Only created when contents exceeds maxBufferSize.
+     */
+    WriteStream stream;
 
-    GitFileSystemObjectSinkImpl(ref<GitRepoImpl> repo)
-        : repo(repo)
-        , repoPool(repo->getPool())
+    /**
+     * Maximum file size that gets buffered in memory before flushing to a
+     * git_writestream backed by a temporary objects/streamed_git2_* file.
+     * We should avoid that for common cases, since creating (and deleting)
+     * a temporary file for each blob is expensive.
+     */
+    static constexpr std::size_t maxBufferSize = 1024 * 1024; /* 1 MiB */
+
+    GitRegularFileSinkImpl(std::function<GitRepoHandle()> getRepo)
+        : getRepo(std::move(getRepo))
     {
-        if (auto * backend = repo->packBackend)
-            packfileOdbRefresh = std::exchange(backend->refresh, nullptr);
     }
 
-    GitFileSystemObjectSinkImpl(GitFileSystemObjectSinkImpl &&) = delete;
-    GitFileSystemObjectSinkImpl(const GitFileSystemObjectSinkImpl &) = delete;
-    GitFileSystemObjectSinkImpl & operator=(GitFileSystemObjectSinkImpl &&) = delete;
-    GitFileSystemObjectSinkImpl & operator=(const GitFileSystemObjectSinkImpl &) = delete;
-
-    ~GitFileSystemObjectSinkImpl()
+    void writeToStream(git_writestream & stream, std::string_view data)
     {
-        // Make sure the worker threads are destroyed before any state
-        // they're referring to.
-        workers.shutdown();
-        if (auto * backend = repo->packBackend; backend && packfileOdbRefresh)
-            backend->refresh = packfileOdbRefresh;
+        if (stream.write(&stream, data.data(), data.size()))
+            throw GitError("writing to blob stream");
     }
 
-    struct Child;
-
-    /// A directory to be written as a Git tree.
-    struct Directory
+    void operator()(std::string_view data) override
     {
-        std::map<std::string, Child, std::less<>> children;
-        std::optional<git_oid> oid;
-
-        Child & lookup(const CanonPath & path)
-        {
-            assert(!path.isRoot());
-            auto parent = path.parent();
-            auto cur = this;
-            for (auto & name : *parent) {
-                auto i = cur->children.find(name);
-                if (i == cur->children.end())
-                    throw Error("path '%s' does not exist", path);
-                auto dir = std::get_if<Directory>(&i->second.file);
-                if (!dir)
-                    throw Error("path '%s' has a non-directory parent", path);
-                cur = dir;
-            }
-
-            auto i = cur->children.find(*path.baseName());
-            if (i == cur->children.end())
-                throw Error("path '%s' does not exist", path);
-            return i->second;
-        }
-    };
-
-    /* FIXME: Most of this logic is independent from git. Come up with a tree sink interface
-       and an adapter for a ExtendedFileSystemObjectSink that implements the tarball unpacking
-       semantics (i.e. overwriting of entries). Also deduplicate with MemorySourceAccessor. */
-
-    struct Child
-    {
-        git_filemode_t mode;
-        std::variant<Directory, git_oid, std::shared_future<git_oid>> file;
-
-        const git_oid & getOid() const &
-        {
-            return std::visit(
-                overloaded{
-                    [](const Directory & dir) -> const git_oid & { return dir.oid.value(); },
-                    [](const git_oid & oid) -> const git_oid & { return oid; },
-                    [](const std::shared_future<git_oid> & oid) -> const git_oid & { return oid.get(); },
-                },
-                file);
-        }
-    };
-
-    Directory root;
-
-    void addNode(const CanonPath & path, Child && child)
-    {
-        if (path.isRoot())
-            throw Error("cannot create a file at the root of the git repository");
-
-        auto parent = path.parent();
-        assert(parent);
-
-        Directory * cur = &root;
-
-        for (auto & i : *parent) {
-            auto child = std::get_if<Directory>(
-                &cur->children.emplace(std::string(i), Child{GIT_FILEMODE_TREE, {Directory()}}).first->second.file);
-            if (!child)
-                throw Error("parent of '%1%' is not a directory", path.rel());
-            cur = child;
-        }
-
-        std::string name(*path.baseName());
-        auto prev = cur->children.find(name);
-
-        if (prev == cur->children.end()) {
-            cur->children.insert_or_assign(std::move(name), std::move(child));
+        /* Already in slow path. Just write to the stream. */
+        if (stream) {
+            writeToStream(*stream, data);
             return;
         }
 
-        /* Overwriting part of the tree. We'd like to behave somewhat
-           similarly to libarchive without ARCHIVE_EXTRACT_NO_OVERWRITE. */
-        const auto & prevChild = prev->second;
-
-        /* libarchive tries to unlink an entry, which only succeeds on empty
-           trees - so behave the same way. Everything else is fair game. */
-        if (const auto * maybePrevDir = std::get_if<Directory>(&prevChild.file)) {
-            /* "Replacing" directory with a directory is always a-ok. */
-            if (std::holds_alternative<Directory>(child.file))
-                return;
-
-            if (!maybePrevDir->children.empty())
-                throw Error("cannot create '%1%', conflicting non-empty directory", path.rel());
+        contents += data;
+        if (contents.size() > maxBufferSize) {
+            /* Lazily acquire a writer and create the stream. */
+            writer.emplace(getRepo());
+            git_writestream * streamRaw = nullptr;
+            if (git_blob_create_from_stream(&streamRaw, **writer, nullptr))
+                throw GitError("creating blob stream");
+            stream = WriteStream{streamRaw};
+            writeToStream(*stream, contents);
+            contents.clear();
         }
-
-        cur->children.insert_or_assign(std::move(name), std::move(child));
     }
 
-    void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func) override
+    Hash finalize() && override
     {
-        checkInterrupt();
-
-        /* Multithreaded blob writing. We read the incoming file data into memory and asynchronously write it to a Git
-           blob object. However, to avoid unbounded memory usage, if the amount of data in flight exceeds a threshold,
-           we switch to writing directly to a Git write stream. */
-
-        using WriteStream = std::unique_ptr<::git_writestream, decltype([](::git_writestream * stream) {
-                                                if (stream)
-                                                    stream->free(stream);
-                                            })>;
-
-        struct CRF : CreateRegularFileSink
-        {
-            CanonPath path;
-            GitFileSystemObjectSinkImpl & parent;
-            WriteStream stream;
-            std::optional<decltype(parent.repoPool)::Handle> repo;
-
-            std::string contents;
-            bool executable = false;
-
-            CRF(CanonPath path, GitFileSystemObjectSinkImpl & parent)
-                : path(std::move(path))
-                , parent(parent)
-            {
-            }
-
-            ~CRF()
-            {
-                parent.totalBufSize -= contents.size();
-            }
-
-            void operator()(std::string_view data) override
-            {
-                if (!stream) {
-                    contents.append(data);
-                    parent.totalBufSize += data.size();
-
-                    if (parent.totalBufSize > parent.maxBufSize) {
-                        repo.emplace(parent.repoPool.get());
-
-                        if (git_blob_create_from_stream(Setter(stream), **repo, nullptr))
-                            throw GitError("creating a blob stream object");
-
-                        if (stream->write(stream.get(), contents.data(), contents.size()))
-                            throw GitError("writing a blob for tarball member '%s'", path);
-
-                        parent.totalBufSize -= contents.size();
-                        contents.clear();
-                    }
-                } else {
-                    if (stream->write(stream.get(), data.data(), data.size()))
-                        throw GitError("writing a blob for tarball member '%s'", path);
-                }
-            }
-
-            void isExecutable() override
-            {
-                executable = true;
-            }
-        };
-
-        auto crf = std::make_shared<CRF>(path, *this);
-
-        func(*crf);
-
-        if (crf->stream) {
-            /* Finish the slow path by creating the blob object synchronously.
-               Call .release(), since git_blob_create_from_stream_commit
-               acquires ownership and frees the stream. */
-            git_oid oid;
-            if (git_blob_create_from_stream_commit(&oid, crf->stream.release()))
-                throw GitError("creating a blob object for '%s'", path);
-            addNode(crf->path, Child{crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB, oid});
-            return;
-        }
-
-        std::promise<git_oid> promise;
-        addNode(
-            crf->path,
-            Child{
-                crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB,
-                promise.get_future(),
-            });
-
-        /* Fast path: create the blob object in a separate thread.
-           FIXME: Ugly, make ThreadPool use std::move_only_function. */
-        workers.enqueue(
-            [this, crf{std::move(crf)}, promise = make_ref<decltype(promise)>(std::move(promise))]() mutable {
-                auto repo(repoPool.get());
-
-                git_oid oid;
-                if (git_blob_create_from_buffer(&oid, *repo, crf->contents.data(), crf->contents.size()))
-                    throw GitError("creating a blob object for '%s' from in-memory buffer", crf->path);
-
-                /* We don't generally bother with exceptions because those will
-                   be propagated by the thread pool during .process(). */
-                promise->set_value(oid);
-            });
-    }
-
-    void createDirectory(const CanonPath & path) override
-    {
-        if (path.isRoot())
-            return;
-        addNode(path, {GIT_FILEMODE_TREE, Directory()});
-    }
-
-    void createSymlink(const CanonPath & path, const std::string & target) override
-    {
-        /* Symlinks are written to the this repo instance, the mempack backend
-           for which includes the trees. This way we flush both symlinks and
-           trees to the same packfile. Doing this synchronously isn't expensive
-           because symlinks are tiny, so hashing them is cheap. */
         git_oid oid;
-        if (git_blob_create_from_buffer(&oid, *repo, requireCString(target), target.size()))
-            throw GitError("creating a blob object for tarball symlink member '%s'", path);
 
-        addNode(path, Child{GIT_FILEMODE_LINK, oid});
-    }
-
-    std::map<CanonPath, CanonPath> hardLinks;
-
-    void createHardlink(const CanonPath & path, const CanonPath & target) override
-    {
-        hardLinks.insert_or_assign(path, target);
-    }
-
-    Hash flush() override
-    {
-        workers.process();
-
-        /* Create hard links. */
-        {
-            for (auto & [path, target] : hardLinks) {
-                if (target.isRoot())
-                    continue;
-                try {
-                    const auto & child = root.lookup(target);
-                    if (std::holds_alternative<Directory>(child.file))
-                        throw Error("cannot create a hard link to a directory");
-                    addNode(path, {child.mode, child.getOid()});
-                } catch (Error & e) {
-                    e.addTrace(nullptr, "while creating a hard link from '%s' to '%s'", path, target);
-                    throw;
-                }
-            }
+        if (stream) {
+            /* Large file: finalize the stream we created earlier. */
+            assert(writer);
+            /* Call .release(), since git_blob_create_from_stream_commit
+               acquires ownership and frees the stream. */
+            if (git_blob_create_from_stream_commit(&oid, stream.release()))
+                throw GitError("finalizing blob stream");
+            writer.reset();
+        } else {
+            /* Small file: get a repo and create blob from buffer. */
+            auto handle = getRepo();
+            if (git_blob_create_from_buffer(&oid, *handle, contents.data(), contents.size()))
+                throw GitError("creating blob from buffer");
         }
 
-        // Flush all repo objects to disk.
-        {
-            auto repos = repoPool.clear();
-            ThreadPool workers{repos.size()};
-            for (auto & repo : repos)
-                workers.enqueue([repo]() { repo->flush(); });
-            workers.enqueue([repo = repo]() { repo->flush(); });
-            workers.process();
-        }
+        return toHash(oid);
+    }
+};
 
-        if (auto * backend = repo->packBackend)
-            /* We are done writing blobs. Need to refresh to get the objects written by other threads. */
-            packfileOdbRefresh(backend);
+struct GitDirectorySinkImpl : merkle::DirectorySinkWithFinalize
+{
+    TreeBuilder builder;
 
-        // Write the Git trees to disk. Would be nice to have this multithreaded too, but that's hard because a tree
-        // can't refer to an object that hasn't been written yet. Also it doesn't make a big difference for performance.
+    GitDirectorySinkImpl(GitRepoImpl & repo)
+    {
+        if (git_treebuilder_new(Setter(builder), repo, nullptr))
+            throw GitError("creating a tree builder");
+    }
 
-        [&, &repo = *repo](this const auto & visit, Directory & node) -> void {
-            checkInterrupt();
+    void insertChild(std::string_view name, merkle::TreeEntry entry) override
+    {
+        auto oid = hashToOID(entry.hash);
+        if (git_treebuilder_insert(
+                nullptr, builder.get(), std::string(name).c_str(), &oid, static_cast<git_filemode_t>(entry.mode)))
+            throw GitError("adding '%s' to a tree builder", name);
+    }
 
-            // Write the child directories.
-            for (auto & child : node.children)
-                if (auto dir = std::get_if<Directory>(&child.second.file))
-                    /* TODO: Limit recursion depth? */
-                    visit(*dir);
-
-            // Write this directory.
-            git_treebuilder * b;
-            if (git_treebuilder_new(&b, repo, nullptr))
-                throw GitError("creating a tree builder");
-            TreeBuilder builder(b);
-
-            for (const auto & [name, child] : node.children) {
-                const auto & oid = child.getOid();
-                if (git_treebuilder_insert(nullptr, builder.get(), name.c_str(), &oid, child.mode))
-                    throw GitError("adding a file to a tree builder");
-            }
-
-            git_oid oid;
-            if (git_treebuilder_write(&oid, builder.get()))
-                throw GitError("creating a tree object");
-            node.oid = oid;
-        }(root);
-
-        repo->flush();
-
-        if (auto * backend = repo->packBackend)
-            backend->refresh = std::exchange(packfileOdbRefresh, nullptr);
-
-        return toHash(root.oid.value());
+    Hash finalize() && override
+    {
+        git_oid oid;
+        if (git_treebuilder_write(&oid, builder.get()))
+            throw GitError("creating a tree object");
+        return toHash(oid);
     }
 };
 
 } // namespace
+
+std::unique_ptr<merkle::DirectorySinkWithFinalize> GitRepoImpl::makeDirectorySink()
+{
+    return std::make_unique<GitDirectorySinkImpl>(*this);
+}
+
+std::unique_ptr<merkle::RegularFileSinkWithFinalize> GitRepoImpl::makeRegularFileSink()
+{
+    return std::make_unique<GitRegularFileSinkImpl>(
+        [self = ref<GitRepoImpl>(shared_from_this())]() -> GitRepoHandle { return {self}; });
+}
 
 ref<GitSourceAccessor> GitRepoImpl::getRawAccessor(const Hash & rev, const GitAccessorOptions & options)
 {
@@ -1650,9 +1415,211 @@ ref<SourceAccessor> GitRepoImpl::getAccessor(
     return fileAccessor;
 }
 
-ref<GitFileSystemObjectSink> GitRepoImpl::getFileSystemObjectSink()
+/**
+ * A pool of `GitRepoImpl` instances for parallel merkle object writing.
+ *
+ * libgit2 repositories are not thread-safe, so concurrent writes
+ * require separate repository handles. This pool manages those handles.
+ *
+ * When `disablePackRefresh` is true, we monkey-patch the pack backend to
+ * only read the pack directory once. Otherwise it will do a readdir for
+ * each added oid when it's not found and that translates to ~6
+ * syscalls. Since we are never writing pack files until flushing we can
+ * force the odb backend to read the directory just once. It's very
+ * convenient that the vtable is semi-public interface and is up for
+ * grabs.
+ *
+ * This is purely an optimization for when we are writing independent
+ * data concurrently. For example, when we are only writing blobs to the
+ * git repo. Blobs are leaf nodes which cannot reference other objects,
+ * and so there is far less need for synchronisation.
+ *
+ * The first `makeDirectorySink` call flushes all idle pool members to
+ * disk and opens the directory repo handle, which reads the pack
+ * directory as it is created --- so that it sees those packfiles --- and
+ * gets the same treatment, since nothing new will appear while we are
+ * writing the directories.
+ *
+ * This comes up in our use-case of the tarball cache. We write all the
+ * files from the tarball to git, and only then write the directories.
+ * When writing files, libgit2 calls refresh() if the backend provides
+ * it when an oid isn't found. We are only writing objects to a mempack
+ * (it has higher priority) and there isn't a realistic use-case where a
+ * previously missing object would appear from thin air on the disk
+ * (unless another process happens to be unpacking a similar tarball to
+ * the cache at the same time, but that's a very unrealistic scenario).
+ * After we are done writing the files, we write the directories to a
+ * single dedicated repo handle (`singleRepo`).
+ */
+struct GitRepoPoolImpl : GitRepoPool
 {
-    return make_ref<GitFileSystemObjectSinkImpl>(ref<GitRepoImpl>(shared_from_this()));
+    std::filesystem::path path;
+    GitRepo::Options options;
+
+    /**
+     * When true, new pool members have `refresh` disabled on their
+     * pack backend. Cleared once we start writing directories --- not
+     * because refreshing is wanted then, but because the handle we write
+     * them with disables it for itself; see `beginDependentPhase`.
+     */
+    bool disablePackRefresh = true;
+
+    Pool<GitRepoImpl> pool;
+
+    /**
+     * Single repo handle used once we start writing directories. All
+     * sinks share this handle, avoiding per-sink pool overhead and extra
+     * packfile flushes. Only initialized by `beginDependentPhase`.
+     */
+    std::shared_ptr<GitRepoImpl> singleRepo;
+
+    GitRepoHandle getRepo()
+    {
+        if (singleRepo)
+            return {ref<GitRepoImpl>(singleRepo)};
+        return {pool.get()};
+    }
+
+    GitRepoPoolImpl(const std::filesystem::path & path, GitRepo::Options options)
+        : path(path)
+        , options(options)
+        , pool(std::numeric_limits<size_t>::max(), [this]() -> ref<GitRepoImpl> {
+            auto repo = make_ref<GitRepoImpl>(this->path, this->options);
+
+            if (disablePackRefresh)
+                repo->readPackDirOnlyOnce();
+
+            return repo;
+        })
+    {
+    }
+
+    /**
+     * Switch from writing independent objects to writing ones that refer
+     * to them: flush every idle pool member to disk, and open a handle
+     * that can see the packfiles just written.
+     *
+     * Idempotent, and called lazily, so that a caller that only ever
+     * writes blobs never pays for it.
+     *
+     * TODO: it would be nicer to merge the pool's mempacks, and let
+     * libgit2 decide when to spill to disk, rather than forcing a
+     * packfile per pool member just so the trees can refer to the blobs.
+     * libgit2 1.9 offers no way to do that: `sys/mempack.h` has no merge
+     * operation, and a `git_odb_backend` cannot be added to a second odb
+     * (`add_backend_internal` asserts it is unowned, and there is no
+     * refcount, so sharing one would double-free).
+     *
+     * The ordering requirement is avoidable from the other end, though.
+     * `git_treebuilder_write` validates nothing; it is
+     * `git_treebuilder_insert` that checks that each child exists, via
+     * `git_object__is_valid`, which is a no-op when
+     * `GIT_OPT_ENABLE_STRICT_OBJECT_CREATION` is off. Turning that off
+     * would let the trees be written to any handle, so every handle
+     * could just flush once at the end, and this phase would not need to
+     * exist. It is a process-global setting, however, so we would be
+     * giving up that check everywhere.
+     */
+    void beginDependentPhase()
+    {
+        if (singleRepo)
+            return;
+
+        auto repos = pool.clear();
+        ThreadPool workers{repos.size()};
+        for (auto & repo : repos)
+            workers.enqueue([repo]() { repo->flush(); });
+        workers.process();
+
+        /* Opened after the flush, so that it sees those packfiles. */
+        singleRepo = make_ref<GitRepoImpl>(path, options);
+
+        /* It read the pack directory as it was created, so it can see
+           the packfiles we just wrote; nothing more will appear while we
+           write the directories. */
+        singleRepo->readPackDirOnlyOnce();
+
+        disablePackRefresh = false;
+    }
+
+    void flush() override
+    {
+        /* Also handles the case where no directory was ever created. */
+        beginDependentPhase();
+
+        // Flush the directory repo's mempack to disk.
+        singleRepo->flush();
+        singleRepo.reset();
+        disablePackRefresh = true;
+    }
+
+    std::unique_ptr<merkle::DirectorySinkWithFinalize> makeDirectorySink() override
+    {
+        beginDependentPhase();
+        return singleRepo->makeDirectorySink();
+    }
+
+    std::unique_ptr<merkle::RegularFileSinkWithFinalize> makeRegularFileSink() override
+    {
+        if (singleRepo)
+            return singleRepo->makeRegularFileSink();
+        return std::make_unique<GitRegularFileSinkImpl>([this]() { return getRepo(); });
+    }
+
+    merkle::TreeEntry makeSymlink(const std::string & target) override
+    {
+        auto handle = getRepo();
+        git_oid oid;
+        if (git_blob_create_from_buffer(&oid, *handle, target.data(), target.size()))
+            throw GitError("creating a blob object for symlink");
+        return merkle::TreeEntry{.mode = merkle::Mode::Symlink, .hash = toHash(oid)};
+    }
+
+    uint64_t getRevCount(const Hash & rev) override
+    {
+        boost::concurrent_flat_set<git_oid, std::hash<git_oid>> done;
+
+        auto startRepo = pool.get();
+        auto startCommit = peelObject<Commit>(lookupObject(*startRepo, hashToOID(rev)).get(), GIT_OBJECT_COMMIT);
+        auto startOid = *git_commit_id(startCommit.get());
+        done.insert(startOid);
+
+        ThreadPool threadPool;
+
+        auto process = [&done, &threadPool, &pool = pool](this const auto & process, const git_oid & oid) -> void {
+            auto repo(pool.get());
+
+            auto _commit = lookupObject(*repo, oid, GIT_OBJECT_COMMIT);
+            auto commit = (const git_commit *) &*_commit;
+
+            for (auto n : std::views::iota(0U, git_commit_parentcount(commit))) {
+                auto parentOid = git_commit_parent_id(commit, n);
+                if (!parentOid) {
+                    throw Error(
+                        "Failed to retrieve the parent of Git commit '%s': %s. "
+                        "This may be due to an incomplete repository history. "
+                        "To resolve this, either enable the shallow parameter in your flake URL (?shallow=1) "
+                        "or add set the shallow parameter to true in builtins.fetchGit, "
+                        "or fetch the complete history for this branch.",
+                        *git_commit_id(commit),
+                        git_error_last()->message);
+                }
+                if (done.insert(*parentOid))
+                    threadPool.enqueue(std::bind(process, *parentOid));
+            }
+        };
+
+        threadPool.enqueue(std::bind(process, startOid));
+
+        threadPool.process();
+
+        return done.size();
+    }
+};
+
+ref<GitRepoPool> GitRepoPool::create(const std::filesystem::path & path, GitRepo::Options options)
+{
+    return make_ref<GitRepoPoolImpl>(path, options);
 }
 
 std::vector<std::tuple<GitRepoImpl::Submodule, Hash>> GitRepoImpl::getSubmodules(const Hash & rev, bool exportIgnore)
@@ -1693,14 +1660,26 @@ std::vector<std::tuple<GitRepoImpl::Submodule, Hash>> GitRepoImpl::getSubmodules
 
 namespace fetchers {
 
-ref<GitRepo> Settings::getTarballCache() const
+static std::filesystem::path tarballCacheDir()
 {
     /* v1: Had either only loose objects or thin packfiles referring to loose objects
      * v2: Must have only packfiles with no loose objects. Should get repacked periodically
      * for optimal packfiles.
      */
     static auto repoDir = std::filesystem::path(getCacheDir()) / "tarball-cache-v2";
-    return GitRepo::openRepo(repoDir, {.create = true, .bare = true, .packfilesOnly = true});
+    return repoDir;
+}
+
+static constexpr GitRepo::Options tarballCacheOptions{.create = true, .bare = true, .packfilesOnly = true};
+
+ref<GitRepo> Settings::getTarballCache() const
+{
+    return GitRepo::openRepo(tarballCacheDir(), tarballCacheOptions);
+}
+
+ref<GitRepoPool> Settings::getTarballWriterPool() const
+{
+    return GitRepoPool::create(tarballCacheDir(), tarballCacheOptions);
 }
 
 } // namespace fetchers

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -10,6 +10,7 @@
 #include "nix/util/users.hh"
 #include "nix/util/fs-sink.hh"
 #include "nix/util/sync.hh"
+#include "nix/util/strings.hh"
 #include "nix/util/util.hh"
 #include "nix/util/thread-pool.hh"
 #include "nix/util/pool.hh"
@@ -543,7 +544,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
     void setRemote(const std::string & name, const std::string & url) override
     {
-        if (git_remote_set_url(*this, name.c_str(), url.c_str()))
+        if (git_remote_set_url(*this, requireCString(name), requireCString(url)))
             throw GitError("setting remote '%s' URL to '%s'", name, url);
     }
 
@@ -556,7 +557,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         // This is to handle the case where it may be an annotated tag which itself has
         // an object_id.
         std::string peeledRef = ref + "^{commit}";
-        if (git_revparse_single(Setter(object), *this, peeledRef.c_str()))
+        if (git_revparse_single(Setter(object), *this, requireCString(peeledRef)))
             throw GitError("resolving Git reference '%s'", ref);
         auto oid = git_object_id(object.get());
         return toHash(*oid);
@@ -683,7 +684,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
     std::string resolveSubmoduleUrl(const std::string & url) override
     {
         git_buf buf = GIT_BUF_INIT;
-        if (git_submodule_resolve_url(&buf, *this, url.c_str()))
+        if (git_submodule_resolve_url(&buf, *this, requireCString(url)))
             throw Error("resolving Git submodule URL '%s'", url);
         Finally cleanup = [&]() { git_buf_dispose(&buf); };
 
@@ -1353,7 +1354,11 @@ struct GitDirectorySinkImpl : merkle::DirectorySinkWithFinalize
     {
         auto oid = hashToOID(entry.hash);
         if (git_treebuilder_insert(
-                nullptr, builder.get(), std::string(name).c_str(), &oid, static_cast<git_filemode_t>(entry.mode)))
+                nullptr,
+                builder.get(),
+                requireCString(std::string(name)),
+                &oid,
+                static_cast<git_filemode_t>(entry.mode)))
             throw GitError("adding '%s' to a tree builder", name);
     }
 
@@ -1570,7 +1575,7 @@ struct GitRepoPoolImpl : GitRepoPool
     {
         auto handle = getRepo();
         git_oid oid;
-        if (git_blob_create_from_buffer(&oid, *handle, target.data(), target.size()))
+        if (git_blob_create_from_buffer(&oid, *handle, requireCString(target), target.size()))
             throw GitError("creating a blob object for symlink");
         return merkle::TreeEntry{.mode = merkle::Mode::Symlink, .hash = toHash(oid)};
     }

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -738,7 +738,7 @@ struct GitInputScheme : InputScheme
         Activity act(
             *logger, lvlChatty, actUnknown, fmt("getting Git revision count of '%s'", repoInfo.locationToArg()));
 
-        auto revCount = GitRepo::openRepo(repoDir, {})->getRevCount(rev);
+        auto revCount = GitRepoPool::create(repoDir, {})->getRevCount(rev);
 
         cache->upsert(key, Attrs{{"revCount", revCount}});
 

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -742,7 +742,7 @@ struct GitInputScheme : InputScheme
         Activity act(
             *logger, lvlChatty, actUnknown, fmt("getting Git revision count of '%s'", repoInfo.locationToArg()));
 
-        auto revCount = GitRepo::openRepo(repoDir, {})->getRevCount(rev);
+        auto revCount = GitRepoPool::create(repoDir, {})->getRevCount(rev);
 
         cache->upsert(key, Attrs{{"revCount", revCount}});
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -10,6 +10,7 @@
 #include "nix/fetchers/tarball.hh"
 #include "nix/util/tarfile.hh"
 #include "nix/fetchers/git-utils.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
 
 #include <optional>
 #include <nlohmann/json.hpp>
@@ -309,14 +310,15 @@ struct GitArchiveInputScheme : InputScheme
 
         TarArchive archive{*source};
         auto tarballCache = settings.getTarballCache();
-        auto parseSink = tarballCache->getFileSystemObjectSink();
+        auto writerPool = settings.getTarballWriterPool();
+        auto parseSink = merkle::makeTarSink(*writerPool);
         auto lastModified = unpackTarfileToSink(archive, *parseSink);
         auto tree = parseSink->flush();
 
         act.reset();
 
         TarballInfo tarballInfo{
-            .treeHash = tarballCache->dereferenceSingletonDirectory(tree), .lastModified = lastModified};
+            .treeHash = tarballCache->dereferenceSingletonDirectory(tree.hash), .lastModified = lastModified};
 
         cache->upsert(treeHashKey, Attrs{{"treeHash", tarballInfo.treeHash.gitRev()}});
         cache->upsert(lastModifiedKey, Attrs{{"lastModified", (uint64_t) tarballInfo.lastModified}});

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -9,6 +9,7 @@
 #include "nix/fetchers/tarball.hh"
 #include "nix/util/tarfile.hh"
 #include "nix/fetchers/git-utils.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
 
 #include <optional>
 #include <nlohmann/json.hpp>
@@ -306,14 +307,15 @@ struct GitArchiveInputScheme : InputScheme
 
         TarArchive archive{*source};
         auto tarballCache = settings.getTarballCache();
-        auto parseSink = tarballCache->getFileSystemObjectSink();
+        auto writerPool = settings.getTarballWriterPool();
+        auto parseSink = merkle::makeTarSink(*writerPool);
         auto lastModified = unpackTarfileToSink(archive, *parseSink);
         auto tree = parseSink->flush();
 
         act.reset();
 
         TarballInfo tarballInfo{
-            .treeHash = tarballCache->dereferenceSingletonDirectory(tree), .lastModified = lastModified};
+            .treeHash = tarballCache->dereferenceSingletonDirectory(tree.hash), .lastModified = lastModified};
 
         cache->upsert(treeHashKey, Attrs{{"treeHash", tarballInfo.treeHash.gitRev()}});
         cache->upsert(lastModifiedKey, Attrs{{"lastModified", (uint64_t) tarballInfo.lastModified}});

--- a/src/libfetchers/include/nix/fetchers/fetch-settings.hh
+++ b/src/libfetchers/include/nix/fetchers/fetch-settings.hh
@@ -14,8 +14,9 @@
 namespace nix {
 
 struct GitRepo;
+struct GitRepoPool;
 
-}
+} // namespace nix
 
 namespace nix::fetchers {
 
@@ -151,6 +152,8 @@ struct Settings : public Config
     ref<Cache> getCache() const;
 
     ref<GitRepo> getTarballCache() const;
+
+    ref<GitRepoPool> getTarballWriterPool() const;
 
 private:
     mutable Sync<std::shared_ptr<Cache>> _cache;

--- a/src/libfetchers/include/nix/fetchers/fetch-settings.hh
+++ b/src/libfetchers/include/nix/fetchers/fetch-settings.hh
@@ -15,6 +15,7 @@ namespace nix {
 
 struct GitRepo;
 struct SrcToStore;
+struct GitRepoPool;
 
 } // namespace nix
 
@@ -161,6 +162,7 @@ struct Settings : public Config
 
     const ref<SrcToStore> srcToStore = createSrcToStore();
 
+    ref<GitRepoPool> getTarballWriterPool() const;
 
 private:
     void anchor() override;

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "nix/fetchers/filtering-source-accessor.hh"
-#include "nix/util/fs-sink.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
 
 namespace nix {
 
@@ -9,18 +9,6 @@ namespace fetchers {
 struct PublicKey;
 struct Settings;
 } // namespace fetchers
-
-/**
- * A sink that writes into a Git repository. Note that nothing may be written
- * until `flush()` is called.
- */
-struct GitFileSystemObjectSink : ExtendedFileSystemObjectSink
-{
-    /**
-     * Flush builder and return a final Git hash.
-     */
-    virtual Hash flush() = 0;
-};
 
 struct GitAccessorOptions
 {
@@ -30,7 +18,7 @@ struct GitAccessorOptions
 
 struct GitRepo
 {
-    virtual ~GitRepo() {}
+    virtual ~GitRepo() = default;
 
     struct Options
     {
@@ -40,8 +28,6 @@ struct GitRepo
     };
 
     static ref<GitRepo> openRepo(const std::filesystem::path & path, Options options);
-
-    virtual uint64_t getRevCount(const Hash & rev) = 0;
 
     virtual uint64_t getLastModified(const Hash & rev) = 0;
 
@@ -107,8 +93,6 @@ struct GitRepo
     virtual ref<SourceAccessor> getAccessor(
         const WorkdirInfo & wd, const GitAccessorOptions & options, MakeNotAllowedError makeNotAllowedError) = 0;
 
-    virtual ref<GitFileSystemObjectSink> getFileSystemObjectSink() = 0;
-
     virtual void flush() = 0;
 
     virtual void fetch(const std::string & url, const std::string & refspec, bool shallow) = 0;
@@ -131,6 +115,15 @@ struct GitRepo
      * Otherwise, return the passed ID unchanged.
      */
     virtual Hash dereferenceSingletonDirectory(const Hash & oid) = 0;
+};
+
+struct GitRepoPool : merkle::FileSinkBuilder
+{
+    virtual ~GitRepoPool() = default;
+
+    static ref<GitRepoPool> create(const std::filesystem::path & path, GitRepo::Options options);
+
+    virtual uint64_t getRevCount(const Hash & rev) = 0;
 };
 
 // A helper to ensure that the `git_*_free` functions get called.

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "nix/fetchers/filtering-source-accessor.hh"
-#include "nix/util/fs-sink.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
 
 namespace nix {
 
@@ -9,22 +9,6 @@ namespace fetchers {
 struct PublicKey;
 struct Settings;
 } // namespace fetchers
-
-/**
- * A sink that writes into a Git repository. Note that nothing may be written
- * until `flush()` is called.
- */
-struct GitFileSystemObjectSink : ExtendedFileSystemObjectSink
-{
-private:
-    void anchor() override;
-
-public:
-    /**
-     * Flush builder and return a final Git hash.
-     */
-    virtual Hash flush() = 0;
-};
 
 struct GitAccessorOptions
 {
@@ -34,7 +18,7 @@ struct GitAccessorOptions
 
 struct GitRepo
 {
-    virtual ~GitRepo() {}
+    virtual ~GitRepo() = default;
 
     struct Options
     {
@@ -44,8 +28,6 @@ struct GitRepo
     };
 
     static ref<GitRepo> openRepo(const std::filesystem::path & path, Options options);
-
-    virtual uint64_t getRevCount(const Hash & rev) = 0;
 
     virtual uint64_t getLastModified(const Hash & rev) = 0;
 
@@ -114,9 +96,10 @@ struct GitRepo
     virtual ref<SourceAccessor> getAccessor(
         const WorkdirInfo & wd, const GitAccessorOptions & options, MakeNotAllowedError makeNotAllowedError) = 0;
 
-    virtual ref<GitFileSystemObjectSink> getFileSystemObjectSink() = 0;
-
     virtual void flush() = 0;
+
+    virtual std::unique_ptr<merkle::DirectorySinkWithFinalize> makeDirectorySink() = 0;
+    virtual std::unique_ptr<merkle::RegularFileSinkWithFinalize> makeRegularFileSink() = 0;
 
     virtual void fetch(const std::string & url, const std::string & refspec, bool shallow) = 0;
 
@@ -138,6 +121,15 @@ struct GitRepo
      * Otherwise, return the passed ID unchanged.
      */
     virtual Hash dereferenceSingletonDirectory(const Hash & oid) = 0;
+};
+
+struct GitRepoPool : merkle::FileSinkBuilder
+{
+    virtual ~GitRepoPool() = default;
+
+    static ref<GitRepoPool> create(const std::filesystem::path & path, GitRepo::Options options);
+
+    virtual uint64_t getRevCount(const Hash & rev) = 0;
 };
 
 // A helper to ensure that we don't leak objects returned by libgit2.

--- a/src/libfetchers/include/nix/fetchers/merkle-tar-adapter.hh
+++ b/src/libfetchers/include/nix/fetchers/merkle-tar-adapter.hh
@@ -1,0 +1,77 @@
+#pragma once
+///@file
+
+#include "nix/util/merkle-files.hh"
+#include "nix/util/ref.hh"
+#include "nix/util/tarfile.hh"
+
+namespace nix::merkle {
+
+/**
+ * A merkle regular file sink that can be flushed to get the content hash.
+ */
+struct RegularFileSinkWithFlush : virtual Sink
+{
+    /**
+     * Flush and return the hash of the blob.
+     */
+    virtual Hash flush() && = 0;
+};
+
+/**
+ * A merkle directory sink that can be flushed to get the tree hash.
+ */
+struct DirectorySinkWithFlush : merkle::DirectorySink
+{
+    /**
+     * Flush the directory and return its tree hash.
+     */
+    virtual Hash flush() && = 0;
+};
+
+/**
+ * Interface for creating merkle file system object sinks.
+ *
+ * By returning sinks rather than taking callbacks, we allow starting
+ * and finishing sink-based creation in an asynchronous manner. This is
+ * crucial to being able to adapt messy providers of file system object
+ * data (like tarballs) to this interface.
+ */
+struct FileSinkBuilder
+{
+    virtual ~FileSinkBuilder() = default;
+
+    virtual ref<DirectorySinkWithFlush> makeDirectorySink() = 0;
+    virtual ref<RegularFileSinkWithFlush> makeRegularFileSink() = 0;
+    virtual merkle::TreeEntry makeSymlink(const std::string & target) = 0;
+
+    /**
+     * Flush all pending writes to persistent storage, and set whether
+     * subsequently created sinks may reference objects produced by
+     * previously created (and completed) sinks.
+     *
+     * When @p allow is false, the builder may apply optimizations
+     * that assume sinks are write-independent.
+     *
+     * When @p allow is true, those optimizations are disabled so that
+     * new sinks can look up objects written by earlier ones.
+     */
+    virtual void flushAndSetAllowDependentCreation(bool allow) = 0;
+};
+
+/**
+ * Adapter that implements TarSink by building a merkle tree.
+ */
+struct TarAdapter : TarSink
+{
+    virtual merkle::TreeEntry flush() = 0;
+};
+
+/**
+ * Create a TarSink that builds a merkle tree from path-based tar entries.
+ *
+ * @param store Factory for creating merkle sinks
+ */
+ref<TarAdapter> makeTarSink(FileSinkBuilder & store);
+
+} // namespace nix::merkle

--- a/src/libfetchers/include/nix/fetchers/merkle-tar-adapter.hh
+++ b/src/libfetchers/include/nix/fetchers/merkle-tar-adapter.hh
@@ -1,0 +1,88 @@
+#pragma once
+///@file
+
+#include "nix/util/merkle-files.hh"
+#include "nix/util/ref.hh"
+#include "nix/util/tarfile.hh"
+
+#include <memory>
+
+namespace nix::merkle {
+
+/**
+ * A merkle regular file sink that can be finalized to get the content hash.
+ */
+struct RegularFileSinkWithFinalize : virtual Sink
+{
+    /**
+     * Finish the file, and return the hash of the blob.
+     */
+    virtual Hash finalize() && = 0;
+};
+
+/**
+ * A merkle directory sink that can be finalized to get the tree hash.
+ */
+struct DirectorySinkWithFinalize : merkle::DirectorySink
+{
+    /**
+     * Finish the directory, and return its tree hash.
+     */
+    virtual Hash finalize() && = 0;
+};
+
+/**
+ * Interface for creating merkle file system object sinks.
+ *
+ * By returning sinks rather than taking callbacks, we allow starting
+ * and finishing sink-based creation in an asynchronous manner. This is
+ * crucial to being able to adapt messy providers of file system object
+ * data (like tarballs) to this interface.
+ *
+ * A directory can only refer to objects that are already written, so
+ * every sink for a directory's children must be finalized before it is
+ * created. Implementations are responsible for whatever that ordering
+ * requires of them --- see @ref nix::merkle::FileSinkBuilder::makeDirectorySink.
+ */
+struct FileSinkBuilder
+{
+    virtual ~FileSinkBuilder() = default;
+
+    /**
+     * Create a sink for one directory.
+     *
+     * Every sink handed out before this call must have been finalized:
+     * an implementation is free to assume that, and to do whatever work
+     * making earlier objects referenceable requires.
+     */
+    virtual std::unique_ptr<DirectorySinkWithFinalize> makeDirectorySink() = 0;
+
+    virtual std::unique_ptr<RegularFileSinkWithFinalize> makeRegularFileSink() = 0;
+
+    virtual merkle::TreeEntry makeSymlink(const std::string & target) = 0;
+
+    /**
+     * Finish any writes that are still in progress.
+     *
+     * Until this is called, objects written through this builder are not
+     * necessarily available to anything else that reads the same store.
+     */
+    virtual void flush() = 0;
+};
+
+/**
+ * Adapter that implements TarSink by building a merkle tree.
+ */
+struct TarAdapter : TarSink
+{
+    virtual merkle::TreeEntry flush() = 0;
+};
+
+/**
+ * Create a TarSink that builds a merkle tree from path-based tar entries.
+ *
+ * @param store Factory for creating merkle sinks
+ */
+ref<TarAdapter> makeTarSink(FileSinkBuilder & store);
+
+} // namespace nix::merkle

--- a/src/libfetchers/include/nix/fetchers/meson.build
+++ b/src/libfetchers/include/nix/fetchers/meson.build
@@ -10,6 +10,7 @@ headers = files(
   'git-lfs-fetch.hh',
   'git-utils.hh',
   'input-cache.hh',
+  'merkle-tar-adapter.hh',
   'registry.hh',
   'tarball.hh',
 )

--- a/src/libfetchers/merkle-tar-adapter.cc
+++ b/src/libfetchers/merkle-tar-adapter.cc
@@ -1,0 +1,259 @@
+#include "nix/fetchers/merkle-tar-adapter.hh"
+#include "nix/util/sync.hh"
+#include "nix/util/thread-pool.hh"
+#include "nix/util/util.hh"
+
+#include <map>
+#include <optional>
+#include <set>
+#include <variant>
+
+namespace nix {
+
+/**
+ * Entry types in the flat path map.
+ */
+
+/**
+ * A file whose content is still being written to a sink.
+ * Will be flushed in Phase 1 and converted to CompletedFile.
+ */
+struct PendingFile
+{
+    ref<merkle::RegularFileSinkWithFlush> sink;
+    merkle::Mode mode;
+};
+
+/**
+ * A file or symlink that has been flushed and has a hash.
+ *
+ * @note Symlinks are not asynchronously sunk to the store, but always written
+ * in one go, because they are presumed to be short.
+ */
+struct CompletedFile
+{
+    Hash hash;
+    merkle::Mode mode;
+};
+
+/**
+ * Hardlinks store the target path and are resolved during flush.
+ */
+struct PendingHardlink
+{
+    CanonPath target;
+};
+
+/**
+ * Marks a directory entry. Content determined by children.
+ */
+struct DirectoryMarker
+{};
+
+using Entry = std::variant<PendingFile, CompletedFile, PendingHardlink, DirectoryMarker>;
+
+/**
+ * Simple tar adapter using a flat path map.
+ *
+ * 1. During tar parsing, builds a flat map of CanonPath -> Entry
+ * 2. At flush time:
+ *    a. Flush all file sinks in parallel
+ *    b. Build directories using processGraph (children before parents)
+ */
+struct TarAdapterImpl : merkle::TarAdapter
+{
+    merkle::FileSinkBuilder & store;
+
+    /**
+     * Flat map from path to entry.
+     * Includes explicit files, symlinks, and directories.
+     * Parent directories are created implicitly when adding children.
+     */
+    std::map<CanonPath, Entry> entries;
+
+    TarAdapterImpl(merkle::FileSinkBuilder & store)
+        : store(store)
+    {
+    }
+
+    /**
+     * Ensure all ancestor directories exist in the map.
+     * Throws if an ancestor already exists as a non-directory.
+     */
+    void ensureParentDirs(const CanonPath & path)
+    {
+        for (auto ancestor = path.parent(); ancestor; ancestor = ancestor->parent()) {
+            auto [it, inserted] = entries.try_emplace(*ancestor, DirectoryMarker{});
+            if (!inserted && !std::holds_alternative<DirectoryMarker>(it->second)) {
+                throw Error("cannot create '%s': ancestor '%s' is not a directory", path, *ancestor);
+            }
+        }
+        // Ensure root is a directory if we have any non-root paths
+        if (!path.isRoot()) {
+            auto [it, inserted] = entries.try_emplace(CanonPath::root, DirectoryMarker{});
+            if (!inserted && !std::holds_alternative<DirectoryMarker>(it->second)) {
+                throw Error("cannot create '%s': root is not a directory", path);
+            }
+        }
+    }
+
+    void createDirectory(const CanonPath & path) override
+    {
+        ensureParentDirs(path);
+        entries.insert_or_assign(path, DirectoryMarker{});
+    }
+
+    void createRegularFile(const CanonPath & path, bool isExecutable, fun<void(Sink &)> callback) override
+    {
+        auto sink = store.makeRegularFileSink();
+        callback(*sink);
+
+        auto mode = isExecutable ? merkle::Mode::Executable : merkle::Mode::Regular;
+        ensureParentDirs(path);
+        entries.insert_or_assign(path, PendingFile{sink, mode});
+    }
+
+    void createSymlink(const CanonPath & path, const std::string & target) override
+    {
+        auto entry = store.makeSymlink(target);
+        ensureParentDirs(path);
+        entries.insert_or_assign(path, CompletedFile{entry.hash, entry.mode});
+    }
+
+    void createHardlink(const CanonPath & path, const CanonPath & target) override
+    {
+        ensureParentDirs(path);
+        entries.insert_or_assign(path, PendingHardlink{target});
+    }
+
+    merkle::TreeEntry flush() override
+    {
+        if (entries.empty())
+            throw Error("tar archive is empty");
+
+        // Phase 1: Flush all PendingFile sinks in parallel, collect hardlink paths
+        std::set<CanonPath> pendingHardlinks;
+        {
+            ThreadPool pool;
+            for (auto & [path, entry] : entries) {
+                if (std::holds_alternative<PendingFile>(entry)) {
+                    pool.enqueue([&entry]() {
+                        auto & file = std::get<PendingFile>(entry);
+                        Hash hash = std::move(*file.sink).flush();
+                        entry = CompletedFile{hash, file.mode};
+                    });
+                } else if (std::holds_alternative<PendingHardlink>(entry)) {
+                    pendingHardlinks.insert(path);
+                }
+            }
+            pool.process();
+        }
+
+        // Phase 2: Resolve hardlinks, loop until all resolved (handles chains)
+        while (!pendingHardlinks.empty()) {
+            std::set<CanonPath> stillPending;
+            for (auto & path : pendingHardlinks) {
+                auto & entry = entries.at(path);
+                auto * linkP = std::get_if<PendingHardlink>(&entry);
+                assert(linkP);
+                auto & link = *linkP;
+                auto targetIt = entries.find(link.target);
+                if (targetIt == entries.end()) {
+                    throw Error("hardlink target '%s' not found", link.target);
+                }
+                std::visit(
+                    overloaded{
+                        [&](CompletedFile & file) { entry = file; },
+                        [&](PendingFile &) { assert(false); },
+                        [&](PendingHardlink &) { stillPending.insert(path); },
+                        [&](DirectoryMarker &) { throw Error("hardlink target '%s' is a directory", link.target); },
+                    },
+                    targetIt->second);
+            }
+            if (stillPending.size() == pendingHardlinks.size()) {
+                throw Error("hardlink cycle detected");
+            }
+            pendingHardlinks = std::move(stillPending);
+        }
+
+        // Persist all blob/symlink writes and enable cross-sink
+        // visibility so that directory sinks created below can
+        // reference objects written during Phase 1.
+        store.flushAndSetAllowDependentCreation(true);
+
+        // Special case: single non-directory entry at root
+        if (entries.size() == 1) {
+            auto & [path, entry] = *entries.begin();
+            if (auto * file = std::get_if<CompletedFile>(&entry)) {
+                return {file->mode, file->hash};
+            }
+            // Must be an empty directory
+            auto dirSink = store.makeDirectorySink();
+            return {merkle::Mode::Directory, std::move(*dirSink).flush()};
+        }
+
+        // Phase 3: Build directories with processGraph (children before parents)
+        // Build maps for efficient child lookup
+        std::set<CanonPath> dirPaths;
+        std::map<CanonPath, std::set<CanonPath>> childDirs;
+        std::map<CanonPath, std::vector<std::pair<CanonPath, Entry *>>> children;
+
+        for (auto & [path, entry] : entries) {
+            auto parent = path.parent();
+            CanonPath parentPath = parent ? CanonPath(*parent) : CanonPath::root;
+            if (path != CanonPath::root)
+                children[parentPath].emplace_back(path, &entry);
+
+            if (std::holds_alternative<DirectoryMarker>(entry)) {
+                dirPaths.insert(path);
+                if (path != CanonPath::root)
+                    childDirs[parentPath].insert(path);
+            }
+        }
+
+        Sync<std::map<CanonPath, Hash>> dirHashes;
+
+        processGraph<CanonPath>(
+            dirPaths,
+            [&](const CanonPath & path) -> const std::set<CanonPath> & {
+                static const std::set<CanonPath> empty;
+                auto it = childDirs.find(path);
+                return it != childDirs.end() ? it->second : empty;
+            },
+            [&](const CanonPath & path) {
+                auto dirSink = store.makeDirectorySink();
+
+                auto it = children.find(path);
+                if (it != children.end()) {
+                    for (auto & [childPath, childEntry] : it->second) {
+                        auto name = std::string(childPath.baseName().value());
+
+                        if (auto * file = std::get_if<CompletedFile>(childEntry)) {
+                            dirSink->insertChild(name, {file->mode, file->hash});
+                        } else if (std::holds_alternative<DirectoryMarker>(*childEntry)) {
+                            auto lockedHashes = dirHashes.lock();
+                            dirSink->insertChild(name, {merkle::Mode::Directory, lockedHashes->at(childPath)});
+                        }
+                    }
+                }
+
+                Hash hash = std::move(*dirSink).flush();
+                dirHashes.lock()->emplace(path, hash);
+            });
+
+        store.flushAndSetAllowDependentCreation(false);
+
+        return {merkle::Mode::Directory, dirHashes.lock()->at(CanonPath::root)};
+    }
+};
+
+} // namespace nix
+
+namespace nix::merkle {
+
+ref<TarAdapter> makeTarSink(FileSinkBuilder & store)
+{
+    return make_ref<nix::TarAdapterImpl>(store);
+}
+
+} // namespace nix::merkle

--- a/src/libfetchers/merkle-tar-adapter.cc
+++ b/src/libfetchers/merkle-tar-adapter.cc
@@ -1,0 +1,344 @@
+#include "nix/fetchers/merkle-tar-adapter.hh"
+#include "nix/util/chunked-vector.hh"
+#include "nix/util/thread-pool.hh"
+#include "nix/util/strings.hh"
+#include "nix/util/util.hh"
+
+#include <cassert>
+#include <map>
+#include <optional>
+#include <memory>
+#include <set>
+#include <utility>
+#include <thread>
+#include <variant>
+
+/**
+ * Implementation of `nix::merkle::makeTarSink`.
+ *
+ * A namespace of its own because the names within are generic: internal
+ * linkage alone would not keep them from colliding in a unity build.
+ */
+namespace nix::merkle::tar {
+
+/**
+ * Still want internal linkage too, though.
+ */
+namespace {
+
+struct Directory;
+
+/**
+ * A regular file.
+ *
+ * The hash lives in a slot of its own rather than in the tree, because a
+ * file is written while the rest of the archive is still being parsed,
+ * and that parsing may overwrite this entry in the meantime. Overwriting
+ * then just drops the pointer: the write finishes into a slot that nobody
+ * reads. It also means a hard link can share the slot rather than copy
+ * the hash out of it.
+ */
+struct File
+{
+    /**
+     * Empty until whatever is writing the file has finished.
+     */
+    std::optional<Hash> * hash;
+
+    bool executable;
+
+    merkle::Mode mode() const
+    {
+        return executable ? merkle::Mode::Executable : merkle::Mode::Regular;
+    }
+};
+
+/**
+ * A symlink.
+ *
+ * Unlike a regular file, it is not sunk to the store asynchronously but
+ * written in one go, because it is presumed to be short --- so it has its
+ * hash from the start, and needs no slot.
+ */
+struct Symlink
+{
+    Hash hash;
+
+    merkle::Mode mode() const
+    {
+        return merkle::Mode::Symlink;
+    }
+};
+
+/**
+ * An entry in a directory: another directory, a file, or a symlink. A
+ * hard link is resolved when it is created, and so is just another one of
+ * whatever it was made from.
+ */
+using Child = std::variant<Directory, File, Symlink>;
+
+/**
+ * A directory, to be written once all of its children are known.
+ */
+struct Directory
+{
+    std::map<std::string, Child, std::less<>> children;
+
+    merkle::Mode mode() const
+    {
+        return merkle::Mode::Directory;
+    }
+};
+
+/**
+ * Adapter that builds a merkle tree from the flat, path-addressed
+ * entries of a tar archive.
+ *
+ * 1. During tar parsing, build a tree of `Directory`, creating parents
+ *    as needed and applying the overwrite semantics of `addNode`. Each
+ *    file is handed to the store as soon as it has been parsed.
+ * 2. At flush time:
+ *    a. Wait for those writes to finish
+ *    b. Resolve hard links
+ *    c. Write the directories bottom-up (children before parents)
+ */
+struct TarAdapterImpl : merkle::TarAdapter
+{
+    merkle::FileSinkBuilder & store;
+
+    /**
+     * The root of the tree. Not necessarily a directory: a tar archive
+     * may contain a single file (or symlink) and nothing else.
+     */
+    Child root = Directory{};
+
+    /**
+     * Groups of paths that name the same file, because hard links were
+     * made between them. Every path in a group maps to the whole group,
+     * so that replacing one of them can say what else it was linked to.
+     */
+    std::map<CanonPath, std::shared_ptr<std::set<CanonPath>>> hardLinked;
+
+    /**
+     * The hash of each file being written, filled in by the writer.
+     *
+     * Chunked so that the pointers we hand out stay put as more files
+     * are added.
+     */
+    static constexpr size_t chunkSize = 1024;
+    ChunkedVector<std::optional<Hash>, chunkSize, std::numeric_limits<uint32_t>::max() / chunkSize> results;
+
+    /**
+     * Writes the files as they are parsed, so that hashing them overlaps
+     * with parsing the rest of the archive.
+     *
+     * Bounded, because each worker occupies a separate writer in the
+     * store, which is not necessarily free to have around.
+     *
+     * Declared last, so that the workers are joined before anything they
+     * write into is destroyed.
+     */
+    ThreadPool workers{std::min(std::thread::hardware_concurrency(), 10U)};
+
+    TarAdapterImpl(merkle::FileSinkBuilder & store)
+        : store(store)
+    {
+    }
+
+    /**
+     * The entry at `path`, or null if there is none --- including when
+     * something along the way is not a directory.
+     */
+    Child * lookup(const CanonPath & path)
+    {
+        auto * cur = &root;
+        for (auto & name : path) {
+            auto * dir = std::get_if<Directory>(cur);
+            if (!dir)
+                return nullptr;
+            auto i = dir->children.find(name);
+            if (i == dir->children.end())
+                return nullptr;
+            cur = &i->second;
+        }
+        return cur;
+    }
+
+    /**
+     * Insert an entry, creating parent directories as needed, and
+     * applying tarball unpacking overwrite semantics.
+     *
+     * We behave like libarchive without `ARCHIVE_EXTRACT_NO_OVERWRITE`:
+     * the last entry wins. The exception is a non-empty directory:
+     * libarchive just tries to `unlink()` whatever is in the way, which
+     * only succeeds for an empty directory, so replacing a non-empty one
+     * is an error.
+     */
+    void addNode(const CanonPath & path, Child && child)
+    {
+        auto * cur = &root;
+
+        if (auto parent = path.parent()) {
+            for (auto & name : *parent) {
+                auto * dir = std::get_if<Directory>(cur);
+                if (!dir)
+                    throw Error("parent of '%s' is not a directory", path);
+                cur = &dir->children.emplace(std::string(name), Directory{}).first->second;
+            }
+
+            auto * dir = std::get_if<Directory>(cur);
+            if (!dir)
+                throw Error("parent of '%s' is not a directory", path);
+
+            std::string name(*path.baseName());
+            auto i = dir->children.find(name);
+            if (i == dir->children.end()) {
+                dir->children.emplace(std::move(name), std::move(child));
+                return;
+            }
+            cur = &i->second;
+        }
+
+        /* Overwriting something that is already there. */
+        if (auto * prev = std::get_if<Directory>(cur)) {
+            /* "Replacing" a directory with a directory is always a-ok. */
+            if (std::holds_alternative<Directory>(child))
+                return;
+
+            if (!prev->children.empty())
+                throw Error("cannot create '%s', conflicting non-empty directory", path);
+        }
+
+        if (auto i = hardLinked.find(path); i != hardLinked.end()) {
+            auto group = i->second;
+            hardLinked.erase(i);
+            group->erase(path);
+
+            warn(
+                "'%s' is replaced, though a hard link makes it the same file as %s. Older versions of Nix "
+                "resolved hard links differently, so this archive unpacks to a different store path than it "
+                "used to.",
+                path,
+                concatMapStringsSep(", ", *group, [](const CanonPath & other) { return quoteString(other.abs()); }));
+
+            /* One path on its own is not linked to anything any more. */
+            if (group->size() < 2)
+                for (auto & other : *group)
+                    hardLinked.erase(other);
+        }
+
+        *cur = std::move(child);
+    }
+
+    void createDirectory(const CanonPath & path) override
+    {
+        addNode(path, Directory{});
+    }
+
+    void createRegularFile(const CanonPath & path, bool isExecutable, fun<void(Sink &)> callback) override
+    {
+        auto sink = store.makeRegularFileSink();
+        callback(*sink);
+
+        /* The file is complete, so start writing it now: that way the
+           store is busy with it while we parse the rest of the archive,
+           and it lets go of whatever resources it holds for this file as
+           soon as it is done. */
+        auto & hash = results.add().first;
+        workers.enqueue([sink = std::move(sink), &hash]() { hash = std::move(*sink).finalize(); });
+
+        addNode(path, File{.hash = &hash, .executable = isExecutable});
+    }
+
+    void createSymlink(const CanonPath & path, const std::string & target) override
+    {
+        addNode(path, Symlink{.hash = store.makeSymlink(target).hash});
+    }
+
+    void createHardlink(const CanonPath & path, const CanonPath & target) override
+    try {
+        /* Resolved now rather than at flush, because a hard link refers
+           to whatever is at `target` at this point in the archive, the
+           way it would refer to an inode. A later entry replacing
+           `target` gets a slot of its own, so this link keeps pointing
+           at the old one --- which is what libarchive does, as it
+           unlinks the file in the way rather than writing through it. */
+        const auto * child = lookup(target);
+
+        if (!child)
+            throw Error("target does not exist");
+
+        std::visit(
+            overloaded{
+                [&](const Directory &) { throw Error("target is a directory"); },
+                /* Share the target's hash slot, rather than copying the
+                   hash out of it --- which is also why a link made
+                   before the target has finished being written works. */
+                [&](const File & file) { addNode(path, File{file}); },
+                [&](const Symlink & link) { addNode(path, Symlink{link}); },
+            },
+            std::as_const(*child));
+
+        /* `path` and `target` are now names for one file. */
+        auto group = [&] {
+            if (auto i = hardLinked.find(target); i != hardLinked.end())
+                return i->second;
+            auto fresh = std::make_shared<std::set<CanonPath>>(std::set<CanonPath>{target});
+            hardLinked.emplace(target, fresh);
+            return fresh;
+        }();
+        group->insert(path);
+        hardLinked.insert_or_assign(path, group);
+    } catch (Error & e) {
+        e.addTrace(nullptr, "while creating a hard link from '%s' to '%s'", path, target);
+        throw;
+    }
+
+    merkle::TreeEntry flush() override
+    {
+        /* Wait for the files to be written. An exception in a worker is
+           propagated here, so every hash below is filled in. */
+        workers.process();
+
+        /* Write the directories, children before parents, which the
+           recursion gives us for free. */
+        auto entry = [&store = store](this const auto & write, const Child & child) -> merkle::TreeEntry {
+            return {
+                .mode = std::visit([](const auto & sub) { return sub.mode(); }, child),
+                .hash = std::visit(
+                    overloaded{
+                        [&](const Directory & dir) {
+                            auto dirSink = store.makeDirectorySink();
+                            for (auto & [name, sub] : dir.children)
+                                dirSink->insertChild(name, write(sub));
+                            return std::move(*dirSink).finalize();
+                        },
+                        [&](const File & file) {
+                            /* Filled in by the writers we waited for just above. */
+                            assert(file.hash->has_value());
+                            return **file.hash;
+                        },
+                        [&](const Symlink & link) { return link.hash; },
+                    },
+                    child),
+            };
+        }(root);
+
+        store.flush();
+
+        return entry;
+    }
+};
+
+} // namespace
+
+} // namespace nix::merkle::tar
+
+namespace nix::merkle {
+
+ref<TarAdapter> makeTarSink(FileSinkBuilder & store)
+{
+    return make_ref<tar::TarAdapterImpl>(store);
+}
+
+} // namespace nix::merkle

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -47,6 +47,7 @@ sources = files(
   'indirect.cc',
   'input-cache.cc',
   'mercurial.cc',
+  'merkle-tar-adapter.cc',
   'path.cc',
   'registry.cc',
   'tarball.cc',

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -47,6 +47,7 @@ sources = files(
   'indirect.cc',
   'input-cache.cc',
   'mercurial.cc',
+  'merkle-tar-adapter.cc',
   'path.cc',
   'register-library-versions.cc',
   'registry.cc',

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -8,6 +8,7 @@
 #include "nix/util/types.hh"
 #include "nix/store/store-api.hh"
 #include "nix/fetchers/git-utils.hh"
+#include "nix/fetchers/merkle-tar-adapter.hh"
 #include "nix/fetchers/fetch-settings.hh"
 
 namespace nix::fetchers {
@@ -188,7 +189,8 @@ static DownloadTarballResult downloadTarball_(
     })
                                                                                     : TarArchive{*source};
     auto tarballCache = settings.getTarballCache();
-    auto parseSink = tarballCache->getFileSystemObjectSink();
+    auto writerPool = settings.getTarballWriterPool();
+    auto parseSink = merkle::makeTarSink(*writerPool);
     auto lastModified = unpackTarfileToSink(archive, *parseSink);
     auto tree = parseSink->flush();
 
@@ -204,7 +206,7 @@ static DownloadTarballResult downloadTarball_(
         infoAttrs = cached->value;
     } else {
         infoAttrs.insert_or_assign("etag", res->etag);
-        infoAttrs.insert_or_assign("treeHash", tarballCache->dereferenceSingletonDirectory(tree).gitRev());
+        infoAttrs.insert_or_assign("treeHash", tarballCache->dereferenceSingletonDirectory(tree.hash).gitRev());
         infoAttrs.insert_or_assign("lastModified", uint64_t(lastModified));
         if (res->immutableUrl)
             infoAttrs.insert_or_assign("immutableUrl", *res->immutableUrl);

--- a/src/libutil-tests/git.cc
+++ b/src/libutil-tests/git.cc
@@ -7,6 +7,22 @@
 
 namespace nix {
 
+/**
+ * Test implementation of merkle::DirectorySink that captures entries.
+ */
+struct TestDirectorySink : merkle::DirectorySink
+{
+    git::Tree entries;
+
+    void insertChild(std::string_view name, merkle::TreeEntry entry) override
+    {
+        auto name2 = std::string{name};
+        if (entry.mode == merkle::Mode::Directory)
+            name2 += '/';
+        entries.insert_or_assign(name2, std::move(entry));
+    }
+};
+
 class GitTest : public CharacterizationTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "git";
@@ -74,14 +90,28 @@ TEST_F(GitTest, blob_read)
     readTest("hello-world-blob.bin", [&](const auto & encoded) {
         StringSource in{encoded};
         StringSink out;
-        RegularFileSink out2{out};
         ASSERT_EQ(parseObjectType(in, mockXpSettings), ObjectType::Blob);
-        parseBlob(out2, CanonPath::root, in, BlobMode::Regular, mockXpSettings);
+        auto size = parseBlob(in, mockXpSettings);
+        in.drainInto(out, size);
 
         auto expected = readFile(goldenMaster("hello-world.bin"));
 
         ASSERT_EQ(out.s, expected);
     });
+}
+
+TEST_F(GitTest, blob_read_large_size)
+{
+    // Test that parseBlob handles sizes larger than INT_MAX (2^31 - 1)
+    // This verifies that a bad overflowing number parser isn't used.
+    uint64_t largeSize = 5000000000ULL; // ~5 GB, larger than INT_MAX
+    std::string blobHeader = std::to_string(largeSize);
+    blobHeader.push_back('\0'); // null terminator expected by parseBlob
+
+    StringSource in{blobHeader};
+    auto size = git::parseBlob(in, mockXpSettings);
+
+    ASSERT_EQ(size, largeSize);
 }
 
 TEST_F(GitTest, blob_write)
@@ -181,23 +211,11 @@ static auto mkTreeReadTest(HashAlgorithm hashAlgo, git::Tree tree, const Experim
     using namespace git;
     return [hashAlgo, tree, mockXpSettings](const auto & encoded) {
         StringSource in{encoded};
-        NullFileSystemObjectSink out;
-        Tree got;
+        TestDirectorySink out;
         ASSERT_EQ(parseObjectType(in, mockXpSettings), ObjectType::Tree);
-        parseTree(
-            out,
-            CanonPath::root,
-            in,
-            hashAlgo,
-            [&](auto & name, auto entry) {
-                auto name2 = std::string{name.rel()};
-                if (entry.mode == Mode::Directory)
-                    name2 += '/';
-                got.insert_or_assign(name2, std::move(entry));
-            },
-            mockXpSettings);
+        parseTree(out, in, hashAlgo, mockXpSettings);
 
-        ASSERT_EQ(got, tree);
+        ASSERT_EQ(out.entries, tree);
     };
 }
 
@@ -245,6 +263,7 @@ TEST_F(GitTest, both_roundrip)
     for (const auto hashAlgo : {HashAlgorithm::SHA1, HashAlgorithm::SHA256}) {
         std::map<Hash, std::string> cas;
 
+        // Dump phase: serialize files to git objects in cas
         fun<DumpHook> dumpHook = [&](const SourcePath & path) {
             StringSink s;
             HashSink hashSink{hashAlgo};
@@ -260,32 +279,58 @@ TEST_F(GitTest, both_roundrip)
 
         auto root = dumpHook(SourcePath{files});
 
+        // Parse phase: deserialize git objects back to files
         auto files2 = make_ref<MemorySourceAccessor>();
 
-        MemorySink sinkFiles2{*files2};
+        // Recursive function to parse a git object into a File
+        std::function<MemorySourceAccessor::File(merkle::TreeEntry)> parseToFile;
 
-        std::function<void(const CanonPath, const Hash &, BlobMode)> mkSinkHook;
-        mkSinkHook = [&](auto prefix, auto & hash, auto blobMode) {
-            StringSource in{cas[hash]};
-            parse(
-                sinkFiles2,
-                prefix,
-                in,
-                blobMode,
-                hashAlgo,
-                [&](const CanonPath & name, const auto & entry) {
-                    mkSinkHook(
-                        prefix / name,
-                        entry.hash,
-                        // N.B. this cast would not be acceptable in real
-                        // code, because it would make an assert reachable,
-                        // but it should harmless in this test.
-                        static_cast<BlobMode>(entry.mode));
-                },
-                mockXpSettings);
+        // DirectorySink that recursively parses children
+        struct RecursiveDirSink : merkle::DirectorySink
+        {
+            std::function<MemorySourceAccessor::File(merkle::TreeEntry)> & parseToFile;
+            MemorySourceAccessor::File::Directory dir;
+
+            RecursiveDirSink(std::function<MemorySourceAccessor::File(merkle::TreeEntry)> & parseToFile)
+                : parseToFile(parseToFile)
+            {
+            }
+
+            void insertChild(std::string_view name, merkle::TreeEntry entry) override
+            {
+                dir.entries.insert_or_assign(std::string{name}, parseToFile(entry));
+            }
         };
 
-        mkSinkHook(CanonPath::root, root.hash, BlobMode::Regular);
+        parseToFile = [&](merkle::TreeEntry entry) -> MemorySourceAccessor::File {
+            StringSource in{cas[entry.hash]};
+            auto type = parseObjectType(in, mockXpSettings);
+
+            switch (type) {
+            case ObjectType::Blob: {
+                StringSink content;
+                auto size = parseBlob(in, mockXpSettings);
+                in.drainInto(content, size);
+                if (entry.mode == merkle::Mode::Symlink) {
+                    return MemorySourceAccessor::File::Symlink{std::move(content.s)};
+                } else {
+                    return MemorySourceAccessor::File::Regular{
+                        .executable = entry.mode == merkle::Mode::Executable,
+                        .contents = std::move(content.s),
+                    };
+                }
+            }
+            case ObjectType::Tree: {
+                RecursiveDirSink dirSink{parseToFile};
+                parseTree(dirSink, in, hashAlgo, mockXpSettings);
+                return std::move(dirSink.dir);
+            }
+            default:
+                assert(false);
+            }
+        };
+
+        files2->root = parseToFile(root);
 
         EXPECT_EQ(files->root, files2->root);
     }

--- a/src/libutil-tests/git.cc
+++ b/src/libutil-tests/git.cc
@@ -9,6 +9,22 @@ namespace nix {
 
 using namespace git;
 
+/**
+ * Test implementation of merkle::DirectorySink that captures entries.
+ */
+struct TestDirectorySink : merkle::DirectorySink
+{
+    Tree entries;
+
+    void insertChild(std::string_view name, merkle::TreeEntry entry) override
+    {
+        auto name2 = std::string{name};
+        if (entry.mode == merkle::Mode::Directory)
+            name2 += '/';
+        entries.insert_or_assign(name2, std::move(entry));
+    }
+};
+
 class GitTest : public CharacterizationTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "git";
@@ -71,14 +87,28 @@ TEST_F(GitTest, blob_read)
     readTest("hello-world-blob.bin", [&](const auto & encoded) {
         StringSource in{encoded};
         StringSink out;
-        RegularFileSink out2{out};
         ASSERT_EQ(parseObjectType(in, mockXpSettings), ObjectType::Blob);
-        parseBlob(out2, CanonPath::root, in, BlobMode::Regular, mockXpSettings);
+        auto size = parseBlob(in, mockXpSettings);
+        in.drainInto(out, size);
 
         auto expected = readFile(goldenMaster("hello-world.bin"));
 
         ASSERT_EQ(out.s, expected);
     });
+}
+
+TEST_F(GitTest, blob_read_large_size)
+{
+    // Test that parseBlob handles sizes larger than INT_MAX (2^31 - 1)
+    // This verifies that a bad overflowing number parser isn't used.
+    uint64_t largeSize = 5000000000ULL; // ~5 GB, larger than INT_MAX
+    std::string blobHeader = std::to_string(largeSize);
+    blobHeader.push_back('\0'); // null terminator expected by parseBlob
+
+    StringSource in{blobHeader};
+    auto size = parseBlob(in, mockXpSettings);
+
+    ASSERT_EQ(size, largeSize);
 }
 
 TEST_F(GitTest, blob_write)
@@ -176,23 +206,11 @@ static auto mkTreeReadTest(HashAlgorithm hashAlgo, Tree tree, const Experimental
 {
     return [hashAlgo, tree, mockXpSettings](const auto & encoded) {
         StringSource in{encoded};
-        NullFileSystemObjectSink out;
-        Tree got;
+        TestDirectorySink out;
         ASSERT_EQ(parseObjectType(in, mockXpSettings), ObjectType::Tree);
-        parseTree(
-            out,
-            CanonPath::root,
-            in,
-            hashAlgo,
-            [&](auto & name, auto entry) {
-                auto name2 = std::string{name.rel()};
-                if (entry.mode == Mode::Directory)
-                    name2 += '/';
-                got.insert_or_assign(name2, std::move(entry));
-            },
-            mockXpSettings);
+        parseTree(out, in, hashAlgo, mockXpSettings);
 
-        ASSERT_EQ(got, tree);
+        ASSERT_EQ(out.entries, tree);
     };
 }
 
@@ -237,6 +255,7 @@ TEST_F(GitTest, both_roundrip)
     for (const auto hashAlgo : {HashAlgorithm::SHA1, HashAlgorithm::SHA256}) {
         std::map<Hash, std::string> cas;
 
+        // Dump phase: serialize files to git objects in cas
         fun<DumpHook> dumpHook = [&](const SourcePath & path) {
             StringSink s;
             HashSink hashSink{hashAlgo};
@@ -252,32 +271,58 @@ TEST_F(GitTest, both_roundrip)
 
         auto root = dumpHook(SourcePath{files});
 
+        // Parse phase: deserialize git objects back to files
         auto files2 = make_ref<MemorySourceAccessor>();
 
-        MemorySink sinkFiles2{*files2};
+        // Recursive function to parse a git object into a File
+        std::function<MemorySourceAccessor::File(merkle::TreeEntry)> parseToFile;
 
-        std::function<void(const CanonPath, const Hash &, BlobMode)> mkSinkHook;
-        mkSinkHook = [&](auto prefix, auto & hash, auto blobMode) {
-            StringSource in{cas[hash]};
-            parse(
-                sinkFiles2,
-                prefix,
-                in,
-                blobMode,
-                hashAlgo,
-                [&](const CanonPath & name, const auto & entry) {
-                    mkSinkHook(
-                        prefix / name,
-                        entry.hash,
-                        // N.B. this cast would not be acceptable in real
-                        // code, because it would make an assert reachable,
-                        // but it should harmless in this test.
-                        static_cast<BlobMode>(entry.mode));
-                },
-                mockXpSettings);
+        // DirectorySink that recursively parses children
+        struct RecursiveDirSink : merkle::DirectorySink
+        {
+            std::function<MemorySourceAccessor::File(merkle::TreeEntry)> & parseToFile;
+            MemorySourceAccessor::File::Directory dir;
+
+            RecursiveDirSink(std::function<MemorySourceAccessor::File(merkle::TreeEntry)> & parseToFile)
+                : parseToFile(parseToFile)
+            {
+            }
+
+            void insertChild(std::string_view name, merkle::TreeEntry entry) override
+            {
+                dir.entries.insert_or_assign(std::string{name}, parseToFile(entry));
+            }
         };
 
-        mkSinkHook(CanonPath::root, root.hash, BlobMode::Regular);
+        parseToFile = [&](merkle::TreeEntry entry) -> MemorySourceAccessor::File {
+            StringSource in{cas[entry.hash]};
+            auto type = parseObjectType(in, mockXpSettings);
+
+            switch (type) {
+            case ObjectType::Blob: {
+                StringSink content;
+                auto size = parseBlob(in, mockXpSettings);
+                in.drainInto(content, size);
+                if (entry.mode == merkle::Mode::Symlink) {
+                    return MemorySourceAccessor::File::Symlink{std::move(content.s)};
+                } else {
+                    return MemorySourceAccessor::File::Regular{
+                        .executable = entry.mode == merkle::Mode::Executable,
+                        .contents = std::move(content.s),
+                    };
+                }
+            }
+            case ObjectType::Tree: {
+                RecursiveDirSink dirSink{parseToFile};
+                parseTree(dirSink, in, hashAlgo, mockXpSettings);
+                return std::move(dirSink.dir);
+            }
+            default:
+                assert(false);
+            }
+        };
+
+        files2->root = parseToFile(root);
 
         EXPECT_EQ(files->root, files2->root);
     }

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -16,8 +16,6 @@ namespace nix {
 
 void FileSystemObjectSink::anchor() {}
 
-void ExtendedFileSystemObjectSink::anchor() {}
-
 void NullFileSystemObjectSink::anchor() {}
 
 void RegularFileSink::anchor() {}

--- a/src/libutil/git.cc
+++ b/src/libutil/git.cc
@@ -1,5 +1,6 @@
 #include <cerrno>
 #include <algorithm>
+#include <charconv>
 #include <vector>
 #include <map>
 #include <regex>
@@ -11,24 +12,12 @@
 
 #include "nix/util/git.hh"
 #include "nix/util/serialise.hh"
+#include "nix/util/util.hh"
 
 namespace nix::git {
 
 using namespace nix;
 using namespace std::string_literals;
-
-std::optional<Mode> decodeMode(RawMode m)
-{
-    switch (m) {
-    case (RawMode) Mode::Directory:
-    case (RawMode) Mode::Executable:
-    case (RawMode) Mode::Regular:
-    case (RawMode) Mode::Symlink:
-        return (Mode) m;
-    default:
-        return std::nullopt;
-    }
-}
 
 static std::string getStringUntil(Source & source, char byte)
 {
@@ -50,78 +39,44 @@ static std::string getString(Source & source, int n)
     return v;
 }
 
-void parseBlob(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
+uint64_t parseBlob(Source & source, const ExperimentalFeatureSettings & xpSettings)
+{
+    xpSettings.require(Xp::GitHashing);
+
+    auto sizeStr = getStringUntil(source, 0);
+    uint64_t size;
+    auto [ptr, ec] = std::from_chars(sizeStr.data(), sizeStr.data() + sizeStr.size(), size);
+    if (ec != std::errc{})
+        throw Error("invalid blob size '%s'", sizeStr);
+    return size;
+}
+
+void parseTree(
+    merkle::DirectorySink & sink,
     Source & source,
-    BlobMode blobMode,
+    HashAlgorithm hashAlgo,
     const ExperimentalFeatureSettings & xpSettings)
 {
     xpSettings.require(Xp::GitHashing);
 
-    const unsigned long long size = std::stoi(getStringUntil(source, 0));
-
-    auto doRegularFile = [&](bool executable) {
-        sink.createRegularFile(sinkPath, [&](auto & crf) {
-            if (executable)
-                crf.isExecutable();
-
-            crf.preallocateContents(size);
-
-            source.drainInto(crf, size);
-        });
-    };
-
-    switch (blobMode) {
-
-    case BlobMode::Regular:
-        doRegularFile(false);
-        break;
-
-    case BlobMode::Executable:
-        doRegularFile(true);
-        break;
-
-    case BlobMode::Symlink: {
-        std::string target;
-        target.resize(size, '0');
-        target.reserve(size);
-        for (size_t n = 0; n < target.size();) {
-            checkInterrupt();
-            n += source.read(const_cast<char *>(target.c_str()) + n, target.size() - n);
-        }
-
-        sink.createSymlink(sinkPath, target);
-        break;
-    }
-
-    default:
-        assert(false);
-    }
-}
-
-void parseTree(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
-    Source & source,
-    HashAlgorithm hashAlgo,
-    fun<SinkHook> hook,
-    const ExperimentalFeatureSettings & xpSettings)
-{
-    const unsigned long long size = std::stoi(getStringUntil(source, 0));
-    unsigned long long left = size;
-
-    sink.createDirectory(sinkPath);
+    auto sizeStr = getStringUntil(source, 0);
+    uint64_t left;
+    auto [ptr, ec] = std::from_chars(sizeStr.data(), sizeStr.data() + sizeStr.size(), left);
+    if (ec != std::errc{})
+        throw Error("invalid tree size '%s'", sizeStr);
 
     while (left) {
         std::string perms = getStringUntil(source, ' ');
         left -= perms.size();
         left -= 1;
 
-        RawMode rawMode = std::stoi(perms, 0, 8);
+        RawMode rawMode;
+        auto [ptr, ec] = std::from_chars(perms.data(), perms.data() + perms.size(), rawMode, 8);
+        if (ec != std::errc{})
+            throw Error("invalid Git permission: %s", perms);
         auto modeOpt = decodeMode(rawMode);
         if (!modeOpt)
-            throw Error("Unknown Git permission: %o", rawMode);
+            throw Error("unknown Git permission: %o", rawMode);
         auto mode = std::move(*modeOpt);
 
         std::string name = getStringUntil(source, '\0');
@@ -139,12 +94,7 @@ void parseTree(
         Hash hash(hashAlgo);
         std::copy(hashs.begin(), hashs.end(), hash.hash);
 
-        hook(
-            CanonPath{name},
-            TreeEntry{
-                .mode = mode,
-                .hash = hash,
-            });
+        sink.insertChild(name, TreeEntry{.mode = mode, .hash = hash});
     }
 }
 
@@ -160,31 +110,6 @@ ObjectType parseObjectType(Source & source, const ExperimentalFeatureSettings & 
         return ObjectType::Tree;
     } else
         throw Error("input doesn't look like a Git object");
-}
-
-void parse(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
-    Source & source,
-    BlobMode rootModeIfBlob,
-    HashAlgorithm hashAlgo,
-    fun<SinkHook> hook,
-    const ExperimentalFeatureSettings & xpSettings)
-{
-    xpSettings.require(Xp::GitHashing);
-
-    auto type = parseObjectType(source, xpSettings);
-
-    switch (type) {
-    case ObjectType::Blob:
-        parseBlob(sink, sinkPath, source, rootModeIfBlob, xpSettings);
-        break;
-    case ObjectType::Tree:
-        parseTree(sink, sinkPath, source, hashAlgo, hook, xpSettings);
-        break;
-    default:
-        assert(false);
-    };
 }
 
 std::optional<Mode> convertMode(SourceAccessor::Type type)
@@ -205,29 +130,6 @@ std::optional<Mode> convertMode(SourceAccessor::Type type)
     default:
         unreachable();
     }
-}
-
-void restore(FileSystemObjectSink & sink, Source & source, HashAlgorithm hashAlgo, fun<RestoreHook> hook)
-{
-    parse(sink, CanonPath::root, source, BlobMode::Regular, hashAlgo, [&](CanonPath name, TreeEntry entry) {
-        auto [accessor, from] = hook(entry.hash);
-        auto stat = accessor->lstat(from);
-        auto gotOpt = convertMode(stat.type);
-        if (!gotOpt)
-            throw Error(
-                "file '%s' (git hash %s) has an unsupported type",
-                from,
-                entry.hash.to_string(HashFormat::Base16, false));
-        auto & got = *gotOpt;
-        if (got != entry.mode)
-            throw Error(
-                "git mode of file '%s' (git hash %s) is %o but expected %o",
-                from,
-                entry.hash.to_string(HashFormat::Base16, false),
-                (RawMode) got,
-                (RawMode) entry.mode);
-        copyRecursive(*accessor, from, sink, name);
-    });
 }
 
 void dumpBlobPrefix(uint64_t size, Sink & sink, const ExperimentalFeatureSettings & xpSettings)

--- a/src/libutil/git.cc
+++ b/src/libutil/git.cc
@@ -1,5 +1,6 @@
 #include <cerrno>
 #include <algorithm>
+#include <charconv>
 #include <regex>
 #include <strings.h> // for strcasecmp
 
@@ -9,21 +10,9 @@
 
 #include "nix/util/git.hh"
 #include "nix/util/serialise.hh"
+#include "nix/util/util.hh"
 
 namespace nix::git {
-
-std::optional<Mode> decodeMode(RawMode m)
-{
-    switch (m) {
-    case (RawMode) Mode::Directory:
-    case (RawMode) Mode::Executable:
-    case (RawMode) Mode::Regular:
-    case (RawMode) Mode::Symlink:
-        return (Mode) m;
-    default:
-        return std::nullopt;
-    }
-}
 
 static std::string getStringUntil(Source & source, char byte)
 {
@@ -45,78 +34,44 @@ static std::string getString(Source & source, int n)
     return v;
 }
 
-void parseBlob(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
+uint64_t parseBlob(Source & source, const ExperimentalFeatureSettings & xpSettings)
+{
+    xpSettings.require(Xp::GitHashing);
+
+    auto sizeStr = getStringUntil(source, 0);
+    auto size = string2Int<uint64_t>(sizeStr);
+    if (!size)
+        throw Error("invalid blob size '%s'", sizeStr);
+    return *size;
+}
+
+void parseTree(
+    merkle::DirectorySink & sink,
     Source & source,
-    BlobMode blobMode,
+    HashAlgorithm hashAlgo,
     const ExperimentalFeatureSettings & xpSettings)
 {
     xpSettings.require(Xp::GitHashing);
 
-    const unsigned long long size = std::stoi(getStringUntil(source, 0));
-
-    auto doRegularFile = [&](bool executable) {
-        sink.createRegularFile(sinkPath, [&](auto & crf) {
-            if (executable)
-                crf.isExecutable();
-
-            crf.preallocateContents(size);
-
-            source.drainInto(crf, size);
-        });
-    };
-
-    switch (blobMode) {
-
-    case BlobMode::Regular:
-        doRegularFile(false);
-        break;
-
-    case BlobMode::Executable:
-        doRegularFile(true);
-        break;
-
-    case BlobMode::Symlink: {
-        std::string target;
-        target.resize(size, '0');
-        target.reserve(size);
-        for (size_t n = 0; n < target.size();) {
-            checkInterrupt();
-            n += source.read(const_cast<char *>(target.c_str()) + n, target.size() - n);
-        }
-
-        sink.createSymlink(sinkPath, target);
-        break;
-    }
-
-    default:
-        assert(false);
-    }
-}
-
-void parseTree(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
-    Source & source,
-    HashAlgorithm hashAlgo,
-    fun<SinkHook> hook,
-    const ExperimentalFeatureSettings & xpSettings)
-{
-    const unsigned long long size = std::stoi(getStringUntil(source, 0));
-    unsigned long long left = size;
-
-    sink.createDirectory(sinkPath);
+    auto sizeStr = getStringUntil(source, 0);
+    auto leftOpt = string2Int<uint64_t>(sizeStr);
+    if (!leftOpt)
+        throw Error("invalid tree size '%s'", sizeStr);
+    auto left = *leftOpt;
 
     while (left) {
         std::string perms = getStringUntil(source, ' ');
         left -= perms.size();
         left -= 1;
 
-        RawMode rawMode = std::stoi(perms, 0, 8);
+        /* Not `string2Int`, which is decimal-only; these are octal. */
+        RawMode rawMode;
+        auto [ptr, ec] = std::from_chars(perms.data(), perms.data() + perms.size(), rawMode, 8);
+        if (ec != std::errc{})
+            throw Error("invalid Git permission: %s", perms);
         auto modeOpt = decodeMode(rawMode);
         if (!modeOpt)
-            throw Error("Unknown Git permission: %o", rawMode);
+            throw Error("unknown Git permission: %o", rawMode);
         auto mode = std::move(*modeOpt);
 
         std::string name = getStringUntil(source, '\0');
@@ -134,12 +89,7 @@ void parseTree(
         Hash hash(hashAlgo);
         std::copy(hashs.begin(), hashs.end(), hash.hash);
 
-        hook(
-            CanonPath{name},
-            TreeEntry{
-                .mode = mode,
-                .hash = hash,
-            });
+        sink.insertChild(name, TreeEntry{.mode = mode, .hash = hash});
     }
 }
 
@@ -155,31 +105,6 @@ ObjectType parseObjectType(Source & source, const ExperimentalFeatureSettings & 
         return ObjectType::Tree;
     } else
         throw Error("input doesn't look like a Git object");
-}
-
-void parse(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
-    Source & source,
-    BlobMode rootModeIfBlob,
-    HashAlgorithm hashAlgo,
-    fun<SinkHook> hook,
-    const ExperimentalFeatureSettings & xpSettings)
-{
-    xpSettings.require(Xp::GitHashing);
-
-    auto type = parseObjectType(source, xpSettings);
-
-    switch (type) {
-    case ObjectType::Blob:
-        parseBlob(sink, sinkPath, source, rootModeIfBlob, xpSettings);
-        break;
-    case ObjectType::Tree:
-        parseTree(sink, sinkPath, source, hashAlgo, hook, xpSettings);
-        break;
-    default:
-        assert(false);
-    };
 }
 
 std::optional<Mode> convertMode(SourceAccessor::Type type)
@@ -200,29 +125,6 @@ std::optional<Mode> convertMode(SourceAccessor::Type type)
     default:
         unreachable();
     }
-}
-
-void restore(FileSystemObjectSink & sink, Source & source, HashAlgorithm hashAlgo, fun<RestoreHook> hook)
-{
-    parse(sink, CanonPath::root, source, BlobMode::Regular, hashAlgo, [&](CanonPath name, TreeEntry entry) {
-        auto [accessor, from] = hook(entry.hash);
-        auto stat = accessor->lstat(from);
-        auto gotOpt = convertMode(stat.type);
-        if (!gotOpt)
-            throw Error(
-                "file '%s' (git hash %s) has an unsupported type",
-                from,
-                entry.hash.to_string(HashFormat::Base16, false));
-        auto & got = *gotOpt;
-        if (got != entry.mode)
-            throw Error(
-                "git mode of file '%s' (git hash %s) is %o but expected %o",
-                from,
-                entry.hash.to_string(HashFormat::Base16, false),
-                (RawMode) got,
-                (RawMode) entry.mode);
-        copyRecursive(*accessor, from, sink, name);
-    });
 }
 
 void dumpBlobPrefix(uint64_t size, Sink & sink, const ExperimentalFeatureSettings & xpSettings)

--- a/src/libutil/include/nix/util/fs-sink.hh
+++ b/src/libutil/include/nix/util/fs-sink.hh
@@ -73,23 +73,6 @@ public:
 };
 
 /**
- * An extension of `FileSystemObjectSink` that supports file types
- * that are not supported by Nix's FSO model.
- */
-struct ExtendedFileSystemObjectSink : virtual FileSystemObjectSink
-{
-private:
-    void anchor() override;
-
-public:
-    /**
-     * Create a hard link. The target must be the path of a previously
-     * encountered file relative to the root of the FSO.
-     */
-    virtual void createHardlink(const CanonPath & path, const CanonPath & target) = 0;
-};
-
-/**
  * Recursively copy file system objects from the source into the sink.
  */
 void copyRecursive(

--- a/src/libutil/include/nix/util/git.hh
+++ b/src/libutil/include/nix/util/git.hh
@@ -10,6 +10,7 @@
 #include "nix/util/hash.hh"
 #include "nix/util/source-path.hh"
 #include "nix/util/fs-sink.hh"
+#include "nix/util/merkle-files.hh"
 
 namespace nix::git {
 
@@ -20,28 +21,10 @@ enum struct ObjectType {
     // Tag,
 };
 
-using RawMode = uint32_t;
-
-enum struct Mode : RawMode {
-    Directory = 0040000,
-    Regular = 0100644,
-    Executable = 0100755,
-    Symlink = 0120000,
-};
-
-std::optional<Mode> decodeMode(RawMode m);
-
-/**
- * An anonymous Git tree object entry (no name part).
- */
-struct TreeEntry
-{
-    Mode mode;
-    Hash hash;
-
-    bool operator==(const TreeEntry &) const = default;
-    auto operator<=>(const TreeEntry &) const = default;
-};
+// Backwards compatibility aliases
+using merkle::Mode;
+using merkle::TreeEntry;
+using nix::RawMode;
 
 /**
  * A Git tree object, fully decoded and stored in memory.
@@ -51,21 +34,10 @@ struct TreeEntry
  */
 using Tree = std::map<std::string, TreeEntry>;
 
-/**
- * Callback for processing a child hash with `parse`
- *
- * The function should
- *
- * 1. Obtain the file system objects denoted by `gitHash`
- *
- * 2. Ensure they match `mode`
- *
- * 3. Feed them into the same sink `parse` was called with
- *
- * Implementations may seek to memoize resources (bandwidth, storage,
- * etc.) for the same Git hash.
- */
-using SinkHook = void(const CanonPath & name, TreeEntry entry);
+inline std::optional<Mode> decodeMode(RawMode m)
+{
+    return merkle::decodeMode(m);
+}
 
 /**
  * Parse the "blob " or "tree " prefix.
@@ -76,72 +48,26 @@ ObjectType
 parseObjectType(Source & source, const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
 
 /**
- * These 3 modes are represented by blob objects.
+ * Read the size of the blob
  *
- * Sometimes we need this information to disambiguate how a blob is
- * being used to better match our own "file system object" data model.
+ * The caller should then call `Source::drainInto` or similar with that
+ * size.
  */
-enum struct BlobMode : RawMode {
-    Regular = static_cast<RawMode>(Mode::Regular),
-    Executable = static_cast<RawMode>(Mode::Executable),
-    Symlink = static_cast<RawMode>(Mode::Symlink),
-};
-
-void parseBlob(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
-    Source & source,
-    BlobMode blobMode,
-    const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
+uint64_t parseBlob(Source & source, const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
 
 /**
  * @param hashAlgo must be `HashAlgo::SHA1` or `HashAlgo::SHA256` for now.
  */
 void parseTree(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
+    merkle::DirectorySink & sink,
     Source & source,
     HashAlgorithm hashAlgo,
-    fun<SinkHook> hook,
     const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
 
 /**
- * Helper putting the previous three `parse*` functions together.
- *
- * @param rootModeIfBlob How to interpret a root blob, for which there is no
- * disambiguating dir entry to answer that questino. If the root it not
- * a blob, this is ignored.
- *
- * @param hashAlgo must be `HashAlgo::SHA1` or `HashAlgo::SHA256` for now.
- */
-void parse(
-    FileSystemObjectSink & sink,
-    const CanonPath & sinkPath,
-    Source & source,
-    BlobMode rootModeIfBlob,
-    HashAlgorithm hashAlgo,
-    fun<SinkHook> hook,
-    const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
-
-/**
- * Assists with writing a `SinkHook` step (2).
+ * Convert a `SourceAccessor::Type` to a `Mode`.
  */
 std::optional<Mode> convertMode(SourceAccessor::Type type);
-
-/**
- * Simplified version of `SinkHook` for `restore`.
- *
- * Given a `Hash`, return a `SourceAccessor` and `CanonPath` pointing to
- * the file system object with that path.
- */
-using RestoreHook = SourcePath(Hash);
-
-/**
- * Wrapper around `parse` and `RestoreSink`
- *
- * @param hashAlgo must be `HashAlgo::SHA1` or `HashAlgo::SHA256` for now.
- */
-void restore(FileSystemObjectSink & sink, Source & source, HashAlgorithm hashAlgo, fun<RestoreHook> hook);
 
 /**
  * Dumps a single file to a sink

--- a/src/libutil/include/nix/util/merkle-files.hh
+++ b/src/libutil/include/nix/util/merkle-files.hh
@@ -1,0 +1,68 @@
+#pragma once
+///@file
+
+#include <cstdint>
+#include <optional>
+
+#include "nix/util/hash.hh"
+#include "nix/util/serialise.hh"
+
+namespace nix {
+
+using RawMode = uint32_t;
+
+namespace merkle {
+
+/**
+ * The mode of a file in a content-addressed/merkle file system.
+ * These values match the Git file modes.
+ */
+enum struct Mode : RawMode {
+    Directory = 0040000,
+    Regular = 0100644,
+    Executable = 0100755,
+    Symlink = 0120000,
+};
+
+inline std::optional<Mode> decodeMode(RawMode m)
+{
+    switch (m) {
+    case (RawMode) Mode::Directory:
+    case (RawMode) Mode::Executable:
+    case (RawMode) Mode::Regular:
+    case (RawMode) Mode::Symlink:
+        return (Mode) m;
+    default:
+        return std::nullopt;
+    }
+}
+
+/**
+ * An entry in a content-addressed/merkle file system directory.
+ */
+struct TreeEntry
+{
+    Mode mode;
+    Hash hash;
+
+    bool operator==(const TreeEntry &) const = default;
+    auto operator<=>(const TreeEntry &) const = default;
+};
+
+/**
+ * A sink for building a shallow Merkle directory by inserting child
+ * entries --- they contain a hash but no data.
+ */
+struct DirectorySink
+{
+    virtual ~DirectorySink() = default;
+
+    /**
+     * Insert an existing object as a child of this directory.
+     */
+    virtual void insertChild(std::string_view name, TreeEntry entry) = 0;
+};
+
+} // namespace merkle
+
+} // namespace nix

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -60,6 +60,7 @@ headers = [ config_pub_h ] + files(
   'logging.hh',
   'lru-cache.hh',
   'memory-source-accessor.hh',
+  'merkle-files.hh',
   'mounted-source-accessor.hh',
   'muxable-pipe.hh',
   'nar-accessor.hh',

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -63,6 +63,7 @@ headers = [ config_pub_h ] + files(
   'lru-cache.hh',
   'memo.hh',
   'memory-source-accessor.hh',
+  'merkle-files.hh',
   'mounted-source-accessor.hh',
   'muxable-pipe.hh',
   'nar-accessor.hh',

--- a/src/libutil/include/nix/util/pool.hh
+++ b/src/libutil/include/nix/util/pool.hh
@@ -64,10 +64,13 @@ private:
 
 public:
 
+    /**
+     * Note: `factory` cannot have a default argument because the
+     * default would be instantiated when Pool<R> is instantiated,
+     * requiring R to be default-constructible.
+     */
     Pool(
-        size_t max = std::numeric_limits<size_t>::max(),
-        const Factory & factory = []() { return make_ref<R>(); },
-        const Validator & validator = [](ref<R> r) { return true; })
+        size_t max, const Factory & factory, const Validator & validator = [](ref<R> r) { return true; })
         : factory(factory)
         , validator(validator)
     {

--- a/src/libutil/include/nix/util/tarfile.hh
+++ b/src/libutil/include/nix/util/tarfile.hh
@@ -1,8 +1,8 @@
 #pragma once
 ///@file
 
+#include "nix/util/canon-path.hh"
 #include "nix/util/serialise.hh"
-#include "nix/util/fs-sink.hh"
 #include <archive.h>
 
 namespace nix {
@@ -39,6 +39,33 @@ int getArchiveFilterCodeByName(const std::string & method);
 
 void unpackTarfile(const std::filesystem::path & tarFile, const std::filesystem::path & destDir);
 
-time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & parseSink);
+/**
+ * Sink for unpacking archives. Uses a path-based interface since
+ * archives can have entries in any order.
+ *
+ * Of the three file system object sinks we have currently (this,
+ * `FileSystemObjectSink`, and `merkle::FileSinkBuilder`), this one is by far
+ * the "messiest", imposing the least structure. It is this rather a
+ * footgun, and one should avoid implementing it directly as much as
+ * possible.
+ */
+struct TarSink
+{
+    virtual ~TarSink() = default;
+
+    virtual void createDirectory(const CanonPath & path) = 0;
+
+    virtual void createRegularFile(const CanonPath & path, bool isExecutable, fun<void(Sink &)> callback) = 0;
+
+    virtual void createSymlink(const CanonPath & path, const std::string & target) = 0;
+
+    /**
+     * Create a hard link. The target must be the path of a previously
+     * encountered file relative to the root.
+     */
+    virtual void createHardlink(const CanonPath & path, const CanonPath & target) = 0;
+};
+
+time_t unpackTarfileToSink(TarArchive & archive, TarSink & parseSink);
 
 } // namespace nix

--- a/src/libutil/include/nix/util/tarfile.hh
+++ b/src/libutil/include/nix/util/tarfile.hh
@@ -1,9 +1,9 @@
 #pragma once
 ///@file
 
+#include "nix/util/canon-path.hh"
 #include "nix/util/compression-algo.hh"
 #include "nix/util/serialise.hh"
-#include "nix/util/fs-sink.hh"
 #include <archive.h>
 
 namespace nix {
@@ -38,6 +38,33 @@ struct TarArchive
 
 void unpackTarfile(const std::filesystem::path & tarFile, const std::filesystem::path & destDir);
 
-time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & parseSink);
+/**
+ * Sink for unpacking archives. Uses a path-based interface since
+ * archives can have entries in any order.
+ *
+ * Of the three file system object sinks we have currently (this,
+ * `FileSystemObjectSink`, and `merkle::FileSinkBuilder`), this one is by far
+ * the "messiest", imposing the least structure. It is this rather a
+ * footgun, and one should avoid implementing it directly as much as
+ * possible.
+ */
+struct TarSink
+{
+    virtual ~TarSink() = default;
+
+    virtual void createDirectory(const CanonPath & path) = 0;
+
+    virtual void createRegularFile(const CanonPath & path, bool isExecutable, fun<void(Sink &)> callback) = 0;
+
+    virtual void createSymlink(const CanonPath & path, const std::string & target) = 0;
+
+    /**
+     * Create a hard link. The target must be the path of a previously
+     * encountered file relative to the root.
+     */
+    virtual void createHardlink(const CanonPath & path, const CanonPath & target) = 0;
+};
+
+time_t unpackTarfileToSink(TarArchive & archive, TarSink & parseSink);
 
 } // namespace nix

--- a/src/libutil/include/nix/util/thread-pool.hh
+++ b/src/libutil/include/nix/util/thread-pool.hh
@@ -2,8 +2,9 @@
 ///@file
 
 #include "nix/util/error.hh"
-#include "nix/util/fun.hh"
 #include "nix/util/sync.hh"
+
+#include <boost/compat/move_only_function.hpp>
 
 #include <queue>
 #include <functional>
@@ -30,9 +31,11 @@ public:
     /**
      * An individual work item.
      *
-     * \todo use std::packaged_task?
+     * Move-only, so that a work item can own what it operates on.
+     * `std::move_only_function` would do, but libc++ does not implement
+     * it yet.
      */
-    typedef fun<void()> work_t;
+    using work_t = boost::compat::move_only_function<void()>;
 
     /**
      * Enqueue a function to be executed by the thread pool.

--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -166,7 +166,7 @@ void unpackTarfile(const std::filesystem::path & tarFile, const std::filesystem:
     extract_archive(archive, destDir);
 }
 
-time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & parseSink)
+time_t unpackTarfileToSink(TarArchive & archive, TarSink & parseSink)
 {
     time_t lastModified = 0;
 
@@ -203,10 +203,8 @@ time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & 
             break;
 
         case AE_IFREG: {
-            parseSink.createRegularFile(cpath, [&](auto & crf) {
-                if (archive_entry_mode(entry) & S_IXUSR)
-                    crf.isExecutable();
-
+            bool isExecutable = archive_entry_mode(entry) & S_IXUSR;
+            parseSink.createRegularFile(cpath, isExecutable, [&](auto & crf) {
                 while (true) {
                     auto n = archive_read_data(archive.archive, buf.data(), buf.size());
                     if (n < 0)

--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -207,7 +207,7 @@ void unpackTarfile(const std::filesystem::path & tarFile, const std::filesystem:
     extract_archive(archive, destDir);
 }
 
-time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & parseSink)
+time_t unpackTarfileToSink(TarArchive & archive, TarSink & parseSink)
 {
     time_t lastModified = 0;
 
@@ -244,10 +244,8 @@ time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & 
             break;
 
         case AE_IFREG: {
-            parseSink.createRegularFile(cpath, [&](auto & crf) {
-                if (archive_entry_mode(entry) & S_IXUSR)
-                    crf.isExecutable();
-
+            bool isExecutable = archive_entry_mode(entry) & S_IXUSR;
+            parseSink.createRegularFile(cpath, isExecutable, [&](auto & crf) {
                 while (true) {
                     auto n = archive_read_data(archive.archive, buf.data(), buf.size());
                     if (n < 0)

--- a/src/libutil/thread-pool.cc
+++ b/src/libutil/thread-pool.cc
@@ -94,7 +94,7 @@ void ThreadPool::doWork(bool mainThread)
     std::exception_ptr exc;
 
     while (true) {
-        std::function<void()> w;
+        work_t w;
         {
             auto state(state_.lock());
 

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -115,7 +115,7 @@ struct CmdHashBase : Command
                 auto sourcePath = makeSourcePath();
                 fun<git::DumpHook> hook = [&](const SourcePath & path) -> git::TreeEntry {
                     auto hashSink = makeSink();
-                    auto mode = dump(path, *hashSink, hook);
+                    auto mode = git::dump(path, *hashSink, hook);
                     auto hash = hashSink->finish().hash;
                     return {
                         .mode = mode,

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -111,7 +111,7 @@ struct CmdHashBase : Command
                 auto sourcePath = makeSourcePath();
                 fun<git::DumpHook> hook = [&](const SourcePath & path) -> git::TreeEntry {
                     auto hashSink = makeSink();
-                    auto mode = dump(path, *hashSink, hook);
+                    auto mode = git::dump(path, *hashSink, hook);
                     auto hash = hashSink->finish().hash;
                     return {
                         .mode = mode,


### PR DESCRIPTION
## Motivation

We were trying to do too much with one interface. Now, we instead have three interfaces:

- `FileSystemObjectSink`
- `merkle::FileSinkBuilder`
- `TarSink`

See the Doxygen on the two new ones for details.

This allows us to factor out the tarball -> Merkle code that makes the tarball cache for fetchers work into its own file, decoupled from the libgit2 internals and the libarchive internals. (This would be `merkle::TarAdapter`.) It is hopefully less scary now, and it is unit tested very comprehensively, including a property test.

The git repo implementation becomes *much* simpler, no longer bending over backwards to support tarballs. It is now just concerned with libgit2 FFI, and presents a very natural interface for a git repo. `GitRegularFileSinkImpl` and `GitDirectorySinkImpl` are thin wrappers around libgit2 --- the directory sink uses `git_treebuilder` directly.

Writing to a git repo *in parallel* is done through a new `GitRepoPool`, which manages a pool of `GitRepoImpl` handles (libgit2 repositories are not thread-safe for concurrent access). That is conceptually clearer than the old `GitRepoImpl` having a pool of itself, and lets us control synchronization more carefully. `GitRepoPool` also owns `getRevCount` (which walks commits in parallel).

Writing a blob is independent, whereas a directory can only refer to objects that are already written. `GitRepoPool` manages that transition itself --- see its Doxygen --- so the interface needs no notion of it, just a `flush` at the end for the caller to read back what it built.

The sinks accordingly `finalize` rather than `flush`: a sink is finished and yields a hash, whereas flushing a whole builder persists it. They are `unique_ptr`, as `finalize` consumes the sink and nothing shares one --- hence the first commit here, since the writing is handed to a thread pool.

The tar adapter keeps the same tree of directories that `GitFileSystemObjectSinkImpl` built, and processes it the same way: hand each file to the store as soon as it is parsed, then at the end write the directories children-first. The bound on how many files are written at once is likewise unchanged. Taken together with the git implementation, this is the algorithm we had before, just divided along a different line: unpacking nixpkgs (some 70k entries) gives the same store path, the same number of packfiles, the same wall time to within noise, and a few percent less CPU.

Overwrite semantics for ordinary entries are unchanged --- `addNode` documents how they follow libarchive --- but they now live in the adapter rather than being tangled up with the git tree building. Their tests accordingly move to `libfetchers-tests/merkle-tar-adapter.cc`, where they no longer need a git repo to state what they mean; `libfetchers-tests/git-utils.cc` keeps just the libgit2 ones. The adapter also settles two cases the old git sink had `FIXME`s on: a hard link to the root directory is now an error rather than silently doing nothing, and a non-directory root is now allowed rather than rejected.

Hard links do change, in order to follow libarchive too. They are resolved as they are parsed rather than at the end, so a link refers to the file that is at the target then --- like an inode --- rather than to whatever ends up at that path. `tar` behaves this way because it unlinks the file in the way instead of writing through it (like, for example, `cp` does), so replacing either end of a link now leaves the other alone, where before the link followed the replacement. Because that changes what such an archive unpacks to, we warn when it happens, naming the paths that were linked together.

Resolving as we parse also means the target must already exist, so a link cannot form a cycle, and there is no fixed point to compute at the end.

## Context

This is two commits:

1. `libutil: Let ThreadPool work items be move-only` --- `work_t` had to be copyable, so a work item could not own what it operates on. `std::move_only_function` is what we want, but libc++ does not implement it yet, so this uses `boost::compat::move_only_function`, Boost already being a dependency of libutil.

2. The change described above, which needs it in order to hand a file sink to the pool.

Additionally:

- Pure visitor interfaces (`merkle::DirectorySink`, `merkle::TreeEntry`, `merkle::Mode`) are now in libutil's `merkle-files.hh`, while the sink builder factory (`merkle::FileSinkBuilder`) and the finalizable sinks (`merkle::RegularFileSinkWithFinalize`, `merkle::DirectorySinkWithFinalize`) are in libfetchers' `merkle-tar-adapter.hh`.

- The Git object parsers report a bad size or mode as a Nix `Error`, rather than letting `std::stoi` throw its own. (`string2Int` is decimal-only, so the octal modes use `std::from_chars`.)

- Finally delete some of the dead `git` code. My thinking has changed with LLMs easily able to write stuff like this, and also the `libgit2` integration, as of this PR, now being more versatile.

In the future, now that it is used for less, this will allow us to tighten down `FileSystemObjectSink`, which will be very useful in preventing security issues and making the Windows port of it easier.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).





