### PR TITLE
Strip com.apple.macl xattr before deleting paths on macOS

### DIFF
--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -28,6 +28,10 @@
 #  include <sys/mount.h>
 #endif
 
+#ifdef __APPLE__
+#  include <sys/xattr.h>
+#endif
+
 #ifdef _WIN32
 #  include <io.h>
 #endif
@@ -462,6 +466,16 @@ static void _deletePath(
             return;
         throw SysError("getting status of %1%", path);
     }
+
+#ifdef __APPLE__
+    /* Strip com.apple.macl extended attribute if present. On macOS,
+       Spotlight and Gatekeeper add this xattr to .app bundles in
+       /nix/store. It prevents chmod and unlink even for root (TCC
+       enforcement), causing GC to corrupt store paths.
+       Best-effort: ignore errors (ENOATTR when xattr is absent).
+       See: https://github.com/NixOS/nix/issues/6765 */
+    removexattr(path.c_str(), "com.apple.macl", XATTR_NOFOLLOW);
+#endif
 
     if (!S_ISDIR(st.st_mode)) {
         /* We are about to delete a file. Will it likely free space? */


### PR DESCRIPTION
## Motivation

On macOS, Spotlight and Gatekeeper add com.apple.macl extended attributes to .app bundles in /nix/store. This xattr prevents chmod and unlink operations even for root (TCC enforcement). When nix GC tries to delete these paths, it partially succeeds and leaves corrupt store paths, causing subsequent dev up to fail with 'chmod: Operation not permitted'.

## Context

Fix: call removexattr() for com.apple.macl on every path during recursive deletion, right after stat and before chmod/unlink. This is a no-op when the xattr is absent (returns ENOATTR), and is gated behind #ifdef __APPLE__.

Upstream issue: https://github.com/NixOS/nix/issues/6765

### Extra verification

Verified that root can strip com.apple.macl from /nix/store on macOS

1️⃣ Found .app bundles in the nix store:

```
find /nix/store -maxdepth 4 -name "*.app" -type d
```

→ Found Android Studio at /nix/store/3k2dcvn7ns0v18pd55x3sn4a5s455ahg-android-studio-2025.1.1.13/Applications/Android [Studio.app](http://studio.app/)

2️⃣  Confirmed no existing com.apple.macl xattr:
```
xattr -l "/nix/store/.../Android [Studio.app](http://studio.app/)" | grep macl
→ Empty (no xattr present)
```

3️⃣  Simulated the problem by adding the xattr:
```
sudo xattr -w com.apple.macl "$(echo 'test' | base64)" "/nix/store/.../Android [Studio.app](http://studio.app/)"
→ Verified with xattr -l ... | grep macl → showed com.apple.macl: dGVzdAo=
```

4️⃣  Stripped the xattr as root
```
sudo xattr -dr com.apple.macl "/nix/store/.../Android [Studio.app](http://studio.app/)"
→ Verified with xattr -l ... | grep macl → empty output, xattr gone :white_check_mark:
```

Conclusion: Root processes can successfully strip com.apple.macl from /nix/store paths.
