### PR TITLE
tests: add Realisation signing tests

### DIFF
--- a/src/libstore-tests/data/realisation/simple-fingerprint.txt
+++ b/src/libstore-tests/data/realisation/simple-fingerprint.txt
@@ -1,0 +1,1 @@
+{"key":{"drvPath":"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv","outputName":"foo"},"value":{"outPath":"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"}}

--- a/src/libstore-tests/data/realisation/with-signature-fingerprint.txt
+++ b/src/libstore-tests/data/realisation/with-signature-fingerprint.txt
@@ -1,0 +1,1 @@
+{"key":{"drvPath":"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv","outputName":"foo"},"value":{"outPath":"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv"}}

--- a/src/libstore-tests/realisation.cc
+++ b/src/libstore-tests/realisation.cc
@@ -5,6 +5,8 @@
 #include <rapidcheck/gtest.h>
 
 #include "nix/store/store-api.hh"
+#include "nix/util/signature/local-keys.hh"
+#include "nix/util/signature/signer.hh"
 
 #include "nix/util/tests/json-characterization.hh"
 #include "nix/store/tests/libstore.hh"
@@ -140,5 +142,93 @@ INSTANTIATE_TEST_SUITE_P(
             "unkeyed-with-signature",
             unkeyedWithSignature,
         }));
+
+/* ----------------------------------------------------------------------------
+ * Signing and verification
+ * --------------------------------------------------------------------------*/
+
+struct RealisationFingerprintTest : RealisationTest,
+                                    ::testing::WithParamInterface<std::pair<std::string_view, Realisation>>
+{};
+
+TEST_P(RealisationFingerprintTest, fingerprint)
+{
+    const auto & [name, realisation] = GetParam();
+    writeTest(std::string{name} + "-fingerprint.txt", [&]() -> std::string {
+        return realisation.fingerprint(realisation.id);
+    });
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RealisationSigning,
+    RealisationFingerprintTest,
+    ::testing::Values(
+        std::pair{
+            "simple",
+            simple,
+        },
+        std::pair{
+            "with-signature",
+            withSignature,
+        }));
+
+TEST_F(RealisationTest, sign_and_verify)
+{
+    auto secretKey = SecretKey::generate("test-key");
+    auto publicKey = secretKey.toPublicKey();
+    PublicKeys publicKeys;
+    publicKeys.insert_or_assign(publicKey.name, publicKey);
+
+    auto unsigned_ = unkeyedSimple;
+    ASSERT_EQ(unsigned_.signatures.size(), 0);
+
+    LocalSigner signer(std::move(secretKey));
+    unsigned_.sign(testDrvOutput, signer);
+
+    ASSERT_EQ(unsigned_.signatures.size(), 1);
+    ASSERT_EQ(unsigned_.checkSignatures(testDrvOutput, publicKeys), 1);
+}
+
+TEST_F(RealisationTest, verify_rejects_wrong_key)
+{
+    auto secretKey = SecretKey::generate("signing-key");
+    auto wrongKey = SecretKey::generate("wrong-key");
+    auto wrongPublicKey = wrongKey.toPublicKey();
+    PublicKeys publicKeys;
+    publicKeys.insert_or_assign(wrongPublicKey.name, wrongPublicKey);
+
+    auto r = unkeyedSimple;
+    LocalSigner signer(std::move(secretKey));
+    r.sign(testDrvOutput, signer);
+
+    ASSERT_EQ(r.signatures.size(), 1);
+    ASSERT_EQ(r.checkSignatures(testDrvOutput, publicKeys), 0);
+}
+
+TEST_F(RealisationTest, verify_rejects_tampered_outpath)
+{
+    auto secretKey = SecretKey::generate("test-key");
+    auto publicKey = secretKey.toPublicKey();
+    PublicKeys publicKeys;
+    publicKeys.insert_or_assign(publicKey.name, publicKey);
+
+    auto r = unkeyedSimple;
+    LocalSigner signer(std::move(secretKey));
+    r.sign(testDrvOutput, signer);
+
+    // Tamper with the output path after signing.
+    r.outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar"};
+
+    ASSERT_EQ(r.checkSignatures(testDrvOutput, publicKeys), 0);
+}
+
+TEST_F(RealisationTest, signatures_stripped_from_fingerprint)
+{
+    auto fp = withSignature.fingerprint(withSignature.id);
+    auto parsed = json::parse(fp);
+    auto value = parsed.find("value");
+    ASSERT_NE(value, parsed.end());
+    ASSERT_EQ(value->find("signatures"), value->end());
+}
 
 } // namespace nix


### PR DESCRIPTION
## Motivation

`UnkeyedRealisation::sign()` and `checkSignatures()` had no test coverage. This adds characterisation tests for fingerprint output and behavioral tests for sign-then-verify, wrong-key rejection, tampered-outpath rejection, and signature stripping.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
