### PR TITLE
File descriptors for `RestoreSink`, internally

### DIFF
--- a/src/libutil-tests/file-system-at.cc
+++ b/src/libutil-tests/file-system-at.cc
@@ -102,12 +102,7 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
             dirSink.createDirectory(CanonPath("d"));
             dirSink.createSymlink(CanonPath("c"), "./d");
         });
-#ifdef _WIN32
         EXPECT_THROW(sink.createDirectory(CanonPath("a/b/c/e")), SymlinkNotAllowed);
-#else
-        // FIXME: This still follows symlinks on Unix (incorrectly succeeds)
-        sink.createDirectory(CanonPath("a/b/c/e"));
-#endif
         // Test that symlinks in intermediate path are detected during nested operations
         EXPECT_THROW(
             sink.createDirectory(

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -70,6 +70,61 @@ static std::filesystem::path append(const std::filesystem::path & src, const Can
     return dst;
 }
 
+#ifndef _WIN32
+/**
+ * Return a descriptor and single-component name suitable for
+ * `*at` operations. The returned `CanonPath` is always a pure
+ * name (no slashes). The `Descriptor` is the fd to use. The
+ * `AutoCloseFD` keeps it alive when it was opened temporarily
+ * (for multi-component paths); otherwise it is empty and the
+ * `Descriptor` borrows from `dirFd`. When `dirFd` is not set,
+ * temporarily opens the parent of `dstPath`.
+ */
+static std::tuple<AutoCloseFD, Descriptor, CanonPath>
+getParentFdAndName(Descriptor dirFd, const std::filesystem::path & dstPath, const CanonPath & path)
+{
+    if (dirFd != INVALID_DESCRIPTOR) {
+        /* dirFd is the root of the restore tree, which means we already created
+           a root directory, which means that path must be relative (i.e. not
+           root) within it. */
+        assert(!path.isRoot());
+        auto parent = path.parent();
+        if (parent->isRoot())
+            return {AutoCloseFD{}, dirFd, CanonPath::fromFilename(*path.baseName())};
+        auto parentFd = openFileEnsureBeneathNoSymlinks(dirFd, *parent, O_RDONLY | O_DIRECTORY | O_CLOEXEC, 0);
+        if (!parentFd)
+            throw SysError("opening parent directory of %s", PathFmt(append(dstPath, path)));
+        auto fd = parentFd.get();
+        return {std::move(parentFd), fd, CanonPath::fromFilename(*path.baseName())};
+    }
+
+    /* Without dirFd, we're creating the root entry itself, so path
+       must be root. If it's not, someone forgot to create the root
+       directory first. */
+    auto p = append(dstPath, path);
+    if (!path.isRoot())
+        throw Error("cannot create non-root path %s without a root directory", PathFmt(p));
+    if (p.empty())
+        throw Error("restore destination path is empty");
+    auto filename = p.filename();
+    if (filename == "." || filename == "..")
+        throw Error(
+            "restore destination '%s' ends in '%s', which is not a valid filename", p.native(), filename.native());
+    auto parentPath = p.parent_path();
+    /* Relative path with no directory component (e.g. "out") —
+       the parent is the current working directory. Open it so we
+       hold a stable reference in case something else in the process
+       changes the working directory mid-unpack. */
+    if (parentPath.empty())
+        parentPath = ".";
+    AutoCloseFD parentFd{::open(parentPath.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC)};
+    if (!parentFd)
+        throw SysError("opening parent directory of %s", PathFmt(p));
+    auto fd = parentFd.get();
+    return {std::move(parentFd), fd, CanonPath::fromFilename(p.filename().native())};
+}
+#endif
+
 void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallback callback)
 {
     if (path.isRoot()) {
@@ -103,34 +158,27 @@ void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallba
 
 void RestoreSink::createDirectory(const CanonPath & path)
 {
-    auto p = append(dstPath, path);
-
 #ifndef _WIN32
-    if (dirFd) {
-        if (path.isRoot())
-            /* Trying to create a directory that we already have a file descriptor for. */
-            throw Error("path %s already exists", PathFmt(p));
+    if (dirFd && path.isRoot())
+        /* Trying to create a directory that we already have a file descriptor for. */
+        throw Error("path %s already exists", PathFmt(append(dstPath, path)));
 
-        if (::mkdirat(dirFd.get(), path.rel_c_str(), 0777) == -1)
-            throw SysError("creating directory %s", PathFmt(p));
+    auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
 
-        return;
-    }
-#endif
+    if (::mkdirat(fd, name.rel_c_str(), 0777) == -1)
+        throw SysError("creating directory %s", PathFmt(append(dstPath, path)));
 
-    if (!std::filesystem::create_directory(p))
-        throw Error("path '%s' already exists", p.string());
-
-#ifndef _WIN32
-    if (path.isRoot()) {
-        assert(!dirFd); // Handled above
-
+    if (!dirFd) {
         /* Open directory for further *at operations relative to the sink root
            directory. */
-        dirFd = open(p.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+        dirFd = openFileEnsureBeneathNoSymlinks(fd, name, O_RDONLY | O_DIRECTORY | O_CLOEXEC, 0);
         if (!dirFd)
-            throw SysError("creating directory %1%", PathFmt(p));
+            throw SysError("opening directory %s", PathFmt(append(dstPath, path)));
     }
+#else
+    auto p = append(dstPath, path);
+    if (!std::filesystem::create_directory(p))
+        throw Error("path '%s' already exists", p.string());
 #endif
 };
 
@@ -172,13 +220,11 @@ struct RestoreRegularFile : CreateRegularFileSink, FdSink
 
 void RestoreSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)
 {
-    auto p = append(dstPath, path);
-
     auto crf = RestoreRegularFile(
         startFsync,
 #ifdef _WIN32
         CreateFileW(
-            p.c_str(),
+            append(dstPath, path).c_str(),
             GENERIC_READ | GENERIC_WRITE,
             FILE_SHARE_READ | FILE_SHARE_WRITE,
             NULL,
@@ -190,14 +236,13 @@ void RestoreSink::createRegularFile(const CanonPath & path, fun<void(CreateRegul
             /* O_EXCL together with O_CREAT ensures symbolic links in the last
                component are not followed. */
             constexpr int flags = O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC;
-            if (!dirFd)
-                return AutoCloseFD{::open(p.c_str(), flags, 0666)};
-            return openFileEnsureBeneathNoSymlinks(dirFd.get(), path, flags, 0666);
+            auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
+            return openFileEnsureBeneathNoSymlinks(fd, name, flags, 0666);
         }()
 #endif
     );
     if (!crf.fd)
-        throw NativeSysError("creating file %1%", PathFmt(p));
+        throw NativeSysError("creating file %1%", PathFmt(append(dstPath, path)));
     func(crf);
     crf.flush();
 }
@@ -233,15 +278,13 @@ void RestoreRegularFile::preallocateContents(uint64_t len)
 
 void RestoreSink::createSymlink(const CanonPath & path, const std::string & target)
 {
-    auto p = append(dstPath, path);
 #ifndef _WIN32
-    if (dirFd) {
-        if (::symlinkat(requireCString(target), dirFd.get(), path.rel_c_str()) == -1)
-            throw SysError("creating symlink from %1% -> '%2%'", PathFmt(p), target);
-        return;
-    }
+    auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
+    if (::symlinkat(requireCString(target), fd, name.rel_c_str()) == -1)
+        throw SysError("creating symlink from %1% -> '%2%'", PathFmt(append(dstPath, path)), target);
+#else
+    nix::createSymlink(target, append(dstPath, path).string());
 #endif
-    nix::createSymlink(target, p.string());
 }
 
 void RegularFileSink::createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func)

--- a/tests/functional/nars.sh
+++ b/tests/functional/nars.sh
@@ -11,18 +11,18 @@ rm -rf "$TEST_ROOT/out"
 expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet "NAR directory is not sorted"
 
 # Check that nix-store --restore fails if the output already exists.
-expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet "path '.*/out' already exists"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'creating directory ".*/out": File exists'
 
 rm -rf "$TEST_ROOT/out"
 echo foo > "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet "File exists"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'creating directory ".*/out": File exists'
 
 rm -rf "$TEST_ROOT/out"
 ln -s "$TEST_ROOT/out2" "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet "File exists"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'creating directory ".*/out": File exists'
 
 mkdir -p "$TEST_ROOT/out2"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet "path '.*/out' already exists"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet 'creating directory ".*/out": File exists'
 
 # The same, but for a regular file.
 nix-store --dump ./nars.sh > "$TEST_ROOT/tmp.nar"
@@ -56,14 +56,14 @@ rm -rf "$TEST_ROOT/out"
 # must already exist, which conflicts with --restore creating
 # something new.
 rm -rf "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet "No such file or directory"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet "ends in '\.'.*not a valid filename"
 
 # Destination with trailing `/..` should fail.
 rm -rf "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out/.." < "$TEST_ROOT/tmp.nar" | grepQuiet "No such file or directory"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/.." < "$TEST_ROOT/tmp.nar" | grepQuiet "ends in '\.\.'.*not a valid filename"
 
 # Empty destination should fail.
-expectStderr 1 nix-store --restore "" < "$TEST_ROOT/tmp.nar" | grepQuiet "No such file or directory"
+expectStderr 1 nix-store --restore "" < "$TEST_ROOT/tmp.nar" | grepQuiet "destination path is empty"
 
 # The same, but for a symlink.
 ln -sfn foo "$TEST_ROOT/symlink"
@@ -93,7 +93,7 @@ rm -rf "$TEST_ROOT/out"
 
 # Trailing `/.` — same baseline as above (currently fails).
 rm -rf "$TEST_ROOT/out"
-expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet "No such file or directory"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet "ends in '\.'.*not a valid filename"
 
 # Check whether restoring and dumping a NAR that contains case
 # collisions is round-tripping, even on a case-insensitive system.
@@ -122,7 +122,7 @@ expectStderr 1 nix-store "${opts[@]}" --dump "$TEST_ROOT/case" > /dev/null
 
 # Trailing `/.` — same baseline as above (currently fails).
 rm -rf "$TEST_ROOT/case"
-expectStderr 1 nix-store "${opts[@]}" --restore "$TEST_ROOT/case/." < case.nar | grepQuiet "No such file or directory"
+expectStderr 1 nix-store "${opts[@]}" --restore "$TEST_ROOT/case/." < case.nar | grepQuiet "ends in '\.'.*not a valid filename"
 
 # Detect NARs that have a directory entry that after case-hacking
 # collides with another entry (e.g. a directory containing 'Test',
@@ -156,7 +156,7 @@ if (( unicodeTestCode == 1 )); then
     # If the command failed (MacOS or ZFS + normalization), checks that it failed
     # with the expected "already exists" error, and that this is the same
     # behavior as `touch`
-    echo "$unicodeTestOut" | grepQuiet "creating directory \".*/out/â\": File exists"
+    echo "$unicodeTestOut" | grepQuiet 'creating directory ".*/out/â": File exists'
 
     (( touchFilesCount == 1 ))
 elif (( unicodeTestCode == 0 )); then

--- a/tests/functional/nars.sh
+++ b/tests/functional/nars.sh
@@ -35,6 +35,11 @@ rm -rf "$TEST_ROOT/out"
 mkdir -p "$TEST_ROOT/out"
 expectStderr 1 nix-store --restore "$TEST_ROOT/out" < "$TEST_ROOT/tmp.nar" | grepQuiet "File exists"
 
+# Note that the target of the symlink doesn't exist, but the parent does.
+#
+# A more lenient implementation could allow this, but it would hard/impossible
+# to implement without TOCTOU (to the extent avoiding TOCTOU is even
+# well-defined with symlinks, though).
 rm -rf "$TEST_ROOT/out"
 ln -s "$TEST_ROOT/out2" "$TEST_ROOT/out"
 expectStderr 1 nix-store --restore "$TEST_ROOT/out" < "$TEST_ROOT/tmp.nar" | grepQuiet "File exists"
@@ -46,6 +51,19 @@ expectStderr 1 nix-store --restore "$TEST_ROOT/out" < "$TEST_ROOT/tmp.nar" | gre
 rm -rf "$TEST_ROOT/out"
 (cd "$TEST_ROOT" && nix-store --restore out < tmp.nar)
 [[ -f "$TEST_ROOT/out" ]]
+
+# Trailing `/.` and `/..` refer to entries within a directory that
+# must already exist, which conflicts with --restore creating
+# something new.
+rm -rf "$TEST_ROOT/out"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet "No such file or directory"
+
+# Destination with trailing `/..` should fail.
+rm -rf "$TEST_ROOT/out"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/.." < "$TEST_ROOT/tmp.nar" | grepQuiet "No such file or directory"
+
+# Empty destination should fail.
+expectStderr 1 nix-store --restore "" < "$TEST_ROOT/tmp.nar" | grepQuiet "No such file or directory"
 
 # The same, but for a symlink.
 ln -sfn foo "$TEST_ROOT/symlink"
@@ -73,6 +91,10 @@ rm -rf "$TEST_ROOT/out"
 [[ -L "$TEST_ROOT/out" ]]
 [[ $(readlink "$TEST_ROOT/out") = foo ]]
 
+# Trailing `/.` — same baseline as above (currently fails).
+rm -rf "$TEST_ROOT/out"
+expectStderr 1 nix-store --restore "$TEST_ROOT/out/." < "$TEST_ROOT/tmp.nar" | grepQuiet "No such file or directory"
+
 # Check whether restoring and dumping a NAR that contains case
 # collisions is round-tripping, even on a case-insensitive system.
 rm -rf "$TEST_ROOT/case"
@@ -96,7 +118,11 @@ rm -rf "$TEST_ROOT/case"
 # Check whether we detect true collisions (e.g. those remaining after
 # removal of the suffix).
 touch "$TEST_ROOT/case/xt_CONNMARK.h~nix~case~hack~3"
-(! nix-store "${opts[@]}" --dump "$TEST_ROOT/case" > /dev/null)
+expectStderr 1 nix-store "${opts[@]}" --dump "$TEST_ROOT/case" > /dev/null
+
+# Trailing `/.` — same baseline as above (currently fails).
+rm -rf "$TEST_ROOT/case"
+expectStderr 1 nix-store "${opts[@]}" --restore "$TEST_ROOT/case/." < case.nar | grepQuiet "No such file or directory"
 
 # Detect NARs that have a directory entry that after case-hacking
 # collides with another entry (e.g. a directory containing 'Test',


### PR DESCRIPTION
This should make it much more robust, e.g. in the face of TOCTOU issues.

See each commit for details. Best to review commit by commit too, ~~even though many things get canceled out~~. Actually it is only 2 commits, now I am saving more for later so we go slowly.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
