### PR TITLE
libutil/serialise: Use zero-copy copy_file_range for copying PosixFileSourceAccessor -> FdSink

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1415,10 +1415,8 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
 
             auto tmpOutput = tempDir / "x";
 
-            /* Serialise and create a fresh copy of the output to break
-               any stale writable file descriptors. Copy through the
-               serialisation/deserialisation. TODO: Use copyRecursive here and
-               make use of reflinking. */
+            /* Copy files to break stale file descriptors. copyRecursive below will use
+               reflinking to optimise the copying overhead. */
             auto pathAccessor = makeFSSourceAccessor(actualPath);
             RestoreSink restoreSink{store.config->getLocalSettings().fsyncStorePaths};
             restoreSink.dstPath = tmpOutput;

--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -2,10 +2,14 @@
 #include <gmock/gmock.h>
 
 #include "nix/util/file-descriptor.hh"
+#include "nix/util/file-system.hh"
 #include "nix/util/serialise.hh"
 #include "nix/util/signals.hh"
 
 #include <cstring>
+#include <random>
+#include <algorithm>
+#include <thread>
 
 #ifndef _WIN32
 #  include <fcntl.h>
@@ -321,5 +325,124 @@ TEST(WriteFull, RespectsAllowInterrupts)
     FdSource source(pipe.readSide.get());
     EXPECT_EQ(source.readLine(/*eofOk=*/true), "hello");
 }
+
+class CopyFdRangeTest : public ::testing::TestWithParam<std::tuple</*tryCoW*/ bool, /* isRegularFile*/ bool>>
+{
+protected:
+    static std::string makeData()
+    {
+        std::mt19937 rng{42};
+        std::string data(192 * 1024 + 1024, '\0');
+        std::ranges::generate(data, rng);
+        return data;
+    }
+
+    bool tryCoW()
+    {
+        return std::get<0>(GetParam());
+    }
+
+    bool isRegularFile()
+    {
+        return std::get<1>(GetParam());
+    }
+};
+
+TEST_P(CopyFdRangeTest, regularToRegular)
+{
+    auto source = createAnonymousTempFile();
+    auto dest = createAnonymousTempFile();
+    auto input = makeData();
+    writeFull(source.get(), input);
+
+    FdSink sink{dest.get()};
+    sink.isRegularFile = isRegularFile();
+    copyFdRange(source.get(), 0, input.size(), sink, tryCoW());
+    sink.flush();
+    ASSERT_EQ(sink.written, input.size());
+    ASSERT_EQ(lseek(dest.get(), 0, SEEK_SET), 0);
+    ASSERT_EQ(readFile(dest.get()), input);
+}
+
+TEST_P(CopyFdRangeTest, offsetWorks)
+{
+    auto source = createAnonymousTempFile();
+    auto dest = createAnonymousTempFile();
+    auto input = makeData();
+    writeFull(source.get(), input);
+
+    static constexpr off_t offset = 4096;
+    FdSink sink{dest.get()};
+    sink.isRegularFile = isRegularFile();
+    copyFdRange(source.get(), offset, input.size() - offset, sink, tryCoW());
+    sink.flush();
+    ASSERT_EQ(sink.written, input.size() - offset);
+    ASSERT_EQ(lseek(dest.get(), 0, SEEK_SET), 0);
+    ASSERT_EQ(readFile(dest.get()), input.substr(offset));
+}
+
+TEST_P(CopyFdRangeTest, endOfFile)
+{
+    auto source = createAnonymousTempFile();
+    Descriptor dest;
+    AutoCloseFD dest_ = createAnonymousTempFile();
+    Pipe pipe;
+    if (isRegularFile()) {
+        dest = dest_.get();
+    } else {
+        pipe.create();
+        dest = pipe.writeSide.get();
+    }
+    FdSink sink(dest);
+    sink.isRegularFile = isRegularFile();
+    /* This can't ever deadlock, because nothing should be written to the pipe anyway. */
+    EXPECT_THROW(copyFdRange(source.get(), 0, 512 * 1024, sink, tryCoW()), EndOfFile);
+}
+
+TEST_P(CopyFdRangeTest, toPipe)
+{
+    auto input = makeData();
+    auto source = createAnonymousTempFile();
+    writeFull(source.get(), input);
+
+    Pipe pipe;
+    pipe.create();
+
+    std::string output;
+    std::thread reader([&] { output = drainFD(pipe.readSide.get()); });
+
+    FdSink sink{pipe.writeSide.get()};
+    /* This is only a hint and isn't load-bearing. */
+    sink.isRegularFile = isRegularFile();
+    copyFdRange(source.get(), 0, input.size(), sink, tryCoW());
+    sink.flush();
+    pipe.writeSide.close();
+    reader.join();
+    ASSERT_EQ(sink.written, input.size());
+    ASSERT_EQ(output, input);
+}
+
+TEST_P(CopyFdRangeTest, nonSeekableInput)
+{
+    Pipe in;
+    in.create();
+    auto dest = createAnonymousTempFile();
+    FdSink sink{dest.get()};
+    sink.isRegularFile = isRegularFile();
+    // TODO: Test the error code accurately.
+    EXPECT_THROW(copyFdRange(in.readSide.get(), 0, 128 * 1024, sink, tryCoW()), SystemError);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CopyFdRange,
+    CopyFdRangeTest,
+    ::testing::Combine(::testing::Values(false, true), ::testing::Values(false, true)),
+    [](const ::testing::TestParamInfo<std::tuple<bool, bool>> & info) {
+        std::string res = "";
+        res += std::get<0>(info.param) ? "fast" : "slow";
+        res += "_";
+        res += std::get<1>(info.param) ? "regular" : "nonregular";
+        return res;
+    });
 
 } // namespace nix

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -138,10 +138,7 @@ if build_unit_tests
     protocol : 'gtest',
   )
 
