### PR TITLE
Add combined AddTempRootReturningPathInfo op to speed up `nix eval`

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -676,6 +676,25 @@ static void performOp(
         break;
     }
 
+    case WorkerProto::Op::AddTempRootReturningPathInfo: {
+        auto path = WorkerProto::Serialise<StorePath>::read(*store, rconn);
+        std::shared_ptr<const ValidPathInfo> info;
+        logger->startWork();
+        store->addTempRoot(path);
+        try {
+            info = store->queryPathInfo(path);
+        } catch (InvalidPath &) {
+        }
+        logger->stopWork();
+        if (info) {
+            conn.to << 1;
+            WorkerProto::write(*store, wconn, static_cast<const UnkeyedValidPathInfo &>(*info));
+        } else {
+            conn.to << 0;
+        }
+        break;
+    }
+
     case WorkerProto::Op::AddPermRoot: {
         if (!trusted)
             throw Error(

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -139,10 +139,10 @@ StorePath Store::writeDerivation(const Derivation & drv, RepairFlag repair)
     /* In case the derivation is already valid, we bail out early since that's
        faster. But we need to make sure that the derivation has a corresponding
        temproot. It is added by the remote in addToStoreFromDump, but we'd like
-       to avoid sending a lot of drv contents to the daemon. */
-    addTempRoot(path);
-
-    if (isValidPath(path) && !repair)
+       to avoid sending a lot of drv contents to the daemon.
+       addTempRootReturningPathInfo combines both operations into a single IPC
+       round-trip for remote stores. */
+    if (addTempRootReturningPathInfo(path) && !repair)
         return path;
 
     StringSource s{contents};

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -149,6 +149,11 @@ private:
     bool isValidPathUncached(const StorePath & path) override;
 
     /**
+     * Copy path metadata from the lower store into the upper DB.
+     */
+    void syncPathInfoFromLower(const ValidPathInfo & info);
+
+    /**
      * Check the lower store and upper DB.
      */
     void queryReferrers(const StorePath & path, StorePathSet & referrers) override;

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -122,6 +122,8 @@ struct RemoteStore : public virtual Store, public virtual GcStore, public virtua
 
     void addTempRoot(const StorePath & path) override;
 
+    std::shared_ptr<const ValidPathInfo> addTempRootReturningPathInfo(const StorePath & path) override;
+
     Roots findRoots(bool censor) override;
 
     void collectGarbage(const GCOptions & options, GCResults & results) override;

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -815,6 +815,20 @@ public:
     }
 
     /**
+     * Combine addTempRoot and queryPathInfo into a single operation.
+     * For remote stores this saves one IPC round-trip per call.
+     */
+    virtual std::shared_ptr<const ValidPathInfo> addTempRootReturningPathInfo(const StorePath & path)
+    {
+        addTempRoot(path);
+        try {
+            return queryPathInfo(path);
+        } catch (InvalidPath &) {
+            return nullptr;
+        }
+    }
+
+    /**
      * @return a string representing information about the path that
      * can be loaded into the database using `nix-store --load-db` or
      * `nix-store --register-validity`.

--- a/src/libstore/include/nix/store/worker-protocol-connection.hh
+++ b/src/libstore/include/nix/store/worker-protocol-connection.hh
@@ -96,6 +96,9 @@ struct WorkerProto::BasicClientConnection : WorkerProto::BasicConnection
 
     void addTempRoot(const StoreDirConfig & remoteStore, bool * daemonException, const StorePath & path);
 
+    std::optional<UnkeyedValidPathInfo>
+    addTempRootReturningPathInfo(const StoreDirConfig & remoteStore, bool * daemonException, const StorePath & path);
+
     StorePathSet queryValidPaths(
         const StoreDirConfig & remoteStore,
         bool * daemonException,

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -125,6 +125,13 @@ struct WorkerProto
     static constexpr std::string_view featureRealisationWithPath = "realisation-with-path-not-hash";
 
     /**
+     * Feature for combining addTempRoot and queryPathInfo into a single
+     * round-trip, used by writeDerivation to avoid 2 separate IPC calls
+     * per derivation. The result can populate the pathInfoCache.
+     */
+    static constexpr std::string_view featureAddTempRootReturningPathInfo = "add-temp-root-returning-path-info";
+
+    /**
      * A unidirectional read connection, to be used by the read half of the
      * canonical serializers below.
      */
@@ -245,6 +252,7 @@ enum struct WorkerProto::Op : uint64_t {
     AddBuildLog = 45,
     BuildPathsWithResults = 46,
     AddPermRoot = 47,
+    AddTempRootReturningPathInfo = 48,
 };
 
 struct WorkerProto::ClientHandshakeInfo

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -101,9 +101,11 @@ void LocalOverlayStore::queryPathInfoUncached(
                 return callbackPtr->rethrow();
             }
             // If we don't have it, check lower store
-            lowerStore->queryPathInfo(path, {[path, callbackPtr](std::future<ref<const ValidPathInfo>> fut) {
+            lowerStore->queryPathInfo(path, {[this, path, callbackPtr](std::future<ref<const ValidPathInfo>> fut) {
                                           try {
-                                              (*callbackPtr)(fut.get().get_ptr());
+                                              auto info = fut.get();
+                                              syncPathInfoFromLower(*info);
+                                              (*callbackPtr)(info.get_ptr());
                                           } catch (...) {
                                               return callbackPtr->rethrow();
                                           }
@@ -146,13 +148,18 @@ bool LocalOverlayStore::isValidPathUncached(const StorePath & path)
     if (res) {
         // Get path info from lower store so upper DB genuinely has it.
         auto p = lowerStore->queryPathInfo(path);
-        // recur on references, syncing entire closure.
-        for (auto & r : p->references)
-            if (r != path)
-                isValidPath(r);
-        LocalStore::registerValidPath(*p);
+        syncPathInfoFromLower(*p);
     }
     return res;
+}
+
+void LocalOverlayStore::syncPathInfoFromLower(const ValidPathInfo & info)
+{
+    // Recur on references, syncing entire closure.
+    for (auto & r : info.references)
+        if (r != info.path)
+            queryPathInfo(r);
+    LocalStore::registerValidPath(info);
 }
 
 void LocalOverlayStore::queryReferrers(const StorePath & path, StorePathSet & referrers)

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -664,6 +664,24 @@ void RemoteStore::addTempRoot(const StorePath & path)
     conn->addTempRoot(*this, &conn.daemonException, path);
 }
 
+std::shared_ptr<const ValidPathInfo> RemoteStore::addTempRootReturningPathInfo(const StorePath & path)
+{
+    {
+        auto conn(getConnection());
+        if (conn->protoVersion.features.contains(WorkerProto::featureAddTempRootReturningPathInfo)) {
+            auto info = conn->addTempRootReturningPathInfo(*this, &conn.daemonException, path);
+            if (!info) {
+                return nullptr;
+            }
+
+            return std::make_shared<ValidPathInfo>(StorePath{path}, *info);
+        }
+    }
+    // Fallback for older daemons: use the default implementation
+    // which calls addTempRoot + queryPathInfo separately.
+    return Store::addTempRootReturningPathInfo(path);
+}
+
 Roots RemoteStore::findRoots(bool censor)
 {
     auto conn(getConnection());

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -285,6 +285,18 @@ void WorkerProto::BasicClientConnection::addTempRoot(
     readInt(from);
 }
 
+std::optional<UnkeyedValidPathInfo> WorkerProto::BasicClientConnection::addTempRootReturningPathInfo(
+    const StoreDirConfig & store, bool * daemonException, const StorePath & path)
+{
+    to << WorkerProto::Op::AddTempRootReturningPathInfo << store.printStorePath(path);
+    processStderr(daemonException);
+    bool valid;
+    from >> valid;
+    if (!valid)
+        return std::nullopt;
+    return WorkerProto::Serialise<UnkeyedValidPathInfo>::read(store, *this);
+}
+
 void WorkerProto::BasicClientConnection::putBuildDerivationRequest(
     const StoreDirConfig & store,
     bool * daemonException,

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -26,6 +26,9 @@ const WorkerProto::Version WorkerProto::latest = {
             std::string{
                 WorkerProto::featureRealisationWithPath,
             },
+            std::string{
+                WorkerProto::featureAddTempRootReturningPathInfo,
+            },
         },
 };
 


### PR DESCRIPTION
## Motivation

writeDerivation() currently makes 2 separate daemon IPC round-trips per derivation: addTempRoot then isValidPath. For a NixOS system with thousands of derivations, this adds a lot of IPC overhead.

This adds a new `Op::AddTempRootReturningPathInfo` that combines both operations into a single round-trip. writeDerivation() now uses addTempRootReturningPathInfo() which for RemoteStore uses the combined op when the daemon supports it, and falls back to sequential calls on the same connection otherwise.

## Context

I was profiling the `nix eval` of a big system we have and figured out that `nix eval --read-only` was taking ~9 seconds but `nix eval` was taking 20 seconds.

With the help of Claude I figured out that this was caused by IPC overhead, `writeDerivation` does two IPCs which adds up since in this case the NixOS system has +8000 derivations. On my system (Apple M3 Pro MacBook Pro, macOS 26.3.1) the overhead per IPC is about 1ms(!).

This PR combines two IPCs into one, which in my case brought `nix eval` from 20 seconds to 15 seconds, 25% faster! I think we could bring it down even more by putting the writeDerivations into a background queue or something so the eval path isn't dependent on the IPC latency, but that would be better as a separate PR.

## Improvement

<table>
<tr>
 <td>Command
 <td>2.34.2+1
 <td>This PR
<tr>
 <td>nix eval --read-only
 <td>9s
 <td>9s
<tr>
 <td>nix eval
 <td>20s
 <td>12.5s
</table>


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
