### PR TITLE
Make the Worker not choke on 70k derivation builds

### DIFF
--- a/src/libstore-tests/worker-substitution.cc
+++ b/src/libstore-tests/worker-substitution.cc
@@ -241,7 +241,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutput)
 
     // Create a derivation goal for the CA derivation output
     // The worker should substitute the output rather than building
-    auto goal = worker.makeDerivationGoal(drvPath, drv, "out", bmNormal, true);
+    auto goal = worker.makeDerivationGoal(drvPath, make_ref<Derivation>(drv), "out", bmNormal, true);
 
     // Run the worker
     Goals goals;
@@ -403,7 +403,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
 
     // Create a derivation goal for the root derivation output
     // The worker should substitute the output rather than building
-    auto goal = worker.makeDerivationGoal(rootDrvPath, rootDrv, "out", bmNormal, false);
+    auto goal = worker.makeDerivationGoal(rootDrvPath, make_ref<Derivation>(rootDrv), "out", bmNormal, false);
 
     // Run the worker
     Goals goals;

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -30,10 +30,10 @@
 namespace nix {
 
 DerivationBuildingGoal::DerivationBuildingGoal(
-    const StorePath & drvPath, const Derivation & drv, Worker & worker, BuildMode buildMode, bool storeDerivation)
+    const StorePath & drvPath, ref<const Derivation> drv, Worker & worker, BuildMode buildMode, bool storeDerivation)
     : Goal(worker, gaveUpOnSubstitution(storeDerivation))
     , drvPath(drvPath)
