### PR TITLE
Separate building/scheduling from storage

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -15,6 +15,7 @@
 #include "nix/expr/eval.hh"
 #include "nix/expr/eval-settings.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 #include "nix/main/shared.hh"
 #include "nix/flake/flake.hh"
 #include "nix/expr/eval-cache.hh"
@@ -631,7 +632,7 @@ std::vector<std::pair<ref<Installable>, BuiltPathWithResult>> Installable::build
         if (settings.printMissing)
             printMissing(store, pathsToBuild, lvlInfo);
 
-        auto buildResults = store->buildPathsWithResults(pathsToBuild, bMode, evalStore);
+        auto buildResults = store->getBuilder(evalStore)->buildPathsWithResults(pathsToBuild, bMode);
         throwBuildErrors(buildResults, *store);
         for (auto & buildResult : buildResults) {
             for (auto & aux : backmap[buildResult.path]) {

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -26,6 +26,7 @@
 #include "nix/util/finally.hh"
 #include "nix/cmd/markdown.hh"
 #include "nix/store/local-fs-store.hh"
+#include "nix/store/build.hh"
 #include "nix/expr/print.hh"
 #include "nix/util/ref.hh"
 #include "nix/expr/value.hh"
@@ -548,7 +549,7 @@ ProcessLineResult NixRepl::processLine(std::string line)
         std::string drvPathRaw = state->store->printStorePath(drvPath);
 
         if (command == ":b" || command == ":bl") {
-            state->store->buildPaths({
+            state->store->getBuilder()->buildPaths({
                 DerivedPath::Built{
                     .drvPath = makeConstantStorePathRef(drvPath),
                     .outputs = OutputsSpec::All{},

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -11,6 +11,7 @@
 #include "nix/store/path-references.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/mounted-source-accessor.hh"
+#include "nix/store/build.hh"
 #include "nix/util/util.hh"
 #include "nix/util/os-string.hh"
 #include "nix/util/processes.hh"
@@ -126,7 +127,7 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
     buildReqs.reserve(drvs.size());
     for (auto & d : drvs)
         buildReqs.emplace_back(DerivedPath{d});
-    buildStore->buildPaths(buildReqs, bmNormal, store);
+    buildStore->getBuilder(store)->buildPaths(buildReqs, bmNormal);
 
     StorePathSet outputsToCopyAndAllow;
 
@@ -1973,7 +1974,7 @@ static void prim_storePath(EvalState & state, const PosIdx pos, Value ** args, V
         state.error<EvalError>("path '%1%' is not in the Nix store", sourcePath).atPos(pos).debugThrow();
     auto storePath = state.store->toStorePath(sourcePath.path.abs()).first;
     if (!state.storeFS->getMount(CanonPath(state.store->printStorePath(storePath))) && !settings.readOnlyMode)
-        state.store->ensurePath(storePath);
+        state.store->getBuilder()->ensurePath(storePath);
     context.insert(NixStringContextElem::Opaque{.path = storePath});
     v.mkString(sourcePath.path.abs(), context, state.mem);
 }

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -2,6 +2,7 @@
 #include "nix/expr/eval-inline.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 #include "nix/store/globals.hh"
 
 namespace nix {
@@ -272,7 +273,7 @@ static void prim_appendContext(EvalState & state, const PosIdx pos, Value ** arg
             state.error<EvalError>("context key '%s' is not a store path", name).atPos(i.pos).debugThrow();
         auto namePath = state.store->parseStorePath(name);
         if (!settings.readOnlyMode)
-            state.store->ensurePath(namePath);
+            state.store->getBuilder()->ensurePath(namePath);
         state.forceAttrs(*i.value, i.pos, "while evaluating the value of a string context");
 
         if (auto attr = i.value->attrs()->get(sPath)) {

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -5,6 +5,7 @@
 #include "nix/expr/eval-settings.hh"
 #include "nix/expr/fetch-tree.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 #include "nix/fetchers/fetchers.hh"
 #include "nix/store/filetransfer.hh"
 #include "nix/fetchers/registry.hh"
@@ -562,7 +563,7 @@ static void fetch(
 
         // Try to get the path from the local store or substituters
         try {
-            state.store->ensurePath(expectedPath);
+            state.store->getBuilder()->ensurePath(expectedPath);
             debug("using substituted/cached path '%s' for '%s'", state.store->printStorePath(expectedPath), *url);
             state.allowAndSetStorePathString(expectedPath, v);
             return;

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -1,6 +1,7 @@
 #include "nix/fetchers/fetchers.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/fs-sink.hh"
+#include "nix/store/build.hh"
 #include "nix/util/source-path.hh"
 #include "nix/fetchers/fetch-to-store.hh"
 #include "nix/util/json-utils.hh"
@@ -321,7 +322,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
 
             store.addTempRoot(storePath);
 
-            store.ensurePath(storePath);
+            store.getBuilder()->ensurePath(storePath);
 
             debug("using substituted/cached input '%s' in '%s'", to_string(), store.printStorePath(storePath));
 

--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -8,6 +8,7 @@
 
 #include "nix/store/path.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 #include "nix/store/store-open.hh"
 #include "nix/store/store-reference.hh"
 #include "nix/store/build-result.hh"
@@ -178,7 +179,7 @@ nix_err nix_store_realise(
             .drvPath = nix::makeConstantStorePathRef(path->path), .outputs = nix::OutputsSpec::All{}}};
 
         const auto nixStore = store->ptr;
-        auto results = nixStore->buildPathsWithResults(paths, nix::bmNormal, nixStore);
+        auto results = nixStore->getBuilder(nixStore)->buildPathsWithResults(paths, nix::bmNormal);
 
         assert(results.size() == 1);
 

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1,5 +1,7 @@
 #include "nix/store/build/derivation-building-goal.hh"
 #include "nix/store/build/derivation-env-desugar.hh"
+#include "nix/store/restricted-store.hh"
+#include "nix/store/daemon.hh"
 #ifndef _WIN32 // TODO enable build hook on Windows
 #  include "nix/store/build/hook-instance.hh"
 #  include "nix/store/build/derivation-builder.hh"
@@ -939,6 +941,22 @@ Goal::Co DerivationBuildingGoal::buildLocally(
                 void closeLogFile() override
                 {
                     closeLogFileFn();
+                }
+
+                void processDaemonConnection(
+                    ref<Store> store, FdSource && from, FdSink && to, RestrictionContext & context) override
+                {
+                    /**
+                     * TODO: We create a fresh Worker here because the
+                     * parent Worker is blocked waiting for the current
+                     * build to finish, so we can't reuse it from a
+                     * daemon thread. Ideally we should reuse the same
+                     * Worker to share scheduling state.
+                     */
+                    Worker freshWorker{goal.worker.store, goal.worker.evalStore};
+                    auto builder = makeRestrictedBuilder(freshWorker, context);
+                    daemon::processConnection(
+                        store, std::move(from), std::move(to), NotTrusted, daemon::Recursive, builder.get_ptr());
                 }
             };
 

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -3,18 +3,47 @@
 #include "nix/store/build/substitution-goal.hh"
 #include "nix/store/build/derivation-trampoline-goal.hh"
 #include "nix/util/strings.hh"
+#include <memory>
 
 namespace nix {
 
-void Store::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMode, std::shared_ptr<Store> evalStore)
+void LocalBuilder::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMode)
 {
-    Worker worker(*this, evalStore ? *evalStore : *this);
+    getWorker()->buildPaths(reqs, buildMode);
+}
 
+std::vector<KeyedBuildResult>
+LocalBuilder::buildPathsWithResults(const std::vector<DerivedPath> & reqs, BuildMode buildMode)
+{
+    return getWorker()->buildPathsWithResults(reqs, buildMode);
+}
+
+BuildResult LocalBuilder::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
+{
+    return getWorker()->buildDerivation(drvPath, drv, buildMode);
+}
+
+void LocalBuilder::ensurePath(const StorePath & path)
+{
+    /* If the path is already valid, we're done. */
+    if (store->isValidPath(path))
+        return;
+
+    getWorker()->ensurePath(path);
+}
+
+void LocalBuilder::repairPath(const StorePath & path)
+{
+    getWorker()->repairPath(path);
+}
+
+void Worker::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMode)
+{
     Goals goals;
     for (auto & br : reqs)
-        goals.insert(worker.makeGoal(br, buildMode));
+        goals.insert(makeGoal(br, buildMode));
 
-    worker.run(goals);
+    run(goals);
 
     StringSet failed;
     BuildResult::Failure * failure = nullptr;
@@ -27,38 +56,35 @@ void Store::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMod
         }
         if (i->exitCode != Goal::ecSuccess) {
             if (auto i2 = dynamic_cast<DerivationTrampolineGoal *>(i.get()))
-                failed.insert(i2->drvReq->to_string(*this));
+                failed.insert(i2->drvReq->to_string(store));
             else if (auto i2 = dynamic_cast<PathSubstitutionGoal *>(i.get()))
-                failed.insert(printStorePath(i2->storePath));
+                failed.insert(store.printStorePath(i2->storePath));
         }
     }
 
     if (failed.size() == 1 && failure) {
-        failure->withExitStatus(worker.exitStatusFlags.failingExitStatus());
+        failure->withExitStatus(exitStatusFlags.failingExitStatus());
         throw *failure;
     } else if (!failed.empty()) {
-        auto exitStatus = worker.exitStatusFlags.failingExitStatus();
+        auto exitStatus = exitStatusFlags.failingExitStatus();
         if (failure)
             logError(failure->info());
         throw Error(exitStatus, "build of %s failed", concatStringsSep(", ", quoteStrings(failed)));
     }
 }
 
-std::vector<KeyedBuildResult> Store::buildPathsWithResults(
-    const std::vector<DerivedPath> & reqs, BuildMode buildMode, std::shared_ptr<Store> evalStore)
+std::vector<KeyedBuildResult> Worker::buildPathsWithResults(const std::vector<DerivedPath> & reqs, BuildMode buildMode)
 {
-    Worker worker(*this, evalStore ? *evalStore : *this);
-
     Goals goals;
     std::vector<std::pair<const DerivedPath &, GoalPtr>> state;
 
     for (const auto & req : reqs) {
-        auto goal = worker.makeGoal(req, buildMode);
+        auto goal = makeGoal(req, buildMode);
         goals.insert(goal);
         state.push_back({req, goal});
     }
 
-    worker.run(goals);
+    run(goals);
 
     std::vector<KeyedBuildResult> results;
     results.reserve(state.size());
@@ -79,13 +105,12 @@ std::vector<KeyedBuildResult> Store::buildPathsWithResults(
     return results;
 }
 
-BuildResult Store::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
+BuildResult Worker::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
 {
-    Worker worker(*this, *this);
-    auto goal = worker.makeDerivationTrampolineGoal(drvPath, OutputsSpec::All{}, drv, buildMode);
+    auto goal = makeDerivationTrampolineGoal(drvPath, OutputsSpec::All{}, drv, buildMode);
 
     try {
-        worker.run(Goals{goal});
+        run(Goals{goal});
         return goal->buildResult;
     } catch (Error & e) {
         return BuildResult{
@@ -96,49 +121,47 @@ BuildResult Store::buildDerivation(const StorePath & drvPath, const BasicDerivat
     };
 }
 
-void Store::ensurePath(const StorePath & path)
+void Worker::ensurePath(const StorePath & path)
 {
     /* If the path is already valid, we're done. */
-    if (isValidPath(path))
+    if (store.isValidPath(path))
         return;
 
-    Worker worker(*this, *this);
-    GoalPtr goal = worker.makePathSubstitutionGoal(path);
+    GoalPtr goal = makePathSubstitutionGoal(path);
     Goals goals = {goal};
 
-    worker.run(goals);
+    run(goals);
 
     if (goal->exitCode != Goal::ecSuccess) {
-        auto exitStatus = worker.exitStatusFlags.failingExitStatus();
+        auto exitStatus = exitStatusFlags.failingExitStatus();
         goal->buildResult.tryThrowBuildError(exitStatus);
-        throw Error(exitStatus, "path '%s' does not exist and cannot be created", printStorePath(path));
+        throw Error(exitStatus, "path '%s' does not exist and cannot be created", store.printStorePath(path));
     }
 }
 
-void Store::repairPath(const StorePath & path)
+void Worker::repairPath(const StorePath & path)
 {
-    Worker worker(*this, *this);
-    GoalPtr goal = worker.makePathSubstitutionGoal(path, Repair);
+    GoalPtr goal = makePathSubstitutionGoal(path, Repair);
     Goals goals = {goal};
 
-    worker.run(goals);
+    run(goals);
 
     if (goal->exitCode != Goal::ecSuccess) {
         /* Since substituting the path didn't work, if we have a valid
            deriver, then rebuild the deriver. */
-        auto info = queryPathInfo(path);
-        if (info->deriver && isValidPath(*info->deriver)) {
+        auto info = store.queryPathInfo(path);
+        if (info->deriver && store.isValidPath(*info->deriver)) {
             goals.clear();
-            goals.insert(worker.makeGoal(
+            goals.insert(makeGoal(
                 DerivedPath::Built{
                     .drvPath = makeConstantStorePathRef(*info->deriver),
                     // FIXME: Should just build the specific output we need.
                     .outputs = OutputsSpec::All{},
                 },
                 bmRepair));
-            worker.run(goals);
+            run(goals);
         } else
-            throw Error(worker.exitStatusFlags.failingExitStatus(), "cannot repair path '%s'", printStorePath(path));
+            throw Error(exitStatusFlags.failingExitStatus(), "cannot repair path '%s'", store.printStorePath(path));
     }
 }
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -4,6 +4,7 @@
 #include "nix/store/worker-protocol.hh"
 #include "nix/store/worker-protocol-connection.hh"
 #include "nix/store/worker-protocol-impl.hh"
+#include "nix/store/build.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/store-cast.hh"
 #include "nix/store/filetransfer.hh"
@@ -308,7 +309,8 @@ static void performOp(
     TrustedFlag trusted,
     RecursiveFlag recursive,
     WorkerProto::BasicServerConnection & conn,
-    WorkerProto::Op op)
+    WorkerProto::Op op,
+    Builder & builder)
 {
     WorkerProto::ReadConn rconn(conn);
     WorkerProto::WriteConn wconn(conn);
@@ -555,7 +557,7 @@ static void performOp(
         if (mode == bmRepair && !trusted)
             throw Error("repairing is not allowed because you are not in 'trusted-users'");
         logger->startWork();
-        store->buildPaths(drvs, mode);
+        builder.buildPaths(drvs, mode);
         logger->stopWork();
         conn.to << 1;
         break;
@@ -574,7 +576,7 @@ static void performOp(
             throw Error("repairing is not allowed because you are not in 'trusted-users'");
 
         logger->startWork();
-        auto results = store->buildPathsWithResults(drvs, mode);
+        auto results = builder.buildPathsWithResults(drvs, mode);
         logger->stopWork();
 
         WorkerProto::write(*store, wconn, results);
@@ -653,7 +655,7 @@ static void performOp(
             drvPath = store->writeDerivation(Derivation{drv2});
         }
 
-        auto res = store->buildDerivation(drvPath, drv, buildMode);
+        auto res = builder.buildDerivation(drvPath, drv, buildMode);
         logger->stopWork();
         WorkerProto::write(*store, wconn, res);
         break;
@@ -662,7 +664,7 @@ static void performOp(
     case WorkerProto::Op::EnsurePath: {
         auto path = WorkerProto::Serialise<StorePath>::read(*store, rconn);
         logger->startWork();
-        store->ensurePath(path);
+        builder.ensurePath(path);
         logger->stopWork();
         conn.to << 1;
         break;
@@ -1052,7 +1054,13 @@ static void performOp(
     }
 }
 
-void processConnection(ref<Store> store, FdSource && from, FdSink && to, TrustedFlag trusted, RecursiveFlag recursive)
+void processConnection(
+    ref<Store> store,
+    FdSource && from,
+    FdSink && to,
+    TrustedFlag trusted,
+    RecursiveFlag recursive,
+    std::shared_ptr<Builder> builder)
 {
 #ifndef _WIN32 // TODO need graceful async exit support on Windows?
     auto monitor = !recursive ? std::make_unique<MonitorFdHup>(from.fd) : nullptr;
@@ -1069,6 +1077,9 @@ void processConnection(ref<Store> store, FdSource && from, FdSink && to, Trusted
         }
     });
 #endif
+
+    if (!builder)
+        builder = store->getBuilder();
 
     /* Exchange the greeting. */
     auto localVersion = WorkerProto::latest;
@@ -1136,7 +1147,7 @@ void processConnection(ref<Store> store, FdSource && from, FdSink && to, Trusted
             debug("performing daemon worker op: %d", op);
 
             try {
-                performOp(tunnelLogger, store, trusted, recursive, conn, op);
+                performOp(tunnelLogger, store, trusted, recursive, conn, op, *builder);
             } catch (Error & e) {
                 /* If we're not in a state where we can send replies, then
                    something went wrong processing the input of the

--- a/src/libstore/include/nix/store/build.hh
+++ b/src/libstore/include/nix/store/build.hh
@@ -1,0 +1,97 @@
+#pragma once
+///@file
+
+#include "nix/store/store-api.hh"
+
+namespace nix {
+
+/**
+ * Abstract interface for the build scheduler entry points.
+ *
+ * `Worker` implements this for local scheduling, including local builds.
+ * Remote stores provide a `Builder` via `Store::getBuilder()`.
+ *
+ * Thread safety should be guaranteed across these methods.
+ */
+struct Builder
+{
+    /* VTable anchor to avoid weak linkage of the vtable - it breaks
+       dynamic_cast across shared libraries on Darwin. */
+    virtual void anchor();
+
+    /**
+     * For each path, if it's a derivation, build it.  Building a
+     * derivation means ensuring that the output paths are valid.  If
+     * they are already valid, this is a no-op.  Otherwise, validity
+     * can be reached in two ways.  First, if the output paths is
+     * substitutable, then build the path that way.  Second, the
+     * output paths can be created by running the builder, after
+     * recursively building any sub-derivations. For inputs that are
+     * not derivations, substitute them.
+     */
+    virtual void buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMode = bmNormal) = 0;
+
+    /**
+     * Like buildPaths(), but return a vector of \ref BuildResult
+     * BuildResults corresponding to each element in paths. Note that in
+     * case of a build/substitution error, this function won't throw an
+     * exception, but return a BuildResult containing an error message.
+     */
+    virtual std::vector<KeyedBuildResult>
+    buildPathsWithResults(const std::vector<DerivedPath> & reqs, BuildMode buildMode = bmNormal) = 0;
+
+    /**
+     * Build a single non-materialized derivation (i.e. not from an
+     * on-disk .drv file).
+     *
+     * @param drvPath This is used to deduplicate worker goals so it is
+     * imperative that is correct. That said, it doesn't literally need
+     * to be store path that would be calculated from writing this
+     * derivation to the store: it is OK if it instead is that of a
+     * Derivation which would resolve to this (by taking the outputs of
+     * it's input derivations and adding them as input sources) such
+     * that the build time referenceable-paths are the same.
+     *
+     * In the input-addressed case, we usually *do* use an "original"
+     * unresolved derivations's path, as that is what will be used in the
+     * buildPaths case. Also, the input-addressed output paths are verified
+     * only by that contents of that specific unresolved derivation, so it is
+     * nice to keep that information around so if the original derivation is
+     * ever obtained later, it can be verified whether the trusted user in fact
+     * used the proper output path.
+     *
+     * In the content-addressed case, we want to always use the resolved
+     * drv path calculated from the provided derivation. This serves two
+     * purposes:
+     *
+     *   - It keeps the operation trustless, by ruling out a maliciously
+     *     invalid drv path corresponding to a non-resolution-equivalent
+     *     derivation.
+     *
+     *   - For the floating case in particular, it ensures that the derivation
+     *     to output mapping respects the resolution equivalence relation, so
+     *     one cannot choose different resolution-equivalent derivations to
+     *     subvert dependency coherence (i.e. the property that one doesn't end
+     *     up with multiple different versions of dependencies without
+     *     explicitly choosing to allow it).
+     */
+    virtual BuildResult
+    buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode = bmNormal) = 0;
+
+    /**
+     * Ensure that a path is valid.  If it is not currently valid, it
+     * may be made valid by running a substitute (if defined for the
+     * path).
+     */
+    virtual void ensurePath(const StorePath & path) = 0;
+
+    /**
+     * Repair the contents of the given path by redownloading it using
+     * a substituter (if available).
+     */
+    virtual void repairPath(const StorePath & path) = 0;
+
+    virtual ~Builder() = default;
+};
+
+} // namespace nix

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -140,6 +140,13 @@ struct DerivationBuilderCallbacks
      * @todo this should be reworked
      */
     virtual void childTerminated() = 0;
+
+    /**
+     * Process a recursive Nix daemon connection, using a builder
+     * that enforces the restrictions of the given context.
+     */
+    virtual void
+    processDaemonConnection(ref<Store> store, FdSource && from, FdSink && to, RestrictionContext & context) = 0;
 };
 
 /**

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -3,6 +3,7 @@
 
 #include "nix/util/types.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 #include "nix/store/derived-path-map.hh"
 #include "nix/store/build/goal.hh"
 #include "nix/store/build-result.hh"
@@ -68,9 +69,43 @@ struct HookInstance;
 #endif
 
 /**
+ * Owns a worker. Optimization around ensurePath to prevent a Worker from
+ * being constructed when it's not needed.
+ */
+class LocalBuilder : public Builder
+{
+public:
+    LocalBuilder(ref<Store> store, ref<Store> evalStore)
+        : store(store)
+        , evalStore(evalStore) {};
+
+    /* Builder interface — see `Builder` for documentation. */
+
+    void buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMode) override;
+    std::vector<KeyedBuildResult>
+    buildPathsWithResults(const std::vector<DerivedPath> & reqs, BuildMode buildMode) override;
+    BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
+    void ensurePath(const StorePath & path) override;
+    void repairPath(const StorePath & path) override;
+
+private:
+    /**
+     * Intentionally construct a new worker for each operation, to avoid
+     * reusing a worker between calls, allowing for thread safety.
+     */
+    inline std::shared_ptr<Worker> getWorker()
+    {
+        return std::make_shared<Worker>(*store, *evalStore);
+    }
+
+    ref<Store> store;
+    ref<Store> evalStore;
+};
+
+/**
  * Coordinates one or more realisations and their interdependencies.
  */
-class Worker
+class Worker : public Builder
 {
 private:
 
@@ -199,6 +234,7 @@ public:
 
     Store & store;
     Store & evalStore;
+
     const WorkerSettings & settings;
 
     /**
@@ -388,6 +424,15 @@ public:
         act.setExpected(actFileTransfer, expectedDownloadSize + doneDownloadSize);
         act.setExpected(actCopyPath, expectedNarSize + doneNarSize);
     }
+
+    /* Builder interface — see `Builder` for documentation. */
+
+    void buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMode) override;
+    std::vector<KeyedBuildResult>
+    buildPathsWithResults(const std::vector<DerivedPath> & reqs, BuildMode buildMode) override;
+    BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
+    void ensurePath(const StorePath & path) override;
+    void repairPath(const StorePath & path) override;
 };
 
 } // namespace nix

--- a/src/libstore/include/nix/store/daemon.hh
+++ b/src/libstore/include/nix/store/daemon.hh
@@ -4,10 +4,22 @@
 #include "nix/util/serialise.hh"
 #include "nix/store/store-api.hh"
 
-namespace nix::daemon {
+namespace nix {
+
+struct Builder;
+
+namespace daemon {
 
 enum RecursiveFlag : bool { NotRecursive = false, Recursive = true };
 
-void processConnection(ref<Store> store, FdSource && from, FdSink && to, TrustedFlag trusted, RecursiveFlag recursive);
+void processConnection(
+    ref<Store> store,
+    FdSource && from,
+    FdSink && to,
+    TrustedFlag trusted,
+    RecursiveFlag recursive,
+    std::shared_ptr<Builder> builder = nullptr);
 
-} // namespace nix::daemon
+} // namespace daemon
+
+} // namespace nix

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -2,7 +2,6 @@
 ///@file
 
 #include "nix/store/common-ssh-store-config.hh"
-#include "nix/store/store-api.hh"
 #include "nix/store/ssh.hh"
 #include "nix/util/callback.hh"
 #include "nix/util/pool.hh"
@@ -140,24 +139,7 @@ public:
 
 public:
 
-    BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
-
-    /**
-     * Note, the returned function must only be called once, or we'll
-     * try to read from the connection twice.
-     *
-     * @todo Use C++23 `std::move_only_function`.
-     */
-    fun<BuildResult()> buildDerivationAsync(
-        const StorePath & drvPath, const BasicDerivation & drv, const ServeProto::BuildOptions & options);
-
-    void buildPaths(
-        const std::vector<DerivedPath> & drvPaths, BuildMode buildMode, std::shared_ptr<Store> evalStore) override;
-
-    void ensurePath(const StorePath & path) override
-    {
-        unsupported("ensurePath");
-    }
+    ref<Builder> getBuilder(std::shared_ptr<Store> evalStore) override;
 
     ref<SourceAccessor> getFSAccessor(bool requireValidPath) override
     {
@@ -167,19 +149,6 @@ public:
     std::shared_ptr<SourceAccessor> getFSAccessor(const StorePath & path, bool requireValidPath) override
     {
         unsupported("getFSAccessor");
-    }
-
-    /**
-     * The default instance would schedule the work on the client side, but
-     * for consistency with `buildPaths` and `buildDerivation` it should happen
-     * on the remote side.
-     *
-     * We make this fail for now so we can add implement this properly later
-     * without it being a breaking change.
-     */
-    void repairPath(const StorePath & path) override
-    {
-        unsupported("repairPath");
     }
 
     void computeFSClosure(
@@ -232,6 +201,8 @@ public:
         // not supported
         return {};
     }
+
+    friend struct LegacySSHBuilder;
 };
 
 } // namespace nix

--- a/src/libstore/include/nix/store/machines.hh
+++ b/src/libstore/include/nix/store/machines.hh
@@ -16,6 +16,13 @@ struct Machine
 {
 
     const StoreReference storeUri;
+    /**
+     * @TODO this information should eventually just exist to update an
+     * underlying setting on `Store::Config`, just as the feature information
+     * updates `Store::Config::systemType`. The only wrinkle is whether the
+     * makes sense for separate local stores to have distinct systems, when they
+     * are all the current OS, just different part of the file system.
+     */
     const StringSet systemTypes;
     const std::optional<std::filesystem::path> sshKey;
     const unsigned int maxJobs;

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -13,6 +13,7 @@ headers = [ config_pub_h ] + files(
   'aws-creds.hh',
   'binary-cache-store.hh',
   'build-result.hh',
+  'build.hh',
   'build/build-log.hh',
   'build/derivation-builder.hh',
   'build/derivation-building-goal.hh',

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -124,15 +124,7 @@ public:
     void queryRealisationUncached(
         const DrvOutput &, Callback<std::shared_ptr<const UnkeyedRealisation>> callback) noexcept override;
 
-    void
-    buildPaths(const std::vector<DerivedPath> & paths, BuildMode buildMode, std::shared_ptr<Store> evalStore) override;
-
-    std::vector<KeyedBuildResult> buildPathsWithResults(
-        const std::vector<DerivedPath> & paths, BuildMode buildMode, std::shared_ptr<Store> evalStore) override;
-
-    BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
-
-    void ensurePath(const StorePath & path) override;
+    ref<Builder> getBuilder(std::shared_ptr<Store> evalStore) override;
 
     void addTempRoot(const StorePath & path) override;
 
@@ -149,19 +141,6 @@ public:
     void optimiseStore() override;
 
     bool verifyStore(bool checkContents, RepairFlag repair) override;
-
-    /**
-     * The default instance would schedule the work on the client side, but
-     * for consistency with `buildPaths` and `buildDerivation` it should happen
-     * on the remote side.
-     *
-     * We make this fail for now so we can add implement this properly later
-     * without it being a breaking change.
-     */
-    void repairPath(const StorePath & path) override
-    {
-        unsupported("repairPath");
-    }
 
     void addSignatures(const StorePath & storePath, const std::set<Signature> & sigs) override;
 
@@ -230,7 +209,7 @@ private:
      */
     Sync<std::set<Descriptor>> connectionFds;
 
-    void copyDrvsFromEvalStore(const std::vector<DerivedPath> & paths, std::shared_ptr<Store> evalStore);
+    friend struct RemoteBuilder;
 };
 
 } // namespace nix

--- a/src/libstore/include/nix/store/restricted-store.hh
+++ b/src/libstore/include/nix/store/restricted-store.hh
@@ -8,8 +8,10 @@
 
 namespace nix {
 
+struct Builder;
 class LocalStore;
 struct LocalStoreConfig;
+class Worker;
 
 /**
  * A restricted store has a pointer to one of these, which manages the
@@ -115,5 +117,11 @@ protected:
  * Create a shared pointer to a restricted store.
  */
 ref<Store> makeRestrictedStore(ref<LocalStoreConfig> config, ref<LocalStore> next, RestrictionContext & context);
+
+/**
+ * Create a builder that wraps an inner builder, adding restriction
+ * checks and dependency tracking for recursive Nix builds.
+ */
+ref<Builder> makeRestrictedBuilder(Worker & inner, RestrictionContext & context);
 
 } // namespace nix

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -57,6 +57,8 @@ enum TrustedFlag : bool { NotTrusted = false, Trusted = true };
 struct BuildResult;
 struct KeyedBuildResult;
 
+struct Builder;
+
 typedef std::map<StorePath, std::optional<ContentAddress>> StorePathCAMap;
 
 /**
@@ -456,6 +458,15 @@ public:
     virtual ~Store() {}
 
     /**
+     * Get a `Builder` for this store.
+     *
+     * @param evalStore If provided and different from this store,
+     * derivation files will be copied from the eval store to this
+     * store before building.
+     */
+    virtual ref<Builder> getBuilder(std::shared_ptr<Store> evalStore = nullptr);
+
+    /**
      * Follow symlinks until we end up with a path in the Nix store.
      */
     std::filesystem::path followLinksToStore(std::string_view path) const;
@@ -481,6 +492,8 @@ public:
      * If requested, substitute missing paths. This
      * implements nix-copy-closure's --use-substitutes
      * flag.
+     *
+     * @TODO suspicious to have a Store method that uses `getBuilder`.
      */
     void substitutePaths(const StorePathSet & paths);
 
@@ -744,77 +757,6 @@ public:
     virtual void narFromPath(const StorePath & path, Sink & sink);
 
     /**
-     * For each path, if it's a derivation, build it.  Building a
-     * derivation means ensuring that the output paths are valid.  If
-     * they are already valid, this is a no-op.  Otherwise, validity
-     * can be reached in two ways.  First, if the output paths is
-     * substitutable, then build the path that way.  Second, the
-     * output paths can be created by running the builder, after
-     * recursively building any sub-derivations. For inputs that are
-     * not derivations, substitute them.
-     */
-    virtual void buildPaths(
-        const std::vector<DerivedPath> & paths,
-        BuildMode buildMode = bmNormal,
-        std::shared_ptr<Store> evalStore = nullptr);
-
-    /**
-     * Like buildPaths(), but return a vector of \ref BuildResult
-     * BuildResults corresponding to each element in paths. Note that in
-     * case of a build/substitution error, this function won't throw an
-     * exception, but return a BuildResult containing an error message.
-     */
-    virtual std::vector<KeyedBuildResult> buildPathsWithResults(
-        const std::vector<DerivedPath> & paths,
-        BuildMode buildMode = bmNormal,
-        std::shared_ptr<Store> evalStore = nullptr);
-
-    /**
-     * Build a single non-materialized derivation (i.e. not from an
-     * on-disk .drv file).
-     *
-     * @param drvPath This is used to deduplicate worker goals so it is
-     * imperative that is correct. That said, it doesn't literally need
-     * to be store path that would be calculated from writing this
-     * derivation to the store: it is OK if it instead is that of a
-     * Derivation which would resolve to this (by taking the outputs of
-     * it's input derivations and adding them as input sources) such
-     * that the build time referenceable-paths are the same.
-     *
-     * In the input-addressed case, we usually *do* use an "original"
-     * unresolved derivations's path, as that is what will be used in the
-     * buildPaths case. Also, the input-addressed output paths are verified
-     * only by that contents of that specific unresolved derivation, so it is
-     * nice to keep that information around so if the original derivation is
-     * ever obtained later, it can be verified whether the trusted user in fact
-     * used the proper output path.
-     *
-     * In the content-addressed case, we want to always use the resolved
-     * drv path calculated from the provided derivation. This serves two
-     * purposes:
-     *
-     *   - It keeps the operation trustless, by ruling out a maliciously
-     *     invalid drv path corresponding to a non-resolution-equivalent
-     *     derivation.
-     *
-     *   - For the floating case in particular, it ensures that the derivation
-     *     to output mapping respects the resolution equivalence relation, so
-     *     one cannot choose different resolution-equivalent derivations to
-     *     subvert dependency coherence (i.e. the property that one doesn't end
-     *     up with multiple different versions of dependencies without
-     *     explicitly choosing to allow it).
-     */
-    virtual BuildResult
-    buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode = bmNormal);
-
-    /**
-     * Ensure that a path is valid.  If it is not currently valid, it
-     * may be made valid by running a substitute (if defined for the
-     * path).
-     */
-    virtual void ensurePath(const StorePath & path);
-
-    /**
      * Add a store path as a temporary root of the garbage collector.
      * The root disappears as soon as we exit.
      * Before exiting, if you want to avoid the path being GC'ed, you either have to make it a permanent root using
@@ -921,12 +863,6 @@ public:
     }
 
     /**
-     * Repair the contents of the given path by redownloading it using
-     * a substituter (if available).
-     */
-    virtual void repairPath(const StorePath & path);
-
-    /**
      * Add signatures to the specified store path. The signatures are
      * not verified.
      */
@@ -948,6 +884,8 @@ public:
     /**
      * Read a derivation, after ensuring its existence through
      * ensurePath().
+     *
+     * @TODO suspicious to have a Store method that uses `getBuilder`.
      */
     Derivation derivationFromPath(const StorePath & drvPath);
 

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -12,11 +12,60 @@
 #include "nix/store/path-with-outputs.hh"
 #include "nix/store/ssh.hh"
 #include "nix/store/derivations.hh"
+#include "nix/store/build.hh"
 #include "nix/util/callback.hh"
 #include "nix/store/store-registration.hh"
 #include "nix/store/globals.hh"
 
 namespace nix {
+
+struct LegacySSHBuilder : Builder
+{
+    ref<LegacySSHStore> store;
+
+    LegacySSHBuilder(ref<LegacySSHStore> store)
+        : store(store)
+    {
+    }
+
+private:
+
+    [[noreturn]] void unsupported(const std::string & op)
+    {
+        throw Unsupported("operation '%s' is not supported by store '%s'", op, store->config->getHumanReadableURI());
+    }
+
+    std::variant<BuildResultSuccessStatus, BuildError>
+    buildPathsRaw(const std::vector<DerivedPath> & reqs, BuildMode buildMode);
+
+public:
+
+    void buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMode) override;
+
+    std::vector<KeyedBuildResult>
+    buildPathsWithResults(const std::vector<DerivedPath> & reqs, BuildMode buildMode) override;
+
+    BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
+
+    /**
+     * Note, the returned function must only be called once, or we'll
+     * try to read from the connection twice.
+     *
+     * @todo Use C++23 `std::move_only_function`.
+     */
+    fun<BuildResult()> buildDerivationAsync(
+        const StorePath & drvPath, const BasicDerivation & drv, const ServeProto::BuildOptions & options);
+
+    void ensurePath(const StorePath & path) override
+    {
+        unsupported("ensurePath");
+    }
+
+    void repairPath(const StorePath & path) override
+    {
+        unsupported("repairPath");
+    }
+};
 
 LegacySSHStoreConfig::LegacySSHStoreConfig(const ParsedURL::Authority & authority, const Params & params)
     : StoreConfig(params, FilePathType::Unix)
@@ -196,32 +245,30 @@ static ServeProto::BuildOptions buildSettings()
     };
 }
 
-BuildResult LegacySSHStore::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
+BuildResult
+LegacySSHBuilder::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
 {
-    auto conn(connections->get());
+    auto conn(store->connections->get());
 
-    conn->putBuildDerivationRequest(*this, drvPath, drv, buildSettings());
+    conn->putBuildDerivationRequest(*store, drvPath, drv, buildSettings());
 
-    return conn->getBuildDerivationResponse(*this);
+    return conn->getBuildDerivationResponse(*store);
 }
 
-fun<BuildResult()> LegacySSHStore::buildDerivationAsync(
+fun<BuildResult()> LegacySSHBuilder::buildDerivationAsync(
     const StorePath & drvPath, const BasicDerivation & drv, const ServeProto::BuildOptions & options)
 {
     // Until we have C++23 std::move_only_function
-    auto conn = std::make_shared<Pool<Connection>::Handle>(connections->get());
-    (*conn)->putBuildDerivationRequest(*this, drvPath, drv, options);
+    auto conn = std::make_shared<Pool<LegacySSHStore::Connection>::Handle>(store->connections->get());
+    (*conn)->putBuildDerivationRequest(*store, drvPath, drv, options);
 
-    return [this, conn]() -> BuildResult { return (*conn)->getBuildDerivationResponse(*this); };
+    return [store = this->store, conn]() -> BuildResult { return (*conn)->getBuildDerivationResponse(*store); };
 }
 
-void LegacySSHStore::buildPaths(
-    const std::vector<DerivedPath> & drvPaths, BuildMode buildMode, std::shared_ptr<Store> evalStore)
+std::variant<BuildResultSuccessStatus, BuildError>
+LegacySSHBuilder::buildPathsRaw(const std::vector<DerivedPath> & drvPaths, BuildMode buildMode)
 {
-    if (evalStore && evalStore.get() != this)
-        throw Error("building on an SSH store is incompatible with '--eval-store'");
-
-    auto conn(connections->get());
+    auto conn(store->connections->get());
 
     conn->to << ServeProto::Command::BuildPaths;
     Strings ss;
@@ -229,11 +276,11 @@ void LegacySSHStore::buildPaths(
         auto sOrDrvPath = StorePathWithOutputs::tryFromDerivedPath(p);
         std::visit(
             overloaded{
-                [&](const StorePathWithOutputs & s) { ss.push_back(s.to_string(*this)); },
+                [&](const StorePathWithOutputs & s) { ss.push_back(s.to_string(*store)); },
                 [&](const StorePath & drvPath) {
                     throw Error(
                         "wanted to fetch '%s' but the legacy ssh protocol doesn't support merely substituting drv files via the build paths command. It would build them instead. Try using ssh-ng://",
-                        printStorePath(drvPath));
+                        store->printStorePath(drvPath));
                 },
                 [&](std::monostate) {
                     throw Error(
@@ -244,16 +291,108 @@ void LegacySSHStore::buildPaths(
     }
     conn->to << ss;
 
-    ServeProto::write(*this, *conn, buildSettings());
+    ServeProto::write(*store, *conn, buildSettings());
 
     conn->to.flush();
 
-    auto status = CommonProto::Serialise<BuildResultStatus>::read(*this, {conn->from});
-    if (auto * failure = std::get_if<BuildResultFailureStatus>(&status)) {
-        std::string errorMsg;
-        conn->from >> errorMsg;
-        throw BuildError(*failure, std::move(errorMsg));
+    auto status = CommonProto::Serialise<BuildResultStatus>::read(*store, {conn->from});
+    return std::visit(
+        overloaded{
+            [&](BuildResultSuccessStatus s) -> std::variant<BuildResultSuccessStatus, BuildError> { return s; },
+            [&](BuildResultFailureStatus s) -> std::variant<BuildResultSuccessStatus, BuildError> {
+                std::string errorMsg;
+                conn->from >> errorMsg;
+                return BuildError{s, std::move(errorMsg)};
+            },
+        },
+        status);
+}
+
+void LegacySSHBuilder::buildPaths(const std::vector<DerivedPath> & drvPaths, BuildMode buildMode)
+{
+    auto status = buildPathsRaw(drvPaths, buildMode);
+    if (auto * failure = std::get_if<BuildError>(&status))
+        throw *failure;
+}
+
+std::vector<KeyedBuildResult>
+LegacySSHBuilder::buildPathsWithResults(const std::vector<DerivedPath> & reqs, BuildMode buildMode)
+{
+    auto status = buildPathsRaw(reqs, buildMode);
+
+    std::vector<KeyedBuildResult> results;
+
+    // N.B. This logic is inspired by the fallback old protocol code in
+    // `RemoteBuilder::buildPathsWithResults`, which handles a very
+    // similar problem.
+    for (auto & req : reqs) {
+        std::visit(
+            overloaded{
+                [&](const DerivedPath::Opaque & bo) {
+                    results.push_back(
+                        KeyedBuildResult{
+                            {.inner = std::visit(
+                                 overloaded{
+                                     [](const BuildResultSuccessStatus & s) -> decltype(BuildResult::inner) {
+                                         return BuildResult::Success{.status = s};
+                                     },
+                                     [](const BuildError & e) -> decltype(BuildResult::inner) { return e; },
+                                 },
+                                 status)},
+                            /* .path = */ req,
+                        });
+                },
+                [&](const DerivedPath::Built & bfd) {
+                    if (auto * failure = std::get_if<BuildError>(&status)) {
+                        results.push_back(
+                            KeyedBuildResult{
+                                {.inner = *failure},
+                                /* .path = */ req,
+                            });
+                        return;
+                    }
+
+                    BuildResult::Success success{
+                        .status = std::get<BuildResultSuccessStatus>(status),
+                    };
+
+                    auto drvPath = resolveDerivedPath(*store, *bfd.drvPath);
+                    auto built = resolveDerivedPath(*store, bfd);
+                    for (auto & [output, outputPath] : built) {
+                        auto outputId = DrvOutput{drvPath, output};
+                        if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations)) {
+                            auto realisation = store->queryRealisation(outputId);
+                            if (!realisation)
+                                throw MissingRealisation(*store, outputId);
+                            success.builtOutputs.emplace(output, *realisation);
+                        } else {
+                            success.builtOutputs.emplace(
+                                output,
+                                UnkeyedRealisation{
+                                    .outPath = outputPath,
+                                });
+                        }
+                    }
+
+                    results.push_back(
+                        KeyedBuildResult{
+                            {.inner = std::move(success)},
+                            /* .path = */ req,
+                        });
+                },
+            },
+            req.raw());
     }
+
+    return results;
+}
+
+ref<Builder> LegacySSHStore::getBuilder(std::shared_ptr<Store> evalStore)
+{
+    if (evalStore && evalStore.get() != this)
+        throw Error("building on an SSH store is incompatible with '--eval-store'");
+    return make_ref<LegacySSHBuilder>(
+        ref<LegacySSHStore>(std::dynamic_pointer_cast<LegacySSHStore>(shared_from_this())));
 }
 
 void LegacySSHStore::computeFSClosure(

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1,4 +1,5 @@
 #include "nix/store/local-store.hh"
+#include "nix/store/build.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/path-references.hh"
 #include "nix/util/git.hh"
@@ -1472,7 +1473,7 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
                         info->narHash.to_string(HashFormat::Nix32, true),
                         current.hash.to_string(HashFormat::Nix32, true));
                     if (repair)
-                        repairPath(i);
+                        getBuilder()->repairPath(i);
                     else
                         errors = true;
                 } else {
@@ -1586,7 +1587,7 @@ void LocalStore::verifyPath(
             printError("path '%s' disappeared, but it still has valid referrers!", pathS);
             if (repair)
                 try {
-                    repairPath(path);
+                    getBuilder()->repairPath(path);
                 } catch (Error & e) {
                     logWarning(e.info());
                     errors = true;

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -412,33 +412,6 @@ StorePath resolveDerivedPath(Store & store, const SingleDerivedPath & req, Store
         req.raw());
 }
 
-OutputPathMap resolveDerivedPath(Store & store, const DerivedPath::Built & bfd)
-{
-    auto drvPath = resolveDerivedPath(store, *bfd.drvPath);
-    auto outputMap = deepQueryDerivationOutputMap(store, drvPath);
-    auto outputsLeft = std::visit(
-        overloaded{
-            [&](const OutputsSpec::All &) { return StringSet{}; },
-            [&](const OutputsSpec::Names & names) { return static_cast<StringSet>(names); },
-        },
-        bfd.outputs.raw);
-    for (auto iter = outputMap.begin(); iter != outputMap.end();) {
-        auto & outputName = iter->first;
-        if (bfd.outputs.contains(outputName)) {
-            outputsLeft.erase(outputName);
-            ++iter;
-        } else {
-            iter = outputMap.erase(iter);
-        }
-    }
-    if (!outputsLeft.empty())
-        throw Error(
-            "derivation '%s' does not have an outputs %s",
-            store.printStorePath(drvPath),
-            concatStringsSep(", ", quoteStrings(std::get<OutputsSpec::Names>(bfd.outputs.raw))));
-    return outputMap;
-}
-
 } // namespace nix
 
 namespace nlohmann {

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -1,3 +1,4 @@
+#include "nix/store/build.hh"
 #include "nix/store/path.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/file-content-address.hh"
@@ -559,60 +560,95 @@ void RemoteStore::queryRealisationUncached(
     }
 }
 
-void RemoteStore::copyDrvsFromEvalStore(const std::vector<DerivedPath> & paths, std::shared_ptr<Store> evalStore)
+struct RemoteBuilder : Builder
 {
-    if (evalStore && evalStore.get() != this) {
+    ref<RemoteStore> store;
+    std::shared_ptr<Store> evalStore;
+
+    RemoteBuilder(ref<RemoteStore> store, std::shared_ptr<Store> evalStore)
+        : store(store)
+        , evalStore(std::move(evalStore))
+    {
+    }
+
+private:
+
+    void copyDrvsFromEvalStore(const std::vector<DerivedPath> & paths);
+
+public:
+
+    void buildPaths(const std::vector<DerivedPath> & drvPaths, BuildMode buildMode) override;
+
+    std::vector<KeyedBuildResult>
+    buildPathsWithResults(const std::vector<DerivedPath> & paths, BuildMode buildMode) override;
+
+    BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
+
+    void ensurePath(const StorePath & path) override;
+
+    /**
+     * The default instance would schedule the work on the client side, but
+     * for consistency with `buildPaths` and `buildDerivation` it should happen
+     * on the remote side.
+     *
+     * We make this fail for now so we can add implement this properly later
+     * without it being a breaking change.
+     */
+    void repairPath(const StorePath & path) override;
+};
+
+void RemoteBuilder::copyDrvsFromEvalStore(const std::vector<DerivedPath> & paths)
+{
+    if (evalStore && evalStore.get() != &*store) {
         /* The remote doesn't have a way to access evalStore, so copy
            the .drvs. */
-        RealisedPath::Set drvPaths2;
+        RealisedPath::Set drvPaths;
         for (const auto & i : paths) {
             std::visit(
                 overloaded{
                     [&](const DerivedPath::Opaque & bp) {
                         // Do nothing, path is hopefully there already
                     },
-                    [&](const DerivedPath::Built & bp) { drvPaths2.insert(bp.drvPath->getBaseStorePath()); },
+                    [&](const DerivedPath::Built & bp) { drvPaths.insert(bp.drvPath->getBaseStorePath()); },
                 },
                 i.raw());
         }
-        copyClosure(*evalStore, *this, drvPaths2);
+        copyClosure(*evalStore, *store, drvPaths);
     }
 }
 
-void RemoteStore::buildPaths(
-    const std::vector<DerivedPath> & drvPaths, BuildMode buildMode, std::shared_ptr<Store> evalStore)
+void RemoteBuilder::buildPaths(const std::vector<DerivedPath> & drvPaths, BuildMode buildMode)
 {
-    copyDrvsFromEvalStore(drvPaths, evalStore);
-
-    auto conn(getConnection());
+    copyDrvsFromEvalStore(drvPaths);
+    auto conn(store->getConnection());
     conn->to << WorkerProto::Op::BuildPaths;
-    WorkerProto::write(*this, *conn, drvPaths);
+    WorkerProto::write(*store, *conn, drvPaths);
     conn->to << buildMode;
     conn.processStderr();
     readInt(conn->from);
 }
 
-std::vector<KeyedBuildResult> RemoteStore::buildPathsWithResults(
-    const std::vector<DerivedPath> & paths, BuildMode buildMode, std::shared_ptr<Store> evalStore)
+std::vector<KeyedBuildResult>
+RemoteBuilder::buildPathsWithResults(const std::vector<DerivedPath> & paths, BuildMode buildMode)
 {
-    copyDrvsFromEvalStore(paths, evalStore);
+    copyDrvsFromEvalStore(paths);
 
-    std::optional<ConnectionHandle> conn_(getConnection());
+    std::optional<RemoteStore::ConnectionHandle> conn_(store->getConnection());
     auto & conn = *conn_;
 
     if (conn->protoVersion >= WorkerProto::Version{.number = {1, 34}}) {
         conn->to << WorkerProto::Op::BuildPathsWithResults;
-        WorkerProto::write(*this, *conn, paths);
+        WorkerProto::write(*store, *conn, paths);
         conn->to << buildMode;
         conn.processStderr();
-        return WorkerProto::Serialise<std::vector<KeyedBuildResult>>::read(*this, *conn);
+        return WorkerProto::Serialise<std::vector<KeyedBuildResult>>::read(*store, *conn);
     } else {
         // Avoid deadlock.
         conn_.reset();
 
         // Note: this throws an exception if a build/substitution
         // fails, but meh.
-        buildPaths(paths, buildMode, evalStore);
+        buildPaths(paths, buildMode);
 
         std::vector<KeyedBuildResult> results;
 
@@ -634,14 +670,14 @@ std::vector<KeyedBuildResult> RemoteStore::buildPathsWithResults(
                         };
 
                         OutputPathMap outputs;
-                        auto drvPath = resolveDerivedPath(*evalStore, *bfd.drvPath);
-                        auto built = resolveDerivedPath(*this, bfd, &*evalStore);
+                        auto drvPath = resolveDerivedPath(*store, *bfd.drvPath);
+                        auto built = resolveDerivedPath(*store, bfd);
                         for (auto & [output, outputPath] : built) {
                             auto outputId = DrvOutput{drvPath, output};
                             if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations)) {
-                                auto realisation = queryRealisation(outputId);
+                                auto realisation = store->queryRealisation(outputId);
                                 if (!realisation)
-                                    throw MissingRealisation(*this, outputId);
+                                    throw MissingRealisation(*store, outputId);
                                 success.builtOutputs.emplace(output, *realisation);
                             } else {
                                 success.builtOutputs.emplace(
@@ -665,21 +701,32 @@ std::vector<KeyedBuildResult> RemoteStore::buildPathsWithResults(
     }
 }
 
-BuildResult RemoteStore::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
+BuildResult RemoteBuilder::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
 {
-    auto conn(getConnection());
-    conn->putBuildDerivationRequest(*this, &conn.daemonException, drvPath, drv, buildMode);
+    auto conn(store->getConnection());
+    conn->putBuildDerivationRequest(*store, &conn.daemonException, drvPath, drv, buildMode);
     conn.processStderr();
-    return WorkerProto::Serialise<BuildResult>::read(*this, *conn);
+    return WorkerProto::Serialise<BuildResult>::read(*store, *conn);
 }
 
-void RemoteStore::ensurePath(const StorePath & path)
+void RemoteBuilder::ensurePath(const StorePath & path)
 {
-    auto conn(getConnection());
+    auto conn(store->getConnection());
     conn->to << WorkerProto::Op::EnsurePath;
-    WorkerProto::write(*this, *conn, path);
+    WorkerProto::write(*store, *conn, path);
     conn.processStderr();
     readInt(conn->from);
+}
+
+void RemoteBuilder::repairPath(const StorePath & path)
+{
+    throw Unsupported("operation 'repairPath' is not supported by store '%s'", store->config.getHumanReadableURI());
+}
+
+ref<Builder> RemoteStore::getBuilder(std::shared_ptr<Store> evalStore)
+{
+    return make_ref<RemoteBuilder>(
+        ref<RemoteStore>(std::dynamic_pointer_cast<RemoteStore>(shared_from_this())), std::move(evalStore));
 }
 
 void RemoteStore::addTempRoot(const StorePath & path)

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -1,9 +1,12 @@
 #include "nix/store/restricted-store.hh"
+#include "nix/store/build.hh"
 #include "nix/store/build-result.hh"
 #include "nix/store/submit-store.hh"
+#include "nix/store/build/worker.hh"
 #include "nix/util/callback.hh"
 #include "nix/store/realisation.hh"
 #include "nix/store/local-store.hh"
+#include "nix/util/error.hh"
 #include "nix/util/repair-flag.hh"
 
 namespace nix {
@@ -110,8 +113,6 @@ public:
 
     void narFromPath(const StorePath & path, Sink & sink) override;
 
-    void ensurePath(const StorePath & path) override;
-
     void registerDrvOutput(const Realisation & info) override;
 
     ref<const ValidPathInfo> addToStoreScanning(
@@ -123,20 +124,6 @@ public:
 
     void queryRealisationUncached(
         const DrvOutput & id, Callback<std::shared_ptr<const UnkeyedRealisation>> callback) noexcept override;
-
-    void
-    buildPaths(const std::vector<DerivedPath> & paths, BuildMode buildMode, std::shared_ptr<Store> evalStore) override;
-
-    std::vector<KeyedBuildResult> buildPathsWithResults(
-        const std::vector<DerivedPath> & paths,
-        BuildMode buildMode = bmNormal,
-        std::shared_ptr<Store> evalStore = nullptr) override;
-
-    BuildResult
-    buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode = bmNormal) override
-    {
-        unsupported("buildDerivation");
-    }
 
     void addTempRoot(const StorePath & path) override {}
 
@@ -172,9 +159,41 @@ public:
     {
         return NotTrusted;
     }
+
+    ref<Builder> getBuilder(std::shared_ptr<Store> evalStore) override
+    {
+        unreachable();
+    }
 };
 
 void RestrictedStore::anchor() {}
+
+/**
+ * A builder that wraps an inner builder, adding restriction checks
+ * and dependency tracking for recursive Nix builds.
+ */
+struct RestrictedBuilder : Builder
+{
+    Worker & inner;
+    RestrictionContext & goal;
+
+    RestrictedBuilder(Worker & inner, RestrictionContext & goal)
+        : inner(inner)
+        , goal(goal)
+    {
+    }
+
+    void buildPaths(const std::vector<DerivedPath> & paths, BuildMode buildMode) override;
+
+    std::vector<KeyedBuildResult>
+    buildPathsWithResults(const std::vector<DerivedPath> & paths, BuildMode buildMode) override;
+
+    BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
+
+    void ensurePath(const StorePath & path) override;
+
+    void repairPath(const StorePath & path) override;
+};
 
 ref<Store> makeRestrictedStore(ref<LocalStore::Config> config, ref<LocalStore> next, RestrictionContext & context)
 {
@@ -251,10 +270,10 @@ void RestrictedStore::narFromPath(const StorePath & path, Sink & sink)
     Store::narFromPath(path, sink);
 }
 
-void RestrictedStore::ensurePath(const StorePath & path)
+void RestrictedBuilder::ensurePath(const StorePath & path)
 {
     if (!goal.isAllowed(path))
-        throw InvalidPath("cannot substitute unknown path '%s' in recursive Nix", printStorePath(path));
+        throw InvalidPath("cannot substitute unknown path '%s' in recursive Nix", inner.store.printStorePath(path));
     /* Nothing to be done; 'path' must already be valid. */
 }
 
@@ -290,36 +309,33 @@ void RestrictedStore::queryRealisationUncached(
     next->queryRealisation(id, std::move(callback));
 }
 
-void RestrictedStore::buildPaths(
-    const std::vector<DerivedPath> & paths, BuildMode buildMode, std::shared_ptr<Store> evalStore)
+void RestrictedBuilder::buildPaths(const std::vector<DerivedPath> & paths, BuildMode buildMode)
 {
-    for (auto & result : buildPathsWithResults(paths, buildMode, evalStore))
+    for (auto & result : buildPathsWithResults(paths, buildMode))
         result.tryThrowBuildError();
 }
 
-std::vector<KeyedBuildResult> RestrictedStore::buildPathsWithResults(
-    const std::vector<DerivedPath> & paths, BuildMode buildMode, std::shared_ptr<Store> evalStore)
+std::vector<KeyedBuildResult>
+RestrictedBuilder::buildPathsWithResults(const std::vector<DerivedPath> & paths, BuildMode buildMode)
 {
-    assert(!evalStore);
-
     if (buildMode != bmNormal)
         throw Error("unsupported build mode");
+
+    for (auto & req : paths) {
+        if (!goal.isAllowed(req))
+            throw InvalidPath("cannot build '%s' in recursive Nix because path is unknown", req.to_string(inner.store));
+    }
+
+    auto results = inner.buildPathsWithResults(paths, buildMode);
 
     StorePathSet newPaths;
     std::set<Realisation> newRealisations;
 
-    for (auto & req : paths) {
-        if (!goal.isAllowed(req))
-            throw InvalidPath("cannot build '%s' in recursive Nix because path is unknown", req.to_string(*next));
-    }
-
-    auto results = next->buildPathsWithResults(paths, buildMode);
-
     for (auto & result : results) {
         if (auto * successP = result.tryGetSuccess()) {
-            if (auto * pathBuilt = std::get_if<DerivedPathBuilt>(&result.path)) {
+            if (auto * pathBuilt = std::get_if<DerivedPath::Built>(&result.path)) {
                 // TODO ugly extra IO
-                auto drvPath = resolveDerivedPath(*next, *pathBuilt->drvPath);
+                auto drvPath = resolveDerivedPath(inner.store, *pathBuilt->drvPath);
                 for (auto & [outputName, output] : successP->builtOutputs) {
                     newPaths.insert(output.outPath);
                     newRealisations.insert(
@@ -334,7 +350,7 @@ std::vector<KeyedBuildResult> RestrictedStore::buildPathsWithResults(
     }
 
     StorePathSet closure;
-    next->computeFSClosure(newPaths, closure);
+    inner.store.computeFSClosure(newPaths, closure);
     for (auto & path : closure)
         goal.addDependency(path);
 
@@ -368,6 +384,22 @@ MissingPaths RestrictedStore::queryMissing(const std::vector<DerivedPath> & targ
         res.unknown.insert(p);
 
     return res;
+}
+
+ref<Builder> makeRestrictedBuilder(Worker & inner, RestrictionContext & context)
+{
+    return make_ref<RestrictedBuilder>(inner, context);
+}
+
+BuildResult
+RestrictedBuilder::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
+{
+    throw Unsupported("buildDerivation");
+}
+
+void RestrictedBuilder::repairPath(const StorePath & path)
+{
+    throw Unsupported("repairPath");
 }
 
 } // namespace nix

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1,3 +1,4 @@
+#include "nix/store/build/worker.hh"
 #include "nix/util/logging.hh"
 #include "nix/util/signature/local-keys.hh"
 #include "nix/util/source-accessor.hh"
@@ -6,6 +7,7 @@
 #include "nix/store/realisation.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 #include "nix/store/store-open.hh"
 #include "nix/store/outputs-query.hh"
 #include "nix/util/util.hh"
@@ -45,6 +47,8 @@ void SubstituterDisabled::anchor() {}
 void InvalidStoreReference::anchor() {}
 
 void StoreConfigBase::anchor() {}
+
+void Builder::anchor() {}
 
 static std::string canonStoreDir(std::string path)
 {
@@ -140,6 +144,13 @@ std::pair<StorePath, CanonPath> StoreDirConfig::toStorePath(std::string_view pat
         return {parseStorePath(path), CanonPath::root};
     else
         return {parseStorePath(path.substr(0, slash)), CanonPath{path.substr(slash)}};
+}
+
+ref<Builder> Store::getBuilder(std::shared_ptr<Store> evalStore)
+{
+    auto store = ref<Store>(shared_from_this());
+    auto evalStoreRef = evalStore ? ref<Store>(std::move(evalStore)) : store;
+    return make_ref<LocalBuilder>(store, evalStoreRef);
 }
 
 std::filesystem::path Store::followLinksToStore(std::string_view _path) const
@@ -734,7 +745,7 @@ void Store::substitutePaths(const StorePathSet & paths)
             std::vector<DerivedPath> subs;
             for (auto & p : missing.willSubstitute)
                 subs.emplace_back(DerivedPath::Opaque{p});
-            buildPaths(subs);
+            getBuilder()->buildPaths(subs, bmNormal);
         } catch (Error & e) {
             logWarning(e.info());
         }
@@ -1176,7 +1187,7 @@ decodeValidPathInfo(const Store & store, std::istream & str, std::optional<HashR
 
 Derivation Store::derivationFromPath(const StorePath & drvPath)
 {
-    ensurePath(drvPath);
+    getBuilder()->ensurePath(drvPath);
     return readDerivation(drvPath);
 }
 

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -8,7 +8,6 @@
 #include "nix/util/util.hh"
 #include "nix/util/archive.hh"
 #include "nix/util/git.hh"
-#include "nix/store/daemon.hh"
 #include "nix/util/topo-sort.hh"
 #include "nix/store/build/child.hh"
 #include "nix/util/unix-domain-socket.hh"
@@ -829,10 +828,9 @@ void DerivationBuilderImpl::startDaemon()
 
             auto doneFlag = make_ref<std::atomic_flag>();
 
-            auto workerThread = std::thread([doneFlag, store, remote{std::move(remote)}]() {
+            auto workerThread = std::thread([this, doneFlag, store, remote{std::move(remote)}]() {
                 try {
-                    daemon::processConnection(
-                        store, FdSource(remote.get()), FdSink(remote.get()), NotTrusted, daemon::Recursive);
+                    miscMethods->processDaemonConnection(store, FdSource(remote.get()), FdSink(remote.get()), *this);
                     debug("terminated daemon connection");
                 } catch (const Interrupted &) {
                     debug("interrupted daemon connection");

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -21,6 +21,7 @@
 #include "nix/util/strings.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/local-store.hh"
+#include "nix/store/build.hh"
 #include "nix/cmd/legacy.hh"
 #include "nix/util/experimental-features.hh"
 #include "nix/store/globals.hh"
@@ -338,7 +339,7 @@ static int main_build_remote(int argc, char ** argv)
             //    output ids, which break CA derivations
             if (!drv.inputDrvs.map.empty())
                 drv.inputSrcs = store->parseStorePathSet(inputs);
-            optResult = sshStore->buildDerivation(*drvPath, static_cast<const BasicDerivation &>(drv));
+            optResult = sshStore->getBuilder()->buildDerivation(*drvPath, static_cast<const BasicDerivation &>(drv));
             auto & result = *optResult;
             if (auto * failureP = result.tryGetFailure()) {
                 if (settings.keepFailed) {
@@ -353,7 +354,7 @@ static int main_build_remote(int argc, char ** argv)
             }
         } else {
             copyClosure(*store, *sshStore, StorePathSet{*drvPath}, NoRepair, NoCheckSigs, substitute);
-            auto res = sshStore->buildPathsWithResults({DerivedPath::Built{
+            auto res = sshStore->getBuilder()->buildPathsWithResults({DerivedPath::Built{
                 .drvPath = makeConstantStorePathRef(*drvPath),
                 .outputs = OutputsSpec::All{},
             }});

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -2,6 +2,7 @@
 #include "nix/cmd/command-installable-value.hh"
 #include "nix/main/shared.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 #include "nix/store/local-fs-store.hh"
 #include "nix/expr/eval-inline.hh"
 #include "nix/store/globals.hh"
@@ -111,7 +112,7 @@ struct CmdBundle : InstallableValueCommand
 
         auto outPath = evalState->coerceToStorePath(attr2->pos, *attr2->value, context2, "");
 
-        store->buildPaths({
+        store->getBuilder()->buildPaths({
             DerivedPath::Built{
                 .drvPath = makeConstantStorePathRef(drvPath),
                 .outputs = OutputsSpec::All{},

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -5,6 +5,7 @@
 #include "nix/main/common-args.hh"
 #include "nix/main/shared.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/outputs-spec.hh"
 #include "nix/store/outputs-query.hh"
@@ -290,13 +291,12 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
     auto shellDrvPath = evalStore->writeDerivation(drv);
 
     /* Build the derivation. */
-    store->buildPaths(
+    store->getBuilder(evalStore)->buildPaths(
         {DerivedPath::Built{
             .drvPath = makeConstantStorePathRef(shellDrvPath),
             .outputs = OutputsSpec::All{},
         }},
-        bmNormal,
-        evalStore);
+        bmNormal);
 
     // `get-env.sh` will write its JSON output to an arbitrary output
     // path, so return the first non-empty output path.

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -22,6 +22,7 @@
 #include "nix/util/users.hh"
 #include "nix/fetchers/fetch-to-store.hh"
 #include "nix/store/local-fs-store.hh"
+#include "nix/store/build.hh"
 #include "nix/store/globals.hh"
 
 #include <filesystem>
@@ -823,9 +824,8 @@ struct CmdFlakeCheck : FlakeCommand, MixPrintOutPaths, MixOutLinkBase
             }
 
             Activity act(*logger, lvlInfo, actUnknown, fmt("running %d flake checks", toBuild.size()));
-
             // once we get rid of the temporary hack above, this tenary operator will also go away
-            results = store->buildPathsWithResults((printOutputPaths || outLink) ? drvPaths : toBuild);
+            results = store->getBuilder()->buildPathsWithResults((printOutputPaths || outLink) ? drvPaths : toBuild);
 
             // Report build failures with attribute paths
             for (auto & result : results) {

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -28,6 +28,7 @@
 #include "nix/util/users.hh"
 #include "nix/cmd/network-proxy.hh"
 #include "nix/cmd/compatibility-settings.hh"
+#include "nix/store/build.hh"
 #include "nix/util/fun.hh"
 #include "man-pages.hh"
 
@@ -449,7 +450,7 @@ static void main_nix_build(int argc, char ** argv)
             printMissing(ref<Store>(store), paths);
 
         if (!dryRun)
-            store->buildPaths(paths, buildMode, evalStore);
+            store->getBuilder(evalStore)->buildPaths(paths, buildMode);
     };
 
     if (isNixShell) {

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -12,6 +12,7 @@
 #include "nix/store/path-with-outputs.hh"
 #include "nix/main/shared.hh"
 #include "nix/store/store-open.hh"
+#include "nix/store/build.hh"
 #include "nix/store/local-fs-store.hh"
 #include "user-env.hh"
 #include "nix/expr/value-to-json.hh"
@@ -793,7 +794,7 @@ static void opSet(Globals & globals, Strings opFlags, Strings opArgs)
     printMissing(globals.state->store, paths);
     if (globals.dryRun)
         return;
-    globals.state->store->buildPaths(paths, globals.state->repair ? bmRepair : bmNormal);
+    globals.state->store->getBuilder()->buildPaths(paths, globals.state->repair ? bmRepair : bmNormal);
 
     debug("switching to new user environment");
     auto generation = createGeneration(*store2, globals.profile, drv.queryOutPath());

--- a/src/nix/nix-env/user-env.cc
+++ b/src/nix/nix-env/user-env.cc
@@ -1,6 +1,7 @@
 #include "user-env.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 #include "nix/store/path-with-outputs.hh"
 #include "nix/store/local-fs-store.hh"
 #include "nix/main/shared.hh"
@@ -44,7 +45,7 @@ bool createUserEnv(
             drvsToBuild.push_back({*drvPath});
 
     debug("building user environment dependencies");
-    state.store->buildPaths(toDerivedPaths(drvsToBuild), state.repair ? bmRepair : bmNormal);
+    state.store->getBuilder()->buildPaths(toDerivedPaths(drvsToBuild), state.repair ? bmRepair : bmNormal);
 
     /* Construct the whole top level derivation. */
     StorePathSet references;
@@ -79,7 +80,7 @@ bool createUserEnv(
             /* This is only necessary when installing store paths, e.g.,
                `nix-env -i /nix/store/abcd...-foo'. */
             state.store->addTempRoot(*j.second);
-            state.store->ensurePath(*j.second);
+            state.store->getBuilder()->ensurePath(*j.second);
 
             references.insert(*j.second);
         }
@@ -154,7 +155,7 @@ bool createUserEnv(
     debug("building user environment");
     std::vector<StorePathWithOutputs> topLevelDrvs;
     topLevelDrvs.push_back({topLevelDrv});
-    state.store->buildPaths(toDerivedPaths(topLevelDrvs), state.repair ? bmRepair : bmNormal);
+    state.store->getBuilder()->buildPaths(toDerivedPaths(topLevelDrvs), state.repair ? bmRepair : bmNormal);
 
     /* Switch the current user environment to the output path. */
     auto store2 = state.store.dynamic_pointer_cast<LocalFSStore>();

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -21,6 +21,7 @@
 #include "nix/store/posix-fs-canonicalise.hh"
 #include "nix/util/error.hh"
 #include "nix/store/gc-store.hh"
+#include "nix/store/build.hh"
 
 #include "man-pages.hh"
 
@@ -76,7 +77,7 @@ static std::set<std::filesystem::path> realisePath(StorePathWithOutputs path, bo
 
     if (path.path.isDerivation()) {
         if (build)
-            store->buildPaths({path.toDerivedPath()});
+            store->getBuilder()->buildPaths({path.toDerivedPath()});
         auto outputPaths = deepQueryDerivationOutputMap(*store, path.path);
         Derivation drv = store->derivationFromPath(path.path);
         rootNr++;
@@ -113,7 +114,7 @@ static std::set<std::filesystem::path> realisePath(StorePathWithOutputs path, bo
 
     else {
         if (build)
-            store->ensurePath(path.path);
+            store->getBuilder()->ensurePath(path.path);
         else if (!store->isValidPath(path.path))
             throw Error("path '%s' does not exist and cannot be created", store->printStorePath(path.path));
         if (store2) {
@@ -173,7 +174,7 @@ static void opRealise(Strings opFlags, Strings opArgs)
         return;
 
     /* Build all paths at the same time to exploit parallelism. */
-    store->buildPaths(toDerivedPaths(paths), buildMode);
+    store->getBuilder()->buildPaths(toDerivedPaths(paths), buildMode);
 
     if (!ignoreUnknown)
         for (auto & i : paths) {
@@ -862,7 +863,7 @@ static void opRepairPath(Strings opFlags, Strings opArgs)
         throw UsageError("no flags expected");
 
     for (auto & i : opArgs)
-        store->repairPath(store->followLinksToStorePath(i));
+        store->getBuilder()->repairPath(store->followLinksToStorePath(i));
 }
 
 /* Optimise the disk space usage of the Nix store by hard-linking
@@ -1009,7 +1010,7 @@ static void opServe(Strings opFlags, Strings opArgs)
 #ifndef _WIN32 // TODO figure out if Windows needs something similar
                 MonitorFdHup monitor(in.fd);
 #endif
-                store->buildPaths(toDerivedPaths(paths));
+                store->getBuilder()->buildPaths(toDerivedPaths(paths));
                 out << 0;
             } catch (Error & e) {
                 assert(e.info().status);
@@ -1032,7 +1033,7 @@ static void opServe(Strings opFlags, Strings opArgs)
 #ifndef _WIN32 // TODO figure out if Windows needs something similar
             MonitorFdHup monitor(in.fd);
 #endif
-            auto status = store->buildDerivation(drvPath, drv);
+            auto status = store->getBuilder()->buildDerivation(drvPath, drv);
 
             ServeProto::write(*store, wconn, status);
             break;

--- a/src/nix/store-repair.cc
+++ b/src/nix/store-repair.cc
@@ -1,5 +1,6 @@
 #include "nix/cmd/command.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 
 namespace nix {
 
@@ -20,7 +21,7 @@ struct CmdStoreRepair : StorePathsCommand
     void run(ref<Store> store, StorePaths && storePaths) override
     {
         for (auto & path : storePaths)
-            store->repairPath(path);
+            store->getBuilder()->repairPath(path);
     }
 };
 

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -3,6 +3,7 @@
 #include "nix/cmd/command.hh"
 #include "nix/main/common-args.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/build.hh"
 #include "nix/store/filetransfer.hh"
 #include "nix/expr/eval.hh"
 #include "nix/expr/eval-settings.hh"
@@ -113,7 +114,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 
         {
             Activity act(*logger, lvlInfo, actUnknown, fmt("downloading '%s'...", store->printStorePath(storePath)));
-            store->ensurePath(storePath);
+            store->getBuilder()->ensurePath(storePath);
         }
 
         {

--- a/tests/functional/test-libstoreconsumer/main.cc
+++ b/tests/functional/test-libstoreconsumer/main.cc
@@ -1,5 +1,6 @@
 #include "nix/store/globals.hh"
 #include "nix/store/store-open.hh"
+#include "nix/store/build.hh"
 #include "nix/store/build-result.hh"
 #include <iostream>
 
@@ -24,7 +25,7 @@ int main(int argc, char ** argv)
         std::vector<DerivedPath> paths{DerivedPath::Built{
             .drvPath = makeConstantStorePathRef(store->parseStorePath(drvPath)), .outputs = OutputsSpec::Names{"out"}}};
 
-        const auto results = store->buildPathsWithResults(paths, bmNormal, store);
+        const auto results = store->getBuilder()->buildPathsWithResults(paths, bmNormal);
 
         for (const auto & result : results) {
             if (auto * successP = result.tryGetSuccess()) {


### PR DESCRIPTION
Separate building/scheduling from storage

This is the major first step of #5025.

Motivation
----------

Right now, there is a bit of conceptual tension between `--store` and
`--builders`:

- With `--store`, it is very convenient to think that the store knows
  how to build. One specifies a store, and gets a different method of
  building (local, some sort of remote) and scheduling (the remote store
  can take an entire derivation graph, multiple jobs) accordingly.

- With `--builders` one has a local scheduler. Stores either act as a
  passive "workbench" for building (the local case) or we give them a
  single job (a single ready-to-build derivation) at a time.

  For historical reasons, this doesn't even use the store interface,
  except on the "other side" of the build hook.

Issue #5025 is about using the store interface for `--builders`. In this
case, we want to invert the relationship between `Store` and `Worker`.
We have no use in this case for various `Store` methods creating a
`Worker` behind the scenes, because we already have our `Worker`:

- `LocalStore`s don't need any build method at all, we can just have our
  `Worker` directly use the local store, as it does with the default
  `worker.store` today.

- remote stores supporting building (`ssh://` and `ssh-ng://`) are only
  fed a single job at a time, their remote-side scheduling being
  overkill for the task at hand.

But we can't just delete the building methods of `--store` that we don't
need anymore, because that would break `--store` building. We need to
support both cases, where some stores effectively build/schedule and
`Worker` can also own/borrow stores to be a single, unified scheduler.

This change
-----------

The way we satisfy both goals is by:

- Pulling the building methods out of `Store` into a new `Builder` class

- Having some stores also give/implement `Builder`

The separation of `Store` vs `Builder` works for the `--builders`
use-case, and the project of making that leverage `Store` and other C++
interfaces directly without indirecting through build hook or other
ad-hoc implementation swapping methods. Here's how: as opposed to
default `Store::` method implementations creating a `Worker` on the fly,
`Worker` will implement `Builder`, and those methods, now on `Builder`,
will become `Worker`'s own implementation.

Local building

To implement this conceptual switch, the methods that directly delegated
to the worker are now instead ripped off `Store` and put in the new
`Builder` class. (For example, `build/entry-points.cc` now contains all
`Worker` methods (virtual method impls of `Builder`) and not `Store`
method impls.)

`Worker` also now owns `ref<...> srcStore, destStore`, directly out of
issue #5025. (`Store & store, evalStore` are kept as aliasing references
to reduce churn.)

(`Worker` should be renamed to `LocalBuilder`, since it is the local
build scheduler, and additionally knows how to build in local stores.)

Remote building

What about the `--store` case? The remote stores have a new method to
provide a `Builder` of their choice given an `evalStore`. (This reflects
the fact that `Builder` no longer has `evalStore` parameters on its
methods.) That new method is a new interface `RemoteBuildStore` which
`RemoteStore` and `LegacySSHStore` implement. Each one has an unexposed
`Builder` implementation which will just do everything over RPC, like
today.

Putting it all together

Introduce:

- `getLocalBuilder`, a freestanding function to make a `Worker`.
  (Really, the details of `Worker` should be considered private to the
  `build/*.cc` files)

- `getDefaultBuilder`, a freestanding function which will call
  `RemoteBuildStore::getBuilder` for `RemoteBuildStore`s, and use
  `getLocalBuilder` otherwise.

Future work
-----------

Issue NixOS#1221

The next step of the #5025 saga is issue #1221. To solve that issue,
`Worker` will not use the build hook, but instead work via C++. In particular,
it will do this:

- if the builder is a `RemoteBuildStore`, use an appropriate method (possibly
  yet to be created) on the remote building store's (remote) `Builder`.

- if the builder is a `LocalStore` `Worker` should *not* create another
  `Worker` (as the `build-remote` program would do today) but instead directly
  manage building in that local store, so we avoid **n** `Worker` instances
  scheduling independently (which is stupid discoordination).

- (Otherwise fail, which matches what happens today, actually, just in fewer
  steps.)

Simplifying the RPC case

I also suspect that longer term, those stores will just implement
`Builder` directly, as `evalStore` doesn't really make sense for RPC
endpoints when the remote side has no idea what the caller is doing with
other stores. We won't need `RemoteBuildStore` anymore then.

Other improvements
------------------

Recursive Nix

Speaking of avoiding redundant schedulers: `RestrictedStore`, when it
used to override the store building methods, would spin up a new
`Worker` for each recursive Nix build call. This is again bad --- we
should have a central scheduler that takes in dynamic jobs, same for
recursive Nix and dynamic derivations. Now this is *almost*, but not
quite, fixed. Three changes were made:

- `RestrictedBuilder` was split out from `RestrictedStore` to wrap the
  build methods.
- `processConnection` takes an optional `Builder` parameter, using it
  directly rather than spinning one up with `getDefaultBuilder`.
- `DerivationBuilder` took a callback to process the connection for
  recursive Nix, so the caller could provide the `processConnection`
  call with the ambient worker in order to reuse it.

This would have solved the redundant scheduler problem very nicely!

This unfortunately deadlocked, so instead the caller explicitly creates
a fresh worker (as before, but not hidden beneath a gazillion
abstractions) with a TODO saying the deadlock should be fixed and this
should not be done.

`LegacySSHStore` fix

As a final note, the old `LegacySSHStore` did not override
`buildPathsWithResults`, which meant that when specifying an `ssh://`
store, the local scheduler was being erroneously used for some commands.
Now, `LegacySSHBuilder::buildPathsWithResults` uses a single
`buildPathsRaw` call (which sends the serve protocol `BuildPaths`
command and returns `std::variant<BuildResultSuccessStatus, BuildError>`
with the error message already read from the wire), and then queries
realisations to reconstruct the `BuildResult`s --- code similar to the
old fallback code for `ssh-ng://`.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
