### PR TITLE
sqlite: replace rand() % 100 with exponential backoff and jitter

### DIFF
--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -86,6 +86,7 @@ sources = files(
   's3-binary-cache-store.cc',
   's3-url.cc',
   'serve-protocol.cc',
+  'sqlite-retry.cc',
   'ssh-store.cc',
   'store-open.cc',
   'store-reference.cc',

--- a/src/libstore-tests/sqlite-retry.cc
+++ b/src/libstore-tests/sqlite-retry.cc
@@ -9,11 +9,12 @@ namespace nix {
 namespace {
 
 // Mirror of clampedExponential for computing expected bounds in tests.
-constexpr unsigned int expectedCeiling(unsigned int baseUs, unsigned int attempt, unsigned int ceilUs)
+constexpr uint32_t expectedCeiling(uint32_t baseUs, uint32_t attempt, uint32_t ceilUs)
 {
-    auto shift = std::min(attempt - 1, 63u);
-    auto unclamped = static_cast<unsigned long long>(baseUs) << shift;
-    return static_cast<unsigned int>(std::min(unclamped, static_cast<unsigned long long>(ceilUs)));
+    constexpr uint32_t maxShift = 63;
+    auto shift = std::min(attempt - 1, maxShift);
+    auto unclamped = static_cast<uint64_t>(baseUs) << shift;
+    return static_cast<uint32_t>(std::min(unclamped, static_cast<uint64_t>(ceilUs)));
 }
 
 } // anonymous namespace
@@ -21,10 +22,10 @@ constexpr unsigned int expectedCeiling(unsigned int baseUs, unsigned int attempt
 TEST(sqliteRetryBackoff, ExponentialGrowth)
 {
     constexpr BackoffConfig config{.baseUs = 1000, .ceilUs = 100'000, .jitterShift = 3};
-    constexpr unsigned int jitter = UINT32_MAX;
+    constexpr uint32_t jitter = UINT32_MAX;
 
-    unsigned int ceiling = config.baseUs;
-    for (unsigned int attempt = 1; attempt <= 12; ++attempt) {
+    uint32_t ceiling = config.baseUs;
+    for (uint32_t attempt = 1; attempt <= 12; ++attempt) {
         auto delay = sqliteRetryBackoff(attempt, jitter, config);
         auto maxJitter = ceiling >> config.jitterShift;
         EXPECT_GE(delay.count(), static_cast<long>(ceiling)) << "attempt " << attempt;
@@ -42,8 +43,8 @@ TEST(sqliteRetryBackoff, JitterScalesLinearly)
     constexpr BackoffConfig config{.baseUs = 100'000, .ceilUs = 5'000'000, .jitterShift = 3};
 
     // Use attempt 1 so ceiling = baseUs
-    constexpr unsigned int attempt = 1;
-    auto halfJitter = static_cast<unsigned int>(UINT32_MAX / 2);
+    constexpr uint32_t attempt = 1;
+    auto halfJitter = static_cast<uint32_t>(UINT32_MAX / 2);
     auto delayHalf = sqliteRetryBackoff(attempt, halfJitter, config);
     auto delayMax = sqliteRetryBackoff(attempt, UINT32_MAX, config);
 
@@ -67,11 +68,11 @@ TEST(sqliteRetryBackoff, ZeroBase)
 TEST(sqliteRetryBackoff, SubMillisecondGrowth)
 {
     constexpr BackoffConfig config{.baseUs = 500, .ceilUs = 100'000, .jitterShift = 3};
-    constexpr unsigned int jitter = UINT32_MAX;
+    constexpr uint32_t jitter = UINT32_MAX;
 
     // All delays should be >= baseUs and grow with each attempt
     long prev = 0;
-    for (unsigned int attempt = 1; attempt <= 4; ++attempt) {
+    for (uint32_t attempt = 1; attempt <= 4; ++attempt) {
         auto delay = sqliteRetryBackoff(attempt, jitter, config);
         EXPECT_GE(delay.count(), static_cast<long>(config.baseUs)) << "attempt " << attempt;
         EXPECT_GT(delay.count(), prev) << "attempt " << attempt;
@@ -93,7 +94,7 @@ TEST(sqliteRetryBackoff, MinimumDelayGuarantee)
 {
     // Delay must always be >= ceiling >= baseUs, regardless of jitter value
     constexpr BackoffConfig config{.baseUs = 500, .ceilUs = 100'000, .jitterShift = 3};
-    for (unsigned int attempt = 1; attempt <= 10; ++attempt) {
+    for (uint32_t attempt = 1; attempt <= 10; ++attempt) {
         EXPECT_GE(sqliteRetryBackoff(attempt, 0, config).count(), static_cast<long>(config.baseUs))
             << "attempt " << attempt;
         EXPECT_GE(sqliteRetryBackoff(attempt, 1, config).count(), static_cast<long>(config.baseUs))
@@ -107,8 +108,8 @@ TEST(sqliteRetryBackoff, MinimumDelayGuarantee)
 
 struct BackoffBoundsCase
 {
-    unsigned int attempt;
-    unsigned int jitter;
+    uint32_t attempt;
+    uint32_t jitter;
     BackoffConfig config;
     std::string description;
 };
@@ -128,7 +129,7 @@ TEST_P(SqliteRetryBackoffBounds, DelayWithinBounds)
 
     auto ceiling = expectedCeiling(c.config.baseUs, c.attempt, c.config.ceilUs);
     auto jitterRange = ceiling >> c.config.jitterShift;
-    auto maxJitterAmount = static_cast<unsigned int>((static_cast<unsigned long long>(jitterRange) * c.jitter) >> 32);
+    auto maxJitterAmount = static_cast<uint32_t>((static_cast<uint64_t>(jitterRange) * c.jitter) >> 32);
 
     EXPECT_GE(delay.count(), static_cast<long>(ceiling));
     EXPECT_LE(delay.count(), static_cast<long>(ceiling + maxJitterAmount));

--- a/src/libstore-tests/sqlite-retry.cc
+++ b/src/libstore-tests/sqlite-retry.cc
@@ -1,6 +1,8 @@
 #include "nix/store/sqlite.hh"
 
+#include <chrono>
 #include <cstdint>
+#include <limits>
 
 #include <gtest/gtest.h>
 
@@ -8,21 +10,57 @@ namespace nix {
 
 TEST(sqliteRetryBackoff, DelayGrowsMonotonically)
 {
-    long prev = 0;
-    for (uint32_t attempt = 1; attempt <= 20; ++attempt) {
+    std::chrono::microseconds prev{0};
+    for (uint32_t attempt = 1; attempt <= 100; ++attempt) {
         auto delay = sqliteRetryBackoff(attempt, 0);
-        EXPECT_GE(delay.count(), prev) << "attempt " << attempt;
-        prev = delay.count();
+        EXPECT_GE(delay, prev) << "attempt " << attempt;
+        prev = delay;
     }
 }
 
 TEST(sqliteRetryBackoff, JitterOnlyAdds)
 {
-    for (uint32_t attempt = 1; attempt <= 20; ++attempt) {
+    for (uint32_t attempt = 1; attempt <= 100; ++attempt) {
         auto base = sqliteRetryBackoff(attempt, 0);
-        auto withJitter = sqliteRetryBackoff(attempt, UINT32_MAX);
-        EXPECT_GE(withJitter.count(), base.count()) << "attempt " << attempt;
+        auto withJitter = sqliteRetryBackoff(attempt, std::numeric_limits<uint32_t>::max());
+        EXPECT_GE(withJitter, base) << "attempt " << attempt;
     }
+}
+
+TEST(sqliteRetryBackoff, BoundedByCeiling)
+{
+    // backoffCeilUs=100,000 with ~12.5% jitter gives max ~112,500µs.
+    // Use a generous upper bound to avoid test brittleness.
+    std::chrono::microseconds bound{113'000};
+    for (uint32_t attempt = 1; attempt <= 100; ++attempt) {
+        auto delay = sqliteRetryBackoff(attempt, std::numeric_limits<uint32_t>::max());
+        EXPECT_LE(delay, bound) << "attempt " << attempt;
+    }
+}
+
+TEST(sqliteRetryBackoff, AttemptZeroReturnsBase)
+{
+    // attempt=0 should not happen in practice — handleSQLiteBusy
+    // pre-increments before calling — but verify it returns the base
+    // delay (500µs) rather than zero.
+    auto delay = sqliteRetryBackoff(0, 0);
+    EXPECT_EQ(delay, std::chrono::microseconds{500});
+}
+
+TEST(sqliteRetryBackoff, AttemptZeroWithJitterAtLeastBase)
+{
+    // Same edge case with max jitter: delay should still be >= base.
+    auto delay = sqliteRetryBackoff(0, std::numeric_limits<uint32_t>::max());
+    EXPECT_GE(delay, std::chrono::microseconds{500});
+}
+
+TEST(sqliteRetryBackoff, ExtremeAttemptStillBounded)
+{
+    // UINT32_MAX attempts would take ~13 years at ceiling; verify
+    // it still produces a reasonable bounded delay.
+    auto delay = sqliteRetryBackoff(std::numeric_limits<uint32_t>::max(), 0);
+    EXPECT_GT(delay, std::chrono::microseconds{0});
+    EXPECT_LE(delay, std::chrono::microseconds{113'000});
 }
 
 } // namespace nix

--- a/src/libstore-tests/sqlite-retry.cc
+++ b/src/libstore-tests/sqlite-retry.cc
@@ -6,40 +6,103 @@
 
 namespace nix {
 
+namespace {
+
+// Mirror of clampedExponential for computing expected bounds in tests.
+constexpr unsigned int expectedCeiling(unsigned int baseUs, unsigned int attempt, unsigned int ceilUs)
+{
+    auto shift = std::min(attempt - 1, 63u);
+    auto unclamped = static_cast<unsigned long long>(baseUs) << shift;
+    return static_cast<unsigned int>(std::min(unclamped, static_cast<unsigned long long>(ceilUs)));
+}
+
+} // anonymous namespace
+
 TEST(sqliteRetryBackoff, ExponentialGrowth)
 {
-    constexpr BackoffConfig config{.baseMs = 1, .capMs = 100};
-    constexpr unsigned int jitter = UINT32_MAX; // maximum jitter => delay == ceiling
+    constexpr BackoffConfig config{.baseUs = 1000, .ceilUs = 100'000, .jitterShift = 3};
+    constexpr unsigned int jitter = UINT32_MAX;
 
-    unsigned int expectedCeiling = config.baseMs;
+    unsigned int ceiling = config.baseUs;
     for (unsigned int attempt = 1; attempt <= 12; ++attempt) {
         auto delay = sqliteRetryBackoff(attempt, jitter, config);
-        // With max jitter, delay should equal ceiling (minus rounding)
-        EXPECT_GE(delay.count(), 0) << "attempt " << attempt;
-        EXPECT_LE(delay.count(), static_cast<long>(expectedCeiling)) << "attempt " << attempt;
+        auto maxJitter = ceiling >> config.jitterShift;
+        EXPECT_GE(delay.count(), static_cast<long>(ceiling)) << "attempt " << attempt;
+        EXPECT_LE(delay.count(), static_cast<long>(ceiling + maxJitter)) << "attempt " << attempt;
 
-        if (expectedCeiling < config.capMs / 2)
-            expectedCeiling *= 2;
+        if (ceiling < config.ceilUs / 2)
+            ceiling *= 2;
         else
-            expectedCeiling = config.capMs;
+            ceiling = config.ceilUs;
     }
 }
 
 TEST(sqliteRetryBackoff, JitterScalesLinearly)
 {
-    constexpr BackoffConfig config{.baseMs = 100, .capMs = 5000};
+    constexpr BackoffConfig config{.baseUs = 100'000, .ceilUs = 5'000'000, .jitterShift = 3};
 
-    // delay = ceiling * jitter / 2^32
-    // With attempt=1, ceiling=100
-    // half jitter should give roughly half the delay of max jitter
+    // Use attempt 1 so ceiling = baseUs
+    constexpr unsigned int attempt = 1;
     auto halfJitter = static_cast<unsigned int>(UINT32_MAX / 2);
-    auto delayHalf = sqliteRetryBackoff(1, halfJitter, config);
-    auto delayMax = sqliteRetryBackoff(1, UINT32_MAX, config);
+    auto delayHalf = sqliteRetryBackoff(attempt, halfJitter, config);
+    auto delayMax = sqliteRetryBackoff(attempt, UINT32_MAX, config);
 
-    EXPECT_GE(delayHalf.count(), 0);
+    auto ceiling = static_cast<long>(config.baseUs);
+    EXPECT_GE(delayHalf.count(), ceiling);
     EXPECT_LE(delayHalf.count(), delayMax.count());
-    // Half jitter should give roughly half the delay (within 1ms of rounding)
-    EXPECT_LE(std::abs(delayHalf.count() - delayMax.count() / 2), 1);
+
+    // The jitter portions should scale linearly (within 1us of rounding)
+    auto jitterHalf = delayHalf.count() - ceiling;
+    auto jitterMax = delayMax.count() - ceiling;
+    EXPECT_LE(std::abs(jitterHalf - jitterMax / 2), 1);
+}
+
+TEST(sqliteRetryBackoff, ZeroBase)
+{
+    constexpr BackoffConfig config{.baseUs = 0, .ceilUs = 100'000, .jitterShift = 3};
+    auto delay = sqliteRetryBackoff(1, UINT32_MAX, config);
+    EXPECT_EQ(delay.count(), 0);
+}
+
+TEST(sqliteRetryBackoff, SubMillisecondGrowth)
+{
+    constexpr BackoffConfig config{.baseUs = 500, .ceilUs = 100'000, .jitterShift = 3};
+    constexpr unsigned int jitter = UINT32_MAX;
+
+    // All delays should be >= baseUs and grow with each attempt
+    long prev = 0;
+    for (unsigned int attempt = 1; attempt <= 4; ++attempt) {
+        auto delay = sqliteRetryBackoff(attempt, jitter, config);
+        EXPECT_GE(delay.count(), static_cast<long>(config.baseUs)) << "attempt " << attempt;
+        EXPECT_GT(delay.count(), prev) << "attempt " << attempt;
+        prev = delay.count();
+    }
+}
+
+TEST(sqliteRetryBackoff, MicrosecondPrecision)
+{
+    // Small baseUs: at attempt 1, ceiling=baseUs, jitterRange=baseUs>>jitterShift
+    // When jitterRange <= 1, (1 * MAX) >> 32 = 0, so delay = ceiling exactly
+    constexpr BackoffConfig config{.baseUs = 10, .ceilUs = 1000, .jitterShift = 3};
+    auto ceiling = expectedCeiling(config.baseUs, 1, config.ceilUs);
+    auto delay = sqliteRetryBackoff(1, UINT32_MAX, config);
+    EXPECT_EQ(delay.count(), static_cast<long>(ceiling));
+}
+
+TEST(sqliteRetryBackoff, MinimumDelayGuarantee)
+{
+    // Delay must always be >= ceiling >= baseUs, regardless of jitter value
+    constexpr BackoffConfig config{.baseUs = 500, .ceilUs = 100'000, .jitterShift = 3};
+    for (unsigned int attempt = 1; attempt <= 10; ++attempt) {
+        EXPECT_GE(sqliteRetryBackoff(attempt, 0, config).count(), static_cast<long>(config.baseUs))
+            << "attempt " << attempt;
+        EXPECT_GE(sqliteRetryBackoff(attempt, 1, config).count(), static_cast<long>(config.baseUs))
+            << "attempt " << attempt;
+        EXPECT_GE(sqliteRetryBackoff(attempt, UINT32_MAX / 2, config).count(), static_cast<long>(config.baseUs))
+            << "attempt " << attempt;
+        EXPECT_GE(sqliteRetryBackoff(attempt, UINT32_MAX, config).count(), static_cast<long>(config.baseUs))
+            << "attempt " << attempt;
+    }
 }
 
 struct BackoffBoundsCase
@@ -47,8 +110,6 @@ struct BackoffBoundsCase
     unsigned int attempt;
     unsigned int jitter;
     BackoffConfig config;
-    long minDelay;
-    long maxDelay;
     std::string description;
 };
 
@@ -64,103 +125,72 @@ TEST_P(SqliteRetryBackoffBounds, DelayWithinBounds)
 {
     auto & c = GetParam();
     auto delay = sqliteRetryBackoff(c.attempt, c.jitter, c.config);
-    EXPECT_GE(delay.count(), c.minDelay);
-    EXPECT_LE(delay.count(), c.maxDelay);
+
+    auto ceiling = expectedCeiling(c.config.baseUs, c.attempt, c.config.ceilUs);
+    auto jitterRange = ceiling >> c.config.jitterShift;
+    auto maxJitterAmount = static_cast<unsigned int>((static_cast<unsigned long long>(jitterRange) * c.jitter) >> 32);
+
+    EXPECT_GE(delay.count(), static_cast<long>(ceiling));
+    EXPECT_LE(delay.count(), static_cast<long>(ceiling + maxJitterAmount));
 }
 
 INSTANTIATE_TEST_SUITE_P(
     Backoff,
     SqliteRetryBackoffBounds,
     ::testing::Values(
-        // CapsAtMax: high attempt saturates at cap regardless of jitter
+        // CapsAtMax: high attempt saturates at cap
         BackoffBoundsCase{
-            .attempt = 50,
-            .jitter = 0,
-            .config = {10, 100},
-            .minDelay = 0,
-            .maxDelay = 100,
-            .description = "CapsAtMax_zeroJitter"},
+            .attempt = 50, .jitter = 0, .config = {10'000, 100'000, 3}, .description = "CapsAtMax_zeroJitter"},
         BackoffBoundsCase{
-            .attempt = 50,
-            .jitter = 1000000000u,
-            .config = {10, 100},
-            .minDelay = 0,
-            .maxDelay = 100,
-            .description = "CapsAtMax_lowJitter"},
+            .attempt = 50, .jitter = 1000000000u, .config = {10'000, 100'000, 3}, .description = "CapsAtMax_lowJitter"},
         BackoffBoundsCase{
-            .attempt = 50,
-            .jitter = 2147483648u,
-            .config = {10, 100},
-            .minDelay = 0,
-            .maxDelay = 100,
-            .description = "CapsAtMax_midJitter"},
+            .attempt = 50, .jitter = 2147483648u, .config = {10'000, 100'000, 3}, .description = "CapsAtMax_midJitter"},
         BackoffBoundsCase{
-            .attempt = 50,
-            .jitter = UINT32_MAX,
-            .config = {10, 100},
-            .minDelay = 0,
-            .maxDelay = 100,
-            .description = "CapsAtMax_maxJitter"},
-        // ZeroBase: base=0 always yields zero delay
-        BackoffBoundsCase{
-            .attempt = 5,
-            .jitter = UINT32_MAX,
-            .config = {0, 1000},
-            .minDelay = 0,
-            .maxDelay = 0,
-            .description = "ZeroBase_maxJitter"},
-        BackoffBoundsCase{
-            .attempt = 5,
-            .jitter = 0,
-            .config = {0, 1000},
-            .minDelay = 0,
-            .maxDelay = 0,
-            .description = "ZeroBase_zeroJitter"},
+            .attempt = 50, .jitter = UINT32_MAX, .config = {10'000, 100'000, 3}, .description = "CapsAtMax_maxJitter"},
         // HighAttemptNoOverflow: extreme attempt count stays bounded
         BackoffBoundsCase{
-            .attempt = 1000,
-            .jitter = 0,
-            .config = {1, 100},
-            .minDelay = 0,
-            .maxDelay = 100,
-            .description = "HighAttempt_zeroJitter"},
+            .attempt = 1000, .jitter = 0, .config = {1000, 100'000, 3}, .description = "HighAttempt_zeroJitter"},
         BackoffBoundsCase{
             .attempt = 1000,
             .jitter = 1000000000u,
-            .config = {1, 100},
-            .minDelay = 0,
-            .maxDelay = 100,
+            .config = {1000, 100'000, 3},
             .description = "HighAttempt_lowJitter"},
         BackoffBoundsCase{
             .attempt = 1000,
             .jitter = UINT32_MAX,
-            .config = {1, 100},
-            .minDelay = 0,
-            .maxDelay = 100,
+            .config = {1000, 100'000, 3},
             .description = "HighAttempt_maxJitter"},
-        // AttemptOneCeiling: at attempt 1, ceiling = base
+        // AttemptOneCeiling: at attempt 1, ceiling = baseUs
         BackoffBoundsCase{
-            .attempt = 1,
-            .jitter = UINT32_MAX,
-            .config = {50, 5000},
-            .minDelay = 0,
-            .maxDelay = 50,
-            .description = "AttemptOneCeiling"},
-        // ZeroJitterGivesZeroDelay: jitter=0 means delay = ceiling * 0 / 2^32 = 0
+            .attempt = 1, .jitter = UINT32_MAX, .config = {50'000, 5'000'000, 3}, .description = "AttemptOneCeiling"},
+        // ZeroJitter: jitter=0 means delay = ceiling exactly
+        BackoffBoundsCase{
+            .attempt = 5, .jitter = 0, .config = {10'000, 100'000, 3}, .description = "ZeroJitter_midAttempt"},
+        BackoffBoundsCase{
+            .attempt = 1, .jitter = 0, .config = {50'000, 5'000'000, 3}, .description = "ZeroJitter_attemptOne"},
+        // Sub-millisecond entries
+        BackoffBoundsCase{
+            .attempt = 1, .jitter = UINT32_MAX, .config = {500, 100'000, 3}, .description = "SubMs_attempt1_maxJitter"},
+        BackoffBoundsCase{
+            .attempt = 5, .jitter = UINT32_MAX, .config = {500, 100'000, 3}, .description = "SubMs_attempt5_maxJitter"},
+        BackoffBoundsCase{
+            .attempt = 1, .jitter = 0, .config = {500, 100'000, 3}, .description = "SubMs_attempt1_zeroJitter"},
+        // Tiny base: jitterRange may truncate to 0
+        BackoffBoundsCase{
+            .attempt = 1, .jitter = UINT32_MAX, .config = {1, 1000, 3}, .description = "TinyBase_attempt1_maxJitter"},
+        BackoffBoundsCase{
+            .attempt = 10, .jitter = UINT32_MAX, .config = {1, 1000, 3}, .description = "TinyBase_attempt10_maxJitter"},
+        // Different jitterShift values
         BackoffBoundsCase{
             .attempt = 5,
-            .jitter = 0,
-            .config = {10, 100},
-            .minDelay = 0,
-            .maxDelay = 0,
-            .description = "ZeroJitter_midAttempt"},
+            .jitter = UINT32_MAX,
+            .config = {1000, 100'000, 4},
+            .description = "Shift4_attempt5_maxJitter"},
         BackoffBoundsCase{
-            .attempt = 1,
-            .jitter = 0,
-            .config = {50, 5000},
-            .minDelay = 0,
-            .maxDelay = 0,
-            .description = "ZeroJitter_attemptOne"}),
+            .attempt = 5,
+            .jitter = UINT32_MAX,
+            .config = {1000, 100'000, 2},
+            .description = "Shift2_attempt5_maxJitter"}),
     [](const auto & info) { return info.param.description; });
 
 } // namespace nix

--- a/src/libstore-tests/sqlite-retry.cc
+++ b/src/libstore-tests/sqlite-retry.cc
@@ -1,0 +1,71 @@
+#include "nix/store/sqlite.hh"
+
+#include <gtest/gtest.h>
+#include <random>
+
+namespace nix {
+
+TEST(sqliteRetryBackoff, ExponentialGrowth)
+{
+    std::mt19937 rng{42};
+
+    constexpr unsigned int base = 1;
+    constexpr unsigned int max = 100;
+
+    for (int trial = 0; trial < 50; ++trial) {
+        unsigned int expectedCeiling = base;
+        for (unsigned int attempt = 1; attempt <= 12; ++attempt) {
+            auto delay = sqliteRetryBackoff(attempt, base, max, rng);
+            EXPECT_GE(delay.count(), 0) << "attempt " << attempt;
+            EXPECT_LE(delay.count(), static_cast<long>(expectedCeiling)) << "attempt " << attempt;
+
+            if (expectedCeiling < max / 2)
+                expectedCeiling *= 2;
+            else
+                expectedCeiling = max;
+        }
+    }
+}
+
+TEST(sqliteRetryBackoff, CapsAtMax)
+{
+    std::mt19937 rng{123};
+    constexpr unsigned int base = 10;
+    constexpr unsigned int max = 100;
+
+    for (int i = 0; i < 200; ++i) {
+        auto delay = sqliteRetryBackoff(50, base, max, rng);
+        EXPECT_GE(delay.count(), 0);
+        EXPECT_LE(delay.count(), static_cast<long>(max));
+    }
+}
+
+TEST(sqliteRetryBackoff, ZeroBase)
+{
+    std::mt19937 rng{0};
+    EXPECT_EQ(sqliteRetryBackoff(5, 0, 1000, rng).count(), 0);
+}
+
+TEST(sqliteRetryBackoff, HighAttemptNoOverflow)
+{
+    std::mt19937 rng{99};
+
+    for (int i = 0; i < 100; ++i) {
+        auto delay = sqliteRetryBackoff(1000, 1, 100, rng);
+        EXPECT_GE(delay.count(), 0);
+        EXPECT_LE(delay.count(), 100);
+    }
+}
+
+TEST(sqliteRetryBackoff, AttemptOneCeiling)
+{
+    std::mt19937 rng{7};
+
+    for (int i = 0; i < 100; ++i) {
+        auto delay = sqliteRetryBackoff(1, 50, 5000, rng);
+        EXPECT_GE(delay.count(), 0);
+        EXPECT_LE(delay.count(), 50);
+    }
+}
+
+} // namespace nix

--- a/src/libstore-tests/sqlite-retry.cc
+++ b/src/libstore-tests/sqlite-retry.cc
@@ -6,192 +6,23 @@
 
 namespace nix {
 
-namespace {
-
-// Mirror of clampedExponential for computing expected bounds in tests.
-constexpr uint32_t expectedCeiling(uint32_t baseUs, uint32_t attempt, uint32_t ceilUs)
+TEST(sqliteRetryBackoff, DelayGrowsMonotonically)
 {
-    constexpr uint32_t maxShift = 63;
-    auto shift = std::min(attempt - 1, maxShift);
-    auto unclamped = static_cast<uint64_t>(baseUs) << shift;
-    return static_cast<uint32_t>(std::min(unclamped, static_cast<uint64_t>(ceilUs)));
-}
-
-} // anonymous namespace
-
-TEST(sqliteRetryBackoff, ExponentialGrowth)
-{
-    constexpr BackoffConfig config{.baseUs = 1000, .ceilUs = 100'000, .jitterShift = 3};
-    constexpr uint32_t jitter = UINT32_MAX;
-
-    uint32_t ceiling = config.baseUs;
-    for (uint32_t attempt = 1; attempt <= 12; ++attempt) {
-        auto delay = sqliteRetryBackoff(attempt, jitter, config);
-        auto maxJitter = ceiling >> config.jitterShift;
-        EXPECT_GE(delay.count(), static_cast<long>(ceiling)) << "attempt " << attempt;
-        EXPECT_LE(delay.count(), static_cast<long>(ceiling + maxJitter)) << "attempt " << attempt;
-
-        if (ceiling < config.ceilUs / 2)
-            ceiling *= 2;
-        else
-            ceiling = config.ceilUs;
-    }
-}
-
-TEST(sqliteRetryBackoff, JitterScalesLinearly)
-{
-    constexpr BackoffConfig config{.baseUs = 100'000, .ceilUs = 5'000'000, .jitterShift = 3};
-
-    // Use attempt 1 so ceiling = baseUs
-    constexpr uint32_t attempt = 1;
-    auto halfJitter = static_cast<uint32_t>(UINT32_MAX / 2);
-    auto delayHalf = sqliteRetryBackoff(attempt, halfJitter, config);
-    auto delayMax = sqliteRetryBackoff(attempt, UINT32_MAX, config);
-
-    auto ceiling = static_cast<long>(config.baseUs);
-    EXPECT_GE(delayHalf.count(), ceiling);
-    EXPECT_LE(delayHalf.count(), delayMax.count());
-
-    // The jitter portions should scale linearly (within 1us of rounding)
-    auto jitterHalf = delayHalf.count() - ceiling;
-    auto jitterMax = delayMax.count() - ceiling;
-    EXPECT_LE(std::abs(jitterHalf - jitterMax / 2), 1);
-}
-
-TEST(sqliteRetryBackoff, ZeroBase)
-{
-    constexpr BackoffConfig config{.baseUs = 0, .ceilUs = 100'000, .jitterShift = 3};
-    auto delay = sqliteRetryBackoff(1, UINT32_MAX, config);
-    EXPECT_EQ(delay.count(), 0);
-}
-
-TEST(sqliteRetryBackoff, SubMillisecondGrowth)
-{
-    constexpr BackoffConfig config{.baseUs = 500, .ceilUs = 100'000, .jitterShift = 3};
-    constexpr uint32_t jitter = UINT32_MAX;
-
-    // All delays should be >= baseUs and grow with each attempt
     long prev = 0;
-    for (uint32_t attempt = 1; attempt <= 4; ++attempt) {
-        auto delay = sqliteRetryBackoff(attempt, jitter, config);
-        EXPECT_GE(delay.count(), static_cast<long>(config.baseUs)) << "attempt " << attempt;
-        EXPECT_GT(delay.count(), prev) << "attempt " << attempt;
+    for (uint32_t attempt = 1; attempt <= 20; ++attempt) {
+        auto delay = sqliteRetryBackoff(attempt, 0);
+        EXPECT_GE(delay.count(), prev) << "attempt " << attempt;
         prev = delay.count();
     }
 }
 
-TEST(sqliteRetryBackoff, MicrosecondPrecision)
+TEST(sqliteRetryBackoff, JitterOnlyAdds)
 {
-    // Small baseUs: at attempt 1, ceiling=baseUs, jitterRange=baseUs>>jitterShift
-    // When jitterRange <= 1, (1 * MAX) >> 32 = 0, so delay = ceiling exactly
-    constexpr BackoffConfig config{.baseUs = 10, .ceilUs = 1000, .jitterShift = 3};
-    auto ceiling = expectedCeiling(config.baseUs, 1, config.ceilUs);
-    auto delay = sqliteRetryBackoff(1, UINT32_MAX, config);
-    EXPECT_EQ(delay.count(), static_cast<long>(ceiling));
-}
-
-TEST(sqliteRetryBackoff, MinimumDelayGuarantee)
-{
-    // Delay must always be >= ceiling >= baseUs, regardless of jitter value
-    constexpr BackoffConfig config{.baseUs = 500, .ceilUs = 100'000, .jitterShift = 3};
-    for (uint32_t attempt = 1; attempt <= 10; ++attempt) {
-        EXPECT_GE(sqliteRetryBackoff(attempt, 0, config).count(), static_cast<long>(config.baseUs))
-            << "attempt " << attempt;
-        EXPECT_GE(sqliteRetryBackoff(attempt, 1, config).count(), static_cast<long>(config.baseUs))
-            << "attempt " << attempt;
-        EXPECT_GE(sqliteRetryBackoff(attempt, UINT32_MAX / 2, config).count(), static_cast<long>(config.baseUs))
-            << "attempt " << attempt;
-        EXPECT_GE(sqliteRetryBackoff(attempt, UINT32_MAX, config).count(), static_cast<long>(config.baseUs))
-            << "attempt " << attempt;
+    for (uint32_t attempt = 1; attempt <= 20; ++attempt) {
+        auto base = sqliteRetryBackoff(attempt, 0);
+        auto withJitter = sqliteRetryBackoff(attempt, UINT32_MAX);
+        EXPECT_GE(withJitter.count(), base.count()) << "attempt " << attempt;
     }
 }
-
-struct BackoffBoundsCase
-{
-    uint32_t attempt;
-    uint32_t jitter;
-    BackoffConfig config;
-    std::string description;
-};
-
-std::ostream & operator<<(std::ostream & os, const BackoffBoundsCase & c)
-{
-    return os << c.description;
-}
-
-class SqliteRetryBackoffBounds : public ::testing::TestWithParam<BackoffBoundsCase>
-{};
-
-TEST_P(SqliteRetryBackoffBounds, DelayWithinBounds)
-{
-    auto & c = GetParam();
-    auto delay = sqliteRetryBackoff(c.attempt, c.jitter, c.config);
-
-    auto ceiling = expectedCeiling(c.config.baseUs, c.attempt, c.config.ceilUs);
-    auto jitterRange = ceiling >> c.config.jitterShift;
-    auto maxJitterAmount = static_cast<uint32_t>((static_cast<uint64_t>(jitterRange) * c.jitter) >> 32);
-
-    EXPECT_GE(delay.count(), static_cast<long>(ceiling));
-    EXPECT_LE(delay.count(), static_cast<long>(ceiling + maxJitterAmount));
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    Backoff,
-    SqliteRetryBackoffBounds,
-    ::testing::Values(
-        // CapsAtMax: high attempt saturates at cap
-        BackoffBoundsCase{
-            .attempt = 50, .jitter = 0, .config = {10'000, 100'000, 3}, .description = "CapsAtMax_zeroJitter"},
-        BackoffBoundsCase{
-            .attempt = 50, .jitter = 1000000000u, .config = {10'000, 100'000, 3}, .description = "CapsAtMax_lowJitter"},
-        BackoffBoundsCase{
-            .attempt = 50, .jitter = 2147483648u, .config = {10'000, 100'000, 3}, .description = "CapsAtMax_midJitter"},
-        BackoffBoundsCase{
-            .attempt = 50, .jitter = UINT32_MAX, .config = {10'000, 100'000, 3}, .description = "CapsAtMax_maxJitter"},
-        // HighAttemptNoOverflow: extreme attempt count stays bounded
-        BackoffBoundsCase{
-            .attempt = 1000, .jitter = 0, .config = {1000, 100'000, 3}, .description = "HighAttempt_zeroJitter"},
-        BackoffBoundsCase{
-            .attempt = 1000,
-            .jitter = 1000000000u,
-            .config = {1000, 100'000, 3},
-            .description = "HighAttempt_lowJitter"},
-        BackoffBoundsCase{
-            .attempt = 1000,
-            .jitter = UINT32_MAX,
-            .config = {1000, 100'000, 3},
-            .description = "HighAttempt_maxJitter"},
-        // AttemptOneCeiling: at attempt 1, ceiling = baseUs
-        BackoffBoundsCase{
-            .attempt = 1, .jitter = UINT32_MAX, .config = {50'000, 5'000'000, 3}, .description = "AttemptOneCeiling"},
-        // ZeroJitter: jitter=0 means delay = ceiling exactly
-        BackoffBoundsCase{
-            .attempt = 5, .jitter = 0, .config = {10'000, 100'000, 3}, .description = "ZeroJitter_midAttempt"},
-        BackoffBoundsCase{
-            .attempt = 1, .jitter = 0, .config = {50'000, 5'000'000, 3}, .description = "ZeroJitter_attemptOne"},
-        // Sub-millisecond entries
-        BackoffBoundsCase{
-            .attempt = 1, .jitter = UINT32_MAX, .config = {500, 100'000, 3}, .description = "SubMs_attempt1_maxJitter"},
-        BackoffBoundsCase{
-            .attempt = 5, .jitter = UINT32_MAX, .config = {500, 100'000, 3}, .description = "SubMs_attempt5_maxJitter"},
-        BackoffBoundsCase{
-            .attempt = 1, .jitter = 0, .config = {500, 100'000, 3}, .description = "SubMs_attempt1_zeroJitter"},
-        // Tiny base: jitterRange may truncate to 0
-        BackoffBoundsCase{
-            .attempt = 1, .jitter = UINT32_MAX, .config = {1, 1000, 3}, .description = "TinyBase_attempt1_maxJitter"},
-        BackoffBoundsCase{
-            .attempt = 10, .jitter = UINT32_MAX, .config = {1, 1000, 3}, .description = "TinyBase_attempt10_maxJitter"},
-        // Different jitterShift values
-        BackoffBoundsCase{
-            .attempt = 5,
-            .jitter = UINT32_MAX,
-            .config = {1000, 100'000, 4},
-            .description = "Shift4_attempt5_maxJitter"},
-        BackoffBoundsCase{
-            .attempt = 5,
-            .jitter = UINT32_MAX,
-            .config = {1000, 100'000, 2},
-            .description = "Shift2_attempt5_maxJitter"}),
-    [](const auto & info) { return info.param.description; });
 
 } // namespace nix

--- a/src/libstore-tests/sqlite-retry.cc
+++ b/src/libstore-tests/sqlite-retry.cc
@@ -1,71 +1,166 @@
 #include "nix/store/sqlite.hh"
 
+#include <cstdint>
+
 #include <gtest/gtest.h>
-#include <random>
 
 namespace nix {
 
 TEST(sqliteRetryBackoff, ExponentialGrowth)
 {
-    std::mt19937 rng{42};
+    constexpr BackoffConfig config{.baseMs = 1, .capMs = 100};
+    constexpr unsigned int jitter = UINT32_MAX; // maximum jitter => delay == ceiling
 
-    constexpr unsigned int base = 1;
-    constexpr unsigned int max = 100;
+    unsigned int expectedCeiling = config.baseMs;
+    for (unsigned int attempt = 1; attempt <= 12; ++attempt) {
+        auto delay = sqliteRetryBackoff(attempt, jitter, config);
+        // With max jitter, delay should equal ceiling (minus rounding)
+        EXPECT_GE(delay.count(), 0) << "attempt " << attempt;
+        EXPECT_LE(delay.count(), static_cast<long>(expectedCeiling)) << "attempt " << attempt;
 
-    for (int trial = 0; trial < 50; ++trial) {
-        unsigned int expectedCeiling = base;
-        for (unsigned int attempt = 1; attempt <= 12; ++attempt) {
-            auto delay = sqliteRetryBackoff(attempt, base, max, rng);
-            EXPECT_GE(delay.count(), 0) << "attempt " << attempt;
-            EXPECT_LE(delay.count(), static_cast<long>(expectedCeiling)) << "attempt " << attempt;
-
-            if (expectedCeiling < max / 2)
-                expectedCeiling *= 2;
-            else
-                expectedCeiling = max;
-        }
+        if (expectedCeiling < config.capMs / 2)
+            expectedCeiling *= 2;
+        else
+            expectedCeiling = config.capMs;
     }
 }
 
-TEST(sqliteRetryBackoff, CapsAtMax)
+TEST(sqliteRetryBackoff, JitterScalesLinearly)
 {
-    std::mt19937 rng{123};
-    constexpr unsigned int base = 10;
-    constexpr unsigned int max = 100;
+    constexpr BackoffConfig config{.baseMs = 100, .capMs = 5000};
 
-    for (int i = 0; i < 200; ++i) {
-        auto delay = sqliteRetryBackoff(50, base, max, rng);
-        EXPECT_GE(delay.count(), 0);
-        EXPECT_LE(delay.count(), static_cast<long>(max));
-    }
+    // delay = ceiling * jitter / 2^32
+    // With attempt=1, ceiling=100
+    // half jitter should give roughly half the delay of max jitter
+    auto halfJitter = static_cast<unsigned int>(UINT32_MAX / 2);
+    auto delayHalf = sqliteRetryBackoff(1, halfJitter, config);
+    auto delayMax = sqliteRetryBackoff(1, UINT32_MAX, config);
+
+    EXPECT_GE(delayHalf.count(), 0);
+    EXPECT_LE(delayHalf.count(), delayMax.count());
+    // Half jitter should give roughly half the delay (within 1ms of rounding)
+    EXPECT_LE(std::abs(delayHalf.count() - delayMax.count() / 2), 1);
 }
 
-TEST(sqliteRetryBackoff, ZeroBase)
+struct BackoffBoundsCase
 {
-    std::mt19937 rng{0};
-    EXPECT_EQ(sqliteRetryBackoff(5, 0, 1000, rng).count(), 0);
+    unsigned int attempt;
+    unsigned int jitter;
+    BackoffConfig config;
+    long minDelay;
+    long maxDelay;
+    std::string description;
+};
+
+std::ostream & operator<<(std::ostream & os, const BackoffBoundsCase & c)
+{
+    return os << c.description;
 }
 
-TEST(sqliteRetryBackoff, HighAttemptNoOverflow)
-{
-    std::mt19937 rng{99};
+class SqliteRetryBackoffBounds : public ::testing::TestWithParam<BackoffBoundsCase>
+{};
 
-    for (int i = 0; i < 100; ++i) {
-        auto delay = sqliteRetryBackoff(1000, 1, 100, rng);
-        EXPECT_GE(delay.count(), 0);
-        EXPECT_LE(delay.count(), 100);
-    }
+TEST_P(SqliteRetryBackoffBounds, DelayWithinBounds)
+{
+    auto & c = GetParam();
+    auto delay = sqliteRetryBackoff(c.attempt, c.jitter, c.config);
+    EXPECT_GE(delay.count(), c.minDelay);
+    EXPECT_LE(delay.count(), c.maxDelay);
 }
 
-TEST(sqliteRetryBackoff, AttemptOneCeiling)
-{
-    std::mt19937 rng{7};
-
-    for (int i = 0; i < 100; ++i) {
-        auto delay = sqliteRetryBackoff(1, 50, 5000, rng);
-        EXPECT_GE(delay.count(), 0);
-        EXPECT_LE(delay.count(), 50);
-    }
-}
+INSTANTIATE_TEST_SUITE_P(
+    Backoff,
+    SqliteRetryBackoffBounds,
+    ::testing::Values(
+        // CapsAtMax: high attempt saturates at cap regardless of jitter
+        BackoffBoundsCase{
+            .attempt = 50,
+            .jitter = 0,
+            .config = {10, 100},
+            .minDelay = 0,
+            .maxDelay = 100,
+            .description = "CapsAtMax_zeroJitter"},
+        BackoffBoundsCase{
+            .attempt = 50,
+            .jitter = 1000000000u,
+            .config = {10, 100},
+            .minDelay = 0,
+            .maxDelay = 100,
+            .description = "CapsAtMax_lowJitter"},
+        BackoffBoundsCase{
+            .attempt = 50,
+            .jitter = 2147483648u,
+            .config = {10, 100},
+            .minDelay = 0,
+            .maxDelay = 100,
+            .description = "CapsAtMax_midJitter"},
+        BackoffBoundsCase{
+            .attempt = 50,
+            .jitter = UINT32_MAX,
+            .config = {10, 100},
+            .minDelay = 0,
+            .maxDelay = 100,
+            .description = "CapsAtMax_maxJitter"},
+        // ZeroBase: base=0 always yields zero delay
+        BackoffBoundsCase{
+            .attempt = 5,
+            .jitter = UINT32_MAX,
+            .config = {0, 1000},
+            .minDelay = 0,
+            .maxDelay = 0,
+            .description = "ZeroBase_maxJitter"},
+        BackoffBoundsCase{
+            .attempt = 5,
+            .jitter = 0,
+            .config = {0, 1000},
+            .minDelay = 0,
+            .maxDelay = 0,
+            .description = "ZeroBase_zeroJitter"},
+        // HighAttemptNoOverflow: extreme attempt count stays bounded
+        BackoffBoundsCase{
+            .attempt = 1000,
+            .jitter = 0,
+            .config = {1, 100},
+            .minDelay = 0,
+            .maxDelay = 100,
+            .description = "HighAttempt_zeroJitter"},
+        BackoffBoundsCase{
+            .attempt = 1000,
+            .jitter = 1000000000u,
+            .config = {1, 100},
+            .minDelay = 0,
+            .maxDelay = 100,
+            .description = "HighAttempt_lowJitter"},
+        BackoffBoundsCase{
+            .attempt = 1000,
+            .jitter = UINT32_MAX,
+            .config = {1, 100},
+            .minDelay = 0,
+            .maxDelay = 100,
+            .description = "HighAttempt_maxJitter"},
+        // AttemptOneCeiling: at attempt 1, ceiling = base
+        BackoffBoundsCase{
+            .attempt = 1,
+            .jitter = UINT32_MAX,
+            .config = {50, 5000},
+            .minDelay = 0,
+            .maxDelay = 50,
+            .description = "AttemptOneCeiling"},
+        // ZeroJitterGivesZeroDelay: jitter=0 means delay = ceiling * 0 / 2^32 = 0
+        BackoffBoundsCase{
+            .attempt = 5,
+            .jitter = 0,
+            .config = {10, 100},
+            .minDelay = 0,
+            .maxDelay = 0,
+            .description = "ZeroJitter_midAttempt"},
+        BackoffBoundsCase{
+            .attempt = 1,
+            .jitter = 0,
+            .config = {50, 5000},
+            .minDelay = 0,
+            .maxDelay = 0,
+            .description = "ZeroJitter_attemptOne"}),
+    [](const auto & info) { return info.param.description; });
 
 } // namespace nix

--- a/src/libstore/include/nix/store/backoff.hh
+++ b/src/libstore/include/nix/store/backoff.hh
@@ -1,0 +1,26 @@
+#pragma once
+/**
+ * @file
+ *
+ * Shared exponential backoff primitive for libstore retry loops
+ * (filetransfer, sqlite, etc.).
+ */
+
+#include <algorithm>
+#include <cstdint>
+
+namespace nix {
+
+/**
+ * Clamped exponential growth: base * 2^(attempt-1), capped at ceil.
+ * Shift is clamped at 31 and the intermediate is widened to uint64_t
+ * so the shift cannot overflow uint32_t.
+ */
+constexpr uint32_t clampedExponential(uint32_t base, uint32_t attempt, uint32_t ceil)
+{
+    auto shift = std::min(attempt == 0 ? 0u : attempt - 1, 31u);
+    uint64_t unclamped = static_cast<uint64_t>(base) << shift;
+    return static_cast<uint32_t>(std::min<uint64_t>(unclamped, ceil));
+}
+
+} // namespace nix

--- a/src/libstore/include/nix/store/filetransfer-impl.hh
+++ b/src/libstore/include/nix/store/filetransfer-impl.hh
@@ -6,7 +6,8 @@
  * Not part of the public libstore API.
  */
 
-#include <algorithm>
+#include "nix/store/backoff.hh"
+
 #include <chrono>
 #include <cstdint>
 #include <limits>
@@ -14,18 +15,6 @@
 #include <random>
 
 namespace nix {
-
-/**
- * Clamped exponential growth: base * 2^(attempt-1), capped at ceil.
- * Shift is clamped at 31 and the intermediate is widened to uint64_t
- * so the shift cannot overflow uint32_t.
- */
-constexpr uint32_t clampedExponential(uint32_t base, uint32_t attempt, uint32_t ceil)
-{
-    auto shift = std::min(attempt == 0 ? 0u : attempt - 1, 31u);
-    uint64_t unclamped = static_cast<uint64_t>(base) << shift;
-    return static_cast<uint32_t>(std::min<uint64_t>(unclamped, ceil));
-}
 
 /**
  * Saturating conversion: chrono duration → uint32_t milliseconds.

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -195,25 +195,6 @@ public:
 
     Setting<bool> useSQLiteWAL{this, !isWSL1(), "use-sqlite-wal", "Whether SQLite should use WAL mode."};
 
-    Setting<unsigned int> sqliteRetryBaseUs{
-        this,
-        500,
-        "sqlite-retry-base-us",
-        "Base delay in microseconds for SQLite busy retries. Doubles each attempt up to the ceiling."};
-
-    Setting<unsigned int> sqliteRetryCeilUs{
-        this, 100'000, "sqlite-retry-ceil-us", "Maximum delay in microseconds for SQLite busy retries."};
-
-    Setting<unsigned int> sqliteRetryJitterShift{
-        this,
-        3,
-        "sqlite-retry-jitter-shift",
-        R"(
-          Right bit-shift controlling jitter band for SQLite busy retries.
-          Jitter adds `[0, ceiling >> shift)` on top of the deterministic
-          exponential delay. The default of 3 gives ~12.5% jitter.
-        )"};
-
     Setting<bool> keepFailed{this, false, "keep-failed", "Whether to keep temporary directories of failed builds."};
 
     /**

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -195,6 +195,25 @@ public:
 
     Setting<bool> useSQLiteWAL{this, !isWSL1(), "use-sqlite-wal", "Whether SQLite should use WAL mode."};
 
+    Setting<unsigned int> sqliteRetryBaseUs{
+        this,
+        500,
+        "sqlite-retry-base-us",
+        "Base delay in microseconds for SQLite busy retries. Doubles each attempt up to the ceiling."};
+
+    Setting<unsigned int> sqliteRetryCeilUs{
+        this, 100'000, "sqlite-retry-ceil-us", "Maximum delay in microseconds for SQLite busy retries."};
+
+    Setting<unsigned int> sqliteRetryJitterShift{
+        this,
+        3,
+        "sqlite-retry-jitter-shift",
+        R"(
+          Right bit-shift controlling jitter band for SQLite busy retries.
+          Jitter adds `[0, ceiling >> shift)` on top of the deterministic
+          exponential delay. The default of 3 gives ~12.5% jitter.
+        )"};
+
     Setting<bool> keepFailed{this, false, "keep-failed", "Whether to keep temporary directories of failed builds."};
 
     /**

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -11,6 +11,7 @@ config_pub_h = configure_file(
 
 headers = [ config_pub_h ] + files(
   'aws-creds.hh',
+  'backoff.hh',
   'binary-cache-store.hh',
   'build-result.hh',
   'build.hh',

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <functional>
+#include <random>
 #include <string>
 
 #include "nix/util/error.hh"
@@ -203,22 +204,33 @@ protected:
 
 MakeError(SQLiteBusy, SQLiteError);
 
-void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning);
+struct SQLiteRetryState
+{
+    unsigned int attempt = 0;
+    time_t nextWarning;
 
-/**
- * Convenience function for retrying a SQLite transaction when the
- * database is busy.
- */
+    SQLiteRetryState()
+        : nextWarning(time(nullptr) + 1)
+    {
+    }
+};
+
+std::chrono::milliseconds
+sqliteRetryBackoff(unsigned int attempt, unsigned int baseMs, unsigned int maxMs, std::mt19937 & rng);
+
+void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state, std::mt19937 & rng);
+
 template<typename T, typename F>
 T retrySQLite(const F & fun)
 {
-    time_t nextWarning = time(nullptr) + 1;
+    thread_local std::mt19937 rng{std::random_device{}()};
+    SQLiteRetryState state;
 
     while (true) {
         try {
             return fun();
         } catch (SQLiteBusy & e) {
-            handleSQLiteBusy(e, nextWarning);
+            handleSQLiteBusy(e, state, rng);
         }
     }
 }

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -218,11 +218,22 @@ struct SQLiteRetryState
 
 struct BackoffConfig
 {
-    unsigned int baseMs;
-    unsigned int capMs;
+    unsigned int baseUs;
+    unsigned int ceilUs; // AWS calls this "cap"
+    // Jitter adds [0, ceiling >> jitterShift) on top of the deterministic ceiling.
+    //
+    // Example configurations:
+    //   {500, 100'000, 3}  — 0.5ms base, 100ms ceil, 12.5% jitter
+    //     attempt 1: ceiling=500us,    delay ∈ [500, 561]us
+    //     attempt 8: ceiling=64'000us, delay ∈ [64'000, 71'999]us
+    //
+    //   {200'000, 5'000'000, 4} — 200ms base, 5s ceil, 6.25% jitter
+    //     attempt 1: ceiling=200'000us, delay ∈ [200'000, 212'499]us
+    //     attempt 5: ceiling=3'200'000us, delay ∈ [3'200'000, 3'399'999]us
+    unsigned int jitterShift;
 };
 
-std::chrono::milliseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config);
+constexpr std::chrono::microseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config);
 
 void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state);
 

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -233,7 +233,7 @@ struct BackoffConfig
     unsigned int jitterShift;
 };
 
-constexpr std::chrono::microseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config);
+std::chrono::microseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config);
 
 void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state);
 

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <functional>
@@ -207,11 +208,13 @@ MakeError(SQLiteBusy, SQLiteError);
 struct SQLiteRetryState
 {
     uint32_t attempt = 0;
-    time_t nextWarning;
-    uint32_t jitter; // random factor, computed once per retry sequence
+    std::chrono::steady_clock::time_point startTime; // monotonic, for the retry timeout
+    time_t nextWarning;                              // wall-clock, for throttling warnings
+    uint32_t jitter;                                 // random factor, computed once per retry sequence
 
     explicit SQLiteRetryState(uint32_t jitter)
-        : nextWarning(time(nullptr) + 1)
+        : startTime(std::chrono::steady_clock::now())
+        , nextWarning(time(nullptr) + 1)
         , jitter(jitter)
     {
     }
@@ -223,6 +226,10 @@ void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state);
 
 SQLiteRetryState newSQLiteRetryState();
 
+/**
+ * Convenience function for retrying a SQLite transaction when the
+ * database is busy.
+ */
 template<typename T, typename F>
 T retrySQLite(const F & fun)
 {

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -208,29 +208,36 @@ struct SQLiteRetryState
 {
     unsigned int attempt = 0;
     time_t nextWarning;
+    unsigned int jitter; // random factor, computed once per retry sequence
 
-    SQLiteRetryState()
+    SQLiteRetryState(std::mt19937 & rng)
         : nextWarning(time(nullptr) + 1)
+        , jitter(rng())
     {
     }
 };
 
-std::chrono::milliseconds
-sqliteRetryBackoff(unsigned int attempt, unsigned int baseMs, unsigned int maxMs, std::mt19937 & rng);
+struct BackoffConfig
+{
+    unsigned int baseMs;
+    unsigned int capMs;
+};
 
-void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state, std::mt19937 & rng);
+std::chrono::milliseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config);
+
+void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state);
 
 template<typename T, typename F>
 T retrySQLite(const F & fun)
 {
     thread_local std::mt19937 rng{std::random_device{}()};
-    SQLiteRetryState state;
+    SQLiteRetryState state{rng};
 
     while (true) {
         try {
             return fun();
         } catch (SQLiteBusy & e) {
-            handleSQLiteBusy(e, state, rng);
+            handleSQLiteBusy(e, state);
         }
     }
 }

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -217,16 +217,7 @@ struct SQLiteRetryState
     }
 };
 
-struct BackoffConfig
-{
-    uint32_t baseUs = 500;
-    uint32_t ceilUs = 100'000; // AWS calls this "cap"
-    // Jitter adds [0, ceiling >> jitterShift) on top of the deterministic ceiling.
-    // The default of 3 gives ~12.5% jitter.
-    uint32_t jitterShift = 3;
-};
-
-std::chrono::microseconds sqliteRetryBackoff(uint32_t attempt, uint32_t jitter, BackoffConfig config);
+std::chrono::microseconds sqliteRetryBackoff(uint32_t attempt, uint32_t jitter);
 
 void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state);
 

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <string>
@@ -205,11 +206,11 @@ MakeError(SQLiteBusy, SQLiteError);
 
 struct SQLiteRetryState
 {
-    unsigned int attempt = 0;
+    uint32_t attempt = 0;
     time_t nextWarning;
-    unsigned int jitter; // random factor, computed once per retry sequence
+    uint32_t jitter; // random factor, computed once per retry sequence
 
-    explicit SQLiteRetryState(unsigned int jitter)
+    explicit SQLiteRetryState(uint32_t jitter)
         : nextWarning(time(nullptr) + 1)
         , jitter(jitter)
     {
@@ -218,22 +219,14 @@ struct SQLiteRetryState
 
 struct BackoffConfig
 {
-    unsigned int baseUs;
-    unsigned int ceilUs; // AWS calls this "cap"
+    uint32_t baseUs = 500;
+    uint32_t ceilUs = 100'000; // AWS calls this "cap"
     // Jitter adds [0, ceiling >> jitterShift) on top of the deterministic ceiling.
-    //
-    // Example configurations:
-    //   {500, 100'000, 3}  — 0.5ms base, 100ms ceil, 12.5% jitter
-    //     attempt 1: ceiling=500us,    delay ∈ [500, 561]us
-    //     attempt 8: ceiling=64'000us, delay ∈ [64'000, 71'999]us
-    //
-    //   {200'000, 5'000'000, 4} — 200ms base, 5s ceil, 6.25% jitter
-    //     attempt 1: ceiling=200'000us, delay ∈ [200'000, 212'499]us
-    //     attempt 5: ceiling=3'200'000us, delay ∈ [3'200'000, 3'399'999]us
-    unsigned int jitterShift;
+    // The default of 3 gives ~12.5% jitter.
+    uint32_t jitterShift = 3;
 };
 
-std::chrono::microseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config);
+std::chrono::microseconds sqliteRetryBackoff(uint32_t attempt, uint32_t jitter, BackoffConfig config);
 
 void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state);
 

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -3,7 +3,6 @@
 
 #include <filesystem>
 #include <functional>
-#include <random>
 #include <string>
 
 #include "nix/util/error.hh"
@@ -210,9 +209,9 @@ struct SQLiteRetryState
     time_t nextWarning;
     unsigned int jitter; // random factor, computed once per retry sequence
 
-    SQLiteRetryState(std::mt19937 & rng)
+    explicit SQLiteRetryState(unsigned int jitter)
         : nextWarning(time(nullptr) + 1)
-        , jitter(rng())
+        , jitter(jitter)
     {
     }
 };
@@ -227,11 +226,12 @@ std::chrono::milliseconds sqliteRetryBackoff(unsigned int attempt, unsigned int 
 
 void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state);
 
+SQLiteRetryState newSQLiteRetryState();
+
 template<typename T, typename F>
 T retrySQLite(const F & fun)
 {
-    thread_local std::mt19937 rng{std::random_device{}()};
-    SQLiteRetryState state{rng};
+    auto state = newSQLiteRetryState();
 
     while (true) {
         try {

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -10,6 +10,9 @@
 
 #include <sqlite3.h>
 
+#include <algorithm>
+#include <atomic>
+#include <random>
 #include <thread>
 
 namespace nix {
@@ -258,6 +261,8 @@ bool SQLiteStmt::Use::isNull(int col)
 SQLiteTxn::SQLiteTxn(sqlite3 * db)
 {
     this->db = db;
+    // TODO: use "begin immediate" when multiple SQLite connections are used,
+    // to acquire the write lock early and avoid deferred-to-write deadlocks.
     if (sqlite3_exec(db, "begin;", 0, 0, 0) != SQLITE_OK)
         SQLiteError::throw_(db, "starting transaction");
     active = true;
@@ -280,19 +285,55 @@ SQLiteTxn::~SQLiteTxn()
     }
 }
 
-void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning)
+namespace {
+
+unsigned int clampedExponential(unsigned int base, unsigned int attempt, unsigned int max)
+{
+    unsigned int value = base;
+    for (unsigned int i = 1; i < attempt; ++i) {
+        if (value >= max / 2)
+            return max;
+        value *= 2;
+    }
+    return std::min(value, max);
+}
+
+unsigned int uniformRandomUpTo(unsigned int ceiling, std::mt19937 & rng)
+{
+    return std::uniform_int_distribution<unsigned int>(0, ceiling)(rng);
+}
+
+void throttledWarning(const SQLiteBusy & e, SQLiteRetryState & state)
 {
     time_t now = time(nullptr);
-    if (now > nextWarning) {
-        nextWarning = now + 10;
+    if (now > state.nextWarning) {
+        state.nextWarning = now + 10;
         logWarning({.msg = e.info().msg});
     }
+}
 
-    /* Sleep for a while since retrying the transaction right away
-       is likely to fail again. */
+} // anonymous namespace
+
+std::chrono::milliseconds
+sqliteRetryBackoff(unsigned int attempt, unsigned int baseMs, unsigned int maxMs, std::mt19937 & rng)
+{
+    if (baseMs == 0)
+        return std::chrono::milliseconds{0};
+
+    auto ceiling = clampedExponential(baseMs, attempt, maxMs);
+    return std::chrono::milliseconds{uniformRandomUpTo(ceiling, rng)};
+}
+
+void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state, std::mt19937 & rng)
+{
+    ++state.attempt;
+
+    throttledWarning(e, state);
     checkInterrupt();
-    /* <= 0.1s */
-    std::this_thread::sleep_for(std::chrono::milliseconds{rand() % 100});
+
+    constexpr unsigned int baseDelayMs = 1;
+    constexpr unsigned int maxDelayMs = 100;
+    std::this_thread::sleep_for(sqliteRetryBackoff(state.attempt, baseDelayMs, maxDelayMs, rng));
 }
 
 } // namespace nix

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -310,10 +310,10 @@ void throttledWarning(const SQLiteBusy & e, SQLiteRetryState & state)
 SQLiteRetryState newSQLiteRetryState()
 {
     thread_local std::mt19937 rng{std::random_device{}()};
-    return SQLiteRetryState{rng()};
+    return SQLiteRetryState{static_cast<unsigned int>(rng())};
 }
 
-constexpr std::chrono::microseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config)
+std::chrono::microseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config)
 {
     auto ceiling = clampedExponential(config.baseUs, attempt, config.ceilUs);
     auto jitterRange = (config.jitterShift >= 32u) ? 0u : (ceiling >> config.jitterShift);

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -12,7 +12,6 @@
 
 #include <algorithm>
 #include <atomic>
-#include <random>
 #include <thread>
 
 namespace nix {
@@ -287,20 +286,12 @@ SQLiteTxn::~SQLiteTxn()
 
 namespace {
 
-unsigned int clampedExponential(unsigned int base, unsigned int attempt, unsigned int max)
+unsigned int clampedExponential(unsigned int base, unsigned int attempt, unsigned int cap)
 {
-    unsigned int value = base;
-    for (unsigned int i = 1; i < attempt; ++i) {
-        if (value >= max / 2)
-            return max;
-        value *= 2;
-    }
-    return std::min(value, max);
-}
-
-unsigned int uniformRandomUpTo(unsigned int ceiling, std::mt19937 & rng)
-{
-    return std::uniform_int_distribution<unsigned int>(0, ceiling)(rng);
+    // Clamp shift to [0, 63] to stay within unsigned long long range.
+    auto shift = std::min(attempt - 1, 63u);
+    auto unclamped = static_cast<unsigned long long>(base) << shift;
+    return static_cast<unsigned int>(std::min(unclamped, static_cast<unsigned long long>(cap)));
 }
 
 void throttledWarning(const SQLiteBusy & e, SQLiteRetryState & state)
@@ -314,26 +305,26 @@ void throttledWarning(const SQLiteBusy & e, SQLiteRetryState & state)
 
 } // anonymous namespace
 
-std::chrono::milliseconds
-sqliteRetryBackoff(unsigned int attempt, unsigned int baseMs, unsigned int maxMs, std::mt19937 & rng)
+std::chrono::milliseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config)
 {
-    if (baseMs == 0)
+    if (config.baseMs == 0)
         return std::chrono::milliseconds{0};
 
-    auto ceiling = clampedExponential(baseMs, attempt, maxMs);
-    return std::chrono::milliseconds{uniformRandomUpTo(ceiling, rng)};
+    auto ceiling = clampedExponential(config.baseMs, attempt, config.capMs);
+    // Scale ceiling by jitter factor: delay = ceiling * (jitter / 2^32)
+    auto delay = static_cast<unsigned int>((static_cast<unsigned long long>(ceiling) * jitter) >> 32);
+    return std::chrono::milliseconds{delay};
 }
 
-void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state, std::mt19937 & rng)
+void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state)
 {
     ++state.attempt;
 
     throttledWarning(e, state);
     checkInterrupt();
 
-    constexpr unsigned int baseDelayMs = 1;
-    constexpr unsigned int maxDelayMs = 100;
-    std::this_thread::sleep_for(sqliteRetryBackoff(state.attempt, baseDelayMs, maxDelayMs, rng));
+    constexpr BackoffConfig config{.baseMs = 1, .capMs = 100};
+    std::this_thread::sleep_for(sqliteRetryBackoff(state.attempt, state.jitter, config));
 }
 
 } // namespace nix

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -1,4 +1,5 @@
 #include "nix/store/sqlite.hh"
+#include "nix/store/backoff.hh"
 #include "nix/util/environment-variables.hh"
 #include "nix/util/util.hh"
 #include "nix/util/url.hh"
@@ -10,7 +11,6 @@
 
 #include <sqlite3.h>
 
-#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <random>
@@ -290,15 +290,14 @@ namespace {
 
 constexpr uint32_t backoffBaseUs = 500;
 constexpr uint32_t backoffCeilUs = 100'000;
-constexpr uint32_t backoffJitterShift = 3; // ~12.5% jitter
 
-// Precondition: attempt >= 1
-constexpr uint32_t clampedExponential(uint32_t attempt)
-{
-    auto shift = std::min(attempt - 1, uint32_t{63});
-    auto unclamped = static_cast<uint64_t>(backoffBaseUs) << shift;
-    return static_cast<uint32_t>(std::min(unclamped, static_cast<uint64_t>(backoffCeilUs)));
-}
+// Additive jitter up to ceiling >> backoffJitterShift (~12.5%), sampled once
+// per sequence. Intentionally weak decorrelation, not AWS-style "full jitter".
+constexpr uint32_t backoffJitterShift = 3;
+
+// Give up after this much monotonic retry time. Checked between calls only;
+// sqlite3_busy_timeout (1 hour) can block a single call for longer.
+constexpr auto sqliteRetryTimeout = std::chrono::minutes{10};
 
 void throttledWarning(const SQLiteBusy & e, SQLiteRetryState & state)
 {
@@ -319,7 +318,7 @@ SQLiteRetryState newSQLiteRetryState()
 
 std::chrono::microseconds sqliteRetryBackoff(uint32_t attempt, uint32_t jitter)
 {
-    auto ceiling = clampedExponential(attempt);
+    auto ceiling = clampedExponential(backoffBaseUs, attempt, backoffCeilUs);
     auto jitterAmount = static_cast<uint32_t>((static_cast<uint64_t>(ceiling >> backoffJitterShift) * jitter) >> 32);
     return std::chrono::microseconds{ceiling + jitterAmount};
 }
@@ -327,6 +326,11 @@ std::chrono::microseconds sqliteRetryBackoff(uint32_t attempt, uint32_t jitter)
 void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state)
 {
     ++state.attempt;
+
+    // Only called from retrySQLite's catch block, so `throw;` re-raises the
+    // active SQLiteBusy; calling outside a handler would std::terminate().
+    if (std::chrono::steady_clock::now() - state.startTime > sqliteRetryTimeout)
+        throw;
 
     throttledWarning(e, state);
     checkInterrupt();

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstdint>
 #include <random>
 #include <thread>
 
@@ -288,12 +289,11 @@ SQLiteTxn::~SQLiteTxn()
 namespace {
 
 // Precondition: attempt >= 1
-constexpr unsigned int clampedExponential(unsigned int base, unsigned int attempt, unsigned int ceil)
+constexpr uint32_t clampedExponential(BackoffConfig config, uint32_t attempt)
 {
-    // Clamp shift to [0, 63] so base << shift is valid for unsigned long long.
-    auto shift = std::min(attempt - 1, 63u);
-    auto unclamped = static_cast<unsigned long long>(base) << shift;
-    return static_cast<unsigned int>(std::min(unclamped, static_cast<unsigned long long>(ceil)));
+    auto shift = std::min(attempt - 1, uint32_t{63});
+    auto unclamped = static_cast<uint64_t>(config.baseUs) << shift;
+    return static_cast<uint32_t>(std::min(unclamped, static_cast<uint64_t>(config.ceilUs)));
 }
 
 void throttledWarning(const SQLiteBusy & e, SQLiteRetryState & state)
@@ -310,14 +310,14 @@ void throttledWarning(const SQLiteBusy & e, SQLiteRetryState & state)
 SQLiteRetryState newSQLiteRetryState()
 {
     thread_local std::mt19937 rng{std::random_device{}()};
-    return SQLiteRetryState{static_cast<unsigned int>(rng())};
+    return SQLiteRetryState{static_cast<uint32_t>(rng())};
 }
 
-std::chrono::microseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config)
+std::chrono::microseconds sqliteRetryBackoff(uint32_t attempt, uint32_t jitter, BackoffConfig config)
 {
-    auto ceiling = clampedExponential(config.baseUs, attempt, config.ceilUs);
-    auto jitterRange = (config.jitterShift >= 32u) ? 0u : (ceiling >> config.jitterShift);
-    auto jitterAmount = static_cast<unsigned int>((static_cast<unsigned long long>(jitterRange) * jitter) >> 32);
+    auto ceiling = clampedExponential(config, attempt);
+    auto jitterRange = (config.jitterShift >= 32u) ? uint32_t{0} : (ceiling >> config.jitterShift);
+    auto jitterAmount = static_cast<uint32_t>((static_cast<uint64_t>(jitterRange) * jitter) >> 32);
     auto delay = ceiling + jitterAmount;
     return std::chrono::microseconds{delay};
 }
@@ -329,12 +329,7 @@ void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state)
     throttledWarning(e, state);
     checkInterrupt();
 
-    BackoffConfig config{
-        .baseUs = settings.sqliteRetryBaseUs,
-        .ceilUs = settings.sqliteRetryCeilUs,
-        .jitterShift = settings.sqliteRetryJitterShift,
-    };
-    std::this_thread::sleep_for(sqliteRetryBackoff(state.attempt, state.jitter, config));
+    std::this_thread::sleep_for(sqliteRetryBackoff(state.attempt, state.jitter, {}));
 }
 
 } // namespace nix

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -288,12 +288,16 @@ SQLiteTxn::~SQLiteTxn()
 
 namespace {
 
+constexpr uint32_t backoffBaseUs = 500;
+constexpr uint32_t backoffCeilUs = 100'000;
+constexpr uint32_t backoffJitterShift = 3; // ~12.5% jitter
+
 // Precondition: attempt >= 1
-constexpr uint32_t clampedExponential(BackoffConfig config, uint32_t attempt)
+constexpr uint32_t clampedExponential(uint32_t attempt)
 {
     auto shift = std::min(attempt - 1, uint32_t{63});
-    auto unclamped = static_cast<uint64_t>(config.baseUs) << shift;
-    return static_cast<uint32_t>(std::min(unclamped, static_cast<uint64_t>(config.ceilUs)));
+    auto unclamped = static_cast<uint64_t>(backoffBaseUs) << shift;
+    return static_cast<uint32_t>(std::min(unclamped, static_cast<uint64_t>(backoffCeilUs)));
 }
 
 void throttledWarning(const SQLiteBusy & e, SQLiteRetryState & state)
@@ -313,13 +317,11 @@ SQLiteRetryState newSQLiteRetryState()
     return SQLiteRetryState{static_cast<uint32_t>(rng())};
 }
 
-std::chrono::microseconds sqliteRetryBackoff(uint32_t attempt, uint32_t jitter, BackoffConfig config)
+std::chrono::microseconds sqliteRetryBackoff(uint32_t attempt, uint32_t jitter)
 {
-    auto ceiling = clampedExponential(config, attempt);
-    auto jitterRange = (config.jitterShift >= 32u) ? uint32_t{0} : (ceiling >> config.jitterShift);
-    auto jitterAmount = static_cast<uint32_t>((static_cast<uint64_t>(jitterRange) * jitter) >> 32);
-    auto delay = ceiling + jitterAmount;
-    return std::chrono::microseconds{delay};
+    auto ceiling = clampedExponential(attempt);
+    auto jitterAmount = static_cast<uint32_t>((static_cast<uint64_t>(ceiling >> backoffJitterShift) * jitter) >> 32);
+    return std::chrono::microseconds{ceiling + jitterAmount};
 }
 
 void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state)
@@ -329,7 +331,7 @@ void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state)
     throttledWarning(e, state);
     checkInterrupt();
 
-    std::this_thread::sleep_for(sqliteRetryBackoff(state.attempt, state.jitter, {}));
+    std::this_thread::sleep_for(sqliteRetryBackoff(state.attempt, state.jitter));
 }
 
 } // namespace nix

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <random>
 #include <thread>
 
 namespace nix {
@@ -304,6 +305,12 @@ void throttledWarning(const SQLiteBusy & e, SQLiteRetryState & state)
 }
 
 } // anonymous namespace
+
+SQLiteRetryState newSQLiteRetryState()
+{
+    thread_local std::mt19937 rng{std::random_device{}()};
+    return SQLiteRetryState{rng()};
+}
 
 std::chrono::milliseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config)
 {

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -287,12 +287,13 @@ SQLiteTxn::~SQLiteTxn()
 
 namespace {
 
-unsigned int clampedExponential(unsigned int base, unsigned int attempt, unsigned int cap)
+// Precondition: attempt >= 1
+constexpr unsigned int clampedExponential(unsigned int base, unsigned int attempt, unsigned int ceil)
 {
-    // Clamp shift to [0, 63] to stay within unsigned long long range.
+    // Clamp shift to [0, 63] so base << shift is valid for unsigned long long.
     auto shift = std::min(attempt - 1, 63u);
     auto unclamped = static_cast<unsigned long long>(base) << shift;
-    return static_cast<unsigned int>(std::min(unclamped, static_cast<unsigned long long>(cap)));
+    return static_cast<unsigned int>(std::min(unclamped, static_cast<unsigned long long>(ceil)));
 }
 
 void throttledWarning(const SQLiteBusy & e, SQLiteRetryState & state)
@@ -312,15 +313,13 @@ SQLiteRetryState newSQLiteRetryState()
     return SQLiteRetryState{rng()};
 }
 
-std::chrono::milliseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config)
+constexpr std::chrono::microseconds sqliteRetryBackoff(unsigned int attempt, unsigned int jitter, BackoffConfig config)
 {
-    if (config.baseMs == 0)
-        return std::chrono::milliseconds{0};
-
-    auto ceiling = clampedExponential(config.baseMs, attempt, config.capMs);
-    // Scale ceiling by jitter factor: delay = ceiling * (jitter / 2^32)
-    auto delay = static_cast<unsigned int>((static_cast<unsigned long long>(ceiling) * jitter) >> 32);
-    return std::chrono::milliseconds{delay};
+    auto ceiling = clampedExponential(config.baseUs, attempt, config.ceilUs);
+    auto jitterRange = (config.jitterShift >= 32u) ? 0u : (ceiling >> config.jitterShift);
+    auto jitterAmount = static_cast<unsigned int>((static_cast<unsigned long long>(jitterRange) * jitter) >> 32);
+    auto delay = ceiling + jitterAmount;
+    return std::chrono::microseconds{delay};
 }
 
 void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state)
@@ -330,7 +329,11 @@ void handleSQLiteBusy(const SQLiteBusy & e, SQLiteRetryState & state)
     throttledWarning(e, state);
     checkInterrupt();
 
-    constexpr BackoffConfig config{.baseMs = 1, .capMs = 100};
+    BackoffConfig config{
+        .baseUs = settings.sqliteRetryBaseUs,
+        .ceilUs = settings.sqliteRetryCeilUs,
+        .jitterShift = settings.sqliteRetryJitterShift,
+    };
     std::this_thread::sleep_for(sqliteRetryBackoff(state.attempt, state.jitter, config));
 }
 


### PR DESCRIPTION
## Motivation

The SQLite busy retry logic has used a flat random 0-100 ms sleep (`rand() % 100`) since this code was factored out in 2016 (d9c5e3bb). Modern hardware resolves local lock contention orders of magnitude faster than it did then, making a fixed 0-100 ms window unnecessarily coarse. The C-style `rand()` is also not thread-safe and provides poor distribution.

**Old retry pattern:** On each `SQLITE_BUSY`, sleep for `rand() % 100` milliseconds (flat uniform 0-100 ms, no back-off, C-style `rand()`). Every retry has the same distribution regardless of how many times we've already retried, and the loop retries forever.

**New retry pattern:** Exponential back-off with a small jitter, at microsecond granularity. The ceiling doubles each attempt starting from a 500 µs base and capping at 100 ms (`500 µs → 1 ms → 2 ms → 4 ms → … → 100 ms`, reaching the cap at attempt 9). Each retry sleeps for that ceiling plus a small additive jitter of up to ~12.5%. This means brief contention resolves in microseconds rather than sleeping up to 100 ms unnecessarily, while sustained contention still backs off to reasonable delays.

The jitter is intentionally weak, additive decorrelation (not AWS-style "full jitter"): local store contention has few contenders, and the jitter factor is sampled once per retry sequence rather than per retry, which avoids per-retry RNG overhead while still decorrelating concurrent callers.

This is a minimal, conservative first step toward better SQLite contention handling:

- Replace C-style `rand()` with thread-local `std::mt19937`
- Use exponential back-off with additive jitter instead of a flat random delay
- Extract the `clampedExponential` back-off primitive into a shared `backoff.hh` header, so both `sqlite.cc` and `filetransfer.cc` use the same well-tested implementation (which safely clamps the shift and widens to `uint64_t` to avoid overflow)
- Replace the bare `time_t` retry state with a `SQLiteRetryState` struct, and factor out named helpers (`sqliteRetryBackoff`, `throttledWarning`, `newSQLiteRetryState`) so the retry logic reads without comments
- Add a 10-minute wall-clock (monotonic `steady_clock`) timeout so a permanently locked database no longer retries forever — it now gives up and propagates `SQLiteBusy`
- Add unit tests for the back-off function

The back-off parameters are internal constants rather than user-facing settings: they are tuning knobs nobody should need to change, so they are kept out of the `nix.conf` surface. The `sqlite3_busy_timeout` (1 hour) is left as-is.

## Context

PR #15449 inspired us to look more closely at the SQLite retry logic. This is a very first step to slightly improve it -- we are looking for feedback and are happy to improve this further in follow-up work.

Future work may include:
- A configurable `sqlite3_busy_timeout` (the current 1-hour hard coded value is very conservative)
- A custom `sqlite3_busy_handler` with microsecond-scale yield/back-off for high-concurrency workloads
- `BEGIN IMMEDIATE` transactions when multiple connections are in use

The diff is small and self-contained: `handleSQLiteBusy` in `sqlite.cc` is rewritten, `SQLiteRetryState` replaces the bare `time_t`, `backoff.hh` holds the shared `clampedExponential` primitive, and `sqlite-retry.cc` adds unit tests for the backoff math.

We have also been looking at the SQLite usage in Nix more broadly. Currently Nix uses a single connection per store, which is likely the primary bottleneck under concurrency rather than the retry logic itself. For this reason we held back a `BEGIN IMMEDIATE` change (which only helps with multiple connections) in favor of this small, safe win. We are working on larger changes around multiple SQLite connections that would be more impactful, and plan to bring those in follow-up PRs.

## Testing

- All existing tests pass: `meson test nix-store-tests` (full suite)
- New unit tests pass: `--gtest_filter='sqliteRetryBackoff.*'` (6 tests: `DelayGrowsMonotonically`, `JitterOnlyAdds`, `BoundedByCeiling`, `AttemptZeroReturnsBase`, `AttemptZeroWithJitterAtLeastBase`, `ExtremeAttemptStillBounded`)
- `./maintainers/format.sh` passes (clang-format, meson-format, nixfmt, shellcheck)

We have unit tests covering the backoff function itself, but we don't have a good way to test this under realistic contention at scale (e.g. multiple nix-daemon processes hitting the same store concurrently). If there is existing test infrastructure or benchmarking for profiling SQLite contention behavior, we would love suggestions.
