### PR TITLE
Add `nix-run` v2 command

### DIFF
--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -109,6 +109,7 @@
     - [nix-hash](command-ref/nix-hash.md)
     - [nix-instantiate](command-ref/nix-instantiate.md)
     - [nix-prefetch-url](command-ref/nix-prefetch-url.md)
+    - [nix-run](command-ref/nix-run.md)
   - [Experimental Commands](command-ref/experimental-commands.md)
 {{#include ./command-ref/new-cli/SUMMARY.md}}
   - [Files](command-ref/files.md)

--- a/doc/manual/source/command-ref/nix-run.md
+++ b/doc/manual/source/command-ref/nix-run.md
@@ -1,0 +1,48 @@
+# Name
+
+`nix-run` - run an executable from a Nix expression
+
+# Synopsis
+
+`nix-run`
+  [{`--attr` | `-A`} *attrPath*]
+  [`--expr` | `-E`]
+  [`--arg` *name* *value*]
+  [*file*]
+  [`--` *args*...]
+
+# Description
+
+The command `nix-run` evaluates a Nix expression, selects a derivation
+(optionally via `--attr`), and executes its main program. The
+executable is chosen the same way `nix run` does when given a
+derivation: `meta.mainProgram` is preferred, falling back to `pname`,
+and finally to the parsed derivation name. This matches the semantics
+of `lib.getExe` in nixpkgs.
+
+*file* defaults to `./default.nix`. When `--expr` is given, the
+positional argument is interpreted as a Nix expression instead of a
+file path. A literal `--` ends option parsing; everything after it is
+passed verbatim to the program.
+
+# Examples
+
+Run `hello` from `<nixpkgs>`:
+
+```console
+$ nix-run '<nixpkgs>' -A hello
+Hello, world!
+```
+
+Evaluate an expression and pass arguments to the program:
+
+```console
+$ nix-run -E 'import <nixpkgs> {}' -A hello -- --greeting=hi
+hi
+```
+
+Run the package produced by a local `release.nix`:
+
+```console
+$ nix-run ./release.nix -A myApp
+```

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -159,6 +159,9 @@ nix_env_sources = files(
 nix_instantiate_sources = files(
   'nix-instantiate/nix-instantiate.cc',
 )
+nix_run_sources = files(
+  'nix-run/nix-run.cc',
+)
 nix_store_sources = files(
   'nix-store/dotgraph.cc',
   'nix-store/graphml.cc',
@@ -175,6 +178,7 @@ sources = [
   nix_env_buildenv_gen,
   nix_env_sources,
   nix_instantiate_sources,
+  nix_run_sources,
   nix_store_sources,
 ]
 
@@ -209,6 +213,7 @@ nix_symlinks = [
   'nix-hash',
   'nix-instantiate',
   'nix-prefetch-url',
+  'nix-run',
   'nix-shell',
   'nix-store',
 ]

--- a/src/nix/nix-run/nix-run.cc
+++ b/src/nix/nix-run/nix-run.cc
@@ -1,0 +1,222 @@
+#include "nix/cmd/common-eval-args.hh"
+#include "nix/cmd/installable-value.hh"
+#include "nix/cmd/legacy.hh"
+#include "nix/expr/attr-path.hh"
+#include "nix/expr/eval-inline.hh"
+#include "nix/expr/eval-settings.hh"
+#include "nix/expr/eval.hh"
+#include "nix/main/shared.hh"
+#include "nix/store/derived-path.hh"
+#include "nix/store/downstream-placeholder.hh"
+#include "nix/store/store-api.hh"
+#include "nix/store/store-open.hh"
+#include "nix/util/util.hh"
+
+#include "../run.hh"
+#include "man-pages.hh"
+
+#include <iostream>
+
+namespace nix {
+
+static void showHelp()
+{
+    std::cout <<
+        R"(Usage: nix-run [OPTIONS] [FILE] [-- ARGS...]
+
+Evaluate FILE (default: ./default.nix) and run the executable selected
+by `nix run`-style `getExe` semantics: `meta.mainProgram`, falling back
+to `pname`, and finally to the parsed derivation name.
+
+Options:
+  -A, --attr ATTR     Select the given attribute path inside the
+                      evaluated expression (e.g. `hello`, `pkgs.hello`).
+  -E, --expr          Interpret the positional argument as a Nix
+                      expression instead of a file path.
+  --                  End of options; remaining arguments are passed
+                      verbatim to the program being run.
+
+Examples:
+  nix-run '<nixpkgs>' -A hello
+  nix-run -E 'import <nixpkgs> {}' -A hello -- --greeting=hi
+  nix-run ./release.nix -A myApp
+)";
+}
+
+static int main_nix_run(int argc, char ** argv)
+{
+    Strings attrPaths;
+    Strings positionals;
+    bool fromArgs = false;
+    bool readStdin = false;
+    bool showHelpAndExit = false;
+
+    /* Argument layout:
+         nix-run [OPTIONS] [FILE | --expr EXPR | -] [PROGRAM ARGS...]
+       The first positional names the source (a file path, or an
+       expression if `-E` is used, or `-` for stdin). Every subsequent
+       positional is forwarded verbatim to the program. A literal `--`
+       is consumed by the base argument parser, which then routes all
+       remaining arguments through `processArgs` as positionals. */
+    struct MyArgs : LegacyArgs, MixEvalArgs
+    {
+        using LegacyArgs::LegacyArgs;
+
+        Strings * positionals = nullptr;
+
+        bool processArgs(const Strings & args, bool finish) override
+        {
+            for (auto & a : args)
+                positionals->push_back(a);
+            return true;
+        }
+    };
+
+    auto parseFlag = [&](Strings::iterator & arg, const Strings::iterator & end) -> bool {
+        if (*arg == "--help")
+            showHelpAndExit = true;
+        else if (*arg == "--version")
+            printVersion("nix-run");
+        else if (*arg == "--attr" || *arg == "-A")
+            attrPaths.push_back(getArg(*arg, arg, end));
+        else if (*arg == "--expr" || *arg == "-E")
+            fromArgs = true;
+        else if (*arg == "-")
+            readStdin = true;
+        else if (*arg != "" && arg->at(0) == '-')
+            return false;
+        else
+            /* Bare positionals are dispatched through `processArgs`, not
+               `processFlag`, so this branch is unreachable. Kept for
+               defence in depth in case the dispatch ever changes. */
+            positionals.push_back(*arg);
+        return true;
+    };
+
+    MyArgs myArgs(std::string(baseNameOf(argv[0])), parseFlag);
+    myArgs.positionals = &positionals;
+
+    myArgs.parseCmdline(argvToStrings(argc, argv));
+
+    if (showHelpAndExit) {
+        showHelp();
+        return 0;
+    }
+
+    auto store = openStore();
+    auto evalStore = myArgs.evalStoreUrl ? openStore(StoreReference{*myArgs.evalStoreUrl}) : store;
+
+    auto state = std::make_shared<EvalState>(myArgs.lookupPath, evalStore, fetchSettings, evalSettings, store);
+    state->repair = myArgs.repair;
+
+    Bindings & autoArgs = *myArgs.getAutoArgs(*state);
+
+    /* The first positional (if any) selects the source; everything
+       after it is forwarded to the program. */
+    std::optional<std::string> source;
+    Strings programArgs;
+    if (!positionals.empty()) {
+        source = positionals.front();
+        positionals.pop_front();
+    }
+    programArgs = std::move(positionals);
+
+    if (readStdin && (source || fromArgs))
+        throw UsageError("nix-run: '-' cannot be combined with a file or '--expr'");
+    if (fromArgs && !source)
+        throw UsageError("nix-run: '--expr' requires an argument");
+
+    /* Parse the source expression to evaluate. */
+    Expr * e;
+    if (readStdin) {
+        e = state->parseStdin();
+    } else if (fromArgs) {
+        e = state->parseExprFromString(*source, state->rootPath("."));
+    } else {
+        auto sourcePath = lookupFileArg(*state, source.value_or("./default.nix"));
+        e = state->parseExprFromFile(resolveExprPath(sourcePath));
+    }
+
+    Value vRoot;
+    state->eval(e, vRoot);
+
+    if (attrPaths.empty())
+        attrPaths = {""};
+    if (attrPaths.size() > 1)
+        throw UsageError("nix-run accepts at most one '--attr' path");
+
+    Value & vPkg = *findAlongAttrPath(*state, attrPaths.front(), autoArgs, vRoot).first;
+    state->forceValue(vPkg, vPkg.determinePos(noPos));
+
+    /* `nix run`-style executable selection, mirroring `lib.getExe`:
+       prefer `meta.mainProgram`, then `pname`, then the parsed
+       derivation name. */
+    auto getExeExpr = state->parseExprFromString(
+        R"RAW(pkg: "${pkg}/bin/${
+          pkg.meta.mainProgram
+            or (pkg.pname
+              or (builtins.parseDrvName pkg.name).name)
+        }")RAW",
+        state->rootPath("."));
+
+    Value vGetExe;
+    state->eval(getExeExpr, vGetExe);
+
+    Value vProgram;
+    state->callFunction(vGetExe, vPkg, vProgram, noPos);
+
+    NixStringContext context;
+    auto program =
+        state->coerceToString(noPos, vProgram, context, "while evaluating the program path for nix-run", false, false)
+            .toOwned();
+
+    /* Turn the string context into derived paths, then let UnresolvedApp
+       build them and resolve placeholders (for CA derivations). This is
+       the same machinery `nix run` uses via InstallableValue::toApp. */
+    std::vector<DerivedPath> context2;
+    for (auto & c : context) {
+        context2.emplace_back(
+            std::visit(
+                overloaded{
+                    [&](const NixStringContextElem::DrvDeep & d) -> DerivedPath {
+                        return DerivedPath::Built{
+                            .drvPath = makeConstantStorePathRef(d.drvPath),
+                            .outputs = OutputsSpec::All{},
+                        };
+                    },
+                    [&](const NixStringContextElem::Built & b) -> DerivedPath {
+                        return DerivedPath::Built{
+                            .drvPath = b.drvPath,
+                            .outputs = OutputsSpec::Names{b.output},
+                        };
+                    },
+                    [&](const NixStringContextElem::Opaque & o) -> DerivedPath {
+                        return DerivedPath::Opaque{.path = o.path};
+                    },
+                },
+                c.raw));
+    }
+
+    UnresolvedApp unresolvedApp{App{
+        .context = std::move(context2),
+        .program = program,
+    }};
+    auto app = unresolvedApp.resolve(evalStore, store);
+
+    Strings allArgs{app.program.string()};
+    for (auto & a : programArgs)
+        allArgs.push_back(std::move(a));
+
+    state->maybePrintStats();
+
+    /* Release eval caches before exec'ing, matching `nix run`. */
+    state->evalCaches.clear();
+
+    execProgramInStore(store, UseLookupPath::DontUse, app.program.string(), allArgs);
+
+    return 0;
+}
+
+static RegisterLegacyCommand r_nix_run("nix-run", main_nix_run);
+
+} // namespace nix

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -68,6 +68,7 @@ suites = [
       'binary-cache.sh',
       'multiple-outputs.sh',
       'nix-build.sh',
+      'nix-run.sh',
       'gc-concurrent.sh',
       'repair.sh',
       'fixed.sh',

--- a/tests/functional/nix-run.nix
+++ b/tests/functional/nix-run.nix
@@ -1,0 +1,69 @@
+with import ./config.nix;
+
+let
+  # Build a trivial executable at `$out/bin/<binName>` that echoes a
+  # recognisable line when run. This lets the test assert which binary
+  # `nix-run` picked without depending on anything from nixpkgs.
+  mkProg =
+    {
+      name,
+      binName,
+      message,
+      extra ? { },
+    }:
+    mkDerivation (
+      {
+        inherit name;
+        buildCommand = ''
+          mkdir -p $out/bin
+          {
+            echo '#!${shell}'
+            echo 'echo ${message}'
+            echo 'for arg in "$@"; do echo "arg:$arg"; done'
+          } > $out/bin/${binName}
+          chmod +x $out/bin/${binName}
+        '';
+      }
+      // extra
+    );
+
+in
+
+rec {
+
+  # `meta.mainProgram` wins over everything else.
+  withMainProgram = mkProg {
+    name = "ignored-name-1.0";
+    binName = "picked-by-main-program";
+    message = "mainProgram";
+    extra.meta.mainProgram = "picked-by-main-program";
+  };
+
+  # No `meta.mainProgram`: fall back to `pname`.
+  withPname = mkProg {
+    name = "ignored-name-2.0";
+    binName = "picked-by-pname";
+    message = "pname";
+    extra.pname = "picked-by-pname";
+  };
+
+  # Neither `meta.mainProgram` nor `pname`: fall back to the parsed
+  # derivation name.
+  withParsedName = mkProg {
+    name = "picked-by-parsed-name-3.0";
+    binName = "picked-by-parsed-name";
+    message = "parsedName";
+  };
+
+  # For the `-E` / expression-mode test: a single top-level derivation.
+  topLevel = withMainProgram;
+
+  # For the program-argument-forwarding test.
+  echoArgs = mkProg {
+    name = "echo-args-1.0";
+    binName = "echo-args";
+    message = "echoArgs";
+    extra.meta.mainProgram = "echo-args";
+  };
+
+}

--- a/tests/functional/nix-run.sh
+++ b/tests/functional/nix-run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+TODO_NixOS
+
+clearStoreIfPossible
+
+# `meta.mainProgram` selects the executable.
+output="$(nix-run ./nix-run.nix -A withMainProgram)"
+echo "$output" | grep -qx 'mainProgram'
+
+# Fallback to `pname` when `meta.mainProgram` is absent.
+output="$(nix-run ./nix-run.nix -A withPname)"
+echo "$output" | grep -qx 'pname'
+
+# Fallback to the parsed derivation name when neither `meta.mainProgram`
+# nor `pname` is present.
+output="$(nix-run ./nix-run.nix -A withParsedName)"
+echo "$output" | grep -qx 'parsedName'
+
+# Default attribute (top-level) works without `-A`, using the root
+# value returned by the expression.
+output="$(nix-run -E '(import ./nix-run.nix).topLevel')"
+echo "$output" | grep -qx 'mainProgram'
+
+# Arguments after `--` are forwarded verbatim to the program.
+output="$(nix-run ./nix-run.nix -A echoArgs -- hello 'a b' --flag)"
+echo "$output" | grep -qx 'echoArgs'
+echo "$output" | grep -qx 'arg:hello'
+echo "$output" | grep -qx 'arg:a b'
+echo "$output" | grep -qx 'arg:--flag'
+
+# Default FILE is `./default.nix`: run from a temporary directory that
+# has its own `default.nix` re-exporting the test fixture.
+runDir="$TEST_ROOT/nix-run-default"
+mkdir -p "$runDir"
+cat > "$runDir/default.nix" <<EOF
+import $PWD/nix-run.nix
+EOF
+(
+    cd "$runDir"
+    output="$(nix-run -A withPname)"
+    echo "$output" | grep -qx 'pname'
+)
+
+# Missing attribute produces a clear error.
+expectStderr 1 nix-run ./nix-run.nix -A doesNotExist \
+    | grep -q 'doesNotExist'


### PR DESCRIPTION
Adds a v2-CLI-style `nix-run` that evaluates a Nix expression and executes the selected derivation's main program, using the same `getExe`-like semantics as `nix run`: prefer `meta.mainProgram`, then `pname`, then the parsed derivation name.

Usage: `nix-run [FILE] [-A ATTR] [-E] [-- ARGS...]`

`FILE` defaults to `./default.nix`. Arguments after the first positional (or after a literal `--`) are forwarded verbatim to the program.

## Motivation

inspired by #14992, tho with `fetchTree`-powered source-fetching deferred to #15654.

## Context

disclaimer i used a coding agent in the creation of this patch.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
