### PR TITLE
libstore-c: expose store path query operations

### DIFF
--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -37,6 +37,7 @@ headers = files(
   'nix_api_store.h',
   'nix_api_store/derivation.h',
   'nix_api_store/store_path.h',
+  'nix_api_store/path_info.h',
 )
 
 # TODO don't install this once tests don't use it and/or move the header into `libstore`, non-`c`

--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -380,4 +380,124 @@ nix_err nix_store_copy_path(
     NIXC_CATCH_ERRS
 }
 
+ValidPathInfo * nix_store_query_path_info(nix_c_context * context, Store * store, const StorePath * path)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        auto info = store->ptr->queryPathInfo(path->path);
+        return new ValidPathInfo{info};
+    }
+    NIXC_CATCH_ERRS_NULL
+}
+
+nix_err nix_store_query_referrers(
+    nix_c_context * context,
+    Store * store,
+    const StorePath * path,
+    void * userdata,
+    void (*callback)(void * userdata, const StorePath * referrer))
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        nix::StorePathSet referrers;
+        store->ptr->queryReferrers(path->path, referrers);
+
+        if (callback) {
+            for (const auto & referrer : referrers) {
+                const StorePath tmp{referrer};
+                callback(userdata, &tmp);
+            }
+        }
+    }
+    NIXC_CATCH_ERRS
+}
+
+nix_err nix_store_query_requisites(
+    nix_c_context * context,
+    Store * store,
+    const StorePath * path,
+    void * userdata,
+    void (*callback)(void * userdata, const StorePath * requisite))
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        nix::StorePathSet requisites;
+        // Compute the forward closure (all transitive dependencies)
+        // flip_direction=false: forward closure (dependencies)
+        // include_outputs=false: don't include derivation outputs
+        // include_derivers=false: don't include derivers
+        store->ptr->computeFSClosure(path->path, requisites, false, false, false);
+
+        if (callback) {
+            for (const auto & requisite : requisites) {
+                const StorePath tmp{requisite};
+                callback(userdata, &tmp);
+            }
+        }
+    }
+    NIXC_CATCH_ERRS
+}
+
+void nix_valid_path_info_free(ValidPathInfo * info)
+{
+    delete info;
+}
+
+nix_err nix_valid_path_info_get_references(
+    nix_c_context * context,
+    const ValidPathInfo * info,
+    void * userdata,
+    void (*callback)(void * userdata, const StorePath * reference))
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        if (callback) {
+            for (const auto & ref : info->ptr->references) {
+                const StorePath tmp{ref};
+                callback(userdata, &tmp);
+            }
+        }
+    }
+    NIXC_CATCH_ERRS
+}
+
+StorePath * nix_valid_path_info_get_deriver(nix_c_context * context, const ValidPathInfo * info)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        if (info->ptr->deriver) {
+            return new StorePath{*info->ptr->deriver};
+        }
+        return nullptr;
+    }
+    NIXC_CATCH_ERRS_NULL
+}
+
+nix_err nix_valid_path_info_get_nar_hash(
+    nix_c_context * context, const ValidPathInfo * info, nix_get_string_callback callback, void * user_data)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        auto hashStr = info->ptr->narHash.to_string(nix::HashFormat::SRI, true);
+        return call_nix_get_string_callback(hashStr, callback, user_data);
+    }
+    NIXC_CATCH_ERRS
+}
+
+uint64_t nix_valid_path_info_get_nar_size(const ValidPathInfo * info)
+{
+    return info->ptr->narSize;
+}
+
+time_t nix_valid_path_info_get_registration_time(const ValidPathInfo * info)
+{
+    return info->ptr->registrationTime;
+}
+
 } // extern "C"

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -14,6 +14,7 @@
 #include "nix_api_util.h"
 #include "nix_api_store/store_path.h"
 #include "nix_api_store/derivation.h"
