### PR TITLE
Add `nix profile replace` command

### DIFF
--- a/src/nix/profile-replace.md
+++ b/src/nix/profile-replace.md
@@ -1,0 +1,26 @@
+R""(
+
+# Examples
+
+* Replace a package with a different one:
+
+  ```console
+  # nix profile replace hello nixpkgs#hello-unfree
+  ```
+
+* Replace a package with a specific version:
+
+  ```console
+  # nix profile replace nodejs nixpkgs#nodejs-18_x
+  ```
+
+# Description
+
+This command replaces an existing package in a profile with a new one.
+The first argument identifies the package to replace, and the second argument
+is the [_installable_](./nix.md#installables) to install in its place.
+
+The new package takes the place of the old one, preserving the element
+name unless the replacement has a different name.
+
+)""

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -767,9 +767,12 @@ struct CmdProfileReplace : virtual SourceExprCommand, MixDefaultProfile, MixProf
                             completions.add(name, element.identifier());
                 },
         });
+        // Marked optional so that completion of the first argument
+        // (`element`) succeeds even when no `installable` has been
+        // typed yet. Missing `installable` is validated in `run()`.
         expectArgs({
             .label = "installable",
-            .optional = false,
+            .optional = true,
             .handler = {&rawInstallable},
             .completer = getCompleteInstallable(),
         });
@@ -789,6 +792,9 @@ struct CmdProfileReplace : virtual SourceExprCommand, MixDefaultProfile, MixProf
 
     void run(ref<Store> store) override
     {
+        if (rawInstallable.empty())
+            throw UsageError("'nix profile replace' requires an installable as the second argument");
+
         ProfileManifest manifest(*getEvalState(), *profile);
 
         auto it = manifest.elements.find(elementName);

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -690,6 +690,158 @@ struct CmdProfileRemove : virtual EvalCommand, MixProfileElementMatchers
     }
 };
 
