### PR TITLE
nix flake clone: support cloning a specific revision

### DIFF
--- a/doc/manual/rl-next/flake-clone-rev.md
+++ b/doc/manual/rl-next/flake-clone-rev.md
@@ -1,0 +1,11 @@
+---
+synopsis: "`nix flake clone` now supports cloning a specific revision"
+prs: []
+issues: [15385]
+---
+
+`nix flake clone` now supports the `rev` query parameter. Previously, specifying a revision would result in an "unimplemented" error. Now, the repository is cloned and then checked out at the specified revision.
+
+```console
+$ nix flake clone --dest ./repo 'git+file:///path/to/repo?ref=main&rev=abc123...'
+```

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -461,12 +461,17 @@ struct GitInputScheme : InputScheme
             args.push_back(string_to_os_string(*ref));
         }
 
-        if (input.getRev())
-            throw UnimplementedError("cloning a specific revision is not implemented");
-
         args.push_back(destDir.native());
 
         runProgram("git", true, args, {}, true);
+
+        if (auto rev = input.getRev())
+            runProgram(
+                "git",
+                true,
+                {OS_STR("-C"), destDir.native(), OS_STR("checkout"), string_to_os_string(rev->gitRev())},
+                {},
+                true);
     }
 
     std::optional<std::filesystem::path> getSourcePath(const Input & input) const override

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -286,6 +286,12 @@ rm -rf "$TEST_ROOT"/flake1-v2
 nix flake clone flake1 --dest "$TEST_ROOT"/flake1-v2
 [ -e "$TEST_ROOT"/flake1-v2/flake.nix ]
 
+# Test 'nix flake clone' with a specific revision.
+rm -rf "$TEST_ROOT"/flake1-v2
+nix flake clone "git+file://$flake1Dir?ref=master&rev=$hash1" --dest "$TEST_ROOT"/flake1-v2
+[ -e "$TEST_ROOT"/flake1-v2/flake.nix ]
+[[ $(git -C "$TEST_ROOT"/flake1-v2 rev-parse HEAD) = "$hash1" ]]
+
 # Test 'follows' inputs.
 cat > "$flake3Dir/flake.nix" <<EOF
 {


### PR DESCRIPTION
## Motivation

`nix flake clone` does not support cloning a specific revision. Specifying `rev` in the flake reference results in:

```
error: cloning a specific revision is not implemented
```

This is unexpected because `rev` is supported in flake references for other commands like `nix build`.

Closes: #15385

## Context

Instead of throwing an `UnimplementedError` when a `rev` is specified, clone the repository and then `git checkout` the requested revision. This is consistent with how the git fetcher handles revisions elsewhere (e.g. in `getAccessorFromCommit`, which fetches the rev and then accesses it).

The change is minimal: the error is replaced with a `git -C <dest> checkout <rev>` after the clone completes.

### Tests

A functional test is added that clones with a specific revision and asserts the result is at the expected commit.

### Documentation

A release note is included.
