### PR TITLE
upgrade-nix: fix profile symlink resolution

### DIFF
--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -16,6 +16,14 @@
 using namespace nix;
 
 /**
+ * Check whether a path has a "profiles" component.
+ */
+static bool hasProfilesComponent(const std::filesystem::path & path)
+{
+    return std::ranges::contains(path, OS_STR("profiles"));
+}
+
+/**
  * Settings related to upgrading Nix itself.
  */
 struct UpgradeSettings : Config
@@ -157,14 +165,13 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 
         auto profileDir = where.parent_path();
 
-        // Resolve profile to /nix/var/nix/profiles/<name> link.
-        while (canonPath(profileDir).string().find("/profiles/") == std::string::npos
-               && std::filesystem::is_symlink(profileDir))
-            profileDir = readLink(profileDir);
-
-        printInfo("found profile %s", PathFmt(profileDir));
-
-        auto userEnv = canonPath(profileDir);
+        // Chase symlinks until we find a path under a "profiles"
+        // directory, or we run out of symlinks.
+        auto resolved = profileDir;
+        while (!hasProfilesComponent(canonPath(resolved)) && std::filesystem::is_symlink(resolved))
+            // Note that operator/ replaces lhs when rhs is absolute.
+            resolved = resolved.parent_path() / readLink(resolved);
+        printInfo("found profile %s", PathFmt(resolved));
 
         if (std::filesystem::exists(profileDir / "manifest.json"))
             throw Error(
@@ -174,8 +181,10 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         if (!std::filesystem::exists(profileDir / "manifest.nix"))
             throw Error("directory %s does not appear to be part of a Nix profile", PathFmt(profileDir));
 
-        if (!store->isValidPath(store->parseStorePath(userEnv.string())))
-            throw Error("directory %s is not in the Nix store", PathFmt(userEnv));
+        auto userEnv = store->followLinksToStorePath(profileDir.string());
+
+        if (!store->isValidPath(userEnv))
+            throw Error("directory %s is not in the Nix store", PathFmt(profileDir));
 
         return profileDir;
     }

--- a/tests/nixos/default.nix
+++ b/tests/nixos/default.nix
@@ -207,4 +207,21 @@ in
   chrootStore = runNixOSTest ./chroot-store.nix;
 
   storeRemount = runNixOSTest ./store-remount.nix;
+
+  upgrade-nix = runNixOSTest {
+    imports = [ ./upgrade-nix.nix ];
+    upgrade-nix.oldNix = nixComponents.nix-cli;
+  };
+
+  upgrade-nix_fromStable = runNixOSTest {
+    imports = [ ./upgrade-nix.nix ];
+    name = lib.mkForce "upgrade-nix-from-stable";
+    upgrade-nix.oldNix = pkgs.nixVersions.stable;
+  };
+
+  upgrade-nix_fromLatest = runNixOSTest {
+    imports = [ ./upgrade-nix.nix ];
+    name = lib.mkForce "upgrade-nix-from-latest";
+    upgrade-nix.oldNix = pkgs.nixVersions.latest;
+  };
 }

--- a/tests/nixos/upgrade-nix.nix
+++ b/tests/nixos/upgrade-nix.nix
@@ -1,0 +1,104 @@
+# This installs an older Nix into a nix-env profile, and then runs `nix upgrade-nix`
+# pointing at a local fallback-paths file containing the locally built nix.
+#
+# This is based on nixpkgs' nixosTests.nix-upgrade test.
+# See https://github.com/NixOS/nixpkgs/blob/e3469a82fbd496d9c8e6192bbaf7cf056c6449ff/nixos/tests/nix/upgrade.nix.
+
+{
+  config,
+  lib,
+  nixComponents,
+  system,
+  ...
+}:
+let
+  pkgs = config.nodes.machine.nixpkgs.pkgs;
+
+  newNix = nixComponents.nix-cli;
+  oldNix = config.upgrade-nix.oldNix;
+
+  fallback-paths = pkgs.writeTextDir "fallback-paths.nix" ''
+    {
+      ${system} = "${newNix}";
+    }
+  '';
+in
+{
+  options.upgrade-nix.oldNix = lib.mkOption {
+    type = lib.types.package;
+    default = newNix;
+    description = "The Nix package to install before upgrading.";
+  };
+
+  config = {
+    name = "upgrade-nix";
+
+    nodes.machine =
+      { lib, ... }:
+      {
+        virtualisation.writableStore = true;
+        nix.settings.substituters = lib.mkForce [ ];
+        nix.settings.hashed-mirrors = null;
+        nix.settings.connect-timeout = 1;
+        nix.extraOptions = "experimental-features = nix-command";
+        environment.localBinInPath = true;
+        system.extraDependencies = [
+          fallback-paths
+          newNix
+          oldNix
+        ];
+        users.users.alice = {
+          isNormalUser = true;
+          packages = [ newNix ];
+        };
+      };
+
+    testScript = /* py */ ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("nix-current"):
+          # Create a profile to pretend we are on non-NixOS
+
+          print(machine.succeed("nix --version"))
+          machine.succeed("nix-env -i ${oldNix} -p /root/.local")
+          result = machine.succeed("/root/.local/bin/nix --version")
+          print(f"installed: {result}")
+
+      with subtest("nix-upgrade"):
+          machine.succeed(
+              "nix upgrade-nix"
+              " --nix-store-paths-url file://${fallback-paths}/fallback-paths.nix"
+              " --profile /root/.local"
+          )
+          result = machine.succeed("/root/.local/bin/nix --version")
+          print(f"after upgrade: {result}")
+          assert "${newNix.version}" in result, \
+              f"expected ${newNix.version} in: {result}"
+
+      with subtest("nix-build-with-mismatched-daemon"):
+          # The daemon is still running oldNix; verify the new client works.
+          machine.succeed(
+              "runuser -u alice -- nix build"
+              " --expr 'derivation { name = \"test\"; system = \"${system}\";"
+              " builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"]; }'"
+              " --print-out-paths"
+          )
+
+      with subtest("nix-upgrade-auto-detect"):
+          # Without passing in --profile, getProfileDir auto-detects the profile
+          # by finding nix-env in PATH and resolving the symlink chain back
+          # to the store.
+          machine.succeed("nix-env -i ${oldNix} -p /root/.local")
+          machine.succeed(
+              "PATH=/root/.local/bin:$PATH"
+              " ${newNix}/bin/nix upgrade-nix"
+              " --nix-store-paths-url file://${fallback-paths}/fallback-paths.nix"
+          )
+          result = machine.succeed("/root/.local/bin/nix --version")
+          print(f"after auto-detect upgrade: {result}")
+          assert "${newNix.version}" in result, \
+              f"expected ${newNix.version} in: {result}"
+    '';
+  };
+}


### PR DESCRIPTION
## Motivation

`canonPath(profileDir, true)` (which resolves symlinks) was converted
to `canonPath(profileDir)` (which doesn't) in a5a25626, so the profile
path was never resolved to its store target. This is fixed by using
`store->followLinksToStorePath` instead.

The while loop that attempted to chase symlinks into `/profiles/` is
removed. It called `readLink`, which returns relative targets for
`nix-env` generation links (e.g. `.local-1-link`), crashing `canonPath`
with "not an absolute path". The loop is also unnecessary now that
`followLinksToStorePath` is used, since it resolves the full symlink
chain to the store path regardless of whether the profile is under
`/profiles/`.

A NixOS VM test was added, which is based on nixpkgs' `nixosTests.nix-upgrade`,
with three variants; one for stable, latest, and current.

## Context

- Fixes #15437

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
