### PR TITLE
Don't detach the auto-GC thread

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -852,12 +852,17 @@ void LocalStore::autoGC(bool sync)
         if (avail > state->availAfterGC * 0.97)
             return;
 
+        /* Note: since gcRunning is false here, any previous GC thread has exited / is exiting so the join() should be
+         * almost instantenous. */
+        if (state->gcThread.joinable())
+            state->gcThread.join();
+
         state->gcRunning = true;
 
         std::promise<void> promise;
         future = state->gcFuture = promise.get_future().share();
 
-        std::thread([promise{std::move(promise)}, this, avail, getAvail, &gcSettings]() mutable {
+        state->gcThread = std::thread([promise{std::move(promise)}, this, avail, getAvail, &gcSettings]() mutable {
             try {
 
                 /* Wake up any threads waiting for the auto-GC to finish. */
@@ -884,7 +889,7 @@ void LocalStore::autoGC(bool sync)
                 // future, but we don't really care. (what??)
                 ignoreExceptionInDestructor();
             }
-        }).detach();
+        });
     }
 
 sync:

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -212,6 +212,7 @@ private:
          */
         bool gcRunning = false;
         std::shared_future<void> gcFuture;
+        std::thread gcThread;
 
         /**
          * How much disk space was available after the previous

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -432,6 +432,12 @@ LocalStore::~LocalStore()
         future.get();
     }
 
+    {
+        auto state(_state->lock());
+        if (state->gcThread.joinable())
+            state->gcThread.join();
+    }
+
     try {
         auto fdTempRoots(_fdTempRoots.lock());
         if (*fdTempRoots) {


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

It could still be running after `this` is destroyed. So we need to join it in the `LocalStore` destructor.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
