### PR TITLE
libutil: Fixup owned case in StringSource to never invalidate pointers

### DIFF
--- a/src/libutil/include/nix/util/serialise.hh
+++ b/src/libutil/include/nix/util/serialise.hh
@@ -263,19 +263,21 @@ struct StringSink : Sink
  */
 struct StringSource : RestartableSource
 {
-    std::optional<std::string> sOwned;
+    /* Put behind a shared_ptr to make sure that copies and moves don't invalidate pointers
+       into a small string buffer. */
+    std::shared_ptr<std::string> sOwned;
     std::string_view s;
     size_t pos;
 
     StringSource(std::string && s)
-        : sOwned(std::move(s))
+        : sOwned(std::make_shared<std::string>(std::move(s)))
         , s(*sOwned)
         , pos(0)
     {
     }
 
     StringSource(std::string_view s)
-        : sOwned(std::nullopt)
+        : sOwned(nullptr)
         , s(s)
         , pos(0)
     {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fixes a potential bug I introduced in 71a97bce2706edc175c779f55d3138af8b0bf158. Not yet an issue, because StringSource doesn't get copied or moved, but still good to be completely correct about it.

std::string has a small buffer optimisation, which means that references can be invalidated on copies and moves.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
