### PR TITLE
libmain: Don't raise the RLIMIT_NOFILE to RLIM_INFINITY, cap at 1048576 us…

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -133,7 +133,14 @@ void bumpFileLimit()
         return;
 
     if (limit.rlim_cur < limit.rlim_max) {
-        limit.rlim_cur = limit.rlim_max;
+        // Some software misbehaves really bad when we try to raise the
+        // limit to RLIM_INFINITY, so cap the limit at the 1048576 limit used
+        // by the daemon.
+        //
+        // GNU patch < 2.8 crashes with **** out of memory, which breaks in nixpkgs darwin bootstrap tools.
+        // This was fixed in:
+        // https://cgit.git.savannah.gnu.org/cgit/patch.git/commit/?id=61d7788b83b302207a67b82786f4fd79e3538f30
+        limit.rlim_cur = std::min(limit.rlim_max, rlim_t(1048576));
         // Ignore errors, this is best effort.
         setrlimit(RLIMIT_NOFILE, &limit);
     }


### PR DESCRIPTION
…ed by the daemon

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

See the comment. ~~Should~~ Fixes https://github.com/NixOS/nix/issues/15619. See: https://cgit.git.savannah.gnu.org/cgit/patch.git/commit/?id=61d7788b83b302207a67b82786f4fd79e3538f30

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
