### PR TITLE
 libutil: Ensure `openFileEnsureBeneathNoSymlinks` throws enough, simplify interface

### DIFF
--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -141,6 +141,11 @@ stdenv.mkDerivation (finalAttrs: {
     nix-functional-tests
   ]
   ++
+    lib.optionals (stdenv.hostPlatform.isLinux && stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+      [
+        nix-util-tests.tests.run-without-new-syscalls
+      ]
+  ++
     lib.optionals (!stdenv.hostPlatform.isStatic && stdenv.buildPlatform.canExecute stdenv.hostPlatform)
       [
         # Perl currently fails in static build

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1273,7 +1273,7 @@ void DerivationBuilderImpl::writeBuilderFile(const std::string & name, std::stri
        a single path component without any `..`, `.` components. */
     auto relPath = CanonPath::fromFilename(name);
     AutoCloseFD fd = openFileEnsureBeneathNoSymlinks(
-        tmpDirFd.get(), relPath, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL | O_NOFOLLOW, 0666);
+        tmpDirFd.get(), relPath, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC | O_EXCL, 0666);
     auto path = tmpDir / relPath.rel(); /* This is used only for error messages. */
     if (!fd)
         throw SysError("creating file %s", PathFmt(path));

--- a/src/libutil-tests/file-system-at.cc
+++ b/src/libutil-tests/file-system-at.cc
@@ -4,6 +4,7 @@
 #include "nix/util/file-system-at.hh"
 #include "nix/util/file-system.hh"
 #include "nix/util/fs-sink.hh"
+#include "nix/util/tests/gmock-matchers.hh"
 
 namespace nix {
 
@@ -120,51 +121,80 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
 
     auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
 
-    // Helper to open files with platform-specific arguments
+    /* Helpers that wrap `openFileEnsureBeneathNoSymlinks` to throw
+       `SysError` on null-fd failure. This way every failure is an
+       exception and tests can use plain `EXPECT_THROW`/`EXPECT_TRUE`
+       without juggling errno-vs-throw state. Callers that want to
+       check a specific errno can catch `SysError` and inspect
+       `.errNo`. */
+    auto check = [](std::string_view what, AutoCloseFD fd) {
+        if (!fd)
+            throw SysError("openFileEnsureBeneathNoSymlinks: %s", what);
+        return fd;
+    };
+
     auto openRead = [&](std::string_view path) -> AutoCloseFD {
-        return openFileEnsureBeneathNoSymlinks(
-            dirFd.get(),
-            CanonPath(path),
+        return check(
+            path,
+            openFileEnsureBeneathNoSymlinks(
+                dirFd.get(),
+                CanonPath(path),
 #ifdef _WIN32
-            FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
-            0
+                FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+                0
 #else
-            O_RDONLY,
-            0
+                O_RDONLY,
+                0
 #endif
-        );
+                ));
     };
 
     auto openReadDir = [&](std::string_view path) -> AutoCloseFD {
-        return openFileEnsureBeneathNoSymlinks(
-            dirFd.get(),
-            CanonPath(path),
+        return check(
+            path,
+            openFileEnsureBeneathNoSymlinks(
+                dirFd.get(),
+                CanonPath(path),
 #ifdef _WIN32
-            FILE_READ_ATTRIBUTES | SYNCHRONIZE,
-            FILE_DIRECTORY_FILE
+                FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+                FILE_DIRECTORY_FILE
 #else
-            O_RDONLY | O_DIRECTORY,
-            0
+                O_RDONLY | O_DIRECTORY,
+                0
 #endif
-        );
+                ));
     };
+
+#if defined(__linux__)
+    auto openReadDirPath = [&](std::string_view path) -> AutoCloseFD {
+        return check(
+            path, openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath(path), O_PATH | O_DIRECTORY | O_CLOEXEC, 0));
+    };
+    auto openPath = [&](std::string_view path) -> AutoCloseFD {
+        return check(path, openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath(path), O_PATH | O_CLOEXEC, 0));
+    };
+#endif
 
     auto openCreateExclusive = [&](std::string_view path) -> AutoCloseFD {
-        return openFileEnsureBeneathNoSymlinks(
-            dirFd.get(),
-            CanonPath(path),
+        return check(
+            path,
+            openFileEnsureBeneathNoSymlinks(
+                dirFd.get(),
+                CanonPath(path),
 #ifdef _WIN32
-            FILE_WRITE_DATA | SYNCHRONIZE,
-            0,
-            FILE_CREATE // Create new file, fail if exists (equivalent to O_CREAT | O_EXCL)
+                FILE_WRITE_DATA | SYNCHRONIZE,
+                0,
+                FILE_CREATE // Create new file, fail if exists (equivalent to O_CREAT | O_EXCL)
 #else
-            O_CREAT | O_WRONLY | O_EXCL,
-            0666
+                O_CREAT | O_WRONLY | O_EXCL,
+                0666
 #endif
-        );
+                ));
     };
 
-    // Test that symlinks are detected and rejected
+    using nix::testing::ThrowsSysError;
+
+    // Symlinks in the path (any position) are rejected.
     EXPECT_THROW(openRead("a/absolute_symlink"), SymlinkNotAllowed);
     EXPECT_THROW(openRead("a/relative_symlink"), SymlinkNotAllowed);
     EXPECT_THROW(openRead("a/absolute_symlink/a"), SymlinkNotAllowed);
@@ -173,21 +203,94 @@ TEST(openFileEnsureBeneathNoSymlinks, works)
     EXPECT_THROW(openRead("a/b/c/d"), SymlinkNotAllowed);
     EXPECT_THROW(openRead("a/broken_symlink"), SymlinkNotAllowed);
 
+    /* Trailing symlink with `O_DIRECTORY` (no `O_NOFOLLOW`): the
+       syscall reports `ELOOP`, handled by the direct
+       `SymlinkNotAllowed` throw in `openFileEnsureBeneathNoSymlinks`. */
+    EXPECT_THROW(openReadDir("a/absolute_symlink"), SymlinkNotAllowed);
+    EXPECT_THROW(openReadDir("a/relative_symlink"), SymlinkNotAllowed);
+    EXPECT_THROW(openReadDir("a/b/c"), SymlinkNotAllowed);
+    EXPECT_THROW(openReadDir("a/broken_symlink"), SymlinkNotAllowed);
+
+#if defined(__linux__)
+    // Same thing for `O_PATH | O_DIRECTORY` (Linux-only flag).
+    EXPECT_THROW(openReadDirPath("a/absolute_symlink"), SymlinkNotAllowed);
+    EXPECT_THROW(openReadDirPath("a/relative_symlink"), SymlinkNotAllowed);
+    EXPECT_THROW(openReadDirPath("a/b/c"), SymlinkNotAllowed);
+    EXPECT_THROW(openReadDirPath("a/broken_symlink"), SymlinkNotAllowed);
+
+    /* `O_PATH` on a trailing symlink is allowed: the caller gets a
+       path fd referring to the symlink itself. Interior symlinks are
+       still rejected. */
+    EXPECT_TRUE(openPath("a/absolute_symlink"));
+    EXPECT_TRUE(openPath("a/relative_symlink"));
+    EXPECT_TRUE(openPath("a/b/c"));
+    EXPECT_TRUE(openPath("a/broken_symlink"));
+    EXPECT_THROW(openPath("a/absolute_symlink/a"), SymlinkNotAllowed);
+    EXPECT_THROW(openPath("a/absolute_symlink/c/d"), SymlinkNotAllowed);
+    EXPECT_THROW(openPath("a/relative_symlink/c"), SymlinkNotAllowed);
+    EXPECT_THROW(openPath("a/b/c/d"), SymlinkNotAllowed);
+#endif
+
 #if !defined(_WIN32) && !defined(__CYGWIN__)
-    // This returns ELOOP on cygwin when O_NOFOLLOW is used
-    EXPECT_FALSE(openCreateExclusive("a/broken_symlink"));
-    /* Sanity check, no symlink shenanigans and behaves the same as regular openat with O_EXCL | O_CREAT. */
-    EXPECT_EQ(errno, EEXIST);
+    /* Sanity check: behaves the same as plain openat with
+       `O_EXCL | O_CREAT` on an existing broken-symlink path —
+       the symlink counts as "already there". */
+    EXPECT_THAT([&] { openCreateExclusive("a/broken_symlink"); }, ThrowsSysError(EEXIST));
 #endif
     EXPECT_THROW(openCreateExclusive("a/absolute_symlink/broken_symlink"), SymlinkNotAllowed);
 
-    // Test invalid paths
-    EXPECT_FALSE(openRead("c/d/regular/a"));
-    EXPECT_FALSE(openReadDir("c/d/regular"));
+    // Non-symlink failure modes: errno must survive.
+    EXPECT_THAT([&] { openRead("c/d/regular/a"); }, ThrowsSysError(ENOTDIR));
+    EXPECT_THAT([&] { openReadDir("c/d/regular"); }, ThrowsSysError(ENOTDIR));
+    EXPECT_THAT([&] { openRead("c/d/nonexistent"); }, ThrowsSysError(ENOENT));
 
-    // Test valid paths work
+    // Happy paths.
     EXPECT_TRUE(openRead("c/d/regular"));
+    EXPECT_TRUE(openReadDir("c"));
+    EXPECT_TRUE(openReadDir("c/d"));
     EXPECT_TRUE(openCreateExclusive("a/regular"));
+#if defined(__linux__)
+    EXPECT_TRUE(openReadDirPath("c"));
+    EXPECT_TRUE(openReadDirPath("c/d"));
+    EXPECT_TRUE(openPath("c/d/regular"));
+    EXPECT_TRUE(openPath("c"));
+#endif
 }
+
+/* ----------------------------------------------------------------------------
+ * openFileEnsureBeneathNoSymlinks — O_NOFOLLOW is forbidden
+ * --------------------------------------------------------------------------*/
+
+#if !defined(_WIN32)
+TEST(openFileEnsureBeneathNoSymlinksDeathTest, rejectsONofollow)
+{
+    std::filesystem::path tmpDir = nix::createTempDir();
+    nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
+
+    {
+        RestoreSink sink(/*startFsync=*/false);
+        sink.dstPath = tmpDir;
+        sink.dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+        sink.createRegularFile(CanonPath("file"), [](CreateRegularFileSink & crf) {});
+    }
+
+    auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
+
+    /* The function asserts that callers don't pass `O_NOFOLLOW` — it
+       owns symlink policy. Verify the assert fires for every flag
+       combination that includes `O_NOFOLLOW`. */
+    EXPECT_DEATH(
+        openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_RDONLY | O_NOFOLLOW, 0), "O_NOFOLLOW");
+    EXPECT_DEATH(
+        openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_RDONLY | O_DIRECTORY | O_NOFOLLOW, 0),
+        "O_NOFOLLOW");
+#  if defined(__linux__)
+    EXPECT_DEATH(openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_PATH | O_NOFOLLOW, 0), "O_NOFOLLOW");
+    EXPECT_DEATH(
+        openFileEnsureBeneathNoSymlinks(dirFd.get(), CanonPath("file"), O_PATH | O_DIRECTORY | O_NOFOLLOW, 0),
+        "O_NOFOLLOW");
+#  endif
+}
+#endif
 
 } // namespace nix

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -126,3 +126,27 @@ test(
   },
   protocol : 'gtest',
 )
