### PR TITLE
perf: compute per-file NAR hashes inline during restorePath

### DIFF
--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -386,10 +386,23 @@ public:
     void optimiseStore() override;
 
     /**
+     * Map from absolute filesystem path to the NAR-serialisation hash
+     * of that file/symlink, precomputed during restorePath to avoid
+     * redundant re-reading and re-hashing in optimisePath.
+     */
+    using FileNarHashes = std::map<std::filesystem::path, Hash>;
+
+    /**
      * Optimise a single store path. Optionally, test the encountered
      * symlinks for corruption.
      */
     void optimisePath(const std::filesystem::path & path, RepairFlag repair);
+
+    /**
+     * Like optimisePath, but uses precomputed per-file NAR hashes to
+     * avoid re-reading and re-hashing files from disk.
+     */
+    void optimisePath(const std::filesystem::path & path, RepairFlag repair, const FileNarHashes & fileHashes);
 
     bool verifyStore(bool checkContents, RepairFlag repair) override;
 
@@ -517,7 +530,8 @@ private:
         OptimiseStats & stats,
         const std::filesystem::path & path,
         InodeHash & inodeHash,
-        RepairFlag repair);
+        RepairFlag repair,
+        const FileNarHashes * precomputedHashes = nullptr);
 
     // Internal versions that are not wrapped in retry_sqlite.
     bool isValidPath_(State & state, const StorePath & path);

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -2,6 +2,7 @@
 #include "nix/store/globals.hh"
 #include "nix/util/git.hh"
 #include "nix/util/archive.hh"
+#include "nix/util/fs-sink.hh"
 #include "nix/store/pathlocks.hh"
 #include "nix/store/worker-protocol.hh"
 #include "nix/store/derivations.hh"
@@ -1017,6 +1018,123 @@ bool LocalStore::realisationIsUntrusted(const Realisation & realisation)
     return config->requireSigs && !realisation.checkSignatures(realisation.id, getPublicKeys());
 }
 
