### PR TITLE
Add deprecation warning to build-hook setting

### DIFF
--- a/src/libstore/include/nix/store/worker-settings.hh
+++ b/src/libstore/include/nix/store/worker-settings.hh
@@ -23,6 +23,32 @@ struct MaxBuildJobsSetting : public BaseSetting<unsigned int>
     unsigned int parse(const std::string & str) const override;
 };
 
+template<typename T>
+class DeprecatedSetting : public Setting<T>
+{
+public:
+    DeprecatedSetting(
+        Config * options,
+        const T & def,
+        const std::string & name,
+        const std::string & description,
+        const StringSet & aliases = {})
+        : Setting<T>(options, def, name, description, aliases)
+    {
+    }
+
+    void operator=(const T & v)
+    {
+        this->assign(v);
+    }
+
+    void assign(const T & v) override
+    {
+        this->value = v;
+        warn("'%s' is deprecated and will be removed from a future version of Nix", this->name);
+    }
+};
+
 struct WorkerSettings : public virtual Config
 {
 protected:
@@ -114,7 +140,7 @@ public:
         )",
         {"build-timeout"}};
 
-    Setting<Strings> buildHook{
+    DeprecatedSetting<Strings> buildHook{
         this,
         {"nix", "__build-remote"},
         "build-hook",
@@ -127,6 +153,11 @@ public:
           > **Important**
           >
           > Change this setting only if you really know what you’re doing.
+
+          > **DEPRECATED**
+          >
+          > This setting is deprecated and will be removed in a future version of Nix.
+          > A migration guide will be published prior to its removal for converting build hooks to either a Store plugin or a program usable with built-in remote building.
         )"};
 
     Setting<std::string> builders{


### PR DESCRIPTION
Adds a deprecation warning to overriding the default value of build-hook. An effort to remove it and to write a migration guide will be undertaken as a GSoC project.

Related to: #1221

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Provide anyone overriding `build-hook` today with a warning that it will be removed in a future release.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#1221
#15533

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
