### PR TITLE
libstore: Use new Worker::Waker mechanism for the substitution thread

### DIFF
--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -308,6 +308,13 @@ Goal::Co Goal::waitForAWhile()
     co_return Return{};
 }
 
+Goal::Co Goal::waitUntilWoken()
+{
+    worker.waitForCompletion(shared_from_this());
+    co_await Suspend{};
+    co_return Return{};
+}
+
 Goal::Co Goal::waitForBuildSlot()
 {
     worker.waitForBuildSlot(shared_from_this());

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -207,53 +207,54 @@ Goal::Co PathSubstitutionGoal::tryToRun(
     auto maintainRunningSubstitutions = std::make_unique<MaintainCount<uint64_t>>(worker.runningSubstitutions);
     worker.updateProgress();
 
-    outPipe = worker.makeMuxablePipe();
-
     auto promise = std::promise<void>();
+    auto future = promise.get_future();
 
-    thr = std::thread([this, &promise, &subPath, &sub]() {
+    /* Be careful with ownership. cleanup() doesn't signal the worker thread
+       to cleanly shutdown, so the worker can die while the thread is still
+       running. That's why we use weak_ptr for everything that is owned by the
+       Worker. */
+    thr = std::thread([weakGoal = weak_from_this(),
+                       promise = std::move(promise),
+                       subPath,
+                       storePath = storePath,
+                       repair = repair,
+                       sub,
+                       maybeWaker = worker.getCrossThreadWaker(),
+                       maybeWorkerStore = worker.store.weak_from_this()]() mutable {
         try {
             ReceiveInterrupts receiveInterrupts;
 
-            /* Wake up the worker loop when we're done. */
-            Finally updateStats([this]() { outPipe.writeSide.close(); });
+            /* The Worker might have died while we were starting up. */
+            auto workerStore = maybeWorkerStore.lock();
+            if (!workerStore)
+                return;
 
             Activity act(
                 *logger,
                 actSubstitute,
-                Logger::Fields{worker.store.printStorePath(storePath), sub->config.getHumanReadableURI()});
+                Logger::Fields{workerStore->printStorePath(storePath), sub->config.getHumanReadableURI()});
             PushActivity pact(act.id);
 
-            copyStorePath(*sub, worker.store, subPath, repair, sub->config.isTrusted ? NoCheckSigs : CheckSigs);
+            copyStorePath(*sub, *workerStore, subPath, repair, sub->config.isTrusted ? NoCheckSigs : CheckSigs);
 
             promise.set_value();
         } catch (...) {
             promise.set_exception(std::current_exception());
         }
+
+        /* The Worker might have already died (and the waker with it) by the
+           time we finished. N.B. if enqueueing to the waker throws, we better
+           std::terminate, since something has gone very wrong. This intentionally
+           lets the thread crash on exceptions for that reason. */
+        if (auto waker = maybeWaker.lock())
+            waker->enqueue(weakGoal);
     });
 
-    worker.childStarted(
-        shared_from_this(),
-        {
-#ifndef _WIN32
-            outPipe.readSide.get()
-#else
-            &outPipe
-#endif
-        },
-        true,
-        false);
-
-    while (true) {
-        auto event = co_await WaitForChildEvent{};
-        if (std::get_if<ChildOutput>(&event)) {
-            // Substitution doesn't process child output
-        } else if (std::get_if<ChildEOF>(&event)) {
-            break;
-        } else if (std::get_if<TimedOut>(&event)) {
-            unreachable(); // Substitution doesn't use timeouts
-        }
-    }
+    /* Use up the substitution slot. */
+    worker.childStarted(shared_from_this(), /*channels=*/{}, /*inBuildSlot=*/true, /*respectTimeouts=*/false);
+    /* Suspend until the thread finishes. */
+    co_await waitUntilWoken();
 
     trace("substitute finished");
 
@@ -261,7 +262,7 @@ Goal::Co PathSubstitutionGoal::tryToRun(
     worker.childTerminated(this);
 
     try {
-        promise.get_future().get();
+        future.get();
     } catch (std::exception & e) {
         /* Cause the parent build to fail unless --fallback is given,
            or the substitute has disappeared. The latter case behaves
@@ -313,8 +314,6 @@ void PathSubstitutionGoal::cleanup()
             thr.join();
             worker.childTerminated(this, JobCategory::Substitution);
         }
-
-        outPipe.close();
     } catch (...) {
         ignoreExceptionInDestructor();
     }

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -607,17 +607,6 @@ void Worker::markContentsGood(const StorePath & path)
     pathContentsGoodCache.insert_or_assign(path, true);
 }
 
-MuxablePipe Worker::makeMuxablePipe()
-{
-    MuxablePipe pipe;
-#ifndef _WIN32
-    pipe.create();
-#else
-    pipe.createAsyncPipe(ioport.get());
-#endif
-    return pipe;
-}
-
 GoalPtr upcast_goal(std::shared_ptr<PathSubstitutionGoal> subGoal)
 {
     return subGoal;

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -609,7 +609,19 @@ public:
 protected:
     Co await(Goals waitees);
 
+    /**
+     * Awaiting on the resulting coroutine yields the goal for several seconds.
+     * Used for retrying goals blocked on acquiring lockfiles.
+     */
     Co waitForAWhile();
+
+    /**
+     * Awaiting on the resulting coroutine yields the goal until it is
+     * explicitly woken up via Worker::wakeUp. Wakeup can be queued from another
+     * thread via Worker::Waker.
+     */
+    Co waitUntilWoken();
+
     Co waitForBuildSlot();
     Co yield();
 };

--- a/src/libstore/include/nix/store/build/substitution-goal.hh
+++ b/src/libstore/include/nix/store/build/substitution-goal.hh
@@ -4,7 +4,6 @@
 #include "nix/store/build/worker.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/build/goal.hh"
-#include "nix/util/muxable-pipe.hh"
 #include <coroutine>
 #include <future>
 #include <source_location>
@@ -22,11 +21,6 @@ struct PathSubstitutionGoal : public Goal
      * Whether to try to repair a valid path.
      */
     RepairFlag repair;
-
-    /**
-     * Pipe for the substituter's standard output.
-     */
-    MuxablePipe outPipe;
 
     /**
      * The substituter thread.

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -150,8 +150,8 @@ private:
     {
 #ifndef _WIN32
         /**
-         * Wakeup pipe polled alongside all other goal FDs. Gets written to by wakeUpCrossThread.
-         * Not needed on Windows.
+         * Wakeup pipe polled alongside all other goal FDs. Gets written to by
+         * enqueue(). Not needed on Windows.
          */
         unix::SelfPipe wakeupPipe;
 #else
@@ -172,13 +172,6 @@ private:
             wakeupPipe.create();
 #endif
         }
-
-#ifdef _WIN32
-        Waker(Descriptor ioport)
-            : ioport(ioport)
-        {
-        }
-#endif
 
     public:
         void enqueue(WeakGoalPtr goal);
@@ -403,12 +396,6 @@ public:
         act.setExpected(actFileTransfer, expectedDownloadSize + doneDownloadSize);
         act.setExpected(actCopyPath, expectedNarSize + doneNarSize);
     }
-
-    /**
-     * Create a MuxablePipe that the worker can poll. Primary exists to
-     * deduplicate WIN32 ifdefs.
-     */
-    MuxablePipe makeMuxablePipe();
 };
 
 } // namespace nix


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Previously we would create a new pipe for each substitution goal, but now we can reuse the new Waker coroutine resumption mechanism that writes to a single wakeup pipe and a thread-safe queue of goals to resume.

Also documents and fixes some lifetimes issues in the thread captures. I haven't seen this fail, but looking at the code, I'm pretty sure that the thread can still be running when the Worker dies, depending on when the SIGUSR1 signal arrives and when the thread unwinds its stack. So use the same weak_ptr approach to optionally share the ownership of all the members (like the store, substituter and the Waker) that are needed by the substitution thread.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