-    , drv{std::make_unique<Derivation>(drv)}
+    , drv{std::move(drv)}
     , buildMode(buildMode)
 {
     name = fmt("building derivation '%s'", worker.store.printStorePath(drvPath));

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -29,7 +29,7 @@ namespace nix {
 
 DerivationGoal::DerivationGoal(
     const StorePath & drvPath,
-    const Derivation & drv,
+    ref<const Derivation> drv,
     const OutputName & wantedOutput,
     Worker & worker,
     BuildMode buildMode,
@@ -37,7 +37,7 @@ DerivationGoal::DerivationGoal(
     : Goal(worker, haveDerivation(storeDerivation))
     , drvPath(drvPath)
     , wantedOutput(wantedOutput)
-    , drv{std::make_unique<Derivation>(drv)}
+    , drv{std::move(drv)}
     , buildMode(buildMode)
 {
 
@@ -167,8 +167,13 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
     if (resolutionGoal->resolvedDrv) {
         auto & [pathResolved, drvResolved] = *resolutionGoal->resolvedDrv;
 
-        auto resolvedDrvGoal =
-            worker.makeDerivationGoal(pathResolved, drvResolved, wantedOutput, buildMode, /*storeDerivation=*/true);
+        auto resolvedDrvGoal = worker.makeDerivationGoal(
+            pathResolved,
+            make_ref<const Derivation>(drvResolved),
+            wantedOutput,
+            buildMode,
+            /*storeDerivation=*/true);
+
         {
             Goals waitees{resolvedDrvGoal};
             co_await await(std::move(waitees));
@@ -227,7 +232,7 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
 
     /* Give up on substitution for the output we want, actually build this derivation */
 
-    auto g = worker.makeDerivationBuildingGoal(drvPath, *drv, buildMode, storeDerivation);
+    auto g = worker.makeDerivationBuildingGoal(drvPath, drv, buildMode, storeDerivation);
 
     /* We will finish with it ourselves, as if we were the derivational goal. */
     g->preserveFailure = true;

--- a/src/libstore/build/derivation-trampoline-goal.cc
+++ b/src/libstore/build/derivation-trampoline-goal.cc
@@ -148,8 +148,10 @@ Goal::Co DerivationTrampolineGoal::haveDerivation(StorePath drvPath, Derivation 
 
     /* Build this step! */
 
+    auto sharedDrv = make_ref<Derivation>(std::move(drv));
+
     for (auto & output : resolvedWantedOutputs) {
-        auto g = upcast_goal(worker.makeDerivationGoal(drvPath, drv, output, buildMode, false));
+        auto g = upcast_goal(worker.makeDerivationGoal(drvPath, sharedDrv, output, buildMode, false));
         g->preserveFailure = true;
         /* We will finish with it ourselves, as if we were the derivational goal. */
         concreteDrvGoals.insert(std::move(g));

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -157,9 +157,7 @@ std::coroutine_handle<> nix::Goal::Co::await_suspend(handle_type caller)
 
 bool CompareGoalPtrs::operator()(const GoalPtr & a, const GoalPtr & b) const
 {
-    std::string s1 = a->key();
-    std::string s2 = b->key();
-    return s1 < s2;
+    return a->keyCached() < b->keyCached();
 }
 
 void addToWeakGoals(WeakGoals & goals, GoalPtr p)

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -141,64 +141,31 @@ GoalPtr Worker::makeGoal(const DerivedPath & req, BuildMode buildMode)
         req.raw());
 }
 
-/**
- * This function is polymorphic (both via type parameters and
- * overloading) and recursive in order to work on a various types of
- * trees
- *
- * @return Whether the tree node we are processing is not empty / should
- * be kept alive. In the case of this overloading the node in question
- * is the leaf, the weak reference itself. If the weak reference points
- * to the goal we are looking for, our caller can delete it. In the
- * inductive case where the node is an interior node, we'll likewise
- * return whether the interior node is non-empty. If it is empty
- * (because we just deleted its last child), then our caller can
- * likewise delete it.
- */
-template<typename G>
-static bool removeGoal(std::shared_ptr<G> goal, std::weak_ptr<G> & gp)
-{
-    return gp.lock() != goal;
-}
-
-template<typename K, typename G, typename Inner>
-static bool removeGoal(std::shared_ptr<G> goal, std::map<K, Inner> & goalMap)
-{
-    /* !!! inefficient */
-    for (auto i = goalMap.begin(); i != goalMap.end();) {
-        if (!removeGoal(goal, i->second))
-            i = goalMap.erase(i);
-        else
-            ++i;
-    }
-    return !goalMap.empty();
-}
-
-template<typename G>
-static bool
-removeGoal(std::shared_ptr<G> goal, typename DerivedPathMap<std::map<OutputsSpec, std::weak_ptr<G>>>::ChildNode & node)
-{
-    bool valueKeep = removeGoal(goal, node.value);
-    bool childMapKeep = removeGoal(goal, node.childMap);
-    return valueKeep || childMapKeep;
-}
-
 void Worker::removeGoal(GoalPtr goal)
 {
-    if (auto drvGoal = std::dynamic_pointer_cast<DerivationTrampolineGoal>(goal))
-        nix::removeGoal(drvGoal, derivationTrampolineGoals.map);
-    else if (auto drvGoal = std::dynamic_pointer_cast<DerivationGoal>(goal))
-        nix::removeGoal(drvGoal, derivationGoals);
-    else if (auto drvResolutionGoal = std::dynamic_pointer_cast<DerivationResolutionGoal>(goal))
-        nix::removeGoal(drvResolutionGoal, derivationResolutionGoals);
-    else if (auto drvBuildingGoal = std::dynamic_pointer_cast<DerivationBuildingGoal>(goal))
-        nix::removeGoal(drvBuildingGoal, derivationBuildingGoals);
-    else if (auto subGoal = std::dynamic_pointer_cast<PathSubstitutionGoal>(goal))
-        nix::removeGoal(subGoal, substitutionGoals);
-    else if (auto subGoal = std::dynamic_pointer_cast<DrvOutputSubstitutionGoal>(goal))
-        nix::removeGoal(subGoal, drvOutputSubstitutionGoals);
-    else
-        assert(false);
+    if (auto drvGoal = std::dynamic_pointer_cast<DerivationTrampolineGoal>(goal)) {
+        derivationTrampolineGoals.removeSlot(*drvGoal->drvReq, [&](auto & node) {
+            node.value.erase(drvGoal->wantedOutputs);
+            /* Return true if ancestors don't need to be pruned. */
+            return !node.value.empty();
+        });
+    } else if (auto drvGoal = std::dynamic_pointer_cast<DerivationGoal>(goal)) {
+        if (auto it = derivationGoals.find(drvGoal->drvPath); it != derivationGoals.end()) {
+            it->second.erase(drvGoal->wantedOutput);
+            if (it->second.empty())
+                derivationGoals.erase(it);
+        }
+    } else if (auto drvResolutionGoal = std::dynamic_pointer_cast<DerivationResolutionGoal>(goal)) {
+        derivationResolutionGoals.erase(drvResolutionGoal->drvPath);
+    } else if (auto drvBuildingGoal = std::dynamic_pointer_cast<DerivationBuildingGoal>(goal)) {
+        derivationBuildingGoals.erase(drvBuildingGoal->drvPath);
+    } else if (auto subGoal = std::dynamic_pointer_cast<PathSubstitutionGoal>(goal)) {
+        substitutionGoals.erase(subGoal->storePath);
+    } else if (auto subGoal = std::dynamic_pointer_cast<DrvOutputSubstitutionGoal>(goal)) {
+        drvOutputSubstitutionGoals.erase(subGoal->id);
+    } else {
+        unreachable();
+    }
 
     if (topGoals.find(goal) != topGoals.end()) {
         topGoals.erase(goal);

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -333,9 +333,24 @@ void Worker::run(const Goals & _topGoals)
                     awake2.insert(goal);
             }
             awake.clear();
+
             for (auto & goal : awake2) {
                 checkInterrupt();
+
+                std::chrono::time_point<std::chrono::steady_clock> startTime;
+                if (verbosity >= lvlVomit)
+                    startTime = std::chrono::steady_clock::now();
+
                 goal->work();
+
+                /* Useful for tracing which goals hod the event loop. */
+                vomit(
+                    "worker event loop worked goal '%1%' for %2$.3fms",
+                    goal->name,
+                    std::chrono::duration_cast<std::chrono::duration<float, std::milli>>(
+                        std::chrono::steady_clock::now() - startTime)
+                        .count());
+
                 if (topGoals.empty())
                     break; // stuff may have been cancelled
             }

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -88,13 +88,19 @@ std::shared_ptr<DerivationTrampolineGoal> Worker::makeDerivationTrampolineGoal(
 
 std::shared_ptr<DerivationGoal> Worker::makeDerivationGoal(
     const StorePath & drvPath,
-    const Derivation & drv,
+    ref<const Derivation> drv,
     const OutputName & wantedOutput,
     BuildMode buildMode,
     bool storeDerivation)
 {
     return initGoalIfNeeded(
-        derivationGoals[drvPath][wantedOutput], drvPath, drv, wantedOutput, *this, buildMode, storeDerivation);
+        derivationGoals[drvPath][wantedOutput],
+        drvPath,
+        std::move(drv),
+        wantedOutput,
+        *this,
+        buildMode,
+        storeDerivation);
 }
 
 std::shared_ptr<DerivationResolutionGoal>
@@ -104,9 +110,10 @@ Worker::makeDerivationResolutionGoal(const StorePath & drvPath, const Derivation
 }
 
 std::shared_ptr<DerivationBuildingGoal> Worker::makeDerivationBuildingGoal(
-    const StorePath & drvPath, const Derivation & drv, BuildMode buildMode, bool storeDerivation)
+    const StorePath & drvPath, ref<const Derivation> drv, BuildMode buildMode, bool storeDerivation)
 {
-    return initGoalIfNeeded(derivationBuildingGoals[drvPath], drvPath, drv, *this, buildMode, storeDerivation);
+    return initGoalIfNeeded(
+        derivationBuildingGoals[drvPath], drvPath, std::move(drv), *this, buildMode, storeDerivation);
 }
 
 std::shared_ptr<PathSubstitutionGoal>
@@ -287,27 +294,37 @@ void Worker::childTerminated(Goal * goal, JobCategory jobCategory, bool wakeSlee
     children.erase(i);
 
     if (wakeSleepers) {
+        auto & waiting = jobCategory == JobCategory::Substitution ? wantingToSubstitute : wantingToBuild;
 
-        /* Wake up goals waiting for a build slot. */
-        for (auto & j : wantingToBuild) {
-            GoalPtr goal = j.lock();
-            if (goal)
+        /* Wake up goals waiting for a build slot. Wake at most one waiter to avoid
+           starting unnecessary work (that is accompanied by coroutine frame allocation). */
+        auto it = waiting.begin();
+        while (it != waiting.end()) {
+            if (auto goal = it->lock()) {
+                waiting.erase(it);
                 wakeUp(goal);
+                break;
+            }
+            it = waiting.erase(it);
         }
-
-        wantingToBuild.clear();
     }
 }
 
 void Worker::waitForBuildSlot(GoalPtr goal)
 {
     goal->trace("wait for build slot");
-    bool isSubstitutionGoal = goal->jobCategory() == JobCategory::Substitution;
-    if ((!isSubstitutionGoal && getNrLocalBuilds() < settings.maxBuildJobs)
-        || (isSubstitutionGoal && getNrSubstitutions() < settings.maxSubstitutionJobs))
-        wakeUp(goal); /* we can do it right away */
+
+    bool slotAvailable = [&] {
+        if (goal->jobCategory() == JobCategory::Substitution)
+            return getNrSubstitutions() < settings.maxSubstitutionJobs;
+        else
+            return getNrLocalBuilds() < settings.maxBuildJobs;
+    }();
+
+    if (slotAvailable)
+        wakeUp(goal); /* Can do it right away. */
     else
-        addToWeakGoals(wantingToBuild, goal);
+        addToWeakGoals(goal->jobCategory() == JobCategory::Substitution ? wantingToSubstitute : wantingToBuild, goal);
 }
 
 void Worker::waitForAnyGoal(GoalPtr goal)

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -254,21 +254,21 @@ void Worker::childStarted(
             nrLocalBuilds++;
             break;
         case JobCategory::Administration:
-            /* Intentionally not limited, see docs */
-            break;
         default:
+            /* Doesn't make sense, since there are only building and substitution slots. */
             unreachable();
         }
     }
 }
 
-void Worker::childTerminated(Goal * goal, bool wakeSleepers)
+void Worker::childTerminated(Goal * goal)
 {
-    childTerminated(goal, goal->jobCategory(), wakeSleepers);
+    childTerminated(goal, goal->jobCategory());
 }
 
-void Worker::childTerminated(Goal * goal, JobCategory jobCategory, bool wakeSleepers)
+void Worker::childTerminated(Goal * goal, JobCategory jobCategory)
 {
+    // FIXME: Inefficient. Make children a map from Goal -> Child instead.
     auto i = std::find_if(children.begin(), children.end(), [&](const Child & child) { return child.goal2 == goal; });
     if (i == children.end())
         return;
@@ -284,29 +284,25 @@ void Worker::childTerminated(Goal * goal, JobCategory jobCategory, bool wakeSlee
             nrLocalBuilds--;
             break;
         case JobCategory::Administration:
-            /* Intentionally not limited, see docs */
-            break;
         default:
+            /* Doesn't make sense, since there are only building and substitution slots. */
             unreachable();
         }
     }
 
     children.erase(i);
+    auto & waiting = jobCategory == JobCategory::Substitution ? wantingToSubstitute : wantingToBuild;
 
-    if (wakeSleepers) {
-        auto & waiting = jobCategory == JobCategory::Substitution ? wantingToSubstitute : wantingToBuild;
-
-        /* Wake up goals waiting for a build slot. Wake at most one waiter to avoid
-           starting unnecessary work (that is accompanied by coroutine frame allocation). */
-        auto it = waiting.begin();
-        while (it != waiting.end()) {
-            if (auto goal = it->lock()) {
-                waiting.erase(it);
-                wakeUp(goal);
-                break;
-            }
-            it = waiting.erase(it);
+    /* Wake up goals waiting for a build slot. Wake at most one waiter to avoid
+       starting unnecessary work (that is accompanied by coroutine frame allocation). */
+    auto it = waiting.begin();
+    while (it != waiting.end()) {
+        if (auto goal = it->lock()) {
+            waiting.erase(it);
+            wakeUp(goal);
+            break;
         }
+        it = waiting.erase(it);
     }
 }
 

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -207,15 +207,6 @@ void Worker::removeGoal(GoalPtr goal)
         if (goal->exitCode == Goal::ecFailed && !settings.keepGoing)
             topGoals.clear();
     }
-
-    /* Wake up goals waiting for any goal to finish. */
-    for (auto & i : waitingForAnyGoal) {
-        GoalPtr goal = i.lock();
-        if (goal)
-            wakeUp(goal);
-    }
-
-    waitingForAnyGoal.clear();
 }
 
 void Worker::wakeUp(GoalPtr goal)
@@ -321,12 +312,6 @@ void Worker::waitForBuildSlot(GoalPtr goal)
         wakeUp(goal); /* Can do it right away. */
     else
         addToWeakGoals(goal->jobCategory() == JobCategory::Substitution ? wantingToSubstitute : wantingToBuild, goal);
-}
-
-void Worker::waitForAnyGoal(GoalPtr goal)
-{
-    goal->trace("wait for any goal");
-    addToWeakGoals(waitingForAnyGoal, goal);
 }
 
 void Worker::waitForAWhile(GoalPtr goal)

--- a/src/libstore/derived-path-map.cc
+++ b/src/libstore/derived-path-map.cc
@@ -48,6 +48,34 @@ typename DerivedPathMap<V>::ChildNode * DerivedPathMap<V>::findSlot(const Single
     return initIter(k);
 }
 
+template<typename V>
+void DerivedPathMap<V>::removeSlot(const SingleDerivedPath & k, fun<bool(ChildNode &)> callback)
+{
+    auto removeIter = [&map =
+                           map](this auto & self, const SingleDerivedPath & k, fun<bool(ChildNode &)> onNode) -> void {
+        std::visit(
+            overloaded{
+                [&](const SingleDerivedPath::Opaque & bo) {
+                    if (auto it = map.find(bo.path); it != map.end() && !onNode(it->second))
+                        map.erase(it);
+                },
+                [&](const SingleDerivedPath::Built & bfd) {
+                    self(*bfd.drvPath, [&](ChildNode & parent) -> bool {
+                        auto it = parent.childMap.find(bfd.output);
+                        if (it == parent.childMap.end())
+                            return !parent.value.empty() || !parent.childMap.empty();
+                        if (!onNode(it->second))
+                            parent.childMap.erase(it);
+                        return !parent.value.empty() || !parent.childMap.empty();
+                    });
+                },
+            },
+            k.raw());
+    };
+
+    removeIter(k, [&](ChildNode & node) -> bool { return callback(node) || !node.childMap.empty(); });
+}
+
 } // namespace nix
 
 // instantiations

--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
@@ -41,7 +41,11 @@ struct DerivationBuildingGoal : public Goal
      * faithfully reconstruct the build history.
      */
     DerivationBuildingGoal(
-        const StorePath & drvPath, const Derivation & drv, Worker & worker, BuildMode buildMode, bool storeDerivation);
+        const StorePath & drvPath,
+        ref<const Derivation> drv,
+        Worker & worker,
+        BuildMode buildMode,
+        bool storeDerivation);
     ~DerivationBuildingGoal();
 
 private:
@@ -52,7 +56,7 @@ private:
     /**
      * The derivation stored at drvPath.
      */
-    const std::unique_ptr<Derivation> drv;
+    const ref<const Derivation> drv;
 
     /**
      * The remainder is state held during the build.

--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
@@ -31,6 +31,8 @@ typedef enum { rpAccept, rpDecline, rpPostpone } HookReply;
  */
 struct DerivationBuildingGoal : public Goal
 {
+    friend class Worker;
+
     /**
      * @param storeDerivation Whether to store the derivation in
      * `worker.store`. This is useful for newly-resolved derivations. In this

--- a/src/libstore/include/nix/store/build/derivation-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-goal.hh
@@ -45,7 +45,7 @@ struct DerivationGoal : public Goal
      */
     DerivationGoal(
         const StorePath & drvPath,
-        const Derivation & drv,
+        ref<const Derivation> drv,
         const OutputName & wantedOutput,
         Worker & worker,
         BuildMode buildMode,
@@ -64,7 +64,7 @@ private:
     /**
      * The derivation stored at drvPath.
      */
-    std::unique_ptr<Derivation> drv;
+    ref<const Derivation> drv;
 
     const BuildMode buildMode;
 

--- a/src/libstore/include/nix/store/build/derivation-resolution-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-resolution-goal.hh
@@ -35,6 +35,8 @@ struct BuilderFailureError;
  */
 struct DerivationResolutionGoal : public Goal
 {
+    friend class Worker;
+
     DerivationResolutionGoal(const StorePath & drvPath, const Derivation & drv, Worker & worker, BuildMode buildMode);
 
     /**

--- a/src/libstore/include/nix/store/build/drv-output-substitution-goal.hh
+++ b/src/libstore/include/nix/store/build/drv-output-substitution-goal.hh
@@ -20,11 +20,12 @@ class Worker;
  * If the output store object itself should also be substituted, that is
  * the responsibility of the caller to do so.
  *
- * @todo rename this `BuidlTraceEntryGoal`, which will make sense
+ * @todo rename this `BuildTraceEntryGoal`, which will make sense
  * especially once `Realisation` is renamed to `BuildTraceEntry`.
  */
 class DrvOutputSubstitutionGoal : public Goal
 {
+    friend class Worker;
 
     /**
      * The drv output we're trying to substitute

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -80,6 +80,11 @@ private:
      */
     Goals waitees;
 
+    /**
+     * Memoised result of key().
+     */
+    std::optional<std::string> cachedKey;
+
 public:
     typedef enum { ecBusy, ecSuccess, ecFailed, ecNoSubstituters } ExitCode;
 
@@ -599,6 +604,17 @@ public:
      * "baboon".
      */
     virtual std::string key() = 0;
+
+    /**
+     * Memoising variant of key(). We really don't want to pay the overhead of
+     * allocating strings just to compare Goals.
+     */
+    std::string_view keyCached() &
+    {
+        if (cachedKey)
+            return *cachedKey;
+        return *(cachedKey = key());
+    }
 
     /**
      * @brief Hint for the scheduler, which concurrency limit applies.

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -331,15 +331,13 @@ public:
         bool respectTimeouts);
 
     /**
-     * Unregisters a running child process.  `wakeSleepers` should be
-     * false if there is no sense in waking up goals that are sleeping
-     * because they can't run yet (e.g., there is no free build slot,
-     * or the hook would still say `postpone`).
+     * Unregisters a running child process. Wakes at most a single goal that is
+     * awaiting on the corresponding build slot type (building or substitution).
      *
      * This overload requires `goal` to point to a fully constructed,
      * valid goal object, as it calls `goal->jobCategory()`.
      */
-    void childTerminated(Goal * goal, bool wakeSleepers = true);
+    void childTerminated(Goal * goal);
 
     /**
      * Unregisters a running child process, like the other overload.
@@ -348,7 +346,7 @@ public:
      * weak goal references, so it is safe to call from destructors
      * where the goal object may be partially destroyed.
      */
-    void childTerminated(Goal * goal, JobCategory jobCategory, bool wakeSleepers = true);
+    void childTerminated(Goal * goal, JobCategory jobCategory);
 
     /**
      * Put `goal` to sleep until a build slot becomes available (which

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -127,11 +127,6 @@ private:
     std::map<DrvOutput, std::weak_ptr<DrvOutputSubstitutionGoal>> drvOutputSubstitutionGoals;
 
     /**
-     * Goals waiting for busy paths to be unlocked.
-     */
-    WeakGoals waitingForAnyGoal;
-
-    /**
      * Goals sleeping for a few seconds (polling a lock).
      */
     WeakGoals waitingForAWhile;
@@ -353,12 +348,6 @@ public:
      * might be right away).
      */
     void waitForBuildSlot(GoalPtr goal);
-
-    /**
-     * Wait for any goal to finish.  Pretty indiscriminate way to
-     * wait for some resource that some other goal is holding.
-     */
-    void waitForAnyGoal(GoalPtr goal);
 
     /**
      * Wait for a few seconds and then retry this goal.  Used when

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -93,6 +93,11 @@ private:
     WeakGoals wantingToBuild;
 
     /**
+     * Goals waiting for a substitution slot.
+     */
+    WeakGoals wantingToSubstitute;
+
+    /**
      * Child processes currently running.
      */
     std::list<Child> children;
@@ -256,7 +261,7 @@ public:
 
     std::shared_ptr<DerivationGoal> makeDerivationGoal(
         const StorePath & drvPath,
-        const Derivation & drv,
+        ref<const Derivation> drv,
         const OutputName & wantedOutput,
         BuildMode buildMode,
         bool storeDerivation);
@@ -271,7 +276,7 @@ public:
      * @ref DerivationBuildingGoal "derivation building goal"
      */
     std::shared_ptr<DerivationBuildingGoal> makeDerivationBuildingGoal(
-        const StorePath & drvPath, const Derivation & drv, BuildMode buildMode, bool storeDerivation);
+        const StorePath & drvPath, ref<const Derivation> drv, BuildMode buildMode, bool storeDerivation);
 
     /**
      * @ref PathSubstitutionGoal "substitution goal"

--- a/src/libstore/include/nix/store/derived-path-map.hh
+++ b/src/libstore/include/nix/store/derived-path-map.hh
@@ -93,6 +93,19 @@ struct DerivedPathMap
      * `ChildNode::value`.
      */
     ChildNode * findSlot(const SingleDerivedPath & k);
+
+    /**
+     * Find the node for `k` and invoke @ref callback on it, pruning empty
+     * ancestors afterwards.
+     *
+     * @param callback Invoked on the found node. Should return true if
+     * the node's value is still non-empty (i.e. the node should be kept).
+     * If it returns false and the node has no children, the node is erased
+     * and empty ancestors are pruned recursively.
+     *
+     * No-op if the node does not exist.
+     */
+    void removeSlot(const SingleDerivedPath & k, fun<bool(ChildNode &)> callback);
 };
 
 template<>


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

For stress-testing purposes I played around with building all `nixosTests` from nixpkgs in one go. No surprise - the Worker scheduler completely choked and ate like 20G of RAM just for the coroutines. We also had very inefficient goal removing logic and very eager coroutine resumption that lead to a thundering herd of coroutines warking up and eating all of the RAM. We were also unnecessarily copying a ton of `Derivation` values in memory - I've changed that to a `ref<const Derivation>`.  `heaptrack` showed that it was using a sizeable chunk of memory allocations.

See each commit for details. We still have a big issue with the event loop getting blocked on derivation sandbox setup and teardown (that slows down to a crawl when the Worker starts eating more memory and `fork()` becomes too slow). We should address that issue by moving all the sandbox setup into `libexec`-style helper binaries that we execute from `vfork`-ed processes. I have seen `killUser()` taking 150ms just because of the `fork` slowness.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