+/**
+ * Wrapper around RestoreSink that computes per-file NAR hashes inline
+ * during restore, so that optimisePath can skip re-reading files from
+ * disk.  Feeds the same NAR framing that dumpPath would produce for
+ * each file/symlink into a HashSink.
+ */
+struct HashingRestoreSink : FileSystemObjectSink
+{
+    RestoreSink & inner;
+    LocalStore::FileNarHashes & fileHashes;
+
+    HashingRestoreSink(RestoreSink & inner, LocalStore::FileNarHashes & fileHashes)
+        : inner(inner)
+        , fileHashes(fileHashes)
+    {
+    }
+
+    void createDirectory(const CanonPath & path) override
+    {
+        inner.createDirectory(path);
+    }
+
+    void createDirectory(const CanonPath & path, DirectoryCreatedCallback callback) override
+    {
+        inner.createDirectory(path, [&](FileSystemObjectSink & dirSink, const CanonPath & dirRelPath) {
+            auto & child = dynamic_cast<RestoreSink &>(dirSink);
+            HashingRestoreSink wrapped{child, fileHashes};
+            callback(wrapped, dirRelPath);
+        });
+    }
+
+    void createSymlink(const CanonPath & path, const std::string & target) override
+    {
+        inner.createSymlink(path, target);
+        HashSink h{HashAlgorithm::SHA256};
+        h << narVersionMagic1 << "(" << "type" << "symlink" << "target" << target << ")";
+        recordHash(path, h);
+    }
+
+    void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func) override
+    {
+        HashSink h{HashAlgorithm::SHA256};
+        bool isExec = false;
+        uint64_t fileSize = 0;
+        bool headerDone = false;
+
+        auto emitNarFileHeader = [&] {
+            headerDone = true;
+            h << narVersionMagic1 << "(" << "type" << "regular";
+            if (isExec)
+                h << "executable" << "";
+            h << "contents" << fileSize;
+        };
+
+        inner.createRegularFile(path, [&](CreateRegularFileSink & crf) {
+            /* Tee: forward everything to crf while mirroring data into h. */
+            struct Tee : CreateRegularFileSink
+            {
+                CreateRegularFileSink & crf;
+                HashSink & h;
+                bool & isExec;
+                uint64_t & fileSize;
+                fun<void()> emitHeader;
+
+                Tee(CreateRegularFileSink & crf,
+                    HashSink & h,
+                    bool & isExec,
+                    uint64_t & fileSize,
+                    fun<void()> emitHeader)
+                    : crf(crf)
+                    , h(h)
+                    , isExec(isExec)
+                    , fileSize(fileSize)
+                    , emitHeader(std::move(emitHeader))
+                {
+                }
+
+                void isExecutable() override
+                {
+                    crf.isExecutable();
+                    isExec = true;
+                }
+                void preallocateContents(uint64_t size) override
+                {
+                    crf.preallocateContents(size);
+                    fileSize = size;
+                }
+                void operator()(std::string_view data) override
+                {
+                    crf(data);
+                    emitHeader();
+                    h(data);
+                }
+            } tee(crf, h, isExec, fileSize, [&] {
+                if (!headerDone)
+                    emitNarFileHeader();
+            });
+            func(tee);
+        });
+
+        if (!headerDone)
+            emitNarFileHeader();
+        writePadding(fileSize, h);
+        h << ")";
+        recordHash(path, h);
+    }
+
+private:
+    void recordHash(const CanonPath & path, HashSink & h)
+    {
+        auto absPath = inner.dstPath;
+        if (!path.rel().empty())
+            absPath /= path.rel();
+        fileHashes.emplace(absPath, h.finish().hash);
+    }
+};
+
 std::optional<PathLocks>
 LocalStore::importPathToDisk(const ValidPathInfo & info, Source & source, RepairFlag repair, CheckSigsFlag checkSigs)
 {
@@ -1057,13 +1175,25 @@ LocalStore::importPathToDisk(const ValidPathInfo & info, Source & source, Repair
                 deletePath(realPath);
 
                 /* While restoring the path from the NAR, compute the hash
-                of the NAR. */
+                of the NAR.  When auto-optimise-store is enabled, also
+                compute per-file NAR hashes inline so that optimisePath
+                can skip re-reading files from disk. */
                 HashSink hashSink(HashAlgorithm::SHA256);
 
                 TeeSource wrapperSource{source, hashSink};
 
+                bool doOptimise = config->getLocalSettings().autoOptimiseStore;
+                FileNarHashes fileHashes;
+
                 narRead = true;
-                restorePath(realPath, wrapperSource, config->getLocalSettings().fsyncStorePaths);
+                if (doOptimise) {
+                    RestoreSink restoreSink{config->getLocalSettings().fsyncStorePaths};
+                    restoreSink.dstPath = realPath;
+                    HashingRestoreSink hashingRestoreSink{restoreSink, fileHashes};
+                    parseDump(hashingRestoreSink, wrapperSource);
+                } else {
+                    restorePath(realPath, wrapperSource, config->getLocalSettings().fsyncStorePaths);
+                }
 
                 auto hashResult = hashSink.finish();
 
@@ -1121,7 +1251,10 @@ LocalStore::importPathToDisk(const ValidPathInfo & info, Source & source, Repair
 
                 canonicalisePathMetaData(realPath, {NIX_WHEN_SUPPORT_ACLS(config->getLocalSettings().ignoredAcls)});
 
-                optimisePath(realPath, repair); // FIXME: combine with hashPath()
+                if (doOptimise)
+                    optimisePath(realPath, repair, fileHashes);
+                else
+                    optimisePath(realPath, repair);
 
                 if (config->getLocalSettings().fsyncStorePaths) {
                     recursiveSync(realPath);

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -97,7 +97,12 @@ Strings LocalStore::readDirectoryIgnoringInodes(const std::filesystem::path & pa
 }
 
 void LocalStore::optimisePath_(
-    Activity * act, OptimiseStats & stats, const std::filesystem::path & path, InodeHash & inodeHash, RepairFlag repair)
+    Activity * act,
+    OptimiseStats & stats,
+    const std::filesystem::path & path,
+    InodeHash & inodeHash,
+    RepairFlag repair,
+    const FileNarHashes * precomputedHashes)
 {
     checkInterrupt();
 
@@ -119,7 +124,7 @@ void LocalStore::optimisePath_(
     if (S_ISDIR(st.st_mode)) {
         Strings names = readDirectoryIgnoringInodes(path, inodeHash);
         for (auto & i : names)
-            optimisePath_(act, stats, path / i, inodeHash, repair);
+            optimisePath_(act, stats, path / i, inodeHash, repair, precomputedHashes);
         return;
     }
 
@@ -155,13 +160,18 @@ void LocalStore::optimisePath_(
        Also note that if `path' is a symlink, then we're hashing the
        contents of the symlink (i.e. the result of readlink()), not
        the contents of the target (which may not even exist). */
-    Hash hash = ({
-        hashPath(
-            {make_ref<PosixSourceAccessor>(), CanonPath(path.string())},
-            FileSerialisationMethod::NixArchive,
-            HashAlgorithm::SHA256)
+    Hash hash = [&]() {
+        if (precomputedHashes) {
+            auto it = precomputedHashes->find(path);
+            if (it != precomputedHashes->end())
+                return it->second;
+        }
+        return hashPath(
+                   {make_ref<PosixSourceAccessor>(), CanonPath(path.string())},
+                   FileSerialisationMethod::NixArchive,
+                   HashAlgorithm::SHA256)
             .hash;
-    });
+    }();
     debug("%s has hash '%s'", PathFmt(path), hash.to_string(HashFormat::Nix32, true));
 
     /* Check if this is a known hash. */
@@ -327,6 +337,15 @@ void LocalStore::optimisePath(const std::filesystem::path & path, RepairFlag rep
 
     if (config->getLocalSettings().autoOptimiseStore)
         optimisePath_(nullptr, stats, path, inodeHash, repair);
+}
+
+void LocalStore::optimisePath(const std::filesystem::path & path, RepairFlag repair, const FileNarHashes & fileHashes)
+{
+    OptimiseStats stats;
+    InodeHash inodeHash;
+
+    if (config->getLocalSettings().autoOptimiseStore)
+        optimisePath_(nullptr, stats, path, inodeHash, repair, &fileHashes);
 }
 
 } // namespace nix

--- a/tests/functional/copy-parallel.nix
+++ b/tests/functional/copy-parallel.nix
@@ -45,4 +45,22 @@ with import ./config.nix;
         ${builtins.concatStringsSep "\n" (map (l: "echo ${l} >> $out/deps") leaves)}
       '';
     };
+
+  # Dedup test: two derivations that each contain a file with the same
+  # content.  After `nix copy` with auto-optimise-store, the files
+  # should be hardlinked together (same inode).
+  dedup-a = mkDerivation {
+    name = "dedup-a";
+    buildCommand = ''
+      mkdir $out
+      echo "identical-content-for-dedup-test" > $out/samefile
+    '';
+  };
+  dedup-b = mkDerivation {
+    name = "dedup-b";
+    buildCommand = ''
+      mkdir $out
+      echo "identical-content-for-dedup-test" > $out/samefile
+    '';
+  };
 }

--- a/tests/functional/copy-parallel.sh
+++ b/tests/functional/copy-parallel.sh
@@ -33,3 +33,30 @@ _NIX_TEST_CHUNK_SIZE=8 nix copy --to "$dstStore" --no-check-sigs "$outPath"
 nix-store --store "$dstStore" --check-validity "$outPath"
 count=$(nix-store --store "$dstStore" -qR "$outPath" | grep -c wide-)
 [[ "$count" -eq 21 ]] || fail "expected 21 wide paths (20 leaves + top), got $count"
+
+# --- Test 3: dedup via precomputed hashes ---
+# Two store paths each containing a file with identical content.
+# With auto-optimise-store enabled, the files should be hardlinked
+# (same inode) after copy, proving that the inline per-file NAR hashes
+# computed during restorePath match what optimisePath would compute.
+dstStore=$(freshDst dedup)
+outA=$(nix-build copy-parallel.nix -A dedup-a --no-out-link)
+outB=$(nix-build copy-parallel.nix -A dedup-b --no-out-link)
+nix copy --to "$dstStore" --option auto-optimise-store true --no-check-sigs "$outA" "$outB"
+nix-store --store "$dstStore" --check-validity "$outA"
+nix-store --store "$dstStore" --check-validity "$outB"
+
+# The dest store uses /nix/store as its store dir regardless of
+# NIX_STORE_DIR, since --to creates a fresh local store with defaults.
+dstStoreDir="$dstStore/nix/store"
+fileA="$dstStoreDir/$(basename "$outA")/samefile"
+fileB="$dstStoreDir/$(basename "$outB")/samefile"
+
+# Both files must exist
+[[ -f "$fileA" ]] || fail "file A not found: $fileA"
+[[ -f "$fileB" ]] || fail "file B not found: $fileB"
+
+# They should be hardlinked (same inode) due to optimisePath dedup
+inodeA=$(stat -c %i "$fileA")
+inodeB=$(stat -c %i "$fileB")
+[[ "$inodeA" -eq "$inodeB" ]] || fail "expected same inode (dedup), got $inodeA vs $inodeB"


### PR DESCRIPTION
During nix copy, importPathToDisk previously called optimisePath after writing files to disk, which re-read every file and re-hashed it as NAR to compute per-file SHA256 hashes for hardlink dedup.  This redundantly re-read data that was just written.

Compute the per-file NAR hashes inline during restorePath by wrapping RestoreSink with HashingRestoreSink.  This feeds file data into a HashSink during the initial write, producing the same hash that optimisePath would compute from disk.  The precomputed hashes are then passed to optimisePath which skips the hashPath() call for files with known hashes.

The inline hashing is only enabled when auto-optimise-store is true; otherwise the original restorePath code path is used unchanged.

Benchmark (AWS EC2 x86_64, Xeon 8488C 64-core, Firefox closure 372 paths / 1.6 GB, 10 iterations):

  auto-optimise-store=false:
    parallel 1.074s, parallel+inline 1.099s, p=0.23 (no regression)

  auto-optimise-store=true:
    sequential 1.643s, parallel+inline 1.344s, p<0.001 (18.2% faster)

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
