### PR TITLE
build: link mimalloc into the nix binary by default

### DIFF
--- a/doc/manual/rl-next/mimalloc.md
+++ b/doc/manual/rl-next/mimalloc.md
@@ -1,0 +1,15 @@
+---
+synopsis: "Link mimalloc for faster evaluation"
+prs: [15596]
+---
+
+The `nix` binary now links [mimalloc](https://github.com/microsoft/mimalloc)
+by default on non-Windows platforms, replacing glibc's malloc for all
+non-GC allocations.
+
+This yields a **5–12% wall-clock improvement** on evaluation workloads,
+ranging from `nix-instantiate hello` to `nix-env -qa` and full NixOS
+configurations.
+
+The allocator can be disabled at build time with `-Dmimalloc=disabled`
+or by passing `withMimalloc = false` to the Nix package.

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -31,6 +31,11 @@ deps_private_maybe_subproject = [
 deps_public_maybe_subproject = []
 subdir('nix-meson-build-support/subprojects')
 
+mimalloc = dependency('mimalloc', required : get_option('mimalloc'))
+if mimalloc.found()
+  deps_private += mimalloc
+endif
+
 subdir('nix-meson-build-support/export-all-symbols')
 subdir('nix-meson-build-support/windows-version')
 

--- a/src/nix/meson.options
+++ b/src/nix/meson.options
@@ -7,3 +7,10 @@ option(
   value : 'etc/profile.d',
   description : 'the path to install shell profile files',
 )
+
+option(
+  'mimalloc',
+  type : 'feature',
+  value : 'auto',
+  description : 'Link against mimalloc to override the default memory allocator',
+)

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -8,9 +8,16 @@
   nix-main,
   nix-cmd,
 
+  mimalloc,
+
   # Configuration Options
 
   version,
+
+  # Whether to link against mimalloc for malloc override.
+  # Significantly improves evaluation performance on allocation-heavy
+  # workloads (~10-15% on large evaluations).
+  withMimalloc ? !stdenv.hostPlatform.isWindows,
 }:
 
 let
@@ -69,9 +76,11 @@ mkMesonExecutable (finalAttrs: {
     nix-expr
     nix-main
     nix-cmd
-  ];
+  ]
+  ++ lib.optional withMimalloc mimalloc;
 
   mesonFlags = [
+    (lib.mesonEnable "mimalloc" withMimalloc)
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isStatic ''


### PR DESCRIPTION
## motivation

the nix evaluator spends a surprising amount of time in malloc — strings, maps, symbol tables, drv parsing buffers. swapping glibc malloc for [mimalloc](https://github.com/microsoft/mimalloc) turns out to be a cheap, consistent win across the board.

this adds a meson `mimalloc` feature option (default `auto`) and wires it into `package.nix` with `withMimalloc ? !isWindows`. the allocator links into the `nix` executable and overrides malloc for all `libnix*` components via symbol interposition. boehm GC's heap is unaffected (it bypasses malloc entirely).

## numbers

benchmarked on x86_64-linux, nix 2.35.0 at `7edcd0a24`, nixpkgs master:

| workload | thunks | glibc | mimalloc | wall speedup |
|---|---|---|---|---|
| `hello` | 275K | 185.4 ms ± 2.1 | 176.4 ms ± 1.9 | **1.05×** |
| `chromium` | 1.9M | 760.3 ms ± 6.0 | 709.3 ms ± 8.7 | **1.07×** |
| `firefox-unwrapped` | 2.4M | 836.2 ms ± 6.4 | 782.0 ms ± 4.9 | **1.07×** |
| `texliveFull` | 5.5M | 1.604 s ± 0.011 | 1.466 s ± 0.017 | **1.09×** |
| large nixos config¹ | 39M | 12.79 s ± 0.29 | 11.90 s ± 0.31 | **1.07×** |
| `nix-env -qa` | 100M+ | 118.96 s ± 1.99 | 105.86 s ± 3.44 | **1.12×** |

¹ `github:lovesegfault/nix-config#nixosConfigurations.spinoza` with `--no-eval-cache`

(user-CPU numbers dropped from an earlier revision of this table — boehm's parallel marking makes them too noisy to attribute to the allocator; see review thread.)

also tested tcmalloc and jemalloc: tcmalloc matches mimalloc on wall-clock; jemalloc lags slightly. mimalloc has the smallest dependency footprint so it wins.

## reproducing

```bash
# build baseline
nix build github:NixOS/nix/7edcd0a24#nix-cli -o result-baseline

# build with mimalloc (this branch)
nix build .#nix-cli -o result-mimalloc

# bench
hyperfine --warmup 2 --runs 10 \
  -n glibc    "result-baseline/bin/nix-instantiate <nixpkgs> -A texliveFull --dry-run" \
  -n mimalloc "result-mimalloc/bin/nix-instantiate <nixpkgs> -A texliveFull --dry-run"
```

or preload mimalloc on any existing nix to test without rebuilding:

```bash
LD_PRELOAD=$(nix build --no-link --print-out-paths nixpkgs#mimalloc)/lib/libmimalloc.so \
  nix-instantiate <nixpkgs> -A texliveFull --dry-run
```

(`LD_PRELOAD` gives identical results to linking — verified via `MIMALLOC_SHOW_STATS=1`)

## checklist

- [x] dynamic build verified (`ldd` shows `libmimalloc.so.3`, `MIMALLOC_VERBOSE=1` confirms active)
- [x] static build (`nix build .#nix-cli-static` completes, malloc override works)
- [x] release note
- [ ] darwin CI — should just work via nixpkgs mimalloc but want eyes
