### PR TITLE
registry: file option

### DIFF
--- a/src/libfetchers/include/nix/fetchers/registry.hh
+++ b/src/libfetchers/include/nix/fetchers/registry.hh
@@ -56,6 +56,8 @@ std::filesystem::path getUserRegistryPath();
 
 Registries getRegistries(const Settings & settings, Store & store);
 
+Registries getRegistries(const Settings & settings, Store & store, const std::shared_ptr<Registry> & customRegistry);
+
 void overrideRegistry(const Input & from, const Input & to, const Attrs & extraAttrs);
 
 enum class UseRegistries : int {
@@ -65,10 +67,15 @@ enum class UseRegistries : int {
 };
 
 /**
- * Rewrite a flakeref using the registries. If `filter` is set, only
- * use the registries for which the filter function returns true.
+ * Rewrite a flakeref using the registries selected by `useRegistries`.
+ * If `customRegistry` is set, it is inserted between the flag and
+ * user registries in precedence order.
  */
-std::pair<Input, Attrs>
-lookupInRegistries(const Settings & settings, Store & store, const Input & input, UseRegistries useRegistries);
+std::pair<Input, Attrs> lookupInRegistries(
+    const Settings & settings,
+    Store & store,
+    const Input & input,
+    UseRegistries useRegistries,
+    const std::shared_ptr<Registry> & customRegistry = {});
 
 } // namespace nix::fetchers

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -120,9 +120,8 @@ std::shared_ptr<Registry> getUserRegistry(const Settings & settings)
 
 std::shared_ptr<Registry> getCustomRegistry(const Settings & settings, const std::filesystem::path & p)
 {
-    static auto customRegistry = Registry::read(
+    return Registry::read(
         settings, SourcePath{getFSSourceAccessor(), CanonPath{p.string()}}.resolveSymlinks(), Registry::Custom);
-    return customRegistry;
 }
 
 std::shared_ptr<Registry> getFlagRegistry()
@@ -165,16 +164,27 @@ static std::shared_ptr<Registry> getGlobalRegistry(const Settings & settings, St
 
 Registries getRegistries(const Settings & settings, Store & store)
 {
+    return getRegistries(settings, store, {});
+}
+
+Registries getRegistries(const Settings & settings, Store & store, const std::shared_ptr<Registry> & customRegistry)
+{
     Registries registries;
     registries.push_back(getFlagRegistry());
+    if (customRegistry)
+        registries.push_back(customRegistry);
     registries.push_back(getUserRegistry(settings));
     registries.push_back(getSystemRegistry(settings));
     registries.push_back(getGlobalRegistry(settings, store));
     return registries;
 }
 
-std::pair<Input, Attrs>
-lookupInRegistries(const Settings & settings, Store & store, const Input & _input, UseRegistries useRegistries)
+std::pair<Input, Attrs> lookupInRegistries(
+    const Settings & settings,
+    Store & store,
+    const Input & _input,
+    UseRegistries useRegistries,
+    const std::shared_ptr<Registry> & customRegistry)
 {
     Attrs extraAttrs;
     int n = 0;
@@ -189,7 +199,7 @@ restart:
     if (n > 100)
         throw Error("cycle detected in flake registry for '%s'", input.to_string());
 
-    for (auto & registry : getRegistries(settings, store)) {
+    for (auto & registry : getRegistries(settings, store, customRegistry)) {
         if (useRegistries == UseRegistries::Limited
             && !(registry->type == fetchers::Registry::Flag || registry->type == fetchers::Registry::Global))
             continue;

--- a/src/nix/registry-add.md
+++ b/src/nix/registry-add.md
@@ -25,7 +25,7 @@ R""(
   registry:
 
   ```console
-  nix registry add --registry ./custom-flake-registry.json nixpkgs github:nixos/nixpkgs
+  nix registry add --file ./flake-registry.json nixpkgs github:nixos/nixpkgs
   ```
 
 # Description

--- a/src/nix/registry-list.md
+++ b/src/nix/registry-list.md
@@ -13,6 +13,13 @@ R""(
   …
   ```
 
+* Show the contents of a custom registry file:
+
+  ```console
+  # nix registry list --file ./flake-registry.json
+  custom flake:nixpkgs github:NixOS/nixpkgs
+  ```
+
 # Description
 
 This command displays the contents of all registries on standard
@@ -23,6 +30,7 @@ output. Each line represents one registry entry in the format *type*
 * `user`: the user registry.
 * `system`: the system registry.
 * `global`: the global registry.
+* `custom`: the registry file specified via `--file`.
 
 See the [`nix registry` manual page](./nix3-registry.md) for more details.
 

--- a/src/nix/registry-pin.md
+++ b/src/nix/registry-pin.md
@@ -27,9 +27,8 @@ R""(
 * Pin `nixpkgs` in a custom registry to its most recent Git revision:
 
   ```console
-  # nix registry pin --registry ./custom-flake-registry.json nixpkgs
+  # nix registry pin --file ./flake-registry.json nixpkgs
   ```
-
 
 # Description
 

--- a/src/nix/registry-remove.md
+++ b/src/nix/registry-remove.md
@@ -11,7 +11,7 @@ R""(
 * Remove the entry `nixpkgs` from a custom registry:
 
   ```console
-  # nix registry remove --registry ./custom-flake-registry.json nixpkgs
+  # nix registry remove --file ./flake-registry.json nixpkgs
   ```
 
 # Description

--- a/src/nix/registry-resolve.md
+++ b/src/nix/registry-resolve.md
@@ -17,11 +17,18 @@ R""(
   github:NixOS/nixpkgs/25.05
   ```
 
+* Resolve flakerefs using a custom registry file:
+
+  ```console
+  # nix registry resolve --file ./flake-registry.json nixpkgs
+  github:NixOS/nixpkgs
+  ```
+
 # Description
 
 This command resolves indirect flakerefs (e.g. `nixpkgs`) to direct flakerefs (e.g. `github:NixOS/nixpkgs`) using the flake registries. It looks up each provided flakeref in all available registries (flag, user, system, and global) and returns the resolved direct flakeref on a separate line on standard output. It does not fetch any flakes.
 
-The resolution process may apply multiple redirections if necessary until a direct flakeref is found. If an indirect flakeref cannot be found in any registry, an error will be thrown.
+The resolution process may apply multiple redirections if necessary until a direct flakeref is found. If an indirect flakeref cannot be found in any registry, an error will be thrown. With `--file`, the specified registry file is added to the lookup chain with precedence between the user and flag registries.
 
 See the [`nix registry` manual page](./nix3-registry.md) for more details on the registry.
 

--- a/src/nix/registry.cc
+++ b/src/nix/registry.cc
@@ -17,12 +17,46 @@ public:
 
     RegistryCommand()
     {
+        auto category = "Registry options";
+
+        addFlag({
+            .longName = "file",
+            .description =
+                "The registry file to operate on. This file will be composed with the default registries (global, system, user) in precedence order.",
+            .category = category,
+            .labels = {"file"},
+            .handler = {[this](std::string s) {
+                if (!registry_path.empty())
+                    throw UsageError("'--file' can only be specified once");
+                registry_path = std::move(s);
+            }},
+            .completer = completePath,
+        });
+
         addFlag({
             .longName = "registry",
-            .description = "The registry to operate on.",
-            .labels = {"registry"},
-            .handler = {&registry_path},
+            .description = R"(
+    Deprecated alias for `--file`.
+
+    > **DEPRECATED**
+    >
+    > Use `--file` instead.
+            )",
+            .category = category,
+            .labels = {"file"},
+            .handler = {[this](std::string s) {
+                if (!registry_path.empty())
+                    throw UsageError("'--registry' (or '--file') can only be specified once");
+                warn("'--registry' is deprecated; use '--file' instead");
+                registry_path = std::move(s);
+            }},
+            .completer = completePath,
         });
+    }
+
+    bool hasCustomRegistry() const
+    {
+        return !registry_path.empty();
     }
 
     std::shared_ptr<fetchers::Registry> getRegistry()
@@ -47,7 +81,7 @@ public:
     }
 };
 
-struct CmdRegistryList : StoreCommand
+struct CmdRegistryList : RegistryCommand, StoreCommand
 {
     std::string description() override
     {
@@ -65,7 +99,11 @@ struct CmdRegistryList : StoreCommand
     {
         using namespace fetchers;
 
-        auto registries = getRegistries(fetchSettings, *store);
+        Registries registries;
+        if (hasCustomRegistry())
+            registries.push_back(getRegistry());
+        else
+            registries = getRegistries(fetchSettings, *store);
 
         for (auto & registry : registries) {
             for (auto & entry : registry->entries) {
@@ -75,6 +113,7 @@ struct CmdRegistryList : StoreCommand
                     registry->type == Registry::Flag     ? "flags "
                     : registry->type == Registry::User   ? "user  "
                     : registry->type == Registry::System ? "system"
+                    : registry->type == Registry::Custom ? "custom"
                                                          : "global",
                     entry.from.toURLString(),
                     entry.to.toURLString(attrsToQuery(entry.extraAttrs)));
@@ -199,7 +238,7 @@ struct CmdRegistryPin : RegistryCommand, EvalCommand
     }
 };
 
-struct CmdRegistryResolve : StoreCommand
+struct CmdRegistryResolve : RegistryCommand, StoreCommand
 {
     std::vector<std::string> urls;
 
@@ -225,10 +264,14 @@ struct CmdRegistryResolve : StoreCommand
 
     void run(nix::ref<nix::Store> store) override
     {
+        auto customRegistry = hasCustomRegistry() ? getRegistry() : std::shared_ptr<fetchers::Registry>{};
+
         for (auto & url : urls) {
             auto ref = parseFlakeRef(fetchSettings, url);
-            auto resolved = ref.resolve(fetchSettings, *store);
-            logger->cout("%s", resolved.to_string());
+            auto [input, extraAttrs] = fetchers::lookupInRegistries(
+                fetchSettings, *store, ref.input, fetchers::UseRegistries::All, customRegistry);
+            auto subdir = fetchers::maybeGetStrAttr(extraAttrs, "dir").value_or(ref.subdir);
+            logger->cout("%s", FlakeRef(std::move(input), subdir).to_string());
         }
     }
 };


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->
Allow users to specify custom registry files via a dedicated `--file` flag (now available to all `nix registry` subcommands that composes with default registries instead of replacing them.
It contributes to #4780

In the future, I'm planning on implementing a filter option to only take into account some registry types, which would compose with this flag

I would also like to make it default to checking for `flake-registry.json`, which would align with flakes defaulting for `flake.nix` and `flake.lock`.
Potentially, it could be made alike and force a `flake-registry.json` naming (one flake registry maximum per directory) as I think it's implicitly already the case

## Context

<!-- Provide context. Reference open issues if available. -->

This enables a better UX for using custom flake registries.
The `--registry` flag is retained as a deprecated alias for backwards compatibility.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

- Rename primary `--registry` flag to `--file`
- Add `--registry` as deprecated alias (with warning)
- Enforce single `--file` usage per command (throws error if repeated)
- Update libfetchers API to support custom registry composition
- Update all registry subcommand docs with new `--file` examples

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 