### PR TITLE
Cleanup openat2

### DIFF
--- a/src/libstore/windows/pathlocks.cc
+++ b/src/libstore/windows/pathlocks.cc
@@ -5,10 +5,9 @@
 #include "nix/util/util.hh"
 #include "nix/util/windows-environment.hh"
 
-#ifdef _WIN32
-#  include <errhandlingapi.h>
-#  include <fileapi.h>
-#  include <windows.h>
+#include <errhandlingapi.h>
+#include <fileapi.h>
+#include <windows.h>
 
 namespace nix {
 
@@ -167,4 +166,3 @@ FdLock::FdLock(Descriptor desc, LockType lockType, bool wait, std::string_view w
 }
 
 } // namespace nix
-#endif

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -120,7 +120,8 @@ namespace linux {
  *
  * @return nullopt if openat2 is not supported by the kernel.
  */
-std::optional<Descriptor> openat2(Descriptor dirFd, const char * path, uint64_t flags, uint64_t mode, uint64_t resolve);
+std::optional<AutoCloseFD>
+openat2(Descriptor dirFd, const char * path, uint64_t flags, uint64_t mode, uint64_t resolve);
 
 } // namespace linux
 #endif

--- a/src/libutil/unix/file-system-at.cc
+++ b/src/libutil/unix/file-system-at.cc
@@ -29,7 +29,7 @@ namespace nix {
 
 namespace linux {
 
-std::optional<Descriptor> openat2(Descriptor dirFd, const char * path, uint64_t flags, uint64_t mode, uint64_t resolve)
+std::optional<AutoCloseFD> openat2(Descriptor dirFd, const char * path, uint64_t flags, uint64_t mode, uint64_t resolve)
 {
 #  if HAVE_OPENAT2
     /* Cache the result of whether openat2 is not supported. */
@@ -47,7 +47,7 @@ std::optional<Descriptor> openat2(Descriptor dirFd, const char * path, uint64_t 
             return std::nullopt;
         }
 
-        return res;
+        return AutoCloseFD{static_cast<Descriptor>(res)};
     }
 #  endif
     return std::nullopt;
@@ -202,9 +202,9 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & 
     auto maybeFd = linux::openat2(
         dirFd, path.rel_c_str(), flags, static_cast<uint64_t>(mode), RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS);
     if (maybeFd) {
-        if (*maybeFd < 0 && errno == ELOOP)
+        if (!*maybeFd && errno == ELOOP)
             throw SymlinkNotAllowed(path);
-        return AutoCloseFD{*maybeFd};
+        return std::move(*maybeFd);
     }
 #endif
     return openFileEnsureBeneathNoSymlinksIterative(dirFd, path, flags, mode);

--- a/src/libutil/windows/current-process.cc
+++ b/src/libutil/windows/current-process.cc
@@ -2,9 +2,8 @@
 #include "nix/util/error.hh"
 #include <cmath>
 
-#ifdef _WIN32
-#  define WIN32_LEAN_AND_MEAN
-#  include <windows.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
 namespace nix {
 
@@ -31,4 +30,3 @@ std::chrono::microseconds getCpuUserTime()
 }
 
 } // namespace nix
-#endif // ifdef _WIN32

--- a/src/libutil/windows/current-process.cc
+++ b/src/libutil/windows/current-process.cc
@@ -1,4 +1,5 @@
 #include "nix/util/current-process.hh"
+#include "nix/util/error.hh"
 #include <cmath>
 
 #ifdef _WIN32

--- a/src/libutil/windows/environment-variables.cc
+++ b/src/libutil/windows/environment-variables.cc
@@ -1,7 +1,6 @@
 #include "nix/util/environment-variables.hh"
 
-#ifdef _WIN32
-#  include <processenv.h>
+#include <processenv.h>
 
 namespace nix {
 
@@ -85,4 +84,3 @@ int setEnvOs(const OsString & name, const OsString & value)
 }
 
 } // namespace nix
