### PR TITLE
Skip redundant canonicalisePathMetaData in registerOutputs

### DIFF
--- a/src/libstore-tests/canonicalize-bench.cc
+++ b/src/libstore-tests/canonicalize-bench.cc
@@ -1,0 +1,128 @@
+#include <benchmark/benchmark.h>
+
+#include "nix/store/posix-fs-canonicalise.hh"
+#include "nix/util/file-system.hh"
+
+#ifndef _WIN32
+
+#  include <filesystem>
+#  include <fstream>
+#  include <sys/stat.h>
+
+using namespace nix;
+
+#  if NIX_SUPPORT_ACL
+static const StringSet emptyAcls{};
+#  endif
+
+/**
+ * Create a directory tree with the given number of files.
+ * If `canonical` is true, directories get 0555 and files 0444 (matching
+ * what canonicalisePathMetaData sets). Otherwise, directories get 0755
+ * and files 0644 (typical defaults from mkdir/open).
+ *
+ * Permissions are applied after all content is created so that
+ * read-only directories don't block file creation.
+ */
+static void createTree(const std::filesystem::path & root, int fileCount, bool canonical)
+{
+    std::filesystem::create_directories(root);
+
+    /* Create a few subdirectories to make the tree realistic. */
+    int dirsCreated = 0;
+    int filesPerDir = std::max(1, fileCount / 10);
+    std::vector<std::filesystem::path> dirs;
+    dirs.push_back(root);
+
+    for (int i = 0; i < fileCount; ++i) {
+        if (i % filesPerDir == 0) {
+            auto subdir = root / ("dir" + std::to_string(dirsCreated++));
+            std::filesystem::create_directory(subdir);
+            dirs.push_back(subdir);
+        }
+
+        auto dir = root / ("dir" + std::to_string(i / filesPerDir));
+        auto file = dir / ("file" + std::to_string(i));
+        {
+            std::ofstream ofs(file, std::ios::binary);
+            ofs << "content-" << i;
+        }
+        if (canonical)
+            chmod(file.c_str(), 0444);
+    }
+
+    /* Set directory permissions last so 0555 doesn't block file creation. */
+    if (canonical)
+        for (auto & d : dirs)
+            chmod(d.c_str(), 0555);
+}
+
+/**
+ * Make a tree writable again so remove_all can delete it.
+ */
+static void makeWritable(const std::filesystem::path & root)
+{
+    for (auto & entry : std::filesystem::recursive_directory_iterator(root))
+        if (entry.is_directory())
+            chmod(entry.path().c_str(), 0755);
+    chmod(root.c_str(), 0755);
+}
+
+/**
+ * Benchmark: canonicalize an already-canonical tree.
+ * This measures the cost of the redundant pass being eliminated.
+ */
+static void BM_CanonicalizeAlreadyCanonical(benchmark::State & state)
+{
+    const int fileCount = state.range(0);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto tmpDir = createTempDir();
+        auto tree = tmpDir / "store-output";
+        createTree(tree, fileCount, /*canonical=*/true);
+        InodesSeen inodesSeen;
+        state.ResumeTiming();
+
+        canonicalisePathMetaData(tree, {.uidRange = std::nullopt, NIX_WHEN_SUPPORT_ACLS(emptyAcls)}, inodesSeen);
+
+        state.PauseTiming();
+        makeWritable(tmpDir);
+        std::filesystem::remove_all(tmpDir);
+        state.ResumeTiming();
+    }
+
+    state.SetItemsProcessed(state.iterations() * fileCount);
+}
+
+/**
+ * Benchmark: canonicalize a fresh tree with non-canonical permissions.
+ * This measures the cost of the necessary first canonicalize pass.
+ */
+static void BM_CanonicalizeFreshTree(benchmark::State & state)
+{
+    const int fileCount = state.range(0);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto tmpDir = createTempDir();
+        auto tree = tmpDir / "store-output";
+        createTree(tree, fileCount, /*canonical=*/false);
+        InodesSeen inodesSeen;
+        state.ResumeTiming();
+
+        canonicalisePathMetaData(tree, {.uidRange = std::nullopt, NIX_WHEN_SUPPORT_ACLS(emptyAcls)}, inodesSeen);
+
+        state.PauseTiming();
+        makeWritable(tmpDir);
+        std::filesystem::remove_all(tmpDir);
+        state.ResumeTiming();
+    }
+
+    state.SetItemsProcessed(state.iterations() * fileCount);
+}
+
+BENCHMARK(BM_CanonicalizeAlreadyCanonical)->Arg(100)->Arg(1000)->Arg(5000);
+BENCHMARK(BM_CanonicalizeFreshTree)->Arg(100)->Arg(1000)->Arg(5000);
+
+#endif

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -128,6 +128,7 @@ if get_option('benchmarks')
 
   benchmark_sources = files(
     'bench-main.cc',
+    'canonicalize-bench.cc',
     'derivation-parser-bench.cc',
     'ref-scan-bench.cc',
     'register-valid-paths-bench.cc',

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1742,6 +1742,8 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
             return newInfo0;
         };
 
