### PR TITLE
doc: add example for git tags

### DIFF
--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -95,6 +95,8 @@ Here are some examples of flake references in their URL-like representation:
   branch of a Git repository.
 * `git+https://github.com/NixOS/patchelf?ref=master&rev=f34751b88bd07d7f44f5cd3200fb4122bf916c7e`:
   A specific branch *and* revision of a Git repository.
+* `git+https://github.com/NixOS/patchelf?ref=refs/tags/0.18.0`: A specific
+  tag of a Git repository.
 * `https://github.com/NixOS/patchelf/archive/master.tar.gz`: A tarball
   flake.
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Add documentation on how to target a git tag in a flake input url. The syntax is not obvious for someone which does not have  internal knowledge of git.

I tested with github and gitlab repos and `git+https` and `git+ssh` schemes.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
