### PR TITLE
fix: set umask(0022) in builder child process

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1331,6 +1331,10 @@ void DerivationBuilderImpl::runChild(RunChildArgs args)
         struct rlimit limit = {0, RLIM_INFINITY};
         setrlimit(RLIMIT_CORE, &limit);
 
+        /* Make sure the builder inherits a predictable umask. It must not be group-writable, since registerOutputs
+         * rejects those as defense-in-depth. */
+        umask(0022);
+
         // FIXME: set other limits to deterministic values?
 
         setUser();


### PR DESCRIPTION
C API consumers (like devenv's nix_string_realise) don't call initNix(), so they don't inherit the umask(0022) that CLI programs set. On systems with a permissive umask (e.g. 0002 on Ubuntu), builder outputs end up group-writable (mode 664), which registerOutputs() rejects as "suspicious ownership or permission" before canonicalisePathMetaData() gets a chance to fix them.

Setting umask in runChild() is the targeted fix: it only affects the forked builder process, not the parent. In-process store operations (addToStore, addToStoreFromDump) are unaffected because they already call canonicalisePathMetaData() which forces 0444/0555 regardless of umask.

Fixes cachix/devenv#2585
