### PR TITLE
tests/functional/stale-file-handle: Skip if the error doesn't happen

### DIFF
--- a/tests/functional/local-overlay-store/stale-file-handle-inner.sh
+++ b/tests/functional/local-overlay-store/stale-file-handle-inner.sh
@@ -36,8 +36,12 @@ triggerStaleFileHandle () {
     buildInStore "$storeB"
 }
 
-# Without remounting, we should encounter errors
-expectStderr 1 triggerStaleFileHandle | grepQuiet 'Stale file handle'
+# Without remounting, we should encounter errors.  However, this doesn't seem to
+# happen on Linux 6.19+ anymore.
+#
+# See https://github.com/NixOS/nixpkgs/issues/496466
+( expectStderr 1 triggerStaleFileHandle | grepQuiet 'Stale file handle' ) || \
+    skipTest "Couldn't trigger the error"
 
 # Configure remount-hook and reset OverlayFS
 storeB="$storeB&remount-hook=$PWD/remount.sh"


### PR DESCRIPTION
This error no longer seems to occur on Linux 6.19+ anymore. Skip in that case to fix build.

This probably needs backporting

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fixes, hopefully, https://github.com/NixOS/nixpkgs/issues/496466 on Linux 6.19

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
