### PR TITLE
test(functional): factor busybox skip check into requireBusybox

### DIFF
--- a/tests/functional/build-remote-trustless-should-fail-0.sh
+++ b/tests/functional/build-remote-trustless-should-fail-0.sh
@@ -9,7 +9,7 @@ restartDaemon
 
 requireSandboxSupport
 requiresUnprivilegedUserNamespaces
-[[ $busybox =~ busybox ]] || skipTest "no busybox"
+requireBusybox
 
 unset NIX_STORE_DIR
 

--- a/tests/functional/build-remote-trustless.sh
+++ b/tests/functional/build-remote-trustless.sh
@@ -6,7 +6,7 @@
 
 requireSandboxSupport
 requiresUnprivilegedUserNamespaces
-[[ "$busybox" =~ busybox ]] || skipTest "no busybox"
+requireBusybox
 
 unset NIX_STORE_DIR
 

--- a/tests/functional/build-remote-with-mounted-ssh-ng.sh
+++ b/tests/functional/build-remote-with-mounted-ssh-ng.sh
@@ -3,7 +3,7 @@
 source common.sh
 
 requireSandboxSupport
-[[ $busybox =~ busybox ]] || skipTest "no busybox"
+requireBusybox
 
 enableFeatures mounted-ssh-store
 

--- a/tests/functional/build-remote.sh
+++ b/tests/functional/build-remote.sh
@@ -1,10 +1,11 @@
 # shellcheck shell=bash
 
+# shellcheck disable=SC2154
 : "${file?must be defined by caller (remote building test case using this)}"
 
 requireSandboxSupport
 requiresUnprivilegedUserNamespaces
-[[ "${busybox-}" =~ busybox ]] || skipTest "no busybox"
+requireBusybox
 
 # Avoid store dir being inside sandbox build-dir
 unset NIX_STORE_DIR

--- a/tests/functional/common/functions.sh
+++ b/tests/functional/common/functions.sh
@@ -162,6 +162,31 @@ requireSandboxSupport () {
     canUseSandbox || skipTest "Sandboxing not supported"
 }
 
+requireBusybox() {
+    # Probe: build a trivial derivation with busybox as builder in a chroot
+    # store, mirroring how callers use it (--arg busybox + --store <chroot>,
+    # builder = busybox; args = ["sh" ...]). Catches the case where the host
+    # path is valid but a chroot-store build sandbox cannot exec it after the
+    # copy through --store (seen on some remote builders).
+    # shellcheck disable=SC2154 # busybox, TEST_ROOT set via common.sh
+    if [[ ! -x "$busybox" ]]; then
+        skipTest "no busybox"
+    fi
+    # shellcheck disable=SC2016 # $out is a Nix variable, not shell
+    local expr='{ busybox }: derivation {
+        name = "busybox-probe";
+        system = builtins.currentSystem;
+        builder = busybox;
+        args = ["sh" "-c" ": > $out"];
+    }'
+    if ! env -u NIX_STORE_DIR nix-build --no-out-link \
+        --store "$TEST_ROOT/requireBusybox-probe" \
+        --arg busybox "$busybox" -E "$expr" &>/dev/null
+    then
+        skipTest "busybox not reachable in chroot-store build sandbox"
+    fi
+}
+
 requireGit() {
     [[ $(type -p git) ]] || skipTest "Git not installed"
 }

--- a/tests/functional/local-overlay-store/common.sh
+++ b/tests/functional/local-overlay-store/common.sh
@@ -29,7 +29,7 @@ export LIBMOUNT_FORCE_MOUNT2=always
 
 requireEnvironment () {
   requireSandboxSupport
-  [[ $busybox =~ busybox ]] || skipTest "no busybox"
+  requireBusybox
   if [[ $(uname) != Linux ]]; then skipTest "Need Linux for overlayfs"; fi
   needLocalStore "The test uses --store always so we would just be bypassing the daemon"
 }

--- a/tests/functional/supplementary-groups.sh
+++ b/tests/functional/supplementary-groups.sh
@@ -3,7 +3,7 @@
 source common.sh
 
 requireSandboxSupport
-[[ $busybox =~ busybox ]] || skipTest "no busybox"
+requireBusybox
 if ! command -p -v unshare; then skipTest "Need unshare"; fi
 needLocalStore "The test uses --store always so we would just be bypassing the daemon"
 


### PR DESCRIPTION
Six tests had a copy-pasted `[[ $busybox =~ busybox ]]` check that only verifies the variable contains the substring "busybox" — passes even when the path doesn't exist.

Factor into `requireBusybox`. The check now does a **probe build**: a trivial derivation with busybox as builder in a chroot store (`--arg busybox "$busybox" --store <chroot>`), mirroring how `build-hook.nix` / `hermetic.nix` use it:

```nix
{ busybox }: derivation {
    name = "busybox-probe";
    system = builtins.currentSystem;
    builder = busybox;
    args = ["sh" "-c" ": > $out"];
}
```

This catches the actual failure seen on some remote builders where the host path is valid but a chroot-store build sandbox cannot exec it after the copy through `--store` — `executing '/nix/store/.../busybox': No such file or directory` inside the sandbox, while `[[ -x "$busybox" ]]` and even `"$busybox" sh -c true` on the host both succeed.

The probe adds ~100ms per test file. A `[[ -x "$busybox" ]]` guard runs first so a missing path skips without attempting the build.