### PR TITLE
Add `--out-link` and `--print-out-paths` to `nix flake check`

### DIFF
--- a/doc/manual/rl-next/flake-check-out-links.md
+++ b/doc/manual/rl-next/flake-check-out-links.md
@@ -1,0 +1,7 @@
+---
+synopsis: nix flake check now supports --out-link
+prs: [15476]
+issues: [13470]
+---
+
+`nix flake check` now supports the flag `--out-link`, defaulting to not creating out links if the flag is not specified.

--- a/doc/manual/rl-next/flake-check-print-output-paths.md
+++ b/doc/manual/rl-next/flake-check-print-output-paths.md
@@ -1,0 +1,7 @@
+---
+synopsis: nix flake check now supports --print-out-paths
+prs: [15476]
+issues: [13470]
+---
+
+`nix flake check` now supports the flag `--print-out-paths`.

--- a/src/libcmd/built-path.cc
+++ b/src/libcmd/built-path.cc
@@ -1,4 +1,5 @@
 #include "nix/cmd/built-path.hh"
+#include "nix/store/build-result.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/outputs-query.hh"
@@ -122,6 +123,52 @@ RealisedPath::Set BuiltPath::toRealisedPaths(Store & store) const
         },
         raw());
     return res;
+}
+
+SingleBuiltPath getBuiltPath(ref<Store> evalStore, ref<Store> store, const SingleDerivedPath & b)
+{
+    return std::visit(
+        overloaded{
+            [&](const SingleDerivedPath::Opaque & bo) -> SingleBuiltPath { return SingleBuiltPath::Opaque{bo.path}; },
+            [&](const SingleDerivedPath::Built & bfd) -> SingleBuiltPath {
+                auto drvPath = getBuiltPath(evalStore, store, *bfd.drvPath);
+                // Resolving this instead of `bfd` will yield the same result, but avoid duplicative work.
+                SingleDerivedPath::Built truncatedBfd{
+                    .drvPath = makeConstantStorePathRef(drvPath.outPath()),
+                    .output = bfd.output,
+                };
+                auto outputPath = resolveDerivedPath(*store, truncatedBfd, &*evalStore);
+                return SingleBuiltPath::Built{
+                    .drvPath = make_ref<SingleBuiltPath>(std::move(drvPath)),
+                    .output = {bfd.output, outputPath},
+                };
+            },
+        },
+        b.raw());
+}
+
+BuiltPath toBuiltPath(KeyedBuildResult & result, ref<Store> evalStore, ref<Store> store)
+{
+    auto success = result.tryGetSuccess();
+    assert(success);
+    return std::visit(
+        overloaded{
+            [&](const DerivedPath::Built & bfd) {
+                std::map<std::string, StorePath> outputs;
+                for (auto & [outputName, realisation] : success->builtOutputs)
+                    outputs.emplace(outputName, realisation.outPath);
+                BuiltPath bp = BuiltPath::Built{
+                    .drvPath = make_ref<SingleBuiltPath>(getBuiltPath(evalStore, store, *bfd.drvPath)),
+                    .outputs = outputs,
+                };
+                return bp;
+            },
+            [&](const DerivedPath::Opaque & bo) {
+                BuiltPath bp = BuiltPath::Opaque{bo.path};
+                return bp;
+            },
+        },
+        result.path.raw());
 }
 
 } // namespace nix

--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -440,9 +440,34 @@ void createOutLinks(const std::filesystem::path & outLink, const BuiltPaths & bu
 
 void MixOutLinkBase::createOutLinksMaybe(const std::vector<BuiltPathWithResult> & buildables, ref<Store> & store)
 {
-    if (outLink != "")
+    createOutLinksMaybe(toBuiltPaths(buildables), store);
+}
+
+void MixOutLinkBase::createOutLinksMaybe(const BuiltPaths & paths, ref<Store> & store)
+{
+    if (outLink)
         if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>())
-            createOutLinks(outLink, toBuiltPaths(buildables), *store2);
+            createOutLinks(*outLink, paths, *store2);
+}
+
+void MixPrintOutPaths::printOutPathsMaybe(const BuiltPaths & paths, ref<Store> store)
+{
+    if (!printOutputPaths)
+        return;
+
+    logger->stop();
+    for (auto & path : paths) {
+        std::visit(
+            overloaded{
+                [&](const BuiltPath::Opaque & bo) { logger->cout(store->printStorePath(bo.path)); },
+                [&](const BuiltPath::Built & bfd) {
+                    for (auto & output : bfd.outputs) {
+                        logger->cout(store->printStorePath(output.second));
+                    }
+                },
+            },
+            path);
+    }
 }
 
 } // namespace nix

