### PR TITLE
libstore: add conn-pipe-size setting for ssh-ng stores

### DIFF
--- a/src/libstore/include/nix/store/ssh-store.hh
+++ b/src/libstore/include/nix/store/ssh-store.hh
@@ -24,6 +24,14 @@ struct SSHStoreConfig : std::enable_shared_from_this<SSHStoreConfig>,
     Setting<Strings> remoteProgram{
         this, {"nix-daemon"}, "remote-program", "Path to the `nix-daemon` executable on the remote machine."};
 
+    Setting<size_t> connPipeSize{
+        this,
+        1024 * 1024,
+        "conn-pipe-size",
+        "Size in bytes of the pipe buffer to the SSH process, set via `F_SETPIPE_SZ`. "
+        "Larger values reduce `write()` blocking when streaming NARs to the remote. "
+        "Set to 0 to leave the pipe at the OS default."};
+
     static const std::string name()
     {
         return "Experimental SSH Store";

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -209,6 +209,8 @@ ref<RemoteStore::Connection> SSHStore::openConnection()
     }
     command.insert(command.end(), extraRemoteProgramArgs.begin(), extraRemoteProgramArgs.end());
     conn->sshConn = master.startCommand(toOsStrings(std::move(command)));
+    if (config->connPipeSize > 0)
+        conn->sshConn->trySetBufferSize(config->connPipeSize);
     conn->to = FdSink(conn->sshConn->in.get());
     conn->from = FdSource(conn->sshConn->out.get());
     return conn;


### PR DESCRIPTION
## Summary

- `legacy-ssh-store.cc` calls `trySetBufferSize()` on the SSH pipe when `connPipeSize` is set (exposed for Hydra), but `ssh-store.cc` (`ssh-ng://`) has no equivalent, leaving the pipe at the OS default (64 KB on Linux).
- This adds a `conn-pipe-size` URL parameter (default 1 MB) to `SSHStoreConfig` and calls `trySetBufferSize()` in `openConnection()`, matching the legacy store behavior.
- A larger pipe reduces `write()` blocking when streaming NARs to a remote builder via `AddMultipleToStore`.

## Test plan

- Build and run `nix store ping --store 'ssh-ng://host?conn-pipe-size=1048576'` against a remote machine; verify the connection succeeds.
- Confirm `conn-pipe-size=0` leaves the pipe at the OS default.
- Run existing `ssh-store` integration tests to check for regressions.