+#include "nix_api_store/path_info.h"
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -125,6 +126,63 @@ StorePath * nix_store_parse_path(nix_c_context * context, Store * store, const c
  * @return true or false, error info in context
  */
 bool nix_store_is_valid_path(nix_c_context * context, Store * store, const StorePath * path);
+
+/**
+ * @brief Query information about a valid store path
+ *
+ * This returns detailed information about a store path including its references,
+ * deriver, NAR hash, and size.
+ *
+ * @note Don't forget to free the returned ValidPathInfo using nix_valid_path_info_free()!
+ * @param[out] context Optional, stores error information
+ * @param[in] store Nix Store reference
+ * @param[in] path The path to query
+ * @return ValidPathInfo pointer, NULL on error
+ */
+ValidPathInfo * nix_store_query_path_info(nix_c_context * context, Store * store, const StorePath * path);
+
+/**
+ * @brief Query the paths that reference the given store path (inverse of references)
+ *
+ * This finds all paths in the store that have the given path in their references.
+ *
+ * @note The callback borrows each StorePath only for the duration of the call.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] store Nix Store reference
+ * @param[in] path The path to query
+ * @param[in] userdata The userdata to pass to the callback
+ * @param[in] callback The function to call for every referrer
+ * @return NIX_OK on success, error code on failure
+ */
+nix_err nix_store_query_referrers(
+    nix_c_context * context,
+    Store * store,
+    const StorePath * path,
+    void * userdata,
+    void (*callback)(void * userdata, const StorePath * referrer));
+
+/**
+ * @brief Query all requisites (transitive dependencies) of a store path
+ *
+ * This returns all store paths that the given path transitively depends on,
+ * including the path itself. This is equivalent to the closure of references.
+ *
+ * @note The callback borrows each StorePath only for the duration of the call.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] store Nix Store reference
+ * @param[in] path The path to query
+ * @param[in] userdata The userdata to pass to the callback
+ * @param[in] callback The function to call for every requisite path
+ * @return NIX_OK on success, error code on failure
+ */
+nix_err nix_store_query_requisites(
+    nix_c_context * context,
+    Store * store,
+    const StorePath * path,
+    void * userdata,
+    void (*callback)(void * userdata, const StorePath * requisite));
 
 /**
  * @brief Get the physical location of a store path

--- a/src/libstore-c/nix_api_store/path_info.h
+++ b/src/libstore-c/nix_api_store/path_info.h
@@ -1,0 +1,107 @@
+#ifndef NIX_API_STORE_PATH_INFO_H
+#define NIX_API_STORE_PATH_INFO_H
+/**
+ * @defgroup libstore_pathinfo PathInfo
+ * @ingroup libstore
+ * @brief Query information about store paths
+ * @{
+ */
+/** @file
+ * @brief Path info operations
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <time.h>
+
+#include "nix_api_util.h"
+#include "nix_api_store/store_path.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// cffi start
+
+/** @brief Information about a valid store path */
+typedef struct ValidPathInfo ValidPathInfo;
+
+/**
+ * @brief Deallocate a ValidPathInfo
+ *
+ * Does not fail.
+ * @param[in] info the path info to free
+ */
+void nix_valid_path_info_free(ValidPathInfo * info);
+
+/**
+ * @brief Get the references of a store path
+ *
+ * References are other store paths that this path depends on.
+ *
+ * @note The callback borrows each StorePath only for the duration of the call.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] info The path info
+ * @param[in] userdata The userdata to pass to the callback
+ * @param[in] callback The function to call for every reference
+ * @return NIX_OK on success, error code on failure
+ */
+nix_err nix_valid_path_info_get_references(
+    nix_c_context * context,
+    const ValidPathInfo * info,
+    void * userdata,
+    void (*callback)(void * userdata, const StorePath * reference));
+
+/**
+ * @brief Get the deriver of a store path
+ *
+ * The deriver is the .drv file that was used to build this path.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] info The path info
+ * @return The deriver store path, or NULL if there is no deriver. Caller must free with nix_store_path_free.
+ */
+StorePath * nix_valid_path_info_get_deriver(nix_c_context * context, const ValidPathInfo * info);
+
+/**
+ * @brief Get the NAR hash of a store path
+ *
+ * The NAR hash is the hash of the NAR (Nix ARchive) serialization of the path's contents.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] info The path info
+ * @param[in] callback Called with the NAR hash in SRI format (e.g., "sha256-...")
+ * @param[in] user_data optional, arbitrary data, passed to the callback when it's called.
+ * @return NIX_OK on success, error code on failure
+ */
+nix_err nix_valid_path_info_get_nar_hash(
+    nix_c_context * context, const ValidPathInfo * info, nix_get_string_callback callback, void * user_data);
+
+/**
+ * @brief Get the NAR size of a store path
+ *
+ * The NAR size is the size in bytes of the NAR serialization of the path's contents.
+ *
+ * @param[in] info The path info
+ * @return The NAR size in bytes, or 0 if unknown
+ */
+uint64_t nix_valid_path_info_get_nar_size(const ValidPathInfo * info);
+
+/**
+ * @brief Get the registration time of a store path
+ *
+ * This is when the path was registered in the store.
+ *
+ * @param[in] info The path info
+ * @return The registration time as a Unix timestamp, or 0 if unknown
+ */
+time_t nix_valid_path_info_get_registration_time(const ValidPathInfo * info);
+
+// cffi end
+#ifdef __cplusplus
+}
+#endif
+/**
+ * @}
+ */
+#endif // NIX_API_STORE_PATH_INFO_H

--- a/src/libstore-c/nix_api_store_internal.h
+++ b/src/libstore-c/nix_api_store_internal.h
@@ -2,6 +2,7 @@
 #define NIX_API_STORE_INTERNAL_H
 #include "nix/store/store-api.hh"
 #include "nix/store/derivations.hh"
+#include "nix/store/path-info.hh"
 
 extern "C" {
 
@@ -18,6 +19,11 @@ struct StorePath
 struct nix_derivation
 {
     nix::Derivation drv;
+};
+
+struct ValidPathInfo
+{
+    nix::ref<const nix::ValidPathInfo> ptr;
 };
 
 } // extern "C"


### PR DESCRIPTION
## Motivation
Allow for information about store paths to be queried. For rendering things like SBOMs or inspecting the merkel DAGs, allowing for the C API to directly handle this is a huge overhead win

## Context

I would like for a way to do `nix-store --query --references`, and `nix-store --query --requisites` without launching subprocesses.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
