### PR TITLE
libutil: Make MemorySourceAccessor exceptions more precise, makeFSSou…

### DIFF
--- a/src/libutil-tests/memory-source-accessor.cc
+++ b/src/libutil-tests/memory-source-accessor.cc
@@ -144,7 +144,7 @@ TEST_F(MemorySourceAccessorTestErrors, addFileParentNotDirectory)
         [&] { accessor->addFile(CanonPath("file/child"), "contents"); },
         ThrowsMessage<Error>(AllOf(
             HasSubstrIgnoreANSIMatcher("somepath/file/child"),
-            HasSubstrIgnoreANSIMatcher("cannot be created because some parent file is not a directory"))));
+            HasSubstrIgnoreANSIMatcher("file 'somepath/file' is not a directory"))));
 }
 
 TEST_F(MemorySourceAccessorTestErrors, addFileNotARegularFile)
@@ -165,7 +165,7 @@ TEST_F(MemorySourceAccessorTestErrors, createDirectoryParentNotDirectory)
         [&] { sink.createDirectory(CanonPath("file/child")); },
         ThrowsMessage<Error>(AllOf(
             HasSubstrIgnoreANSIMatcher("somepath/file/child"),
-            HasSubstrIgnoreANSIMatcher("cannot be created because some parent file is not a directory"))));
+            HasSubstrIgnoreANSIMatcher("file 'somepath/file' is not a directory"))));
 }
 
 TEST_F(MemorySourceAccessorTestErrors, createDirectoryNotADirectory)
@@ -185,8 +185,8 @@ TEST_F(MemorySourceAccessorTestErrors, createRegularFileParentNotDirectory)
     EXPECT_THAT(
         [&] { sink.createRegularFile(CanonPath("file/child"), [](CreateRegularFileSink &) {}); },
         ThrowsMessage<Error>(AllOf(
-            HasSubstrIgnoreANSIMatcher("file/child"),
-            HasSubstrIgnoreANSIMatcher("cannot be created because some parent file is not a directory"))));
+            HasSubstrIgnoreANSIMatcher("somepath/file/child"),
+            HasSubstrIgnoreANSIMatcher("file 'somepath/file' is not a directory"))));
 }
 
 TEST_F(MemorySourceAccessorTestErrors, createRegularFileNotARegularFile)
@@ -207,7 +207,7 @@ TEST_F(MemorySourceAccessorTestErrors, createSymlinkParentNotDirectory)
         [&] { sink.createSymlink(CanonPath("file/child"), "target"); },
         ThrowsMessage<Error>(AllOf(
             HasSubstrIgnoreANSIMatcher("somepath/file/child"),
-            HasSubstrIgnoreANSIMatcher("cannot be created because some parent file is not a directory"))));
+            HasSubstrIgnoreANSIMatcher("file 'somepath/file' is not a directory"))));
 }
 
 TEST_F(MemorySourceAccessorTestErrors, createSymlinkNotASymlink)
