### PR TITLE
packaging/dependencies: bump mimalloc to 3.1.6

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -16,6 +16,16 @@ in
 scope: {
   inherit stdenv;
 
+  mimalloc = pkgs.mimalloc.overrideAttrs rec {
+    version = "3.1.6";
+    src = pkgs.fetchFromGitHub {
+      owner = "microsoft";
+      repo = "mimalloc";
+      tag = "v${version}";
+      hash = "sha256-7zG0Sqloanz/b+fkJ4wzO86uBmtf9fdYNAT9ixLouyY=";
+    };
+  };
+
   boehmgc =
     (pkgs.boehmgc.override {
       enableLargeConfig = true;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

3.1.5 seems to be broken with freebsd cross
https://hydra.nixos.org/build/325420458/nixlog/1

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 

cc @lovesegfault @xokdvium 