### PR TITLE
makeFSSourceAccessor: Drop too many asserts

### DIFF
--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -311,12 +311,7 @@ ref<SourceAccessor> getFSSourceAccessor()
 ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackLastModified)
 {
 #ifndef _WIN32
-    /* Die if the path ends in a / or /. That is a footgun that matters
-       for symlink resolution. TODO: Strip them or make this a proper error if
-       this becomes an issue. Defense-in-depth. */
-    assert(!root.native().ends_with(OS_STR("/.")));
-    assert(!root.native().ends_with(OS_STR("/")));
-
+    assert(root.is_absolute());
     AutoCloseFD fd = openFileReadonly(root, FinalSymlink::DontFollow);
 
     if (!fd) {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Those asserts were a bit overzealous and could be hit from user code like using `git+file:///path/to/repo/.` flakeref.
Old code before 02e4f4ad75f constructed the `PosixSourceAccessor` directly and asserted that the path is absolute, which do do too.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
