### PR TITLE
libstore: handle root path in RemoteFSAccessor::maybeLstat

### DIFF
--- a/src/libstore/remote-fs-accessor.cc
+++ b/src/libstore/remote-fs-accessor.cc
@@ -35,6 +35,8 @@ std::shared_ptr<SourceAccessor> RemoteFSAccessor::accessObject(const StorePath &
 
 std::optional<SourceAccessor::Stat> RemoteFSAccessor::maybeLstat(const CanonPath & path)
 {
+    if (path.isRoot())
+        return Stat{.type = tDirectory};
     auto res = fetch(path);
     return res.first->maybeLstat(res.second);
 }


### PR DESCRIPTION
`RemoteFSAccessor::fetch()` crashes when called with the root path.

```
  $ nix build nixpkgs#hello --store ssh-ng://host
  error: path '/nix/store/' is not in the Nix store
```

Add `path.isRoot()` guard like `LocalStoreAccessor::maybeLstat`

Fixes: eb643d034 ("`Store::getFSAccessor`: Do not include the store dir")
Fixes #15418

---

```
$ nix run "github:NixOS/nix/2.34.0" -- build "github:nixos/nixpkgs/nixos-25.11#hello" --store ssh-ng://hoshitsuki-nixos -vvvvvvv                                                                                                                                                         ↵ 1
evaluating file '«nix-internal»/derivation-internal.nix'
evaluating derivation 'github:nixos/nixpkgs/nixos-25.11#hello'...
using cache entry 'file:{"name":"source","store":"/nix/store","url":"https://api.github.com/repos/nixos/nixpkgs/commits/nixos-25.11"}' -> '{"etag":"W/\"b901e52b4708dfb8b8f3307911dd831d8e9bb2b4b92b708cc1dd64346c0b1a4f\"","storePath":"r237iz9k6cs1v85xzpmk0llk64iz6wj4-source","url":"https://api.github.com/repos/nixos/nixpkgs/commits/nixos-25.11"}'
debug1: OpenSSH_10.2p1, OpenSSL 3.6.1 27 Jan 2026
debug1: Reading configuration data ~/.ssh/config
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: Reading configuration data /nix/store/71xqvh7zv0p9qd7mvrfvv2npmrfc3b61-libvirt-12.1.0/etc/ssh/ssh_config.d/30-libvirt-ssh-proxy.conf
debug1: /etc/ssh/ssh_config line 3: Applying options for *
debug1: /etc/ssh/ssh_config line 9: Applying options for *
debug1: Reading configuration data /nix/store/wxyn8d3m8g4fnn6xazinjwhzhzdg6wib-systemd-259/lib/systemd/ssh_config.d/20-systemd-ssh-proxy.conf
debug1: auto-mux: Trying existing master at '~/.ssh/master-5df66ec91a31c19703aa3490b0027cb27f732841'
debug1: mux_client_request_session: master session id: 2
using cache entry 'file:{"name":"source","store":"/nix/store","url":"https://api.github.com/repos/nixos/nixpkgs/commits/nixos-25.11"}' -> '{"etag":"W/\"b901e52b4708dfb8b8f3307911dd831d8e9bb2b4b92b708cc1dd64346c0b1a4f\"","url":"https://api.github.com/repos/nixos/nixpkgs/commits/nixos-25.11"}', '/nix/store/r237iz9k6cs1v85xzpmk0llk64iz6wj4-source'
HEAD revision for 'github:nixos/nixpkgs/nixos-25.11' is 71caefce12ba78d84fe618cf61644dce01cf3a96
using cache entry 'gitRevToTreeHash:{"rev":"71caefce12ba78d84fe618cf61644dce01cf3a96"}' -> '{"treeHash":"4121994f09f2d1a5d8efcb04c1e450240336f0a8"}'
using cache entry 'gitRevToLastModified:{"rev":"71caefce12ba78d84fe618cf61644dce01cf3a96"}' -> '{"lastModified":1772822230}'
got tree '«github:nixos/nixpkgs/71caefce12ba78d84fe618cf61644dce01cf3a96»/' from 'github:nixos/nixpkgs/71caefce12ba78d84fe618cf61644dce01cf3a96'
evaluating file '«github:nixos/nixpkgs/71caefce12ba78d84fe618cf61644dce01cf3a96»/flake.nix'
using cache entry 'sourcePathToHash:{"fingerprint":"71caefce12ba78d84fe618cf61644dce01cf3a96","method":"nar","path":"/"}' -> '{"hash":"sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw="}'
source path '«github:nixos/nixpkgs/71caefce12ba78d84fe618cf61644dce01cf3a96»/' cache hit in '/nix/store/arylzmnn080w2i8hi0x45pgkd3mmp53r-source' (hash 'sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=')
killing process 3027067
error: path '/nix/store/' is not in the Nix store
```

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
