### PR TITLE
cli: for v3 cli use `default.nix` as fallback default entrypoint

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -4,8 +4,12 @@
 #include "nix/cmd/installable-attr-path.hh"
 #include "nix/cmd/installable-flake.hh"
 #include "nix/store/outputs-spec.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/fmt.hh"
 #include "nix/util/users.hh"
 #include "nix/util/util.hh"
+
+#include <regex>
 #include "nix/cmd/command.hh"
 #include "nix/expr/attr-path.hh"
 #include "nix/cmd/common-eval-args.hh"
@@ -503,6 +507,99 @@ Installables SourceExprCommand::parseInstallables(ref<Store> store, std::vector<
                 }
             }
 
+            /* If the installable looks like `<path>[#<fragment>]` and
+               `<path>` resolves to a local directory, `<fragment>` can be
+               interpreted as an attribute path into that directory's
+               `default.nix` instead of treating `<path>` as a flake. This
+               lets e.g. `nix build .#foo` work in repositories that only
+               have a `default.nix`, and also in repositories that have both
+               files when the `flakes` experimental feature is disabled.
+
+               To match the existing flake walk-up behavior, both
+               `flake.nix` and `default.nix` are searched for in `<path>`
+               and its parent directories (up to a `.git` boundary or
+               filesystem root). The flake search runs first: if a
+               `flake.nix` is found anywhere in the ancestor chain and
+               flakes are enabled, flake resolution takes precedence --
+               even over a `default.nix` closer to `<path>`. This
+               preserves the invariant that a parent directory's
+               `flake.nix` is never silently shadowed.
+
+               When neither file is found anywhere in the ancestor chain
+               we still let flake parsing run (its own walk-up may apply
+               additional heuristics), but on failure we augment the error
+               to mention that a `default.nix` was not found either. */
+            std::optional<std::filesystem::path> localDir;
+            std::string localAttrPath;
+            {
+                static std::regex pathFragmentRegex(R"(([^?#]*)(#(.*))?)", std::regex::ECMAScript);
+                std::smatch match;
+                auto prefixStr = std::string{prefix};
+                if (std::regex_match(prefixStr, match, pathFragmentRegex) && !match[1].str().empty()) {
+                    auto pathPart = match[1].str();
+                    localAttrPath = match[3].str();
+                    try {
+                        auto baseDir = absPath(getCommandBaseDir());
+                        auto absPathPart = absPath(std::filesystem::path{pathPart}, &baseDir);
+                        if (pathExists(absPathPart) && std::filesystem::is_directory(absPathPart))
+                            localDir = absPathPart;
+                    } catch (...) {
+                    }
+                }
+            }
+
+            /* Search upward from `start` for a directory containing
+               `filename`, stopping at `.git` boundaries or the
+               filesystem root. Mirrors the walk-up in
+               `parsePathFlakeRefWithFragment`. */
+            auto searchUpFor = [](const std::filesystem::path & start,
+                                  const char * filename) -> std::optional<std::filesystem::path> {
+                auto path = start;
+                while (true) {
+                    if (pathExists(path / filename))
+                        return path;
+                    if (pathExists(path / ".git"))
+                        break;
+                    auto parent = path.parent_path();
+                    if (parent == path)
+                        break;
+                    path = parent;
+                }
+                return std::nullopt;
+            };
+
+            bool flakesEnabled = experimentalFeatureSettings.isEnabled(Xp::Flakes);
+            auto flakeNixDir = localDir ? searchUpFor(*localDir, "flake.nix") : std::nullopt;
+            auto defaultNixDir = localDir ? searchUpFor(*localDir, "default.nix") : std::nullopt;
+            bool hasFlakeNix = flakeNixDir.has_value();
+            bool hasDefaultNix = defaultNixDir.has_value();
+            bool useFlake = flakesEnabled && hasFlakeNix;
+
+            /* Fast path: the local directory has a usable `default.nix`.
+               Use it directly, before attempting flake parsing, to avoid the
+               misleading "searching up" notice and to keep the behavior
+               entirely local. Skip trying `default.nix` when `--pure-eval` was
+               explicitly set (see the note below about pure mode). */
+            if (localDir && !useFlake && hasDefaultNix
+                && !(evalSettings.pureEval && evalSettings.pureEval.overridden)) {
+                /* Reading `default.nix` requires the real filesystem to be
+                   reachable from the evaluator. In pure-eval mode the root
+                   accessor is restricted to the Nix store, so arbitrary
+                   local paths are not readable at all -- this is the same
+                   constraint that makes `-f` incompatible with pure-eval.
+                   Mirror the `-f` behavior: force pure-eval off for the
+                   duration of this command. */
+                evalSettings.pureEval = false;
+                auto state = getEvalState();
+                auto vFile = state->allocValue();
+                auto baseDir = absPath(getCommandBaseDir());
+                state->evalFile(lookupFileArg(*state, (*defaultNixDir / "default.nix").string(), &baseDir), *vFile);
+                result.push_back(
+                    make_ref<InstallableAttrPath>(InstallableAttrPath::parse(
+                        state, *this, vFile, localAttrPath, std::move(extendedOutputsSpec))));
+                continue;
+            }
+
             try {
                 auto [flakeRef, fragment] =
                     parseFlakeRefWithFragment(fetchSettings, std::string{prefix}, absPath(getCommandBaseDir()));
@@ -517,6 +614,18 @@ Installables SourceExprCommand::parseInstallables(ref<Store> store, std::vector<
                         getDefaultFlakeAttrPathPrefixes(),
                         lockFlags));
                 continue;
