### PR TITLE
gc: fix race where concurrent addTempRoot is ignored during deletion

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -563,6 +563,7 @@ string_t AttrCursor::getStringWithContext()
                             [&](const NixStringContextElem::Opaque & o) -> const StorePath & { return o.path; },
                         },
                         c.raw);
+                    root->state.store->addTempRoot(path);
                     if (!root->state.store->isValidPath(path)) {
                         valid = false;
                         break;

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -320,6 +320,8 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
         try {
             auto storePath = computeStorePath(store);
 
+            store.addTempRoot(storePath);
+
             store.ensurePath(storePath);
 
             debug("using substituted/cached input '%s' in '%s'", to_string(), store.printStorePath(storePath));

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -713,6 +713,32 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
             if (!dead.insert(path).second)
                 continue;
             if (shouldDelete) {
+                /* Re-check tempRoots before deleting and set pending
+                   to synchronise with addTempRoot. Between the BFS
+                   and this deletion loop, new temproots may have been
+                   added via the GC socket by a concurrent process
+                   (e.g. an evaluator calling addTempRoot). The BFS
+                   only checks tempRoots when it first visits a path,
+                   but the "pending" mechanism only blocks the socket
+                   handler for the single path currently being visited,
+                   not for paths already queued for deletion. */
+                {
+                    auto hashPart = std::string(path.hashPart());
+                    auto shared(_shared.lock());
+                    if (shared->tempRoots.count(hashPart)) {
+                        debug(
+                            "not deleting '%s' because it became a temporary root after initial scan",
+                            printStorePath(path));
+                        alive.insert(path);
+                        continue;
+                    }
+                    shared->pending = hashPart;
+                }
+                Finally resetPending([&]() {
+                    auto shared(_shared.lock());
+                    shared->pending.reset();
+                    wakeup.notify_all();
+                });
                 try {
                     invalidatePathChecked(path);
                     deleteFromStore(path.to_string(), true);

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -57,8 +57,8 @@ void LocalStore::createTempRootsFile()
 
     while (1) {
         if (pathExists(fnTempRoots))
-            /* It *must* be stale, since there can be no two
-               processes with the same pid. */
+            /* The file is stale since each LocalStore instance
+               uses a unique filename (pid + counter). */
             tryUnlink(fnTempRoots);
 
         *fdTempRoots = openLockFile(fnTempRoots, true);
@@ -170,8 +170,6 @@ void LocalStore::findTempRoots(Roots & tempRoots, bool censor)
         }
         auto path = i.path();
 
-        pid_t pid = std::stoi(name);
-
         debug("reading temporary root file %1%", PathFmt(path));
         AutoCloseFD fd(toDescriptor(open(
             path.string().c_str(),
@@ -206,7 +204,7 @@ void LocalStore::findTempRoots(Roots & tempRoots, bool censor)
         while ((end = contents.find((char) 0, pos)) != std::string::npos) {
             auto root = std::string_view(contents).substr(pos, end - pos);
             debug("got temporary root '%s'", root);
-            tempRoots[parseStorePath(root)].emplace(censor ? censored : fmt("{temp:%d}", pid));
+            tempRoots[parseStorePath(root)].emplace(censor ? censored : fmt("{temp:%s}", name));
             pos = end + 1;
         }
     }
@@ -593,6 +591,33 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 todo.push(path);
         };
 
+        auto markAlive = [&](const StorePath & p) {
+            alive.insert(p);
+            try {
+                StorePathSet closure;
+                bool includeOutputs = false;
+                bool includeDerivers = false;
+                std::visit(
+                    overloaded{
+                        [&](const GCOptions::WholeStore &) {
+                            includeOutputs = gcSettings.keepOutputs;
+                            includeDerivers = gcSettings.keepDerivations;
+                        },
+                        [](const GCOptions::SpecificPaths &) {},
+                    },
+                    options.pathsToDelete);
+                computeFSClosure(
+                    p,
+                    closure,
+                    /* flipDirection */ false,
+                    includeOutputs,
+                    includeDerivers);
+                for (auto & c : closure)
+                    alive.insert(c);
+            } catch (InvalidPath &) {
+            }
+        };
+
         enqueue(start);
 
         while (auto path = pop(todo)) {
@@ -611,38 +636,11 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
             if (dead.contains(*path))
                 continue;
 
-            auto markAlive = [&]() {
-                alive.insert(*path);
-                alive.insert(start);
-                try {
-                    StorePathSet closure;
-                    bool includeOutputs = false;
-                    bool includeDerivers = false;
-                    std::visit(
-                        overloaded{
-                            [&](const GCOptions::WholeStore &) {
-                                includeOutputs = gcSettings.keepOutputs;
-                                includeDerivers = gcSettings.keepDerivations;
-                            },
-                            [](const GCOptions::SpecificPaths &) {},
-                        },
-                        options.pathsToDelete);
-                    computeFSClosure(
-                        *path,
-                        closure,
-                        /* flipDirection */ false,
-                        includeOutputs,
-                        includeDerivers);
-                    for (auto & p : closure)
-                        alive.insert(p);
-                } catch (InvalidPath &) {
-                }
-            };
-
             /* If this is a root, bail out. */
             if (roots.contains(*path)) {
                 debug("cannot delete '%s' because it's a root", printStorePath(*path));
-                return markAlive();
+                alive.insert(start);
+                return markAlive(*path);
             }
 
             if (std::visit(
@@ -667,7 +665,8 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 auto shared(_shared.lock());
                 if (shared->tempRoots.contains(hashPart)) {
                     debug("cannot delete '%s' because it's a temporary root", printStorePath(*path));
-                    return markAlive();
+                    alive.insert(start);
+                    return markAlive(*path);
                 }
                 shared->pending = hashPart;
             }
@@ -725,11 +724,11 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 {
                     auto hashPart = std::string(path.hashPart());
                     auto shared(_shared.lock());
-                    if (shared->tempRoots.count(hashPart)) {
+                    if (shared->tempRoots.contains(hashPart)) {
                         debug(
                             "not deleting '%s' because it became a temporary root after initial scan",
                             printStorePath(path));
-                        alive.insert(path);
+                        markAlive(path);
                         continue;
                     }
                     shared->pending = hashPart;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -131,7 +131,7 @@ LocalStore::LocalStore(ref<const Config> config)
     , reservedPath(dbDir / "reserved")
     , schemaPath(dbDir / "schema")
     , tempRootsDir(config->stateDir.get() / "temproots")
-    , fnTempRoots(tempRootsDir / std::to_string(getpid()))
+    , fnTempRoots(makeTempPath(tempRootsDir, "temproots"))
 {
     auto state(_state->lock());
     state->stmts = std::make_unique<State::Stmts>();


### PR DESCRIPTION
The GC's deleteReferrersClosure has a BFS phase that checks shared->tempRoots for each path, and a deletion phase that removes all visited paths. The "pending" mechanism synchronises with addTempRoot's socket handler, but only for the single path currently being visited in the BFS. Once the BFS moves on, pending is overwritten, so a concurrent addTempRoot for an already-visited path would add it to tempRoots without blocking, and the deletion phase would then delete it anyway because it never re-checked.

Fix by re-checking tempRoots and setting pending before each deletion, mirroring the same check+pending pattern used in the BFS phase. This closes the window where a path could be deleted despite having a valid temproot from a concurrent evaluator.

We've been running this on our CI and observed evaluations no longer fail with https://github.com/cachix/devenv/issues/2530