### PR TITLE
Don't destroy windowSize mutex

### DIFF
--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -161,14 +161,16 @@ std::string filterANSIEscapes(std::string_view s, bool filterAll, unsigned int w
 
 //////////////////////////////////////////////////////////////////////
 
-static Sync<std::pair<unsigned short, unsigned short>> windowSize{{0, 0}};
+// Note: this object intentionally leaks to avoid a destructor ordering issue (specifically, ~ProgressBar() calling
+// getWindowSize() after windowSize has been destroyed).
+static auto * const windowSize = new Sync<std::pair<unsigned short, unsigned short>>{{0, 0}};
 
 void updateWindowSize()
 {
 #ifndef _WIN32
     struct winsize ws;
     if (ioctl(2, TIOCGWINSZ, &ws) == 0) {
-        auto windowSize_(windowSize.lock());
+        auto windowSize_(windowSize->lock());
         windowSize_->first = ws.ws_row;
         windowSize_->second = ws.ws_col;
     }
@@ -176,7 +178,7 @@ void updateWindowSize()
     CONSOLE_SCREEN_BUFFER_INFO info;
     // From https://stackoverflow.com/a/12642749
     if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) != 0) {
-        auto windowSize_(windowSize.lock());
+        auto windowSize_(windowSize->lock());
         // From https://github.com/libuv/libuv/blob/v1.48.0/src/win/tty.c#L1130
         windowSize_->first = info.srWindow.Bottom - info.srWindow.Top + 1;
         windowSize_->second = info.dwSize.X;
@@ -186,7 +188,7 @@ void updateWindowSize()
 
 std::pair<unsigned short, unsigned short> getWindowSize()
 {
-    return *windowSize.lock();
+    return *windowSize->lock();
 }
 
 #ifndef _WIN32


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This fixes a a destructor ordering issue where during shutdown, `~ProgressBar()` calls `getWindowSize()` after the `windowSize` object (and thus its mutex) has been destroyed. This happens when a `draw()` call happens to be active during destruction.

Fixes https://github.com/DeterminateSystems/nix-src/issues/361, https://github.com/NixOS/nix/issues/14300, https://github.com/NixOS/nix/issues/14361.
<!-- Briefly explain what the change is about and why it is desirable. -->

BTW we should probably do something similar to `logger` so that calls to `printError()` etc during shutdown don't randomly crash the program. I seem to remember I made a PR for that once but I can't find it...

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
