### PR TITLE
When doing concurrent substitutions of the same path, download only once

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -934,8 +934,9 @@ static void performOp(
 
             logger->startWork();
 
-            // FIXME: race if addToStore doesn't read source?
-            store->addToStore(info, *source, (RepairFlag) repair, dontCheckSigs ? NoCheckSigs : CheckSigs);
+            EnsureRead wrapper{*source, info.narSize};
+            store->addToStore(info, wrapper, (RepairFlag) repair, dontCheckSigs ? NoCheckSigs : CheckSigs);
+            wrapper.finish();
 
             logger->stopWork();
         }

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -634,7 +634,8 @@ public:
     virtual void querySubstitutablePathInfos(const StorePathCAMap & paths, SubstitutablePathInfos & infos);
 
     /**
-     * Import a path into the store.
+     * Import a path into the store. Note that the entire NAR may not be read from `narSource`, e.g. if the path is
+     * already valid.
      */
     virtual void addToStore(
         const ValidPathInfo & info,

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1033,18 +1033,6 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
         throw Error("cannot add path '%s' because it lacks a signature by a trusted key", printStorePath(info.path));
 
     {
-        /* In case we are not interested in reading the NAR: discard it. */
-        bool narRead = false;
-        Finally cleanup = [&]() {
-            if (!narRead)
-                try {
-                    source.skip(info.narSize);
-                } catch (...) {
-                    // TODO: should Interrupted be handled here?
-                    ignoreExceptionInDestructor();
-                }
-        };
-
         addTempRoot(info.path);
 
         if (repair || !isValidPath(info.path)) {
@@ -1069,7 +1057,6 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
 
                 TeeSource wrapperSource{source, hashSink};
 
-                narRead = true;
                 restorePath(realPath, wrapperSource, config->getLocalSettings().fsyncStorePaths);
 
                 auto hashResult = hashSink.finish();

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -283,7 +283,9 @@ void Store::addMultipleToStore(Source & source, RepairFlag repair, CheckSigsFlag
                 .version = {.number = {.major = 1, .minor = 16}},
             });
         info.ultimate = false;
-        addToStore(info, source, repair, checkSigs);
+        EnsureRead wrapper{source, info.narSize};
+        addToStore(info, wrapper, repair, checkSigs);
+        wrapper.finish();
     }
 }
 
@@ -948,6 +950,9 @@ void copyStorePath(
         info2->ultimate = false;
         info = info2;
     }
+
+    if (getEnv("_NIX_TEST_CONCURRENT_SUBSTITUTION"))
+        std::this_thread::sleep_for(std::chrono::seconds(1));
 
     auto source = sinkToSource(
         [&](Sink & sink) {

--- a/src/libutil/include/nix/util/serialise.hh
+++ b/src/libutil/include/nix/util/serialise.hh
@@ -722,4 +722,52 @@ struct FramedSink : nix::BufferedSink
     };
 };
 
+/**
+ * A wrapper source that ensures that at least a specified number of bytes are read from the underlying source.
+ */
+struct EnsureRead : Source
+{
+    Source & source;
+    uint64_t bytesRead = 0, bytesExpected;
+
+    EnsureRead(Source & source, uint64_t bytesExpected)
+        : source(source)
+        , bytesExpected(bytesExpected)
+    {
+    }
+
+    ~EnsureRead()
+    {
+        try {
+            finish();
+        } catch (...) {
+            ignoreExceptionInDestructor();
+        }
+    }
+
+    void finish()
+    {
+        if (bytesRead < bytesExpected)
+            skip(bytesExpected - bytesRead);
+    }
+
+    size_t read(char * data, size_t len) override
+    {
+        auto n = source.read(data, len);
+        bytesRead += n;
+        return n;
+    }
+
+    bool good() override
+    {
+        return source.good();
+    }
+
+    void skip(size_t len) override
+    {
+        source.skip(len);
+        bytesRead += len;
+    }
+};
+
 } // namespace nix

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -15,6 +15,7 @@ nix-instantiate --store "file://$cacheDir" dependencies.nix
 clearStore
 clearCache
 outPath=$(nix-build dependencies.nix --no-out-link)
+depPath=$(nix-build dependencies.nix -A input0_drv --no-out-link)
 
 nix copy --to "file://$cacheDir" "$outPath"
 
@@ -84,6 +85,19 @@ basicDownloadTests
 # Test HttpBinaryCacheStore.
 export _NIX_FORCE_HTTP=1
 basicDownloadTests
+
+
+# Test that multiple concurrent substitutions do only one download.
+clearStore
+nix-store --init # needed because concurrent creation of the store can give SQLite errors
+_NIX_TEST_CONCURRENT_SUBSTITUTION=1 nix-store -r "$depPath" --substituters "file://$cacheDir" --no-require-sigs -vvvv 2> "$TEST_ROOT/log1" &
+pid1="$!"
+_NIX_TEST_CONCURRENT_SUBSTITUTION=1 nix-store -r "$depPath" --substituters "file://$cacheDir" --no-require-sigs -vvvv 2> "$TEST_ROOT/log2" &
+pid2="$!"
+wait "$pid1"
+wait "$pid2"
+[[ $(cat "$TEST_ROOT/log1" "$TEST_ROOT/log2" | grep -c "copying path ") -eq 2 ]]
+[[ $(cat "$TEST_ROOT/log1" "$TEST_ROOT/log2" | grep -c "downloading.*nar.xz") -eq 1 ]]
 
 
 # Test whether Nix notices if the NAR doesn't match the hash in the NAR info.

--- a/tests/functional/nix-copy-ssh-ng.sh
+++ b/tests/functional/nix-copy-ssh-ng.sh
@@ -15,4 +15,8 @@ nix store info --store "$remoteStore"
 
 # Regression test for https://github.com/NixOS/nix/issues/6253
 nix copy --to "$remoteStore" "$outPath" --no-check-sigs &
-nix copy --to "$remoteStore" "$outPath" --no-check-sigs
+pid1="$!"
+nix copy --to "$remoteStore" "$outPath" --no-check-sigs &
+pid2="$!"
+wait "$pid1"
+wait "$pid2"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation


Previously, `LocalStore::addToStore()` always read `info.narSize` bytes from its source. This caused `copyStorePath()` (used by substitution) to always initiate a download even when the store path is valid after the path lock is acquired. So if N clients trigger a substition of some large store path, then that store path would be downloaded N times.

Now `LocalStore::addToStore()` no longer reads from its source if the path turns out to be valid. In that case, `srcStore.narFromPath()` in `copyStorePath()` doesn't get called (since coroutines are lazy), so no download will be started.

If `addToStore()`'s new behaviour is a problem for the caller (e.g. when the NAR is part of a larger stream), then it's the caller's responsibility now to skip `info.narSize` bytes. This can be done using the `EnsureRead` source wrapper class.
## Context

This addresses the duplicate substitution problem identified in https://github.com/NixOS/nix/pull/14991.

Based on https://github.com/DeterminateSystems/nix-src/pull/398.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
