### PR TITLE
Use `statusToString` for child process exit diagnostics

### DIFF
--- a/src/libstore/unix/build/freebsd-derivation-builder.cc
+++ b/src/libstore/unix/build/freebsd-derivation-builder.cc
@@ -440,8 +440,8 @@ struct ChrootFreeBSDDerivationBuilder : ChrootDerivationBuilder, FreeBSDDerivati
             });
 
             /* TODO: Capture the error from the helper? */
-            if (helper.wait() != 0) {
-                throw SysError("failed to configure loopback address");
+            if (auto status = helper.wait(); !statusOk(status)) {
+                throw Error("failed to configure loopback address: %s", statusToString(status));
             }
         } else {
             jid = jail_setv(

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -374,10 +374,10 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
 
         sendPid.writeSide.close();
 
-        if (helper.wait() != 0) {
+        if (auto status = helper.wait(); !statusOk(status)) {
             processSandboxSetupMessages();
             // Only reached if the child process didn't send an exception.
-            throw Error("unable to start build process");
+            throw Error("unable to start build process: %s", statusToString(status));
         }
 
         userNamespaceSync.readSide = -1;
@@ -749,8 +749,8 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
         }));
 
         int status = child.wait();
-        if (status != 0)
-            throw Error("could not add path '%s' to sandbox", store.printStorePath(path));
+        if (!statusOk(status))
+            throw Error("could not add path '%s' to sandbox: %s", store.printStorePath(path), statusToString(status));
     }
 };
 

--- a/src/libutil-tests/unix/file-system-at.cc
+++ b/src/libutil-tests/unix/file-system-at.cc
@@ -96,22 +96,22 @@ TEST(fchmodatTryNoFollow, fallbackWithoutProc)
     Pid pid = startProcess(
         [&] {
             if (unshare(CLONE_NEWNS) == -1)
-                _exit(1);
+                _exit(2);
 
             if (mount(0, "/", 0, MS_PRIVATE | MS_REC, 0) == -1)
-                _exit(1);
+                _exit(2);
 
             if (mount("tmpfs", "/proc", "tmpfs", 0, 0) == -1)
-                _exit(1);
+                _exit(2);
 
             auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
             if (!dirFd)
-                exit(1);
+                _exit(3);
 
             try {
                 fchmodatTryNoFollow(dirFd.get(), CanonPath("file"), 0600);
             } catch (SysError & e) {
-                _exit(1);
+                _exit(4);
             }
 
             try {
@@ -121,12 +121,15 @@ TEST(fchmodatTryNoFollow, fallbackWithoutProc)
                     _exit(0); /* Success. */
             }
 
-            _exit(1); /* Didn't throw the expected exception. */
+            _exit(5); /* Didn't throw the expected exception. */
         },
         {.cloneFlags = CLONE_NEWUSER});
 
     int status = pid.wait();
-    ASSERT_TRUE(statusOk(status));
+    EXPECT_TRUE(WIFEXITED(status));
+    if (WEXITSTATUS(status) == 2)
+        GTEST_SKIP() << "Could not mount, system may be misconfigured";
+    EXPECT_EQ(WEXITSTATUS(status), 0);
 
     struct ::stat st;
     ASSERT_EQ(stat((tmpDir / "file").c_str(), &st), 0);

--- a/src/libutil/linux/linux-namespaces.cc
+++ b/src/libutil/linux/linux-namespaces.cc
@@ -39,7 +39,10 @@ bool userNamespacesSupported()
             Pid pid = startProcess([&]() { _exit(0); }, {.cloneFlags = CLONE_NEWUSER});
 
             auto r = pid.wait();
-            assert(!r);
+            /* The assert is OK because if we cannot do CLONE_NEWUSER we will
+               throw above, and if the process does run, it must exit this way
+               (or something else is really wrong). */
+            assert(statusOk(r));
         } catch (SysError & e) {
             debug("user namespaces do not work on this system: %s", e.msg());
             return false;
@@ -72,8 +75,8 @@ bool mountAndPidNamespacesSupported()
                 },
                 {.cloneFlags = CLONE_NEWNS | CLONE_NEWPID | (userNamespacesSupported() ? CLONE_NEWUSER : 0)});
 
-            if (pid.wait()) {
-                debug("PID namespaces do not work on this system: cannot remount /proc");
+            if (auto status = pid.wait(); !statusOk(status)) {
+                debug("PID namespaces do not work on this system: cannot remount /proc: %s", statusToString(status));
                 return false;
             }
 


### PR DESCRIPTION
Use `statusOk`/`statusToString` consistently when checking child process wait statuses, so that failures produce human-readable messages (e.g. "exited with code 2") rather than raw integer comparisons or nothing at all.

Also give distinct exit codes to each failure path in the `fchmodatTryNoFollow` test for easier debugging.

Note that `status == 0` and `statusOk(status)` do not do the same thing, because the latter does not check all the bits. So by changing the code from the former to the latter, we are technically changing behavior. However, it is not really proper to check the other bits, rather than use the macros which (essentially) parse a discriminated union. The other bits are probably guaranteed to be 0 in practice, but in theory, they are reserved for future use, and we should not guessing that that future use is / what the bits mean in that case.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

The `statusOk` function exists to check exit codes from processes, but it was not used everywhere. `!= 0` is also commonly used, but is not technically correct by the standard.

## Context

This came about while attempting to debug a broken test when building nix master on certain versions of nix on ubuntu. This PR also includes fixes to make that test easier to debug.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
