### PR TITLE
libstore: Fix generation numbers being parsed as 32-bit

### DIFF
--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -25,7 +25,7 @@ static std::optional<GenerationNumber> parseName(const std::string & profileName
     auto p = s.find("-link");
     if (p == std::string::npos)
         return {};
-    if (auto n = string2Int<unsigned int>(s.substr(0, p)))
+    if (auto n = string2Int<GenerationNumber>(s.substr(0, p)))
         return *n;
     else
         return {};


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

`GenerationNumber` is an alias for `uint64_t`, but when parsing generation numbers out of filenames, they are parsed as `unsigned int` instead. This causes tools like `nix-env` to ignore generations numbered higher than `ULONG_MAX` (~4 billion).

The fix is a simple one-line change in the `parseName` function.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

While it's unlikely that someone will reach 4B+ generations on their Nix profile "naturally", I ran into this issue while trying to encode Git metadata into generation numbers, like `system-${lastModified}${dirtyBit}-link`, which went over the 4B threshold. Whether that's a good idea or not, this is still a small inconsistency that should be fixed IMO.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