@@ -218,6 +218,36 @@ TEST_F(MemorySourceAccessorTestErrors, createSymlinkNotASymlink)
         [&] { sink.createSymlink(CanonPath("file"), "target"); },
         ThrowsMessage<NotASymlink>(
             AllOf(HasSubstrIgnoreANSIMatcher("somepath/file"), HasSubstrIgnoreANSIMatcher("is not a symbolic link"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, pathExistsThroughRegularFile)
+{
+    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+    EXPECT_FALSE(accessor->pathExists(CanonPath("file/child")));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, maybeLstatThroughRegularFile)
+{
+    sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink &) {});
+    EXPECT_FALSE(accessor->maybeLstat(CanonPath("file/child")));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, pathExistsThroughSymlink)
+{
+    sink.createSymlink(CanonPath("link"), "target");
+    EXPECT_THAT(
+        [&] { accessor->pathExists(CanonPath("link/child")); },
+        ThrowsMessage<SymlinkNotAllowed>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/link"), HasSubstrIgnoreANSIMatcher("is a symlink"))));
+}
+
+TEST_F(MemorySourceAccessorTestErrors, createFileThroughSymlink)
+{
+    sink.createSymlink(CanonPath("link"), "target");
+    EXPECT_THAT(
+        [&] { sink.createRegularFile(CanonPath("link/child"), [](CreateRegularFileSink &) {}); },
+        ThrowsMessage<SymlinkNotAllowed>(
+            AllOf(HasSubstrIgnoreANSIMatcher("somepath/link"), HasSubstrIgnoreANSIMatcher("is a symlink"))));
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -34,6 +34,35 @@ namespace nix {
  */
 PosixStat fstat(Descriptor fd);
 
+#ifndef _WIN32
+
+/**
+ * Get status of a file relative to a directory file descriptor.
+ *
+ * @param dirFd Directory file descriptor
+ * @param path Relative path to stat
+ *
+ * @return nullopt if the path does not exist.
+ * @throws SystemError on other I/O errors.
+ *
+ * @pre `path` must be relative (not absolute) and non-empty.
+ */
+std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const std::filesystem::path & path);
+
+/**
+ * Get status of a file relative to a directory file descriptor.
+ *
+ * @param dirFd Directory file descriptor
+ * @param path Relative path to stat
+ *
+ * @throws SystemError if the path does not exist or on other I/O errors.
+ *
+ * @pre `path` must be relative (not absolute) and non-empty.
+ */
+PosixStat fstatat(Descriptor dirFd, const std::filesystem::path & path);
+
+#endif
+
 /**
  * Read a symlink relative to a directory file descriptor.
  *

--- a/src/libutil/memory-source-accessor.cc
+++ b/src/libutil/memory-source-accessor.cc
@@ -1,6 +1,8 @@
 #include "nix/util/memory-source-accessor.hh"
 #include "nix/util/json-utils.hh"
 
+#include <ranges>
+
 namespace nix {
 
 MemorySourceAccessor::File * MemorySourceAccessor::open(const CanonPath & path, std::optional<File> create)
@@ -24,10 +26,20 @@ MemorySourceAccessor::File * MemorySourceAccessor::open(const CanonPath & path, 
 
     bool newF = false;
 
+    unsigned j = 0;
     for (std::string_view name : path) {
         auto * curDirP = std::get_if<File::Directory>(&cur->raw);
-        if (!curDirP)
+        if (!curDirP) {
+            CanonPath curDirPath = CanonPath::root;
+            for (auto name2 : std::views::take(path, j))
+                curDirPath.push(name2);
+            if (std::holds_alternative<File::Symlink>(cur->raw))
+                throw SymlinkNotAllowed(curDirPath, "file '%s' is a symlink", showPath(curDirPath));
+            if (create)
+                throw NotADirectory("file '%s' is not a directory", showPath(curDirPath));
             return nullptr;
+        }
+
         auto & curDir = *curDirP;
 
         auto i = curDir.entries.find(name);
@@ -45,6 +57,7 @@ MemorySourceAccessor::File * MemorySourceAccessor::open(const CanonPath & path, 
             }
         }
         cur = &i->second;
+        ++j;
     }
 
     if (newF && create)
@@ -58,12 +71,17 @@ void MemorySourceAccessor::readFile(const CanonPath & path, Sink & sink, fun<voi
     auto * f = open(path, std::nullopt);
     if (!f)
         throw FileNotFound("file '%s' does not exist", showPath(path));
-    if (auto * r = std::get_if<File::Regular>(&f->raw)) {
-        sizeCallback(r->contents.size());
-        StringSource source{r->contents};
-        source.drainInto(sink);
-    } else
-        throw NotARegularFile("file '%s' is not a regular file", showPath(path));
+    std::visit(
+        overloaded{
+            [&](const File::Regular & r) {
+                sizeCallback(r.contents.size());
+                StringSource source{r.contents};
+                source.drainInto(sink);
+            },
+            [&](const File::Directory &) { throw NotARegularFile("file '%s' is not a regular file", showPath(path)); },
+            [&](const File::Symlink &) { throw SymlinkNotAllowed(path, "file '%s' is a symlink", showPath(path)); },
+        },
+        f->raw);
 }
 
 bool MemorySourceAccessor::pathExists(const CanonPath & path)
@@ -108,14 +126,22 @@ MemorySourceAccessor::DirEntries MemorySourceAccessor::readDirectory(const Canon
     auto * f = open(path, std::nullopt);
     if (!f)
         throw FileNotFound("file '%s' does not exist", showPath(path));
-    if (auto * d = std::get_if<File::Directory>(&f->raw)) {
-        DirEntries res;
-        for (auto & [name, file] : d->entries)
-            res.insert_or_assign(name, file.lstat().type);
-        return res;
-    } else
-        throw NotADirectory("file '%s' is not a directory", showPath(path));
-    return {};
+    return std::visit(
+        overloaded{
+            [&](const File::Directory & d) {
+                DirEntries res;
+                for (auto & [name, file] : d.entries)
+                    res.insert_or_assign(name, file.lstat().type);
+                return res;
+            },
+            [&](const File::Regular &) -> DirEntries {
+                throw NotADirectory("file '%s' is not a directory", showPath(path));
+            },
+            [&](const File::Symlink &) -> DirEntries {
+                throw SymlinkNotAllowed(path, "file '%s' is a symlink", showPath(path));
+            },
+        },
+        f->raw);
 }
 
 std::string MemorySourceAccessor::readLink(const CanonPath & path)
@@ -135,9 +161,15 @@ SourcePath MemorySourceAccessor::addFile(CanonPath path, std::string && contents
     if (!root && !path.isRoot())
         open(CanonPath::root, File::Directory{});
 
-    auto * f = open(path, File{File::Regular{}});
-    if (!f)
-        throw Error("file '%s' cannot be created because some parent file is not a directory", showPath(path));
+    MemorySourceAccessor::File * f = nullptr;
+    try {
+        f = open(path, File{File::Regular{}});
+        if (!f)
+            throw Error("file '%s' cannot be created because some parent directories don't exist", showPath(path));
+    } catch (SourceAccessorError & e) {
+        e.addTrace({}, "while creating file '%s'", showPath(path));
+        throw;
+    }
     if (auto * r = std::get_if<File::Regular>(&f->raw))
         r->contents = std::move(contents);
     else
@@ -150,10 +182,16 @@ using File = MemorySourceAccessor::File;
 
 void MemorySink::createDirectory(const CanonPath & path)
 {
-    auto * f = dst.open(path, File{File::Directory{}});
-    if (!f)
-        throw Error("directory '%s' cannot be created because some parent file is not a directory", dst.showPath(path));
-
+    MemorySourceAccessor::File * f = nullptr;
+    try {
+        f = dst.open(path, File{File::Directory{}});
+        if (!f)
+            throw Error(
+                "directory '%s' cannot be created because some parent directories don't exist", dst.showPath(path));
+    } catch (SourceAccessorError & e) {
+        e.addTrace({}, "while creating directory '%s'", dst.showPath(path));
+        throw;
+    }
     if (!std::holds_alternative<File::Directory>(f->raw))
         throw NotADirectory("file '%s' is not a directory", dst.showPath(path));
 };
@@ -174,9 +212,15 @@ struct CreateMemoryRegularFile : CreateRegularFileSink
 
 void MemorySink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)
 {
-    auto * f = dst.open(path, File{File::Regular{}});
-    if (!f)
-        throw Error("file '%s' cannot be created because some parent file is not a directory", path);
+    MemorySourceAccessor::File * f = nullptr;
+    try {
+        f = dst.open(path, File{File::Regular{}});
+        if (!f)
+            throw Error("file '%s' cannot be created because some parent directories don't exist", dst.showPath(path));
+    } catch (SourceAccessorError & e) {
+        e.addTrace({}, "while creating regular file '%s'", dst.showPath(path));
+        throw;
+    }
     if (auto * rp = std::get_if<File::Regular>(&f->raw)) {
         CreateMemoryRegularFile crf{*rp};
         func(crf);
@@ -201,9 +245,16 @@ void CreateMemoryRegularFile::operator()(std::string_view data)
 
 void MemorySink::createSymlink(const CanonPath & path, const std::string & target)
 {
-    auto * f = dst.open(path, File{File::Symlink{}});
-    if (!f)
-        throw Error("symlink '%s' cannot be created because some parent file is not a directory", dst.showPath(path));
+    MemorySourceAccessor::File * f = nullptr;
+    try {
+        f = dst.open(path, File{File::Symlink{}});
+        if (!f)
+            throw Error(
+                "symlink '%s' cannot be created because some parent directories don't exist", dst.showPath(path));
+    } catch (SourceAccessorError & e) {
+        e.addTrace({}, "while creating symlink '%s'", dst.showPath(path));
+        throw;
+    }
     if (auto * s = std::get_if<File::Symlink>(&f->raw))
         s->target = target;
     else

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -315,20 +315,69 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackL
     AutoCloseFD fd = openFileReadonly(root, FinalSymlink::DontFollow);
 
     if (!fd) {
-        if (errno == ELOOP) {
-            /* This branch is taken either if the final component is a symlink
-               or we hit a symlink loop. If that's the latter this will also
-               throw. This can be done with O_PATH descriptor for the symlink
-               itself, but it's not portable. */
-            auto linkTarget = readLink(root);
-            auto res = make_ref<MemorySourceAccessor>();
-            /* Create an in-memory accessor with the symlink at the root. */
-            MemorySink sink{*res};
-            sink.createSymlink(CanonPath::root, os_string_to_string(linkTarget));
-            return res;
+        if (errno != ELOOP)
+            throw NativeSysError("opening file %1%", PathFmt(root));
+
+        /* A helper class that holds the symlink destination in memory. */
+        class SymlinkSourceAccessor : public MemorySourceAccessor
+        {
+            bool trackLastModified;
+            std::time_t mtime;
+            std::filesystem::path fsPath;
+
+        public:
+            SymlinkSourceAccessor(
+                std::string target, std::filesystem::path fsPath_, bool trackLastModified, std::time_t mtime)
+                : trackLastModified(trackLastModified)
+                , mtime(mtime)
+                , fsPath(std::move(fsPath_))
+            {
+                MemorySink sink{*this};
+                sink.createSymlink(CanonPath::root, target);
+                displayPrefix = fsPath.native();
+            }
+
+            std::optional<std::time_t> getLastModified() override
+            {
+                return trackLastModified ? std::optional{mtime} : std::nullopt;
+            }
+
+            std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override
+            {
+                if (path.isRoot())
+                    return fsPath;
+                return fsPath / path.rel(); /* RHS must be a relative path. */
+            }
+
+            std::string showPath(const CanonPath & path) override
+            {
+                /* When rendering the file itself omit the trailing slash. */
+                return path.isRoot() ? displayPrefix : SourceAccessor::showPath(path);
+            }
+        };
+
+        assert(root.has_parent_path());
+        assert(root.has_filename());
+
+        /* This branch is taken either if the final component is a symlink
+           or we hit a symlink loop. If that's the latter this will also
+           throw. This can be done with O_PATH descriptor for the symlink
+           itself, but it's not portable. Note that file must have a parent directory
+           (it's required to be absolute and root directories can't fail with ELOOP). */
+
+        auto parentFd = openDirectory(root.parent_path(), FinalSymlink::Follow);
+        std::time_t mtime = 0;
+        if (!parentFd)
+            throw SysError("opening %1%", PathFmt(root));
+
+        auto relPath = CanonPath::fromFilename(root.filename().native());
+        if (trackLastModified) {
+            auto st = fstatat(parentFd.get(), root.filename());
+            mtime = st.st_mtime;
         }
 
-        throw NativeSysError("opening file %1%", PathFmt(root));
+        auto linkTarget = readLinkAt(parentFd.get(), relPath);
+        return make_ref<SymlinkSourceAccessor>(std::move(linkTarget), std::move(root), trackLastModified, mtime);
     }
 
     auto st = nix::fstat(fd.get());

--- a/src/libutil/unix/file-system-at.cc
+++ b/src/libutil/unix/file-system-at.cc
@@ -168,8 +168,7 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
             });
 
             if (errno == ENOTDIR) /* Path component might be a symlink. */ {
-                struct ::stat st;
-                if (::fstatat(getParentFd(), component.c_str(), &st, AT_SYMLINK_NOFOLLOW) == 0 && S_ISLNK(st.st_mode))
+                if (auto st = maybeFstatat(getParentFd(), component); st && S_ISLNK(st->st_mode))
                     throw SymlinkNotAllowed(path2);
                 errno = ENOTDIR; /* Restore the errno. */
             } else if (errno == ELOOP) {
@@ -226,6 +225,30 @@ PosixStat fstat(Descriptor fd)
     PosixStat st;
     if (::fstat(fd, &st)) {
         throw SysError([&] { return HintFmt("getting status of %s", PathFmt(descriptorToPath(fd))); });
+    }
+    return st;
+}
+
+PosixStat fstatat(Descriptor dirFd, const std::filesystem::path & path)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+    PosixStat st;
+    if (::fstatat(dirFd, path.c_str(), &st, AT_SYMLINK_NOFOLLOW)) {
+        throw SysError([&] { return HintFmt("getting status of %s", PathFmt(descriptorToPath(dirFd) / path)); });
+    }
+    return st;
+}
+
+std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const std::filesystem::path & path)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+    PosixStat st;
+    if (::fstatat(dirFd, path.c_str(), &st, AT_SYMLINK_NOFOLLOW)) {
+        if (errno == ENOENT || errno == ENOTDIR)
+            return std::nullopt;
+        throw SysError([&] { return HintFmt("getting status of %s", PathFmt(descriptorToPath(dirFd) / path)); });
     }
     return st;
 }

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -169,12 +169,10 @@ static void _deletePath(
 
     auto name = CanonPath::fromFilename(path.filename().native());
 
-    PosixStat st;
-    if (fstatat(parentfd, name.rel_c_str(), &st, AT_SYMLINK_NOFOLLOW) == -1) {
-        if (errno == ENOENT)
-            return;
-        throw SysError("getting status of %1%", PathFmt(path));
-    }
+    auto st_ = maybeFstatat(parentfd, name.rel());
+    if (!st_)
+        return;
+    auto & st = *st_;
 
     if (!S_ISDIR(st.st_mode)) {
         /* We are about to delete a file. Will it likely free space? */


### PR DESCRIPTION
…rceAccessor tracks metadata

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Changes makeFSSourceAccessor to behave better on symlinks. We had an unfortunate footgun of PosixSourceAccessor following interior links if root was a symlink. Prior commits changed that to first load the symlink in MemorySourceAccessor, but its exceptions were imprecise and pathExists didn't reject interior symlinks and instead returned false in such cases. mtime tracking of symlinks is now also restored, with more precise showPath and getPhysicalPath.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
