### PR TITLE
libcmd: Fix ReadlineLikeInteracter::init crash with editline

### DIFF
--- a/src/libcmd/repl-interacter.cc
+++ b/src/libcmd/repl-interacter.cc
@@ -124,10 +124,20 @@ ReadlineLikeInteracter::Guard ReadlineLikeInteracter::init(detail::ReplCompleter
         logWarning(e.info());
     }
 #if !USE_READLINE
-    el_hist_size = 1000;
-    // editline's read_history uses a fixed 256-byte buffer (SCREEN_INC),
-    // which silently splits lines longer than 255 characters into separate
-    // history entries. Read the file ourselves to avoid the length limit.
+    /* editline's read_history uses a fixed 256-byte buffer (SCREEN_INC),
+       which silently splits lines longer than 255 characters into separate
+       history entries. Read the file ourselves to avoid the length limit. See:
+       https://github.com/troglobit/editline/blob/2e0504d31e6878208036a4dd91f44841dabb1ee7/src/editline.c#L1617-L1635
+
+       ::rl_initialize must be called before the subsequent calls to
+       ::add_history to ensure that the buffer has actually been allocated
+       (but before setting ::el_hist_size).
+       Best I can tell it's supposed to idempotent, e.g. ::readline calls it
+       unconditionally anyway. */
+
+    ::el_hist_size = 1000; /* FIXME: Why the arbitrary limit? */
+    ::rl_initialize();
+
     auto fd = openFileReadonly(historyFile);
     if (!fd) {
         NativeSysError err("opening file %s", PathFmt(historyFile));

--- a/tests/repl-completion.nix
+++ b/tests/repl-completion.nix
@@ -63,6 +63,9 @@ runCommand "repl-completion"
     nix-store --init
     expect $expectScriptPath
 
+    # FIXME: Please let's have test infrastructure that allows us to write such
+    # tests in not so utterly humiliating ways.
+    #
     # Write a 300-char line to the history file, then run a REPL session
     # that reads it back (read_history) and writes it out (write_history).
     histFile=$HOME/.local/share/nix/repl-history
@@ -70,10 +73,7 @@ runCommand "repl-completion"
     printf '%0300d\n' 0 | tr '0' 'a' > "$histFile"
     echo "short" >> "$histFile"
 
-    # unbuffer allocates a pty so nix repl runs the interactive
-    # ReadlineLikeInteracter path (read_history on init, write_history
-    # on exit). Plain piped input skips history entirely.
-    echo ":q" | unbuffer -p nix repl --offline --extra-experimental-features nix-command 2>/dev/null || true
+    echo ":q" | nix repl --offline --extra-experimental-features nix-command
 
     # Verify the long line survived the read/write cycle.
     maxLen=$(awk '{ print length }' "$histFile" | sort -rn | head -1)
@@ -81,7 +81,6 @@ runCommand "repl-completion"
       echo "FAIL: long history line was truncated (max length: $maxLen)"
       exit 1
     fi
-    echo "Long history line preserved (length: $maxLen)."
 
     touch $out
   ''


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Before calling into `::add_history` we must actually initialise the library. Buffer is allocated implicitly in `::readline` and `::read_history`, but not in this case.

Also get rid of `unbuffer` and utterly wrong comment in the test, since it just plain wrong. Piping the input straight into `nix repl` catches the bug like intended.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
