### PR TITLE
libstore: root inputSrcs before validity check

### DIFF
--- a/doc/manual/rl-next/root-inputsrcs-remote-builds.md
+++ b/doc/manual/rl-next/root-inputsrcs-remote-builds.md
@@ -1,0 +1,15 @@
+---
+synopsis: Protect build inputs from GC during remote builds
+issues: [1970, 2285]
+prs: []
+---
+
+Remote builds via `ssh-ng://` send a `BasicDerivation` with all dependencies
+flattened into `inputSrcs`. The builder-side goal previously skipped
+already-valid input paths without registering them as temp GC roots, so a
+`min-free` auto-GC on the builder could delete them mid-build. `copyPaths()`
+on the client side does root paths it copies, but it skips paths already
+present on the builder, leaving precisely those unprotected.
+
+Inputs are now rooted unconditionally at goal start, mirroring what
+`PathSubstitutionGoal` already does.

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -93,6 +93,17 @@ Goal::Co DerivationBuildingGoal::gaveUpOnSubstitution(bool storeDerivation)
     }
 
     for (auto & i : drv->inputSrcs) {
+        /* Root the input before the validity check to close the race
+           against a concurrent GC. This matters most for remote builds
+           receiving a BasicDerivation: all inputs arrive flattened into
+           inputSrcs with no sub-goals to root them transitively, and the
+           builder's auto-GC has no visibility into the client's temp
+           roots. copyPaths() on the client side roots paths it copies,
+           but skips paths already present on the builder, leaving those
+           unprotected for the whole build. Substitution goals created
+           below also root their target, so the extra call in that path
+           is harmless. See #1970. */
+        worker.store.addTempRoot(i);
         if (worker.store.isValidPath(i))
             continue;
         if (!worker.settings.useSubstitutes)


### PR DESCRIPTION
## Motivation

Remote builds via `ssh-ng://` send a `BasicDerivation` with all dependencies flattened into `inputSrcs`. The builder-side goal iterates these and skips paths that are already valid, without adding a temp root:

```cpp
for (auto & i : drv->inputSrcs) {
    if (worker.store.isValidPath(i))
        continue;  // <-- no temp root
    ...
    waitees.insert(upcast_goal(worker.makePathSubstitutionGoal(i)));
}
```

Paths that need substitution get a goal which adds a temp root ([substitution-goal.cc:36](https://github.com/NixOS/nix/blob/master/src/libstore/build/substitution-goal.cc#L36)). Paths that are already valid get nothing.

- **Local builds** read a full `Derivation` with `inputDrvs`. Each input derivation gets a sub-goal, and each sub-goal's `haveDerivation()` roots its own outputs. Inputs are protected transitively through the goal graph.
- `copyPaths()` on the client side *does* root paths it copies (via `addToStore`), but it [queries valid paths on the destination first and skips those](https://github.com/NixOS/nix/blob/master/src/libstore/store-api.cc) — so paths already present on the builder are left unprotected.
- The remote daemon child process holds temp roots for the connection lifetime (`maxConnections=1`, `maxConnectionAge=UINT_MAX`), so paths that *did* get rooted during copy stay rooted. Only the skipped-as-valid paths are exposed.

## Context

Fixes #1970. Related: #2285.

Cost per call: one non-blocking flock attempt + ~60 bytes appended to the per-PID temproots file. For a typical kernel build, ~30 calls total. The substitution-goal path adds the same root again; `findTempRoots` reads into a set, so duplicates are harmless.
