### PR TITLE
libutil: Implement descriptor-based PosixFileSourceAccessor

### DIFF
--- a/src/libutil-tests/source-accessor.cc
+++ b/src/libutil-tests/source-accessor.cc
@@ -127,9 +127,7 @@ TEST_F(FSSourceAccessorTest, works)
     }
 
     {
-        auto accessor = makeFSSourceAccessor(tmpDir / "nonexistent");
-        EXPECT_FALSE(accessor->maybeLstat(CanonPath::root));
-        EXPECT_THROW(accessor->readFile(CanonPath::root), SystemError);
+        EXPECT_THROW(makeFSSourceAccessor(tmpDir / "nonexistent"), SystemError);
     }
 
     {

--- a/src/libutil/file-descriptor.cc
+++ b/src/libutil/file-descriptor.cc
@@ -1,3 +1,4 @@
+#include "nix/util/file-system.hh"
 #include "nix/util/serialise.hh"
 #include "nix/util/util.hh"
 #include "nix/util/signals.hh"
@@ -208,7 +209,7 @@ void copyFdRange(Descriptor fd, off_t offset, size_t nbytes, Sink & sink)
         auto limit = std::min<size_t>(left, buf.size());
         auto n = readOffset(fd, offset, std::span(buf.data(), limit));
         if (n == 0)
-            throw EndOfFile("unexpected end-of-file");
+            throw EndOfFile("unexpected end-of-file reading from %1%", PathFmt(descriptorToPath(fd)));
         assert(n <= left);
         sink(std::string_view(reinterpret_cast<const char *>(buf.data()), n));
         offset += n;

--- a/src/libutil/include/nix/util/posix-source-accessor.hh
+++ b/src/libutil/include/nix/util/posix-source-accessor.hh
@@ -6,10 +6,49 @@ namespace nix {
 
 struct SourcePath;
 
+namespace detail {
+
+/**
+ * Common base helper class for deduplicating common code paths for tracking mtime.
+ */
+class PosixSourceAccessorBase : virtual public SourceAccessor
+{
+protected:
+    const bool trackLastModified = false;
+
+    /**
+     * The most recent mtime seen by lstat(). This is a hack to
+     * support dumpPathAndGetMtime(). Should remove this eventually.
+     */
+    time_t mtime = 0;
+
+    void maybeUpdateMtime(time_t seenMTime)
+    {
+        /* The contract is that trackLastModified implies that the caller uses the accessor
+           from a single thread. Thus this is not a CAS loop. */
+        if (trackLastModified)
+            mtime = std::max(mtime, seenMTime);
+    }
+
+    PosixSourceAccessorBase(bool trackLastModified)
+        : trackLastModified(trackLastModified)
+    {
+    }
+
+    virtual std::optional<time_t> getLastModified() override
+    {
+        if (trackLastModified)
+            return mtime;
+        return std::nullopt;
+    }
+};
+
+} // namespace detail
+
 /**
  * A source accessor that uses the Unix filesystem.
  */
-class PosixSourceAccessor : virtual public SourceAccessor
+class PosixSourceAccessor : public detail::PosixSourceAccessorBase
 {
     /**
      * Optional root path to prefix all operations into the native file
@@ -18,18 +57,10 @@ class PosixSourceAccessor : virtual public SourceAccessor
      */
     const std::filesystem::path root;
 
-    const bool trackLastModified = false;
-
 public:
 
     PosixSourceAccessor();
     PosixSourceAccessor(std::filesystem::path && root, bool trackLastModified = false);
-
-    /**
-     * The most recent mtime seen by lstat(). This is a hack to
-     * support dumpPathAndGetMtime(). Should remove this eventually.
-     */
-    time_t mtime = 0;
 
     void readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback) override;
 
@@ -74,11 +105,6 @@ public:
      * [`std::filesystem::path::relative_path`](https://en.cppreference.com/w/cpp/filesystem/path/relative_path).
      */
     static SourcePath createAtRoot(const std::filesystem::path & path, bool trackLastModified = false);
-
-    std::optional<std::time_t> getLastModified() override
-    {
-        return trackLastModified ? std::optional{mtime} : std::nullopt;
-    }
 
     void invalidateCache(const CanonPath & path) override;
 

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -259,6 +259,8 @@ ref<SourceAccessor> getFSSourceAccessor();
  * that it is not possible to escape `root` by appending `..` path
  * elements, and that absolute symlinks are resolved relative to
  * `root`.
+ *
+ * Symlinks in parents of `root` are resolved. Final symlink is not.
  */
 ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackLastModified = false);
 

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -1,4 +1,6 @@
 #include "nix/util/posix-source-accessor.hh"
+#include "nix/util/file-system-at.hh"
+#include "nix/util/memory-source-accessor.hh"
 #include "nix/util/source-path.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/sync.hh"
@@ -7,9 +9,125 @@
 
 namespace nix {
 
+static SourceAccessor::Stat sourceAccessorStatFromPosixStat(const PosixStat & st)
+{
+    using enum SourceAccessor::Type;
+    return SourceAccessor::Stat{
+        .type = S_ISREG(st.st_mode)   ? tRegular
+                : S_ISDIR(st.st_mode) ? tDirectory
+                : S_ISLNK(st.st_mode) ? tSymlink
+                : S_ISCHR(st.st_mode) ? tChar
+                : S_ISBLK(st.st_mode) ? tBlock
+                :
+#ifdef S_ISSOCK
+                S_ISSOCK(st.st_mode) ? tSocket
+                :
+#endif
+                S_ISFIFO(st.st_mode) ? tFifo
+                                     : tUnknown,
+        .fileSize = S_ISREG(st.st_mode) ? std::optional<uint64_t>(st.st_size) : std::nullopt,
+        .isExecutable = S_ISREG(st.st_mode) && st.st_mode & S_IXUSR,
+    };
+}
+
+namespace {
+
+class PosixFileSourceAccessor : public detail::PosixSourceAccessorBase
+{
+    AutoCloseFD fd;
+    std::filesystem::path fsPath;
+    /**
+     * Stat is memoised once opened. This does mean that modifying the same file
+     * while we are reading is busted, but caching it might be considered an
+     * improvement. Since we have a file descriptor for a regular file it can't
+     * be swapped out for another file type. Thus, we are only really caching
+     * the file size and mtime, which shouldn't change. Providing a consistent
+     * size value here is also fine. If the file becomes smaller than we expect
+     * then readFile will barf with an EOF exception. If it becomes larger then
+     * we are just going to silently ignore the extra bytes.
+     */
+    PosixStat st;
+
+public:
+    PosixFileSourceAccessor(AutoCloseFD fd, std::filesystem::path path, bool trackLastModified, const PosixStat & st_)
+        : PosixSourceAccessorBase(trackLastModified)
+        , fd(std::move(fd))
+        , fsPath(std::move(path))
+        , st(st_)
+    {
+        assert(S_ISREG(st.st_mode));
+        assert(fsPath.is_absolute()); /* Only used for error messages, but still nice to enforce this invariant. */
+        setPathDisplay(fsPath.generic_string());
+        maybeUpdateMtime(st.st_mtime);
+    }
+
+    void readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback) override;
+
+    bool pathExists(const CanonPath & path) override;
+
+    std::optional<Stat> maybeLstat(const CanonPath & path) override;
+
+    DirEntries readDirectory(const CanonPath & path) override;
+
+    std::string readLink(const CanonPath & path) override;
+
+    std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override
+    {
+        if (path.isRoot())
+            return fsPath;
+        return std::nullopt; /* Definitely doesn't exist. */
+    }
+
+    std::string showPath(const CanonPath & path) override
+    {
+        if (path.isRoot())
+            return displayPrefix; /* No trailing slash. */
+        return displayPrefix + path.abs();
+    }
+};
+
+void PosixFileSourceAccessor::readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback)
+{
+    if (!path.isRoot()) /* We are the parent and also a regular file. */
+        throw NotADirectory("reading file '%1%': %2%", showPath(path), "Not a directory");
+
+    auto size = st.st_size;
+    sizeCallback(size);
+    /* The most important invariant we care about here is writing exactly size
+       bytes to the sink. copyFdRange should throw an EndOfFile if we fail to read
+       `size` bytes. */
+    copyFdRange(fd.get(), /*offset=*/0, size, sink);
+}
+
+bool PosixFileSourceAccessor::pathExists(const CanonPath & path)
+{
+    return path.isRoot();
+}
+
+std::optional<SourceAccessor::Stat> PosixFileSourceAccessor::maybeLstat(const CanonPath & path)
+{
+    if (!path.isRoot())
+        return std::nullopt;
+    return sourceAccessorStatFromPosixStat(st);
+}
+
+SourceAccessor::DirEntries PosixFileSourceAccessor::readDirectory(const CanonPath & path)
+{
+    throw NotADirectory("reading directory '%1%': %2%", showPath(path), "Not a directory");
+}
+
+std::string PosixFileSourceAccessor::readLink(const CanonPath & path)
+{
+    if (!path.isRoot())
+        throw NotADirectory("reading symlink '%1%': %2%", showPath(path), "Not a directory");
+    throw NotASymlink("path '%1%' is not a symlink", showPath(path));
+}
+
+} // namespace
+
 PosixSourceAccessor::PosixSourceAccessor(std::filesystem::path && argRoot, bool trackLastModified)
-    : root(std::move(argRoot))
-    , trackLastModified(trackLastModified)
+    : PosixSourceAccessorBase(trackLastModified)
+    , root(std::move(argRoot))
 {
     assert(root.empty() || root.is_absolute());
     displayPrefix = root.string();
@@ -106,27 +224,8 @@ std::optional<SourceAccessor::Stat> PosixSourceAccessor::maybeLstat(const CanonP
     if (!st)
         return std::nullopt;
 
-    /* The contract is that trackLastModified implies that the caller uses the accessor
-       from a single thread. Thus this is not a CAS loop. */
-    if (trackLastModified)
-        mtime = std::max(mtime, st->st_mtime);
-
-    return Stat{
-        .type = S_ISREG(st->st_mode)   ? tRegular
-                : S_ISDIR(st->st_mode) ? tDirectory
-                : S_ISLNK(st->st_mode) ? tSymlink
-                : S_ISCHR(st->st_mode) ? tChar
-                : S_ISBLK(st->st_mode) ? tBlock
-                :
-#ifdef S_ISSOCK
-                S_ISSOCK(st->st_mode) ? tSocket
-                :
-#endif
-                S_ISFIFO(st->st_mode) ? tFifo
-                                      : tUnknown,
-        .fileSize = S_ISREG(st->st_mode) ? std::optional<uint64_t>(st->st_size) : std::nullopt,
-        .isExecutable = S_ISREG(st->st_mode) && st->st_mode & S_IXUSR,
-    };
+    PosixSourceAccessorBase::maybeUpdateMtime(st->st_mtime);
+    return sourceAccessorStatFromPosixStat(*st);
 }
 
 SourceAccessor::DirEntries PosixSourceAccessor::readDirectory(const CanonPath & path)
@@ -211,6 +310,40 @@ ref<SourceAccessor> getFSSourceAccessor()
 
 ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackLastModified)
 {
+#ifndef _WIN32
+    /* Die if the path ends in a / or /. That is a footgun that matters
+       for symlink resolution. TODO: Strip them or make this a proper error if
+       this becomes an issue. Defense-in-depth. */
+    assert(!root.native().ends_with(OS_STR("/.")));
+    assert(!root.native().ends_with(OS_STR("/")));
+
+    AutoCloseFD fd = openFileReadonly(root, FinalSymlink::DontFollow);
+
+    if (!fd) {
+        if (errno == ELOOP) {
+            /* This branch is taken either if the final component is a symlink
+               or we hit a symlink loop. If that's the latter this will also
+               throw. This can be done with O_PATH descriptor for the symlink
+               itself, but it's not portable. */
+            auto linkTarget = readLink(root);
+            auto res = make_ref<MemorySourceAccessor>();
+            /* Create an in-memory accessor with the symlink at the root. */
+            MemorySink sink{*res};
+            sink.createSymlink(CanonPath::root, os_string_to_string(linkTarget));
+            return res;
+        }
+
+        throw NativeSysError("opening file %1%", PathFmt(root));
+    }
+
+    auto st = nix::fstat(fd.get());
+    if (S_ISREG(st.st_mode))
+        return make_ref<PosixFileSourceAccessor>(std::move(fd), std::move(root), trackLastModified, st);
+
+    /* TODO: Use the file descriptor for fd-relative operations on the directory. */
+#endif
+
     return make_ref<PosixSourceAccessor>(std::move(root), trackLastModified);
 }
+
 } // namespace nix


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Changes `makeFSSourceAccessor` to open a file descriptor first and then operates on it. Symlinks get copied into a `MemorySourceAccessor` instead to avoid any accidental symlink following issues. This does mean that `makeFSSourceAccessor` now dies on a non-existent path, but all existing call-sites would already fail afterwards, so I think it's fine.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