-#endif

--- a/src/libutil/windows/include/nix/util/windows-async-pipe.hh
+++ b/src/libutil/windows/include/nix/util/windows-async-pipe.hh
@@ -2,7 +2,6 @@
 ///@file
 
 #include "nix/util/file-descriptor.hh"
-#ifdef _WIN32
 
 namespace nix::windows {
 
@@ -26,4 +25,3 @@ public:
 };
 
 } // namespace nix::windows
-#endif

--- a/src/libutil/windows/muxable-pipe.cc
+++ b/src/libutil/windows/muxable-pipe.cc
@@ -1,9 +1,8 @@
-#ifdef _WIN32
-#  include <ioapiset.h>
+#include <ioapiset.h>
 
-#  include "nix/util/logging.hh"
-#  include "nix/util/util.hh"
-#  include "nix/util/muxable-pipe.hh"
+#include "nix/util/logging.hh"
+#include "nix/util/util.hh"
+#include "nix/util/muxable-pipe.hh"
 
 namespace nix {
 
@@ -70,4 +69,3 @@ void MuxablePipePollState::iterate(
 }
 
 } // namespace nix
-#endif

--- a/src/libutil/windows/os-string.cc
+++ b/src/libutil/windows/os-string.cc
@@ -5,8 +5,6 @@
 
 #include "nix/util/os-string.hh"
 
-#ifdef _WIN32
-
 namespace nix {
 
 std::string os_string_to_string(OsStringView s)
@@ -32,5 +30,3 @@ OsString string_to_os_string(std::string s)
 }
 
 } // namespace nix
-
-#endif

--- a/src/libutil/windows/processes.cc
+++ b/src/libutil/windows/processes.cc
@@ -25,10 +25,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#ifdef _WIN32
-
-#  define WIN32_LEAN_AND_MEAN
-#  include <windows.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
 namespace nix {
 
@@ -404,5 +402,3 @@ int execvpe(const wchar_t * file0, const wchar_t * const argv[], const wchar_t *
 }
 
 } // namespace nix
-
-#endif

--- a/src/libutil/windows/users.cc
+++ b/src/libutil/windows/users.cc
@@ -3,9 +3,8 @@
 #include "nix/util/environment-variables.hh"
 #include "nix/util/file-system.hh"
 
-#ifdef _WIN32
-#  define WIN32_LEAN_AND_MEAN
-#  include <windows.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
 namespace nix {
 
@@ -50,4 +49,3 @@ bool isRootUser()
 }
 
 } // namespace nix
-#endif

--- a/src/libutil/windows/windows-async-pipe.cc
+++ b/src/libutil/windows/windows-async-pipe.cc
@@ -1,7 +1,4 @@
-
-
-#ifdef _WIN32
-#  include "nix/util/windows-async-pipe.hh"
+#include "nix/util/windows-async-pipe.hh"
 
 namespace nix::windows {
 
@@ -49,5 +46,3 @@ void AsyncPipe::close()
 }
 
 } // namespace nix::windows
-
-#endif

--- a/src/libutil/windows/windows-error.cc
+++ b/src/libutil/windows/windows-error.cc
@@ -1,10 +1,8 @@
-#ifdef _WIN32
+#include "nix/util/error.hh"
 
-#  include "nix/util/error.hh"
-
-#  include <error.h>
-#  define WIN32_LEAN_AND_MEAN
-#  include <windows.h>
+#include <error.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
 namespace nix::windows {
 
@@ -33,4 +31,3 @@ std::string WinError::renderError(DWORD lastError)
 }
 
 } // namespace nix::windows
-#endif


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
Most opening functions return an `AutoCloseFd`, but `openat2` was only returning a `Descriptor`. This makes it easy to accidentally leak file descriptors

Also fix a windows issue found during testing
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context
This is a dependency of some further cleanups.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