+        bool needsFinalCanonicalize = false;
+
         ValidPathInfo newInfo = std::visit(
             overloaded{
 
@@ -1777,6 +1779,10 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
 
                     std::filesystem::rename(tmpOutput, actualPath);
 
+                    // copyFile creates directories with default permissions (not canonical 0555),
+                    // so we need to re-canonicalize after the copy.
+                    needsFinalCanonicalize = true;
+
                     return newInfoFromCA(
                         DerivationOutput::CAFloating{
                             .method = dof.ca.method,
@@ -1803,17 +1809,24 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
             },
             output->raw);
 
-        /* FIXME: set proper permissions in restorePath() so
-            we don't have to do another traversal. */
-        canonicalisePathMetaData(
-            actualPath,
-            {
+        if (needsFinalCanonicalize) {
+            /* The CAFixed path copies the output tree via copyFile(), which
+               creates directories with default permissions rather than the
+               canonical 0555. Re-canonicalize to fix this.
+               For input-addressed outputs (the common case), Loop 1 already
+               set correct permissions and nothing modified the tree since.
+               For rewritten trees, rewriteOutput() already canonicalizes
+               internally after the dump/restore. */
+            canonicalisePathMetaData(
+                actualPath,
+                {
 #ifndef _WIN32
-                // builder UIDs are already dealt with
-                .uidRange = std::nullopt,
+                    // builder UIDs are already dealt with
+                    .uidRange = std::nullopt,
 #endif
-                NIX_WHEN_SUPPORT_ACLS(localSettings.ignoredAcls)},
-            inodesSeen);
+                    NIX_WHEN_SUPPORT_ACLS(localSettings.ignoredAcls)},
+                inodesSeen);
+        }
 
         /* Calculate where we'll move the output files. In the checking case we
            will leave leave them where they are, for now, rather than move to


### PR DESCRIPTION
## Summary

- Skip the redundant third `canonicalisePathMetaData` call in `registerOutputs()` Loop 2, addressing the existing FIXME comment
- Retain the call only for `CAFixed` outputs where `copyFile()` creates directories with non-canonical permissions
- Add `canonicalize-bench.cc` measuring canonicalize cost on already-canonical vs fresh trees

## Problem

`registerOutputs()` has three calls to `canonicalisePathMetaData`. The third (Loop 2) is unconditional and carries a FIXME:

```cpp
/* FIXME: set proper permissions in restorePath() so
    we don't have to do another traversal. */
```

For input-addressed outputs (the common case), this re-walks the entire output tree only to discover permissions are already correct — Loop 1 already canonicalized them.

## Analysis of all three calls

| Call | Location | Purpose | When needed |
|---|---|---|---|
| 1st (Loop 1) | ~line 1514 | Security check + initial canonicalize with UID range | Always |
| 2nd (rewriteOutput) | ~line 1643 | Re-canonicalize after dump/restore rewrite | Only when rewrites applied (already conditional) |
| 3rd (Loop 2) | ~line 1808 | Unconditional re-canonicalize | **Redundant for most paths** |

### Why the 3rd call is redundant

| Output type | Rewrites? | Who canonicalizes | 3rd call needed? |
|---|---|---|---|
| InputAddressed | No | 1st (Loop 1) | No |
| InputAddressed | Yes | 2nd (rewriteOutput) | No |
| CAFixed | — | copyFile breaks perms → **3rd call** | **Yes** (flag set) |
| CAFloating | No | 1st (Loop 1) | No |
| CAFloating | Yes | 2nd (rewriteOutput) | No |
| Impure | No/Yes | 1st or 2nd | No |

### The one exception: CAFixed

`CAFixed` does `copyFile()` + `std::filesystem::rename()`. `copyFile()` uses `std::filesystem::create_directory()` internally, which creates directories with the process umask (typically 0755) rather than canonical 0555. So for CAFixed outputs, we genuinely need the final canonicalize pass.

## Fix

Add a `needsFinalCanonicalize` flag (default `false`), set it to `true` only in the `CAFixed` lambda after `copyFile`, and guard the third canonicalize with the flag.

## Test plan

- [x] All 690 `nix-store-tests` pass (clang, `debugoptimized`)
- [ ] Manual test: `nix build nixpkgs#hello`, verify output permissions with `stat`
- [ ] Verify CAFixed outputs still get correct permissions

## Benchmark results

Added `canonicalize-bench.cc` with two cases × three file counts (100, 1000, 5000):

```
-----------------------------------------------------------------------------------------------
Benchmark                                     Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------
BM_CanonicalizeAlreadyCanonical/100      805402 ns       786447 ns          897 items_per_second=127.154k/s
BM_CanonicalizeAlreadyCanonical/1000    6903698 ns      6813047 ns          105 items_per_second=146.777k/s
BM_CanonicalizeAlreadyCanonical/5000   34528426 ns     34148116 ns           20 items_per_second=146.421k/s
BM_CanonicalizeFreshTree/100            1114449 ns      1086176 ns          652 items_per_second=92.0662k/s
BM_CanonicalizeFreshTree/1000           9563764 ns      9441245 ns           74 items_per_second=105.918k/s
BM_CanonicalizeFreshTree/5000          48289367 ns     47808017 ns           15 items_per_second=104.585k/s
```

| Files | Already canonical (redundant) | Fresh tree (necessary) | Redundant / Fresh |
|---|---|---|---|
| 100 | 0.8 ms | 1.1 ms | 72% |
| 1000 | 6.9 ms | 9.6 ms | 72% |
| 5000 | 34.5 ms | 48.3 ms | 71% |

The already-canonical pass costs **~72% of a full canonicalize** — pure `lstat` + `lchown` + `lutimes` syscall overhead on every inode even when nothing needs changing. For a typical package with 1000 output files this eliminates ~7 ms per output; for larger packages (GCC, LLVM) with tens of thousands of files the savings scale linearly.

## How we built and tested

Note: the default `nix develop` (GCC stdenv) currently has a pre-existing `-Wchanges-meaning` error in `closure.hh` unrelated to this change. We used the clang stdenv:

```bash
# Configure with benchmarks enabled
nix develop .#native-clangStdenv -c bash -c \
  "cd build && meson setup --reconfigure --wipe -Dbenchmarks=true . .."

# Build store tests and benchmarks
nix develop .#native-clangStdenv -c bash -c \
  "cd build && ninja -j$(nproc) src/libstore-tests/nix-store-tests src/libstore-tests/nix-store-benchmarks"

# Run tests (690 passed)
nix develop .#native-clangStdenv -c bash -c \
  "cd build && meson test nix-store-tests -v"

# Run benchmarks
nix develop .#native-clangStdenv -c bash -c \
  "cd build && ./src/libstore-tests/nix-store-benchmarks --benchmark_filter='Canonicalize'"

# Verify formatting
nix develop -c ./maintainers/format.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)