### PR TITLE
github: use libgit2 transport for ref resolution

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -19,6 +19,7 @@
 #include <git2/branch.h>
 #include <git2/commit.h>
 #include <git2/config.h>
+#include <git2/credential.h>
 #include <git2/describe.h>
 #include <git2/errors.h>
 #include <git2/global.h>
@@ -1539,6 +1540,57 @@ bool isLegalRefName(const std::string & refName)
     }
 
     return false;
+}
+
+/**
+ * Set up libgit2 remote callbacks that authenticate using a token
+ * via x-access-token basic auth. The token string must outlive the
+ * returned callbacks struct.
+ */
+static git_remote_callbacks makeTokenCallbacks(const std::string & token)
+{
+    git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
+    callbacks.payload = const_cast<void *>(static_cast<const void *>(&token));
+    callbacks.credentials =
+        [](git_credential ** out, const char *, const char *, unsigned int allowed_types, void * payload) -> int {
+        auto * tok = static_cast<const std::string *>(payload);
+        if (tok->empty())
+            return GIT_PASSTHROUGH;
+        if (allowed_types & GIT_CREDENTIAL_USERPASS_PLAINTEXT)
+            return git_credential_userpass_plaintext_new(out, "x-access-token", tok->c_str());
+        return GIT_PASSTHROUGH;
+    };
+    return callbacks;
+}
+
+Hash resolveRemoteRef(const std::string & url, const std::string & ref, const std::string & token)
+{
+    initLibGit2();
+
+    Remote remote;
+    if (git_remote_create_detached(Setter(remote), url.c_str()))
+        throw GitError("creating detached remote for '%s'", url);
+
+    auto callbacks = makeTokenCallbacks(token);
+
+    if (git_remote_connect(remote.get(), GIT_DIRECTION_FETCH, &callbacks, nullptr, nullptr))
+        throw GitError("connecting to remote '%s'", url);
+
+    const git_remote_head ** refs;
+    size_t refCount;
+    if (git_remote_ls(&refs, &refCount, remote.get()))
+        throw GitError("listing remote refs for '%s'", url);
+
+    auto headsRef = "refs/heads/" + ref;
+    auto tagsRef = "refs/tags/" + ref;
+
+    for (size_t i = 0; i < refCount; i++) {
+        std::string_view name(refs[i]->name);
+        if (ref == "HEAD" ? name == "HEAD" : (name == headsRef || name == tagsRef))
+            return toHash(refs[i]->oid);
+    }
+
+    throw Error("could not find ref '%s' in remote '%s'", ref, url);
 }
 
 } // namespace nix

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1581,14 +1581,37 @@ Hash resolveRemoteRef(const std::string & url, const std::string & ref, const st
     if (git_remote_ls(&refs, &refCount, remote.get()))
         throw GitError("listing remote refs for '%s'", url);
 
-    auto headsRef = "refs/heads/" + ref;
-    auto tagsRef = "refs/tags/" + ref;
+    auto findRef = [&](const std::string & refName, bool preferPeeled) -> std::optional<Hash> {
+        if (preferPeeled) {
+            auto peeledRef = refName + "^{}";
+            for (size_t i = 0; i < refCount; i++) {
+                if (std::string_view(refs[i]->name) == peeledRef)
+                    return toHash(refs[i]->oid);
+            }
+        }
 
-    for (size_t i = 0; i < refCount; i++) {
-        std::string_view name(refs[i]->name);
-        if (ref == "HEAD" ? name == "HEAD" : (name == headsRef || name == tagsRef))
-            return toHash(refs[i]->oid);
+        for (size_t i = 0; i < refCount; i++) {
+            if (std::string_view(refs[i]->name) == refName)
+                return toHash(refs[i]->oid);
+        }
+
+        return std::nullopt;
+    };
+
+    std::vector<std::pair<std::string, bool>> candidates;
+    if (ref == "HEAD") {
+        candidates.push_back({"HEAD", false});
+    } else if (ref.rfind("refs/", 0) == 0) {
+        candidates.push_back({ref, ref.rfind("refs/tags/", 0) == 0});
+    } else {
+        candidates.push_back({"refs/" + ref, ref.rfind("tags/", 0) == 0});
+        candidates.push_back({"refs/tags/" + ref, true});
+        candidates.push_back({"refs/heads/" + ref, false});
     }
+
+    for (auto & [candidate, preferPeeled] : candidates)
+        if (auto resolved = findRef(candidate, preferPeeled))
+            return *resolved;
 
     throw Error("could not find ref '%s' in remote '%s'", ref, url);
 }

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1612,10 +1612,10 @@ Hash resolveRemoteRef(const std::string & url, const std::string & ref, const st
     std::vector<std::pair<std::string, bool>> candidates;
     if (ref == "HEAD") {
         candidates.push_back({"HEAD", false});
-    } else if (ref.rfind("refs/", 0) == 0) {
-        candidates.push_back({ref, ref.rfind("refs/tags/", 0) == 0});
+    } else if (hasPrefix(ref, "refs/")) {
+        candidates.push_back({ref, hasPrefix(ref, "refs/tags/")});
     } else {
-        candidates.push_back({"refs/" + ref, ref.rfind("tags/", 0) == 0});
+        candidates.push_back({"refs/" + ref, hasPrefix(ref, "tags/")});
         candidates.push_back({"refs/tags/" + ref, true});
         candidates.push_back({"refs/heads/" + ref, false});
     }

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1551,13 +1551,24 @@ static git_remote_callbacks makeTokenCallbacks(const std::string & token)
 {
     git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
     callbacks.payload = const_cast<void *>(static_cast<const void *>(&token));
-    callbacks.credentials =
-        [](git_credential ** out, const char *, const char *, unsigned int allowed_types, void * payload) -> int {
+    callbacks.credentials = [](git_credential ** out,
+                               const char *,
+                               const char * username_from_url,
+                               unsigned int allowed_types,
+                               void * payload) -> int {
         auto * tok = static_cast<const std::string *>(payload);
-        if (tok->empty())
-            return GIT_PASSTHROUGH;
-        if (allowed_types & GIT_CREDENTIAL_USERPASS_PLAINTEXT)
+        /* HTTPS: authenticate with the access token via basic auth. */
+        if (!tok->empty() && (allowed_types & GIT_CREDENTIAL_USERPASS_PLAINTEXT))
             return git_credential_userpass_plaintext_new(out, "x-access-token", tok->c_str());
+        /* SSH: a `url.<base>.insteadOf` rewrite can turn the HTTPS URL into an
+           SSH one (e.g. ssh://git@github.com/). Authenticate via the user's
+           ssh-agent, the same way git/ssh would, instead of failing with
+           "authentication required but no callback set" (#2842). */
+        const char * username = username_from_url ? username_from_url : "git";
+        if (allowed_types & GIT_CREDENTIAL_SSH_KEY)
+            return git_credential_ssh_key_from_agent(out, username);
+        if (allowed_types & GIT_CREDENTIAL_USERNAME)
+            return git_credential_username_new(out, username);
         return GIT_PASSTHROUGH;
     };
     return callbacks;

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -414,22 +414,14 @@ struct GitHubInputScheme : GitArchiveInputScheme
     RefInfo getRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const override
     {
         auto host = getHost(input);
-        auto url = fmt(
-            host == "github.com" ? "https://api.%s/repos/%s/%s/commits/%s" : "https://%s/api/v3/repos/%s/%s/commits/%s",
-            host,
-            getOwner(input),
-            getRepo(input),
-            *input.getRef());
+        auto owner = getOwner(input);
+        auto repo = getRepo(input);
+        auto url = fmt("https://%s/%s/%s.git", host, owner, repo);
+        auto hostAndPath = fmt("%s/%s/%s", host, owner, repo);
+        auto token = getAccessToken(settings, host, hostAndPath).value_or("");
 
-        Headers headers = makeHeadersWithAuthTokens(settings, host, input);
-
-        auto downloadResult = downloadFile(store, settings, url, "source", headers);
-        auto json = nlohmann::json::parse(
-            store.requireStoreObjectAccessor(downloadResult.storePath)->readFile(CanonPath::root));
-
-        return RefInfo{
-            .rev = Hash::parseAny(std::string{json["sha"]}, HashAlgorithm::SHA1),
-            .treeHash = Hash::parseAny(std::string{json["commit"]["tree"]["sha"]}, HashAlgorithm::SHA1)};
+        auto rev = resolveRemoteRef(url, *input.getRef(), token);
+        return RefInfo{.rev = rev};
     }
 
     DownloadUrl getDownloadUrl(const Settings & settings, const Input & input) const override

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -420,12 +420,21 @@ struct GitHubInputScheme : GitArchiveInputScheme
         auto url = fmt("https://%s/%s/%s.git", host, owner, repo);
 
         Cache::Key refToRevKey{"gitHubRefToRev", {{"url", url}, {"ref", ref}}};
-        if (auto res = settings.getCache()->lookupWithTTL(refToRevKey))
-            return RefInfo{.rev = getRevAttr(*res, "rev")};
+        auto cached = settings.getCache()->lookupExpired(refToRevKey);
+        if (cached && !cached->expired)
+            return RefInfo{.rev = getRevAttr(cached->value, "rev")};
 
         auto hostAndPath = fmt("%s/%s/%s", host, owner, repo);
         auto token = getAccessToken(settings, host, hostAndPath).value_or("");
-        auto rev = resolveRemoteRef(url, ref, token);
+        Hash rev(HashAlgorithm::SHA1);
+        try {
+            rev = resolveRemoteRef(url, ref, token);
+        } catch (Error & e) {
+            if (!cached)
+                throw;
+            warn("%s; using cached GitHub revision for ref '%s' of '%s'", e.message(), ref, url);
+            return RefInfo{.rev = getRevAttr(cached->value, "rev")};
+        }
 
         settings.getCache()->upsert(refToRevKey, {{"rev", rev.gitRev()}});
         return RefInfo{.rev = rev};

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -416,11 +416,18 @@ struct GitHubInputScheme : GitArchiveInputScheme
         auto host = getHost(input);
         auto owner = getOwner(input);
         auto repo = getRepo(input);
+        auto ref = *input.getRef();
         auto url = fmt("https://%s/%s/%s.git", host, owner, repo);
+
+        Cache::Key refToRevKey{"gitHubRefToRev", {{"url", url}, {"ref", ref}}};
+        if (auto res = settings.getCache()->lookupWithTTL(refToRevKey))
+            return RefInfo{.rev = getRevAttr(*res, "rev")};
+
         auto hostAndPath = fmt("%s/%s/%s", host, owner, repo);
         auto token = getAccessToken(settings, host, hostAndPath).value_or("");
+        auto rev = resolveRemoteRef(url, ref, token);
 
-        auto rev = resolveRemoteRef(url, *input.getRef(), token);
+        settings.getCache()->upsert(refToRevKey, {{"rev", rev.gitRev()}});
         return RefInfo{.rev = rev};
     }
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -426,18 +426,16 @@ struct GitHubInputScheme : GitArchiveInputScheme
 
         auto hostAndPath = fmt("%s/%s/%s", host, owner, repo);
         auto token = getAccessToken(settings, host, hostAndPath).value_or("");
-        Hash rev(HashAlgorithm::SHA1);
         try {
-            rev = resolveRemoteRef(url, ref, token);
+            auto rev = resolveRemoteRef(url, ref, token);
+            settings.getCache()->upsert(refToRevKey, {{"rev", rev.gitRev()}});
+            return RefInfo{.rev = rev};
         } catch (Error & e) {
             if (!cached)
                 throw;
             warn("%s; using cached GitHub revision for ref '%s' of '%s'", e.message(), ref, url);
             return RefInfo{.rev = getRevAttr(cached->value, "rev")};
         }
-
-        settings.getCache()->upsert(refToRevKey, {{"rev", rev.gitRev()}});
-        return RefInfo{.rev = rev};
     }
 
     DownloadUrl getDownloadUrl(const Settings & settings, const Input & input) const override

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -2,6 +2,7 @@
 
 #include "nix/fetchers/filtering-source-accessor.hh"
 #include "nix/util/fs-sink.hh"
+#include "nix/util/types.hh"
 
 namespace nix {
 
@@ -177,5 +178,15 @@ struct Setter
  * that Git can make sense of.
  */
 bool isLegalRefName(const std::string & refName);
+
+/**
+ * Resolve a ref on a remote repository to a commit hash using
+ * libgit2's smart HTTP transport. The ref can be "HEAD" or a branch/tag
+ * name (matched against refs/heads and refs/tags).
+ *
+ * If a token is provided, it is used for authentication via the
+ * libgit2 credential callback (x-access-token basic auth).
+ */
+Hash resolveRemoteRef(const std::string & url, const std::string & ref, const std::string & token = "");
 
 } // namespace nix

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -181,8 +181,9 @@ bool isLegalRefName(const std::string & refName);
 
 /**
  * Resolve a ref on a remote repository to a commit hash using
- * libgit2's smart HTTP transport. The ref can be "HEAD" or a branch/tag
- * name (matched against refs/heads and refs/tags).
+ * libgit2's smart HTTP transport. The ref can be "HEAD", a branch/tag
+ * name, or another ref name. Shorthand names are matched against
+ * refs/heads, refs/tags, and refs.
  *
  * If a token is provided, it is used for authentication via the
  * libgit2 credential callback (x-access-token basic auth).

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -2,7 +2,7 @@
 
 #include "nix/fetchers/filtering-source-accessor.hh"
 #include "nix/util/fs-sink.hh"
-#include "nix/util/types.hh"
+#include "nix/util/hash.hh"
 
 namespace nix {
 

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -57,24 +57,60 @@ let
 
   private-flake-rev = "9f1dd0df5b54a7dc75b618034482ed42ce34383d";
 
-  private-flake-api = pkgs.runCommand "private-flake" { } ''
-    mkdir -p $out/{commits,tarball}
+  private-flake-git-refs = pkgs.runCommand "private-flake-git-refs" { } ''
+        mkdir -p $out/info
+        pkt_line() {
+          local content="$1"
+          local len=$(( ''${#content} + 4 ))
+          printf '%04x%s' "$len" "$content"
+        }
+        # First ref line needs a null byte to separate ref name from capabilities (git smart HTTP protocol)
+        first_ref_pkt_line() {
+          local content="$1"
+          local len=$(( ''${#content} + 4 + 2 ))
+          printf '%04x%s\0\n' "$len" "$content"
+        }
+        {
+          pkt_line "# service=git-upload-pack
+    "
+          printf '0000'
+          first_ref_pkt_line "${private-flake-rev} HEAD"
+          pkt_line "${private-flake-rev} refs/heads/master
+    "
+          printf '0000'
+        } > $out/info/refs
+  '';
 
-    # Setup https://docs.github.com/en/rest/commits/commits#get-a-commit
-    echo '{"sha": "${private-flake-rev}", "commit": {"tree": {"sha": "ffffffffffffffffffffffffffffffffffffffff"}}}' > $out/commits/HEAD
-
-    # Setup tarball download via API
+  private-flake-tarball = pkgs.runCommand "private-flake-tarball" { } ''
+    mkdir -p $out/tarball
     dir=private-flake
     mkdir $dir
     echo '{ outputs = {...}: {}; }' > $dir/flake.nix
     tar cfz $out/tarball/${private-flake-rev} $dir --hard-dereference
   '';
 
-  nixpkgs-api = pkgs.runCommand "nixpkgs-flake" { } ''
-    mkdir -p $out/commits
-
-    # Setup https://docs.github.com/en/rest/commits/commits#get-a-commit
-    echo '{"sha": "${nixpkgs.rev}", "commit": {"tree": {"sha": "ffffffffffffffffffffffffffffffffffffffff"}}}' > $out/commits/HEAD
+  nixpkgs-git-refs = pkgs.runCommand "nixpkgs-git-refs" { } ''
+        mkdir -p $out/info
+        pkt_line() {
+          local content="$1"
+          local len=$(( ''${#content} + 4 ))
+          printf '%04x%s' "$len" "$content"
+        }
+        # First ref line needs a null byte to separate ref name from capabilities (git smart HTTP protocol)
+        first_ref_pkt_line() {
+          local content="$1"
+          local len=$(( ''${#content} + 4 + 2 ))
+          printf '%04x%s\0\n' "$len" "$content"
+        }
+        {
+          pkt_line "# service=git-upload-pack
+    "
+          printf '0000'
+          first_ref_pkt_line "${nixpkgs.rev} HEAD"
+          pkt_line "${nixpkgs.rev} refs/heads/master
+    "
+          printf '0000'
+        } > $out/info/refs
   '';
 
   archive = pkgs.runCommand "nixpkgs-flake" { } ''
@@ -124,12 +160,8 @@ in
           sslServerCert = "${cert}/server.crt";
           servedDirs = [
             {
-              urlPath = "/repos/NixOS/nixpkgs";
-              dir = nixpkgs-api;
-            }
-            {
               urlPath = "/repos/fancy-enterprise/private-flake";
-              dir = private-flake-api;
+              dir = private-flake-tarball;
             }
           ];
         };
@@ -137,10 +169,23 @@ in
           forceSSL = true;
           sslServerKey = "${cert}/server.key";
           sslServerCert = "${cert}/server.crt";
+          extraConfig = ''
+            <LocationMatch "\.git/info/refs$">
+              ForceType application/x-git-upload-pack-advertisement
+            </LocationMatch>
+          '';
           servedDirs = [
             {
               urlPath = "/NixOS/nixpkgs";
               dir = archive;
+            }
+            {
+              urlPath = "/NixOS/nixpkgs.git";
+              dir = nixpkgs-git-refs;
+            }
+            {
+              urlPath = "/fancy-enterprise/private-flake.git";
+              dir = private-flake-git-refs;
             }
           ];
         };

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -56,6 +56,7 @@ let
   };
 
   private-flake-rev = "9f1dd0df5b54a7dc75b618034482ed42ce34383d";
+  annotated-tag-object = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
   private-flake-git-refs = pkgs.runCommand "private-flake-git-refs" { } ''
         mkdir -p $out/info
@@ -108,6 +109,12 @@ let
           printf '0000'
           first_ref_pkt_line "${nixpkgs.rev} HEAD"
           pkt_line "${nixpkgs.rev} refs/heads/master
+    "
+          pkt_line "${nixpkgs.rev} refs/pull/357207/head
+    "
+          pkt_line "${annotated-tag-object} refs/tags/annotated
+    "
+          pkt_line "${nixpkgs.rev} refs/tags/annotated^{}
     "
           printf '0000'
         } > $out/info/refs
@@ -249,6 +256,16 @@ in
       assert info["revision"] == "${nixpkgs.rev}", f"revision mismatch: {info['revision']} != ${nixpkgs.rev}"
       cat_log()
 
+      out = client.succeed("nix flake metadata github:NixOS/nixpkgs/pull/357207/head --json --tarball-ttl 0")
+      print(out)
+      info = json.loads(out)
+      assert info["revision"] == "${nixpkgs.rev}", f"pull ref revision mismatch: {info['revision']} != ${nixpkgs.rev}"
+
+      out = client.succeed("nix flake metadata github:NixOS/nixpkgs/annotated --json --tarball-ttl 0")
+      print(out)
+      info = json.loads(out)
+      assert info["revision"] == "${nixpkgs.rev}", f"annotated tag revision mismatch: {info['revision']} != ${nixpkgs.rev}"
+
       # ... otherwise it should use the API
       out = client.succeed("nix flake metadata private-flake --json --access-tokens github.com=ghp_000000000000000000000000000000000000 --tarball-ttl 0")
       print(out)
@@ -277,6 +294,9 @@ in
 
       # Shut down the web server. The flake should be cached on the client.
       github.succeed("systemctl stop httpd.service")
+
+      info = json.loads(client.succeed("nix flake metadata github:NixOS/nixpkgs --json --tarball-ttl 0"))
+      assert info["revision"] == "${nixpkgs.rev}", f"cached revision mismatch: {info['revision']} != ${nixpkgs.rev}"
 
       info = json.loads(client.succeed("nix flake metadata nixpkgs --json"))
       date = time.strftime("%Y%m%d%H%M%S", time.gmtime(info['lastModified']))

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -58,29 +58,46 @@ let
   private-flake-rev = "9f1dd0df5b54a7dc75b618034482ed42ce34383d";
   annotated-tag-object = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
-  private-flake-git-refs = pkgs.runCommand "private-flake-git-refs" { } ''
-        mkdir -p $out/info
-        pkt_line() {
-          local content="$1"
-          local len=$(( ''${#content} + 4 ))
-          printf '%04x%s' "$len" "$content"
-        }
-        # First ref line needs a null byte to separate ref name from capabilities (git smart HTTP protocol)
-        first_ref_pkt_line() {
-          local content="$1"
-          local len=$(( ''${#content} + 4 + 2 ))
-          printf '%04x%s\0\n' "$len" "$content"
-        }
-        {
-          pkt_line "# service=git-upload-pack
-    "
-          printf '0000'
-          first_ref_pkt_line "${private-flake-rev} HEAD"
-          pkt_line "${private-flake-rev} refs/heads/master
-    "
-          printf '0000'
-        } > $out/info/refs
-  '';
+  # Build a mock git smart-HTTP ref advertisement (the `info/refs` response
+  # for `git-upload-pack`). `headRev` is advertised as HEAD; `refLines` are the
+  # remaining "<oid> <refname>" advertisement lines.
+  mkGitRefs =
+    name: headRev: refLines:
+    pkgs.runCommand name { } ''
+      mkdir -p $out/info
+      pkt_line() {
+        local content="$1"
+        # length prefix (4) + content + trailing newline (1)
+        local len=$(( ''${#content} + 4 + 1 ))
+        printf '%04x%s\n' "$len" "$content"
+      }
+      # The first ref line carries a trailing null byte separating the ref name
+      # from the server capabilities (git smart HTTP protocol).
+      first_ref_pkt_line() {
+        local content="$1"
+        # length prefix (4) + content + null byte (1) + trailing newline (1)
+        local len=$(( ''${#content} + 4 + 2 ))
+        printf '%04x%s\0\n' "$len" "$content"
+      }
+      {
+        pkt_line "# service=git-upload-pack"
+        printf '0000'
+        first_ref_pkt_line "${headRev} HEAD"
+        ${lib.concatMapStringsSep "\n        " (l: ''pkt_line "${l}"'') refLines}
+        printf '0000'
+      } > $out/info/refs
+    '';
+
+  private-flake-git-refs = mkGitRefs "private-flake-git-refs" private-flake-rev [
+    "${private-flake-rev} refs/heads/master"
+  ];
+
+  nixpkgs-git-refs = mkGitRefs "nixpkgs-git-refs" nixpkgs.rev [
+    "${nixpkgs.rev} refs/heads/master"
+    "${nixpkgs.rev} refs/pull/357207/head"
+    "${annotated-tag-object} refs/tags/annotated"
+    "${nixpkgs.rev} refs/tags/annotated^{}"
+  ];
 
   private-flake-tarball = pkgs.runCommand "private-flake-tarball" { } ''
     mkdir -p $out/tarball
@@ -88,36 +105,6 @@ let
     mkdir $dir
     echo '{ outputs = {...}: {}; }' > $dir/flake.nix
     tar cfz $out/tarball/${private-flake-rev} $dir --hard-dereference
-  '';
-
-  nixpkgs-git-refs = pkgs.runCommand "nixpkgs-git-refs" { } ''
-        mkdir -p $out/info
-        pkt_line() {
-          local content="$1"
-          local len=$(( ''${#content} + 4 ))
-          printf '%04x%s' "$len" "$content"
-        }
-        # First ref line needs a null byte to separate ref name from capabilities (git smart HTTP protocol)
-        first_ref_pkt_line() {
-          local content="$1"
-          local len=$(( ''${#content} + 4 + 2 ))
-          printf '%04x%s\0\n' "$len" "$content"
-        }
-        {
-          pkt_line "# service=git-upload-pack
-    "
-          printf '0000'
-          first_ref_pkt_line "${nixpkgs.rev} HEAD"
-          pkt_line "${nixpkgs.rev} refs/heads/master
-    "
-          pkt_line "${nixpkgs.rev} refs/pull/357207/head
-    "
-          pkt_line "${annotated-tag-object} refs/tags/annotated
-    "
-          pkt_line "${nixpkgs.rev} refs/tags/annotated^{}
-    "
-          printf '0000'
-        } > $out/info/refs
   '';
 
   archive = pkgs.runCommand "nixpkgs-flake" { } ''
@@ -266,7 +253,8 @@ in
       info = json.loads(out)
       assert info["revision"] == "${nixpkgs.rev}", f"annotated tag revision mismatch: {info['revision']} != ${nixpkgs.rev}"
 
-      # ... otherwise it should use the API
+      # ... otherwise the access token is used to authenticate (passed to the git
+      # credential callback for ref resolution, and to the API for tarball download).
       out = client.succeed("nix flake metadata private-flake --json --access-tokens github.com=ghp_000000000000000000000000000000000000 --tarball-ttl 0")
       print(out)
       info = json.loads(out)


### PR DESCRIPTION
Resolve branch/tag names to commit SHAs via the git HTTP protocol (/info/refs endpoint) instead of the GitHub REST API. This is the same approach already used by SourceHut and avoids API rate limits.
