### PR TITLE
libutil/fs-sink: Flush FdSink before closing the file descriptor

### DIFF
--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -148,6 +148,16 @@ struct RestoreRegularFile : CreateRegularFileSink, FdSink
 
     ~RestoreRegularFile()
     {
+        /* Flush the sink before FdSink destructor has a chance to run and we've
+           closed the file descriptor. */
+        if (fd) {
+            try {
+                FdSink::flush();
+            } catch (...) {
+                ignoreExceptionInDestructor();
+            }
+        }
+
         /* Initiate an fsync operation without waiting for the
            result. The real fsync should be run before registering a
            store path, but this is a performance optimization to allow


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

In 08887caa1ae977103b342ec6469664ce192395b9 I neglected the case of interrupts and got bitten by destruction order. fd gets closed before FdSink destructor gets a chance to run. This doesn't matter in the successful code path, but does get hit during interrupts and leads to a bunch of annoying ignored error messages:

```
error (ignored): write of 16384 bytes: Bad file descriptor
error (ignored): write of 16384 bytes: Bad file descriptor
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