-  # Run the same tests again under `enosys -d openat2` to exercise the
-  # iterative (non-openat2) fallback path on Linux.  `enosys` uses
-  # seccomp to make `openat2` return `ENOSYS`, which the wrapper in
-  # file-system-at.cc caches and falls back to the iterative impl.
+  # Run the same tests again under `enosys` to exercise fallback paths on Linux.
   if host_machine.system() == 'linux'
     enosys = find_program('enosys', required : false)
     if enosys.found()
@@ -152,6 +149,7 @@ if build_unit_tests
           '--syscall', 'openat2',
           '--syscall', 'fchmodat2',
           '--syscall', 'close_range',
+          '--syscall', 'copy_file_range',
           '--',
           this_exe,
         ],

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -98,9 +98,8 @@ mkMesonExecutable (finalAttrs: {
           withUnitTests && stdenv.hostPlatform.isLinux && stdenv.buildPlatform.canExecute stdenv.hostPlatform
         )
         {
-          # Run the same tests with newer syscalls disabled via seccomp,
-          # to exercise fallback paths (iterative openat for openat2,
-          # /proc/self/fd for fchmodat2).
+          # Run the same tests with newer syscalls disabled via seccomp, to
+          # exercise fallback paths.
           run-without-new-syscalls =
             runCommand "${finalAttrs.pname}-run-without-new-syscalls"
               {
@@ -113,6 +112,7 @@ mkMesonExecutable (finalAttrs: {
                   --syscall openat2 \
                   --syscall fchmodat2 \
                   --syscall close_range \
+                  --syscall copy_file_range \
                   -- ${lib.getExe finalAttrs.finalPackage}
                 touch $out
               '';

--- a/src/libutil/file-descriptor-private.hh
+++ b/src/libutil/file-descriptor-private.hh
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "nix/util/file-descriptor.hh"
+
+namespace nix {
+
+struct FdSink;
+
+/**
+ * Try to copy @p nbytes bytes from @p from fd to @p to fd, starting at @p offset.
+ * The intent is to try to use optimized file copies like copy_file_range (on Linux) first
+ * and only fall back to the slower copying when the fast path fails or is unsupported.
+ *
+ * @throws SystemError in case the copy was started, but failed halfway.
+ *
+ * @return true if the copy succeeded, false if it's unsupported. Partial copies
+ *         should be reported as errors.
+ *
+ * @pre written should be set to 0 before calling this function.
+ */
+bool tryCopyFdRangeFast(Descriptor from, Descriptor to, off_t offset, size_t nbytes, size_t & written);
+
+} // namespace nix

--- a/src/libutil/file-descriptor.cc
+++ b/src/libutil/file-descriptor.cc
@@ -3,6 +3,8 @@
 #include "nix/util/util.hh"
 #include "nix/util/signals.hh"
 
+#include "file-descriptor-private.hh"
+
 #include <span>
 #include <fcntl.h>
 #include <unistd.h>
@@ -202,10 +204,30 @@ std::string drainFD(Descriptor fd, DrainFdOpts opts)
     return std::move(sink.s);
 }
 
-void copyFdRange(Descriptor fd, off_t offset, size_t nbytes, Sink & sink)
+void copyFdRange(Descriptor fd, off_t offset, size_t nbytes, Sink & sink, bool tryCoW)
 {
+    /* Nothing to do. */
+    if (!nbytes)
+        return;
+
+    static constexpr size_t copyBufferSize = 64 * 1024;
+
+    if (tryCoW) {
+        /* dynamic_cast here is slightly annoying, but it's much cheaper than
+           doing I/O so it doesn't really matter. */
+        FdSink * fdSink = dynamic_cast<FdSink *>(&sink);
+        /* Destination is a regular file which hasn't been written to and we've
+           been hinted that we should try block cloning. Try it and in case we
+           can't do block cloning then fall back to the loop below. Also, don't
+           bother with files smaller than the copy buffer. */
+        if (fdSink && !fdSink->hasData() && fdSink->written == 0 && fdSink->isRegularFile && nbytes > copyBufferSize
+            && tryCopyFdRangeFast(fd, fdSink->fd, offset, nbytes, fdSink->written)) {
+            return;
+        }
+    }
+
     auto left = nbytes;
-    std::array<std::byte, 64 * 1024> buf;
+    std::array<std::byte, copyBufferSize> buf;
 
     while (left) {
         auto limit = std::min<size_t>(left, buf.size());

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -210,6 +210,7 @@ struct RestoreRegularFile : CreateRegularFileSink, FdSink
         , fd(std::move(fd_))
         , startFsync(startFSync_)
     {
+        isRegularFile = true; /* Hint for copying contents via CoW copy_file_range. */
     }
 
     void anchor() override;

--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -115,11 +115,13 @@ size_t readOffset(Descriptor fd, off_t offset, std::span<std::byte> buffer);
 /**
  * Read @p nbytes starting at @p offset from a seekable file into a sink.
  *
+ * @param tryCoW Used as a hint to use optimised file copying like copy_file_range.
+ *
  * @throws SystemError if @p fd is not seekable or any operation fails
  * @throws Interrupted if the operation was interrupted
  * @throws EndOfFile if an EOF was reached before reading @p nbytes
  */
-void copyFdRange(Descriptor fd, off_t offset, size_t nbytes, Sink & sink);
+void copyFdRange(Descriptor fd, off_t offset, size_t nbytes, Sink & sink, bool tryCoW = false);
 
 /**
  * Wrappers around read()/write() that read/write exactly the

--- a/src/libutil/include/nix/util/serialise.hh
+++ b/src/libutil/include/nix/util/serialise.hh
@@ -79,6 +79,14 @@ public:
 
     void flush();
 
+    /**
+     * Check whether the buffer has unflushed data.
+     */
+    bool hasData() const noexcept
+    {
+        return bufPos;
+    }
+
 protected:
 
     virtual void writeUnbuffered(std::string_view data) = 0;
@@ -194,6 +202,12 @@ private:
 public:
     Descriptor fd;
     size_t written = 0;
+    /**
+     * A hint to the sink as to whether the destination is a regular file.
+     * Specifying a true for a non regular file doesn't affect correctness - only
+     * efficiency.
+     */
+    bool isRegularFile:1 = false;
 
     FdSink()
         : fd(INVALID_DESCRIPTOR)

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -150,7 +150,7 @@ void PosixFileSourceAccessor::readFile(const CanonPath & path, Sink & sink, fun<
     /* The most important invariant we care about here is writing exactly size
        bytes to the sink. copyFdRange should throw an EndOfFile if we fail to read
        `size` bytes. */
-    copyFdRange(fd.get(), /*offset=*/0, size, sink);
+    copyFdRange(fd.get(), /*offset=*/0, size, sink, /*tryCoW=*/true);
 }
 
 bool PosixFileSourceAccessor::pathExists(const CanonPath & path)

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -5,8 +5,10 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <span>
+#include <atomic>
 
 #include "util-unix-config-private.hh"
+#include "../file-descriptor-private.hh"
 
 namespace nix {
 
@@ -190,6 +192,74 @@ void unix::SelfPipe::drain()
                 throw SysError("reading from self-pipe");
         }
     }
+}
+
+bool tryCopyFdRangeFast(Descriptor from, Descriptor to, off_t offset, size_t nbytes, size_t & written)
+{
+#if HAVE_COPY_FILE_RANGE
+
+    /* Otherwise trying block cloning is pretty pointless. Also used to error
+       out on partial copies (unless we happen to hit block alignment boundary,
+       but that seems unlikely to be useful). */
+    assert(written == 0);
+    size_t left = nbytes;
+    static std::atomic_flag copyFileRangeUnsupported = {};
+
+    if (copyFileRangeUnsupported.test(std::memory_order_relaxed))
+        return false;
+
+    while (left) {
+        checkInterrupt();
+
+        ssize_t n = ::copy_file_range(
+            from,
+            &offset,
+            to,
+            nullptr,
+            left,
+            0
+#  ifdef COPY_FILE_RANGE_CLONE /* FreeBSD */
+                | COPY_FILE_RANGE_CLONE
+#  endif
+        );
+
+        /* Reached EOF too early. */
+        if (n == 0)
+            throw EndOfFile(
+                "unexpected end-of-file copying from %1% to %2%",
+                PathFmt(descriptorToPath(from)),
+                PathFmt(descriptorToPath(to)));
+
+        if (n == -1) {
+            if (errno == EINTR)
+                continue; /* Loop over to hit checkInterrupt. */
+
+            if (written == 0 && (errno == EINVAL || errno == EOPNOTSUPP || errno == EXDEV || errno == EBADF)) {
+                /* Retry with fallback. */
+            } else if (written == 0 && errno == ENOSYS) {
+                /* Cache ENOSYS. */
+                copyFileRangeUnsupported.test_and_set();
+            } else {
+                throw SysError([&] {
+                    return HintFmt(
+                        "copying contents of %1% to %2% via copy_file_range",
+                        PathFmt(descriptorToPath(from)),
+                        PathFmt(descriptorToPath(to)));
+                });
+            }
+
+            return false;
+        }
+
+        assert(static_cast<uint64_t>(n) <= left);
+        left -= n;
+        written += n;
+    }
+
+    return true;
+#else
+    return false;
+#endif
 }
 
 } // namespace nix

--- a/src/libutil/unix/meson.build
+++ b/src/libutil/unix/meson.build
@@ -52,6 +52,23 @@ foreach funcspec : check_funcs_unix
   configdata_unix.set(define_name, define_value, description : funcspec[1])
 endforeach
 
+# Detects the Linux signature of the copy_file_range.
+have_copy_file_range = cxx.links(
+  '''#include <unistd.h>
+int main() {
+  static_assert(sizeof(off_t) == 8);
+  copy_file_range(0, nullptr, 0, nullptr, 0, 0);
+}
+  ''',
+  name : 'have copy_file_range',
+)
+
+configdata_unix.set(
+  'HAVE_COPY_FILE_RANGE',
+  have_copy_file_range.to_int(),
+  description : 'Optionally used for optimised file copying',
+)
+
 config_unix_priv_h = configure_file(
   configuration : configdata_unix,
   output : 'util-unix-config-private.hh',

--- a/src/libutil/windows/file-descriptor.cc
+++ b/src/libutil/windows/file-descriptor.cc
@@ -3,6 +3,8 @@
 #include "nix/util/finally.hh"
 #include "nix/util/serialise.hh"
 
+#include "../file-descriptor-private.hh"
+
 #include <span>
 
 #include <fileapi.h>
@@ -45,12 +47,19 @@ size_t readOffset(Descriptor fd, off_t offset, std::span<std::byte> buffer)
     ov.Offset = static_cast<DWORD>(offset);
     if constexpr (sizeof(offset) > 4) /* We don't build with 32 bit off_t, but let's be safe. */
         ov.OffsetHigh = static_cast<DWORD>(offset >> 32);
+    // TODO: Don't do this on each call maybe?
+    if (::GetFileType(fd) != FILE_TYPE_DISK)
+        // Not the most accurate error code, but it will do.
+        throw windows::WinError(
+            DWORD(ERROR_SEEK_ON_DEVICE), "reading at offset %1% from a non-seekable handle", offset);
     DWORD n;
     if (!ReadFile(fd, buffer.data(), static_cast<DWORD>(buffer.size()), &n, &ov)) {
-        throw windows::WinError([&] {
-            return HintFmt(
-                "reading %1% bytes at offset %2% from %3%", buffer.size(), offset, PathFmt(descriptorToPath(fd)));
-        });
+        auto err = ::GetLastError();
+        // We report EOF as 0 return code, not an actual error.
+        if (err == ERROR_HANDLE_EOF)
+            return 0;
+        throw windows::WinError(
+            err, "reading %1% bytes at offset %2% from %3%", buffer.size(), offset, PathFmt(descriptorToPath(fd)));
     }
     return static_cast<size_t>(n);
 }
@@ -131,6 +140,13 @@ void syncDescriptor(Descriptor fd)
     if (!::FlushFileBuffers(fd)) {
         throw windows::WinError([&] { return HintFmt("flushing file %s", PathFmt(descriptorToPath(fd))); });
     }
+}
+
+bool tryCopyFdRangeFast(Descriptor from, Descriptor to, off_t offset, size_t nbytes, size_t & written)
+{
+    /* TODO: Implement if this becomes relevant. Seems like windows maybe has some reflinking capabilities:
+       https://devblogs.microsoft.com/engineering-at-microsoft/dev-drive-and-copy-on-write-for-developer-performance/ */
+    return false;
 }
 
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

On modern filesystems like ZFS/BTRFS copy_file_range can do use block
cloning for copying file contents. In the future we could use something
similar via sendfile for sending data to a socket from a file descriptor
(or even send the descriptor via SCM_RIGHTS). This is only beneficial
for copying files wholesale (like we do with NAR unpacking).

This cuts down the overhead of copying FOD outputs (for breaking file handles)
significantly. These are numbers from building with store on ZFS of a simple FOD
with a large output:

(After)

```
 79.03    1.752192           9    183511           pread64
  8.42    0.186688      186688         1           copy_file_range
  8.40    0.186341       46585         4           wait4
  1.06    0.023536           7      3092           getdents64

User time (seconds): 4.69
System time (seconds): 3.80
Percent of CPU this job got: 63%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:13.32
```

(Before)

```
 74.80    3.831072          15    244547           pread64
 20.07    1.027953          16     61730           write
  3.16    0.161804       40451         4           wait4
  0.59    0.030202           9      3092           getdents64

User time (seconds): 4.71
System time (seconds): 7.27
Percent of CPU this job got: 82%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:14.47
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
