### PR TITLE
tests: RAII guard for experimental feature settings

### DIFF
--- a/src/libstore-test-support/include/nix/store/tests/libstore.hh
+++ b/src/libstore-test-support/include/nix/store/tests/libstore.hh
@@ -10,6 +10,29 @@
 
 namespace nix {
 
+/**
+ * Scoped guard that enables an experimental feature for the lifetime
+ * of the object.
+ */
+struct EnableExperimentalFeature
+{
+    std::set<ExperimentalFeature> previous;
+
+    explicit EnableExperimentalFeature(std::string_view feature)
+        : previous(experimentalFeatureSettings.experimentalFeatures.get())
+    {
+        experimentalFeatureSettings.set("extra-experimental-features", std::string{feature});
+    }
+
+    ~EnableExperimentalFeature()
+    {
+        experimentalFeatureSettings.experimentalFeatures.assign(previous);
+    }
+
+    EnableExperimentalFeature(const EnableExperimentalFeature &) = delete;
+    EnableExperimentalFeature & operator=(const EnableExperimentalFeature &) = delete;
+};
+
 class LibStoreTest : public virtual ::testing::Test
 {
 public:

--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -5,6 +5,7 @@
 #include "nix_api_util.h"
 #include "nix_api_store.h"
 
+#include "nix/store/tests/libstore.hh"
 #include "nix/store/tests/nix_api_store.hh"
 #include "nix/store/globals.hh"
 #include "nix/util/tests/string_callback.hh"
@@ -293,6 +294,7 @@ struct LambdaAdapter
 class NixApiStoreTestWithRealisedPath : public nix_api_store_test_base
 {
 public:
+    std::optional<nix::EnableExperimentalFeature> enableCA;
     StorePath * drvPath = nullptr;
     nix_derivation * drv = nullptr;
     Store * store = nullptr;
@@ -305,7 +307,7 @@ public:
         GTEST_SKIP() << "Wine does not support symlinks needed for local store gcroots";
 #endif
 
-        nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
+        enableCA.emplace("ca-derivations");
         nix::settings.getWorkerSettings().substituters = {};
 
         store = open_local_store();
@@ -363,7 +365,7 @@ TEST_F(nix_api_store_test_base, build_from_json)
     GTEST_SKIP() << "Wine does not support symlinks needed for local store gcroots";
 #endif
     // FIXME get rid of these
-    nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
+    nix::EnableExperimentalFeature enableCA{"ca-derivations"};
     nix::settings.getWorkerSettings().substituters = {};
 
     auto * store = open_local_store();
@@ -413,7 +415,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_invalid_system)
     GTEST_SKIP() << "Wine does not support symlinks needed for local store gcroots";
 #endif
     // Test that nix_store_realise properly reports errors when the system is invalid
-    nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
+    nix::EnableExperimentalFeature enableCA{"ca-derivations"};
     nix::settings.getWorkerSettings().substituters = {};
 
     auto * store = open_local_store();
@@ -461,7 +463,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_builder_fails)
     GTEST_SKIP() << "Wine does not support symlinks needed for local store gcroots";
 #endif
     // Test that nix_store_realise properly reports errors when the builder fails
-    nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
+    nix::EnableExperimentalFeature enableCA{"ca-derivations"};
     nix::settings.getWorkerSettings().substituters = {};
 
     auto * store = open_local_store();
@@ -509,7 +511,7 @@ TEST_F(nix_api_store_test_base, nix_store_realise_builder_no_output)
     GTEST_SKIP() << "Wine does not support symlinks needed for local store gcroots";
 #endif
     // Test that nix_store_realise properly reports errors when builder succeeds but produces no output
-    nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
+    nix::EnableExperimentalFeature enableCA{"ca-derivations"};
     nix::settings.getWorkerSettings().substituters = {};
 
     auto * store = open_local_store();
@@ -705,7 +707,7 @@ TEST_F(NixApiStoreTestWithRealisedPath, nix_store_realise_output_ordering)
     // Test that nix_store_realise returns outputs in alphabetical order by output name.
     // This test uses a CA derivation with 10 outputs in randomized input order
     // to verify that the callback order is deterministic and alphabetical.
-    nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
+    nix::EnableExperimentalFeature enableCA{"ca-derivations"};
     nix::settings.getWorkerSettings().substituters = {};
 
     auto * store = open_local_store();

--- a/src/libstore-tests/worker-substitution.cc
+++ b/src/libstore-tests/worker-substitution.cc
@@ -176,8 +176,7 @@ TEST_F(WorkerSubstitutionTest, singleRootStoreObjectWithSingleDepStoreObject)
 
 TEST_F(WorkerSubstitutionTest, floatingDerivationOutput)
 {
-    // Enable CA derivations experimental feature
-    experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
+    EnableExperimentalFeature enableCA{"ca-derivations"};
 
     // Create a CA floating output derivation
     Derivation drv;
@@ -262,9 +261,6 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutput)
 
     // Verify the goal succeeded
     ASSERT_EQ(upcast_goal(goal)->exitCode, Goal::ecSuccess);
-
-    // Disable CA derivations experimental feature
-    experimentalFeatureSettings.set("extra-experimental-features", "");
 }
 
 /**
@@ -274,8 +270,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutput)
  */
 TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
 {
-    // Enable CA derivations experimental feature
-    experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
+    EnableExperimentalFeature enableCA{"ca-derivations"};
 
     // Create the dependency CA floating derivation
     Derivation depDrv;
@@ -426,9 +421,6 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
 
     // Verify the goal succeeded
     ASSERT_EQ(upcast_goal(goal)->exitCode, Goal::ecSuccess);
-
-    // Disable CA derivations experimental feature
-    experimentalFeatureSettings.set("extra-experimental-features", "");
 }
 
 } // namespace nix


### PR DESCRIPTION
## Motivation

Mutating global state in tests is fragile since manual restore calls are easy to forget or skip on early returns; an RAII guard ensures cleanup always happens.

## Context

- This was pulled out from #15289

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
