### PR TITLE
libstore: forward trusted client settings to fileTransferSettings in daemon

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -6,6 +6,7 @@
 #include "nix/store/build-result.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/store-cast.hh"
+#include "nix/store/filetransfer.hh"
 #include "nix/store/gc-store.hh"
 #include "nix/store/log-store.hh"
 #include "nix/store/indirect-root-store.hh"
@@ -296,9 +297,10 @@ struct ClientSettings
                     trusted || name == settings.getWorkerSettings().buildTimeout.name
                     || name == settings.getWorkerSettings().maxSilentTime.name
                     || name == settings.getWorkerSettings().pollInterval.name || name == "connect-timeout"
-                    || (name == "builders" && value == ""))
+                    || (name == "builders" && value == "")) {
                     settings.set(name, value);
-                else if (setSubstituters(settings.getWorkerSettings().substituters))
+                    fileTransferSettings.set(name, value);
+                } else if (setSubstituters(settings.getWorkerSettings().substituters))
                     ;
                 else
                     warn(


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Client setting overrides from trusted users were not passed to fileTransferSettings, so settings like `netrc-file` had no effect when set by the client.

This regression was introduced in v2.34.0.

## Context

On 03/03/2026 we bumped Nix to v2.34.0 in `cachix/install-nix-action` and began receiving reports of authentication failures against private cachix.org caches. Tracking issue: https://github.com/cachix/install-nix-action/issues/268

We found that [a recent refactor of the settings](https://github.com/NixOS/nix/commit/04d13a96e) moved the `netrc-file` option from `Settings` to `FileTransferSettings`, but did not forward the client overrides to `FileTransferSettings.` on the daemon side.
`settings.set("netrc-file", ...)` would silently fail to find the setting.

Big thank you to @xokdvium for hopping on a call and helping to debug this.

## Open questions

There are several open questions left to resolve:

- This fix currently mirrors what the client side does. Another option is to use `globalConfig`, but that might be too broad? 
- Should `.set` display a warning if it fails to find the setting by name?

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