--- a/src/libcmd/include/nix/cmd/built-path.hh
+++ b/src/libcmd/include/nix/cmd/built-path.hh
@@ -105,4 +105,10 @@ struct BuiltPath : _BuiltPathRaw
 
 typedef std::vector<BuiltPath> BuiltPaths;
 
+SingleBuiltPath getBuiltPath(ref<Store> evalStore, ref<Store> store, const SingleDerivedPath & b);
+
+struct KeyedBuildResult;
+
+BuiltPath toBuiltPath(KeyedBuildResult & result, ref<Store> evalStore, ref<Store> store);
+
 } // namespace nix

--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -407,13 +407,16 @@ void createOutLinks(const std::filesystem::path & outLink, const BuiltPaths & bu
 struct MixOutLinkBase : virtual Args
 {
     /** Prefix for any output symlinks. Empty means do not write an output symlink. */
-    std::filesystem::path outLink;
+    std::optional<std::filesystem::path> outLink = std::nullopt;
 
-    MixOutLinkBase(const std::string & defaultOutLink)
+    MixOutLinkBase(const std::optional<std::filesystem::path> & defaultOutLink)
         : outLink(defaultOutLink)
     {
     }
 
+    /** underlying function */
+    void createOutLinksMaybe(const BuiltPaths & paths, ref<Store> & store);
+    /** smaller wrapper for convenience (historically this was the only one) */
     void createOutLinksMaybe(const std::vector<BuiltPathWithResult> & buildables, ref<Store> & store);
 };
 
@@ -435,9 +438,25 @@ struct MixOutLinkByDefault : MixOutLinkBase, virtual Args
         addFlag({
             .longName = "no-link",
             .description = "Do not create symlinks to the build results.",
-            .handler = {&outLink, std::filesystem::path{}},
+            .handler = {[&] { outLink = std::nullopt; }},
         });
     }
+};
+
+struct MixPrintOutPaths : virtual Args
+{
+    bool printOutputPaths = false;
+
+    MixPrintOutPaths()
+    {
+        addFlag({
+            .longName = "print-out-paths",
+            .description = "Print the resulting output paths",
+            .handler = {&printOutputPaths, true},
+        });
+    }
+
+    void printOutPathsMaybe(const BuiltPaths & paths, ref<Store> store);
 };
 
 } // namespace nix

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -1,3 +1,4 @@
+#include "nix/cmd/built-path.hh"
 #include "nix/store/globals.hh"
 #include "nix/cmd/installables.hh"
 #include "nix/cmd/installable-derived-path.hh"
@@ -535,28 +536,6 @@ ref<Installable> SourceExprCommand::parseInstallable(ref<Store> store, const std
     return installables.front();
 }
 
