### PR TITLE
tests: add `UnkeyedRealisation` JSON characterisation tests

### DIFF
--- a/src/libstore-tests/data/realisation/unkeyed-simple.json
+++ b/src/libstore-tests/data/realisation/unkeyed-simple.json
@@ -1,0 +1,4 @@
+{
+  "outPath": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo",
+  "signatures": []
+}

--- a/src/libstore-tests/data/realisation/unkeyed-with-signature.json
+++ b/src/libstore-tests/data/realisation/unkeyed-with-signature.json
@@ -1,0 +1,9 @@
+{
+  "outPath": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv",
+  "signatures": [
+    {
+      "keyName": "asdf",
+      "sig": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+    }
+  ]
+}

--- a/src/libstore-tests/realisation.cc
+++ b/src/libstore-tests/realisation.cc
@@ -11,6 +11,43 @@
 
 namespace nix {
 
+using nlohmann::json;
+
+/* ----------------------------------------------------------------------------
+ * Test data
+ * --------------------------------------------------------------------------*/
+
+UnkeyedRealisation unkeyedSimple{
+    .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
+};
+
+UnkeyedRealisation unkeyedWithSignature{
+    .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv"},
+    .signatures =
+        {
+            Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
+        },
+};
+
+DrvOutput testDrvOutput{
+    .drvPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv"},
+    .outputName = "foo",
+};
+
+Realisation simple{
+    unkeyedSimple,
+    testDrvOutput,
+};
+
+Realisation withSignature{
+    unkeyedWithSignature,
+    testDrvOutput,
+};
+
+/* ----------------------------------------------------------------------------
+ * Realisation JSON
+ * --------------------------------------------------------------------------*/
+
 class RealisationTest : public JsonCharacterizationTest<Realisation>, public LibStoreTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "realisation";
@@ -22,12 +59,6 @@ public:
         return unitTestData / testStem;
     }
 };
-
-/* ----------------------------------------------------------------------------
- * JSON
- * --------------------------------------------------------------------------*/
-
-using nlohmann::json;
 
 struct RealisationJsonTest : RealisationTest, ::testing::WithParamInterface<std::pair<std::string_view, Realisation>>
 {};
@@ -43,30 +74,6 @@ TEST_P(RealisationJsonTest, to_json)
     const auto & [name, value] = GetParam();
     writeJsonTest(name, value);
 }
-
-Realisation simple{
-    {
-        .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
-    },
-    {
-        .drvPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv"},
-        .outputName = "foo",
-    },
-};
-
-Realisation withSignature{
-    {
-        .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv"},
-        .signatures =
-            {
-                Signature{.keyName = "asdf", .sig = std::string(64, '\0')},
-            },
-    },
-    {
-        .drvPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv"},
-        .outputName = "foo",
-    },
-};
 
 INSTANTIATE_TEST_SUITE_P(
     RealisationJSON,
@@ -88,5 +95,50 @@ TEST_F(RealisationTest, with_signature_from_json)
 {
     readJsonTest("with-signature", withSignature);
 }
+
+/* ----------------------------------------------------------------------------
+ * UnkeyedRealisation JSON
+ * --------------------------------------------------------------------------*/
+
+class UnkeyedRealisationTest : public JsonCharacterizationTest<UnkeyedRealisation>, public LibStoreTest
+{
+    std::filesystem::path unitTestData = getUnitTestData() / "realisation";
+
+public:
+
+    std::filesystem::path goldenMaster(std::string_view testStem) const override
+    {
+        return unitTestData / testStem;
+    }
+};
+
+struct UnkeyedRealisationJsonTest : UnkeyedRealisationTest,
+                                    ::testing::WithParamInterface<std::pair<std::string_view, UnkeyedRealisation>>
+{};
+
+TEST_P(UnkeyedRealisationJsonTest, from_json)
+{
+    const auto & [name, expected] = GetParam();
+    readJsonTest(name, expected);
+}
+
+TEST_P(UnkeyedRealisationJsonTest, to_json)
+{
+    const auto & [name, value] = GetParam();
+    writeJsonTest(name, value);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    UnkeyedRealisationJSON,
+    UnkeyedRealisationJsonTest,
+    ::testing::Values(
+        std::pair{
+            "unkeyed-simple",
+            unkeyedSimple,
+        },
+        std::pair{
+            "unkeyed-with-signature",
+            unkeyedWithSignature,
+        }));
 
 } // namespace nix


### PR DESCRIPTION
## Motivation

This commit extracts `UnkeyedRealisation` test values from `Realisation` and reuses them, matching how `Realisation` composes `UnkeyedRealisation` + `DrvOutput`. The new unkeyed-simple and unkeyed-with-signature fixtures test the JSON format independently of the keyed wrapper.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
