### PR TITLE
fix: refresh tarball cache on nix profile upgrade

### DIFF
--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -12,6 +12,7 @@
 #include "nix/store/names.hh"
 #include "nix/util/url.hh"
 #include "nix/flake/url-name.hh"
+#include "nix/fetchers/fetch-settings.hh"
 
 #include <nlohmann/json.hpp>
 #include <regex>
@@ -688,6 +689,7 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixDefaultProfile, MixProf
 
     void run(ref<Store> store) override
     {
+        fetchSettings.tarballTtl = 0;
         ProfileManifest manifest(*getEvalState(), *profile);
 
         Installables installables;


### PR DESCRIPTION
Setting tarball-ttl to 0 prevent the use of stale flake inputs when upgrading a profile.

Closes: #15396

## Motivation

Using the tarball cache when upgrading the flake profile is really confusing, making it seem like there are no updates available. It's not obvious that the tarball cache is causing this and the workaround of passing `--tarball-ttl 0` is not very user friendly or discoverable. 

## Context

See #15396

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