+struct CmdProfileReplace : virtual SourceExprCommand, MixDefaultProfile
+{
+    std::string elementName;
+    std::string rawInstallable;
+    std::optional<int64_t> priority;
+
+    CmdProfileReplace()
+    {
+        addFlag({
+            .longName = "priority",
+            .description = "The priority of the replacement package.",
+            .labels = {"priority"},
+            .handler = {&priority},
+        });
+        expectArgs({
+            .label = "element",
+            .optional = false,
+            .handler = {&elementName},
+            .completer =
+                [this](AddCompletions & completions, size_t, std::string_view prefix) {
+                    auto * evalCmd = dynamic_cast<EvalCommand *>(this);
+                    if (!evalCmd)
+                        return;
+                    auto evalState = evalCmd->getEvalState();
+                    ProfileManifest manifest(*evalState, *profile);
+                    for (auto & [name, element] : manifest.elements)
+                        if (name.starts_with(prefix))
+                            completions.add(name, element.identifier());
+                },
+        });
+        expectArgs({
+            .label = "installable",
+            .optional = false,
+            .handler = {&rawInstallable},
+            .completer = getCompleteInstallable(),
+        });
+    }
+
+    std::string description() override
+    {
+        return "replace a package in a profile";
+    }
+
+    std::string doc() override
+    {
+        return
+#include "profile-replace.md"
+            ;
+    }
+
+    void run(ref<Store> store) override
+    {
+        ProfileManifest manifest(*getEvalState(), *profile);
+
+        auto it = manifest.elements.find(elementName);
+        if (it == manifest.elements.end())
+            throw Error(
+                "package '%s' not found in the profile. Use 'nix profile list' to see installed packages.",
+                elementName);
+
+        notice("replacing '%s'", it->second.identifier());
+
+        // Build the new installable.
+        auto installable = parseInstallable(store, rawInstallable);
+
+        auto builtPaths = builtPathsPerInstallable(
+            Installable::build2(getEvalStore(), store, Realise::Outputs, {installable}, bmNormal));
+
+        auto iter = builtPaths.find(&*installable);
+        if (iter == builtPaths.end())
+            throw Error("failed to build '%s'", rawInstallable);
+        auto & [res, info] = iter->second;
+
+        ProfileElement element;
+
+        if (auto * info2 = dynamic_cast<ExtraPathInfoFlake *>(&*info)) {
+            element.source = ProfileElementSource{
+                .originalRef = info2->flake.originalRef,
+                .lockedRef = info2->flake.lockedRef,
+                .attrPath = info2->value.attrPath,
+                .outputs = info2->value.extendedOutputsSpec,
+            };
+        }
+
+        element.priority = priority ? *priority : ({
+            auto * info2 = dynamic_cast<ExtraPathInfoValue *>(&*info);
+            info2 ? info2->value.priority.value_or(defaultPriority) : defaultPriority;
+        });
+
+        element.updateStorePaths(getEvalStore(), store, res);
+
+        // Remove the old element and add the new one under the same name.
+        manifest.elements.erase(it);
+        manifest.elements.insert_or_assign(elementName, std::move(element));
+
+        try {
+            updateProfile(*store, manifest.build(store));
+        } catch (BuildEnvFileConflictError & conflictError) {
+            // FIXME use C++20 std::ranges once macOS has it
+            auto findRefByFilePath = [&]<typename Iterator>(Iterator begin, Iterator end) {
+                for (auto it = begin; it != end; it++) {
+                    auto & [name, profileElement] = *it;
+                    for (auto & storePath : profileElement.storePaths) {
+                        if (conflictError.fileA.string().starts_with(store->printStorePath(storePath))) {
+                            return std::tuple(conflictError.fileA, name, profileElement.toInstallables(*store));
+                        }
+                        if (conflictError.fileB.string().starts_with(store->printStorePath(storePath))) {
+                            return std::tuple(conflictError.fileB, name, profileElement.toInstallables(*store));
+                        }
+                    }
+                }
+                throw conflictError;
+            };
+            auto [originalConflictingFilePath, originalEntryName, originalConflictingRefs] =
+                findRefByFilePath(manifest.elements.begin(), manifest.elements.end());
+            auto [newConflictingFilePath, newEntryName, newConflictingRefs] =
+                findRefByFilePath(manifest.elements.rbegin(), manifest.elements.rend());
+
+            throw Error(
+                "An existing package already provides the following file:\n"
+                "\n"
+                "  %1%\n"
+                "\n"
+                "This is the conflicting file from the new package:\n"
+                "\n"
+                "  %2%\n"
+                "\n"
+                "To remove the existing package:\n"
+                "\n"
+                "  nix profile remove %3%\n"
+                "\n"
+                "The new package can also be installed by assigning a different priority.\n"
+                "The conflicting packages have a priority of %5%.\n"
+                "To prioritise the new package:\n"
+                "\n"
+                "  nix profile replace %6% %4% --priority %7%\n"
+                "\n"
+                "To prioritise the existing package:\n"
+                "\n"
+                "  nix profile replace %6% %4% --priority %8%\n",
+                PathFmt(originalConflictingFilePath),
+                PathFmt(newConflictingFilePath),
+                originalEntryName,
+                concatStringsSep(" ", newConflictingRefs),
+                conflictError.priority,
+                elementName,
+                conflictError.priority - 1,
+                conflictError.priority + 1);
+        }
+    }
+};
+
 struct CmdProfileUpgrade : virtual SourceExprCommand, MixProfileElementMatchers, MixDryRun
 {
     std::string description() override
@@ -1002,6 +1154,7 @@ struct CmdProfile : NixMultiCommand
               {
                   {"add", []() { return make_ref<CmdProfileAdd>(); }},
                   {"remove", []() { return make_ref<CmdProfileRemove>(); }},
+                  {"replace", []() { return make_ref<CmdProfileReplace>(); }},
                   {"upgrade", []() { return make_ref<CmdProfileUpgrade>(); }},
                   {"list", []() { return make_ref<CmdProfileList>(); }},
                   {"diff-closures", []() { return make_ref<CmdProfileDiffClosures>(); }},

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -402,6 +402,22 @@ static void rethrowProfileFileConflict(
 }
 
 /**
+ * Build the manifest and update the profile, translating any
+ * `BuildEnvFileConflictError` into a user-facing error via
+ * `rethrowProfileFileConflict`. `prioritiseSubcommand` is forwarded to
+ * the conflict reporter (e.g. `"add"` or `"replace foo"`).
+ */
+static void buildAndUpdateProfileWithCatchConflict(
+    MixProfile & cmd, ref<Store> store, ProfileManifest & manifest, std::string_view prioritiseSubcommand)
+{
+    try {
+        cmd.updateProfile(*store, manifest.build(store));
+    } catch (BuildEnvFileConflictError & conflictError) {
+        rethrowProfileFileConflict(manifest, *store, conflictError, prioritiseSubcommand);
+    }
+}
+
+/**
  * Adds a `--priority` flag for commands that build a single
  * `ProfileElement` from an installable.
  */
@@ -507,11 +523,7 @@ struct CmdProfileAdd : InstallablesCommand, MixDefaultProfile, MixProfilePriorit
             manifest.addElement(elementName, std::move(element));
         }
 
-        try {
-            updateProfile(*store, manifest.build(store));
-        } catch (BuildEnvFileConflictError & conflictError) {
-            rethrowProfileFileConflict(manifest, *store, conflictError, "add");
-        }
+        buildAndUpdateProfileWithCatchConflict(*this, store, manifest, "add");
     }
 };
 
