### PR TITLE
libstore: pass atermEnv by reference

### DIFF
--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -748,7 +748,7 @@ std::string Derivation::unparse(
     s += ",["sv;
     first = true;
 
-    auto unparseEnv = [&](const StringPairs atermEnv) {
+    auto unparseEnv = [&](const StringPairs & atermEnv) {
         for (auto & i : atermEnv) {
             if (first)
                 first = false;


### PR DESCRIPTION
Seems like an oversight, since the value is thrown away right after