### PR TITLE
Remove shallow.lock before running git fetch

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -638,6 +638,11 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         //       then use code that was removed in this commit (see blame)
 
         auto dir = this->path;
+
+        // Remove shallow.lock left behind by a previously interrupted `git fetch`, as it would prevent `git fetch`
+        // from running. Note that we already have a repository-wide `PathLock` (see git.cc), so this is safe.
+        tryUnlink(dir / "shallow.lock");
+
         OsStrings gitArgs = {
             OS_STR("-C"),
             dir.native(),


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

An interrupted `git fetch` can leave behind a `shallow.lock` file which causes subsequent fetches to fail. Since Nix already has a PathLock on the repo, it should be safe to just delete this file.

Based on https://github.com/DeterminateSystems/nix-src/pull/414.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