@@ -803,11 +815,7 @@ struct CmdProfileReplace : virtual SourceExprCommand, MixDefaultProfile, MixProf
         manifest.elements.erase(it);
         manifest.elements.insert_or_assign(elementName, std::move(element));
 
-        try {
-            updateProfile(*store, manifest.build(store));
-        } catch (BuildEnvFileConflictError & conflictError) {
-            rethrowProfileFileConflict(manifest, *store, conflictError, fmt("replace %s", elementName));
-        }
+        buildAndUpdateProfileWithCatchConflict(*this, store, manifest, fmt("replace %s", elementName));
     }
 };
 

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -402,6 +402,25 @@ static void rethrowProfileFileConflict(
 }
 
 /**
+ * Adds a `--priority` flag for commands that build a single
+ * `ProfileElement` from an installable.
+ */
+struct MixProfilePriority : virtual Args
+{
+    std::optional<int64_t> priority;
+
+    MixProfilePriority(std::string_view description)
+    {
+        addFlag({
+            .longName = "priority",
+            .description = std::string(description),
+            .labels = {"priority"},
+            .handler = {&priority},
+        });
+    }
+};
+
+/**
  * Build a `ProfileElement` from an installable's build result. `built` is the
  * `(BuiltPaths, ExtraPathInfo)` entry produced by `builtPathsPerInstallable`.
  * If `priorityOverride` is set, it takes precedence over any priority recorded
@@ -436,19 +455,12 @@ static ProfileElement makeProfileElement(
     return element;
 }
 
-struct CmdProfileAdd : InstallablesCommand, MixDefaultProfile
+struct CmdProfileAdd : InstallablesCommand, MixDefaultProfile, MixProfilePriority
 {
-    std::optional<int64_t> priority;
-
     CmdProfileAdd()
+        : MixProfilePriority("The priority of the package to add.")
     {
-        addFlag({
-            .longName = "priority",
-            .description = "The priority of the package to add.",
-            .labels = {"priority"},
-            .handler = {&priority},
-        });
-    };
+    }
 
     std::string description() override
     {
@@ -719,20 +731,14 @@ struct CmdProfileRemove : virtual EvalCommand, MixProfileElementMatchers
     }
 };
 
-struct CmdProfileReplace : virtual SourceExprCommand, MixDefaultProfile
+struct CmdProfileReplace : virtual SourceExprCommand, MixDefaultProfile, MixProfilePriority
 {
     std::string elementName;
     std::string rawInstallable;
-    std::optional<int64_t> priority;
 
     CmdProfileReplace()
+        : MixProfilePriority("The priority of the replacement package.")
     {
-        addFlag({
-            .longName = "priority",
-            .description = "The priority of the replacement package.",
-            .labels = {"priority"},
-            .handler = {&priority},
-        });
         expectArgs({
             .label = "element",
             .optional = false,

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -382,7 +382,7 @@ static void rethrowProfileFileConflict(
         "\n"
         "  nix profile remove %3%\n"
         "\n"
-        "The new package can also be installed by assigning a different priority.\n"
+        "The new package can also be added next to the existing one by assigning a different priority.\n"
         "The conflicting packages have a priority of %4%.\n"
         "To prioritise the new package:\n"
         "\n"

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -334,6 +334,73 @@ builtPathsPerInstallable(const std::vector<std::pair<ref<Installable>, BuiltPath
     return res;
 }
 
+/**
+ * Translate a `BuildEnvFileConflictError` raised by `updateProfile` into a
+ * user-facing `Error` explaining the conflict. `prioritiseSubcommand` is the
+ * `nix profile` subcommand (with any required arguments) used to suggest how
+ * to re-prioritise the new package, e.g. `"add"` or `"replace foo"`.
+ */
+static void rethrowProfileFileConflict(
+    ProfileManifest & manifest,
+    Store & store,
+    BuildEnvFileConflictError & conflictError,
+    std::string_view prioritiseSubcommand)
+{
+    // FIXME use C++20 std::ranges once macOS has it
+    //       See
+    //       https://github.com/NixOS/nix/compare/3efa476c5439f8f6c1968a6ba20a31d1239c2f04..1fe5d172ece51a619e879c4b86f603d9495cc102
+    auto findRefByFilePath = [&]<typename Iterator>(Iterator begin, Iterator end) {
+        for (auto it = begin; it != end; it++) {
+            auto & [name, profileElement] = *it;
+            for (auto & storePath : profileElement.storePaths) {
+                if (conflictError.fileA.string().starts_with(store.printStorePath(storePath)))
+                    return std::tuple(conflictError.fileA, name, profileElement.toInstallables(store));
+                if (conflictError.fileB.string().starts_with(store.printStorePath(storePath)))
+                    return std::tuple(conflictError.fileB, name, profileElement.toInstallables(store));
+            }
+        }
+        throw conflictError;
+    };
+    // The first matching package is the one already installed; the last is the new one.
+    auto [originalPath, originalName, _origRefs] =
+        findRefByFilePath(manifest.elements.begin(), manifest.elements.end());
+    auto [newPath, _newName, newRefs] = findRefByFilePath(manifest.elements.rbegin(), manifest.elements.rend());
+
+    auto newRefsStr = concatStringsSep(" ", newRefs);
+    auto p = conflictError.priority;
+
+    throw Error(
+        "An existing package already provides the following file:\n"
+        "\n"
+        "  %1%\n"
+        "\n"
+        "This is the conflicting file from the new package:\n"
+        "\n"
+        "  %2%\n"
+        "\n"
+        "To remove the existing package:\n"
+        "\n"
+        "  nix profile remove %3%\n"
+        "\n"
+        "The new package can also be installed by assigning a different priority.\n"
+        "The conflicting packages have a priority of %4%.\n"
+        "To prioritise the new package:\n"
+        "\n"
+        "  nix profile %5% %6% --priority %7%\n"
+        "\n"
+        "To prioritise the existing package:\n"
+        "\n"
+        "  nix profile %5% %6% --priority %8%\n",
+        PathFmt(originalPath),
+        PathFmt(newPath),
+        originalName,
+        p,
+        prioritiseSubcommand,
+        newRefsStr,
+        p - 1,
+        p + 1);
+}
+
 struct CmdProfileAdd : InstallablesCommand, MixDefaultProfile
 {
     std::optional<int64_t> priority;
@@ -415,61 +482,7 @@ struct CmdProfileAdd : InstallablesCommand, MixDefaultProfile
         try {
             updateProfile(*store, manifest.build(store));
         } catch (BuildEnvFileConflictError & conflictError) {
-            // FIXME use C++20 std::ranges once macOS has it
-            //       See
-            //       https://github.com/NixOS/nix/compare/3efa476c5439f8f6c1968a6ba20a31d1239c2f04..1fe5d172ece51a619e879c4b86f603d9495cc102
-            auto findRefByFilePath = [&]<typename Iterator>(Iterator begin, Iterator end) {
-                for (auto it = begin; it != end; it++) {
-                    auto & [name, profileElement] = *it;
-                    for (auto & storePath : profileElement.storePaths) {
-                        if (conflictError.fileA.string().starts_with(store->printStorePath(storePath))) {
-                            return std::tuple(conflictError.fileA, name, profileElement.toInstallables(*store));
-                        }
-                        if (conflictError.fileB.string().starts_with(store->printStorePath(storePath))) {
-                            return std::tuple(conflictError.fileB, name, profileElement.toInstallables(*store));
-                        }
-                    }
-                }
-                throw conflictError;
-            };
-            // There are 2 conflicting files. We need to find out which one is from the already installed package and
-            // which one is the package that is the new package that is being installed.
-            // The first matching package is the one that was already installed (original).
-            auto [originalConflictingFilePath, originalEntryName, originalConflictingRefs] =
-                findRefByFilePath(manifest.elements.begin(), manifest.elements.end());
-            // The last matching package is the one that was going to be installed (new).
-            auto [newConflictingFilePath, newEntryName, newConflictingRefs] =
-                findRefByFilePath(manifest.elements.rbegin(), manifest.elements.rend());
-
-            throw Error(
-                "An existing package already provides the following file:\n"
-                "\n"
-                "  %1%\n"
-                "\n"
-                "This is the conflicting file from the new package:\n"
-                "\n"
-                "  %2%\n"
-                "\n"
-                "To remove the existing package:\n"
-                "\n"
-                "  nix profile remove %3%\n"
-                "\n"
-                "The new package can also be added next to the existing one by assigning a different priority.\n"
-                "The conflicting packages have a priority of %5%.\n"
-                "To prioritise the new package:\n"
-                "\n"
-                "  nix profile add %4% --priority %6%\n"
-                "\n"
-                "To prioritise the existing package:\n"
-                "\n"
-                "  nix profile add %4% --priority %7%\n",
-                PathFmt(originalConflictingFilePath),
-                PathFmt(newConflictingFilePath),
-                originalEntryName,
-                concatStringsSep(" ", newConflictingRefs),
-                conflictError.priority,
-                conflictError.priority - 1,
-                conflictError.priority + 1);
+            rethrowProfileFileConflict(manifest, *store, conflictError, "add");
         }
     }
 };
