### PR TITLE
fix: fetchTree using its own experimental features, rather than flakes'

### DIFF
--- a/doc/manual/rl-next/fetchtree-no-flakes-url.md
+++ b/doc/manual/rl-next/fetchtree-no-flakes-url.md
@@ -1,0 +1,13 @@
+---
+synopsis: "`builtins.fetchTree` accepts URL-like string arguments without `flakes`"
+issues: [5541]
+---
+
+Calling `builtins.fetchTree` with a URL-like string argument (for example,
+`builtins.fetchTree "github:NixOS/nixpkgs/..."`) no longer requires the
+`flakes` experimental feature. The `fetch-tree` experimental feature, which
+gates `builtins.fetchTree` itself, is now sufficient.
+
+Indirect references that need to be resolved through the flake registry
+(such as the bare `nixpkgs`) still require `flakes` to be enabled, since
+the registry is part of the flakes machinery.

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -183,12 +183,6 @@ static void fetchTree(
             }
             input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
         } else {
-            if (!experimentalFeatureSettings.isEnabled(Xp::Flakes))
-                state
-                    .error<EvalError>(
-                        "passing a string argument to '%s' requires the 'flakes' experimental feature", fetcher)
-                    .atPos(pos)
-                    .debugThrow();
             input = fetchers::Input::fromURL(state.fetchSettings, url);
         }
     }
@@ -317,7 +311,7 @@ static RegisterPrimOp primop_fetchTree({
           - `"mercurial"`
 
          *input* can also be a [URL-like reference](@docroot@/command-ref/new-cli/nix3-flake.md#flake-references).
-         The additional input types and the URL-like syntax requires the [`flakes` experimental feature](@docroot@/development/experimental-features.md#xp-feature-flakes) to be enabled.
+         Indirect references (such as `nixpkgs`) additionally require the [`flakes` experimental feature](@docroot@/development/experimental-features.md#xp-feature-flakes) to be enabled, because they are resolved via the flake registry.
 
           > **Example**
           >

--- a/tests/functional/fetchTree-file.sh
+++ b/tests/functional/fetchTree-file.sh
@@ -118,5 +118,33 @@ EOF
 EOF
 }
 
+# builtins.fetchTree (both the attribute-set and URL-like string forms) must
+# work with only the `fetch-tree` experimental feature enabled, i.e. without
+# also enabling `flakes`.
+test_fetch_tree_without_flakes () {
+    echo foo > test_input_no_flakes
+    tar cfz test_input_no_flakes.tar.gz test_input_no_flakes
+
+    # Attribute-set form.
+    nix --experimental-features 'nix-command fetch-tree' eval --impure --file - <<EOF
+    let
+        tree = builtins.fetchTree { type = "file"; url = "file://$PWD/test_input_no_flakes"; };
+    in
+    assert builtins.readFile tree == "foo\n";
+    tree
+EOF
+
+    # URL-like string form — previously errored with
+    #   "passing a string argument to 'fetchTree' requires the 'flakes' experimental feature"
+    nix --experimental-features 'nix-command fetch-tree' eval --impure --expr \
+        "builtins.fetchTree \"file://$PWD/test_input_no_flakes.tar.gz\"" >/dev/null
+
+    # Without fetch-tree (and without flakes), the builtin is unavailable.
+    expectStderr 1 nix --experimental-features 'nix-command' eval --impure --expr \
+        "builtins.fetchTree \"file://$PWD/test_input_no_flakes.tar.gz\"" \
+        | grepQuiet "attribute 'fetchTree' missing"
+}
+
 test_fetch_file
 test_file_flake_input
+test_fetch_tree_without_flakes


### PR DESCRIPTION
closes #5541.

## Motivation

makes more sense given this feature had its own experimental feature

## Context

disclaimer i used a coding agent in the creation of this patch.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
