### PR TITLE
Replace top-level `using namespace nix...;`

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -33,6 +33,8 @@ namespace nix {
   struct LexerState;
 }
 
+// OK because we keep this in a separate compilation unit even for unity
+// builds.
 using namespace nix;
 using namespace nix::lexer::internal;
 

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -63,8 +63,6 @@
 namespace nix {
 struct SourceAccessor;
 
-using namespace flake;
-
 namespace flake {
 
 static void forceTrivialValue(EvalState & state, Value & value, const PosIdx pos)

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -270,7 +270,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
     bool isFlake,
     bool preserveRelativePaths)
 {
-    using namespace fetchers;
+    using namespace nix::fetchers;
 
     if (auto res = parseFlakeIdRef(fetchSettings, url, isFlake)) {
         return *res;

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -37,8 +37,6 @@
 
 namespace nix {
 
-using namespace nix::linux;
-
 static void setupSeccomp(const LocalSettings & localSettings)
 {
     if (!localSettings.filterSyscalls)
@@ -337,10 +335,10 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
             /* If we're running from the daemon, then this will return the
                root cgroup of the service. Otherwise, it will return the
                current cgroup. */
-            auto cgroupFS = getCgroupFS();
+            auto cgroupFS = linux::getCgroupFS();
             if (!cgroupFS)
                 throw Error("cannot determine the cgroups file system");
-            auto rootCgroupPath = *cgroupFS / getRootCgroup().rel();
+            auto rootCgroupPath = *cgroupFS / linux::getRootCgroup().rel();
             if (!pathExists(rootCgroupPath))
                 throw Error("expected cgroup directory %s", PathFmt(rootCgroupPath));
 
@@ -363,7 +361,7 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
 
                 if (pathExists(cgroupFile)) {
                     auto prevCgroup = readFile(cgroupFile);
-                    destroyCgroup(prevCgroup);
+                    linux::destroyCgroup(prevCgroup);
                 }
 
                 writeFile(cgroupFile, cgroup->native());
@@ -825,7 +823,7 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
     void killSandbox(bool getStats) override
     {
         if (cgroup) {
-            auto stats = destroyCgroup(*cgroup);
+            auto stats = linux::destroyCgroup(*cgroup);
             if (getStats) {
                 buildResult.cpuUser = stats.cpuUser;
                 buildResult.cpuSystem = stats.cpuSystem;

--- a/src/libstore/windows/pathlocks.cc
+++ b/src/libstore/windows/pathlocks.cc
@@ -11,8 +11,6 @@
 
 namespace nix {
 
-using namespace nix::windows;
-
 void deleteLockFile(const std::filesystem::path & path, Descriptor desc)
 {
 
@@ -59,6 +57,7 @@ AutoCloseFD openLockFile(const std::filesystem::path & path, bool create)
 template<typename... Args>
 static bool warnOrThrowWine(DWORD lastError, const std::string & fs, const Args &... args)
 {
+    using namespace nix::windows;
     if (isWine()) {
         warn(fs + ": %s (ignored under Wine)", args..., lastError);
         return true;

--- a/src/libutil-test-support/hash.cc
+++ b/src/libutil-test-support/hash.cc
@@ -8,6 +8,7 @@
 #include "nix/util/tests/hash.hh"
 
 namespace rc {
+
 using namespace nix;
 
 Gen<Hash> Arbitrary<Hash>::arbitrary()

--- a/src/libutil-test-support/include/nix/util/tests/hash.hh
+++ b/src/libutil-test-support/include/nix/util/tests/hash.hh
@@ -6,6 +6,7 @@
 #include "nix/util/hash.hh"
 
 namespace rc {
+
 using namespace nix;
 
 template<>

--- a/src/libutil-tests/checked-arithmetic.cc
+++ b/src/libutil-tests/checked-arithmetic.cc
@@ -10,6 +10,7 @@
 #include "nix/util/tests/gtest-with-params.hh"
 
 namespace rc {
+
 using namespace nix;
 
 template<std::integral T>

--- a/src/libutil-tests/git.cc
+++ b/src/libutil-tests/git.cc
@@ -7,8 +7,6 @@
 
 namespace nix {
 
-using namespace git;
-
 class GitTest : public CharacterizationTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / "git";
@@ -36,6 +34,7 @@ private:
 
 TEST(GitMode, gitMode_directory)
 {
+    using namespace git;
     Mode m = Mode::Directory;
     RawMode r = 0040000;
     ASSERT_EQ(static_cast<RawMode>(m), r);
@@ -44,6 +43,7 @@ TEST(GitMode, gitMode_directory)
 
 TEST(GitMode, gitMode_executable)
 {
+    using namespace git;
     Mode m = Mode::Executable;
     RawMode r = 0100755;
     ASSERT_EQ(static_cast<RawMode>(m), r);
@@ -52,6 +52,7 @@ TEST(GitMode, gitMode_executable)
 
 TEST(GitMode, gitMode_regular)
 {
+    using namespace git;
     Mode m = Mode::Regular;
     RawMode r = 0100644;
     ASSERT_EQ(static_cast<RawMode>(m), r);
@@ -60,6 +61,7 @@ TEST(GitMode, gitMode_regular)
 
 TEST(GitMode, gitMode_symlink)
 {
+    using namespace git;
     Mode m = Mode::Symlink;
     RawMode r = 0120000;
     ASSERT_EQ(static_cast<RawMode>(m), r);
@@ -68,6 +70,7 @@ TEST(GitMode, gitMode_symlink)
 
 TEST_F(GitTest, blob_read)
 {
+    using namespace git;
     readTest("hello-world-blob.bin", [&](const auto & encoded) {
         StringSource in{encoded};
         StringSink out;
@@ -83,6 +86,7 @@ TEST_F(GitTest, blob_read)
 
 TEST_F(GitTest, blob_write)
 {
+    using namespace git;
     writeTest("hello-world-blob.bin", [&]() {
         auto decoded = readFile(goldenMaster("hello-world.bin"));
         StringSink s;
@@ -97,11 +101,11 @@ TEST_F(GitTest, blob_write)
  * so that we can check our test data in a small shell script test test
  * (`src/libutil-tests/data/git/check-data.sh`).
  */
-const static Tree treeSha1 = {
+const static git::Tree treeSha1 = {
     {
         "Foo",
         {
-            .mode = Mode::Regular,
+            .mode = git::Mode::Regular,
             // hello world with special chars from above
             .hash = Hash::parseAny("63ddb340119baf8492d2da53af47e8c7cfcd5eb2", HashAlgorithm::SHA1),
         },
@@ -109,7 +113,7 @@ const static Tree treeSha1 = {
     {
         "bAr",
         {
-            .mode = Mode::Executable,
+            .mode = git::Mode::Executable,
             // ditto
             .hash = Hash::parseAny("63ddb340119baf8492d2da53af47e8c7cfcd5eb2", HashAlgorithm::SHA1),
         },
@@ -117,7 +121,7 @@ const static Tree treeSha1 = {
     {
         "baZ/",
         {
-            .mode = Mode::Directory,
+            .mode = git::Mode::Directory,
             // Empty directory hash
             .hash = Hash::parseAny("4b825dc642cb6eb9a060e54bf8d69288fbee4904", HashAlgorithm::SHA1),
         },
@@ -125,7 +129,7 @@ const static Tree treeSha1 = {
     {
         "quuX",
         {
-            .mode = Mode::Symlink,
+            .mode = git::Mode::Symlink,
             // hello world with special chars from above (symlink target
             // can be anything)
             .hash = Hash::parseAny("63ddb340119baf8492d2da53af47e8c7cfcd5eb2", HashAlgorithm::SHA1),
@@ -137,11 +141,11 @@ const static Tree treeSha1 = {
  * Same conceptual object as `treeSha1`, just different hash algorithm.
  * See that one for details.
  */
-const static Tree treeSha256 = {
+const static git::Tree treeSha256 = {
     {
         "Foo",
         {
-            .mode = Mode::Regular,
+            .mode = git::Mode::Regular,
             .hash = Hash::parseAny(
                 "ce60f5ad78a08ac24872ef74d78b078f077be212e7a246893a1a5d957dfbc8b1", HashAlgorithm::SHA256),
         },
@@ -149,7 +153,7 @@ const static Tree treeSha256 = {
     {
         "bAr",
         {
-            .mode = Mode::Executable,
+            .mode = git::Mode::Executable,
             .hash = Hash::parseAny(
                 "ce60f5ad78a08ac24872ef74d78b078f077be212e7a246893a1a5d957dfbc8b1", HashAlgorithm::SHA256),
         },
@@ -157,7 +161,7 @@ const static Tree treeSha256 = {
     {
         "baZ/",
         {
-            .mode = Mode::Directory,
+            .mode = git::Mode::Directory,
             .hash = Hash::parseAny(
                 "6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321", HashAlgorithm::SHA256),
         },
@@ -165,15 +169,16 @@ const static Tree treeSha256 = {
     {
         "quuX",
         {
-            .mode = Mode::Symlink,
+            .mode = git::Mode::Symlink,
             .hash = Hash::parseAny(
                 "ce60f5ad78a08ac24872ef74d78b078f077be212e7a246893a1a5d957dfbc8b1", HashAlgorithm::SHA256),
         },
     },
 };
 
-static auto mkTreeReadTest(HashAlgorithm hashAlgo, Tree tree, const ExperimentalFeatureSettings & mockXpSettings)
+static auto mkTreeReadTest(HashAlgorithm hashAlgo, git::Tree tree, const ExperimentalFeatureSettings & mockXpSettings)
 {
+    using namespace git;
     return [hashAlgo, tree, mockXpSettings](const auto & encoded) {
         StringSource in{encoded};
         NullFileSystemObjectSink out;
@@ -208,6 +213,7 @@ TEST_F(GitTest, tree_sha256_read)
 
 TEST_F(GitTest, tree_sha1_write)
 {
+    using namespace git;
     writeTest("tree-sha1.bin", [&]() {
         StringSink s;
         dumpTree(treeSha1, s, mockXpSettings);
@@ -217,6 +223,7 @@ TEST_F(GitTest, tree_sha1_write)
 
 TEST_F(GitTest, tree_sha256_write)
 {
+    using namespace git;
     writeTest("tree-sha256.bin", [&]() {
         StringSink s;
         dumpTree(treeSha256, s, mockXpSettings);
@@ -232,6 +239,7 @@ extern ref<MemorySourceAccessor> exampleComplex();
 
 TEST_F(GitTest, both_roundrip)
 {
+    using namespace git;
     auto files = memory_source_accessor::exampleComplex();
 
     for (const auto hashAlgo : {HashAlgorithm::SHA1, HashAlgorithm::SHA256}) {
@@ -285,6 +293,7 @@ TEST_F(GitTest, both_roundrip)
 
 TEST(GitLsRemote, parseSymrefLineWithReference)
 {
+    using namespace git;
     auto line = "ref: refs/head/main	HEAD";
     auto res = parseLsRemoteLine(line);
     ASSERT_TRUE(res.has_value());
@@ -295,6 +304,7 @@ TEST(GitLsRemote, parseSymrefLineWithReference)
 
 TEST(GitLsRemote, parseSymrefLineWithNoReference)
 {
+    using namespace git;
     auto line = "ref: refs/head/main";
     auto res = parseLsRemoteLine(line);
     ASSERT_TRUE(res.has_value());
@@ -305,6 +315,7 @@ TEST(GitLsRemote, parseSymrefLineWithNoReference)
 
 TEST(GitLsRemote, parseObjectRefLine)
 {
+    using namespace git;
     auto line = "abc123	refs/head/main";
     auto res = parseLsRemoteLine(line);
     ASSERT_TRUE(res.has_value());

--- a/src/libutil-tests/unix/file-system-at.cc
+++ b/src/libutil-tests/unix/file-system-at.cc
@@ -15,14 +15,14 @@
 
 namespace nix {
 
-using namespace nix::unix;
-
 /* ----------------------------------------------------------------------------
  * fchmodatTryNoFollow
  * --------------------------------------------------------------------------*/
 
 TEST(fchmodatTryNoFollow, works)
 {
+    using namespace nix::unix;
+
     std::filesystem::path tmpDir = nix::createTempDir();
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
 
@@ -106,6 +106,8 @@ TEST(fchmodatTryNoFollow, works)
 
 TEST(fchmodatTryNoFollow, fallbackWithoutProc)
 {
+    using namespace nix::unix;
+
     if (!userNamespacesSupported())
         GTEST_SKIP() << "User namespaces not supported";
 

--- a/src/libutil-tests/unix/unix-domain-socket.cc
+++ b/src/libutil-tests/unix/unix-domain-socket.cc
@@ -9,14 +9,14 @@
 
 namespace nix {
 
-using namespace nix::unix;
-
 /* ----------------------------------------------------------------------------
  * sendMessageWithFds / receiveMessageWithFds
  * --------------------------------------------------------------------------*/
 
 TEST(MessageWithFds, streamWithData)
 {
+    using namespace nix::unix;
+
     int sockets[2];
     ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
     AutoCloseFD sender(sockets[0]);
@@ -77,6 +77,8 @@ TEST(MessageWithFds, streamWithData)
 
 TEST(MessageWithFds, datagramEmptyData)
 {
+    using namespace nix::unix;
+
     int sockets[2];
     ASSERT_EQ(socketpair(AF_UNIX, SOCK_DGRAM, 0, sockets), 0);
     AutoCloseFD sender(sockets[0]);

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -33,7 +33,7 @@ size_t readOffset(Descriptor fd, off_t offset, std::span<std::byte> buffer)
     ssize_t n;
     do {
         checkInterrupt();
-        n = pread(fd, buffer.data(), buffer.size(), offset);
+        n = ::pread(fd, buffer.data(), buffer.size(), offset);
     } while (n == -1 && errno == EINTR);
     if (n == -1)
         throw SysError("pread of %1% bytes at offset %2%", buffer.size(), offset);

--- a/src/libutil/unix/include/nix/util/signals-impl.hh
+++ b/src/libutil/unix/include/nix/util/signals-impl.hh
@@ -77,7 +77,7 @@ static inline bool getInterrupted()
 
 static inline bool isInterrupted()
 {
-    using namespace unix;
+    using namespace nix::unix;
     return _isInterrupted || (interruptCheck && interruptCheck());
 }
 

--- a/src/libutil/unix/signals.cc
+++ b/src/libutil/unix/signals.cc
@@ -9,8 +9,6 @@
 
 namespace nix {
 
-using namespace unix;
-
 std::atomic<bool> unix::_isInterrupted = false;
 
 thread_local std::function<bool()> unix::interruptCheck;
@@ -56,6 +54,7 @@ static Sync<InterruptCallbacks> & getInterruptCallbacks()
 
 static void signalHandlerThread(sigset_t set)
 {
+    using namespace nix::unix;
     while (true) {
         int signal = 0;
         sigwait(&set, &signal);

--- a/src/libutil/windows/file-descriptor.cc
+++ b/src/libutil/windows/file-descriptor.cc
@@ -14,13 +14,11 @@
 
 namespace nix {
 
-using namespace nix::windows;
-
 std::make_unsigned_t<off_t> getFileSize(Descriptor fd)
 {
     LARGE_INTEGER li;
     if (!GetFileSizeEx(fd, &li)) {
-        throw WinError([&] { return HintFmt("getting size of file %s", PathFmt(descriptorToPath(fd))); });
+        throw windows::WinError([&] { return HintFmt("getting size of file %s", PathFmt(descriptorToPath(fd))); });
     }
     return li.QuadPart;
 }
@@ -34,7 +32,8 @@ size_t read(Descriptor fd, std::span<std::byte> buffer)
         if (lastError == ERROR_BROKEN_PIPE)
             n = 0; // Treat as EOF
         else
-            throw WinError(lastError, "reading %1% bytes from %2%", buffer.size(), PathFmt(descriptorToPath(fd)));
+            throw windows::WinError(
+                lastError, "reading %1% bytes from %2%", buffer.size(), PathFmt(descriptorToPath(fd)));
     }
     return static_cast<size_t>(n);
 }
@@ -48,7 +47,7 @@ size_t readOffset(Descriptor fd, off_t offset, std::span<std::byte> buffer)
         ov.OffsetHigh = static_cast<DWORD>(offset >> 32);
     DWORD n;
     if (!ReadFile(fd, buffer.data(), static_cast<DWORD>(buffer.size()), &n, &ov)) {
-        throw WinError([&] {
+        throw windows::WinError([&] {
             return HintFmt(
                 "reading %1% bytes at offset %2% from %3%", buffer.size(), offset, PathFmt(descriptorToPath(fd)));
         });
@@ -62,7 +61,7 @@ size_t write(Descriptor fd, std::span<const std::byte> buffer, bool allowInterru
         checkInterrupt(); // For consistency with unix
     DWORD n;
     if (!WriteFile(fd, buffer.data(), static_cast<DWORD>(buffer.size()), &n, NULL)) {
-        throw WinError(
+        throw windows::WinError(
             [&] { return HintFmt("writing %1% bytes to %2%", buffer.size(), PathFmt(descriptorToPath(fd))); });
     }
     return static_cast<size_t>(n);
@@ -72,7 +71,7 @@ AutoCloseFD dupDescriptor(Descriptor fd)
 {
     HANDLE newHandle;
     if (!DuplicateHandle(GetCurrentProcess(), fd, GetCurrentProcess(), &newHandle, 0, FALSE, DUPLICATE_SAME_ACCESS)) {
-        throw WinError("duplicating handle");
+        throw windows::WinError("duplicating handle");
     }
     return AutoCloseFD{newHandle};
 }
@@ -88,7 +87,7 @@ void Pipe::create()
 
     HANDLE hReadPipe, hWritePipe;
     if (!CreatePipe(&hReadPipe, &hWritePipe, &saAttr, 0))
-        throw WinError("CreatePipe");
+        throw windows::WinError("CreatePipe");
 
     readSide = hReadPipe;
     writeSide = hWritePipe;
@@ -130,7 +129,7 @@ off_t lseek(HANDLE h, off_t offset, int whence)
 void syncDescriptor(Descriptor fd)
 {
     if (!::FlushFileBuffers(fd)) {
-        throw WinError([&] { return HintFmt("flushing file %s", PathFmt(descriptorToPath(fd))); });
+        throw windows::WinError([&] { return HintFmt("flushing file %s", PathFmt(descriptorToPath(fd))); });
     }
 }
 

--- a/src/libutil/windows/file-system-at.cc
+++ b/src/libutil/windows/file-system-at.cc
@@ -13,8 +13,6 @@
 
 namespace nix {
 
-using namespace nix::windows;
-
 namespace windows {
 
 namespace {
@@ -214,7 +212,7 @@ PosixStat fstat(Descriptor fd)
 {
     BY_HANDLE_FILE_INFORMATION info;
     if (!GetFileInformationByHandle(fd, &info))
-        throw WinError("getting file information for %s", PathFmt(descriptorToPath(fd)));
+        throw windows::WinError("getting file information for %s", PathFmt(descriptorToPath(fd)));
 
     PosixStat st;
     windows::statFromFileInfo(
@@ -253,9 +251,9 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
     /* Helper to check if a component is a symlink and throw SymlinkNotAllowed if so */
     auto throwIfSymlink = [&](std::wstring_view component, const CanonPath & pathForError) {
         try {
-            auto testHandle =
-                ntOpenAt(getParentFd(), component, FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
-            if (isReparsePoint(testHandle.get()))
+            auto testHandle = windows::ntOpenAt(
+                getParentFd(), component, FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+            if (windows::isReparsePoint(testHandle.get()))
                 throw SymlinkNotAllowed(pathForError);
         } catch (SymlinkNotAllowed &) {
             throw;
@@ -272,13 +270,13 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
         /* Open directory without following symlinks */
         AutoCloseFD parentFd2;
         try {
-            parentFd2 = ntOpenAt(
+            parentFd2 = windows::ntOpenAt(
                 getParentFd(),
                 wcomponent,
                 FILE_TRAVERSE | SYNCHRONIZE,                  // Just need traversal rights
                 FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT // Open directory, don't follow symlinks
             );
-        } catch (WinError & e) {
+        } catch (windows::WinError & e) {
             /* Check if this is because it's a symlink */
             if (e.lastError == ERROR_CANT_ACCESS_FILE || e.lastError == ERROR_ACCESS_DENIED) {
                 throwIfSymlink(wcomponent, pathUpTo(std::next(it)));
@@ -287,7 +285,7 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
         }
 
         /* Check if what we opened is actually a symlink */
-        if (isReparsePoint(parentFd2.get())) {
+        if (windows::isReparsePoint(parentFd2.get())) {
             throw SymlinkNotAllowed(pathUpTo(std::next(it)));
         }
 
@@ -299,13 +297,13 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
 
     AutoCloseFD finalHandle;
     try {
-        finalHandle = ntOpenAt(
+        finalHandle = windows::ntOpenAt(
             getParentFd(),
             finalComponent,
             desiredAccess,
             createOptions | FILE_OPEN_REPARSE_POINT, // Don't follow symlinks on final component either
             createDisposition);
-    } catch (WinError & e) {
+    } catch (windows::WinError & e) {
         /* Check if final component is a symlink when we requested to not follow it */
         if (e.lastError == ERROR_CANT_ACCESS_FILE) {
             throwIfSymlink(finalComponent, path);
@@ -314,7 +312,7 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
     }
 
     /* Final check: did we accidentally open a symlink? */
-    if (isReparsePoint(finalHandle.get()))
+    if (windows::isReparsePoint(finalHandle.get()))
         throw SymlinkNotAllowed(path);
 
     return finalHandle;

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -16,8 +16,6 @@ static_assert(S_IFLNK != S_IFCHR, "S_IFLNK must not equal S_IFCHR");
 
 namespace nix {
 
-using namespace nix::windows;
-
 void setWriteTime(
     const std::filesystem::path & path, time_t accessedTime, time_t modificationTime, std::optional<bool> optIsSymlink)
 {
@@ -72,7 +70,7 @@ std::filesystem::path defaultTempDir()
     wchar_t buf[MAX_PATH + 1];
     DWORD len = GetTempPathW(MAX_PATH + 1, buf);
     if (len == 0 || len > MAX_PATH)
-        throw WinError("getting default temporary directory");
+        throw windows::WinError("getting default temporary directory");
     return std::filesystem::path(buf);
 }
 
@@ -106,7 +104,7 @@ std::filesystem::path descriptorToPath(Descriptor handle)
     if (dw > buf.size()) {
         buf.resize(dw);
         if (GetFinalPathNameByHandleW(handle, buf.data(), buf.size(), FILE_NAME_OPENED) != dw - 1)
-            throw WinError("GetFinalPathNameByHandleW");
+            throw windows::WinError("GetFinalPathNameByHandleW");
         dw -= 1;
     }
     return std::filesystem::path{std::wstring{buf.data(), dw}};
@@ -179,7 +177,7 @@ PosixStat lstat(const std::filesystem::path & path)
 {
     WIN32_FILE_ATTRIBUTE_DATA attrData;
     if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attrData))
-        throw WinError("getting status of %s", PathFmt(path));
+        throw windows::WinError("getting status of %s", PathFmt(path));
     return statFromFileInfo(attrData);
 }
 
@@ -190,7 +188,7 @@ std::optional<PosixStat> maybeLstat(const std::filesystem::path & path)
         auto lastError = GetLastError();
         if (lastError == ERROR_FILE_NOT_FOUND || lastError == ERROR_PATH_NOT_FOUND)
             return std::nullopt;
-        throw WinError(lastError, "getting status of %s", PathFmt(path));
+        throw windows::WinError(lastError, "getting status of %s", PathFmt(path));
     }
     return statFromFileInfo(attrData);
 }

--- a/src/libutil/windows/known-folders.cc
+++ b/src/libutil/windows/known-folders.cc
@@ -8,8 +8,6 @@
 
 namespace nix::windows::known_folders {
 
-using namespace nix::windows;
-
 static std::filesystem::path getKnownFolder(REFKNOWNFOLDERID rfid)
 {
     PWSTR str = nullptr;

--- a/src/libutil/windows/muxable-pipe.cc
+++ b/src/libutil/windows/muxable-pipe.cc
@@ -6,8 +6,6 @@
 
 namespace nix {
 
-using namespace nix::windows;
-
 void MuxablePipePollState::poll(HANDLE ioport, std::optional<unsigned int> timeout)
 {
     /* We are on at least Windows Vista / Server 2008 and can get many
@@ -16,7 +14,7 @@ void MuxablePipePollState::poll(HANDLE ioport, std::optional<unsigned int> timeo
             ioport, oentries, sizeof(oentries) / sizeof(*oentries), &removed, timeout ? *timeout : INFINITE, false)) {
         auto lastError = GetLastError();
         if (lastError != WAIT_TIMEOUT)
-            throw WinError(lastError, "GetQueuedCompletionStatusEx");
+            throw windows::WinError(lastError, "GetQueuedCompletionStatusEx");
         assert(removed == 0);
     } else {
         assert(0 < removed && removed <= sizeof(oentries) / sizeof(*oentries));
@@ -58,7 +56,7 @@ void MuxablePipePollState::iterate(
                             handleEOF((*p)->readSide.get());
                             nextp = channels.erase(p); // no need to maintain `channels` ?
                         } else if (lastError != ERROR_IO_PENDING)
-                            throw WinError(lastError, "ReadFile(%s, ..)", (*p)->readSide.get());
+                            throw windows::WinError(lastError, "ReadFile(%s, ..)", (*p)->readSide.get());
                     }
                 }
                 break;

--- a/src/libutil/windows/processes.cc
+++ b/src/libutil/windows/processes.cc
@@ -30,8 +30,6 @@
 
 namespace nix {
 
-using namespace nix::windows;
-
 Pid::Pid() {}
 
 Pid::Pid(Pid && other) noexcept
@@ -64,7 +62,7 @@ int Pid::kill(bool allowInterrupts)
     debug("killing process %1%", pid.get());
 
     if (!TerminateProcess(pid.get(), 1))
-        logError(WinError("terminating process %1%", pid.get()).info());
+        logError(windows::WinError("terminating process %1%", pid.get()).info());
 
     return wait(allowInterrupts);
 }
@@ -76,11 +74,11 @@ int Pid::wait(bool allowInterrupts)
     assert(pid.get() != INVALID_DESCRIPTOR);
     DWORD status = WaitForSingleObject(pid.get(), INFINITE);
     if (status != WAIT_OBJECT_0)
-        throw WinError("waiting for process %1%", pid.get());
+        throw windows::WinError("waiting for process %1%", pid.get());
 
     DWORD exitCode = 0;
     if (GetExitCodeProcess(pid.get(), &exitCode) == FALSE)
-        throw WinError("getting exit code of process %1%", pid.get());
+        throw windows::WinError("getting exit code of process %1%", pid.get());
 
     pid.close();
     return exitCode;
@@ -126,7 +124,7 @@ void setFDInheritable(AutoCloseFD & fd, bool inherit)
 {
     if (fd.get() != INVALID_DESCRIPTOR) {
         if (!SetHandleInformation(fd.get(), HANDLE_FLAG_INHERIT, inherit ? HANDLE_FLAG_INHERIT : 0)) {
-            throw WinError("Couldn't disable inheriting of handle");
+            throw windows::WinError("Couldn't disable inheriting of handle");
         }
     }
 }
@@ -146,7 +144,7 @@ AutoCloseFD nullFD()
         0,
         NULL);
     if (!nul.get()) {
-        throw WinError("Couldn't open NUL device");
+        throw windows::WinError("Couldn't open NUL device");
     }
     // Let this handle be inheritable by child processes
     setFDInheritable(nul, true);
@@ -258,7 +256,7 @@ Pid spawnProcess(const std::filesystem::path & realProgram, const RunOptions & o
             &startInfo,
             &procInfo)
         == 0) {
-        throw WinError("CreateProcessW failed (%1%)", os_string_to_string(cmdline));
+        throw windows::WinError("CreateProcessW failed (%1%)", os_string_to_string(cmdline));
     }
 
     // Convert these to use RAII
@@ -271,15 +269,15 @@ Pid spawnProcess(const std::filesystem::path & realProgram, const RunOptions & o
     Descriptor job = CreateJobObjectW(NULL, NULL);
     if (job == NULL) {
         TerminateProcess(procInfo.hProcess, 0);
-        throw WinError("Couldn't create job object for child process");
+        throw windows::WinError("Couldn't create job object for child process");
     }
     if (AssignProcessToJobObject(job, procInfo.hProcess) == FALSE) {
         TerminateProcess(procInfo.hProcess, 0);
-        throw WinError("Couldn't assign child process to job object");
+        throw windows::WinError("Couldn't assign child process to job object");
     }
     if (ResumeThread(procInfo.hThread) == (DWORD) -1) {
         TerminateProcess(procInfo.hProcess, 0);
-        throw WinError("Couldn't resume child process thread");
+        throw windows::WinError("Couldn't resume child process thread");
     }
 
     return process;

--- a/src/libutil/windows/users.cc
+++ b/src/libutil/windows/users.cc
@@ -8,8 +8,6 @@
 
 namespace nix {
 
-using namespace nix::windows;
-
 std::string getUserName()
 {
     // Get the required buffer size
@@ -17,7 +15,7 @@ std::string getUserName()
     if (!GetUserNameA(nullptr, &size)) {
         auto lastError = GetLastError();
         if (lastError != ERROR_INSUFFICIENT_BUFFER)
-            throw WinError(lastError, "cannot figure out size of user name");
+            throw windows::WinError(lastError, "cannot figure out size of user name");
     }
 
     std::string name;
@@ -28,7 +26,7 @@ std::string getUserName()
 
     // Retrieve the username
     if (!GetUserNameA(&name[0], &size))
-        throw WinError("cannot figure out user name");
+        throw windows::WinError("cannot figure out user name");
 
     return name;
 }

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -4,7 +4,7 @@
 #include "nix/util/posix-source-accessor.hh"
 #include "nix/cmd/misc-store-flags.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdAddToStore : MixDryRun, StoreCommand
 {
@@ -84,3 +84,5 @@ struct CmdAddPath : CmdAddToStore
 static auto rCmdAddFile = registerCommand2<CmdAddFile>({"store", "add-file"});
 static auto rCmdAddPath = registerCommand2<CmdAddPath>({"store", "add-path"});
 static auto rCmdAdd = registerCommand2<CmdAdd>({"store", "add"});
+
+} // namespace nix

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -5,6 +5,7 @@
 #include <set>
 #include <memory>
 #include <tuple>
+
 #ifdef __APPLE__
 #  include <sys/time.h>
 #endif
@@ -24,8 +25,7 @@
 #include "nix/util/experimental-features.hh"
 #include "nix/store/globals.hh"
 
-using namespace nix;
-using std::cin;
+namespace nix {
 
 static void handleAlarm(int sig) {}
 
@@ -410,3 +410,5 @@ static int main_build_remote(int argc, char ** argv)
 }
 
 static RegisterLegacyCommand r_build_remote("build-remote", main_build_remote);
+
+} // namespace nix

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -5,7 +5,7 @@
 
 #include <nlohmann/json.hpp>
 
-using namespace nix;
+namespace nix {
 
 /* This serialization code is diferent from the canonical (single)
    derived path serialization because:
@@ -186,3 +186,5 @@ struct CmdBuild : InstallablesCommand, MixOutLinkByDefault, MixDryRun, MixJSON, 
 };
 
 static auto rCmdBuild = registerCommand<CmdBuild>("build");
+
+} // namespace nix

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -6,7 +6,7 @@
 #include "nix/expr/eval-inline.hh"
 #include "nix/store/globals.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdBundle : InstallableValueCommand
 {
@@ -131,3 +131,5 @@ struct CmdBundle : InstallableValueCommand
 };
 
 static auto r2 = registerCommand<CmdBundle>("bundle");
+
+} // namespace nix

--- a/src/nix/cat.cc
+++ b/src/nix/cat.cc
@@ -6,7 +6,7 @@
 
 #include <nlohmann/json.hpp>
 
-using namespace nix;
+namespace nix {
 
 struct MixCat : virtual Args
 {
@@ -120,3 +120,5 @@ struct CmdCatNar : StoreCommand, MixCat
 
 static auto rCmdCatStore = registerCommand2<CmdCatStore>({"store", "cat"});
 static auto rCmdCatNar = registerCommand2<CmdCatNar>({"nar", "cat"});
+
+} // namespace nix

--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -11,7 +11,7 @@
 #include "nix/util/executable-path.hh"
 #include "nix/store/globals.hh"
 
-using namespace nix;
+namespace nix {
 
 namespace {
 
@@ -178,3 +178,5 @@ struct CmdConfigCheck : StoreCommand
 };
 
 static auto rCmdConfigCheck = registerCommand2<CmdConfigCheck>({"config", "check"});
+
+} // namespace nix

--- a/src/nix/config.cc
+++ b/src/nix/config.cc
@@ -4,7 +4,7 @@
 
 #include <nlohmann/json.hpp>
 
-using namespace nix;
+namespace nix {
 
 struct CmdConfig : NixMultiCommand
 {
@@ -79,3 +79,5 @@ struct CmdConfigShow : Command, MixJSON
 
 static auto rCmdConfig = registerCommand<CmdConfig>("config");
 static auto rShowConfig = registerCommand2<CmdConfigShow>({"config", "show"});
+
+} // namespace nix

--- a/src/nix/copy.cc
+++ b/src/nix/copy.cc
@@ -3,7 +3,7 @@
 #include "nix/store/store-api.hh"
 #include "nix/store/local-fs-store.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdCopy : virtual CopyCommand, virtual BuiltPathsCommand, MixProfile, MixNoCheckSigs
 {
@@ -75,3 +75,5 @@ struct CmdCopy : virtual CopyCommand, virtual BuiltPathsCommand, MixProfile, Mix
 };
 
 static auto rCmdCopy = registerCommand<CmdCopy>("copy");
+
+} // namespace nix

--- a/src/nix/derivation-add.cc
+++ b/src/nix/derivation-add.cc
@@ -7,8 +7,9 @@
 #include "nix/store/globals.hh"
 #include <nlohmann/json.hpp>
 
-using namespace nix;
 using json = nlohmann::json;
+
+namespace nix {
 
 struct CmdAddDerivation : MixDryRun, StoreCommand
 {
@@ -43,3 +44,5 @@ struct CmdAddDerivation : MixDryRun, StoreCommand
 };
 
 static auto rCmdAddDerivation = registerCommand2<CmdAddDerivation>({"derivation", "add"});
+
+} // namespace nix

--- a/src/nix/derivation-show.cc
+++ b/src/nix/derivation-show.cc
@@ -7,8 +7,9 @@
 #include "nix/store/derivations.hh"
 #include <nlohmann/json.hpp>
 
-using namespace nix;
 using json = nlohmann::json;
+
+namespace nix {
 
 struct CmdShowDerivation : InstallablesCommand, MixPrintJSON
 {
@@ -68,3 +69,5 @@ struct CmdShowDerivation : InstallablesCommand, MixPrintJSON
 };
 
 static auto rCmdShowDerivation = registerCommand2<CmdShowDerivation>({"derivation", "show"});
+
+} // namespace nix

--- a/src/nix/derivation.cc
+++ b/src/nix/derivation.cc
@@ -1,6 +1,6 @@
 #include "nix/cmd/command.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdDerivation : NixMultiCommand
 {
@@ -21,3 +21,5 @@ struct CmdDerivation : NixMultiCommand
 };
 
 static auto rCmdDerivation = registerCommand<CmdDerivation>("derivation");
+
+} // namespace nix

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -21,7 +21,7 @@
 
 #include "nix/util/strings.hh"
 
-using namespace nix;
+namespace nix {
 
 struct DevelopSettings : Config
 {
@@ -752,3 +752,5 @@ struct CmdPrintDevEnv : Common, MixJSON
 
 static auto rCmdPrintDevEnv = registerCommand<CmdPrintDevEnv>("print-dev-env");
 static auto rCmdDevelop = registerCommand<CmdDevelop>("develop");
+
+} // namespace nix

--- a/src/nix/diff-closures.cc
+++ b/src/nix/diff-closures.cc
@@ -112,10 +112,6 @@ void printClosureDiff(
     }
 }
 
-} // namespace nix
-
-using namespace nix;
-
 struct CmdDiffClosures : SourceExprCommand, MixOperateOnOptions
 {
     std::string _before, _after;
@@ -149,3 +145,5 @@ struct CmdDiffClosures : SourceExprCommand, MixOperateOnOptions
 };
 
 static auto rCmdDiffClosures = registerCommand2<CmdDiffClosures>({"store", "diff-closures"});
+
+} // namespace nix

--- a/src/nix/dump-path.cc
+++ b/src/nix/dump-path.cc
@@ -3,7 +3,7 @@
 #include "nix/util/archive.hh"
 #include "nix/util/terminal.hh"
 
-using namespace nix;
+namespace nix {
 
 static FdSink getNarSink()
 {
@@ -77,3 +77,5 @@ struct CmdNarDumpPath : CmdDumpPath2
 
 static auto rCmdNarPack = registerCommand2<CmdDumpPath2>({"nar", "pack"});
 static auto rCmdNarDumpPath = registerCommand2<CmdNarDumpPath>({"nar", "dump-path"});
+
+} // namespace nix

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -7,7 +7,7 @@
 
 #include <unistd.h>
 
-using namespace nix;
+namespace nix {
 
 struct CmdEdit : InstallableValueCommand
 {
@@ -58,3 +58,5 @@ struct CmdEdit : InstallableValueCommand
 };
 
 static auto rCmdEdit = registerCommand<CmdEdit>("edit");
+
+} // namespace nix

--- a/src/nix/env.cc
+++ b/src/nix/env.cc
@@ -10,7 +10,7 @@
 #include "nix/util/environment-variables.hh"
 #include "nix/util/mounted-source-accessor.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdEnv : NixMultiCommand
 {
@@ -121,3 +121,5 @@ struct CmdShell : InstallablesCommand, MixEnvironment
 };
 
 static auto rCmdShell = registerCommand2<CmdShell>({"env", "shell"});
+
+} // namespace nix

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -8,7 +8,7 @@
 
 #include <nlohmann/json.hpp>
 
-using namespace nix;
+namespace nix {
 
 struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
 {
@@ -126,3 +126,5 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
 };
 
 static auto rCmdEval = registerCommand<CmdEval>("eval");
+
+} // namespace nix

--- a/src/nix/flake-command.hh
+++ b/src/nix/flake-command.hh
@@ -6,8 +6,6 @@
 
 namespace nix {
 
-using namespace nix::flake;
-
 class FlakeCommand : virtual Args, public MixFlakeOptions
 {
 protected:
@@ -19,7 +17,7 @@ public:
 
     FlakeRef getFlakeRef();
 
-    LockedFlake lockFlake();
+    flake::LockedFlake lockFlake();
 
     std::vector<FlakeRef> getFlakeRefsForCompletion() override;
 };

--- a/src/nix/flake-prefetch-inputs.cc
+++ b/src/nix/flake-prefetch-inputs.cc
@@ -6,8 +6,7 @@
 
 #include <nlohmann/json.hpp>
 
-using namespace nix;
-using namespace nix::flake;
+namespace nix {
 
 struct CmdFlakePrefetchInputs : FlakeCommand
 {
@@ -25,6 +24,7 @@ struct CmdFlakePrefetchInputs : FlakeCommand
 
     void run(nix::ref<nix::Store> store) override
     {
+        using namespace nix::flake;
         auto flake = lockFlake();
 
         ThreadPool pool{fileTransferSettings.httpConnections};
@@ -69,3 +69,5 @@ struct CmdFlakePrefetchInputs : FlakeCommand
 };
 
 static auto rCmdFlakePrefetchInputs = registerCommand2<CmdFlakePrefetchInputs>({"flake", "prefetch-inputs"});
+
+} // namespace nix

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -30,9 +30,7 @@
 // FIXME is this supposed to be private or not?
 #include "flake-command.hh"
 
-using namespace nix;
-using namespace nix::flake;
-using json = nlohmann::json;
+namespace nix {
 
 struct CmdFlakeUpdate;
 
@@ -52,7 +50,7 @@ FlakeRef FlakeCommand::getFlakeRef()
     return parseFlakeRef(fetchSettings, flakeUrl, std::filesystem::current_path().string()); // FIXME
 }
 
-LockedFlake FlakeCommand::lockFlake()
+flake::LockedFlake FlakeCommand::lockFlake()
 {
     return flake::lockFlake(flakeSettings, *getEvalState(), getFlakeRef(), lockFlags);
 }
@@ -89,7 +87,7 @@ public:
             .optional = true,
             .handler = {[&](std::vector<std::string> inputsToUpdate) {
                 for (const auto & inputToUpdate : inputsToUpdate) {
-                    std::optional<NonEmptyInputAttrPath> inputAttrPath;
+                    std::optional<flake::NonEmptyInputAttrPath> inputAttrPath;
                     try {
                         inputAttrPath = flake::NonEmptyInputAttrPath::parse(inputToUpdate);
                         if (!inputAttrPath)
@@ -269,9 +267,9 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
             if (!lockedFlake.lockFile.root->inputs.empty())
                 logger->cout(ANSI_BOLD "Inputs:" ANSI_NORMAL);
 
-            std::set<ref<Node>> visited{lockedFlake.lockFile.root};
+            std::set<ref<flake::Node>> visited{lockedFlake.lockFile.root};
 
-            [&](this const auto & recurse, const Node & node, const std::string & prefix) -> void {
+            [&](this const auto & recurse, const flake::Node & node, const std::string & prefix) -> void {
                 for (const auto & [i, input] : enumerate(node.inputs)) {
                     bool last = i + 1 == node.inputs.size();
 
@@ -295,7 +293,7 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
                             "%s" ANSI_BOLD "%s" ANSI_NORMAL " follows input '%s'",
                             prefix + (last ? treeLast : treeConn),
                             input.first,
-                            printInputAttrPath(*follows));
+                            flake::printInputAttrPath(*follows));
                     }
                 }
             }(*lockedFlake.lockFile.root, "");
@@ -856,7 +854,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
     std::string templateUrl = "templates";
     std::filesystem::path destDir;
 
-    const LockFlags lockFlags{.writeLockFile = false};
+    const flake::LockFlags lockFlags{.writeLockFile = false};
 
     CmdFlakeInitCommon()
     {
@@ -1097,9 +1095,9 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun, MixNoCheckSigs
         sources.insert(storePath);
 
         // FIXME: use graph output, handle cycles.
-        std::function<nlohmann::json(const Node & node)> traverse;
-        traverse = [&](const Node & node) {
-            nlohmann::json jsonObj2 = json ? json::object() : nlohmann::json(nullptr);
+        std::function<nlohmann::json(const flake::Node & node)> traverse;
+        traverse = [&](const flake::Node & node) {
+            nlohmann::json jsonObj2 = json ? nlohmann::json::object() : nlohmann::json(nullptr);
             for (auto & [inputName, input] : node.inputs) {
                 if (auto inputNode = std::get_if<0>(&input)) {
                     std::optional<StorePath> storePath;
@@ -1174,7 +1172,7 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
         evalSettings.enableImportFromDerivation.setDefault(false);
 
         auto state = getEvalState();
-        auto flake = make_ref<LockedFlake>(lockFlake());
+        auto flake = make_ref<flake::LockedFlake>(lockFlake());
         auto localSystem = std::string(settings.thisSystem.get());
 
         std::function<bool(eval_cache::AttrCursor & visitor, const AttrPath & attrPath, const Symbol & attr)>
@@ -1567,3 +1565,5 @@ static auto rCmdFlakeNew = registerCommand2<CmdFlakeNew>({"flake", "new"});
 static auto rCmdFlakePrefetch = registerCommand2<CmdFlakePrefetch>({"flake", "prefetch"});
 static auto rCmdFlakeShow = registerCommand2<CmdFlakeShow>({"flake", "show"});
 static auto rCmdFlakeUpdate = registerCommand2<CmdFlakeUpdate>({"flake", "update"});
+
+} // namespace nix

--- a/src/nix/formatter.cc
+++ b/src/nix/formatter.cc
@@ -7,7 +7,7 @@
 
 #include "run.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdFormatter : NixMultiCommand
 {
@@ -158,3 +158,5 @@ struct CmdFmt : CmdFormatterRun
 };
 
 static auto rFmt = registerCommand<CmdFmt>("fmt");
+
+} // namespace nix

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -9,7 +9,7 @@
 #include "man-pages.hh"
 #include "nix/util/fun.hh"
 
-using namespace nix;
+namespace nix {
 
 /**
  * Base for `nix hash path`, `nix hash file` (deprecated), and `nix-hash` (legacy).
@@ -366,3 +366,5 @@ static int compatNixHash(int argc, char ** argv)
 }
 
 static RegisterLegacyCommand r_nix_hash("nix-hash", compatNixHash);
+
+} // namespace nix

--- a/src/nix/log.cc
+++ b/src/nix/log.cc
@@ -3,7 +3,7 @@
 #include "nix/main/shared.hh"
 #include "nix/store/globals.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdLog : InstallableCommand
 {
@@ -47,3 +47,5 @@ struct CmdLog : InstallableCommand
 };
 
 static auto rCmdLog = registerCommand<CmdLog>("log");
+
+} // namespace nix

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -4,7 +4,7 @@
 #include "nix/main/common-args.hh"
 #include <nlohmann/json.hpp>
 
-using namespace nix;
+namespace nix {
 
 struct MixLs : virtual Args, MixJSON
 {
@@ -160,3 +160,5 @@ struct CmdLsNar : Command, MixLs
 
 static auto rCmdLsStore = registerCommand2<CmdLsStore>({"store", "ls"});
 static auto rCmdLsNar = registerCommand2<CmdLsNar>({"nar", "ls"});
+
+} // namespace nix

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -41,15 +41,15 @@
 #  include "nix/util/linux-namespaces.hh"
 #endif
 
+#include "nix/util/strings.hh"
+
+namespace nix {
+
 #ifndef _WIN32
 extern std::string chrootHelperName;
 
 void chrootHelper(int argc, char ** argv);
 #endif
-
-#include "nix/util/strings.hh"
-
-namespace nix {
 
 /* Check if we have a non-loopback/link-local network interface. */
 static bool haveInternet()

--- a/src/nix/make-content-addressed.cc
+++ b/src/nix/make-content-addressed.cc
@@ -5,9 +5,9 @@
 
 #include <nlohmann/json.hpp>
 
-using namespace nix;
-
 using nlohmann::json;
+
+namespace nix {
 
 struct CmdMakeContentAddressed : virtual CopyCommand, virtual StorePathsCommand, MixJSON
 {
@@ -56,3 +56,5 @@ struct CmdMakeContentAddressed : virtual CopyCommand, virtual StorePathsCommand,
 };
 
 static auto rCmdMakeContentAddressed = registerCommand2<CmdMakeContentAddressed>({"store", "make-content-addressed"});
+
+} // namespace nix

--- a/src/nix/nar.cc
+++ b/src/nix/nar.cc
@@ -1,6 +1,6 @@
 #include "nix/cmd/command.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdNar : NixMultiCommand
 {
@@ -28,3 +28,5 @@ struct CmdNar : NixMultiCommand
 };
 
 static auto rCmdNar = registerCommand<CmdNar>("nar");
+
+} // namespace nix

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -31,10 +31,11 @@
 #include "nix/util/fun.hh"
 #include "man-pages.hh"
 
-using namespace nix;
 using namespace std::string_literals;
 
 extern char ** environ __attribute__((weak));
+
+namespace nix {
 
 /* Recreate the effect of the perl shellwords function, breaking up a
  * string into arguments like a shell word, including escapes
@@ -747,3 +748,5 @@ static void main_nix_build(int argc, char ** argv)
 
 static RegisterLegacyCommand r_nix_build("nix-build", main_nix_build);
 static RegisterLegacyCommand r_nix_shell("nix-shell", main_nix_build);
+
+} // namespace nix

--- a/src/nix/nix-channel/nix-channel.cc
+++ b/src/nix/nix-channel/nix-channel.cc
@@ -16,7 +16,7 @@
 #include <regex>
 #include <pwd.h>
 
-using namespace nix;
+namespace nix {
 
 typedef StringMap Channels;
 
@@ -306,3 +306,5 @@ static int main_nix_channel(int argc, char ** argv)
 }
 
 static RegisterLegacyCommand r_nix_channel("nix-channel", main_nix_channel);
+
+} // namespace nix

--- a/src/nix/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix/nix-collect-garbage/nix-collect-garbage.cc
@@ -12,7 +12,7 @@
 
 #include <cerrno>
 
-using namespace nix;
+namespace nix {
 
 std::string deleteOlderThan;
 bool dryRun = false;
@@ -109,3 +109,5 @@ static int main_nix_collect_garbage(int argc, char ** argv)
 }
 
 static RegisterLegacyCommand r_nix_collect_garbage("nix-collect-garbage", main_nix_collect_garbage);
+
+} // namespace nix

--- a/src/nix/nix-copy-closure/nix-copy-closure.cc
+++ b/src/nix/nix-copy-closure/nix-copy-closure.cc
@@ -5,7 +5,7 @@
 #include "nix/cmd/legacy.hh"
 #include "man-pages.hh"
 
-using namespace nix;
+namespace nix {
 
 static int main_nix_copy_closure(int argc, char ** argv)
 {
@@ -69,3 +69,5 @@ static int main_nix_copy_closure(int argc, char ** argv)
 }
 
 static RegisterLegacyCommand r_nix_copy_closure("nix-copy-closure", main_nix_copy_closure);
+
+} // namespace nix

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -33,8 +33,7 @@
 #include <unistd.h>
 #include <nlohmann/json.hpp>
 
-using namespace nix;
-using std::cout;
+namespace nix {
 
 /**
  * Settings related to Nix user environments.
@@ -1073,7 +1072,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
     /* Print the desired columns, or XML output. */
     if (jsonOutput) {
         queryJSON(globals, elems, printOutPath, printDrvPath, printMeta);
-        cout << '\n';
+        std::cout << '\n';
         return;
     }
 
@@ -1082,7 +1081,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
 
     Table table;
     std::ostringstream dummy;
-    XMLWriter xml(true, *(xmlOutput ? &cout : &dummy));
+    XMLWriter xml(true, *(xmlOutput ? &std::cout : &dummy));
     XMLOpenElement xmlRoot(xml, "items");
 
     for (auto & i : elems) {
@@ -1274,7 +1273,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
             } else
                 table.push_back(columns);
 
-            cout.flush();
+            std::cout.flush();
 
         } catch (AssertionError & e) {
             printMsg(lvlTalkative, "skipping derivation named '%1%' which gives an assertion failure", i.queryName());
@@ -1536,3 +1535,5 @@ static int main_nix_env(int argc, char ** argv)
 }
 
 static RegisterLegacyCommand r_nix_env("nix-env", main_nix_env);
+
+} // namespace nix

--- a/src/nix/nix-instantiate/nix-instantiate.cc
+++ b/src/nix/nix-instantiate/nix-instantiate.cc
@@ -15,7 +15,7 @@
 
 #include <iostream>
 
-using namespace nix;
+namespace nix {
 
 std::filesystem::path gcRoot;
 static int rootNr = 0;
@@ -207,3 +207,5 @@ static int main_nix_instantiate(int argc, char ** argv)
 }
 
 static RegisterLegacyCommand r_nix_instantiate("nix-instantiate", main_nix_instantiate);
+
+} // namespace nix

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -41,8 +41,6 @@
 namespace nix_store {
 
 using namespace nix;
-using std::cin;
-using std::cout;
 
 typedef void (*Operation)(Strings opFlags, Strings opArgs);
 
@@ -182,7 +180,7 @@ static void opRealise(Strings opFlags, Strings opArgs)
             auto paths2 = realisePath(i, false);
             if (!noOutput)
                 for (auto & j : paths2)
-                    cout << fmt("%s\n", j.string());
+                    std::cout << fmt("%s\n", j.string());
         }
 }
 
@@ -194,7 +192,7 @@ static void opAdd(Strings opFlags, Strings opArgs)
 
     for (auto & i : opArgs) {
         auto sourcePath = PosixSourceAccessor::createAtRoot(makeParentCanonical(i));
-        cout << fmt("%s\n", store->printStorePath(store->addToStore(std::string(baseNameOf(i)), sourcePath)));
+        std::cout << fmt("%s\n", store->printStorePath(store->addToStore(std::string(baseNameOf(i)), sourcePath)));
     }
 }
 
@@ -242,7 +240,7 @@ static void opPrintFixedPath(Strings opFlags, Strings opArgs)
     std::string hash = *i++;
     std::string name = *i++;
 
-    cout << fmt(
+    std::cout << fmt(
         "%s\n",
         store->printStorePath(store->makeFixedOutputPath(
             name,
@@ -280,11 +278,11 @@ static void
 printTree(const StorePath & path, const std::string & firstPad, const std::string & tailPad, StorePathSet & done)
 {
     if (!done.insert(path).second) {
-        cout << fmt("%s%s [...]\n", firstPad, store->printStorePath(path));
+        std::cout << fmt("%s%s [...]\n", firstPad, store->printStorePath(path));
         return;
     }
 
-    cout << fmt("%s%s\n", firstPad, store->printStorePath(path));
+    std::cout << fmt("%s%s\n", firstPad, store->printStorePath(path));
 
     auto info = store->queryPathInfo(path);
 
@@ -387,7 +385,7 @@ static void opQuery(Strings opFlags, Strings opArgs)
         for (auto & i : opArgs) {
             auto outputs = maybeUseOutputs(store->followLinksToStorePath(i), true, forceRealise);
             for (auto & outputPath : outputs)
-                cout << fmt("%1%\n", store->printStorePath(outputPath));
+                std::cout << fmt("%1%\n", store->printStorePath(outputPath));
         }
         break;
     }
@@ -416,14 +414,14 @@ static void opQuery(Strings opFlags, Strings opArgs)
         }
         auto sorted = store->topoSortPaths(paths);
         for (StorePaths::reverse_iterator i = sorted.rbegin(); i != sorted.rend(); ++i)
-            cout << fmt("%s\n", store->printStorePath(*i));
+            std::cout << fmt("%s\n", store->printStorePath(*i));
         break;
     }
 
     case qDeriver:
         for (auto & i : opArgs) {
             auto info = store->queryPathInfo(store->followLinksToStorePath(i));
-            cout << fmt("%s\n", info->deriver ? store->printStorePath(*info->deriver) : "unknown-deriver");
+            std::cout << fmt("%s\n", info->deriver ? store->printStorePath(*info->deriver) : "unknown-deriver");
         }
         break;
 
@@ -437,7 +435,7 @@ static void opQuery(Strings opFlags, Strings opArgs)
         }
         auto sorted = store->topoSortPaths(result);
         for (StorePaths::reverse_iterator i = sorted.rbegin(); i != sorted.rend(); ++i)
-            cout << fmt("%s\n", store->printStorePath(*i));
+            std::cout << fmt("%s\n", store->printStorePath(*i));
         break;
     }
 
@@ -449,7 +447,7 @@ static void opQuery(Strings opFlags, Strings opArgs)
             if (j == drv.env.end())
                 throw Error(
                     "derivation '%s' has no environment binding named '%s'", store->printStorePath(path), bindingName);
-            cout << fmt("%s\n", j->second);
+            std::cout << fmt("%s\n", j->second);
         }
         break;
 
@@ -460,9 +458,9 @@ static void opQuery(Strings opFlags, Strings opArgs)
                 auto info = store->queryPathInfo(j);
                 if (query == qHash) {
                     assert(info->narHash.algo == HashAlgorithm::SHA256);
-                    cout << fmt("%s\n", info->narHash.to_string(HashFormat::Nix32, true));
+                    std::cout << fmt("%s\n", info->narHash.to_string(HashFormat::Nix32, true));
                 } else if (query == qSize)
-                    cout << fmt("%d\n", info->narSize);
+                    std::cout << fmt("%d\n", info->narSize);
             }
         }
         break;
@@ -494,7 +492,7 @@ static void opQuery(Strings opFlags, Strings opArgs)
 
     case qResolve: {
         for (auto & i : opArgs)
-            cout << fmt("%s\n", store->printStorePath(store->followLinksToStorePath(i)));
+            std::cout << fmt("%s\n", store->printStorePath(store->followLinksToStorePath(i)));
         break;
     }
 
@@ -513,7 +511,7 @@ static void opQuery(Strings opFlags, Strings opArgs)
         for (auto & [target, links] : roots)
             if (referrers.find(target) != referrers.end())
                 for (auto & link : links)
-                    cout << fmt("%1% -> %2%\n", link, gcStore.printStorePath(target));
+                    std::cout << fmt("%1% -> %2%\n", link, gcStore.printStorePath(target));
         break;
     }
 
@@ -539,7 +537,7 @@ static void opPrintEnv(Strings opFlags, Strings opArgs)
 
     /* Also output the arguments. */
     std::string argsStr = concatStringsSep(" ", drv.args);
-    cout << "export _args; _args=" << escapeShellArgAlways(argsStr) << "\n";
+    std::cout << "export _args; _args=" << escapeShellArgAlways(argsStr) << "\n";
 }
 
 static void opReadLog(Strings opFlags, Strings opArgs)
@@ -566,10 +564,10 @@ static void opDumpDB(Strings opFlags, Strings opArgs)
         throw UsageError("unknown flag");
     if (!opArgs.empty()) {
         for (auto & i : opArgs)
-            cout << store->makeValidityRegistration({store->followLinksToStorePath(i)}, true, true);
+            std::cout << store->makeValidityRegistration({store->followLinksToStorePath(i)}, true, true);
     } else {
         for (auto & i : store->queryAllValidPaths())
-            cout << store->makeValidityRegistration({i}, true, true);
+            std::cout << store->makeValidityRegistration({i}, true, true);
     }
 }
 
@@ -585,7 +583,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
                                               std::numeric_limits<uint64_t>::max(),
                                           }}
                                         : std::nullopt;
-        auto info = decodeValidPathInfo(*store, cin, hashResultOpt);
+        auto info = decodeValidPathInfo(*store, std::cin, hashResultOpt);
         if (!info)
             break;
         if (!store->isValidPath(info->path) || reregister) {
@@ -651,7 +649,7 @@ static void opCheckValidity(Strings opFlags, Strings opArgs)
         auto path = store->followLinksToStorePath(i);
         if (!store->isValidPath(path)) {
             if (printInvalid)
-                cout << fmt("%s\n", store->printStorePath(path));
+                std::cout << fmt("%s\n", store->printStorePath(path));
             else
                 throw Error("path '%s' is not valid", store->printStorePath(path));
         }
@@ -703,7 +701,7 @@ static void opGC(Strings opFlags, Strings opArgs)
         Finally printer([&] {
             if (options.action != GCOptions::gcDeleteDead)
                 for (auto & i : results.paths)
-                    cout << i << std::endl;
+                    std::cout << i << std::endl;
             else
                 printFreed(false, results);
         });
@@ -788,7 +786,7 @@ static void opImport(Strings opFlags, Strings opArgs)
     auto paths = importPaths(*store, source, NoCheckSigs);
 
     for (auto & i : paths)
-        cout << fmt("%s\n", store->printStorePath(i)) << std::flush;
+        std::cout << fmt("%s\n", store->printStorePath(i)) << std::flush;
 }
 
 /* Initialise the Nix databases. */

--- a/src/nix/optimise-store.cc
+++ b/src/nix/optimise-store.cc
@@ -2,7 +2,7 @@
 #include "nix/main/shared.hh"
 #include "nix/store/store-api.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdOptimiseStore : StoreCommand
 {
@@ -25,3 +25,5 @@ struct CmdOptimiseStore : StoreCommand
 };
 
 static auto rCmdOptimiseStore = registerCommand2<CmdOptimiseStore>({"store", "optimise"});
+
+} // namespace nix

--- a/src/nix/path-from-hash-part.cc
+++ b/src/nix/path-from-hash-part.cc
@@ -1,7 +1,7 @@
 #include "nix/cmd/command.hh"
 #include "nix/store/store-api.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdPathFromHashPart : StoreCommand
 {
@@ -37,3 +37,5 @@ struct CmdPathFromHashPart : StoreCommand
 };
 
 static auto rCmdPathFromHashPart = registerCommand2<CmdPathFromHashPart>({"store", "path-from-hash-part"});
+
+} // namespace nix

--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -10,7 +10,8 @@
 
 #include "nix/util/strings.hh"
 
-using namespace nix;
+namespace nix {
+
 using nlohmann::json;
 
 /**
@@ -237,3 +238,5 @@ struct CmdPathInfo : StorePathsCommand, MixJSON
 };
 
 static auto rCmdPathInfo = registerCommand<CmdPathInfo>("path-info");
+
+} // namespace nix

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -18,7 +18,7 @@
 
 #include <nlohmann/json.hpp>
 
-using namespace nix;
+namespace nix {
 
 /* If ‘url’ starts with ‘mirror://’, then resolve it using the list of
    mirrors defined in Nixpkgs. */
@@ -349,3 +349,5 @@ struct CmdStorePrefetchFile : StoreCommand, MixJSON
 };
 
 static auto rCmdStorePrefetchFile = registerCommand2<CmdStorePrefetchFile>({"store", "prefetch-file"});
+
+} // namespace nix

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -20,7 +20,7 @@
 
 #include "nix/util/strings.hh"
 
-using namespace nix;
+namespace nix {
 
 struct ProfileElementSource
 {
@@ -1029,3 +1029,5 @@ struct CmdProfile : NixMultiCommand
 };
 
 static auto rCmdProfile = registerCommand<CmdProfile>("profile");
+
+} // namespace nix

--- a/src/nix/realisation.cc
+++ b/src/nix/realisation.cc
@@ -3,7 +3,7 @@
 
 #include <nlohmann/json.hpp>
 
-using namespace nix;
+namespace nix {
 
 struct CmdRealisation : NixMultiCommand
 {
@@ -78,3 +78,5 @@ struct CmdRealisationInfo : BuiltPathsCommand, MixJSON
 };
 
 static auto rCmdRealisationInfo = registerCommand2<CmdRealisationInfo>({"realisation", "info"});
+
+} // namespace nix

--- a/src/nix/registry.cc
+++ b/src/nix/registry.cc
@@ -5,8 +5,7 @@
 #include "nix/fetchers/fetchers.hh"
 #include "nix/fetchers/registry.hh"
 
-using namespace nix;
-using namespace nix::flake;
+namespace nix {
 
 class RegistryCommand : virtual Args
 {
@@ -268,3 +267,5 @@ struct CmdRegistry : NixMultiCommand
 };
 
 static auto rCmdRegistry = registerCommand<CmdRegistry>("registry");
+
+} // namespace nix

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -20,11 +20,9 @@
 
 extern char ** environ __attribute__((weak));
 
-using namespace nix;
+namespace nix {
 
 std::string chrootHelperName = "__run_in_chroot";
-
-namespace nix {
 
 /* Convert `env` to a list of strings suitable for `execve`'s `envp` argument. */
 Strings toEnvp(StringMap env)
@@ -107,8 +105,6 @@ void execProgramInStore(
 
     throw SysError("unable to execute '%s'", program);
 }
-
-} // namespace nix
 
 struct CmdRun : InstallableValueCommand, MixEnvironment
 {
@@ -264,3 +260,5 @@ void chrootHelper(int argc, char ** argv)
     throw Error("mounting the Nix store on '%s' is not supported on this platform", storeDir);
 #endif
 }
+
+} // namespace nix

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -16,8 +16,9 @@
 
 #include "nix/util/strings.hh"
 
-using namespace nix;
 using json = nlohmann::json;
+
+namespace nix {
 
 std::string wrap(std::string prefix, std::string s)
 {
@@ -196,3 +197,5 @@ struct CmdSearch : InstallableValueCommand, MixJSON
 };
 
 static auto rCmdSearch = registerCommand<CmdSearch>("search");
+
+} // namespace nix

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -7,7 +7,7 @@
 
 #include <atomic>
 
-using namespace nix;
+namespace nix {
 
 struct CmdCopySigs : StorePathsCommand
 {
@@ -226,3 +226,5 @@ struct CmdKey : NixMultiCommand
 };
 
 static auto rCmdKey = registerCommand<CmdKey>("key");
+
+} // namespace nix

--- a/src/nix/store-copy-log.cc
+++ b/src/nix/store-copy-log.cc
@@ -4,7 +4,7 @@
 #include "nix/store/store-cast.hh"
 #include "nix/store/log-store.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdCopyLog : virtual CopyCommand, virtual InstallablesCommand
 {
@@ -37,3 +37,5 @@ struct CmdCopyLog : virtual CopyCommand, virtual InstallablesCommand
 };
 
 static auto rCmdCopyLog = registerCommand2<CmdCopyLog>({"store", "copy-log"});
+
+} // namespace nix

--- a/src/nix/store-delete.cc
+++ b/src/nix/store-delete.cc
@@ -4,7 +4,7 @@
 #include "nix/store/store-cast.hh"
 #include "nix/store/gc-store.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdStoreDelete : StorePathsCommand
 {
@@ -45,3 +45,5 @@ struct CmdStoreDelete : StorePathsCommand
 };
 
 static auto rCmdStoreDelete = registerCommand2<CmdStoreDelete>({"store", "delete"});
+
+} // namespace nix

--- a/src/nix/store-gc.cc
+++ b/src/nix/store-gc.cc
@@ -6,7 +6,7 @@
 #include "nix/store/gc-store.hh"
 #include "nix/util/error.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdStoreGC : StoreCommand, MixDryRun
 {
@@ -49,3 +49,5 @@ struct CmdStoreGC : StoreCommand, MixDryRun
 };
 
 static auto rCmdStoreGC = registerCommand2<CmdStoreGC>({"store", "gc"});
+
+} // namespace nix

--- a/src/nix/store-info.cc
+++ b/src/nix/store-info.cc
@@ -5,7 +5,7 @@
 
 #include <nlohmann/json.hpp>
 
-using namespace nix;
+namespace nix {
 
 struct CmdInfoStore : StoreCommand, MixJSON
 {
@@ -45,3 +45,5 @@ struct CmdInfoStore : StoreCommand, MixJSON
 };
 
 static auto rCmdInfoStore = registerCommand2<CmdInfoStore>({"store", "info"});
+
+} // namespace nix

--- a/src/nix/store-repair.cc
+++ b/src/nix/store-repair.cc
@@ -1,7 +1,7 @@
 #include "nix/cmd/command.hh"
 #include "nix/store/store-api.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdStoreRepair : StorePathsCommand
 {
@@ -25,3 +25,5 @@ struct CmdStoreRepair : StorePathsCommand
 };
 
 static auto rStoreRepair = registerCommand2<CmdStoreRepair>({"store", "repair"});
+
+} // namespace nix

--- a/src/nix/store.cc
+++ b/src/nix/store.cc
@@ -1,6 +1,6 @@
 #include "nix/cmd/command.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdStore : NixMultiCommand
 {
@@ -24,3 +24,5 @@ struct CmdStore : NixMultiCommand
 };
 
 static auto rCmdStore = registerCommand<CmdStore>("store");
+
+} // namespace nix

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -38,8 +38,7 @@
 #  include "nix/util/cgroup.hh"
 #endif
 
-using namespace nix;
-using namespace nix::daemon;
+namespace nix {
 
 /**
  * Settings related to authenticating clients for the Nix daemon.
@@ -106,12 +105,12 @@ static ssize_t splice(int fd_in, void * off_in, int fd_out, void * off_out, size
 {
     // We ignore most parameters, we just have them for conformance with the linux syscall
     std::vector<char> buf(8192);
-    auto read_count = read(fd_in, buf.data(), buf.size());
+    auto read_count = ::read(fd_in, buf.data(), buf.size());
     if (read_count == -1)
         return read_count;
     auto write_count = decltype(read_count)(0);
     while (write_count < read_count) {
-        auto res = write(fd_out, buf.data() + write_count, read_count - write_count);
+        auto res = ::write(fd_out, buf.data() + write_count, read_count - write_count);
         if (res == -1)
             return res;
         write_count += res;
@@ -250,6 +249,8 @@ static void daemonLoop(
     std::optional<TrustedFlag> forceTrustClientOpt,
     std::filesystem::path socketPath)
 {
+    using namespace nix::daemon;
+
     if (chdir("/") == -1)
         throw SysError("cannot change current directory");
 
@@ -404,7 +405,7 @@ static void forwardStdioConnection(RemoteStore & store)
  */
 static void processStdioConnection(ref<Store> store, TrustedFlag trustClient)
 {
-    processConnection(store, FdSource(STDIN_FILENO), FdSink(STDOUT_FILENO), trustClient, NotRecursive);
+    processConnection(store, FdSource(STDIN_FILENO), FdSink(STDOUT_FILENO), trustClient, daemon::NotRecursive);
 }
 
 /**
@@ -622,3 +623,5 @@ struct CmdDaemon : StoreConfigCommand
 };
 
 static auto rCmdDaemon = registerCommand2<CmdDaemon>({"daemon"});
+
+} // namespace nix

--- a/src/nix/unix/store-roots-daemon.cc
+++ b/src/nix/unix/store-roots-daemon.cc
@@ -7,7 +7,7 @@
 
 #include <thread>
 
-using namespace nix;
+namespace nix {
 
 struct CmdRootsDaemon : StoreConfigCommand
 {
@@ -64,3 +64,5 @@ struct CmdRootsDaemon : StoreConfigCommand
 };
 
 static auto rCmdStoreRootsDaemon = registerCommand2<CmdRootsDaemon>({"store", "roots-daemon"});
+
+} // namespace nix

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -13,7 +13,7 @@
 #include "nix/util/config-global.hh"
 #include "self-exe.hh"
 
-using namespace nix;
+namespace nix {
 
 /**
  * Check whether a path has a "profiles" component.
@@ -210,3 +210,5 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 };
 
 static auto rCmdUpgradeNix = registerCommand<CmdUpgradeNix>("upgrade-nix");
+
+} // namespace nix

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -9,7 +9,7 @@
 
 #include "nix/util/exit.hh"
 
-using namespace nix;
+namespace nix {
 
 struct CmdVerify : StorePathsCommand
 {
@@ -186,3 +186,5 @@ struct CmdVerify : StorePathsCommand
 };
 
 static auto rCmdVerify = registerCommand2<CmdVerify>({"store", "verify"});
+
+} // namespace nix

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -7,7 +7,7 @@
 
 #include <queue>
 
-using namespace nix;
+namespace nix {
 
 static std::string hilite(const std::string & s, size_t pos, size_t len, const std::string & colour = ANSI_RED)
 {
@@ -295,3 +295,5 @@ struct CmdWhyDepends : SourceExprCommand, MixOperateOnOptions
 };
 
 static auto rCmdWhyDepends = registerCommand<CmdWhyDepends>("why-depends");
+
+} // namespace nix

--- a/tests/functional/plugins/plugintest.cc
+++ b/tests/functional/plugins/plugintest.cc
@@ -1,7 +1,7 @@
 #include "nix/util/config-global.hh"
 #include "nix/expr/primops.hh"
 
-using namespace nix;
+namespace nix {
 
 struct MySettings : Config
 {
@@ -25,3 +25,5 @@ static RegisterPrimOp rp({
     .arity = 0,
     .impl = prim_anotherNull,
 });
+
+} // namespace nix

--- a/tests/functional/test-libstoreconsumer/main.cc
+++ b/tests/functional/test-libstoreconsumer/main.cc
@@ -3,10 +3,10 @@
 #include "nix/store/build-result.hh"
 #include <iostream>
 
-using namespace nix;
-
 int main(int argc, char ** argv)
 {
+    using namespace nix;
+
     try {
         if (argc != 2) {
             std::cerr << "Usage: " << argv[0] << " store/path/to/something.drv\n";


### PR DESCRIPTION
Instead of pulling in the `nix` namespace at file scope with `using namespace nix;`, wrap the code in `namespace nix { }` blocks. This is cleaner and avoids polluting the global namespace.

Sub-namespace `using namespace nix::*;` declarations are either replaced with explicit qualification (e.g. `linux::getCgroupFS()`) or moved into the functions that need them. All remaining `using namespace` directives now use the fully qualified form (e.g. `using namespace nix::fetchers;` rather than `using namespace fetchers;`).

Also remove `using std::cin;` and `using std::cout;` in `nix-store.cc`, qualifying them explicitly as `std::cin`/`std::cout` instead.

Some POSIX functions (`read`, `write`) that could collide with `nix::` members now use `::` global scope qualification. (`pread` won't collide, but it doesn't hurt to use `::pread` too for symmetry.)

---

Depends on #15653

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
