### PR TITLE
doc: render C API doc for nix-main-c and nix-fetchers-c

### DIFF
--- a/src/external-api-docs/doxygen.cfg.in
+++ b/src/external-api-docs/doxygen.cfg.in
@@ -42,6 +42,8 @@ INPUT                  = \
   @src@/src/libexpr-c \
   @src@/src/libflake-c \
   @src@/src/libstore-c \
+  @src@/src/libfetchers-c \
+  @src@/src/libmain-c \
   @src@/src/external-api-docs/README.md
 
 FILE_PATTERNS = nix_api_*.h *.md

--- a/src/external-api-docs/package.nix
+++ b/src/external-api-docs/package.nix
@@ -31,7 +31,9 @@ mkMesonDerivation (finalAttrs: {
       # Source is not compiled, but still must be available for Doxygen
       # to gather comments.
       (cpp ../libexpr-c)
+      (cpp ../libfetchers-c)
       (cpp ../libflake-c)
+      (cpp ../libmain-c)
       (cpp ../libstore-c)
       (cpp ../libutil-c)
     ];


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

When reading the C API manual(`nix build .#hydraJobs.external-api-docs`), I find doc for these two components is missing.  I guess there is no reason not to render their doc 😄

<!-- Briefly explain what the change is about and why it is desirable. -->



<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
