### PR TITLE
packaging: Make binaryTarball more reproducible

### DIFF
--- a/packaging/binary-tarball.nix
+++ b/packaging/binary-tarball.nix
@@ -79,7 +79,8 @@ runCommand "nix-binary-tarball-${version}" env ''
   fn=$out/$dir.tar.xz
   mkdir -p $out/nix-support
   echo "file binary-dist $fn" >> $out/nix-support/hydra-build-products
-  tar cfJ $fn \
+  tar cf - \
+    --sort=name \
     --owner=0 --group=0 --mode=u+rw,uga+r \
     --mtime='1970-01-01' \
     --absolute-names \
@@ -95,5 +96,5 @@ runCommand "nix-binary-tarball-${version}" env ''
     $TMPDIR/install-freebsd-multi-user.sh \
     $TMPDIR/install-multi-user \
     $TMPDIR/reginfo \
-    $(cat ${installerClosureInfo}/store-paths)
+    $(cat ${installerClosureInfo}/store-paths) | xz --threads=1 > $fn
 ''


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

While debugging https://github.com/NixOS/nix/issues/15564 I noticed that our release tarball don't seem to be reproducible. This doesn't explain why hydra calculated the different hash of the tarball, which should only be built once (???).

Regardless, I noticed that checking the build reproducibility against hydra built tarballs fails with e.g.

nix build .\#hydraJobs.binaryTarball.x86_64-linux -L --keep-failed --rebuild

Looking with diffoscope, it was the entry ordering issue. Let's nip this in the bud.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
