### PR TITLE
libutil: Initialize Handler::arity with in-class default

### DIFF
--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -84,7 +84,7 @@ protected:
     struct Handler
     {
         std::function<void(std::vector<std::string>)> fun;
-        size_t arity;
+        size_t arity = 0;
 
         Handler() = default;
 


### PR DESCRIPTION
## Motivation

`Handler() = default` leaves `size_t arity` uninitialized. Add an in-class default (`size_t arity = 0`) to eliminate latent undefined behavior. Consistent with the existing pattern in the same file (`shortName = 0`, `timesUsed = 0`).

## Context

Found by cppcheck (`uninitMemberVar`). Currently unreachable since all callers use parameterized constructors that explicitly set `arity`, but a future caller using the default constructor could read an indeterminate value. This is my second small PR for Nix — trying to work through static analysis findings incrementally.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
