### PR TITLE
Add dry-run support to nix profile upgrade

### DIFF
--- a/src/nix/profile-upgrade.md
+++ b/src/nix/profile-upgrade.md
@@ -21,6 +21,12 @@ R""(
   # nix profile upgrade --regex '.*vim.*'
   ```
 
+* Show what packages would be upgraded, without actually upgrading:
+
+  ```console
+  # nix profile upgrade --all --dry-run
+  ```
+
 # Description
 
 This command upgrades a previously installed package in a Nix profile,

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -690,7 +690,7 @@ struct CmdProfileRemove : virtual EvalCommand, MixProfileElementMatchers
     }
 };
 
-struct CmdProfileUpgrade : virtual SourceExprCommand, MixProfileElementMatchers
+struct CmdProfileUpgrade : virtual SourceExprCommand, MixProfileElementMatchers, MixDryRun
 {
     std::string description() override
     {
@@ -784,6 +784,9 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixProfileElementMatchers
             warn("Found some packages but none of them could be upgraded.");
             return;
         }
+
+        if (dryRun)
+            return;
 
         auto builtPaths = builtPathsPerInstallable(
             Installable::build2(getEvalStore(), store, Realise::Outputs, installables, bmNormal));


### PR DESCRIPTION




<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
Allow users to see what packages would be upgraded without actually building or updating the profile.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context
Part of https://github.com/NixOS/nix/issues/7227

Since nix profile upgrade already splits eval and build, simply return before build starts in dry-run mode.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
