### PR TITLE
libmain/progress-bar: invalidate redraw cache when clearing the bar

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -131,7 +131,7 @@ public:
             auto state(state_.lock());
             if (state->active) {
                 state->active = false;
-                writeToStderr("\r\e[K");
+                clearProgressDisplay();
                 updateCV.notify_one();
                 quitCV.notify_one();
             }
@@ -150,7 +150,7 @@ public:
         }
 
         if (state->active)
-            writeToStderr("\r\e[K");
+            clearProgressDisplay();
     }
 
     void resume() override
@@ -164,7 +164,7 @@ public:
         }
         if (state->suspensions == 0) {
             if (state->active)
-                writeToStderr("\r\e[K");
+                clearProgressDisplay();
             state->haveUpdate = true;
             updateCV.notify_one();
         }
@@ -196,6 +196,7 @@ public:
     void log(State & state, Verbosity lvl, std::string_view s)
     {
         if (state.active) {
+            invalidateRedrawCache();
             writeToStderr("\r\e[K" + filterANSIEscapes(s, !isTTY) + ANSI_NORMAL "\n");
             draw(state);
         } else {
@@ -406,6 +407,17 @@ public:
             writeToStderr(newOutput);
             *lastOutput = std::move(newOutput);
         }
+    }
+
+    void invalidateRedrawCache()
+    {
+        *lastOutput_.lock() = "";
+    }
+
+    void clearProgressDisplay()
+    {
+        invalidateRedrawCache();
+        writeToStderr("\r\e[K");
     }
 
     std::chrono::milliseconds draw(State & state)
@@ -647,6 +659,7 @@ public:
     {
         auto state(state_.lock());
         if (state->active) {
+            invalidateRedrawCache();
             std::cerr << "\r\e[K";
             Logger::writeToStdout(s);
             draw(*state);
@@ -660,6 +673,7 @@ public:
         auto state(state_.lock());
         if (!state->active)
             return {};
+        invalidateRedrawCache();
         std::cerr << fmt("\r\e[K%s ", msg);
         auto s = trim(readLine(getStandardInput(), true));
         if (s.size() != 1)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

  This fixes intermittent disappearance of the bottom progress bar during
  `nix build -L`.



## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


  The progress bar redraw path caches the last rendered line and skips
  writing identical output. That breaks when some other path clears the
  terminal line first: the bar is gone on screen, but draw() suppresses
  the repaint because the formatted status string did not change.

  Invalidate the redraw cache whenever the progress display is explicitly
  cleared or the terminal is temporarily borrowed for other output
  (pause/resume/stop, log lines, stdout writes, prompts). This forces the
  next draw() to repaint the bottom progress bar even if its contents are
  unchanged.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
