### PR TITLE
tests: add fetch-tree test suite with test for #15423

### DIFF
--- a/tests/functional/fetchers/meson.build
+++ b/tests/functional/fetchers/meson.build
@@ -1,0 +1,8 @@
+suites += {
+  'name' : 'fetchers',
+  'deps' : [],
+  'tests' : [
+    'submodule-without-gitmodules.sh',
+  ],
+  'workdir' : meson.current_source_dir(),
+}

--- a/tests/functional/fetchers/submodule-without-gitmodules.nix
+++ b/tests/functional/fetchers/submodule-without-gitmodules.nix
@@ -1,0 +1,34 @@
+# Helper for submodule-without-gitmodules.sh
+# Checks the state of the "sub" path in a fetchGit result
+
+{ url, rev }:
+
+let
+  fetch = builtins.fetchGit {
+    inherit url rev;
+    submodules = true;
+  };
+
+  rootDir = builtins.readDir fetch;
+in
+if !(rootDir ? sub) then
+  {
+    exists = false;
+    type = null;
+    hasContent = false;
+  }
+else if rootDir.sub != "directory" then
+  {
+    exists = true;
+    type = rootDir.sub;
+    hasContent = false;
+  }
+else
+  let
+    subDir = builtins.readDir (fetch + "/sub");
+  in
+  {
+    exists = true;
+    type = "directory";
+    hasContent = subDir != { };
+  }