+
+# Run the same tests again under `enosys -d openat2` to exercise the
+# iterative (non-openat2) fallback path on Linux.  `enosys` uses
+# seccomp to make `openat2` return `ENOSYS`, which the wrapper in
+# file-system-at.cc caches and falls back to the iterative impl.
+if host_machine.system() == 'linux'
+  enosys = find_program('enosys', required : false)
+  if enosys.found()
+    test(
+      meson.project_name() + '-without-new-syscalls',
+      enosys,
+      args : [
+        '--syscall', 'openat2',
+        '--syscall', 'fchmodat2',
+        '--',
+        this_exe,
+      ],
+      env : {
+        '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
+      },
+      protocol : 'gtest',
+    )
+  endif
+endif

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -11,6 +11,7 @@
   rapidcheck,
   gtest,
   runCommand,
+  util-linux,
 
   # Configuration Options
 
@@ -44,6 +45,9 @@ mkMesonExecutable (finalAttrs: {
     nix-util-test-support
     rapidcheck
     gtest
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    util-linux
   ];
 
   mesonFlags = [
@@ -67,7 +71,29 @@ mkMesonExecutable (finalAttrs: {
               touch $out
             ''
           );
-    };
+    }
+    //
+      lib.optionalAttrs
+        (stdenv.hostPlatform.isLinux && stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+        {
+          # Run the same tests with newer syscalls disabled via seccomp,
+          # to exercise fallback paths (iterative openat for openat2,
+          # /proc/self/fd for fchmodat2).
+          run-without-new-syscalls =
+            runCommand "${finalAttrs.pname}-run-without-new-syscalls"
+              {
+                meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
+                nativeBuildInputs = [ util-linux ];
+              }
+              ''
+                export _NIX_TEST_UNIT_DATA=${./data}
+                enosys \
+                  --syscall openat2 \
+                  --syscall fchmodat2 \
+                  -- ${lib.getExe finalAttrs.finalPackage}
+                touch $out
+              '';
+        };
   };
 
   meta = {

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -90,7 +90,7 @@ void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallba
         FILE_READ_ATTRIBUTES | SYNCHRONIZE,
         FILE_DIRECTORY_FILE
 #else
-        O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC,
+        O_RDONLY | O_DIRECTORY | O_CLOEXEC,
         0
 #endif
     );

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -72,25 +72,45 @@ PosixStat fstatat(Descriptor dirFd, const std::filesystem::path & path);
 OsString readLinkAt(Descriptor dirFd, const CanonPath & path);
 
 /**
- * Safe(r) function to open a file relative to dirFd, while
- * disallowing escaping from a directory and any symlinks in the process.
+ * Open a file relative to @p dirFd, ensuring the path stays beneath
+ * @p dirFd and that no path component is a symlink (with the
+ * exception that `O_PATH` (without `O_DIRECTORY`) on Unix permits a
+ * trailing symlink).
  *
- * @note On Windows, implemented via NtCreateFile single path component traversal
- * with FILE_OPEN_REPARSE_POINT. On Unix, uses RESOLVE_BENEATH with openat2 when
- * available, or falls back to openat single path component traversal.
+ * Callers must not pass `O_NOFOLLOW` on Unix (enforced by assert);
+ * this function owns symlink policy and handles the flag internally.
  *
  * @param dirFd Directory handle to open relative to
- * @param path Relative path (no .. or . components)
- * @param desiredAccess (Windows) Windows ACCESS_MASK (e.g., GENERIC_READ, FILE_WRITE_DATA)
- * @param createOptions (Windows) Windows create options (e.g., FILE_NON_DIRECTORY_FILE)
- * @param createDisposition (Windows) FILE_OPEN, FILE_CREATE, etc.
- * @param flags (Unix) O_* flags
- * @param mode (Unix) Mode for O_{CREAT,TMPFILE}
+ * @param path Relative path (with no `..` or `.` components)
  *
- * @pre path.isRoot() is false
+ * @param desiredAccess (Windows) Windows `ACCESS_MASK`
+ * @param createOptions (Windows) Windows create options
+ * @param createDisposition (Windows) `FILE_OPEN`, `FILE_CREATE`, etc.
  *
- * @throws SymlinkNotAllowed if any path components are symlinks
- * @throws SystemError on other errors
+ * @param flags (Unix) `O_*` flags (must not include `O_NOFOLLOW`)
+ * @param mode (Unix) Mode for `O_{CREAT,TMPFILE}`
+ *
+ * @pre `path.isRoot()` is false
+ *
+ * @throws SymlinkNotAllowed if an interior path component is a
+ *     symlink, or if the final component is a symlink and `O_PATH`
+ *     (without `O_DIRECTORY`) was *not* passed. With `O_PATH`
+ *     (without `O_DIRECTORY`) on Unix, a trailing symlink is
+ *     permitted and the caller receives a "path fd" to the symlink
+ *     itself.
+ *
+ * @note With `O_CREAT | O_EXCL`, a pre-existing symlink at the
+ *     final component causes the OS to return `EEXIST` rather
+ *     than `ELOOP`, so `SymlinkNotAllowed` is *not* thrown — the
+ *     caller sees a failed descriptor with `errno == EEXIST`.
+ *
+ * @return A valid descriptor on success, or an invalid descriptor
+ *     on non-symlink errors (Unix: `errno` set, e.g. `ENOENT`,
+ *     `ENOTDIR`, `EACCES`; Windows: last error set). The caller is
+ *     responsible for checking the return value.
+ *
+ *     `errno` will never be `ELOOP` because that case is translated
+ *     to a `SymlinkNotAllowed` throw instead.
  */
 AutoCloseFD openFileEnsureBeneathNoSymlinks(
     Descriptor dirFd,

--- a/src/libutil/unix/file-system-at.cc
+++ b/src/libutil/unix/file-system-at.cc
@@ -175,6 +175,9 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
             });
 
             if (errno == ENOTDIR) /* Path component might be a symlink. */ {
+                /* Does not follow final symlink. We know `component` is a
+                   single component so we don't have to worry about intermediate
+                   symlinks either. */
                 if (auto st = maybeFstatat(getParentFd(), component); st && S_ISLNK(st->st_mode))
                     throw SymlinkNotAllowed(path2);
                 errno = ENOTDIR; /* Restore the errno. */
@@ -188,25 +191,78 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
         parentFd = std::move(parentFd2);
     }
 