@@ -788,56 +801,7 @@ struct CmdProfileReplace : virtual SourceExprCommand, MixDefaultProfile
         try {
             updateProfile(*store, manifest.build(store));
         } catch (BuildEnvFileConflictError & conflictError) {
-            // FIXME use C++20 std::ranges once macOS has it
-            auto findRefByFilePath = [&]<typename Iterator>(Iterator begin, Iterator end) {
-                for (auto it = begin; it != end; it++) {
-                    auto & [name, profileElement] = *it;
-                    for (auto & storePath : profileElement.storePaths) {
-                        if (conflictError.fileA.string().starts_with(store->printStorePath(storePath))) {
-                            return std::tuple(conflictError.fileA, name, profileElement.toInstallables(*store));
-                        }
-                        if (conflictError.fileB.string().starts_with(store->printStorePath(storePath))) {
-                            return std::tuple(conflictError.fileB, name, profileElement.toInstallables(*store));
-                        }
-                    }
-                }
-                throw conflictError;
-            };
-            auto [originalConflictingFilePath, originalEntryName, originalConflictingRefs] =
-                findRefByFilePath(manifest.elements.begin(), manifest.elements.end());
-            auto [newConflictingFilePath, newEntryName, newConflictingRefs] =
-                findRefByFilePath(manifest.elements.rbegin(), manifest.elements.rend());
-
-            throw Error(
-                "An existing package already provides the following file:\n"
-                "\n"
-                "  %1%\n"
-                "\n"
-                "This is the conflicting file from the new package:\n"
-                "\n"
-                "  %2%\n"
-                "\n"
-                "To remove the existing package:\n"
-                "\n"
-                "  nix profile remove %3%\n"
-                "\n"
-                "The new package can also be installed by assigning a different priority.\n"
-                "The conflicting packages have a priority of %5%.\n"
-                "To prioritise the new package:\n"
-                "\n"
-                "  nix profile replace %6% %4% --priority %7%\n"
-                "\n"
-                "To prioritise the existing package:\n"
-                "\n"
-                "  nix profile replace %6% %4% --priority %8%\n",
-                PathFmt(originalConflictingFilePath),
-                PathFmt(newConflictingFilePath),
-                originalEntryName,
-                concatStringsSep(" ", newConflictingRefs),
-                conflictError.priority,
-                elementName,
-                conflictError.priority - 1,
-                conflictError.priority + 1);
+            rethrowProfileFileConflict(manifest, *store, conflictError, fmt("replace %s", elementName));
         }
     }
 };

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -401,6 +401,41 @@ static void rethrowProfileFileConflict(
         p + 1);
 }
 
