### PR TITLE
libutil: reset all signal dispositions to `SIG_DFL` before exec'ing builders

### DIFF
--- a/src/libstore/unix/build/child.cc
+++ b/src/libstore/unix/build/child.cc
@@ -3,6 +3,7 @@
 #include "nix/util/logging.hh"
 
 #include <fcntl.h>
+#include <signal.h>
 #include <unistd.h>
 
 namespace nix {
@@ -13,6 +14,22 @@ void commonChildInit()
 
     const static std::string pathNullDevice = "/dev/null";
     restoreProcessContext(false);
+
+    /* Reset all signal dispositions to SIG_DFL. The process that started
+       the daemon (typically systemd) may have set SIG_IGN for certain
+       signals, and ignored signal dispositions survive both fork() and
+       execve(). Without this reset, builds are non-deterministic depending
+       on how the daemon was started. */
+    {
+        struct sigaction act = {};
+        act.sa_handler = SIG_DFL;
+        sigemptyset(&act.sa_mask);
+        for (int sig = 1; sig < NSIG; sig++) {
+            if (sig == SIGKILL || sig == SIGSTOP)
+                continue;
+            sigaction(sig, &act, nullptr);
+        }
+    }
 
     /* Put the child in a separate session (and thus a separate
        process group) so that it has no controlling terminal (meaning

--- a/tests/nixos/default.nix
+++ b/tests/nixos/default.nix
@@ -208,6 +208,8 @@ in
 
   storeRemount = runNixOSTest ./store-remount.nix;
 
+  signalDisposition = runNixOSTest ./signal-disposition;
+
   upgrade-nix = runNixOSTest {
     imports = [ ./upgrade-nix.nix ];
     upgrade-nix.oldNix = nixComponents.nix-cli;

--- a/tests/nixos/signal-disposition/check-signals.c
+++ b/tests/nixos/signal-disposition/check-signals.c
@@ -1,0 +1,36 @@
+/*
+ * Builder that asserts no signals have SIG_IGN disposition.
+ *
+ * Nix builders should start with all signal dispositions at SIG_DFL.
+ * If any signal is SIG_IGN, builds become non-deterministic as the result
+ * now additionally depends on how the daemon was started rather than just
+ * on the derivation inputs.
+ */
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void)
+{
+    struct sigaction sa;
+    int bad = 0;
+
+    for (int sig = 1; sig < NSIG; sig++) {
+        if (sig == SIGKILL || sig == SIGSTOP)
+            continue;
+        if (sigaction(sig, NULL, &sa) != 0)
+            continue;
+        if (sa.sa_handler == SIG_IGN) {
+            fprintf(stderr, "FAIL: signal %d has disposition SIG_IGN\n", sig);
+            bad = 1;
+        }
+    }
+
+    if (!bad) {
+        FILE * f = fopen(getenv("out"), "w");
+        fputs("PASS\n", f);
+        fclose(f);
+    }
+
+    return bad;
+}

--- a/tests/nixos/signal-disposition/default.nix
+++ b/tests/nixos/signal-disposition/default.nix
@@ -1,0 +1,46 @@
+# This test verifies that no signals have the SIG_IGN disposition inside a nix builder.
+#
+# systemd sets SIG_IGN for SIGPIPE on all services (IgnoreSIGPIPE=yes),
+# and other service managers or parent processes could ignore other signals.
+# Ignored dispositions survive fork() and execve(), so builders inherit
+# them unless `commonChildInit()` explicitly resets them to SIG_DFL.
+
+{ config, ... }:
+
+let
+  pkgs = config.nodes.machine.nixpkgs.pkgs;
+
+  # Compiled statically so it works inside the build sandbox without
+  # needing the dynamic linker in the sandbox closure.
+  checker =
+    pkgs.runCommandWith
+      {
+        name = "check-signals";
+        stdenv = pkgs.pkgsStatic.stdenv;
+      }
+      ''
+        $CC -static -o $out ${./check-signals.c}
+      '';
+in
+
+{
+  name = "signal-disposition";
+
+  nodes.machine = {
+    virtualisation.writableStore = true;
+    virtualisation.additionalPaths = [ checker ];
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed(r"""
+      nix-build -E '
+        derivation {
+          name = "check-signals";
+          system = builtins.currentSystem;
+          builder = builtins.storePath "${checker}";
+        }'
+    """.strip())
+  '';
+}


### PR DESCRIPTION
## Motivation

`restoreProcessContext()` restores the signal mask via `sigprocmask` but never resets signal dispositions set via `sigaction`. Ignored dispositions (`SIG_IGN`) survive both `fork()` and `execve()`, so builders inherit whatever the daemon's parent set. This becomes a problem with systemd as it sets `SIG_IGN` for `SIGPIPE` on all services (`IgnoreSIGPIPE=yes`), making builds non-deterministic - for example, `write()` on a broken pipe returns `EPIPE` instead of killing the writer, breaking test suites that rely on pipe semantics (e.g. GNU patch `bad-filenames` on s390x).

This commit resets all catchable signal dispositions to `SIG_DFL` in `restoreProcessContext()`, mirroring what `posix_spawn` does with `POSIX_SPAWN_SETSIGDEF`. I've added a NixOS VM test that builds a derivation asserting no signals have `SIG_IGN` disposition inside the builder, though `SIGPIPE` is the only signal that has the `SIG_IGN` disposition set in the VM anyway.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
