### PR TITLE
libutil: add machine origin field to Logger activity events

### DIFF
--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -19,7 +19,7 @@ public:
         return oss.str();
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s, std::optional<std::string_view> machine = {}) override
     {
         oss << s << std::endl;
     }

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -175,7 +175,7 @@ public:
         return printBuildLogs;
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s, std::optional<std::string_view> machine = {}) override
     {
         if (lvl > verbosity)
             return;
@@ -209,7 +209,8 @@ public:
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent,
+        std::optional<std::string_view> machine) override
     {
         auto state(state_.lock());
 
@@ -228,7 +229,9 @@ public:
                 name = name.substr(0, name.size() - 4);
             i->s = fmt("building " ANSI_BOLD "%s" ANSI_NORMAL, name);
             auto machineName = getS(fields, 1);
-            if (machineName != "")
+            if (machineName.empty() && machine)
+                machineName = *machine;
+            if (!machineName.empty())
                 i->s += fmt(" on " ANSI_BOLD "%s" ANSI_NORMAL, machineName);
 
             // Used to be curRound and nrRounds, but the

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -665,8 +665,12 @@ Goal::Co DerivationBuildingGoal::buildWithHook(
                     if (c == '\n') {
                         auto json = parseJSONMessage(currentHookLine, "the derivation builder");
                         if (json) {
+                            auto machineOpt = hook->machineName.empty()
+                                                  ? std::optional<std::string_view>{}
+                                                  : std::optional<std::string_view>{hook->machineName};
                             auto s = handleJSONLogMessage(
-                                *json, worker.act, hook->activities, "the derivation builder", true);
+                                *json, worker.act, hook->activities, "the derivation builder", true, machineOpt);
+
                             // ensure that logs from a builder using `ssh-ng://` as protocol
                             // are also available to `nix log`.
                             if (s && logFile->sink) {
@@ -1142,7 +1146,10 @@ HookReply DerivationBuildingGoal::tryBuildHook(const DerivationOptions<StorePath
                     throw;
                 }
             }();
-            if (handleJSONLogMessage(s, worker.act, worker.hook->activities, "the build hook", true))
+            auto hookMachine = worker.hook->machineName.empty()
+                                   ? std::optional<std::string_view>{}
+                                   : std::optional<std::string_view>{worker.hook->machineName};
+            if (handleJSONLogMessage(s, worker.act, worker.hook->activities, "the build hook", true, hookMachine))
                 ;
             else if (s.substr(0, 2) == "# ") {
                 reply = s.substr(2);

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -85,7 +85,7 @@ struct TunnelLogger : public Logger
             state->pendingMsgs.push_back(s);
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s, std::optional<std::string_view> machine = {}) override
     {
         if (lvl > verbosity)
             return;
@@ -148,7 +148,8 @@ struct TunnelLogger : public Logger
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent,
+        std::optional<std::string_view> machine) override
     {
         if (clientVersion.number < WorkerProto::Version::Number{1, 20}) {
             if (!s.empty())
@@ -156,6 +157,8 @@ struct TunnelLogger : public Logger
             return;
         }
 
+        // Note: `machine` is intentionally not serialized on the wire.
+        // Adding it would require a worker protocol version bump.
         StringSink buf;
         buf << STDERR_START_ACTIVITY << act << lvl << type << s << fields << parent;
         enqueueMsg(buf.s);

--- a/src/libstore/include/nix/store/worker-protocol-connection.hh
+++ b/src/libstore/include/nix/store/worker-protocol-connection.hh
@@ -4,6 +4,9 @@
 #include "nix/store/worker-protocol.hh"
 #include "nix/store/store-api.hh"
 
+#include <map>
+#include <optional>
+
 namespace nix {
 
 struct WorkerProto::BasicConnection
@@ -62,6 +65,21 @@ struct WorkerProto::BasicClientConnection : WorkerProto::BasicConnection
      * Flush to direction
      */
     virtual ~BasicClientConnection();
+
+    /**
+     * The remote machine name (e.g. "ssh-ng://host").
+     * Used to tag all log messages and activities forwarded from
+     * the remote daemon so that consumers can identify their origin.
+     * Absent when the connection has no meaningful remote identity.
+     */
+    std::optional<std::string> machineName;
+
+    /**
+     * Maps activity IDs received from the remote daemon to fresh
+     * locally-allocated IDs, since remote IDs are only unique within
+     * the remote process and could collide with local activities.
+     */
+    std::map<ActivityId, ActivityId> activityIds;
 
     virtual void closeWrite() = 0;
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -76,6 +76,10 @@ ref<RemoteStore::Connection> RemoteStore::openConnectionWrapper()
 
 void RemoteStore::initConnection(Connection & conn)
 {
+    /* Set the machine name so that build activities forwarded from
+       the remote daemon have the correct origin. */
+    conn.machineName = config.getHumanReadableURI();
+
     /* Send the magic greeting, check for the reply. */
     try {
         conn.from.endOfFileError = "Nix daemon disconnected unexpectedly (maybe it crashed?)";

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -73,27 +73,37 @@ WorkerProto::BasicClientConnection::processStderrReturn(Sink * sink, Source * so
         }
 
         else if (msg == STDERR_NEXT)
-            printError(chomp(readString(from)));
+            logger->log(lvlError, chomp(readString(from)), machineName);
 
         else if (msg == STDERR_START_ACTIVITY) {
-            auto act = readNum<ActivityId>(from);
+            auto remoteAct = readNum<ActivityId>(from);
             auto lvl = (Verbosity) readInt(from);
             auto type = (ActivityType) readInt(from);
             auto s = readString(from);
             auto fields = readFields(from);
-            auto parent = readNum<ActivityId>(from);
-            logger->startActivity(act, lvl, type, s, fields, parent);
+            auto remoteParent = readNum<ActivityId>(from);
+            auto act = nextActivityId();
+            activityIds[remoteAct] = act;
+            auto i = activityIds.find(remoteParent);
+            auto parent = i != activityIds.end() ? i->second : remoteParent;
+            logger->startActivity(act, lvl, type, s, fields, parent, machineName);
         }
 
         else if (msg == STDERR_STOP_ACTIVITY) {
-            auto act = readNum<ActivityId>(from);
+            auto remoteAct = readNum<ActivityId>(from);
+            auto i = activityIds.find(remoteAct);
+            auto act = i != activityIds.end() ? i->second : remoteAct;
+            if (i != activityIds.end())
+                activityIds.erase(i);
             logger->stopActivity(act);
         }
 
         else if (msg == STDERR_RESULT) {
-            auto act = readNum<ActivityId>(from);
+            auto remoteAct = readNum<ActivityId>(from);
             auto type = (ResultType) readInt(from);
             auto fields = readFields(from);
+            auto i = activityIds.find(remoteAct);
+            auto act = i != activityIds.end() ? i->second : remoteAct;
             logger->result(act, type, fields);
         }
 

--- a/src/libutil/include/nix/util/logging.hh
+++ b/src/libutil/include/nix/util/logging.hh
@@ -130,7 +130,12 @@ public:
         return false;
     }
 
-    virtual void log(Verbosity lvl, std::string_view s) = 0;
+    /**
+     * @param machine The origin machine for messages forwarded from
+     * a remote store connection (e.g. "ssh-ng://host"). Absent
+     * (nullopt) for locally-generated messages.
+     */
+    virtual void log(Verbosity lvl, std::string_view s, std::optional<std::string_view> machine = {}) = 0;
 
     void log(std::string_view s)
     {
@@ -147,13 +152,17 @@ public:
 
     virtual void warn(const std::string & msg);
 
+    /**
+     * @param machine Remote store origin, see `log()`.
+     */
     virtual void startActivity(
         ActivityId act,
         Verbosity lvl,
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) {};
+        ActivityId parent,
+        std::optional<std::string_view> machine = {}) {};
 
     virtual void stopActivity(ActivityId act) {};
 
@@ -191,6 +200,11 @@ struct nop
 ActivityId getCurActivity();
 void setCurActivity(const ActivityId activityId);
 
+/**
+ * Allocate a fresh activity ID, unique within this process.
+ */
+ActivityId nextActivityId();
+
 struct Activity
 {
     Logger & logger;
@@ -203,7 +217,8 @@ struct Activity
         ActivityType type,
         const std::string & s = "",
         const Logger::Fields & fields = {},
-        ActivityId parent = getCurActivity());
+        ActivityId parent = getCurActivity(),
+        std::optional<std::string_view> machine = {});
 
     Activity(
         Logger & logger, ActivityType type, const Logger::Fields & fields = {}, ActivityId parent = getCurActivity())
@@ -286,7 +301,8 @@ bool handleJSONLogMessage(
     const Activity & act,
     std::map<ActivityId, Activity> & activities,
     std::string_view source,
-    bool trusted);
+    bool trusted,
+    std::optional<std::string_view> machine = {});
 
 /**
  * @param source A noun phrase describing the source of the message, e.g. "the builder".
@@ -296,7 +312,8 @@ bool handleJSONLogMessage(
     const Activity & act,
     std::map<ActivityId, Activity> & activities,
     std::string_view source,
-    bool trusted);
+    bool trusted,
+    std::optional<std::string_view> machine = {});
 
 /**
  * suppress msgs > this

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -78,7 +78,7 @@ public:
         return printBuildLogs;
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s, std::optional<std::string_view> machine = {}) override
     {
         if (lvl > verbosity)
             return;
@@ -130,7 +130,8 @@ public:
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent,
+        std::optional<std::string_view> machine) override
     {
         if (lvl <= verbosity && !s.empty())
             log(lvl, s + "...");
@@ -172,7 +173,7 @@ std::unique_ptr<Logger> makeSimpleLogger(bool printBuildLogs)
     return std::make_unique<SimpleLogger>(printBuildLogs);
 }
 
-std::atomic<uint64_t> nextId{0};
+static std::atomic<uint64_t> nextId{0};
 
 static uint64_t getPid()
 {
@@ -183,17 +184,23 @@ static uint64_t getPid()
 #endif
 }
 
+ActivityId nextActivityId()
+{
+    return nextId++ + (((uint64_t) getPid()) << 32);
+}
+
 Activity::Activity(
     Logger & logger,
     Verbosity lvl,
     ActivityType type,
     const std::string & s,
     const Logger::Fields & fields,
-    ActivityId parent)
+    ActivityId parent,
+    std::optional<std::string_view> machine)
     : logger(logger)
-    , id(nextId++ + (((uint64_t) getPid()) << 32))
+    , id(nextActivityId())
 {
-    logger.startActivity(id, lvl, type, s, fields, parent);
+    logger.startActivity(id, lvl, type, s, fields, parent, machine);
 }
 
 void to_json(nlohmann::json & json, std::shared_ptr<const Pos> pos)
@@ -269,12 +276,19 @@ struct JSONLogger : Logger
         }
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void addOrigin(nlohmann::json & json, std::optional<std::string_view> machine)
+    {
+        if (machine && !machine->empty())
+            json["machine"] = *machine;
+    }
+
+    void log(Verbosity lvl, std::string_view s, std::optional<std::string_view> machine = {}) override
     {
         nlohmann::json json;
         json["action"] = "msg";
         json["level"] = lvl;
         json["msg"] = s;
+        addOrigin(json, machine);
         write(json);
     }
 
@@ -311,7 +325,8 @@ struct JSONLogger : Logger
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent,
+        std::optional<std::string_view> machine) override
     {
         nlohmann::json json;
         json["action"] = "start";
@@ -321,6 +336,7 @@ struct JSONLogger : Logger
         json["text"] = s;
         json["parent"] = parent;
         addFields(json, fields);
+        addOrigin(json, machine);
         write(json);
     }
 
@@ -419,7 +435,8 @@ bool handleJSONLogMessage(
     const Activity & act,
     std::map<ActivityId, Activity> & activities,
     std::string_view source,
-    bool trusted)
+    bool trusted,
+    std::optional<std::string_view> machine)
 {
     try {
         std::string action = json["action"];
@@ -431,7 +448,13 @@ bool handleJSONLogMessage(
                     std::piecewise_construct,
                     std::forward_as_tuple(json["id"]),
                     std::forward_as_tuple(
-                        *logger, (Verbosity) json["level"], type, json["text"], getFields(json["fields"]), act.id));
+                        *logger,
+                        (Verbosity) json["level"],
+                        type,
+                        json["text"],
+                        getFields(json["fields"]),
+                        act.id,
+                        machine));
         }
 
         else if (action == "stop")
@@ -450,7 +473,7 @@ bool handleJSONLogMessage(
 
         else if (action == "msg") {
             std::string msg = json["msg"];
-            logger->log((Verbosity) json["level"], msg);
+            logger->log((Verbosity) json["level"], msg, machine);
         }
 
         return true;
@@ -465,13 +488,14 @@ bool handleJSONLogMessage(
     const Activity & act,
     std::map<ActivityId, Activity> & activities,
     std::string_view source,
-    bool trusted)
+    bool trusted,
+    std::optional<std::string_view> machine)
 {
     auto json = parseJSONMessage(msg, source);
     if (!json)
         return false;
 
-    return handleJSONLogMessage(*json, act, activities, source, trusted);
+    return handleJSONLogMessage(*json, act, activities, source, trusted, machine);
 }
 
 Activity::~Activity()

--- a/src/libutil/tee-logger.cc
+++ b/src/libutil/tee-logger.cc
@@ -29,10 +29,10 @@ struct TeeLogger : Logger
             logger->resume();
     };
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s, std::optional<std::string_view> machine = {}) override
     {
         for (auto & logger : loggers)
-            logger->log(lvl, s);
+            logger->log(lvl, s, machine);
     }
 
     void logEI(const ErrorInfo & ei) override
@@ -47,10 +47,11 @@ struct TeeLogger : Logger
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent,
+        std::optional<std::string_view> machine) override
     {
         for (auto & logger : loggers)
-            logger->startActivity(act, lvl, type, s, fields, parent);
+            logger->startActivity(act, lvl, type, s, fields, parent, machine);
     }
 
     void stopActivity(ActivityId act) override


### PR DESCRIPTION
## Motivation

When using remote builders (via `--builders` or `--store ssh-ng://`), build monitors like [nix-output-monitor](https://github.com/maralorn/nix-output-monitor) receive degraded structured logging compared to local builds.

This PR adds an optional `machine` parameter to `Logger::log()` and `startActivity()` so that log messages and activities forwarded from a remote store connection can be tagged with their origin (e.g. `"ssh-ng://host"`).

## Context

Split from #15215 into smaller reviewable changes. Related to #15055 — adopts the same `machine` origin string approach reviewed favorably there.

## What changed

- `Logger::log()` and `startActivity()` gain an optional `machine` parameter
- `JSONLogger` emits a `"machine"` field on `msg`/`start` events
- Progress bar falls back to the `machine` parameter when `actBuild` fields lack a machine name
- `TeeLogger` forwards the parameter to all sub-loggers
- `TunnelLogger` accepts the parameter but does not serialize it (would need a worker protocol version bump)
- `BasicClientConnection` gains a `machineName` field populated by `RemoteStore::initConnection()` from `getHumanReadableURI()`
- Build hook paths convert empty `machineName` to `nullopt` before forwarding

### Activity ID remapping

`ActivityId` is `(pid << 32) | counter`, so IDs from a remote daemon are not guaranteed unique against local activities (or other remotes). `BasicClientConnection` now allocates fresh local IDs when forwarding `STDERR_START_ACTIVITY` and remaps subsequent stop/result/parent references through a per-connection map — mirroring what `handleJSONLogMessage` already does for the build-hook path. This means `stopActivity()`/`result()` don't need a `machine` parameter; loggers correlate via the activity map populated at start time. `nextActivityId()` is extracted so the connection allocates from the same sequence as `Activity`.