### PR TITLE
nix: add recursive nixConfig support for flake inputs

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -67,6 +67,17 @@ MixFlakeOptions::MixFlakeOptions()
     });
 
     addFlag({
+        .longName = "recursive-nix-config",
+        .shortName = 'r',
+        .description = "Apply nixConfig recursively for transitive flake inputs.",
+        .category = category,
+        .handler = {[&]() {
+            lockFlags.recursiveNixConfig = true;
+            lockFlags.applyNixConfig = true;
+        }},
+    });
+
+    addFlag({
         .longName = "no-update-lock-file",
         .description = "Do not allow any updates to the flake's lock file.",
         .category = category,

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -429,10 +429,21 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
 
     auto flake = getFlake(state, topRef, useRegistriesTop, {});
 
-    if (lockFlags.applyNixConfig) {
-        flake.config.apply(settings);
+    std::set<std::string> appliedNixConfigRefs;
+
+    auto applyConfigFromFlake = [&](Flake & configFlake) {
+        if (!lockFlags.applyNixConfig)
+            return;
+        if (lockFlags.recursiveNixConfig) {
+            auto refKey = configFlake.lockedRef.to_string();
+            if (!appliedNixConfigRefs.insert(refKey).second)
+                return;
+        }
+        configFlake.config.apply(settings);
         state.store->setOptions();
-    }
+    };
+
+    applyConfigFromFlake(flake);
 
     try {
         if (!state.fetchSettings.allowDirty && lockFlags.referenceLockFilePath) {
@@ -686,6 +697,8 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
 
                         if (mustRefetch) {
                             auto inputFlake = getInputFlake(oldLock->lockedRef, useRegistriesInputs);
+                            if (lockFlags.recursiveNixConfig && oldLock->isFlake)
+                                applyConfigFromFlake(inputFlake);
                             nodePaths.emplace(childNode, inputFlake.path.parent());
                             computeLocks(
                                 inputFlake.inputs,
@@ -696,6 +709,10 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
                                 inputFlake.path,
                                 false);
                         } else {
+                            if (lockFlags.recursiveNixConfig && oldLock->isFlake) {
+                                auto inputFlake = getInputFlake(oldLock->lockedRef, useRegistriesInputs);
+                                applyConfigFromFlake(inputFlake);
+                            }
                             computeLocks(
                                 fakeInputs, childNode, inputAttrPath, oldLock, followsPrefix, sourcePath, true);
                         }
@@ -722,6 +739,8 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
                         if (input.isFlake) {
                             auto inputFlake = getInputFlake(
                                 *input.ref, inputIsOverride ? fetchers::UseRegistries::All : useRegistriesInputs);
+                            if (lockFlags.recursiveNixConfig)
+                                applyConfigFromFlake(inputFlake);
 
                             auto childNode =
                                 make_ref<LockedNode>(inputFlake.lockedRef, ref, true, overriddenParentPath);

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -443,6 +443,12 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
         state.store->setOptions();
     };
 
+    auto needsRecursiveNixConfigFor = [&](const FlakeRef & lockedRef) {
+        if (!lockFlags.recursiveNixConfig)
+            return false;
+        return !appliedNixConfigRefs.contains(lockedRef.to_string());
+    };
+
     applyConfigFromFlake(flake);
 
     try {
@@ -709,7 +715,8 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
                                 inputFlake.path,
                                 false);
                         } else {
-                            if (lockFlags.recursiveNixConfig && oldLock->isFlake) {
+                            if (lockFlags.recursiveNixConfig && oldLock->isFlake
+                                && needsRecursiveNixConfigFor(oldLock->lockedRef)) {
                                 auto inputFlake = getInputFlake(oldLock->lockedRef, useRegistriesInputs);
                                 applyConfigFromFlake(inputFlake);
                             }

--- a/src/libflake/include/nix/flake/flake.hh
+++ b/src/libflake/include/nix/flake/flake.hh
@@ -180,6 +180,11 @@ struct LockFlags
     bool applyNixConfig = false;
 
     /**
+     * Whether to apply nixConfig recursively to inputs of inputs.
+     */
+    bool recursiveNixConfig = false;
+
+    /**
      * Whether unlocked flake references (i.e. those without a Git
      * revision or similar) without a corresponding lock are
      * allowed. Unlocked flake references with a lock are always


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

CLOSES: #6771

Add a `-r` / `--recursive-nix-config` flag to the unified `nix` CLI so `nixConfig` from flakes is applied not only to the top-level flake, but also recursively to transitive flake inputs.

It can make flake configuration behavior more consistent in projects where transitive dependencies also rely on `nixConfig`.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

This is a non-trivial change in flake evaluation and lock traversal

Implementation approach:
- add a new `LockFlags` field to track recursive nixConfig application
- add a unified CLI flag in the common flake options
- apply `nixConfig` while traversing flake inputs recursively
- deduplicate repeated application of the same flake config when traversing transitive inputs

I did not see an existing open issue referenced for this specific behavior

Also important to know is that I am an absolute jester in cpp and do not enjoy writing it, so I might have missed something even though I tried my best

Also see https://github.com/cachix/devenv/pull/2474#issuecomment-4144847387

## Blocked-by

- [ ] #9649

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
