### PR TITLE
nix develop: use `runPhase` to run phases

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -605,7 +605,13 @@ struct CmdDevelop : Common, MixEnvironment
             // FIXME: foundMakefile is set by buildPhase, need to get
             // rid of that.
             script += fmt("foundMakefile=1\n");
-            script += fmt("runHook %1%Phase\n", *phase);
+            script +=
+                fmt("if declare -f runPhase >/dev/null; then\n"
+                    "  runPhase %1%Phase\n"
+                    "else\n"
+                    "  runHook %1%Phase\n"
+                    "fi\n",
+                    *phase);
         }
 
         else if (!command.empty()) {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Using `runHook`, `nix develop --phase <x>` still executes stdenv's generic `<x>Phase` when `<x>Phase` is explicitly defined when calling `stdenv.mkDerivation` (#6202).

Using `runPhase` instead of `runHook`, which was added in https://github.com/NixOS/nixpkgs/pull/230874 specifically to avoid this problem and to be more consistent with `genericBuild` behavior, overridden phases are executed correctly with `nix develop --phase <x>`.

### Example

Currently, running `nix develop --phase build` (or shorter: `nix develop --build`) on

```nix
stdenv.mkDerivation {
  name = "something";
  buildPhase = "echo 'Successfully overridden!'";
}
```

prints

```
no Makefile or custom buildPhase, doing nothing
```

because stdenv's generic `buildPhase` is executed.

With the change in this PR, running `nix develop --phase build` on the same derivation correctly executes the overridden `buildPhase`:

```
Running phase: buildPhase
Successfully overridden!
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Closes #6202

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