-static SingleBuiltPath getBuiltPath(ref<Store> evalStore, ref<Store> store, const SingleDerivedPath & b)
-{
-    return std::visit(
-        overloaded{
-            [&](const SingleDerivedPath::Opaque & bo) -> SingleBuiltPath { return SingleBuiltPath::Opaque{bo.path}; },
-            [&](const SingleDerivedPath::Built & bfd) -> SingleBuiltPath {
-                auto drvPath = getBuiltPath(evalStore, store, *bfd.drvPath);
-                // Resolving this instead of `bfd` will yield the same result, but avoid duplicative work.
-                SingleDerivedPath::Built truncatedBfd{
-                    .drvPath = makeConstantStorePathRef(drvPath.outPath()),
-                    .output = bfd.output,
-                };
-                auto outputPath = resolveDerivedPath(*store, truncatedBfd, &*evalStore);
-                return SingleBuiltPath::Built{
-                    .drvPath = make_ref<SingleBuiltPath>(std::move(drvPath)),
-                    .output = {bfd.output, outputPath},
-                };
-            },
-        },
-        b.raw());
-}
-
 std::vector<BuiltPathWithResult> Installable::build(
     ref<Store> evalStore, ref<Store> store, Realise mode, const Installables & installables, BuildMode bMode)
 {
@@ -655,33 +634,15 @@ std::vector<std::pair<ref<Installable>, BuiltPathWithResult>> Installable::build
         auto buildResults = store->buildPathsWithResults(pathsToBuild, bMode, evalStore);
         throwBuildErrors(buildResults, *store);
         for (auto & buildResult : buildResults) {
-            // If we didn't throw, they must all be sucesses
-            auto & success = std::get<nix::BuildResult::Success>(buildResult.inner);
             for (auto & aux : backmap[buildResult.path]) {
-                std::visit(
-                    overloaded{
-                        [&](const DerivedPath::Built & bfd) {
-                            std::map<std::string, StorePath> outputs;
-                            for (auto & [outputName, realisation] : success.builtOutputs)
-                                outputs.emplace(outputName, realisation.outPath);
-                            res.push_back(
-                                {aux.installable,
-                                 {.path =
-                                      BuiltPath::Built{
-                                          .drvPath =
-                                              make_ref<SingleBuiltPath>(getBuiltPath(evalStore, store, *bfd.drvPath)),
-                                          .outputs = outputs,
-                                      },
-                                  .info = aux.info,
-                                  .result = buildResult}});
-                        },
-                        [&](const DerivedPath::Opaque & bo) {
-                            res.push_back(
-                                {aux.installable,
-                                 {.path = BuiltPath::Opaque{bo.path}, .info = aux.info, .result = buildResult}});
-                        },
+                res.push_back({
+                    aux.installable,
+                    BuiltPathWithResult{
+                        .path = toBuiltPath(buildResult, evalStore, store),
+                        .info = aux.info,
+                        .result = buildResult,
                     },
-                    buildResult.path.raw());
+                });
             }
         }
 

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -1,4 +1,5 @@
 #include "nix/cmd/command.hh"
+#include "nix/cmd/installables.hh"
 #include "nix/main/common-args.hh"
 #include "nix/main/shared.hh"
 #include "nix/store/store-api.hh"
@@ -105,19 +106,12 @@ builtPathsWithResultToJSON(const std::vector<BuiltPathWithResult> & buildables, 
     return res;
 }
 
-struct CmdBuild : InstallablesCommand, MixOutLinkByDefault, MixDryRun, MixJSON, MixProfile
+struct CmdBuild : InstallablesCommand, MixOutLinkByDefault, MixDryRun, MixJSON, MixProfile, MixPrintOutPaths
 {
-    bool printOutputPaths = false;
     BuildMode buildMode = bmNormal;
 
     CmdBuild()
     {
-        addFlag({
-            .longName = "print-out-paths",
-            .description = "Print the resulting output paths",
-            .handler = {&printOutputPaths, true},
-        });
-
         addFlag({
             .longName = "rebuild",
             .description = "Rebuild an already built package and compare the result to the existing store paths.",
@@ -160,23 +154,11 @@ struct CmdBuild : InstallablesCommand, MixOutLinkByDefault, MixDryRun, MixJSON, 
         if (json)
             logger->cout("%s", builtPathsWithResultToJSON(buildables, *store).dump());
 
-        createOutLinksMaybe(buildables, store);
+        auto builtPaths = toBuiltPaths(buildables);
 
-        if (printOutputPaths) {
-            logger->stop();
-            for (auto & buildable : buildables) {
-                std::visit(
-                    overloaded{
-                        [&](const BuiltPath::Opaque & bo) { logger->cout(store->printStorePath(bo.path)); },
-                        [&](const BuiltPath::Built & bfd) {
-                            for (auto & output : bfd.outputs) {
-                                logger->cout(store->printStorePath(output.second));
-                            }
-                        },
-                    },
-                    buildable.path.raw());
-            }
-        }
+        createOutLinksMaybe(builtPaths, store);
+
+        printOutPathsMaybe(builtPaths, store);
 
         BuiltPaths buildables2;
         for (auto & b : buildables)

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1,3 +1,4 @@
+#include "nix/cmd/command.hh"
 #include "nix/cmd/common-eval-args.hh"
 #include "nix/main/common-args.hh"
 #include "nix/main/shared.hh"
@@ -5,6 +6,7 @@
 #include "nix/expr/eval-inline.hh"
 #include "nix/expr/eval-settings.hh"
 #include "nix/expr/get-drvs.hh"
+#include "nix/store/derived-path.hh"
 #include "nix/util/os-string.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/mounted-source-accessor.hh"
@@ -313,12 +315,13 @@ struct CmdFlakeInfo : CmdFlakeMetadata
     }
 };
 
-struct CmdFlakeCheck : FlakeCommand
+struct CmdFlakeCheck : FlakeCommand, MixPrintOutPaths, MixOutLinkBase
 {
     bool build = true;
     bool checkAllSystems = false;
 
     CmdFlakeCheck()
+        : MixOutLinkBase(std::nullopt)
     {
         addFlag({
             .longName = "no-build",
@@ -329,6 +332,15 @@ struct CmdFlakeCheck : FlakeCommand
             .longName = "all-systems",
             .description = "Check the outputs for all systems.",
             .handler = {&checkAllSystems, true},
+        });
+        addFlag({
+            .longName = "out-link",
+            .shortName = 'o',
+            .description =
+                "Use *path* as prefix for the symlinks to the check results. By default, no out links are created.",
+            .labels = {"path"},
+            .handler = {&outLink},
+            .completer = completePath,
         });
     }
 
@@ -786,6 +798,7 @@ struct CmdFlakeCheck : FlakeCommand
             });
         }
 
+        std::vector<KeyedBuildResult> results;
         if (build && !attrPathsByDrv.empty()) {
             auto keys = std::views::keys(attrPathsByDrv);
             std::vector<DerivedPath> drvPaths(keys.begin(), keys.end());
@@ -812,7 +825,9 @@ struct CmdFlakeCheck : FlakeCommand
             }
 
             Activity act(*logger, lvlInfo, actUnknown, fmt("running %d flake checks", toBuild.size()));
-            auto results = store->buildPathsWithResults(toBuild);
+
+            // once we get rid of the temporary hack above, this tenary operator will also go away
+            results = store->buildPathsWithResults((printOutputPaths || outLink) ? drvPaths : toBuild);
 
             // Report build failures with attribute paths
             for (auto & result : results) {
@@ -846,6 +861,14 @@ struct CmdFlakeCheck : FlakeCommand
                 "Use '--all-systems' to check all.",
                 concatStringsSep(", ", omittedSystems));
         };
+
+        auto builtPaths =
+            results | std::views::transform([&](auto & result) { return toBuiltPath(result, getEvalStore(), store); })
+            | std::ranges::to<BuiltPaths>();
+
+        printOutPathsMaybe(builtPaths, store);
+
+        createOutLinksMaybe(builtPaths, store);
     };
 };
 

