### PR TITLE
libstore: use Windows known folders API for runtime path configuration

### DIFF
--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -249,14 +249,14 @@ endif
 # by joining it with prefix, unless it was already an absolute path
 # (which is the default for store-dir, localstatedir, and log-dir).
 configdata_priv.set_quoted('NIX_STORE_DIR', store_dir)
-configdata_priv.set_quoted('NIX_STATE_DIR', localstatedir / 'nix')
-configdata_priv.set_quoted('NIX_LOG_DIR', log_dir)
-# On Windows, NIX_CONF_DIR is determined at runtime using the Windows known
-# folders API (FOLDERID_ProgramData), so we don't define it at compile time.
+# On Windows, NIX_STATE_DIR, NIX_LOG_DIR, and NIX_CONF_DIR are determined at
+# runtime using the Windows known folders API (FOLDERID_ProgramData), so we
+# don't define them at compile time.
 if host_machine.system() != 'windows'
+  configdata_priv.set_quoted('NIX_STATE_DIR', localstatedir / 'nix')
+  configdata_priv.set_quoted('NIX_LOG_DIR', log_dir)
   configdata_priv.set_quoted('NIX_CONF_DIR', sysconfdir / 'nix')
 endif
-configdata_priv.set_quoted('NIX_MAN_DIR', mandir)
 
 lsof = find_program('lsof', required : false)
 configdata_priv.set_quoted(


### PR DESCRIPTION
## Motivation

On Windows the compile-time path constants (`NIX_CONF_DIR`, `NIX_STATE_DIR`, `NIX_LOG_DIR`) are meaningless because the install drive varies, so this resolves them at runtime via `FOLDERID_ProgramData` through the existing known-folders API.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