-    AutoCloseFD res = ::openat(getParentFd(), std::string(path.baseName().value()).c_str(), flags | O_NOFOLLOW, mode);
-    if (!res && errno == ELOOP)
-        throw SymlinkNotAllowed(path);
+    auto lastComponent = std::string(path.baseName().value());
+    AutoCloseFD res = ::openat(getParentFd(), lastComponent.c_str(), flags | O_NOFOLLOW, mode);
+
+    if (!res) {
+        if (errno == ELOOP)
+            throw SymlinkNotAllowed(path);
+        /* `O_DIRECTORY | O_NOFOLLOW` on a trailing symlink returns
+           `ENOTDIR` rather than `ELOOP`. Post-check via `fstatat` to
+           disambiguate — only on the error path, so the common
+           successful-directory-open case pays no extra syscall. */
+        if (errno == ENOTDIR) {
+            if (auto st = maybeFstatat(getParentFd(), lastComponent); st && S_ISLNK(st->st_mode))
+                throw SymlinkNotAllowed(path);
+            /* Put back errno so the caller will get the original
+               error. */
+            errno = ENOTDIR;
+        }
+        return res;
+    }
+
+    /* For `O_PATH`, the defensive `| O_NOFOLLOW` we added above
+       means a trailing symlink silently succeeds with an fd to the
+       symlink itself (`O_PATH | O_NOFOLLOW` is the idiomatic way to
+       obtain a symlink fd). This is intentional — `O_PATH` callers
+       are asking for a path reference, and interior symlinks are
+       already guarded by the component-by-component walk above. */
+
     return res;
 }
 
 AutoCloseFD openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & path, int flags, mode_t mode)
 {
-    assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */
+    /* Just in case the invariant is somehow broken. */
+    assert(!path.rel().starts_with('/'));
     assert(!path.isRoot());
+
+    /* We don't want callers of this function to think about the presence or
+       absence of `O_NOFOLLOW`. "ensure beneath no symlinks" is in the name, so
+       we want them to trust us to handle it instead. */
+    assert(!(flags & O_NOFOLLOW));
+
+    /* See doxygen in `file-system-at.hh` for why we reject this. */
+
 #if HAVE_OPENAT2
-    auto maybeFd = linux::openat2(
-        dirFd, path.rel_c_str(), flags, static_cast<uint64_t>(mode), RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS);
-    if (maybeFd) {
+    /* Two things are being fixed here:
+
+       1. For `O_PATH` (without `O_DIRECTORY`), add `O_NOFOLLOW` so
+          that a trailing symlink returns an fd to the symlink itself
+          rather than `ELOOP`. `O_PATH | O_NOFOLLOW` is the idiomatic
+          way to obtain a symlink fd, and `RESOLVE_NO_SYMLINKS` does
+          not refuse it.
+
+       2. We must not add `O_NOFOLLOW` when `O_DIRECTORY` is set,
+          because `O_DIRECTORY | O_NOFOLLOW` on a trailing symlink
+          returns `ENOTDIR` instead of `ELOOP`. Interior symlinks are
+          still caught by `RESOLVE_NO_SYMLINKS` regardless, but the
+          non-inclusion of `O_NOFOLLOW` is needed for
+          `RESOLVE_NO_SYMLINKS` to make the final symlink an `ELOOP`
+          rather than `O_DIRECTORY` making it an `ENOTDIR`.
+
+       For other cases, `O_NOFOLLOW` doesn't really matter, but we
+       default to not including it. */
+    auto flagsAdj = (flags & O_PATH) && !(flags & O_DIRECTORY) ? flags | O_NOFOLLOW : flags;
+
+    if (auto maybeFd = linux::openat2(
+            dirFd, path.rel_c_str(), flagsAdj, static_cast<uint64_t>(mode), RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)) {
         if (!*maybeFd && errno == ELOOP)
             throw SymlinkNotAllowed(path);
         return std::move(*maybeFd);
     }
 #endif
+
     return openFileEnsureBeneathNoSymlinksIterative(dirFd, path, flags, mode);
 }
 


### PR DESCRIPTION
We had some issues where `openFileEnsureBeneathNoSymlinks` was not always throwing `SymlinkNotAllowed` when expected. This wasn't necessarily a problem, but opened the door to a bad situation where callers might handle different errors differently in unexpected and unintentional ways.

When I was investigating this, I realized the presence or absence of `O_NOFOLLOW` in the caller-provided flags was doubling the number of cases that we needed to handle, and this was becoming quite burdensome. The function doesn't need to work with arbitrary, e.g. user-provided flags. All its callers (at least eventually, if you trace back far enough) in Nix should always have statically-known flags. So we can use our own invariants to cut down that state space.

Specifically, callers of `openFileEnsureBeneathNoSymlinks` should never pass `O_NOFOLLOW` — the function owns symlink policy (it's in the name). Add an assert enforcing this and drop `O_NOFOLLOW` from the one caller that had it (`fs-sink.cc`'s directory open). Each implementation then handles trailing-symlink detection internally:

  - The `openat2` path uses `RESOLVE_NO_SYMLINKS`, which gives a uniform `ELOOP` for every trailing-symlink case.

  - The iterative fallback adds its own defensive `O_NOFOLLOW` on the final `::openat`, with post-checks for two kernel oddities where `O_NOFOLLOW` produces unexpected results (`O_DIRECTORY` gives `ENOTDIR` instead of `ELOOP`; `O_PATH` silently succeeds with a symlink fd).

With `O_PATH` (without `O_DIRECTORY`), a trailing symlink is intentionally allowed — the caller gets a path fd to the symlink itself. Interior symlinks are always rejected regardless of flags.

Also add comprehensive tests covering every flag combination (`O_RDONLY`, `O_DIRECTORY`, `O_PATH | O_DIRECTORY`, `O_PATH`), including symlink rejection, trailing-symlink-fd success for `O_PATH`, non-symlink `ENOTDIR` propagation, happy paths, and death tests for the `O_NOFOLLOW` assert.

---

Depends on #15653

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
