### PR TITLE
libstore: add macOS Spotlight integration for profile app bundles

### DIFF
--- a/doc/manual/rl-next/macos-spotlight-apps.md
+++ b/doc/manual/rl-next/macos-spotlight-apps.md
@@ -1,0 +1,12 @@
+---
+synopsis: macOS Spotlight integration for Nix-installed `.app` bundles
+issues: [7055]
+---
+
+On macOS, profile-installed `.app` bundles now appear in Spotlight, `mdfind`, and `open -a Foo`.
+
+Nix creates a small shadow bundle under a profile-specific subdirectory of `~/Applications/Nix Profile Apps/` (or `/Applications/Nix Profile Apps/` when run as root).
+It copies `Info.plist`, `PkgInfo` if present, and the icon file.
+The executable, frameworks, and other resources remain symlinks into `/nix/store`.
+
+See [macOS Spotlight Integration](@docroot@/installation/macos-spotlight-apps.md) for details.

--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -16,6 +16,7 @@
   - [Environment Variables](installation/env-variables.md)
   - [Upgrading Nix](installation/upgrading.md)
   - [Uninstalling Nix](installation/uninstall.md)
+  - [macOS Spotlight Integration](installation/macos-spotlight-apps.md)
 - [Nix Store](store/index.md)
   - [File System Object](store/file-system-object.md)
     - [Content-Addressing File System Objects](store/file-system-object/content-address.md)