+/**
+ * Build a `ProfileElement` from an installable's build result. `built` is the
+ * `(BuiltPaths, ExtraPathInfo)` entry produced by `builtPathsPerInstallable`.
+ * If `priorityOverride` is set, it takes precedence over any priority recorded
+ * on the installable.
+ */
+static ProfileElement makeProfileElement(
+    ref<Store> evalStore,
+    ref<Store> store,
+    const std::pair<BuiltPaths, ref<ExtraPathInfo>> & built,
+    std::optional<int64_t> priorityOverride)
+{
+    auto & [res, info] = built;
+
+    ProfileElement element;
+
+    if (auto * info2 = dynamic_cast<ExtraPathInfoFlake *>(&*info)) {
+        element.source = ProfileElementSource{
+            .originalRef = info2->flake.originalRef,
+            .lockedRef = info2->flake.lockedRef,
+            .attrPath = info2->value.attrPath,
+            .outputs = info2->value.extendedOutputsSpec,
+        };
+    }
+
+    element.priority = priorityOverride ? *priorityOverride : ({
+        auto * info2 = dynamic_cast<ExtraPathInfoValue *>(&*info);
+        info2 ? info2->value.priority.value_or(defaultPriority) : defaultPriority;
+    });
+
+    element.updateStorePaths(evalStore, store, res);
+
+    return element;
+}
+
 struct CmdProfileAdd : InstallablesCommand, MixDefaultProfile
 {
     std::optional<int64_t> priority;
@@ -435,30 +470,11 @@ struct CmdProfileAdd : InstallablesCommand, MixDefaultProfile
             Installable::build2(getEvalStore(), store, Realise::Outputs, installables, bmNormal));
 
         for (auto & installable : installables) {
-            ProfileElement element;
-
             auto iter = builtPaths.find(&*installable);
             if (iter == builtPaths.end())
                 continue;
-            auto & [res, info] = iter->second;
 
-            if (auto * info2 = dynamic_cast<ExtraPathInfoFlake *>(&*info)) {
-                element.source = ProfileElementSource{
-                    .originalRef = info2->flake.originalRef,
-                    .lockedRef = info2->flake.lockedRef,
-                    .attrPath = info2->value.attrPath,
-                    .outputs = info2->value.extendedOutputsSpec,
-                };
-            }
-
-            // If --priority was specified we want to override the
-            // priority of the installable.
-            element.priority = priority ? *priority : ({
-                auto * info2 = dynamic_cast<ExtraPathInfoValue *>(&*info);
-                info2 ? info2->value.priority.value_or(defaultPriority) : defaultPriority;
-            });
-
-            element.updateStorePaths(getEvalStore(), store, res);
+            auto element = makeProfileElement(getEvalStore(), store, iter->second, priority);
 
             auto elementName = getNameFromElement(element);
 
@@ -774,25 +790,8 @@ struct CmdProfileReplace : virtual SourceExprCommand, MixDefaultProfile
         auto iter = builtPaths.find(&*installable);
         if (iter == builtPaths.end())
             throw Error("failed to build '%s'", rawInstallable);
-        auto & [res, info] = iter->second;
 
-        ProfileElement element;
-
-        if (auto * info2 = dynamic_cast<ExtraPathInfoFlake *>(&*info)) {
-            element.source = ProfileElementSource{
-                .originalRef = info2->flake.originalRef,
-                .lockedRef = info2->flake.lockedRef,
-                .attrPath = info2->value.attrPath,
-                .outputs = info2->value.extendedOutputsSpec,
-            };
-        }
-
-        element.priority = priority ? *priority : ({
-            auto * info2 = dynamic_cast<ExtraPathInfoValue *>(&*info);
-            info2 ? info2->value.priority.value_or(defaultPriority) : defaultPriority;
-        });
-
-        element.updateStorePaths(getEvalStore(), store, res);
+        auto element = makeProfileElement(getEvalStore(), store, iter->second, priority);
 
         // Remove the old element and add the new one under the same name.
         manifest.elements.erase(it);

--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -266,6 +266,30 @@ clearProfiles
 nix profile add $(nix build "$flake1Dir" --no-link --print-out-paths)
 expect 1 nix profile add --impure --expr "(builtins.getFlake ''$flake2Dir'').packages.$system.default"
 
+# Test 'nix profile replace'.
+clearProfiles
+printf World > "$flake1Dir"/who
+printf World2 > "$flake2Dir"/who
+nix profile add "$flake1Dir"
+[[ $("$TEST_HOME"/.nix-profile/bin/hello) = "Hello World" ]]
+
+# Replace flake1 with flake2; the element name is preserved.
+nix profile replace flake1 "$flake2Dir"
+[[ $("$TEST_HOME"/.nix-profile/bin/hello) = "Hello World2" ]]
+nix profile list | grep -q 'Name:.*flake1'
+
+# --priority is accepted.
+nix profile replace flake1 "$flake2Dir" --priority 42
+
+# Replacing a non-existent element fails with a clear error.
+expect 1 nix profile replace nonexistent "$flake1Dir" 2> "$TEST_ROOT/replace-err"
+grep -q "not found in the profile" "$TEST_ROOT/replace-err"
+
+# Tab completion of the element-name argument.
+completion_output=$(NIX_GET_COMPLETIONS=3 nix profile replace '' 2>&1)
+echo "$completion_output" | grep -q "^normal$"
+echo "$completion_output" | grep -q "^flake1"
+
 # Test upgrading from profile version 2.
 clearProfiles
 mkdir -p "$TEST_ROOT"/import-profile

--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -276,7 +276,7 @@ nix profile add "$flake1Dir"
 # Replace flake1 with flake2; the element name is preserved.
 nix profile replace flake1 "$flake2Dir"
 [[ $("$TEST_HOME"/.nix-profile/bin/hello) = "Hello World2" ]]
-nix profile list | grep -q 'Name:.*flake1'
+nix profile list | grep 'Name:.*flake1'
 
 # --priority is accepted.
 nix profile replace flake1 "$flake2Dir" --priority 42


### PR DESCRIPTION
Adds a new subcommand that atomically replaces an existing profile element with a new installable.

Usage: nix profile replace <element-name> <flake-expression>

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Replacing an existing package without removal removes the issue that a tool is temporarily unavailable from profile/path, which is currently not achivable with nix profile remove + add. Example: replacing nix when it is installed in the profile (I'm aware of upgrade-nix, this is also meant for other usecases where similar problems arise)

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
