### PR TITLE
Revert "fix(libstore/filetransfer): enable TCP keep-alive on curl han…

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -653,12 +653,6 @@ struct curlFileTransfer : public FileTransfer
 #endif
             curl_easy_setopt(req, CURLOPT_CONNECTTIMEOUT, fileTransfer.settings.connectTimeout.get());
 
-            // Enable TCP keep-alive so that idle connections in curl's reuse pool
-            // are not silently dropped by NATs, firewalls, or load balancers.
-            curl_easy_setopt(req, CURLOPT_TCP_KEEPALIVE, 1L);
-            curl_easy_setopt(req, CURLOPT_TCP_KEEPIDLE, 60L);
-            curl_easy_setopt(req, CURLOPT_TCP_KEEPINTVL, 60L);
-
             curl_easy_setopt(req, CURLOPT_LOW_SPEED_LIMIT, 1L);
             curl_easy_setopt(req, CURLOPT_LOW_SPEED_TIME, fileTransfer.settings.stalledDownloadTimeout.get());
 


### PR DESCRIPTION
…dles"

This reverts commit 736abd50ff5ed6e41b20091371662c6581a8a7cd.

TCP keepalive with 60s idle/interval causes S3 to respond with RequestTimeout (HTTP 400) when curl reuses connections that S3 has already logically closed.  S3 aggressively drops idle connections and sends 'Connection: close', but keepalive keeps the TCP socket alive, so curl thinks it can reuse a connection the server has already abandoned.

This produced ~17.8k upload failures on Hydra after the change was deployed.
