### PR TITLE
prim_elemAt: reuse a pointer

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3653,8 +3653,9 @@ static void prim_elemAt(EvalState & state, const PosIdx pos, Value ** args, Valu
         state.error<EvalError>("'builtins.elemAt' called with index %d on a list of size %d", n, args[0]->listSize())
             .atPos(pos)
             .debugThrow();
-    state.forceValue(*args[0]->listView()[n], pos);
-    v = *args[0]->listView()[n];
+    auto ptr = args[0]->listView()[n];
+    state.forceValue(*ptr, pos);
+    v = *ptr;
 }
 
 static RegisterPrimOp primop_elemAt({


### PR DESCRIPTION
## Motivation

A very humble optimization for `builtins.elemAt`. `elemAt` is invoked about 37 million times in a full evaluation of Nixpkgs (it is the second-most frequently invoked builtin, after `isString`), so even a tiny effect like this adds up. According to my benchmarking, when applied to Nix 2.33.1, this patch improves the CPU time used to evaluate Nixpkgs by 0.2%.

## Context

<details>
<summary>A probably unnecessary graph of my benchmark results.</summary>

These data were collected over 22 unparallelized evaluations of Nixpkgs using the ci/eval infrastructure, with chunk size of 1000, randomly selecting for each chunk whether to do an unpatched or patched run first. The resulting CPU times for each chunk were normalized to the median unpatched time, and the 0.2% figure is arrived at by taking the mean over chunks of the normalized median patched times. The graph shows violin plots aggregating the 22 runs with minima, maxima, and medians presented for each chunk.

<img width="1600" alt="A graph of the CPU time used for each chunk of Nixpkgs before and after this patch" src="https://github.com/user-attachments/assets/13055827-e92a-4be1-90f3-80b894bebfb4" />

</details>


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
