### PR TITLE
flake: Bump nixpkgs, libgit2, mimalloc, drop hack for static libcurl and brotli

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771903837,
-        "narHash": "sha256-jEA8WggGKtMFeNeCKq3NK8cLEjJmG6/RLUElYYbBZ0E=",
-        "rev": "e764fc9a405871f1f6ca3d1394fb422e0a0c3951",
+        "lastModified": 1778003029,
+        "narHash": "sha256-amc4Y3GF3+anUi7IJeLVzf7hVqLb3ZqCGzYtkVyp7Qw=",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/25.11/nixos-25.11.6495.e764fc9a4058/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/25.11/nixos-25.11.10470.0c88e1f2bdb9/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -17,16 +17,16 @@ scope: {
   inherit stdenv;
 
   mimalloc =
-    if lib.versionAtLeast pkgs.mimalloc.version "3.3.0" then
+    if lib.versionAtLeast pkgs.mimalloc.version "3.3.2" then
       pkgs.mimalloc
     else
       pkgs.mimalloc.overrideAttrs rec {
-        version = "3.3.0";
+        version = "3.3.2";
         src = pkgs.fetchFromGitHub {
           owner = "microsoft";
           repo = "mimalloc";
           tag = "v${version}";
-          hash = "sha256-xy9gPihw3xvhnd6BrCYfMnnRp5dPSodynKRToYwxuzg=";
+          hash = "sha256-GZ37qQVDe9jgMb4Coe5oKvgaLTspZDlSkS5rdy1MfUU=";
         };
       };
 

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -62,6 +62,21 @@ scope: {
     useTBB = !(stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isStatic);
   };
 
+  libgit2 =
+    if lib.versionAtLeast pkgs.libgit2.version "1.9.3" then
+      pkgs.libgit2
+    else
+      # Grab newer libgit2.
+      pkgs.libgit2.overrideAttrs rec {
+        version = "1.9.3";
+        src = pkgs.fetchFromGitHub {
+          owner = "libgit2";
+          repo = "libgit2";
+          tag = "v${version}";
+          hash = "sha256-nJrRdPs86oGNL4W2CJb16oSUgfzYr9A2i5sw9BAehME=";
+        };
+      };
+
   # TODO Hack until https://github.com/NixOS/nixpkgs/issues/45462 is fixed.
   boost =
     (pkgs.boost.override {

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -44,19 +44,13 @@ scope: {
         NIX_CFLAGS_COMPILE = "-DINITIAL_MARK_STACK_SIZE=1048576";
       });
 
-  curl =
-    (pkgs.curl.override {
-      http3Support = !pkgs.stdenv.hostPlatform.isWindows;
-      # Make sure we enable all the dependencies for Content-Encoding/Transfer-Encoding decompression.
-      zstdSupport = true;
-      brotliSupport = true;
-      zlibSupport = true;
-    }).overrideAttrs
-      {
-        # TODO: Fix in nixpkgs. Static build with brotli is marked as broken, but it's not the case.
-        # Remove once https://github.com/NixOS/nixpkgs/pull/494111 lands in the 25.11 channel.
-        meta.broken = false;
-      };
+  curl = pkgs.curl.override {
+    http3Support = !pkgs.stdenv.hostPlatform.isWindows;
+    # Make sure we enable all the dependencies for Content-Encoding/Transfer-Encoding decompression.
+    zstdSupport = true;
+    brotliSupport = true;
+    zlibSupport = true;
+  };
 
   libblake3 = pkgs.libblake3.override {
     useTBB = !(stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isStatic);

--- a/tests/functional/structured-attrs.sh
+++ b/tests/functional/structured-attrs.sh
@@ -51,15 +51,17 @@ expectStderr 0 nix-instantiate --expr "$hackyExpr" --eval --strict | grepQuiet "
 hacky=$(nix-instantiate --expr "$hackyExpr")
 nix derivation show "$hacky" | jq --exit-status '.derivations."'"$(basename "$hacky")"'".structuredAttrs | . == {"a": 1}'
 
-# Test warning for non-object exportReferencesGraph in structured attrs
-# shellcheck disable=SC2016
-expectStderr 0 nix-build --no-out-link --expr '
-  with import ./config.nix;
-  mkDerivation {
-    name = "export-graph-non-object";
-    __structuredAttrs = true;
-    exportReferencesGraph = [ "foo" "bar" ];
-    builder = "/bin/sh";
-    args = ["-c" "echo foo > ${builtins.placeholder "out"}"];
-  }
-' | grepQuiet "warning:.*exportReferencesGraph.*not a JSON object"
+if isDaemonNewer "2.34pre"; then
+    # Test warning for non-object exportReferencesGraph in structured attrs
+    # shellcheck disable=SC2016
+    expectStderr 0 nix-build --no-out-link --expr '
+    with import ./config.nix;
+    mkDerivation {
+        name = "export-graph-non-object";
+        __structuredAttrs = true;
+        exportReferencesGraph = [ "foo" "bar" ];
+        builder = "/bin/sh";
+        args = ["-c" "echo foo > ${builtins.placeholder "out"}"];
+    }
+    ' | grepQuiet "warning:.*exportReferencesGraph.*not a JSON object"
+fi


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Updates several dependencies, including a nixpkgs bump and bumps for libgit2/mimalloc.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
