### PR TITLE
fix(build-remote): hash slot-lock filename on ENAMETOOLONG

### DIFF
--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -40,7 +40,17 @@ static std::filesystem::path currentLoad;
 
 static AutoCloseFD openSlotLock(const Machine & m, uint64_t slot)
 {
-    return openLockFile(currentLoad / fmt("%s-%d", escapeUri(m.storeUri.render()), slot), true);
+    auto storeUri = m.storeUri.render();
+    auto open = [&](auto && base) { return openLockFile(currentLoad / fmt("%s-%d", escapeUri(base), slot), true); };
+    try {
+        return open(storeUri);
+    } catch (SystemError & e) {
+        if (!e.is(std::errc::filename_too_long))
+            throw;
+        // Try again hashing the store URL so we have a shorter path
+        auto h = hashString(HashAlgorithm::MD5, storeUri);
+        return open(h.to_string(HashFormat::Base64, false));
+    }
 }
 
 static bool allSupportedLocally(Store & store, const StringSet & requiredFeatures)


### PR DESCRIPTION
## Motivation

`openSlotLock` constructs its lock filename from the full rendered store URI:

```cpp
openLockFile(currentLoad / fmt("%s-%d", escapeUri(m.storeUri.render()), slot), true);
```

When the remote builder URI contains a long path — e.g. the functional tests use `ssh://localhost?remote-store=$TEST_ROOT/machineN?system-features=...`, and on CI runners with ~60-char tmpdir components the escaped URI alone pushes the filename past `NAME_MAX` — `openLockFile` fails with `File name too long`. This is what breaks `build-remote-trustless-should-pass-{2,3}` on nixbuild.net.

The upload-lock a few lines down already handles this (e92dd06a7b):

https://github.com/NixOS/nix/blob/f2d4cc70726244f9fdea0ca9e4d3c76c4d635573/src/nix/build-remote/build-remote.cc#L278-L291

## Fix

Apply the same fallback to `openSlotLock`: catch `filename_too_long`, hash the store URI with MD5, retry. The `-<slot>` suffix is preserved so different slots for the same machine still get distinct lock files.