### PR TITLE
installer: make --no-modify-profile work for multi-user installs

### DIFF
--- a/doc/manual/rl-next/installer-no-modify-profile-multi-user.md
+++ b/doc/manual/rl-next/installer-no-modify-profile-multi-user.md
@@ -1,0 +1,11 @@
+---
+synopsis: "`--no-modify-profile` now works for multi-user installs"
+issues: [12134]
+prs: [15648]
+---
+
+Passing `--no-modify-profile` to the installer now correctly suppresses
+shell profile modification for multi-user installations.
+Previously, the flag was accepted but silently ignored when installing
+in daemon mode: the variable was not exported before handing off to
+`install-multi-user`, and that script never checked it regardless.

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -472,6 +472,9 @@ EOF
         # TODO: I think it would be good to accumulate a list of all
         #       of the copies so that people don't hit this 2 or 3x in
         #       a row for different files.
+        if [ -n "${NIX_INSTALLER_NO_MODIFY_PROFILE:-}" ]; then
+            continue
+        fi
         if [ -e "$profile_target$PROFILE_BACKUP_SUFFIX" ]; then
             # this backup process first released in Nix 2.1
 
@@ -784,14 +787,16 @@ I will:
  - set up the "default profile" by creating some Nix-related files in
    $ROOT_HOME
 EOF
-        for profile_target in "${PROFILE_TARGETS[@]}"; do
-            if [ -e "$profile_target" ]; then
-                cat <<EOF
+        if [ -z "${NIX_INSTALLER_NO_MODIFY_PROFILE:-}" ]; then
+            for profile_target in "${PROFILE_TARGETS[@]}"; do
+                if [ -e "$profile_target" ]; then
+                    cat <<EOF
  - back up $profile_target to $profile_target$PROFILE_BACKUP_SUFFIX
  - update $profile_target to include some Nix configuration
 EOF
-            fi
-        done
+                fi
+            done
+        fi
         poly_service_setup_note
         if ! ui_confirm "Ready to continue?"; then
             failure <<EOF
@@ -909,6 +914,11 @@ EOF
 }
 
 configure_shell_profile() {
+    if [ -n "${NIX_INSTALLER_NO_MODIFY_PROFILE:-}" ]; then
+        reminder "Skipping shell profile modification (--no-modify-profile). To use Nix, manually source:"
+        reminder "  ${PROFILE_NIX_FILE}"
+        return
+    fi
     task "Setting up shell profiles: ${PROFILE_TARGETS[*]}"
     for profile_target in "${PROFILE_TARGETS[@]}"; do
         if [ -e "$profile_target" ]; then

--- a/scripts/install-nix-from-tarball.sh
+++ b/scripts/install-nix-from-tarball.sh
@@ -77,7 +77,7 @@ while [ $# -gt 0 ]; do
             export NIX_USER_COUNT="$2"
             shift;;
         --no-modify-profile)
-            NIX_INSTALLER_NO_MODIFY_PROFILE=1;;
+            export NIX_INSTALLER_NO_MODIFY_PROFILE=1;;
         --darwin-use-unencrypted-nix-store-volume)
             {
                 echo "Warning: the flag --darwin-use-unencrypted-nix-store-volume"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

`--no-modify-profile` was silently ignored for multi-user installs.

## Context

`NIX_INSTALLER_NO_MODIFY_PROFILE` was set but not exported in `install-nix-from-tarball.sh`, so it was lost when exec-ing into `install-multi-user`. The multi-user script also never checked the variable.

Export it from the entry point and guard `configure_shell_profile()`, the backup conflict validation loop, and the setup report in `install-multi-user.sh`.

Closes: #12134

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
