### PR TITLE
Fix compatibility with lowdown 3

### DIFF
--- a/src/libcmd/markdown.cc
+++ b/src/libcmd/markdown.cc
@@ -38,7 +38,9 @@ static std::string doRenderMarkdownToTerminal(std::string_view markdown)
 #  endif
         .feat = LOWDOWN_COMMONMARK | LOWDOWN_FENCED | LOWDOWN_DEFLIST | LOWDOWN_TABLES,
         .oflags =
-#  if HAVE_LOWDOWN_1_4
+#  if HAVE_LOWDOWN_3
+            LOWDOWN_NORELLINK
+#  elif HAVE_LOWDOWN_1_4
             LOWDOWN_TERM_NORELLINK // To render full links while skipping relative ones
 #  else
             LOWDOWN_TERM_NOLINK

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -44,6 +44,10 @@ configdata.set(
   'HAVE_LOWDOWN_1_4',
   lowdown.version().version_compare('>= 1.4.0').to_int(),
 )
+configdata.set(
+  'HAVE_LOWDOWN_3',
+  lowdown.version().version_compare('>= 3.0.0').to_int(),
+)
 
 readline_flavor = get_option('readline-flavor')
 if readline_flavor == 'editline'


### PR DESCRIPTION
Resolves #15420

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Alpine is on lowdown 3.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#15420

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
