### PR TITLE
feat(cli): add `--tree` flag for evaluating a Nix file from a fetchTree URL

### DIFF
--- a/doc/manual/rl-next/tree-cli-flag.md
+++ b/doc/manual/rl-next/tree-cli-flag.md
@@ -1,0 +1,24 @@
+---
+synopsis: "Add a `--tree` CLI flag for evaluating a Nix expression from a remote tree"
+issues: [10047]
+---
+
+New CLI commands (`nix eval`, `nix build`, `nix repl`, ...) and the
+legacy `nix-instantiate`, `nix-build` and `nix-shell` commands now
+accept a `--tree <tree-ref>` flag. It takes any reference understood by
+[`builtins.fetchTree`](@docroot@/language/builtins.md#builtins-fetchTree)
+— for example `github:NixOS/nixpkgs` or `git+https://example.com/repo` —
+fetches it into the store, and evaluates the `default.nix` inside the
+fetched tree. Installables / `--attr` values are resolved as attribute
+paths within that expression.
+
+It is the non-flake counterpart of the flake-ref syntax used by the new
+CLI and is similar in spirit to running
+`nix eval --file "$(nix flake prefetch <tree-ref> --json | jq -r .storePath)" attr.path`,
+but without requiring the `flakes` experimental feature. The flag is
+gated on the `fetch-tree` experimental feature (which is implied by
+`flakes`).
+
+`--tree` is mutually exclusive with `--file` / `--expr` (new CLI), with
+`--expr` / `-E`, `-p`, positional file arguments and reading from stdin
+(legacy CLI).

--- a/doc/manual/source/command-ref/opt-common.md
+++ b/doc/manual/source/command-ref/opt-common.md
@@ -203,6 +203,17 @@ Most Nix commands accept the following command-line options:
   For `nix-shell`, this option is commonly used to give you a shell in which you can build the packages returned by the expression.
   If you want to get a shell which contain the *built* packages ready for use, give your expression to the `nix-shell --packages ` convenience flag instead.
 
+- <span id="opt-tree">[`--tree`](#opt-tree)</span> *tree-ref*
+
+  Fetch *tree-ref* using the [`fetchTree`](@docroot@/language/builtins.md#builtins-fetchTree) infrastructure and evaluate the `default.nix` inside the fetched tree.
+  *tree-ref* is any reference understood by `builtins.fetchTree`, such as `github:NixOS/nixpkgs` or `git+https://example.com/repo`.
+  Positional `--attr` / `-A` attribute paths select attributes from the resulting expression.
+  (`nix-instantiate`, `nix-build` and `nix-shell` only.)
+
+  This flag cannot be combined with positional file arguments, `--expr` / `-E`, `-p` (for `nix-shell`), or reading from standard input.
+
+  `--tree` requires the [`fetch-tree`](@docroot@/development/experimental-features.md#xp-feature-fetch-tree) experimental feature (which is implied by [`flakes`](@docroot@/development/experimental-features.md#xp-feature-flakes)).
+
 - <span id="opt-I">[`-I` / `--include`](#opt-I)</span> *path*
 
   Add an entry to the list of search paths used to resolve [lookup paths](@docroot@/language/constructs/lookup-path.md).

--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -204,4 +204,15 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s, const std::files
         return state.rootPath(absPath(std::filesystem::path{s}, baseDir).string());
 }
 
+SourcePath fetchTreeArg(EvalState & state, std::string_view treeRef, const std::filesystem::path & baseDir)
+{
+    experimentalFeatureSettings.require(Xp::FetchTree);
+    auto flakeRef = parseFlakeRef(fetchSettings, std::string{treeRef}, baseDir, true, false);
+    auto [accessor, lockedRef] = flakeRef.resolve(fetchSettings, *state.store).lazyFetch(fetchSettings, *state.store);
+    auto storePath = nix::fetchToStore(
+        state.fetchSettings, *state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
+    state.allowPath(storePath);
+    return state.storePath(storePath);
+}
+
 } // namespace nix

--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -152,6 +152,7 @@ struct SourceExprCommand : virtual Args, MixFlakeOptions
 {
     std::optional<std::filesystem::path> file;
     std::optional<std::string> expr;
+    std::optional<std::string> tree;
 
     SourceExprCommand();
 

--- a/src/libcmd/include/nix/cmd/common-eval-args.hh
+++ b/src/libcmd/include/nix/cmd/common-eval-args.hh
@@ -87,4 +87,21 @@ private:
  */
 SourcePath lookupFileArg(EvalState & state, std::string_view s, const std::filesystem::path * baseDir = nullptr);
 
+/**
+ * Fetch a tree reference (as accepted by the `--tree` CLI flag and by
+ * [`builtins.fetchTree`](@docroot@/language/builtins.md#builtins-fetchTree))
+ * into the store and return a `SourcePath` that can be passed to
+ * `EvalState::evalFile`.
+ *
+ * This is the implementation shared between the new CLI's `--tree`
+ * flag (in `SourceExprCommand`) and the legacy `nix-build` /
+ * `nix-instantiate` commands.
+ *
+ * Requires the `fetch-tree` experimental feature.
+ *
+ * @param baseDir Base directory used to resolve relative path
+ * references (typically the command base directory).
+ */
+SourcePath fetchTreeArg(EvalState & state, std::string_view treeRef, const std::filesystem::path & baseDir);
+
 } // namespace nix

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -223,6 +223,22 @@ SourceExprCommand::SourceExprCommand()
         .labels = {"expr"},
         .handler = {&expr},
     });
+
+    addFlag({
+        .longName = "tree",
+        .description =
+            "Interpret [*installables*](@docroot@/command-ref/new-cli/nix.md#installables) as attribute paths relative to the Nix expression stored in the tree fetched from *tree-ref*. "
+            "*tree-ref* is any reference accepted by [`builtins.fetchTree`](@docroot@/language/builtins.md#builtins-fetchTree), such as `github:NixOS/nixpkgs` or `git+https://example.com/repo`. "
+            "This flag is the non-flake equivalent of the flake-ref syntax used by the new CLI: it fetches a source tree and evaluates `default.nix` inside it. "
+            "Implies `--impure`.",
+        .category = installablesCategory,
+        .labels = {"tree-ref"},
+        .handler = {&tree},
+        .completer = {[&](AddCompletions & completions, size_t, std::string_view prefix) {
+            completeFlakeRef(completions, getEvalState()->store, prefix);
+        }},
+        .experimentalFeature = Xp::FetchTree,
+    });
 }
 
 MixReadOnlyOption::MixReadOnlyOption()
@@ -261,12 +277,14 @@ Args::CompleterClosure SourceExprCommand::getCompleteInstallable()
 void SourceExprCommand::completeInstallable(AddCompletions & completions, std::string_view prefix)
 {
     try {
-        if (file) {
+        if (file || tree) {
             completions.setType(AddCompletions::Type::Attrs);
 
             evalSettings.pureEval = false;
             auto state = getEvalState();
-            auto e = state->parseExprFromFile(resolveExprPath(lookupFileArg(*state, file->string())));
+            auto sourcePath = file ? lookupFileArg(*state, file->string())
+                                   : fetchTreeArg(*state, *tree, absPath(getCommandBaseDir()));
+            auto e = state->parseExprFromFile(resolveExprPath(sourcePath));
 
             Value root;
             state->eval(e, root);
@@ -447,14 +465,14 @@ Installables SourceExprCommand::parseInstallables(ref<Store> store, std::vector<
 {
     Installables result;
 
-    if (file || expr) {
-        if (file && expr)
-            throw UsageError("'--file' and '--expr' are exclusive");
+    if (file || expr || tree) {
+        if ((file && expr) || (file && tree) || (expr && tree))
+            throw UsageError("'--file', '--expr' and '--tree' are mutually exclusive");
 
         // FIXME: backward compatibility hack
-        if (file) {
+        if (file || tree) {
             if (evalSettings.pureEval && evalSettings.pureEval.overridden)
-                throw UsageError("'--file' is not compatible with '--pure-eval'");
+                throw UsageError("'%s' is not compatible with '--pure-eval'", file ? "--file" : "--tree");
             evalSettings.pureEval = false;
         }
 
@@ -467,6 +485,9 @@ Installables SourceExprCommand::parseInstallables(ref<Store> store, std::vector<
         } else if (file) {
             auto dir = absPath(getCommandBaseDir());
             state->evalFile(lookupFileArg(*state, file->string(), &dir), *vFile);
+        } else if (tree) {
+            auto dir = absPath(getCommandBaseDir());
+            state->evalFile(fetchTreeArg(*state, *tree, dir), *vFile);
         } else {
             auto dir = absPath(getCommandBaseDir());
             auto e = state->parseExprFromString(*expr, state->rootPath(dir.string()));

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -132,6 +132,7 @@ static void main_nix_build(int argc, char ** argv)
     auto interactive = isatty(STDIN_FILENO) && isatty(STDERR_FILENO);
     Strings attrPaths;
     Strings remainingArgs;
+    std::optional<std::string> treeRef;
     BuildMode buildMode = bmNormal;
     bool readStdin = false;
 
@@ -252,6 +253,9 @@ static void main_nix_build(int argc, char ** argv)
         else if (*arg == "--expr" || *arg == "-E")
             fromArgs = true;
 
+        else if (*arg == "--tree")
+            treeRef = getArg(*arg, arg, end);
+
         else if (*arg == "--pure")
             pure = true;
         else if (*arg == "--impure")
@@ -317,6 +321,17 @@ static void main_nix_build(int argc, char ** argv)
     if (packages && fromArgs)
         throw UsageError("'-p' and '-E' are mutually exclusive");
 
+    if (treeRef) {
+        if (fromArgs)
+            throw UsageError("'--tree' and '--expr' are mutually exclusive");
+        if (packages)
+            throw UsageError("'--tree' and '-p' are mutually exclusive");
+        if (!remainingArgs.empty())
+            throw UsageError("'--tree' cannot be combined with positional file arguments");
+        if (readStdin)
+            throw UsageError("'--tree' and '-' (read from stdin) are mutually exclusive");
+    }
+
     auto store = openStore();
     auto evalStore = myArgs.evalStoreUrl ? openStore(StoreReference{*myArgs.evalStoreUrl}) : store;
 
@@ -376,7 +391,11 @@ static void main_nix_build(int argc, char ** argv)
 
     if (readStdin)
         exprs = {state->parseStdin()};
-    else
+    else if (treeRef) {
+        auto sourcePath = fetchTreeArg(*state, *treeRef, absPath(myArgs.getCommandBaseDir()));
+        auto resolvedPath = isNixShell ? resolveShellExprPath(sourcePath) : resolveExprPath(sourcePath);
+        exprs.push_back(state->parseExprFromFile(resolvedPath));
+    } else
         for (auto i : remainingArgs) {
             auto shebangBaseDir = absPath(script.parent_path());
             if (fromArgs) {

--- a/src/nix/nix-instantiate/nix-instantiate.cc
+++ b/src/nix/nix-instantiate/nix-instantiate.cc
@@ -101,6 +101,7 @@ static int main_nix_instantiate(int argc, char ** argv)
 {
     {
         Strings files;
+        std::optional<std::string> treeRef;
         bool readStdin = false;
         bool fromArgs = false;
         bool findFile = false;
@@ -126,6 +127,8 @@ static int main_nix_instantiate(int argc, char ** argv)
                 readStdin = true;
             else if (*arg == "--expr" || *arg == "-E")
                 fromArgs = true;
+            else if (*arg == "--tree")
+                treeRef = getArg(*arg, arg, end);
             else if (*arg == "--eval" || *arg == "--eval-only")
                 evalOnly = true;
             else if (*arg == "--read-write-mode")
@@ -161,6 +164,17 @@ static int main_nix_instantiate(int argc, char ** argv)
 
         myArgs.parseCmdline(argvToStrings(argc, argv));
 
+        if (treeRef) {
+            if (fromArgs)
+                throw UsageError("'--tree' and '--expr' are mutually exclusive");
+            if (findFile)
+                throw UsageError("'--tree' and '--find-file' are mutually exclusive");
+            if (readStdin)
+                throw UsageError("'--tree' and '-' (read from stdin) are mutually exclusive");
+            if (!files.empty())
+                throw UsageError("'--tree' cannot be combined with positional file arguments");
+        }
+
         if (evalOnly && !wantsReadWrite)
             settings.readOnlyMode = true;
 
@@ -188,6 +202,11 @@ static int main_nix_instantiate(int argc, char ** argv)
 
         if (readStdin) {
             Expr * e = state->parseStdin();
+            processExpr(
+                *state, attrPaths, parseOnly, strict, autoArgs, evalOnly, outputKind, xmlOutputSourceLocation, e);
+        } else if (treeRef) {
+            auto sourcePath = fetchTreeArg(*state, *treeRef, absPath(myArgs.getCommandBaseDir()));
+            Expr * e = state->parseExprFromFile(resolveExprPath(sourcePath));
             processExpr(
                 *state, attrPaths, parseOnly, strict, autoArgs, evalOnly, outputKind, xmlOutputSourceLocation, e);
         } else if (files.empty() && !fromArgs)

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -446,6 +446,29 @@ nix store delete "$(nix store add-path "$badFlakeDir")"
 [[ $(nix-instantiate -I flake3=flake:flake3 --eval '<flake3>' -A x) = 123 ]]
 [[ $(NIX_PATH=flake3=flake:flake3 nix-instantiate --eval '<flake3>' -A x) = 123 ]]
 
+# Test the `--tree` flag: evaluate a `default.nix` from a tree reference
+# without requiring the `flakes` experimental feature.
+[[ $(nix eval --extra-experimental-features fetch-tree --tree "git+file://$percentEncodedFlake3Dir" x) = 123 ]]
+[[ $(nix eval --tree "git+file://$percentEncodedFlake3Dir" x) = 123 ]]
+# `--tree` and `--file` are mutually exclusive.
+expectStderr 1 nix eval --tree "git+file://$percentEncodedFlake3Dir" --file "$flake3Dir/default.nix" x \
+    | grepQuiet "mutually exclusive"
+# `--tree` requires the `fetch-tree` experimental feature when flakes are disabled.
+expectStderr 1 nix eval --experimental-features 'nix-command' --tree "git+file://$percentEncodedFlake3Dir" x \
+    | grepQuiet "experimental"
+
+# `--tree` also works with the legacy CLI (`nix-instantiate`, `nix-build`).
+[[ $(nix-instantiate --extra-experimental-features fetch-tree --eval --tree "git+file://$percentEncodedFlake3Dir" -A x) = 123 ]]
+[[ $(nix-instantiate --eval --tree "git+file://$percentEncodedFlake3Dir" -A x) = 123 ]]
+# `--tree` is mutually exclusive with `--expr` and positional file arguments in the legacy CLI.
+expectStderr 1 nix-instantiate --eval --tree "git+file://$percentEncodedFlake3Dir" --expr "1" \
+    | grepQuiet "mutually exclusive"
+expectStderr 1 nix-instantiate --eval --tree "git+file://$percentEncodedFlake3Dir" "$flake3Dir/default.nix" \
+    | grepQuiet "positional file arguments"
+# `--tree` in the legacy CLI is also gated on the `fetch-tree` experimental feature.
+expectStderr 1 nix-instantiate --experimental-features '' --eval --tree "git+file://$percentEncodedFlake3Dir" -A x \
+    | grepQuiet "experimental"
+
 # Test alternate lockfile paths.
 nix flake lock "$flake2Dir" --output-lock-file "$TEST_ROOT"/flake2.lock
 cmp "$flake2Dir/flake.lock" "$TEST_ROOT"/flake2.lock >/dev/null # lockfiles should be identical, since we're referencing flake2's original one


### PR DESCRIPTION
provides for a non-flake way to use fetchtree by cli.
works with both v3 and v2 commands.

usage:

```sh
# v2
nix-instantiate --extra-experimental-features 'fetch-tree' --eval --tree 'github:NixOS/nixpkgs' -A lib.version
nix-build --extra-experimental-features 'fetch-tree' --no-out-link --tree 'github:NixOS/nixpkgs' -A hello
nix-shell --extra-experimental-features 'fetch-tree' --tree 'github:NixOS/nixpkgs' -A hello --run 'hello'
# v3
nix --extra-experimental-features 'nix-command fetch-tree' eval --tree 'github:NixOS/nixpkgs' lib.version
```

(`fetch-tree` is implied in `flakes`)

## Motivation

closes #10047.

## Context

disclaimer i used a coding agent in the creation of this patch.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
