### PR TITLE
libutil: emit multi-frame zstd for parallel-decodable output

### DIFF
--- a/doc/manual/rl-next/zstd-multiframe.md
+++ b/doc/manual/rl-next/zstd-multiframe.md
@@ -1,0 +1,18 @@
+---
+synopsis: zstd compression now emits multi-frame output and uses less memory
+prs: [15550]
+---
+
+zstd-compressed NARs are now written as a sequence of independent 16 MiB
+frames instead of a single large frame. This lays the groundwork for
+parallel decompression in a future release without requiring caches to be
+repopulated, and significantly lowers peak memory use during compression
+(e.g. from ~600 MiB to ~100 MiB for a 1 GiB store path).
+
+The output remains standard zstd and is decoded unchanged by existing Nix
+binaries and the `zstd` CLI; compression ratio is effectively unchanged.
+
+Per-frame compression now uses up to 4 worker threads. For zstd this is the
+new default: the `parallel-compression` store setting defaults to `true` when
+`compression=zstd` (it remains `false` for `xz`). Set
+`?parallel-compression=false` to opt out.

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -150,8 +150,10 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
     {
         FdSink fileSink(fdTemp.get());
         TeeSink teeSinkCompressed{fileSink, fileHashSink};
-        auto compressionSink = makeCompressionSink(
-            config.compression, teeSinkCompressed, config.parallelCompression, config.compressionLevel);
+        bool parallel = config.parallelCompression.overridden ? config.parallelCompression.get()
+                                                              : config.compression.get() == CompressionAlgo::zstd;
+        auto compressionSink =
+            makeCompressionSink(config.compression, teeSinkCompressed, parallel, config.compressionLevel);
         TeeSink teeSinkUncompressed{*compressionSink, narHashSink};
         TeeSource teeSource{narSource, teeSinkUncompressed};
         narAccessor = makeNarAccessor(parseNarListing(teeSource));

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -58,7 +58,11 @@ struct BinaryCacheStoreConfig : virtual StoreConfig
         this,
         false,
         "parallel-compression",
-        "Enable multi-threaded compression of NARs. This is currently only available for `xz` and `zstd`."};
+        R"(
+          Enable multi-threaded compression of NARs. This is currently only available for `xz` and `zstd`.
+
+          If not set explicitly, defaults to `true` when `compression` is `zstd` and `false` otherwise.
+        )"};
 
     Setting<int> compressionLevel{
         this,

--- a/src/libutil-tests/compression.cc
+++ b/src/libutil-tests/compression.cc
@@ -1,5 +1,6 @@
 #include "nix/util/compression.hh"
 #include <gtest/gtest.h>
+#include <zstd.h>
 
 namespace nix {
 
@@ -59,6 +60,63 @@ TEST(decompress, decompressBrCompressed)
     auto o = decompress(method, compress(CompressionAlgo::brotli, str));
 
     ASSERT_EQ(o, str);
+}
+
+TEST(decompress, decompressZstdCompressed)
+{
+    auto method = "zstd";
+    auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
+    auto o = decompress(method, compress(CompressionAlgo::zstd, str));
+
+    ASSERT_EQ(o, str);
+}
+
+TEST(decompress, decompressZstdCompressedParallel)
+{
+    auto method = "zstd";
+    auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
+    auto o = decompress(method, compress(CompressionAlgo::zstd, str, true));
+
+    ASSERT_EQ(o, str);
+}
+
+TEST(decompress, decompressZstdMultiFrameLargeInput)
+{
+    // Create input larger than the 16 MiB frame boundary to exercise
+    // multi-frame emission.
+    std::string str(20 * 1024 * 1024, 'x');
+    for (size_t i = 0; i < str.size(); i += 997)
+        str[i] = 'y'; // add some variation
+    auto compressed = compress(CompressionAlgo::zstd, str);
+    auto o = decompress("zstd", compressed);
+
+    ASSERT_EQ(o, str);
+}
+
+TEST(compress, zstdEmptyInput)
+{
+    auto compressed = compress(CompressionAlgo::zstd, "");
+    // Empty input should still emit a valid (empty-content) zstd
+    // frame so it round-trips through the decompressor.
+    ASSERT_FALSE(compressed.empty());
+    auto o = decompress("zstd", compressed);
+    ASSERT_EQ(o, "");
+}
+
+TEST(compress, zstdExactFrameBoundary)
+{
+    // Input exactly equal to the 16 MiB frame boundary should not
+    // emit a trailing zero-content frame.
+    std::string str(16 * 1024 * 1024, 'z');
+    auto compressed = compress(CompressionAlgo::zstd, str);
+    auto o = decompress("zstd", compressed);
+    ASSERT_EQ(o, str);
+
+    // Verify there is exactly one frame by checking that
+    // the first frame's compressed size equals the total size.
+    size_t frameSize = ZSTD_findFrameCompressedSize(compressed.data(), compressed.size());
+    ASSERT_FALSE(ZSTD_isError(frameSize));
+    ASSERT_EQ(frameSize, compressed.size());
 }
 
 TEST(decompress, decompressInvalidInputThrowsCompressionError)

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -36,6 +36,9 @@ deps_private += gtest
 gmock = dependency('gmock')
 deps_private += gmock
 
+zstd = dependency('libzstd', version : '>= 1.4.0')
+deps_private += zstd
+
 if host_machine.system() == 'windows'
   # Boost.ASIO needs this unconditionally.
   socket = cxx.find_library('ws2_32')

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -10,6 +10,7 @@
 
   rapidcheck,
   gtest,
+  zstd,
   runCommand,
   util-linux,
 
@@ -45,6 +46,7 @@ mkMesonExecutable (finalAttrs: {
     nix-util-test-support
     rapidcheck
     gtest
+    zstd
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     util-linux

--- a/src/libutil/compression.cc
+++ b/src/libutil/compression.cc
@@ -2,6 +2,7 @@
 #include "nix/util/signals.hh"
 #include "nix/util/tarfile.hh"
 #include "nix/util/logging.hh"
+#include "nix/util/current-process.hh"
 
 #include <archive.h>
 #include <archive_entry.h>
@@ -10,6 +11,9 @@
 
 #include <brotli/decode.h>
 #include <brotli/encode.h>
+
+#include <zstd.h>
+#include <thread>
 
 namespace nix {
 
@@ -68,7 +72,11 @@ struct ArchiveDecompressionSource : Source
     }
 };
 
-/* Happens to match enum names. */
+/* Algorithms whose *compression* is handled by libarchive.  zstd is
+   intentionally absent: ZstdMultiFrameCompressionSink compresses it
+   directly so the output is split into independent frames; zstd
+   *decompression* is still handled by libarchive via
+   ArchiveDecompressionSource. */
 #define NIX_FOR_EACH_LA_ALGO(MACRO) \
     MACRO(bzip2)                    \
     MACRO(compress)                 \
@@ -79,8 +87,7 @@ struct ArchiveDecompressionSource : Source
     MACRO(lzip)                     \
     MACRO(lzma)                     \
     MACRO(lzop)                     \
-    MACRO(xz)                       \
-    MACRO(zstd)
+    MACRO(xz)
 
 struct ArchiveCompressionSink : CompressionSink
 {
@@ -99,6 +106,7 @@ struct ArchiveCompressionSink : CompressionSink
             switch (method) {
             case CompressionAlgo::none:
             case CompressionAlgo::brotli:
+            case CompressionAlgo::zstd:
                 unreachable();
 #define NIX_DEF_LA_ALGO_CASE(algo) \
     case CompressionAlgo::algo:    \
@@ -317,6 +325,124 @@ struct BrotliCompressionSink : ChunkedCompressionSink
     }
 };
 
+/**
+ * Zstd compression that cuts a new frame every `bytesPerFrame` of
+ * uncompressed input.  The result is a concatenation of independent
+ * frames, which any conformant zstd decoder (RFC 8878 §3.1) handles
+ * transparently — including libarchive's, which is what the nix
+ * substituter path uses for decompression.  Because each frame is
+ * independent and carries its decompressed size, a parallel decoder
+ * can split work across them.
+ *
+ * Frame size is fixed at 16 MiB of input.  zstd's window size is
+ * level-dependent (~2 MiB at the default level 3, up to 8 MiB at
+ * higher levels), so the ratio loss from not being able to reference
+ * across a frame boundary is small.  16 MiB gives ~700 frames for the
+ * biggest NARs, which is ample parallelism and lets a decoder start
+ * work before the whole blob is downloaded.
+ */
+struct ZstdMultiFrameCompressionSink : CompressionSink
+{
+    Sink & nextSink;
+    std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> cctx{nullptr, ZSTD_freeCCtx};
+    std::vector<char> outbuf;
+    /**
+     * Input buffer for the current frame.  We accumulate a full
+     * frame's worth before compressing so we can set an exact
+     * `ZSTD_CCtx_setPledgedSrcSize` — that writes `Frame_Content_Size`
+     * into the frame header, allowing a parallel decoder to compute
+     * each frame's output offset up front.
+     */
+    std::vector<char> inbuf;
+    bool emittedAnyFrame = false;
+    static constexpr uint64_t bytesPerFrame = 16 * 1024 * 1024;
+
+    ZstdMultiFrameCompressionSink(Sink & nextSink, bool parallel, int level)
+        : nextSink(nextSink)
+        , outbuf(ZSTD_CStreamOutSize())
+    {
+        inbuf.reserve(bytesPerFrame);
+        cctx.reset(ZSTD_createCCtx());
+        if (!cctx)
+            throw CompressionError("unable to initialise zstd encoder");
+        if (level != COMPRESSION_LEVEL_DEFAULT)
+            checkZstd(ZSTD_CCtx_setParameter(cctx.get(), ZSTD_c_compressionLevel, level));
+        if (parallel) {
+            unsigned ncpu = getMaxCPU();
+            if (ncpu == 0)
+                ncpu = std::thread::hardware_concurrency();
+            /* Cap nbWorkers: zstd's MT engine splits each frame into
+               per-worker jobs.  With 16 MiB frames, more than ~4
+               workers yields diminishing returns (< 4 MiB per worker)
+               and the thread synchronisation overhead can make
+               compression slower than single-threaded. */
+            if (ncpu > 4)
+                ncpu = 4;
+            if (ncpu > 1)
+                /* Don't checkZstd(): if libzstd was built without
+                   ZSTD_MULTITHREAD this returns an error, but per the
+                   zstd docs the parameter is simply ignored and
+                   compression falls back to single-threaded. */
+                ZSTD_CCtx_setParameter(cctx.get(), ZSTD_c_nbWorkers, ncpu);
+        }
+    }
+
+    void checkZstd(size_t ret)
+    {
+        if (ZSTD_isError(ret))
+            throw CompressionError("zstd error: %s", ZSTD_getErrorName(ret));
+    }
+
+    /**
+     * Compress all of `inbuf` as one complete frame, pledged at its
+     * exact size so `Frame_Content_Size` lands in the header.
+     */
+    void emitFrame()
+    {
+        checkZstd(ZSTD_CCtx_reset(cctx.get(), ZSTD_reset_session_only));
+        checkZstd(ZSTD_CCtx_setPledgedSrcSize(cctx.get(), inbuf.size()));
+
+        ZSTD_inBuffer in = {inbuf.data(), inbuf.size(), 0};
+        for (;;) {
+            checkInterrupt();
+            ZSTD_outBuffer out = {outbuf.data(), outbuf.size(), 0};
+            size_t remaining = ZSTD_compressStream2(cctx.get(), &out, &in, ZSTD_e_end);
+            checkZstd(remaining);
+            if (out.pos > 0)
+                nextSink({outbuf.data(), out.pos});
+            if (remaining == 0)
+                break;
+        }
+        inbuf.clear();
+        emittedAnyFrame = true;
+    }
+
+    void writeUnbuffered(std::string_view data) override
+    {
+        while (!data.empty()) {
+            uint64_t room = bytesPerFrame - inbuf.size();
+            size_t n = (room < data.size()) ? room : data.size();
+
+            inbuf.insert(inbuf.end(), data.data(), data.data() + n);
+            data.remove_prefix(n);
+
+            if (inbuf.size() >= bytesPerFrame)
+                emitFrame();
+        }
+    }
+
+    void finish() override
+    {
+        flush();
+        /* Emit the trailing partial frame, or an empty frame if we
+           never wrote anything — the output must contain at least one
+           frame header to be valid zstd (otherwise the libarchive
+           decoder chokes on round-tripped empty input). */
+        if (!inbuf.empty() || !emittedAnyFrame)
+            emitFrame();
+    }
+};
+
 ref<CompressionSink> makeCompressionSink(CompressionAlgo method, Sink & nextSink, const bool parallel, int level)
 {
     switch (method) {
@@ -324,6 +450,8 @@ ref<CompressionSink> makeCompressionSink(CompressionAlgo method, Sink & nextSink
         return make_ref<NoneSink>(nextSink);
     case CompressionAlgo::brotli:
         return make_ref<BrotliCompressionSink>(nextSink);
+    case CompressionAlgo::zstd:
+        return make_ref<ZstdMultiFrameCompressionSink>(nextSink, parallel, level);
         /* Everything else is supported via libarchive. */
 #define NIX_DEF_LA_ALGO_CASE(algo) case CompressionAlgo::algo:
         NIX_FOR_EACH_LA_ALGO(NIX_DEF_LA_ALGO_CASE)

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -101,6 +101,10 @@ brotli = [
 ]
 deps_private += brotli
 
+# Direct libzstd linkage for ZstdMultiFrameCompressionSink.
+zstd = dependency('libzstd', version : '>= 1.4.0')
+deps_private += zstd
+
 cpuid_required = get_option('cpuid')
 if host_machine.cpu_family() != 'x86_64' and cpuid_required.enabled()
   warning('Force-enabling seccomp on non-x86_64 does not make sense')

--- a/src/libutil/package.nix
+++ b/src/libutil/package.nix
@@ -11,6 +11,7 @@
   libsodium,
   nlohmann_json,
   openssl,
+  zstd,
 
   # Configuration Options
 
@@ -52,6 +53,7 @@ mkMesonLibrary (finalAttrs: {
     libblake3
     libsodium
     openssl
+    zstd
   ]
   ++ lib.optional stdenv.hostPlatform.isx86_64 libcpuid;
 


### PR DESCRIPTION
Libarchive's zstd filter produces a single frame regardless of ZSTD_c_nbWorkers, so decompression is stuck on one core.  For large NARs (e.g. 11 GiB) that means ~9 seconds of single-threaded zstd while everything else waits.

Replace the libarchive zstd path with a direct-libzstd sink that cuts a new frame every 16 MiB of uncompressed input.  Each frame buffers its input and compresses in one shot with an exact ZSTD_CCtx_setPledgedSrcSize, so Frame_Content_Size is written to every frame header.

Frame concatenation is mandatory in RFC 8878 §3.1, so existing nix binaries, libarchive, and the zstd CLI all decode the result unchanged.  Nix currently still decompresses serially, but the independent frames with known content sizes mean a future parallel decoder can exploit them without any change to the compressed data already on disk.

When parallel=true, nbWorkers is set from
std::thread::hardware_concurrency() for MT compression within each frame; parallel=false compresses single-threaded but still emits independent frames.

The 16 MiB frame size matches zstd's 8 MiB default window well (minimal ratio loss from not referencing across boundaries) and gives ample frame counts for parallel decode of large NARs.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