--- a/tests/functional/flakes/check.sh
+++ b/tests/functional/flakes/check.sh
@@ -156,6 +156,17 @@ cp "${config_nix}" "$flakeDir/"
 
 expectStderr 0 nix flake check "$flakeDir" | grepQuiet 'running 1 flake check'
 
+# Test that `nix flake check --print-out-paths` produces the same out path as `nix build --print-out-paths`
+outPath=$(nix flake check "$flakeDir" --print-out-paths)
+outPathBuild=$(nix build "${flakeDir}#checks.$system.foo" --print-out-paths --no-link)
+[[ "$outPath" = "$outPathBuild" ]] || fail "out paths from flake check and build don't match"
+
+# Test out links
+! test -e result || fail "unexpected out link result found"
+nix flake check "$flakeDir" --out-link result
+test -e result || fail "out link result not found"
+rm result
+
 cat > "$flakeDir"/flake.nix <<EOF
 {
   outputs = { self }: {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

- Support `--out-link` in `nix flake check`, retaining current default of not creating them
- Support `--print-out-paths` in `nix flake check`

These are in the same PR because they share underlying logic changes to support both of them.

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Out links for flake checks enable easier CI caching and avoidance of garbage collection, and printing output paths was requested by a user in the matrix chat. It's also good to have consistent flag support across the different commands.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Resolves #13470

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