--- a/tests/functional/fetchers/submodule-without-gitmodules.sh
+++ b/tests/functional/fetchers/submodule-without-gitmodules.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# This test demonstrates that Nix's git fetcher incorrectly uses .gitmodules
+# as the source of truth for submodules, rather than the git merkle dag.
+#
+# The real source of truth for which submodules exist is the tree object in
+# git's merkle dag - entries with type "commit" (mode 160000) are submodules.
+# The .gitmodules file is merely metadata (URL, branch hints, etc.).
+#
+# This test creates a submodule entry directly in the git tree without a
+# corresponding .gitmodules entry. Currently Nix silently returns an empty
+# directory for the submodule path. The ideal fix would be to fetch the
+# submodule content, but without .gitmodules Nix doesn't know the URL.
+# At minimum, Nix should error rather than silently succeeding with an
+# empty directory.
+#
+# See: https://github.com/NixOS/nix/issues/15423
+
+source ../common.sh
+
+requireGit
+
+clearStoreIfPossible
+
+# Submodules can't be fetched locally by default.
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=protocol.file.allow
+export GIT_CONFIG_VALUE_0=always
+
+rootRepo=$TEST_ROOT/rootRepo
+subRepo=$TEST_ROOT/subRepo
+
+rm -rf "$rootRepo" "$subRepo" "$TEST_HOME"/.cache/nix
+
+# Create the submodule repository
+createGitRepo "$subRepo"
+echo "content from submodule" > "$subRepo/file.txt"
+git -C "$subRepo" add file.txt
+git -C "$subRepo" commit -m "Initial commit in submodule"
+
+# Create the root repository
+createGitRepo "$rootRepo"
+echo "content from root" > "$rootRepo/root.txt"
+git -C "$rootRepo" add root.txt
+git -C "$rootRepo" commit -m "Initial commit"
+
+# Now we'll add a submodule to the tree WITHOUT using .gitmodules.
+# In git, a submodule is simply a tree entry with mode 160000 (commit).
+# We can create this directly using git's plumbing commands.
+
+# First, let's create a proper submodule using `git submodule add`, just to test that also works.
+git -C "$rootRepo" submodule add "$subRepo" sub
+git -C "$rootRepo" commit -m "Add submodule"
+
+rev_with_gitmodules=$(git -C "$rootRepo" rev-parse HEAD)
+
+# Now remove .gitmodules but keep the submodule tree entry
+# The submodule entry in the tree (mode 160000) is the real source of truth
+git -C "$rootRepo" rm .gitmodules
+git -C "$rootRepo" commit -m "Remove .gitmodules but keep submodule in tree"
+
+rev_without_gitmodules=$(git -C "$rootRepo" rev-parse HEAD)
+
+# Verify the tree still has the submodule entry (mode 160000 = commit)
+git -C "$rootRepo" ls-tree HEAD | grep -q "^160000 commit"
+
+# Helper to probe submodule state using Nix builtins
+checkSubmodule() {
+    local rev="$1"
+    nix eval --impure --json --expr \
+        "import $(dirname "${BASH_SOURCE[0]}")/submodule-without-gitmodules.nix { url = \"file://$rootRepo\"; rev = \"$rev\"; }"
+}
+
+# Verify .gitmodules case works: submodule should exist with content
+result=$(checkSubmodule "$rev_with_gitmodules")
+
+[[ "$(echo "$result" | jq -r '.exists')" == "true" ]] || fail "With .gitmodules: sub should exist"
+[[ "$(echo "$result" | jq -r '.type')" == "directory" ]] || fail "With .gitmodules: sub should be a directory"
+[[ "$(echo "$result" | jq -r '.hasContent')" == "true" ]] || fail "With .gitmodules: sub should have content"
+
+# Check behavior without .gitmodules
+result=$(checkSubmodule "$rev_without_gitmodules")
+
+withoutGitmodules_exists=$(echo "$result" | jq -r '.exists')
+withoutGitmodules_hasContent=$(echo "$result" | jq -r '.hasContent')
+
+# BUG: Nix should either:
+# 1. Fetch the submodule content (ideal, but requires knowing the URL), or
+# 2. Error because the submodule commit is missing and can't be fetched
+#
+# Currently it silently succeeds with an empty directory, which is wrong.
+
+if [[ "$withoutGitmodules_hasContent" == "true" ]]; then
+    # Ideal fix: submodule was fetched correctly
+    echo "FIXED (ideal): Submodule was fetched correctly from merkle dag" >&2
+    echo "Please update this test to expect success." >&2
+    exit 1
+elif [[ "$withoutGitmodules_exists" == "false" ]]; then
+    # Acceptable fix: submodule entry doesn't exist
+    echo "FIXED (acceptable): Submodule directory not created" >&2
+    echo "Please update this test to expect this behavior." >&2
+    exit 1
+else
+    # Current buggy behavior: empty directory created silently
+    # TODO: change to a proper expected failure once Meson >= 1.11.0 is required
+    # (for should_fail with custom exit code support)
+    skipTest "Submodule without .gitmodules silently creates empty directory (known bug)"
+fi

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -219,6 +219,7 @@ endif
 
 subdir('ca')
 subdir('dyn-drv')
+subdir('fetchers')
 subdir('flakes')
 subdir('git')
 subdir('git-hashing')
@@ -249,6 +250,10 @@ foreach suite : suites
     asan_options += ':log_path=@0@'.format(
       meson.current_build_dir() / 'asan-log',
     )
+
+    # TODO: use Meson's 'should_fail' with a custom exit code once we require
+    # Meson >= 1.11.0 for proper expected failure support. For now, tests that
+    # demonstrate known bugs use skipTest in the test script itself.
 
     test(
       name,


### PR DESCRIPTION
## Motivation

This is a bug that has...bugged me for a while, but which was just oral knowledge and not written down anywhere. (Or, at least, I failed to find the issue just now.) I finally made the issue, and then (mostly with the LLM) made this test to illustrate the problem.

## Context

#15423

I put the test in a new "fetchers" test suite because we really do need much more tests centered around libfetchers / `builtins.fetchTree`.

The expected fix "it should just work" is probably overlay ambitious ---- the commit object would be dangling (missing) by default, and without `.gitmodules` Nix (or git) wouldn't know how to fetch it. But in that case, we should at least make it an error, rather than silently succeeding with an empty directory.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
