### PR TITLE
Use OpenSSL EVP API for hashing

### DIFF
--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -3,8 +3,7 @@
 
 #include <blake3.h>
 #include <openssl/crypto.h>
-#include <openssl/md5.h>
-#include <openssl/sha.h>
+#include <openssl/evp.h>
 
 #include "nix/util/args.hh"
 #include "nix/util/hash.hh"
@@ -290,24 +289,34 @@ Hash newHashAllowEmpty(std::string_view hashStr, std::optional<HashAlgorithm> ha
 union Hash::Ctx
 {
     blake3_hasher blake3;
-    MD5_CTX md5;
-    SHA_CTX sha1;
-    SHA256_CTX sha256;
-    SHA512_CTX sha512;
+    EVP_MD_CTX * evp;
 };
+
+static const EVP_MD * getEVPAlgo(HashAlgorithm ha)
+{
+    switch (ha) {
+    case HashAlgorithm::BLAKE3:
+        return nullptr;
+    case HashAlgorithm::MD5:
+        return EVP_md5();
+    case HashAlgorithm::SHA1:
+        return EVP_sha1();
+    case HashAlgorithm::SHA256:
+        return EVP_sha256();
+    case HashAlgorithm::SHA512:
+        return EVP_sha512();
+    }
+    return nullptr;
+}
 
 static void start(HashAlgorithm ha, Hash::Ctx & ctx)
 {
-    if (ha == HashAlgorithm::BLAKE3)
+    if (ha == HashAlgorithm::BLAKE3) {
         blake3_hasher_init(&ctx.blake3);
-    else if (ha == HashAlgorithm::MD5)
-        MD5_Init(&ctx.md5);
-    else if (ha == HashAlgorithm::SHA1)
-        SHA1_Init(&ctx.sha1);
-    else if (ha == HashAlgorithm::SHA256)
-        SHA256_Init(&ctx.sha256);
-    else if (ha == HashAlgorithm::SHA512)
-        SHA512_Init(&ctx.sha512);
+    } else {
+        ctx.evp = EVP_MD_CTX_new();
+        EVP_DigestInit_ex(ctx.evp, getEVPAlgo(ha), nullptr);
+    }
 }
 
 // BLAKE3 data size threshold beyond which parallel hashing with TBB is likely faster.
@@ -335,28 +344,19 @@ static void update(HashAlgorithm ha, Hash::Ctx & ctx, std::string_view data)
 {
     if (ha == HashAlgorithm::BLAKE3)
         blake3_hasher_update_with_heuristics(&ctx.blake3, data);
-    else if (ha == HashAlgorithm::MD5)
-        MD5_Update(&ctx.md5, data.data(), data.size());
-    else if (ha == HashAlgorithm::SHA1)
-        SHA1_Update(&ctx.sha1, data.data(), data.size());
-    else if (ha == HashAlgorithm::SHA256)
-        SHA256_Update(&ctx.sha256, data.data(), data.size());
-    else if (ha == HashAlgorithm::SHA512)
-        SHA512_Update(&ctx.sha512, data.data(), data.size());
+    else
+        EVP_DigestUpdate(ctx.evp, data.data(), data.size());
 }
 
 static void finish(HashAlgorithm ha, Hash::Ctx & ctx, unsigned char * hash)
 {
-    if (ha == HashAlgorithm::BLAKE3)
+    if (ha == HashAlgorithm::BLAKE3) {
         blake3_hasher_finalize(&ctx.blake3, hash, BLAKE3_OUT_LEN);
-    else if (ha == HashAlgorithm::MD5)
-        MD5_Final(hash, &ctx.md5);
-    else if (ha == HashAlgorithm::SHA1)
-        SHA1_Final(hash, &ctx.sha1);
-    else if (ha == HashAlgorithm::SHA256)
-        SHA256_Final(hash, &ctx.sha256);
-    else if (ha == HashAlgorithm::SHA512)
-        SHA512_Final(hash, &ctx.sha512);
+    } else {
+        unsigned int len;
+        EVP_DigestFinal_ex(ctx.evp, hash, &len);
+        EVP_MD_CTX_free(ctx.evp);
+    }
 }
 
 Hash hashString(HashAlgorithm ha, std::string_view s, const ExperimentalFeatureSettings & xpSettings)
@@ -387,6 +387,9 @@ HashSink::HashSink(HashAlgorithm ha)
 HashSink::~HashSink()
 {
     bufPos = 0;
+    if (ha != HashAlgorithm::BLAKE3 && ctx->evp) {
+        EVP_MD_CTX_free(ctx->evp);
+    }
     delete ctx;
 }
 
@@ -401,12 +404,23 @@ HashResult HashSink::finish()
     flush();
     Hash hash(ha);
     nix::finish(ha, *ctx, hash.hash);
+    if (ha != HashAlgorithm::BLAKE3)
+        ctx->evp = nullptr; // already freed by nix::finish
     return HashResult(hash, bytes);
 }
 
 HashResult HashSink::currentHash()
 {
     flush();
+    if (ha != HashAlgorithm::BLAKE3) {
+        EVP_MD_CTX * ctx2 = EVP_MD_CTX_new();
+        EVP_MD_CTX_copy_ex(ctx2, ctx->evp);
+        Hash hash(ha);
+        unsigned int len;
+        EVP_DigestFinal_ex(ctx2, hash.hash, &len);
+        EVP_MD_CTX_free(ctx2);
+        return HashResult(hash, bytes);
+    }
     Hash::Ctx ctx2 = *ctx;
     Hash hash(ha);
     nix::finish(ha, ctx2, hash.hash);


### PR DESCRIPTION
## Summary

Replace deprecated low-level OpenSSL hash functions (`MD5_Init`/`SHA256_Update`/`SHA512_Final`/etc.) with the EVP digest API (`EVP_DigestInit_ex`, `EVP_DigestUpdate`, `EVP_DigestFinal_ex`).

- The low-level APIs (`MD5_*`, `SHA1_*`, `SHA256_*`, `SHA512_*`) are deprecated in OpenSSL 3.x
- The EVP API is the recommended interface since OpenSSL 1.1.0
- EVP routes through OpenSSL's provider system (future-proof for hardware acceleration, FIPS modules)
- Nix already requires OpenSSL >= 1.1.1 (checked in `meson.build`)
- Hash output is identical — EVP is a higher-level wrapper around the same algorithms

## Changes

**Single file modified:** `src/libutil/hash.cc`

### Includes
- Removed: `<openssl/md5.h>`, `<openssl/sha.h>`
- Added: `<openssl/evp.h>`

### Hash context union
Replaced four algorithm-specific context structs with a single `EVP_MD_CTX *` pointer:

```cpp
// Before
union Hash::Ctx {
    blake3_hasher blake3;
    MD5_CTX md5;
    SHA_CTX sha1;
    SHA256_CTX sha256;
    SHA512_CTX sha512;
};

// After
union Hash::Ctx {
    blake3_hasher blake3;
    EVP_MD_CTX * evp;
};
```

Added `getEVPAlgo()` helper to map `HashAlgorithm` enum to EVP algorithm objects.

### Init / Update / Final
Replaced per-algorithm if/else chains with unified EVP calls:
- `start()`: `EVP_MD_CTX_new()` + `EVP_DigestInit_ex()`
- `update()`: `EVP_DigestUpdate()`
- `finish()`: `EVP_DigestFinal_ex()` + `EVP_MD_CTX_free()`

BLAKE3 paths are unchanged (it doesn't use OpenSSL).

### HashSink lifetime management
Since `EVP_MD_CTX *` is heap-allocated (unlike the old value-type structs):
- **Destructor** frees the EVP context if still live
- **finish()** nulls the pointer after `nix::finish()` frees it
- **currentHash()** uses `EVP_MD_CTX_copy_ex()` to snapshot the digest state (can't memcpy an opaque EVP context)

## Test plan

### Formatting
- [x] `nix develop -c ./maintainers/format.sh` — passes clean (clang-format, meson-format, nixfmt, shellcheck)

### Build
- [x] Full build compiles cleanly (`meson setup build --buildtype=debugoptimized && ninja -C build` — 508/508 targets)
- [x] No changes to `meson.build`, `meson.options`, or `package.nix` — `libcrypto` already provides `<openssl/evp.h>`

### Unit tests (22/22 hash tests pass)
- [x] `BLAKE3HashTest.testKnownBLAKE3Hashes{1,2,3}` — BLAKE3 known-vector tests
- [x] `hashString.testKnownMD5Hashes{1,2}` — MD5 known-vector tests
- [x] `hashString.testKnownSHA1Hashes{1,2}` — SHA-1 known-vector tests
- [x] `hashString.testKnownSHA256Hashes{1,2}` — SHA-256 known-vector tests
- [x] `hashString.testKnownSHA512Hashes{1,2}` — SHA-512 known-vector tests
- [x] `hashParseExplicitFormatUnprefixed` — parse/format round-trip tests
- [x] `hashFormat.testRoundTripPrintParse` — hash format serialization
- [x] `HashJSON` and `BLAKE3HashJSON` — JSON serialization round-trips

### Functional tests (125/125 pass, 5 skipped for unrelated reasons)
- [x] `nix-functional-tests:main / hash-convert` — `nix hash convert` CLI
- [x] `nix-functional-tests:main / hash-path` — `nix hash path` CLI
- [x] `nix-functional-tests:main / path-from-hash-part` — store path hash resolution
- [x] `nix-functional-tests:git-hashing / simple-sha1` — git SHA-1 hashing
- [x] `nix-functional-tests:git-hashing / simple-sha256` — git SHA-256 hashing
- [x] `nix-functional-tests:git-hashing / fixed` — fixed-output derivation hashing
- [x] All other functional tests that depend on hashing (fetchTree, binary-cache, flakes, etc.)

### Manual verification
- [x] `nix hash file` output for MD5, SHA-1, SHA-256, SHA-512 matches coreutils (`md5sum`, `sha1sum`, `sha256sum`, `sha512sum`) byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)