--- a/doc/manual/source/installation/macos-spotlight-apps.md
+++ b/doc/manual/source/installation/macos-spotlight-apps.md
@@ -1,0 +1,89 @@
+# macOS Spotlight Integration
+
+On macOS, Nix makes profile-installed `.app` bundles visible to Spotlight, `mdfind`, and `open -a <app-name>`.
+
+When a profile generation contains an `Applications/` directory, Nix creates one shadow bundle per app under a profile-specific subdirectory of:
+
+| Command user | Destination directory              |
+| ------------ | ---------------------------------- |
+| Non-root     | `~/Applications/Nix Profile Apps/` |
+| Root         | `/Applications/Nix Profile Apps/`  |
+
+The shadow is a small hybrid bundle.
+`Contents/Info.plist`, `Contents/PkgInfo` if present, and the icon named by `CFBundleIconFile` are copied onto the boot volume.
+Other entries under `Contents/` and `Contents/Resources/` are symlinks back into the original store path.
+
+For example:
+
+```console
+~/Applications/Nix Profile Apps/profile-.../Foo.app/
+└── Contents/
+    ├── Info.plist
+    ├── PkgInfo
+    ├── MacOS -> /nix/store/.../Foo.app/Contents/MacOS
+    ├── Frameworks -> /nix/store/.../Foo.app/Contents/Frameworks
+    └── Resources/
+        ├── AppIcon.icns
+        └── en.lproj -> /nix/store/.../Foo.app/Contents/Resources/en.lproj
+```
+
+The executable, frameworks, and other runtime resources stay in `/nix/store`.
+The shadow directory is not a garbage-collection root.
+The profile generation still owns the store references.
+
+## Why this is needed
+
+Nix's macOS store volume is mounted with `nobrowse`.
+That keeps the volume out of Finder, but it also prevents Spotlight from creating an index store on `/nix`.
+Even as root, `mdutil -i on /nix` fails with error `-400` and leaves `/nix` in an unknown indexing state.
+
+Plain symlinks from `~/Applications` into `/nix/store` are not enough, because Spotlight's filesystem walk does not follow them across the volume boundary.
+Launch Services registration alone is not enough either: `open -a` may work while Spotlight still has no application-bundle record.
+
+The hybrid bundle gives Apple's application importer a real bundle directory, real bundle metadata, and a real icon on an indexed volume.
+The launch path can remain symlinked into the store.
+
+## When it runs
+
+This runs after profile switches made by [`nix profile`] operations (`add`, `remove`, `upgrade`, `rollback`) and the corresponding [`nix-env`] operations.
+Nix removes and recreates that profile's subdirectory each time, then asks Launch Services and Spotlight to pick up the new bundles.
+
+Failures are warnings only.
+A Spotlight integration error never aborts a profile switch.
+
+## Verifying
+
+After installing a package that contains an application bundle:
+
+```console
+$ app=Foo
+$ ls -la "$HOME/Applications/Nix Profile Apps/"
+$ mdfind -onlyin "$HOME/Applications/Nix Profile Apps/" 'kMDItemKind == "Application"'
+$ appPath=$(mdfind -onlyin "$HOME/Applications/Nix Profile Apps/" "kMDItemFSName == '$app.app'" | head -n1)
+$ mdls "$appPath" \
+    | grep -E 'kMDItemKind|kMDItemCFBundleIdentifier|kMDItemContentType '
+$ open -a "$app"
+```
+
+Spotlight indexing is asynchronous, so `mdfind` and `mdls` may take a few seconds to show a newly installed app.
+
+If `mdfind` sees the app but Spotlight search does not, check that Spotlight is enabled on the boot volume:
+
+```console
+$ mdutil -s /
+```
+
+If needed, re-enable it with:
+
+```console
+$ sudo mdutil -i on /
+```
+
+The `/nix` volume does not need indexing; the `nobrowse` volume rejects it.
+
+## Other macOS app managers
+
+This integration writes only to `Nix Profile Apps`, so it does not manage or delete `nix-darwin`'s `/Applications/Nix Apps/` or Home Manager's `~/Applications/Home Manager Apps/`.
+
+[`nix profile`]: @docroot@/command-ref/new-cli/nix3-profile.md
+[`nix-env`]: @docroot@/command-ref/nix-env.md

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -96,6 +96,12 @@ sources = files(
 
 include_dirs = [ include_directories('.') ]
 
+if host_machine.system() == 'darwin'
+  sources += files(
+    'spotlight-apps.cc',
+  )
+endif
+
 
 this_exe = executable(
   meson.project_name(),

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -39,6 +39,7 @@ mkMesonExecutable (finalAttrs: {
     ./.version
     ./meson.build
     ./meson.options
+    ../libstore/darwin/spotlight-apps-private.hh
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
   ];

--- a/src/libstore-tests/spotlight-apps.cc
+++ b/src/libstore-tests/spotlight-apps.cc
@@ -1,0 +1,293 @@
+#include <gtest/gtest.h>
+
+#include "../libstore/darwin/spotlight-apps-private.hh"
+#include "nix/util/file-system.hh"
+
+#include <optional>
+#include <string>
+
+namespace nix::darwin {
+
+namespace fs = std::filesystem;
+
+namespace {
+
+void writeInfoPlist(const fs::path & path, const std::string & bundleName, const std::string & iconKey = "")
+{
+    std::string contents =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" "
+        "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+        "<plist version=\"1.0\"><dict>\n"
+        "  <key>CFBundleIdentifier</key><string>org.nix.test."
+        + bundleName
+        + "</string>\n"
+          "  <key>CFBundleName</key><string>"
+        + bundleName + "</string>\n";
+    if (!iconKey.empty())
+        contents += "  <key>CFBundleIconFile</key><string>" + iconKey + "</string>\n";
+    contents += "</dict></plist>\n";
+    writeFile(path, contents);
+}
+
+class SpotlightAppsTest : public ::testing::Test
+{
+protected:
+    std::optional<AutoDelete> tmpDirGuard;
+    fs::path tmpRoot;
+    fs::path profile;
+    fs::path appsDir;
+    fs::path destRoot;
+
+    void SetUp() override
+    {
+        tmpRoot = createTempDir("", "nix-spotlight-test");
+        tmpDirGuard.emplace(tmpRoot, /*recursive=*/true);
+        profile = tmpRoot / "profile";
+        appsDir = profile / "Applications";
+        destRoot = tmpRoot / "dest";
+        createDirs(appsDir);
+        createDirs(destRoot);
+    }
+
+    fs::path makeBundle(
+        const std::string & name,
+        bool withInfoPlist = true,
+        const std::string & iconKey = "",
+        const std::string & extraResource = "")
+    {
+        fs::path app = appsDir / (name + ".app");
+        fs::path contents = app / "Contents";
+        fs::path macos = contents / "MacOS";
+        fs::path resources = contents / "Resources";
+        createDirs(macos);
+        createDirs(resources);
+
+        writeFile(macos / name, "#!/bin/sh\n");
+
+        if (withInfoPlist)
+            writeInfoPlist(contents / "Info.plist", name, iconKey);
+
+        if (!iconKey.empty()) {
+            std::string iconName = iconKey;
+            if (fs::path(iconName).extension().empty())
+                iconName += ".icns";
+            writeFile(resources / iconName, "icns-stub");
+        }
+
+        if (!extraResource.empty())
+            writeFile(resources / extraResource, "extra");
+
+        return app;
+    }
+
+    void sync()
+    {
+        detail::syncProfileAppBundlesAt(profile, destRoot, /*notifySystem=*/false);
+    }
+};
+
+TEST_F(SpotlightAppsTest, materializesSingleBundleWithIcon)
+{
+    auto srcApp = makeBundle("Foo", true, "AppIcon");
+
+    sync();
+
+    fs::path destApp = destRoot / "Foo.app";
+    EXPECT_TRUE(fs::is_directory(destApp));
+
+    fs::path destInfoPlist = destApp / "Contents" / "Info.plist";
+    EXPECT_TRUE(fs::is_regular_file(destInfoPlist));
+    EXPECT_FALSE(fs::is_symlink(destInfoPlist));
+
+    fs::path destIcon = destApp / "Contents" / "Resources" / "AppIcon.icns";
+    EXPECT_TRUE(fs::is_regular_file(destIcon));
+    EXPECT_FALSE(fs::is_symlink(destIcon));
+
+    fs::path destMacOS = destApp / "Contents" / "MacOS";
+    EXPECT_TRUE(fs::is_symlink(destMacOS));
+    EXPECT_EQ(fs::read_symlink(destMacOS), srcApp / "Contents" / "MacOS");
+}
+
+TEST_F(SpotlightAppsTest, symlinksOtherResourceEntries)
+{
+    auto srcApp = makeBundle("Foo", true, "AppIcon", "extra-data.bin");
+
+    sync();
+
+    fs::path destExtra = destRoot / "Foo.app" / "Contents" / "Resources" / "extra-data.bin";
+    EXPECT_TRUE(fs::is_symlink(destExtra));
+    EXPECT_EQ(fs::read_symlink(destExtra), srcApp / "Contents" / "Resources" / "extra-data.bin");
+}
+
+TEST_F(SpotlightAppsTest, preservesBundleSymlinks)
+{
+    auto srcApp = makeBundle("Foo", true, "AppIcon", "extra-data.bin");
+    replaceSymlink("extra-data.bin", appsDir / "Foo.app" / "Contents" / "Resources" / "extra-link");
+
+    sync();
+
+    fs::path destLink = destRoot / "Foo.app" / "Contents" / "Resources" / "extra-link";
+    EXPECT_TRUE(fs::is_symlink(destLink));
+    EXPECT_EQ(fs::read_symlink(destLink), srcApp / "Contents" / "Resources" / "extra-link");
+}
+
+TEST_F(SpotlightAppsTest, copiesPkgInfo)
+{
+    auto srcApp = makeBundle("Foo", true, "AppIcon");
+    writeFile(srcApp / "Contents" / "PkgInfo", "APPL????");
+
+    sync();
+
+    fs::path destPkgInfo = destRoot / "Foo.app" / "Contents" / "PkgInfo";
+    EXPECT_TRUE(fs::is_regular_file(destPkgInfo));
+    EXPECT_FALSE(fs::is_symlink(destPkgInfo));
+}
+
+TEST_F(SpotlightAppsTest, skipsBundlesWithoutInfoPlist)
+{
+    makeBundle("Good", true, "AppIcon");
+    makeBundle("Broken", /*withInfoPlist=*/false);
+
+    sync();
+
+    EXPECT_TRUE(fs::is_directory(destRoot / "Good.app"));
+    EXPECT_FALSE(fs::exists(destRoot / "Broken.app"));
+}
+
+TEST_F(SpotlightAppsTest, removesDestWhenProfileHasNoApps)
+{
+    createDirs(destRoot / "Stale.app" / "Contents");
+    writeFile(destRoot / "Stale.app" / "Contents" / "Info.plist", "stale");
+    deletePath(appsDir);
+
+    sync();
+
+    EXPECT_FALSE(fs::exists(destRoot));
+}
+
+TEST_F(SpotlightAppsTest, wipeAndRebuildClearsStaleEntries)
+{
+    makeBundle("Foo", true, "AppIcon");
+    sync();
+    EXPECT_TRUE(fs::is_directory(destRoot / "Foo.app"));
+
+    writeFile(destRoot / "garbage.txt", "trash");
+    createDirs(destRoot / "Stale.app" / "Contents");
+    writeFile(destRoot / "Stale.app" / "Contents" / "Info.plist", "stale");
+
+    deletePath(appsDir / "Foo.app");
+    makeBundle("Bar", true, "AppIcon");
+    sync();
+
+    EXPECT_TRUE(fs::is_directory(destRoot / "Bar.app"));
+    EXPECT_FALSE(fs::exists(destRoot / "Foo.app"));
+    EXPECT_FALSE(fs::exists(destRoot / "Stale.app"));
+    EXPECT_FALSE(fs::exists(destRoot / "garbage.txt"));
+}
+
+TEST_F(SpotlightAppsTest, idempotentRepeatedSync)
+{
+    makeBundle("Foo", true, "AppIcon");
+
+    sync();
+    sync();
+    sync();
+
+    EXPECT_TRUE(fs::is_regular_file(destRoot / "Foo.app" / "Contents" / "Info.plist"));
+    EXPECT_TRUE(fs::is_regular_file(destRoot / "Foo.app" / "Contents" / "Resources" / "AppIcon.icns"));
+    EXPECT_TRUE(fs::is_symlink(destRoot / "Foo.app" / "Contents" / "MacOS"));
+}
+
+TEST_F(SpotlightAppsTest, handlesIconKeyWithExplicitExtension)
+{
+    // CFBundleIconFile may already include the extension.
+    makeBundle("Foo", true, "AppIcon.icns");
+
+    sync();
+
+    EXPECT_TRUE(fs::is_regular_file(destRoot / "Foo.app" / "Contents" / "Resources" / "AppIcon.icns"));
+}
+
+TEST_F(SpotlightAppsTest, ignoresIconKeyOutsideResources)
+{
+    makeBundle("Foo", true, "../Leaked");
+
+    sync();
+
+    EXPECT_TRUE(fs::is_regular_file(destRoot / "Foo.app" / "Contents" / "Info.plist"));
+    EXPECT_FALSE(fs::exists(destRoot / "Foo.app" / "Contents" / "Resources" / "Leaked.icns"));
+}
+
+TEST_F(SpotlightAppsTest, handlesBundleWithoutIcon)
+{
+    makeBundle("Foo", true, /*iconKey=*/"");
+
+    sync();
+
+    EXPECT_TRUE(fs::is_regular_file(destRoot / "Foo.app" / "Contents" / "Info.plist"));
+    EXPECT_TRUE(fs::is_symlink(destRoot / "Foo.app" / "Contents" / "MacOS"));
+}
+
+TEST_F(SpotlightAppsTest, ignoresNonAppEntriesInApplicationsDir)
+{
+    makeBundle("Foo", true, "AppIcon");
+    writeFile(appsDir / "README.txt", "ignored");
+    createDirs(appsDir / "stuff");
+
+    sync();
+
+    EXPECT_TRUE(fs::is_directory(destRoot / "Foo.app"));
+    EXPECT_FALSE(fs::exists(destRoot / "README.txt"));
+    EXPECT_FALSE(fs::exists(destRoot / "stuff"));
+}
+
+TEST_F(SpotlightAppsTest, followsProfileApplicationsSymlink)
+{
+    fs::path realAppsDir = tmpRoot / "real-applications";
+    createDirs(realAppsDir);
+
+    deletePath(appsDir);
+    replaceSymlink(realAppsDir, appsDir);
+
+    fs::path oldAppsDir = appsDir;
+    appsDir = realAppsDir;
+    makeBundle("Foo", true, "AppIcon");
+    appsDir = oldAppsDir;
+
+    sync();
+
+    EXPECT_TRUE(fs::is_directory(destRoot / "Foo.app"));
+    EXPECT_TRUE(fs::is_regular_file(destRoot / "Foo.app" / "Contents" / "Info.plist"));
+}
+
+TEST_F(SpotlightAppsTest, missingProfileIsHarmless)
+{
+    createDirs(destRoot / "Old.app" / "Contents");
+    writeFile(destRoot / "Old.app" / "Contents" / "Info.plist", "old");
+
+    detail::syncProfileAppBundlesAt(tmpRoot / "no-such-profile", destRoot, /*notifySystem=*/false);
+
+    EXPECT_FALSE(fs::exists(destRoot));
+}
+
+TEST_F(SpotlightAppsTest, profileScopedDestinationsDoNotClobberEachOther)
+{
+    makeBundle("Foo", true, "AppIcon");
+
+    fs::path base = tmpRoot / "base";
+    fs::path firstDest = detail::profileAppBundlesDirAt(profile, base);
+    detail::syncProfileAppBundlesAt(profile, firstDest, /*notifySystem=*/false);
+
+    fs::path otherProfile = tmpRoot / "other-profile";
+    createDirs(otherProfile);
+    fs::path secondDest = detail::profileAppBundlesDirAt(otherProfile, base);
+    detail::syncProfileAppBundlesAt(otherProfile, secondDest, /*notifySystem=*/false);
+
+    EXPECT_TRUE(fs::is_regular_file(firstDest / "Foo.app" / "Contents" / "Info.plist"));
+    EXPECT_FALSE(fs::exists(secondDest));
+}
+
+} // anonymous namespace
+
+} // namespace nix::darwin

--- a/src/libstore/darwin/include/nix/store/meson.build
+++ b/src/libstore/darwin/include/nix/store/meson.build
@@ -1,0 +1,5 @@
+include_dirs += include_directories('../..')
+
+headers += files(
+  'spotlight-apps.hh',
+)

--- a/src/libstore/darwin/include/nix/store/spotlight-apps.hh
+++ b/src/libstore/darwin/include/nix/store/spotlight-apps.hh
@@ -1,0 +1,16 @@
+#pragma once
+/**
+ * @file
+ *
+ * macOS-only support for materializing profile-installed `.app` bundles in a
+ * Spotlight-indexable location.
+ */
+
+#include <filesystem>
+
+namespace nix::darwin {
+
+/** Best-effort; never lets failures abort a profile switch. */
+void syncProfileAppBundles(const std::filesystem::path & profile) noexcept;
+
+} // namespace nix::darwin

--- a/src/libstore/darwin/meson.build
+++ b/src/libstore/darwin/meson.build
@@ -1,0 +1,13 @@
+sources += files(
+  'spotlight-apps.cc',
+)
+
+# Frameworks needed by the hybrid app-bundle materializer. CoreFoundation is
+# already pulled in transitively by Apple's libSystem on darwin, but listing
+# it explicitly here documents the dependency. CoreServices gives us
+# LSRegisterURL.
+deps_other += [
+  dependency('appleframeworks', modules : [ 'CoreFoundation', 'CoreServices' ]),
+]
+
+subdir('include/nix/store')

--- a/src/libstore/darwin/spotlight-apps-private.hh
+++ b/src/libstore/darwin/spotlight-apps-private.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <filesystem>
+
+namespace nix::darwin::detail {
+
+std::filesystem::path profileAppBundlesDirAt(const std::filesystem::path & profile, const std::filesystem::path & base);
+
+void syncProfileAppBundlesAt(
+    const std::filesystem::path & profile, const std::filesystem::path & dest, bool notifySystem);
+
+} // namespace nix::darwin::detail

--- a/src/libstore/darwin/spotlight-apps.cc
+++ b/src/libstore/darwin/spotlight-apps.cc
@@ -1,0 +1,335 @@
+#include "nix/store/spotlight-apps.hh"
+
+#include "spotlight-apps-private.hh"
+
+#include "nix/util/deleter.hh"
+#include "nix/util/error.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/hash.hh"
+#include "nix/util/logging.hh"
+#include "nix/util/processes.hh"
+#include "nix/util/users.hh"
+#include "nix/util/util.hh"
+
+#include <sys/stat.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreServices/CoreServices.h>
+
+namespace nix::darwin {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+template<typename T>
+using CFRef = std::unique_ptr<std::remove_pointer_t<T>, Deleter<CFRelease>>;
+
+static CFRef<CFURLRef> cfURL(const fs::path & path, bool isDirectory)
+{
+    auto s = path.string();
+    return CFRef<CFURLRef>(CFURLCreateFromFileSystemRepresentation(
+        kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(s.data()), s.size(), isDirectory));
+}
+
+static std::optional<std::string> cfString(CFStringRef string)
+{
+    if (const char * ptr = CFStringGetCStringPtr(string, kCFStringEncodingUTF8))
+        return ptr;
+
+    CFIndex size = CFStringGetMaximumSizeForEncoding(CFStringGetLength(string), kCFStringEncodingUTF8) + 1;
+    std::vector<char> buffer(size);
+    if (!CFStringGetCString(string, buffer.data(), size, kCFStringEncodingUTF8))
+        return std::nullopt;
+
+    return buffer.data();
+}
+
+static bool isDirectory(const fs::path & path)
+{
+    auto st = maybeStat(path);
+    return st && S_ISDIR(st->st_mode);
+}
+
+static bool isRegularFile(const fs::path & path)
+{
+    auto st = maybeStat(path);
+    return st && S_ISREG(st->st_mode);
+}
+
+static std::optional<fs::path> iconFileName(CFBundleRef bundle)
+{
+    auto value = CFBundleGetValueForInfoDictionaryKey(bundle, CFSTR("CFBundleIconFile"));
+    if (!value || CFGetTypeID(value) != CFStringGetTypeID())
+        return std::nullopt;
+
+    auto icon = cfString(static_cast<CFStringRef>(value));
+    if (!icon)
+        return std::nullopt;
+
+    fs::path iconPath = *icon;
+    if (iconPath.empty() || iconPath.is_absolute() || iconPath.has_parent_path())
+        return std::nullopt;
+
+    if (iconPath.extension().empty())
+        iconPath += ".icns";
+
+    return iconPath;
+}
+
+static std::optional<fs::path>
+materializeIcon(CFBundleRef bundle, const fs::path & srcResources, const fs::path & destResources)
+{
+    auto icon = iconFileName(bundle);
+    if (!icon)
+        return std::nullopt;
+
+    fs::path srcIcon = srcResources / *icon;
+    if (!isRegularFile(srcIcon))
+        return std::nullopt;
+
+    copyFile(srcIcon, destResources / *icon, /*andDelete=*/false, /*contents=*/true);
+    return icon;
+}
+
+static void materializeResources(CFBundleRef bundle, const fs::path & srcResources, const fs::path & destResources)
+{
+    if (!isDirectory(srcResources))
+        return;
+
+    createDirs(destResources);
+
+    auto copiedIcon = materializeIcon(bundle, srcResources, destResources);
+
+    for (auto & entry : DirectoryIterator{srcResources}) {
+        auto name = entry.path().filename();
+        if (copiedIcon && name == *copiedIcon)
+            continue;
+        createSymlink(entry.path(), destResources / name);
+    }
+}
+
+static void copyBundleMetadata(const fs::path & srcContents, const fs::path & destContents)
+{
+    copyFile(srcContents / "Info.plist", destContents / "Info.plist", /*andDelete=*/false, /*contents=*/true);
+
+    fs::path srcPkgInfo = srcContents / "PkgInfo";
+    if (isRegularFile(srcPkgInfo))
+        copyFile(srcPkgInfo, destContents / "PkgInfo", /*andDelete=*/false, /*contents=*/true);
+}
+
+static void symlinkRuntimeContents(const fs::path & srcContents, const fs::path & destContents)
+{
+    for (auto & entry : DirectoryIterator{srcContents}) {
+        auto name = entry.path().filename();
+        if (name == "Info.plist" || name == "PkgInfo" || name == "Resources")
+            continue;
+        createSymlink(entry.path(), destContents / name);
+    }
+}
+
+static void registerAppBundle(const fs::path & destApp)
+{
+    auto url = cfURL(destApp, true);
+    if (!url)
+        return;
+
+    auto status = LSRegisterURL(url.get(), true);
+    if (status != noErr)
+        warn("could not register app bundle %s with Launch Services: OSStatus %d", PathFmt(destApp), status);
+}
+
+static bool materializeAppBundle(const fs::path & srcApp, const fs::path & destApp, bool notifySystem)
+{
+    fs::path srcContents = srcApp / "Contents";
+    fs::path srcInfoPlist = srcContents / "Info.plist";
+
+    if (!isDirectory(srcContents))
+        return false;
+
+    if (!isRegularFile(srcInfoPlist))
+        return false;
+
+    auto bundleURL = cfURL(srcApp, true);
+    auto bundle = CFRef<CFBundleRef>(bundleURL ? CFBundleCreate(kCFAllocatorDefault, bundleURL.get()) : nullptr);
+    if (!bundle)
+        return false;
+
+    fs::path destContents = destApp / "Contents";
+    createDirs(destContents);
+
+    copyBundleMetadata(srcContents, destContents);
+    materializeResources(bundle.get(), srcContents / "Resources", destContents / "Resources");
+    symlinkRuntimeContents(srcContents, destContents);
+
+    if (notifySystem)
+        registerAppBundle(destApp);
+
+    return true;
+}
+
+static std::string profileDirName(const fs::path & profile)
+{
+    return "profile-"
+           + hashString(HashAlgorithm::SHA256, absPath(profile).string()).to_string(HashFormat::Nix32, false);
+}
+
+static fs::path destinationBaseDir()
+{
+    if (isRootUser())
+        return "/Applications/Nix Profile Apps";
+
+    return getHome() / "Applications" / "Nix Profile Apps";
+}
+
+static std::vector<fs::path> findAppBundles(const fs::path & profileTarget)
+{
+    std::vector<fs::path> out;
+    fs::path appsDir = profileTarget / "Applications";
+
+    try {
+        if (!isDirectory(appsDir))
+            return out;
+
+        for (auto & entry : DirectoryIterator{appsDir}) {
+            if (entry.path().extension() != ".app")
+                continue;
+            try {
+                out.push_back(canonPath(entry.path(), /*resolveSymlinks=*/true));
+            } catch (Error & e) {
+                warn("could not resolve app bundle %s for Spotlight indexing: %s", PathFmt(entry.path()), e.what());
+            }
+        }
+    } catch (Error & e) {
+        warn("could not enumerate %s for Spotlight indexing: %s", PathFmt(appsDir), e.what());
+    }
+
+    return out;
+}
+
+static std::optional<fs::path> resolveProfileTarget(const fs::path & profile)
+{
+    try {
+        if (!pathExists(profile))
+            return std::nullopt;
+
+        return canonPath(profile, /*resolveSymlinks=*/true);
+    } catch (Error & e) {
+        warn("could not resolve profile %s for Spotlight indexing: %s", PathFmt(profile), e.what());
+        return std::nullopt;
+    }
+}
+
+static bool removeProfileAppBundlesDir(const fs::path & dest)
+{
+    try {
+        deletePath(dest);
+        return true;
+    } catch (Error & e) {
+        warn("could not remove stale Spotlight app bundle directory %s: %s", PathFmt(dest), e.what());
+        return false;
+    }
+}
+
+static bool recreateProfileAppBundlesDir(const fs::path & dest)
+{
+    if (!removeProfileAppBundlesDir(dest))
+        return false;
+
+    try {
+        createDirs(dest);
+        return true;
+    } catch (Error & e) {
+        warn("could not create Spotlight app bundle directory %s: %s", PathFmt(dest), e.what());
+        return false;
+    }
+}
+
+static void cleanupFailedBundle(const fs::path & destApp)
+{
+    try {
+        deletePath(destApp);
+    } catch (Error & e) {
+        debug("could not clean up failed Spotlight app bundle %s: %s", PathFmt(destApp), e.what());
+    }
+}
+
+static void importProfileAppBundles(const fs::path & dest)
+{
+    try {
+        (void) runProgram(
+            RunOptions{
+                .program = "/usr/bin/mdimport",
+                .lookupPath = false,
+                .args = {"-i", dest.string()},
+                .mergeStderrToStdout = true,
+            });
+    } catch (Error & e) {
+        warn("could not ask Spotlight to import app bundles in %s: %s", PathFmt(dest), e.what());
+    }
+}
+
+} // anonymous namespace
+
+namespace detail {
+
+fs::path profileAppBundlesDirAt(const fs::path & profile, const fs::path & base)
+{
+    return base / profileDirName(profile);
+}
+
+void syncProfileAppBundlesAt(const fs::path & profile, const fs::path & dest, bool notifySystem)
+{
+    auto target = resolveProfileTarget(profile);
+    std::vector<fs::path> bundles;
+    if (target)
+        bundles = findAppBundles(*target);
+
+    if (bundles.empty()) {
+        removeProfileAppBundlesDir(dest);
+        return;
+    }
+
+    if (!recreateProfileAppBundlesDir(dest))
+        return;
+
+    size_t ok = 0;
+    for (const auto & srcApp : bundles) {
+        fs::path destApp = dest / srcApp.filename();
+
+        try {
+            if (materializeAppBundle(srcApp, destApp, notifySystem))
+                ok++;
+            else
+                cleanupFailedBundle(destApp);
+        } catch (Error & e) {
+            warn("could not materialize app bundle for %s: %s", PathFmt(srcApp), e.what());
+            cleanupFailedBundle(destApp);
+        }
+    }
+
+    if (notifySystem && ok > 0)
+        importProfileAppBundles(dest);
+
+    debug("syncProfileAppBundles: materialized %d/%d bundles into %s", ok, bundles.size(), PathFmt(dest));
+}
+
+} // namespace detail
+
+void syncProfileAppBundles(const fs::path & profile) noexcept
+{
+    try {
+        detail::syncProfileAppBundlesAt(
+            profile, detail::profileAppBundlesDirAt(profile, destinationBaseDir()), /* notifySystem = */ true);
+    } catch (...) {
+        ignoreExceptionInDestructor();
+    }
+}
+
+} // namespace nix::darwin

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -370,6 +370,10 @@ if host_machine.system() == 'linux'
   subdir('linux')
 endif
 
+if host_machine.system() == 'darwin'
+  subdir('darwin')
+endif
+
 if host_machine.system() == 'windows'
   subdir('windows')
 else

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -61,6 +61,8 @@ mkMesonLibrary (finalAttrs: {
     ./linux/include/nix/store/meson.build
     ./unix/meson.build
     ./unix/include/nix/store/meson.build
+    ./darwin/meson.build
+    ./darwin/include/nix/store/meson.build
     ./windows/meson.build
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -4,6 +4,10 @@
 #include "nix/store/local-fs-store.hh"
 #include "nix/util/users.hh"
 
+#ifdef __APPLE__
+#  include "nix/store/spotlight-apps.hh"
+#endif
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -239,6 +243,10 @@ void switchLink(std::filesystem::path link, std::filesystem::path target)
         target = target.filename();
 
     replaceSymlink(target, link);
+
+#ifdef __APPLE__
+    nix::darwin::syncProfileAppBundles(link);
+#endif
 }
 
 void switchGeneration(const std::filesystem::path & profile, std::optional<GenerationNumber> dstGen, bool dryRun)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

On macOS, apps installed via `nix profile install` (or `nix-env`) don't appear
in Spotlight, in `mdfind`, or as targets for `open -a Foo`. The Nix store volume
is mounted `nobrowse`, which Apple's metadata code refuses to create a Spotlight
index store on (`mdutil -i on /nix` fails with `MDConfigCreateStore` error
`-400`), and `mds` does not follow symlinks across volume boundaries during
indexing - so a plain symlink in `~/Applications` pointing into the store is
never picked up

This PR makes profile-installed `.app` bundles show up in Spotlight
automatically, with no opt-in and no extra tooling. After every profile switch,
Nix materializes a hybrid shadow of each `.app` under `~/Applications/Nix
Profile Apps/` (or `/Applications/Nix Profile Apps/` for the root profile): the
`Info.plist` and icon are real copies on the indexed boot volume - that is the
minimum `Application.mdimporter` needs - and everything else under `Contents/`
is symlinked back into `/nix/store`. The store remains authoritative for every
byte that executes, the shadow directory is not a GC root, and uninstalls
propagate on the next switch

## Context

Closes: #7055

The hybrid-copy approach (real `Info.plist` + icon, the rest symlinked) was
previously prototyped in `home-manager` userland by @Jabb0 in
https://gist.github.com/Jabb0/1b7ad92e8ab3065ac999c21edc23311f (linked from
#7055). This PR is an independent C++ reimplementation in `libstore` so that
the integration also covers plain `nix profile install` / `nix-env` users
who are not running `home-manager` or `nix-darwin`. Background investigation
into the `nobrowse` constraint on the issue thread by @abathur was also
helpful in framing the problem.

The integration runs from `nix::switchLink()`, so it covers `nix profile
install`/`remove`/`upgrade`/`rollback`, `nix-env`, and any future profile-switch
path. It is best-effort and `noexcept`: any failure is logged via `warn(...)`
and never aborts a profile switch. The Darwin code is gated in meson and behind
`#ifdef __APPLE__`, so non-Darwin builds are unaffected.

A number of other approaches were tried first and rejected - `mdutil
-i on /nix` (refused on `nobrowse`), plain symlinks (not crossed during
indexing), Finder alias files (indexed as `com.apple.alias-file`,
wrong UTI for the Applications category), `LSRegisterURL` alone
(LS knows but the Spotlight UI is populated from `mds`, not LS),
copying the whole bundle (defeats store dedup, atomic rollback, and
GC), and `CSSearchableIndex` donation (lands in the AppIntents/Siri
pipeline, not the launchable-app pipeline). The full reasoning is in
`src/libstore/darwin/include/nix/store/spotlight-apps.hh` and the user-facing
manual page added in `doc/manual/source/installation/macos-spotlight-apps.md`

The Darwin module is plain C++ + the CoreFoundation C API (no Objective-C
runtime), so libstore's meson project does not need to add `objc`/`objcpp` to
its language list. Unit tests in `src/libstore-tests/spotlight-apps.cc` exercise
the file-ops half against a tempdir via a `notifySystem = false` test seam,
so they don't touch the host's Launch Services database or the real Spotlight
indexer. No functional tests are added: end-to-end verification would require
a real macOS host with the Spotlight daemon and `mds` actually indexing, which
is not feasible in CI; the unit tests cover everything Nix is responsible for.

## Verified on macOS 26 (aarch64-darwin)

Built this branch and installed Rectangle through the freshly built `nix`:

```console
$ nix develop -c meson setup build
$ nix develop -c ninja -C build
$ ./build/src/nix/nix profile add nixpkgs#rectangle
```

The hybrid shadow is materialized correctly:

```console
$ ls -la ~/Applications/Nix\ Profile\ Apps/Rectangle.app/Contents/
total 8
drwxr-xr-x 10 flame staff  320 Apr  6 16:00 .
drwxr-xr-x  3 flame staff   96 Apr  6 16:00 ..
lrwxr-xr-x  1 flame staff  108 Apr  6 16:00 CodeResources -> /nix/store/v8521ydy8ib6nsif0h18isvqb6054by9-rectangle-0.94/Applications/Rectangle.app/Contents/CodeResources
lrwxr-xr-x  1 flame staff  105 Apr  6 16:00 Frameworks -> /nix/store/v8521ydy8ib6nsif0h18isvqb6054by9-rectangle-0.94/Applications/Rectangle.app/Contents/Frameworks
-r--r--r--  1 flame staff 2141 Apr  6 16:00 Info.plist
lrwxr-xr-x  1 flame staff  102 Apr  6 16:00 Library -> /nix/store/v8521ydy8ib6nsif0h18isvqb6054by9-rectangle-0.94/Applications/Rectangle.app/Contents/Library
lrwxr-xr-x  1 flame staff  100 Apr  6 16:00 MacOS -> /nix/store/v8521ydy8ib6nsif0h18isvqb6054by9-rectangle-0.94/Applications/Rectangle.app/Contents/MacOS
-r--r--r--  1 flame staff    8 Apr  6 16:00 PkgInfo
drwxr-xr-x 40 flame staff 1280 Apr  6 16:00 Resources
lrwxr-xr-x  1 flame staff  109 Apr  6 16:00 _CodeSignature -> /nix/store/v8521ydy8ib6nsif0h18isvqb6054by9-rectangle-0.94/Applications/Rectangle.app/Contents/_CodeSignature


$ ls -l ~/Applications/Nix\ Profile\ Apps/Rectangle.app/Contents/Resources/AppIcon.icns
-r--r--r-- 1 flame staff 48417 Apr  6 16:00 '/Users/flame/Applications/Nix Profile Apps/Rectangle.app/Contents/Resources/AppIcon.icns'
```

Spotlight picks it up with the right metadata:

```console
$ mdls "$HOME/Applications/Nix Profile Apps/Rectangle.app" | grep -E 'kMDItemKind|kMDItemDisplayName|kMDItemCFBundleIdentifier|kMDItemContentType '
kMDItemCFBundleIdentifier              = "com.knollsoft.Rectangle"
kMDItemContentType                     = "com.apple.application-bundle"
kMDItemDisplayName                     = "Rectangle.app"
kMDItemKind                            = "Application"

$ mdfind 'kMDItemCFBundleIdentifier == "com.knollsoft.Rectangle"'
/Users/flame/Applications/Nix Profile Apps/Rectangle.app
```

Note `kMDItemContentType = com.apple.application-bundle` - that is the UTI
Spotlight's "Applications" category filters on, which is exactly why
`home-manager`'s Finder-alias approach (UTI `com.apple.alias-file`) does not
work.

Then you can just search "Rectangle" in Spotlight

To clean up after the test:

```console
$ ./build/src/nix/nix profile remove rectangle
```

The shadow bundle disappears as part of the same command (the `remove` itself
goes through `switchLink()`), and `mdfind` no longer returns the bundle
identifier afterwards.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
