### PR TITLE
libstore: Replace strcpy with strncpy for loopback interface setup

### DIFF
--- a/src/libstore-test-support/libstore-network.cc
+++ b/src/libstore-test-support/libstore-network.cc
@@ -5,6 +5,8 @@
 #ifdef __linux__
 #  include "nix/util/file-system.hh"
 #  include "nix/util/linux-namespaces.hh"
+#  include <algorithm>
+#  include <string_view>
 #  include <sched.h>
 #  include <sys/ioctl.h>
 #  include <net/if.h>
@@ -34,8 +36,9 @@ static void enterNetworkNamespace()
     if (!fd)
         throw SysError("cannot open IP socket for loopback interface");
 
+    using namespace std::string_view_literals;
     struct ::ifreq ifr = {};
-    strcpy(ifr.ifr_name, "lo");
+    std::ranges::copy("lo"sv, ifr.ifr_name);
     ifr.ifr_flags = IFF_UP | IFF_LOOPBACK | IFF_RUNNING;
     if (::ioctl(fd.get(), SIOCSIFFLAGS, &ifr) == -1)
         throw SysError("cannot set loopback interface flags");

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -9,6 +9,8 @@
 #  include "nix/util/serialise.hh"
 #  include "linux/fchmodat2-compat.hh"
 
+#  include <algorithm>
+#  include <string_view>
 #  include <sys/ioctl.h>
 #  include <net/if.h>
 #  include <netinet/ip.h>
@@ -472,8 +474,9 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
             if (!fd)
                 throw SysError("cannot open IP socket");
 
-            struct ifreq ifr;
-            strcpy(ifr.ifr_name, "lo");
+            using namespace std::string_view_literals;
+            struct ifreq ifr = {};
+            std::ranges::copy("lo"sv, ifr.ifr_name);
             ifr.ifr_flags = IFF_UP | IFF_LOOPBACK | IFF_RUNNING;
             if (ioctl(fd.get(), SIOCSIFFLAGS, &ifr) == -1)
                 throw SysError("cannot set loopback interface flags");


### PR DESCRIPTION
## Motivation

Replace `strcpy()` with `std::ranges::copy()` and a `string_view` literal in two loopback interface initialization sites, avoiding C string functions in favour of idiomatic C++.

While the existing `strcpy()` calls are safe in practice (the literal `"lo"` is 3 bytes, the buffer `ifr.ifr_name` is `IFNAMSIZ`/16 bytes), `strcpy` is flagged by static analysis tools (semgrep `unsafe-strcpy`, CWE-120) and is a banned function in several secure coding standards (CERT C STR31-C, MISRA C 21.17).

This also adds zero-initialization (`= {}`) to the `ifreq` struct in `linux-derivation-builder.cc`, which was previously uninitialized. The test-support copy already had this.

## Context

This is my first pull request for Nix — I appreciate your time reviewing it. I found this while running semgrep against the codebase, which flagged the `strcpy` call as `unsafe-strcpy` (CWE-120: buffer copy without checking size of input). I wanted to start with a small, low-risk fix to get familiar with the contribution process.

**Files changed:**
- `src/libstore-test-support/libstore-network.cc` — `strcpy` → `std::ranges::copy` (test support)
- `src/libstore/unix/build/linux-derivation-builder.cc` — `strcpy` → `std::ranges::copy` + add `= {}` zero-initialization (production)

**Testing:**
- The test-support path is covered by the `HttpsBinaryCacheStore` unit test suite, which exercises `setupNetworkTests()` → `enterNetworkNamespace()`. All 5 tests pass.
- The production path in `linux-derivation-builder.cc` runs inside a Linux sandbox namespace during derivation builds, so it is not directly reachable from unit tests — it is covered by the functional test suite (`tests/functional/linux-sandbox.sh`).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