+            } catch (Error & e) {
+                /* If the target was a local directory that had neither a
+                   `flake.nix` nor a `default.nix`, make that visible in the
+                   error: the user probably expected one of the two. */
+                if (localDir && !hasFlakeNix && !hasDefaultNix) {
+                    e.addTrace(
+                        nullptr,
+                        "neither %s nor its parent directories contain a 'default.nix' to fall back to",
+                        PathFmt(*localDir));
+                    throw;
+                }
+                ex = std::current_exception();
             } catch (...) {
                 ex = std::current_exception();
             }

--- a/tests/functional/flakes/default-nix-fallback.sh
+++ b/tests/functional/flakes/default-nix-fallback.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+# The flakes common.sh sets _NIX_TEST_BARF_ON_UNCACHEABLE=1, which makes reads
+# of local source paths (outside flake inputs) error out. The whole point of
+# this test is the non-flake path, so disable that guard for this test.
+unset _NIX_TEST_BARF_ON_UNCACHEABLE
+
+clearStoreIfPossible
+
+# Test that `.#foo` falls back to evaluating `default.nix` when the directory
+# contains a `default.nix` but no `flake.nix`. See NixOS/nix#1929.
+
+# Copy the shared fixtures into TEST_HOME while our cwd is still the test
+# directory, so the relative `..` paths resolve to tests/functional.
+cp ../simple.nix ../simple.builder.sh "${config_nix}" "$TEST_HOME/"
+
+cd "$TEST_HOME"
+
+cat > default.nix <<EOF
+with import ./config.nix;
+{
+  foo = mkDerivation { name = "foo-from-default"; builder = ./simple.builder.sh; PATH = ""; goodPath = path; };
+  bar = mkDerivation { name = "bar-from-default"; builder = ./simple.builder.sh; PATH = ""; goodPath = path; };
+  nested.baz = mkDerivation { name = "baz-from-default"; builder = ./simple.builder.sh; PATH = ""; goodPath = path; };
+}
+EOF
+
+# 1. `.#foo` should fall back to default.nix.foo
+out=$(nix eval --raw .#foo.name)
+[[ $out == foo-from-default ]] || fail "expected .#foo.name to be 'foo-from-default', got '$out'"
+
+# 2. A second attribute through the fragment.
+out=$(nix eval --raw .#bar.name)
+[[ $out == bar-from-default ]] || fail "expected .#bar.name to be 'bar-from-default', got '$out'"
+
+# 3. Nested attribute paths through the fragment should work.
+out=$(nix eval --raw .#nested.baz.name)
+[[ $out == baz-from-default ]] || fail "expected .#nested.baz.name to be 'baz-from-default', got '$out'"
+
+# 4. Absolute path with fragment.
+out=$(nix eval --raw "$PWD#foo.name")
+[[ $out == foo-from-default ]] || fail "expected \$PWD#foo.name to be 'foo-from-default', got '$out'"
+
+# 5. `nix build .#foo` should build via default.nix.
+nix build --no-link .#foo || fail "nix build .#foo via default.nix fallback should succeed"
+
+# 6. When a flake.nix exists alongside, it should take precedence.
+cat > flake.nix <<EOF
+{
+  outputs = { self }:
+    let config = import ./config.nix; in {
+      packages.$system.foo = config.mkDerivation {
+        name = "foo-from-flake";
+        builder = ./simple.builder.sh;
+        PATH = "";
+        goodPath = config.path;
+      };
+    };
+}
+EOF
+
+out=$(nix eval --raw .#foo.name)
+[[ $out == foo-from-flake ]] || fail "with flake.nix present, expected 'foo-from-flake', got '$out'"
+
+rm flake.nix flake.lock 2>/dev/null || true
+
+# 7. With `--pure-eval` explicitly set, the fallback must be skipped.
+#    Since there is no flake.nix, flake parsing then runs and errors out.
+#    This guarantees the fallback never silently disables a user-set pure mode.
+expectStderr 1 nix eval --pure-eval --raw .#foo | grepQuietInverse "foo-from-default"
+
+# 8. When the `flakes` experimental feature is not enabled, `.#foo` should
+#    use `default.nix` even if a `flake.nix` happens to sit alongside it —
+#    the flake.nix would be unusable anyway.
+cat > flake.nix <<EOF
+{
+  outputs = { self }:
+    let config = import ./config.nix; in {
+      packages.$system.foo = config.mkDerivation {
+        name = "foo-from-flake";
+        builder = ./simple.builder.sh;
+        PATH = "";
+        goodPath = config.path;
+      };
+    };
+}
+EOF
+
+out=$(nix --experimental-features 'nix-command' eval --raw .#foo.name)
+[[ $out == foo-from-default ]] \
+    || fail "with flakes feature disabled, expected 'foo-from-default', got '$out'"
+
+rm flake.nix flake.lock 2>/dev/null || true
+
+# 9. In a directory that has neither `flake.nix` nor `default.nix`, the error
+#    should mention that `default.nix` was not found either — that's the
+#    likely thing the user expected.
+#    Place a `.git` sentinel inside the directory so `searchUpFor` does not
+#    walk past it and find $TEST_HOME's `default.nix`.
+mkdir -p empty-dir/.git
+expectStderr 1 nix eval --raw ./empty-dir#foo 2>&1 | grepQuiet "contain a 'default\.nix'"

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -21,6 +21,7 @@ suites += {
     'prefetch.sh',
     'eval-cache.sh',
     'search-root.sh',
+    'default-nix-fallback.sh',
     'config.sh',
     'show.sh',
     'dubious-query.sh',


### PR DESCRIPTION
For the v3 cli, consider using `default.nix` files as the default endpoint when the flakes experimental feature is disabled or no `flake.nix` can be found. `default.nix` files are searched for in both current and parent directories similar as `flake.nix` files.

Both `flake.nix` and `default.nix` are searched for in the target directory and its parent directories (up to a `.git` boundary or filesystem root), mirroring the walk-up in `parsePathFlakeRefWithFragment`. The flake search runs first: if a `flake.nix` is found anywhere in the ancestor chain and flakes are enabled, flake resolution takes precedence -- even over a `default.nix` closer to the target. This preserves the invariant that a parent directory's flake is never silently shadowed.

When neither file is found anywhere in the ancestor chain, flake parsing is still allowed to run, but on failure the error is augmented with a trace noting that no
`default.nix` was found either -- the user probably expected one of the two.

Key behavior:

- `.#foo` with only `default.nix` → evaluates `default.nix`'s attribute `foo`
- `.#foo` with both files and flakes enabled → uses `flake.nix`
- `.#foo` with both files and flakes disabled → uses `default.nix` (the `flake.nix` would be unusable anyway)
- `.#foo` in a subdirectory of a flake project (parent has `flake.nix`) → uses the parent's flake, not a local `default.nix`
- `.#foo` in a subdirectory with a `default.nix` in a parent (no flake anywhere) → uses the parent's `default.nix`
- `.#foo` with neither file in any ancestor → flake parsing runs; if it fails, the error also mentions the missing `default.nix`
- `nixpkgs#hello`, `github:...`, etc. → unchanged (local path check fails for non-local paths)
- `/abs/path#foo` works too

## Motivation

closes #1929.

## Context

Note on pure-eval: reading a local `default.nix` requires the real filesystem to be reachable from the evaluator, but in `--pure-eval` mode the root source accessor is restricted to the Nix store -- arbitrary local paths are not readable at all. This is the same constraint that makes `-f` incompatible with pure-eval. When pure-eval was not explicitly set we mirror `-f` and silently disable it for the fallback; when the user explicitly asked for `--pure-eval` we skip the fallback entirely so their pure mode is never silently overridden (flake parsing then runs and errors out as usual).

disclaimer i used a coding agent in the creation of this patch.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
