### PR TITLE
nix profile: fix tab completion for remove and upgrade

### DIFF
--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -565,16 +565,42 @@ class MixProfileElementMatchers : virtual Args, virtual StoreCommand, public vir
 
     void completeProfileElements(AddCompletions & completions, std::string_view prefix)
     {
-        auto * evalCmd = dynamic_cast<EvalCommand *>(this);
-        if (!evalCmd)
+        if (!profile)
             return;
 
-        auto evalState = evalCmd->getEvalState();
-        ProfileManifest manifest(*evalState, *profile);
+        // Read the manifest JSON directly to avoid the cost of
+        // initialising an EvalState, which is prohibitively slow
+        // in an interactive completion context.
+        try {
+            auto manifestPath = *profile / "manifest.json";
+            if (!std::filesystem::exists(manifestPath))
+                return;
 
-        for (auto & [name, element] : manifest.elements)
-            if (name.starts_with(prefix))
-                completions.add(name, element.identifier());
+            auto json = nlohmann::json::parse(readFile(manifestPath.string()));
+            auto elems = json["elements"];
+            if (!elems.is_object())
+                return;
+
+            for (auto & elem : elems.items()) {
+                auto name = elem.key();
+                if (!name.starts_with(prefix))
+                    continue;
+
+                // Build a human-readable description from the JSON
+                // without parsing flake refs or store paths.
+                std::string description;
+                auto & e = elem.value();
+                auto url = e.value("originalUrl", e.value("originalUri", ""));
+                auto attrPath = e.value("attrPath", "");
+                if (!url.empty())
+                    description = url + "#" + attrPath;
+
+                completions.add(name, description);
+            }
+        } catch (...) {
+            // If anything goes wrong reading the manifest, silently
+            // skip completions rather than breaking the shell.
+        }
     }
 
 public:


### PR DESCRIPTION
Disclaimer: this PR was vibe-coded.
I have tested it and it works well.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->
The completeProfileElements function initialised a full EvalState just to read element names from the profile manifest. This made completion too slow to be usable in an interactive shell context, causing NIX_GET_COMPLETIONS to return zero results.

For v3 manifests, element names are simply the keys of the JSON "elements" object. Read manifest.json directly and extract names and descriptions without EvalState. The completion description is built from the originalUrl and attrPath fields.

Failures are caught silently so a broken or missing manifest never interrupts the user's shell.
## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
