### PR TITLE
tests/functional: cover `nix-store --restore` with bare relative destination

### DIFF
--- a/tests/functional/nars.sh
+++ b/tests/functional/nars.sh
@@ -42,6 +42,11 @@ expectStderr 1 nix-store --restore "$TEST_ROOT/out" < "$TEST_ROOT/tmp.nar" | gre
 mkdir -p "$TEST_ROOT/out2"
 expectStderr 1 nix-store --restore "$TEST_ROOT/out" < "$TEST_ROOT/tmp.nar" | grepQuiet "File exists"
 
+# Check that a bare relative destination (no directory component) works.
+rm -rf "$TEST_ROOT/out"
+(cd "$TEST_ROOT" && nix-store --restore out < tmp.nar)
+[[ -f "$TEST_ROOT/out" ]]
+
 # The same, but for a symlink.
 ln -sfn foo "$TEST_ROOT/symlink"
 nix-store --dump "$TEST_ROOT/symlink" > "$TEST_ROOT/tmp.nar"
@@ -62,6 +67,12 @@ expectStderr 1 nix-store --restore "$TEST_ROOT/out" < "$TEST_ROOT/tmp.nar" | gre
 mkdir -p "$TEST_ROOT/out2"
 expectStderr 1 nix-store --restore "$TEST_ROOT/out" < "$TEST_ROOT/tmp.nar" | grepQuiet "File exists"
 
+# Likewise for a bare relative destination.
+rm -rf "$TEST_ROOT/out"
+(cd "$TEST_ROOT" && nix-store --restore out < tmp.nar)
+[[ -L "$TEST_ROOT/out" ]]
+[[ $(readlink "$TEST_ROOT/out") = foo ]]
+
 # Check whether restoring and dumping a NAR that contains case
 # collisions is round-tripping, even on a case-insensitive system.
 rm -rf "$TEST_ROOT/case"
@@ -76,6 +87,11 @@ nix-store "${opts[@]}" --restore "$TEST_ROOT/case" < case.nar
 nix-store "${opts[@]}" --dump "$TEST_ROOT/case" > "$TEST_ROOT/case.nar"
 cmp case.nar "$TEST_ROOT/case.nar"
 [ "$(nix-hash "${opts[@]}" --type sha256 "$TEST_ROOT/case")" = "$(nix-hash --flat --type sha256 case.nar)" ]
+
+# Likewise for a bare relative destination.
+rm -rf "$TEST_ROOT/case"
+(cd "$TEST_ROOT" && nix-store "${opts[@]}" --restore case) < case.nar
+[[ -e "$TEST_ROOT/case/xt_CONNMARK.h" ]]
 
 # Check whether we detect true collisions (e.g. those remaining after
 # removal of the suffix).


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Regression test for `restorePath` when the destination has no directory component.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Regression in an earlier version of https://github.com/NixOS/nix/pull/15643.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
