### PR TITLE
libexpr: add function serialization builtins

### DIFF
--- a/src/libexpr-tests/main.cc
+++ b/src/libexpr-tests/main.cc
@@ -9,8 +9,8 @@ int main(int argc, char ** argv)
     if (res)
         return res;
 
-    // For pipe operator tests in trivial.cc
-    nix::experimentalFeatureSettings.set("experimental-features", "pipe-operators");
+    // For pipe operator tests in trivial.cc and function serialization tests in primops.cc
+    nix::experimentalFeatureSettings.set("experimental-features", "pipe-operators function-serialization");
 
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -883,9 +883,32 @@ TEST_F(PrimOpTest, serializeFunctionAttrsetNoFnThrows)
 }
 
 // preserveStringContext = false (default): plain string, no appendContext.
+TEST_F(PrimOpTest, serializeFunctionStringContextNotPreservedByDefault)
+{
+    auto v = eval(R"nix(
+        let s = "hello";
+        in builtins.serializeFunction (x: s)
+    )nix");
+    auto out = std::string(v.string_view());
+    ASSERT_EQ(out.find("appendContext"), std::string::npos);
+}
+
 // preserveStringContext = true: strings with context get appendContext wrapping.
 // We can't easily create real store path context in the test harness, so
 // we verify the flag is accepted and plain strings (no context) are unaffected.
+TEST_F(PrimOpTest, serializeFunctionPreserveStringContextFlagAccepted)
+{
+    auto v = eval(R"nix(
+        builtins.serializeFunction {
+          fn = x: "hello";
+          preserveStringContext = true;
+        }
+    )nix");
+    // Plain string without context: no appendContext wrapping needed.
+    auto out = std::string(v.string_view());
+    ASSERT_EQ(out.find("appendContext"), std::string::npos);
+}
+
 // Eta-reduction: direct `builtins.head` access is now detected.
 TEST_F(PrimOpTest, serializeFunctionEtaReducesDirectBuiltin)
 {
@@ -1085,6 +1108,19 @@ TEST_F(PrimOpTest, dynDrvStringContextLostOnRoundTrip)
 // Scenario: `preserveStringContext` emits `builtins.appendContext` wrapping
 // for strings with context.  We verify the output format since the test
 // harness uses a dummy store that cannot validate real store paths.
+TEST_F(PrimOpTest, dynDrvPreserveStringContextOutput)
+{
+    auto v = eval(R"nix(
+        let
+          s = "hello";
+          f = _: s;
+        in builtins.serializeFunction { fn = f; preserveStringContext = true; }
+    )nix");
+    // Plain string without context: no wrapping needed even with the flag.
+    auto out = std::string(v.string_view());
+    ASSERT_EQ(out.find("appendContext"), std::string::npos);
+}
+
 // Scenario: eta-reduced polyfills in a dynamic derivation pipeline.
 // A `lib.head`-style polyfill round-trips to the underlying primop.
 TEST_F(PrimOpTest, dynDrvEtaReducedPolyfill)

--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -631,9 +631,22 @@ TEST_F(PrimOpTest, toStringAttrsThrows)
     ASSERT_THROW(eval("builtins.toString {}"), EvalError);
 }
 
-TEST_F(PrimOpTest, toStringLambdaThrows)
+TEST_F(PrimOpTest, toStringLambda)
 {
-    ASSERT_THROW(eval("builtins.toString (x: x)"), EvalError);
+    auto v = eval("builtins.toString (x: x)");
+    ASSERT_THAT(v, IsStringEq("(x: x)"));
+}
+
+TEST_F(PrimOpTest, toStringLambdaWithFormals)
+{
+    auto v = eval("builtins.toString ({ a, b ? 1 }: a)");
+    ASSERT_THAT(v, IsStringEq("({ a, b ? 1 }: a)"));
+}
+
+TEST_F(PrimOpTest, toStringPrimOp)
+{
+    auto v = eval("builtins.toString builtins.head");
+    ASSERT_THAT(v, IsStringEq("builtins.head"));
 }
 
 class ToStringPrimOpTest : public PrimOpTest,

--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -1228,7 +1228,112 @@ TEST_F(PrimOpTest, dynDrvImportPrimOpRoundTrip)
     ASSERT_THAT(v, IsStringEq("builtins.import"));
 }
 
+// externalBindings: named closure variables become wrapper function params.
+TEST_F(PrimOpTest, serializeFunctionExternalBindings)
+{
+    auto v = eval(R"(
+        let
+          greet = name: "hello ${name}";
+        in builtins.serializeFunction {
+          fn = x: greet x;
+          externalBindings = ["greet"];
+        }
+    )");
+    auto s = std::string(v.string_view());
+    // The output should be a wrapper function taking `greet` as a parameter.
+    EXPECT_THAT(s, ::testing::HasSubstr("{ greet }"));
+    // `greet` should NOT be inlined as a let binding.
+    ASSERT_EQ(s.find("let "), std::string::npos);
+}
+
+// externalBindings round-trip: caller provides bindings at deserialization.
+TEST_F(PrimOpTest, serializeFunctionExternalBindingsRoundTrip)
+{
+    auto v = eval(R"(
+        let
+          double = x: x * 2;
+          serialized = builtins.serializeFunction {
+            fn = x: double x;
+            externalBindings = ["double"];
+          };
+          restored = builtins.deserializeFunction serialized;
+        in restored { double = x: x * 2; } 21
+    )");
+    ASSERT_EQ(v.type(), nInt);
+    ASSERT_EQ(v.integer().value, 42);
+}
+
+// externalBindings with mixed inline and external bindings.
+TEST_F(PrimOpTest, serializeFunctionMixedBindings)
+{
+    auto v = eval(R"(
+        let
+          prefix = "hello";
+          greet = name: "${prefix} ${name}";
+        in builtins.serializeFunction {
+          fn = x: greet x + prefix;
+          externalBindings = ["greet"];
+        }
+    )");
+    auto s = std::string(v.string_view());
+    // `greet` is external (wrapper param), `prefix` is inline (let binding).
+    EXPECT_THAT(s, ::testing::HasSubstr("{ greet }"));
+    EXPECT_THAT(s, ::testing::HasSubstr("prefix"));
+}
+
+// externalBindings in a dynamic derivation scenario: lib functions
 // provided at deserialization time, not inlined.
+TEST_F(PrimOpTest, dynDrvExternalLibBindings)
+{
+    auto v = eval(R"(
+        let
+          concatStrings = builtins.concatStringsSep "";
+          serialized = builtins.serializeFunction {
+            fn = items: concatStrings items;
+            externalBindings = ["concatStrings"];
+          };
+          restored = builtins.deserializeFunction serialized;
+          f = restored { concatStrings = builtins.concatStringsSep ""; };
+        in f ["a" "b" "c"]
+    )");
+    ASSERT_THAT(v, IsStringEq("abc"));
+}
+
+class ToStringPrimOpTest : public PrimOpTest,
+                           public ::testing::WithParamInterface<std::tuple<std::string, std::string_view>>
+{};
+
+TEST_P(ToStringPrimOpTest, toString)
+{
+    const auto & [input, output] = GetParam();
+    auto v = eval(input);
+    ASSERT_THAT(v, IsStringEq(output));
+}
+
+#define CASE(input, output) (std::make_tuple(std::string_view("builtins.toString " input), std::string_view(output)))
+INSTANTIATE_TEST_SUITE_P(
+    toString,
+    ToStringPrimOpTest,
+    ::testing::Values(
+        CASE(R"("foo")", "foo"),
+        CASE(R"(1)", "1"),
+        CASE(R"([1 2 3])", "1 2 3"),
+        CASE(R"(.123)", "0.123000"),
+        CASE(R"(true)", "1"),
+        CASE(R"(false)", ""),
+        CASE(R"(null)", ""),
+        CASE(R"({ v = "bar"; __toString = self: self.v; })", "bar"),
+        CASE(R"({ v = "bar"; __toString = self: self.v; outPath = "foo"; })", "bar"),
+        CASE(R"({ outPath = "foo"; })", "foo")
+// this is broken on cygwin because canonPath("//./test", false) returns //./test
+// FIXME: don't use canonPath
+#ifndef __CYGWIN__
+            ,
+        CASE(R"(./test)", "/test")
+#endif
+            ));
+#undef CASE
+
 TEST_F(PrimOpTest, substring)
 {
     auto v = eval("builtins.substring 0 3 \"nixos\"");

--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -686,6 +686,54 @@ TEST_F(PrimOpTest, serializeFunctionPrimOp)
     ASSERT_THAT(v, IsStringEq("builtins.head"));
 }
 
+TEST_F(PrimOpTest, serializeFunctionPrimOpRoundTrip)
+{
+    auto v = eval(R"nix(
+        let f = builtins.deserializeFunction (builtins.serializeFunction builtins.head);
+        in f [42 1 2]
+    )nix");
+    ASSERT_EQ(v.type(), nInt);
+    ASSERT_EQ(v.integer().value, 42);
+}
+
+TEST_F(PrimOpTest, deserializeFunctionSimple)
+{
+    auto v = eval(R"nix(let f = builtins.deserializeFunction "(x: x + 1)"; in f 41)nix");
+    ASSERT_EQ(v.type(), nInt);
+    ASSERT_EQ(v.integer().value, 42);
+}
+
+TEST_F(PrimOpTest, deserializeFunctionNonFunctionThrows)
+{
+    ASSERT_THROW(eval(R"nix(builtins.deserializeFunction "42")nix"), EvalError);
+}
+
+TEST_F(PrimOpTest, serializeDeserializeRoundTrip)
+{
+    auto v = eval(R"(
+        let
+          original = let x = 10; in (y: x + y);
+          serialized = builtins.serializeFunction original;
+          restored = builtins.deserializeFunction serialized;
+        in restored 5
+    )");
+    ASSERT_EQ(v.type(), nInt);
+    ASSERT_EQ(v.integer().value, 15);
+}
+
+TEST_F(PrimOpTest, serializeDeserializeRoundTripString)
+{
+    auto v = eval(R"(
+        let
+          greeting = "hello";
+          original = (name: "${greeting} ${name}");
+          serialized = builtins.serializeFunction original;
+          restored = builtins.deserializeFunction serialized;
+        in restored "world"
+    )");
+    ASSERT_THAT(v, IsStringEq("hello world"));
+}
+
 // `toString` for partially applied primops shows only the base name (lossy).
 TEST_F(PrimOpTest, toStringPartiallyAppliedPrimOp)
 {
@@ -700,8 +748,46 @@ TEST_F(PrimOpTest, serializeFunctionPartiallyAppliedPrimOp)
     ASSERT_THAT(v, IsStringEq("(builtins.map builtins.head)"));
 }
 
+// Partially applied primop round-trips through serialize/deserialize.
+TEST_F(PrimOpTest, serializeDeserializePartialPrimOpRoundTrip)
+{
+    auto v = eval(R"nix(
+        let
+          f = builtins.deserializeFunction
+                (builtins.serializeFunction (builtins.map builtins.head));
+        in f [[1 2] [3 4] [5 6]]
+    )nix");
+    ASSERT_EQ(v.type(), nList);
+    ASSERT_EQ(v.listSize(), 3);
+}
+
 // Nested closures: inner closure bindings are now reconstructed.
+TEST_F(PrimOpTest, serializeFunctionNestedClosureRoundTrip)
+{
+    auto v = eval(R"(
+        let
+          inner = let x = 10; in (y: x + y);
+          serialized = builtins.serializeFunction (z: inner z);
+          restored = builtins.deserializeFunction serialized;
+        in restored 5
+    )");
+    ASSERT_EQ(v.type(), nInt);
+    ASSERT_EQ(v.integer().value, 15);
+}
+
 // `with`-bound variables are now captured in serialized output.
+TEST_F(PrimOpTest, serializeFunctionWithBindingCaptured)
+{
+    auto v = eval(R"nix(
+        let
+          serialized = with { greeting = "hi"; };
+            builtins.serializeFunction (x: greeting);
+          restored = builtins.deserializeFunction serialized;
+        in restored null
+    )nix");
+    ASSERT_THAT(v, IsStringEq("hi"));
+}
+
 // Recursive attrset in closure: emits back-reference to let-binding name.
 TEST_F(PrimOpTest, serializeFunctionRecursiveAttrset)
 {
@@ -712,7 +798,38 @@ TEST_F(PrimOpTest, serializeFunctionRecursiveAttrset)
     EXPECT_THAT(s, ::testing::HasSubstr("s"));
 }
 
+// Recursive attrset round-trips through serialize/deserialize.
+TEST_F(PrimOpTest, serializeDeserializeRecursiveAttrsetRoundTrip)
+{
+    auto v = eval(R"(
+        let
+          s = { x = s; val = 42; };
+          serialized = builtins.serializeFunction (y: s.val);
+          restored = builtins.deserializeFunction serialized;
+        in restored null
+    )");
+    ASSERT_EQ(v.type(), nInt);
+    ASSERT_EQ(v.integer().value, 42);
+}
+
 // Edge case: closure with list and attrset values round-trips correctly.
+TEST_F(PrimOpTest, serializeDeserializeRoundTripCompound)
+{
+    auto v = eval(R"(
+        let
+          xs = [1 2 3];
+          cfg = { a = true; b = null; };
+        in
+          let
+            serialized = builtins.serializeFunction (f: { inherit xs cfg; val = f; });
+            restored = builtins.deserializeFunction serialized;
+            result = restored 42;
+          in result.xs
+    )");
+    ASSERT_EQ(v.type(), nList);
+    ASSERT_EQ(v.listSize(), 3);
+}
+
 // Edge case: float precision.
 TEST_F(PrimOpTest, serializeFunctionFloatPrecision)
 {
@@ -821,37 +938,260 @@ TEST_F(PrimOpTest, serializeFunctionEtaReducesMultiArgLambda)
 }
 
 // Eta-reduction does not apply to partial forwarding.
+TEST_F(PrimOpTest, serializeFunctionNoEtaPartialForward)
+{
+    auto v = eval(R"(
+        let f = a: b: a + b;
+        in builtins.serializeFunction (x: f x 1)
+    )");
+    auto s = std::string(v.string_view());
+    // Not eta-reduced: second arg is `1`, not a lambda param.
+    EXPECT_THAT(s, ::testing::HasSubstr("(x:"));
+}
+
+/*
+ * Dynamic derivations scenario tests.
+ *
+ * The dynamic derivations use case (RFC 0092) requires serializing a
+ * function during evaluation, passing it into a build sandbox, and
+ * deserializing it there to produce further derivations.  These tests
+ * simulate that pipeline: construct a function that builds derivation-
+ * like attrsets, serialize it, deserialize it, and verify the result.
+ */
+
 // Scenario: a "mkDerivation" helper captures shared config from the
 // evaluation phase, gets serialized into a builder, and is called at
 // build time with per-source-file arguments.
+TEST_F(PrimOpTest, dynDrvMkDerivationFactory)
+{
+    auto v = eval(R"(
+        let
+          system = "x86_64-linux";
+          baseFlags = ["-O2" "-Wall"];
+          mkCompile = src: {
+            name = "compile-${src}";
+            inherit system;
+            flags = baseFlags ++ [src];
+          };
+          serialized = builtins.serializeFunction mkCompile;
+          restored = builtins.deserializeFunction serialized;
+          drv = restored "main.c";
+        in drv.name
+    )");
+    ASSERT_THAT(v, IsStringEq("compile-main.c"));
+}
+
 // Scenario: the serialized function captures a dependency map (like a
 // lockfile parsed during evaluation) and uses it at build time.
+TEST_F(PrimOpTest, dynDrvLockfileDependencyMap)
+{
+    auto v = eval(R"(
+        let
+          lockfile = {
+            "express" = { version = "4.18.2"; resolved = "/nix/store/fake-express"; };
+            "lodash" = { version = "4.17.21"; resolved = "/nix/store/fake-lodash"; };
+          };
+          resolve = name: lockfile.${name}.resolved;
+          serialized = builtins.serializeFunction resolve;
+          restored = builtins.deserializeFunction serialized;
+        in restored "lodash"
+    )");
+    ASSERT_THAT(v, IsStringEq("/nix/store/fake-lodash"));
+}
+
 // Scenario: higher-order -- a serialized function itself returns
 // functions (e.g. a build system that produces per-target builders).
+TEST_F(PrimOpTest, dynDrvHigherOrderBuilder)
+{
+    auto v = eval(R"(
+        let
+          cc = "/nix/store/fake-gcc";
+          mkBuilder = target: src: {
+            name = "${target}-${src}";
+            compiler = cc;
+          };
+          serialized = builtins.serializeFunction mkBuilder;
+          restored = builtins.deserializeFunction serialized;
+          builder = restored "aarch64";
+          drv = builder "kernel.c";
+        in drv.compiler
+    )");
+    ASSERT_THAT(v, IsStringEq("/nix/store/fake-gcc"));
+}
+
 // Scenario: the function uses builtins (primops) captured through
 // partial application -- e.g. a pre-configured map operation.
+TEST_F(PrimOpTest, dynDrvPartialPrimopInClosure)
+{
+    auto v = eval(R"nix(
+        let
+          transform = builtins.map (x: x * 2);
+          apply = inputs: transform inputs;
+          serialized = builtins.serializeFunction apply;
+          restored = builtins.deserializeFunction serialized;
+        in restored [1 2 3]
+    )nix");
+    ASSERT_EQ(v.type(), nList);
+    ASSERT_EQ(v.listSize(), 3);
+}
+
 // Scenario: mutual recursion between closure values -- a "plugin
 // system" where plugins reference each other.
+TEST_F(PrimOpTest, dynDrvMutuallyRecursiveClosures)
+{
+    auto v = eval(R"(
+        let
+          plugins = {
+            a = { name = "plugin-a"; deps = [ plugins.b ]; };
+            b = { name = "plugin-b"; deps = []; };
+          };
+          getName = p: (builtins.head plugins.${p}.deps).name or plugins.${p}.name;
+          serialized = builtins.serializeFunction getName;
+          restored = builtins.deserializeFunction serialized;
+        in restored "a"
+    )");
+    ASSERT_THAT(v, IsStringEq("plugin-b"));
+}
+
 // Limitation test: string context is lost on round-trip.
 // In a real dynamic derivation scenario, store paths in closure strings
 // would lose their dependency tracking after deserialization.
 // We verify this by checking that a path-containing string in a closure
+// loses its context after serialize/deserialize.
+TEST_F(PrimOpTest, dynDrvStringContextLostOnRoundTrip)
+{
+    // builtins.storePath would add context, but requires a real store path.
+    // Instead, test that the serialized string itself carries context
+    // from the closure (via copyContext in serializeValue), but the
+    // deserialized result does not.  We use builtins.toFile to create
+    // a real store path with context.
+    //
+    // This test cannot easily be written without a store, so we test
+    // the simpler case: a plain string in a closure round-trips as a
+    // plain string (no context to lose), documenting the gap.
+    auto v = eval(R"(
+        let
+          path = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello";
+          f = _: path;
+          serialized = builtins.serializeFunction f;
+          restored = builtins.deserializeFunction serialized;
+        in restored null
+    )");
+    // The string survives, but in a real scenario with store path context
+    // attached, the context would be lost after deserialization.
+    ASSERT_THAT(v, IsStringEq("/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello"));
+}
+
 // Scenario: `preserveStringContext` emits `builtins.appendContext` wrapping
 // for strings with context.  We verify the output format since the test
 // harness uses a dummy store that cannot validate real store paths.
 // Scenario: eta-reduced polyfills in a dynamic derivation pipeline.
 // A `lib.head`-style polyfill round-trips to the underlying primop.
+TEST_F(PrimOpTest, dynDrvEtaReducedPolyfill)
+{
+    auto v = eval(R"(
+        let
+          head = builtins.head;
+          getFirst = x: head x;
+          serialized = builtins.serializeFunction getFirst;
+          restored = builtins.deserializeFunction serialized;
+        in restored [ 42 1 2 ]
+    )");
+    ASSERT_EQ(v.type(), nInt);
+    ASSERT_EQ(v.integer().value, 42);
+}
+
 // Scenario: a build system that combines eval-time configuration,
 // a polyfilled lib function, and a dependency map -- the full pipeline.
+TEST_F(PrimOpTest, dynDrvFullPipeline)
+{
+    auto v = eval(R"(
+        let
+          system = "x86_64-linux";
+          concatStringsSep = builtins.concatStringsSep;
+          deps = { "main.c" = [ "stdio.h" "stdlib.h" ]; };
+          mkCompileCmd = src: {
+            name = "compile-${src}";
+            inherit system;
+            includes = concatStringsSep " " (builtins.map (h: "-I${h}") (deps.${src} or []));
+          };
+          serialized = builtins.serializeFunction mkCompileCmd;
+          restored = builtins.deserializeFunction serialized;
+          cmd = restored "main.c";
+        in cmd.includes
+    )");
+    ASSERT_THAT(v, IsStringEq("-Istdio.h -Istdlib.h"));
+}
+
 // Scenario: the attrset form with `allowedPluginPrimOps` in a
 // dynamic derivation pipeline.  Plugin primops are not available in
 // the test harness, but we verify the option is accepted and does
 // not interfere with normal serialization.
+TEST_F(PrimOpTest, dynDrvAttrsetFormWithOptions)
+{
+    auto v = eval(R"(
+        let
+          f = x: x + 1;
+          serialized = builtins.serializeFunction {
+            fn = f;
+            allowedPluginPrimOps = [ "hypotheticalPlugin" ];
+            preserveStringContext = true;
+          };
+          restored = builtins.deserializeFunction serialized;
+        in restored 41
+    )");
+    ASSERT_EQ(v.type(), nInt);
+    ASSERT_EQ(v.integer().value, 42);
+}
+
 // The `derivation` function (a top-level constant, not a primop) is
+// available after deserialization because `deserializeFunction` parses
 // in the base environment.
+TEST_F(PrimOpTest, dynDrvDerivationRoundTrip)
+{
+    auto v = eval(R"(
+        let
+          mkDrv = builtins.deserializeFunction
+            (builtins.serializeFunction
+              (name: derivation {
+                inherit name;
+                system = "x86_64-linux";
+                builder = "/bin/sh";
+              }));
+        in (mkDrv "hello").name
+    )");
+    ASSERT_THAT(v, IsStringEq("hello"));
+}
+
 // The `derivation` function works when captured indirectly in a closure.
+TEST_F(PrimOpTest, dynDrvDerivationInClosure)
+{
+    auto v = eval(R"(
+        let
+          system = "x86_64-linux";
+          mkDrv = name: derivation {
+            inherit name system;
+            builder = "/bin/sh";
+          };
+          serialized = builtins.serializeFunction mkDrv;
+          restored = builtins.deserializeFunction serialized;
+        in (restored "test").type
+    )");
+    ASSERT_THAT(v, IsStringEq("derivation"));
+}
+
 // `import` serializes as `builtins.import` and is available after
 // deserialization.
+TEST_F(PrimOpTest, dynDrvImportPrimOpRoundTrip)
+{
+    auto v = eval(R"nix(
+        let
+          serialized = builtins.serializeFunction (x: import x);
+        in serialized
+    )nix");
+    ASSERT_THAT(v, IsStringEq("builtins.import"));
+}
+
 // provided at deserialization time, not inlined.
 TEST_F(PrimOpTest, substring)
 {

--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -5,6 +5,7 @@
 #include "nix/util/memory-source-accessor.hh"
 
 #include "nix/expr/tests/libexpr.hh"
+#include "nix/util/tests/gmock-matchers.hh"
 
 namespace nix {
 class CaptureLogger : public Logger
@@ -649,41 +650,209 @@ TEST_F(PrimOpTest, toStringPrimOp)
     ASSERT_THAT(v, IsStringEq("builtins.head"));
 }
 
-class ToStringPrimOpTest : public PrimOpTest,
-                           public ::testing::WithParamInterface<std::tuple<std::string, std::string_view>>
-{};
-
-TEST_P(ToStringPrimOpTest, toString)
+TEST_F(PrimOpTest, serializeFunctionSimple)
 {
-    const auto & [input, output] = GetParam();
-    auto v = eval(input);
-    ASSERT_THAT(v, IsStringEq(output));
+    auto v = eval("builtins.serializeFunction (x: x)");
+    ASSERT_THAT(v, IsStringEq("(x: x)"));
 }
 
-#define CASE(input, output) (std::make_tuple(std::string_view("builtins.toString " input), std::string_view(output)))
-INSTANTIATE_TEST_SUITE_P(
-    toString,
-    ToStringPrimOpTest,
-    ::testing::Values(
-        CASE(R"("foo")", "foo"),
-        CASE(R"(1)", "1"),
-        CASE(R"([1 2 3])", "1 2 3"),
-        CASE(R"(.123)", "0.123000"),
-        CASE(R"(true)", "1"),
-        CASE(R"(false)", ""),
-        CASE(R"(null)", ""),
-        CASE(R"({ v = "bar"; __toString = self: self.v; })", "bar"),
-        CASE(R"({ v = "bar"; __toString = self: self.v; outPath = "foo"; })", "bar"),
-        CASE(R"({ outPath = "foo"; })", "foo")
-// this is broken on cygwin because canonPath("//./test", false) returns //./test
-// FIXME: don't use canonPath
-#ifndef __CYGWIN__
-            ,
-        CASE(R"(./test)", "/test")
-#endif
-            ));
-#undef CASE
+TEST_F(PrimOpTest, serializeFunctionWithClosure)
+{
+    auto v = eval("let x = 1; in builtins.serializeFunction (y: x + y)");
+    ASSERT_THAT(v, IsStringEq("(let x = 1; in (y: (x + y)))"));
+}
 
+TEST_F(PrimOpTest, serializeFunctionWithMultipleCaptured)
+{
+    auto v = eval("let x = 1; y = 2; in builtins.serializeFunction (z: x + y + z)");
+    ASSERT_THAT(v, IsStringEq("(let x = 1; y = 2; in (z: ((x + y) + z)))"));
+}
+
+TEST_F(PrimOpTest, serializeFunctionWithStringClosure)
+{
+    auto v = eval(R"(let name = "world"; in builtins.serializeFunction (x: "hello ${name}"))");
+    ASSERT_THAT(v, IsStringEq(R"((let name = "world"; in (x: ("hello " + name))))"));
+}
+
+TEST_F(PrimOpTest, serializeFunctionNoClosure)
+{
+    auto v = eval("builtins.serializeFunction ({ a, b ? 1 }: a + b)");
+    ASSERT_THAT(v, IsStringEq("({ a, b ? 1 }: (a + b))"));
+}
+
+TEST_F(PrimOpTest, serializeFunctionPrimOp)
+{
+    auto v = eval("builtins.serializeFunction builtins.head");
+    ASSERT_THAT(v, IsStringEq("builtins.head"));
+}
+
+// `toString` for partially applied primops shows only the base name (lossy).
+TEST_F(PrimOpTest, toStringPartiallyAppliedPrimOp)
+{
+    auto v = eval("builtins.toString (builtins.map builtins.head)");
+    ASSERT_THAT(v, IsStringEq("(builtins.map builtins.head)"));
+}
+
+// serializeFunction preserves partially applied primop arguments.
+TEST_F(PrimOpTest, serializeFunctionPartiallyAppliedPrimOp)
+{
+    auto v = eval("builtins.serializeFunction (builtins.map builtins.head)");
+    ASSERT_THAT(v, IsStringEq("(builtins.map builtins.head)"));
+}
+
+// Nested closures: inner closure bindings are now reconstructed.
+// `with`-bound variables are now captured in serialized output.
+// Recursive attrset in closure: emits back-reference to let-binding name.
+TEST_F(PrimOpTest, serializeFunctionRecursiveAttrset)
+{
+    auto v = eval("let s = { x = s; }; in builtins.serializeFunction (y: s)");
+    // The let binding is recursive: `let s = { x = s; }; in ...`
+    auto s = std::string(v.string_view());
+    EXPECT_THAT(s, ::testing::HasSubstr("let "));
+    EXPECT_THAT(s, ::testing::HasSubstr("s"));
+}
+
+// Edge case: closure with list and attrset values round-trips correctly.
+// Edge case: float precision.
+TEST_F(PrimOpTest, serializeFunctionFloatPrecision)
+{
+    auto v = eval(R"(
+        let pi = 3.14159265358979;
+        in builtins.serializeFunction (x: x + pi)
+    )");
+    auto s = std::string(v.string_view());
+    // std::to_string produces 6 decimal places by default.
+    EXPECT_THAT(s, ::testing::HasSubstr("3.141593"));
+}
+
+// Plugin primops: the isPluginPrimOp flag is set for extraPrimOps.
+// We can't easily test the serialization rejection in the test harness
+// (the EvalState is already constructed), but we verify the flag works
+// on a hand-crafted PrimOp.
+TEST_F(PrimOpTest, pluginPrimOpFlagIsSet)
+{
+    auto * v = state.allocValue();
+    v->mkPrimOp(new PrimOp{
+        .name = "fakePlugin",
+        .args = {"x"},
+        .impl = [](EvalState &, const PosIdx, Value **, Value & v) { v.mkNull(); },
+        .isPluginPrimOp = true,
+    });
+    ASSERT_TRUE(v->primOp()->isPluginPrimOp);
+
+    // Built-in primops do not have the flag set.
+    auto builtinHead = eval("builtins.head", false);
+    state.forceValue(builtinHead, noPos);
+    ASSERT_TRUE(builtinHead.isPrimOp());
+    ASSERT_FALSE(builtinHead.primOp()->isPluginPrimOp);
+}
+
+// Attrset form: accepts { fn, allowedPluginPrimOps }.
+TEST_F(PrimOpTest, serializeFunctionAttrsetForm)
+{
+    auto v = eval(R"(
+        builtins.serializeFunction {
+          fn = x: x + 1;
+          allowedPluginPrimOps = [];
+        }
+    )");
+    ASSERT_THAT(v, IsStringEq("(x: (x + 1))"));
+}
+
+// Attrset form without fn attribute throws.
+TEST_F(PrimOpTest, serializeFunctionAttrsetNoFnThrows)
+{
+    ASSERT_THROW(eval("builtins.serializeFunction { }"), EvalError);
+}
+
+// preserveStringContext = false (default): plain string, no appendContext.
+// preserveStringContext = true: strings with context get appendContext wrapping.
+// We can't easily create real store path context in the test harness, so
+// we verify the flag is accepted and plain strings (no context) are unaffected.
+// Eta-reduction: direct `builtins.head` access is now detected.
+TEST_F(PrimOpTest, serializeFunctionEtaReducesDirectBuiltin)
+{
+    auto v = eval("builtins.serializeFunction (x: builtins.head x)");
+    ASSERT_THAT(v, IsStringEq("builtins.head"));
+}
+
+// Eta-reduction: polyfill in closure normalizes to the underlying primop.
+TEST_F(PrimOpTest, serializeFunctionEtaReducesClosurePolyfill)
+{
+    auto v = eval("let head = builtins.head; in builtins.serializeFunction (x: head x)");
+    ASSERT_THAT(v, IsStringEq("builtins.head"));
+}
+
+// Eta-reduction does not apply when the body does more than forward args.
+TEST_F(PrimOpTest, serializeFunctionNoEtaWhenBodyDiffers)
+{
+    auto v = eval("builtins.serializeFunction (x: builtins.head x + 1)");
+    auto s = std::string(v.string_view());
+    EXPECT_THAT(s, ::testing::HasSubstr("(x:"));
+}
+
+// Multi-arg eta-reduction: `x: y: f x y` reduces to `f`.
+TEST_F(PrimOpTest, serializeFunctionEtaReducesMultiArg)
+{
+    auto v = eval(R"(
+        let elemAt = builtins.elemAt;
+        in builtins.serializeFunction (list: index: elemAt list index)
+    )");
+    ASSERT_THAT(v, IsStringEq("builtins.elemAt"));
+}
+
+// Multi-arg eta-reduction with direct builtin: `x: y: builtins.elemAt x y`.
+TEST_F(PrimOpTest, serializeFunctionEtaReducesMultiArgDirectBuiltin)
+{
+    auto v = eval("builtins.serializeFunction (list: index: builtins.elemAt list index)");
+    ASSERT_THAT(v, IsStringEq("builtins.elemAt"));
+}
+
+// Multi-arg eta-reduction with a user-defined function.
+TEST_F(PrimOpTest, serializeFunctionEtaReducesMultiArgLambda)
+{
+    auto v = eval(R"(
+        let myAdd = a: b: a + b;
+        in builtins.serializeFunction (x: y: myAdd x y)
+    )");
+    // Reduces to `myAdd` which itself has a closure with no free vars,
+    // so it serializes as the lambda body.
+    ASSERT_THAT(v, IsStringEq("(a: (b: (a + b)))"));
+}
+
+// Eta-reduction does not apply to partial forwarding.
+// Scenario: a "mkDerivation" helper captures shared config from the
+// evaluation phase, gets serialized into a builder, and is called at
+// build time with per-source-file arguments.
+// Scenario: the serialized function captures a dependency map (like a
+// lockfile parsed during evaluation) and uses it at build time.
+// Scenario: higher-order -- a serialized function itself returns
+// functions (e.g. a build system that produces per-target builders).
+// Scenario: the function uses builtins (primops) captured through
+// partial application -- e.g. a pre-configured map operation.
+// Scenario: mutual recursion between closure values -- a "plugin
+// system" where plugins reference each other.
+// Limitation test: string context is lost on round-trip.
+// In a real dynamic derivation scenario, store paths in closure strings
+// would lose their dependency tracking after deserialization.
+// We verify this by checking that a path-containing string in a closure
+// Scenario: `preserveStringContext` emits `builtins.appendContext` wrapping
+// for strings with context.  We verify the output format since the test
+// harness uses a dummy store that cannot validate real store paths.
+// Scenario: eta-reduced polyfills in a dynamic derivation pipeline.
+// A `lib.head`-style polyfill round-trips to the underlying primop.
+// Scenario: a build system that combines eval-time configuration,
+// a polyfilled lib function, and a dependency map -- the full pipeline.
+// Scenario: the attrset form with `allowedPluginPrimOps` in a
+// dynamic derivation pipeline.  Plugin primops are not available in
+// the test harness, but we verify the option is accepted and does
+// not interfere with normal serialization.
+// The `derivation` function (a top-level constant, not a primop) is
+// in the base environment.
+// The `derivation` function works when captured indirectly in a closure.
+// `import` serializes as `builtins.import` and is available after
+// deserialization.
+// provided at deserialization time, not inlined.
 TEST_F(PrimOpTest, substring)
 {
     auto v = eval("builtins.substring 0 3 \"nixos\"");

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2528,6 +2528,42 @@ BackedStringView EvalState::coerceToString(
         if (v.type() == nNull)
             return "";
 
+        if (v.type() == nFunction && experimentalFeatureSettings.isEnabled(Xp::FunctionSerialization)) {
+            if (v.isLambda() && v.lambda().fun) {
+                std::ostringstream s;
+                v.lambda().fun->show(symbols, s);
+                return s.str();
+            } else if (v.isPrimOp() && v.primOp()) {
+                return fmt("builtins.%s", v.primOp()->name);
+            } else if (v.isPrimOpApp()) {
+                // Walk the left-spine to collect the base primop and arguments.
+                std::vector<Value *> args;
+                Value * cur = const_cast<Value *>(&v);
+                while (cur->isPrimOpApp()) {
+                    auto thunk = cur->primOpApp();
+                    args.push_back(thunk.right);
+                    cur = thunk.left;
+                }
+                std::ostringstream s;
+                s << "(builtins." << (cur->isPrimOp() && cur->primOp() ? cur->primOp()->name : "?");
+                for (auto it = args.rbegin(); it != args.rend(); ++it) {
+                    s << " ";
+                    auto arg = coerceToString(
+                        pos,
+                        **it,
+                        context,
+                        "while coercing a partially applied primop argument to a string",
+                        coerceMore,
+                        copyToStore,
+                        canonicalizePath);
+                    s << *arg;
+                }
+                s << ")";
+                return s.str();
+            }
+            return "<<function>>";
+        }
+
         if (v.isList()) {
             std::string result;
             auto listView = v.listView();

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -134,6 +134,14 @@ struct PrimOp
     bool internal = false;
 
     /**
+     * If true, this primop was registered via `extraPrimOps` (e.g. from
+     * a plugin or flake subsystem) rather than being a core Nix builtin.
+     * Used by `builtins.serializeFunction` to detect primops that may
+     * not be available in the deserialization environment.
+     */
+    bool isPluginPrimOp = false;
+
+    /**
      * Validity check to be performed by functions that introduce primops,
      * such as RegisterPrimOp() and Value::mkPrimOp().
      */

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -460,7 +460,7 @@ void ExprList::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> &
 
 void ExprLambda::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & env)
 {
-    if (es.debugRepl)
+    if (es.debugRepl || experimentalFeatureSettings.isEnabled(Xp::FunctionSerialization))
         es.exprEnvs.insert(std::make_pair(this, env));
 
     auto newEnv =

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <set>
 #include <sstream>
 #include <regex>
 
@@ -2642,31 +2643,15 @@ static void prim_fromJSON(EvalState & state, const PosIdx pos, Value ** args, Va
 static RegisterPrimOp primop_fromJSON({
     .name = "__fromJSON",
     .args = {"e"},
-    .doc = R"doc(
-      Convert the expression *e* to a string. *e* can be:
+    .doc = R"(
+      Convert a JSON string to a Nix value. For example,
 
-        - A string (in which case the string is returned unmodified).
+      ```nix
+      builtins.fromJSON ''{"x": [1, 2, 3], "y": null}''
+      ```
 
-        - A path (e.g., `toString /foo/bar` yields `"/foo/bar"`.
-
-        - A set containing `{ __toString = self: ...; }` or `{ outPath = ...; }`.
-
-        - An integer.
-
-        - A list, in which case the string representations of its elements
-          are joined with spaces.
-
-        - A Boolean (`false` yields `""`, `true` yields `"1"`).
-
-        - `null`, which yields the empty string.
-
-        - A function (requires the [`function-serialization`](@docroot@/development/experimental-features.md#xp-feature-function-serialization) experimental feature).
-          Lambdas produce their source representation (e.g. `toString (x: x)` yields `"(x: x)"`).
-          Primops produce their qualified `builtins.` name
-          (e.g. `toString builtins.head` yields `"builtins.head"`).
-          Partially applied primops include their arguments
-          (e.g. `toString (builtins.map builtins.head)` yields `"(builtins.map builtins.head)"`).
-    )doc",
+      returns the value `{ x = [ 1 2 3 ]; y = null; }`.
+    )",
     .impl = prim_fromJSON,
 });
 
@@ -4520,6 +4505,635 @@ static RegisterPrimOp primop_toString({
     .impl = prim_toString,
 });
 
+/**
+ * Collect free variable names from an expression tree that reference bindings
+ * from outside the lambda (i.e., closure captures).
+ *
+ * `depth` is the number of scope levels between the current position and the
+ * lambda's parameter scope.  An `ExprVar` with `level > depth` refers to a
+ * binding captured from the enclosing environment.
+ */
+static void collectFreeVars(Expr * e, int depth, std::set<Symbol> & freeVars)
+{
+    if (!e)
+        return;
+
+    // Leaves / literals -- no free variables.
+    if (dynamic_cast<ExprInt *>(e) || dynamic_cast<ExprFloat *>(e) || dynamic_cast<ExprString *>(e)
+        || dynamic_cast<ExprPath *>(e) || dynamic_cast<ExprPos *>(e) || dynamic_cast<ExprBlackHole *>(e))
+        return;
+
+    if (auto var = dynamic_cast<ExprVar *>(e)) {
+        // Captures both lexically-bound and `with`-bound variables
+        // from enclosing scopes.  `mapStaticEnvBindings` includes
+        // `with` bindings when the attrset has been forced.
+        if (var->level > (Level) depth)
+            freeVars.insert(var->name);
+        return;
+    }
+
+    if (auto sel = dynamic_cast<ExprSelect *>(e)) {
+        collectFreeVars(sel->e, depth, freeVars);
+        collectFreeVars(sel->def, depth, freeVars);
+        for (auto & an : sel->getAttrPath())
+            if (an.expr)
+                collectFreeVars(an.expr, depth, freeVars);
+        return;
+    }
+
+    if (auto hasAttr = dynamic_cast<ExprOpHasAttr *>(e)) {
+        collectFreeVars(hasAttr->e, depth, freeVars);
+        for (auto & an : hasAttr->attrPath)
+            if (an.expr)
+                collectFreeVars(an.expr, depth, freeVars);
+        return;
+    }
+
+    if (auto attrs = dynamic_cast<ExprAttrs *>(e)) {
+        int innerDepth = attrs->recursive ? depth + 1 : depth;
+        for (auto & [name, def] : *attrs->attrs)
+            collectFreeVars(def.e, innerDepth, freeVars);
+        if (attrs->inheritFromExprs)
+            for (auto * expr : *attrs->inheritFromExprs)
+                collectFreeVars(expr, depth, freeVars);
+        for (auto & dyn : *attrs->dynamicAttrs) {
+            collectFreeVars(dyn.nameExpr, depth, freeVars);
+            collectFreeVars(dyn.valueExpr, innerDepth, freeVars);
+        }
+        return;
+    }
+
+    if (auto list = dynamic_cast<ExprList *>(e)) {
+        for (auto * elem : list->elems)
+            collectFreeVars(elem, depth, freeVars);
+        return;
+    }
+
+    if (auto lambda = dynamic_cast<ExprLambda *>(e)) {
+        // Nested lambda: adds one scope level for its parameters.
+        if (auto formals = lambda->getFormals())
+            for (auto & f : formals->formals)
+                if (f.def)
+                    collectFreeVars(f.def, depth + 1, freeVars);
+        collectFreeVars(lambda->body, depth + 1, freeVars);
+        return;
+    }
+
+    if (auto call = dynamic_cast<ExprCall *>(e)) {
+        collectFreeVars(call->fun, depth, freeVars);
+        for (auto * arg : *call->args)
+            collectFreeVars(arg, depth, freeVars);
+        return;
+    }
+
+    if (auto let = dynamic_cast<ExprLet *>(e)) {
+        for (auto & [name, def] : *let->attrs->attrs)
+            collectFreeVars(def.e, depth + 1, freeVars);
+        if (let->attrs->inheritFromExprs)
+            for (auto * expr : *let->attrs->inheritFromExprs)
+                collectFreeVars(expr, depth, freeVars);
+        collectFreeVars(let->body, depth + 1, freeVars);
+        return;
+    }
+
+    if (auto with = dynamic_cast<ExprWith *>(e)) {
+        collectFreeVars(with->attrs, depth, freeVars);
+        collectFreeVars(with->body, depth + 1, freeVars);
+        return;
+    }
+
+    if (auto if_ = dynamic_cast<ExprIf *>(e)) {
+        collectFreeVars(if_->cond, depth, freeVars);
+        collectFreeVars(if_->then, depth, freeVars);
+        collectFreeVars(if_->else_, depth, freeVars);
+        return;
+    }
+
+    if (auto assert_ = dynamic_cast<ExprAssert *>(e)) {
+        collectFreeVars(assert_->cond, depth, freeVars);
+        collectFreeVars(assert_->body, depth, freeVars);
+        return;
+    }
+
+    if (auto not_ = dynamic_cast<ExprOpNot *>(e)) {
+        collectFreeVars(not_->e, depth, freeVars);
+        return;
+    }
+
+    if (auto concat = dynamic_cast<ExprConcatStrings *>(e)) {
+        for (auto & [pos, expr] : concat->es)
+            collectFreeVars(expr, depth, freeVars);
+        return;
+    }
+
+    // Binary operators all have e1/e2 members.
+#define HANDLE_BINOP(Type)                         \
+    if (auto * bin = dynamic_cast<Type *>(e)) {    \
+        collectFreeVars(bin->e1, depth, freeVars); \
+        collectFreeVars(bin->e2, depth, freeVars); \
+        return;                                    \
+    }
+    HANDLE_BINOP(ExprOpEq)
+    HANDLE_BINOP(ExprOpNEq)
+    HANDLE_BINOP(ExprOpAnd)
+    HANDLE_BINOP(ExprOpOr)
+    HANDLE_BINOP(ExprOpImpl)
+    HANDLE_BINOP(ExprOpConcatLists)
+    HANDLE_BINOP(ExprOpUpdate)
+#undef HANDLE_BINOP
+
+    // ExprInheritFrom is a subclass of ExprVar -- handled by the ExprVar case above.
+    // Unknown expression type -- skip conservatively.
+}
+
+using BackRefMap = std::map<const void *, std::string>;
+
+/**
+ * Policy for serializing plugin primops (those registered via `extraPrimOps`).
+ * - `nullopt`: allow all plugin primops unconditionally
+ * - empty set: reject all plugin primops (default for `builtins.serializeFunction`)
+ * - non-empty set: allow only the listed primop names
+ */
+using PluginPrimOpPolicy = std::optional<std::set<std::string>>;
+
+/**
+ * Mutable context threaded through the serialization functions,
+ * avoiding 8-parameter signatures on every call.
+ */
+struct SerializeContext
+{
+    EvalState & state;
+    PosIdx pos;
+    std::ostream & out;
+    NixStringContext & context;
+    std::set<const void *> & visited;
+    BackRefMap backRefs;
+    const PluginPrimOpPolicy & pluginPolicy;
+
+    void checkPluginPrimOp(const PrimOp & primOp)
+    {
+        if (!primOp.isPluginPrimOp)
+            return;
+        if (!pluginPolicy.has_value())
+            return;
+        if (pluginPolicy->count(primOp.name))
+            return;
+        state
+            .error<EvalError>(
+                "cannot serialize plugin primop `builtins.%s`: "
+                "it may not be available in the deserialization environment "
+                "(add it to the allowed plugin primops list to override)",
+                primOp.name)
+            .atPos(pos)
+            .debugThrow();
+    }
+
+    /**
+     * Check for cycles via the visited set.  If a cycle is detected and
+     * the value has a back-reference name, emit it and return true.
+     * Otherwise throw on cycle, or return false (no cycle -- caller
+     * should serialize the value and call `leaveVisited` when done).
+     */
+    bool enterVisited(Value & v)
+    {
+        auto ptr = &v;
+        if (visited.insert(ptr).second)
+            return false;
+        auto it = backRefs.find(ptr);
+        if (it != backRefs.end()) {
+            out << it->second;
+            return true;
+        }
+        state.error<EvalError>("infinite recursion encountered while serializing a function closure")
+            .atPos(pos)
+            .debugThrow();
+    }
+
+    void leaveVisited(Value & v)
+    {
+        visited.erase(&v);
+    }
+};
+
+static void serializeValue(SerializeContext & ctx, Value & v);
+static void serializeLambdaWithClosure(SerializeContext & ctx, Value & v);
+
+/**
+ * Collect the base primop and accumulated arguments from a
+ * `tPrimOpApp` value by walking the left-spine.  Arguments are
+ * returned in application order (innermost first).
+ */
+static std::pair<const PrimOp *, std::vector<Value *>>
+collectPrimOpAppArgs(EvalState & state, const PosIdx pos, Value & v)
+{
+    std::vector<Value *> args;
+    Value * cur = &v;
+    while (cur->isPrimOpApp()) {
+        auto thunk = cur->primOpApp();
+        args.push_back(thunk.right);
+        cur = thunk.left;
+    }
+    if (!cur->isPrimOp() || !cur->primOp())
+        state.error<EvalError>("cannot serialize a partially applied primop without a known base")
+            .atPos(pos)
+            .debugThrow();
+    std::reverse(args.begin(), args.end());
+    return {cur->primOp(), std::move(args)};
+}
+
+static void serializeValue(SerializeContext & ctx, Value & v)
+{
+    ctx.state.forceValue(v, ctx.pos);
+
+    switch (v.type()) {
+    case nInt:
+        ctx.out << v.integer().value;
+        break;
+    case nFloat:
+        ctx.out << std::to_string(v.fpoint());
+        break;
+    case nBool:
+        ctx.out << (v.boolean() ? "true" : "false");
+        break;
+    case nNull:
+        ctx.out << "null";
+        break;
+    case nString:
+        printLiteralString(ctx.out, v.string_view());
+        copyContext(v, ctx.context);
+        break;
+    case nPath:
+        ctx.out << v.path().to_string();
+        break;
+    case nList: {
+        if (ctx.enterVisited(v))
+            break;
+        ctx.out << "[ ";
+        for (auto * elem : v.listView()) {
+            serializeValue(ctx, *elem);
+            ctx.out << " ";
+        }
+        ctx.out << "]";
+        ctx.leaveVisited(v);
+        break;
+    }
+    case nAttrs: {
+        if (ctx.enterVisited(v))
+            break;
+        ctx.out << "{ ";
+        for (auto & attr : *v.attrs()) {
+            printAttributeName(ctx.out, ctx.state.symbols[attr.name]);
+            ctx.out << " = ";
+            serializeValue(ctx, *attr.value);
+            ctx.out << "; ";
+        }
+        ctx.out << "}";
+        ctx.leaveVisited(v);
+        break;
+    }
+    case nFunction: {
+        if (v.isLambda() && v.lambda().fun) {
+            serializeLambdaWithClosure(ctx, v);
+        } else if (v.isPrimOp() && v.primOp()) {
+            ctx.checkPluginPrimOp(*v.primOp());
+            ctx.out << "builtins." << v.primOp()->name;
+        } else if (v.isPrimOpApp()) {
+            auto [primOp, args] = collectPrimOpAppArgs(ctx.state, ctx.pos, v);
+            ctx.checkPluginPrimOp(*primOp);
+            ctx.out << "(builtins." << primOp->name;
+            for (auto * arg : args) {
+                ctx.out << " ";
+                serializeValue(ctx, *arg);
+            }
+            ctx.out << ")";
+        } else {
+            ctx.state.error<EvalError>("cannot serialize %1%", showType(v)).atPos(ctx.pos).debugThrow();
+        }
+        break;
+    }
+    default:
+        ctx.state.error<EvalError>("cannot serialize %1%", showType(v)).atPos(ctx.pos).debugThrow();
+    }
+}
+
+/**
+ * Collect all parameter names from a chain of nested lambdas, and
+ * return the innermost body.  For `x: y: z: body`, this returns
+ * `body` and fills `params` with `[x, y, z]`.  Each lambda must be
+ * a simple positional-arg lambda (not formals) for multi-level
+ * unwinding; the outermost lambda may use formals.
+ */
+static Expr * collectNestedLambdaParams(ExprLambda * outerFun, std::vector<Symbol> & params, int & depth)
+{
+    // Collect params from the outermost lambda.
+    if (outerFun->arg)
+        params.push_back(outerFun->arg);
+    if (auto formals = outerFun->getFormals())
+        for (auto & f : formals->formals)
+            params.push_back(f.name);
+    depth = 1;
+
+    // Unwrap nested simple lambdas (`x: y: ... : body`).
+    Expr * body = outerFun->body;
+    while (auto * inner = dynamic_cast<ExprLambda *>(body)) {
+        // Only unwrap simple positional-arg lambdas, not formals.
+        if (!inner->arg || inner->getFormals())
+            break;
+        params.push_back(inner->arg);
+        depth++;
+        body = inner->body;
+    }
+    return body;
+}
+
+/**
+ * Check whether `call->args` are exactly `params` forwarded in order
+ * as simple variable references at the given `depth` levels.
+ */
+static bool argsMatchParams(ExprCall * call, const std::vector<Symbol> & params, int depth)
+{
+    if (!call->args || call->args->size() != params.size())
+        return false;
+    for (size_t i = 0; i < params.size(); ++i) {
+        auto * argVar = dynamic_cast<ExprVar *>((*call->args)[i]);
+        if (!argVar || argVar->fromWith || argVar->name != params[i])
+            return false;
+        // Each arg must reference its own lambda scope level.
+        // The innermost params are at level 0, outermost at depth-1,
+        // but they're all within the nested lambda stack.  In practice,
+        // each param is at level (depth - 1 - its_lambda_index), but
+        // since params are collected from outer to inner and variables
+        // are resolved relative to the point of use (innermost body),
+        // we just need level < depth (referencing a lambda param, not
+        // the closure).
+        if (argVar->level >= (Level) depth)
+            return false;
+    }
+    return true;
+}
+
+/**
+ * Attempt eta-reduction to normalize `lib` polyfills.  Detects:
+ *
+ * - `x: f x` where `f` is a closure variable (handles `let head = builtins.head;`)
+ * - `x: builtins.head x` where the called function is a direct builtin select
+ * - `x: y: f x y` (multi-arg) through nested lambda unwinding
+ *
+ * Returns true if eta-reduction was applied (and output was written).
+ */
+static bool tryEtaReduce(SerializeContext & ctx, Value & v)
+{
+    auto * fun = v.lambda().fun;
+    auto * closureEnv = v.lambda().env;
+    if (!fun || !closureEnv)
+        return false;
+
+    // Collect params from potentially nested lambdas.
+    std::vector<Symbol> params;
+    int depth;
+    Expr * body = collectNestedLambdaParams(fun, params, depth);
+
+    auto * call = dynamic_cast<ExprCall *>(body);
+    if (!call)
+        return false;
+
+    if (!argsMatchParams(call, params, depth))
+        return false;
+
+    // Case 1: called function is a closure variable (`x: f x`).
+    if (auto * calledVar = dynamic_cast<ExprVar *>(call->fun)) {
+        if (calledVar->fromWith || calledVar->level < (Level) depth)
+            return false;
+
+        Env * env = closureEnv;
+        for (Level l = calledVar->level - depth; l > 0; --l)
+            env = env->up;
+        Value * calledValue = env->values[calledVar->displ];
+        ctx.state.forceValue(*calledValue, ctx.pos);
+
+        if (calledValue->type() != nFunction)
+            return false;
+
+        serializeValue(ctx, *calledValue);
+        return true;
+    }
+
+    // Case 2: called function is `<var>.<name>` (e.g. `builtins.head`).
+    if (auto * sel = dynamic_cast<ExprSelect *>(call->fun)) {
+        if (sel->def || sel->getAttrPath().size() != 1)
+            return false;
+        auto & attrName = sel->getAttrPath()[0];
+        if (attrName.expr)
+            return false;
+
+        auto * baseVar = dynamic_cast<ExprVar *>(sel->e);
+        if (!baseVar || baseVar->fromWith || baseVar->level < (Level) depth)
+            return false;
+
+        // Look up the base variable in the closure env (same as case 1).
+        Env * env = closureEnv;
+        for (Level l = baseVar->level - depth; l > 0; --l)
+            env = env->up;
+        Value * baseValue = env->values[baseVar->displ];
+        ctx.state.forceAttrs(*baseValue, ctx.pos, "while eta-reducing a builtin select");
+
+        auto * attr = baseValue->attrs()->get(attrName.symbol);
+        if (!attr)
+            return false;
+
+        ctx.state.forceValue(*attr->value, ctx.pos);
+        if (attr->value->type() != nFunction)
+            return false;
+
+        serializeValue(ctx, *attr->value);
+        return true;
+    }
+
+    return false;
+}
+
+static void serializeLambdaWithClosure(SerializeContext & ctx, Value & v)
+{
+    if (tryEtaReduce(ctx, v))
+        return;
+
+    auto * fun = v.lambda().fun;
+    auto * closureEnv = v.lambda().env;
+
+    if (!fun) {
+        ctx.out << "<<lambda>>";
+        return;
+    }
+
+    auto staticEnv = ctx.state.getStaticEnv(*fun);
+    if (!staticEnv) {
+        fun->show(ctx.state.symbols, ctx.out);
+        return;
+    }
+
+    std::set<Symbol> freeVarNames;
+    if (auto formals = fun->getFormals())
+        for (auto & f : formals->formals)
+            if (f.def)
+                collectFreeVars(f.def, 1, freeVarNames);
+    collectFreeVars(fun->body, 0, freeVarNames);
+
+    if (freeVarNames.empty()) {
+        fun->show(ctx.state.symbols, ctx.out);
+        return;
+    }
+
+    // Force `with` attrset thunks so `mapStaticEnvBindings` can enumerate them.
+    {
+        const StaticEnv * se = staticEnv.get();
+        Env * env = closureEnv;
+        while (se && env && se->up && env->up) {
+            if (se->isWith && env->values[0]->isThunk())
+                ctx.state.forceValue(*env->values[0], ctx.pos);
+            se = se->up.get();
+            env = env->up;
+        }
+    }
+
+    auto allBindings = mapStaticEnvBindings(ctx.state.symbols, *staticEnv, *closureEnv);
+
+    std::map<std::string, Value *> neededBindings;
+    for (auto & [name, val] : *allBindings) {
+        auto sym = ctx.state.symbols.create(name);
+        if (freeVarNames.count(sym))
+            neededBindings.emplace(name, val);
+    }
+
+    if (neededBindings.empty()) {
+        fun->show(ctx.state.symbols, ctx.out);
+        return;
+    }
+
+    BackRefMap savedBackRefs = ctx.backRefs;
+    for (auto & [name, val] : neededBindings) {
+        ctx.state.forceValue(*val, ctx.pos);
+        ctx.backRefs.emplace(val, name);
+    }
+
+    ctx.out << "(let ";
+    for (auto & [name, val] : neededBindings) {
+        printIdentifier(ctx.out, name);
+        ctx.out << " = ";
+        serializeValue(ctx, *val);
+        ctx.out << "; ";
+    }
+    ctx.out << "in ";
+    fun->show(ctx.state.symbols, ctx.out);
+    ctx.out << ")";
+
+    ctx.backRefs = std::move(savedBackRefs);
+}
+
+static void prim_serializeFunction(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+{
+    state.forceValue(*args[0], pos);
+
+    PluginPrimOpPolicy pluginPolicy = std::set<std::string>{}; // reject all by default
+    Value * fn;
+
+    if (args[0]->type() == nAttrs) {
+        // Called as: serializeFunction { fn = <function>; allowedPluginPrimOps = [...]; }
+        auto * fnAttr = args[0]->attrs()->get(state.symbols.create("fn"));
+        if (!fnAttr)
+            state.error<TypeError>("`builtins.serializeFunction` attrset argument must contain a `fn` attribute")
+                .atPos(pos)
+                .debugThrow();
+        state.forceValue(*fnAttr->value, pos);
+        fn = fnAttr->value;
+
+        auto * allowedAttr = args[0]->attrs()->get(state.symbols.create("allowedPluginPrimOps"));
+        if (allowedAttr) {
+            state.forceList(*allowedAttr->value, pos, "while evaluating the `allowedPluginPrimOps` attribute");
+            std::set<std::string> allowed;
+            for (auto * elem : allowedAttr->value->listView()) {
+                auto name = state.forceStringNoCtx(*elem, pos, "while evaluating an element of `allowedPluginPrimOps`");
+                allowed.emplace(name);
+            }
+            pluginPolicy = std::move(allowed);
+        }
+    } else {
+        fn = args[0];
+    }
+
+    if (fn->type() != nFunction)
+        state
+            .error<TypeError>(
+                "`builtins.serializeFunction` expects a function or an attrset with `fn`, but got %1%", showType(*fn))
+            .atPos(pos)
+            .debugThrow();
+
+    SerializeContext ctx{state, pos, out, context, visited, {}, pluginPolicy};
+    serializeValue(ctx, *fn);
+
+    v.mkString(out.str(), context, state.mem);
+}
+
+static RegisterPrimOp primop_serializeFunction({
+    .name = "serializeFunction",
+    .args = {"f"},
+    .doc = R"doc(
+      Serialize a function to a string containing a self-contained Nix
+      expression.  The resulting string includes `let` bindings for all
+      variables captured from the function's closure, so that the expression
+      can be evaluated independently of its original context.
+
+      The argument *f* can be a function directly:
+
+      ```nix
+      builtins.serializeFunction (x: x + 1)
+      ```
+
+      Or an attrset with options:
+
+      ```nix
+      builtins.serializeFunction {
+        fn = myFunction;
+        allowedPluginPrimOps = [ "getFlake" ];
+      }
+      ```
+
+      Attributes:
+      - `fn` (required): the function to serialize.
+      - `allowedPluginPrimOps` (optional, default `[]`): a list of
+        plugin primop names to allow.  By default, user-provided primops
+        (from plugins or the flake subsystem) are rejected since they
+        may not be available in the deserialization environment.
+      Lambdas, primops, and partially applied primops are all supported.
+
+      > **Warning**
+      >
+      > The serialized form is **not stable** across Nix versions.
+      > Primops are referenced by name (`builtins.<name>`), which can
+      > change between versions; `lib` polyfills may also change whether
+      > an operation is a primop or a lambda.  Intended for same-version
+      > use cases: debugging, code generation, and evaluation
+      > continuations (e.g. dynamic derivations).
+
+      ```nix
+      let x = 1; in builtins.serializeFunction (y: x + y)
+      ```
+      evaluates to
+      ```nix
+      "(let x = 1; in (y: (x + y)))"
+      ```
+
+      Serialization forces all captured thunks.  Recursive values in
+      closures are handled via self-referencing `let` bindings.  String
+      contexts (store path dependencies) are attached to the output string
+      but lost if the result is passed through
+      [`builtins.deserializeFunction`](#builtins-deserializeFunction)
+      Float values are serialized with limited precision (`std::to_string`).
+    )doc",
+    .impl = prim_serializeFunction,
+    .experimentalFeature = Xp::FunctionSerialization,
+});
+
+
 /* `substring start len str' returns the substring of `str' starting
    at byte position `min(start, stringLength str)' inclusive and
    ending at `min(start + len, stringLength str)'.  `start' must be
@@ -5449,6 +6063,7 @@ void EvalState::createBaseEnv(const EvalSettings & evalSettings)
     for (auto & primOp : evalSettings.extraPrimOps) {
         auto primOpAdjusted = primOp;
         primOpAdjusted.arity = std::max(primOp.args.size(), primOp.arity);
+        primOpAdjusted.isPluginPrimOp = true;
         addPrimOp(std::move(primOpAdjusted));
     }
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -5133,6 +5133,68 @@ static RegisterPrimOp primop_serializeFunction({
     .experimentalFeature = Xp::FunctionSerialization,
 });
 
+static void prim_deserializeFunction(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+{
+    // Accept strings with context (serializeFunction attaches store path
+    // contexts from closure values).  The context is not restored in the
+    // deserialized result -- see the feature flag documentation.
+    NixStringContext context;
+    auto s = state.forceString(
+        *args[0], context, pos, "while evaluating the first argument passed to builtins.deserializeFunction");
+
+    Expr * e;
+    try {
+        e = state.parseExprFromString(std::string(s), state.rootPath("."), state.staticBaseEnv);
+    } catch (Error & err) {
+        err.addTrace(state.positions[pos], "while parsing the string passed to builtins.deserializeFunction");
+        throw;
+    }
+
+    e->eval(state, state.baseEnv, v);
+    state.forceValue(v, pos);
+
+    if (v.type() != nFunction)
+        state
+            .error<TypeError>(
+                "`builtins.deserializeFunction` expects the string to evaluate to a function, but got %1%", showType(v))
+            .atPos(pos)
+            .debugThrow();
+}
+
+static RegisterPrimOp primop_deserializeFunction({
+    .name = "deserializeFunction",
+    .args = {"s"},
+    .doc = R"doc(
+      Parse and evaluate the string *s* as a Nix expression, which must
+      produce a function value.  This is the inverse of
+      [`builtins.serializeFunction`](#builtins-serializeFunction).
+
+      > **Warning**
+      >
+      > This evaluates arbitrary Nix expressions (the result is only
+      > type-checked after evaluation).  Side effects such as
+      > `builtins.fetchurl` or import-from-derivation can be triggered
+      > during evaluation.  Only use this on trusted input.  This is
+      > inherent to the string-eval approach.
+
+      String contexts from the serialized form are **not** restored
+      by default, since the input is parsed as fresh Nix source.
+      However, if `preserveStringContext = true` was used during
+      serialization, the output contains `builtins.appendContext`
+      calls that reconstruct contexts on evaluation.
+
+      Paths are absolute (resolved at original parse time) but the
+      referenced files may not exist in the deserialization environment.
+
+      ```nix
+      let f = builtins.deserializeFunction "(x: x + 1)";
+      in f 41
+      ```
+      evaluates to `42`.
+    )doc",
+    .impl = prim_deserializeFunction,
+    .experimentalFeature = Xp::FunctionSerialization,
+});
 
 /* `substring start len str' returns the substring of `str' starting
    at byte position `min(start, stringLength str)' inclusive and

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -4669,6 +4669,7 @@ struct SerializeContext
     std::set<const void *> & visited;
     BackRefMap backRefs;
     const PluginPrimOpPolicy & pluginPolicy;
+    bool preserveStringContext = false;
 
     void checkPluginPrimOp(const PrimOp & primOp)
     {
@@ -4758,10 +4759,69 @@ static void serializeValue(SerializeContext & ctx, Value & v)
     case nNull:
         ctx.out << "null";
         break;
-    case nString:
-        printLiteralString(ctx.out, v.string_view());
-        copyContext(v, ctx.context);
+    case nString: {
+        bool hasContext = v.context() && *v.context()->begin();
+        if (hasContext && ctx.preserveStringContext) {
+            // Emit `builtins.appendContext "..." { ... }` so that string
+            // contexts (store path dependencies) survive round-trip
+            // through deserializeFunction.
+            NixStringContext strCtx;
+            copyContext(v, strCtx);
+
+            ctx.out << "(builtins.appendContext ";
+            printLiteralString(ctx.out, v.string_view());
+            ctx.out << " { ";
+
+            // Group context elements by store path, matching the format
+            // expected by `builtins.appendContext`.
+            struct CtxInfo
+            {
+                bool path = false;
+                bool allOutputs = false;
+                std::vector<std::string> outputs;
+            };
+
+            std::map<std::string, CtxInfo> grouped;
+            for (auto & elem : strCtx) {
+                std::visit(
+                    overloaded{
+                        [&](const NixStringContextElem::Opaque & o) {
+                            grouped[ctx.state.store->printStorePath(o.path)].path = true;
+                        },
+                        [&](const NixStringContextElem::DrvDeep & d) {
+                            grouped[ctx.state.store->printStorePath(d.drvPath)].allOutputs = true;
+                        },
+                        [&](const NixStringContextElem::Built & b) {
+                            auto drvPath = resolveDerivedPath(*ctx.state.store, *b.drvPath);
+                            grouped[ctx.state.store->printStorePath(drvPath)].outputs.push_back(b.output);
+                        },
+                    },
+                    elem.raw);
+            }
+            for (auto & [path, info] : grouped) {
+                printLiteralString(ctx.out, path);
+                ctx.out << " = { ";
+                if (info.path)
+                    ctx.out << "path = true; ";
+                if (info.allOutputs)
+                    ctx.out << "allOutputs = true; ";
+                if (!info.outputs.empty()) {
+                    ctx.out << "outputs = [ ";
+                    for (auto & o : info.outputs) {
+                        printLiteralString(ctx.out, o);
+                        ctx.out << " ";
+                    }
+                    ctx.out << "]; ";
+                }
+                ctx.out << "}; ";
+            }
+            ctx.out << "})";
+        } else {
+            printLiteralString(ctx.out, v.string_view());
+            copyContext(v, ctx.context);
+        }
         break;
+    }
     case nPath:
         ctx.out << v.path().to_string();
         break;
@@ -5067,7 +5127,27 @@ static void prim_serializeFunction(EvalState & state, const PosIdx pos, Value **
             .atPos(pos)
             .debugThrow();
 
-    SerializeContext ctx{state, pos, out, context, visited, {}, pluginPolicy};
+    bool preserveCtx = false;
+    if (args[0]->type() == nAttrs) {
+        auto * ctxAttr = args[0]->attrs()->get(state.symbols.create("preserveStringContext"));
+        if (ctxAttr)
+            preserveCtx =
+                state.forceBool(*ctxAttr->value, pos, "while evaluating the `preserveStringContext` attribute");
+
+        auto * extAttr = args[0]->attrs()->get(state.symbols.create("externalBindings"));
+        if (extAttr) {
+            state.forceList(*extAttr->value, pos, "while evaluating the `externalBindings` attribute");
+            for (auto * elem : extAttr->value->listView()) {
+                auto name = state.forceStringNoCtx(*elem, pos, "while evaluating an element of `externalBindings`");
+                externalBindings.emplace(name);
+            }
+        }
+    }
+
+    NixStringContext context;
+    std::ostringstream out;
+    std::set<const void *> visited;
+    SerializeContext ctx{state, pos, out, context, visited, {}, pluginPolicy, preserveCtx};
     serializeValue(ctx, *fn);
 
     v.mkString(out.str(), context, state.mem);
@@ -5103,6 +5183,10 @@ static RegisterPrimOp primop_serializeFunction({
         plugin primop names to allow.  By default, user-provided primops
         (from plugins or the flake subsystem) are rejected since they
         may not be available in the deserialization environment.
+      - `preserveStringContext` (optional, default `false`): if true,
+        strings with store path contexts are wrapped in
+        `builtins.appendContext` calls so that contexts survive
+        round-trip through `builtins.deserializeFunction`.
       Lambdas, primops, and partially applied primops are all supported.
 
       > **Warning**
@@ -5127,6 +5211,7 @@ static RegisterPrimOp primop_serializeFunction({
       contexts (store path dependencies) are attached to the output string
       but lost if the result is passed through
       [`builtins.deserializeFunction`](#builtins-deserializeFunction)
+      unless `preserveStringContext` is enabled.
       Float values are serialized with limited precision (`std::to_string`).
     )doc",
     .impl = prim_serializeFunction,

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -4670,6 +4670,7 @@ struct SerializeContext
     BackRefMap backRefs;
     const PluginPrimOpPolicy & pluginPolicy;
     bool preserveStringContext = false;
+    std::set<std::string> externalBindings;
 
     void checkPluginPrimOp(const PrimOp & primOp)
     {
@@ -4964,6 +4965,9 @@ static bool tryEtaReduce(SerializeContext & ctx, Value & v)
     if (auto * calledVar = dynamic_cast<ExprVar *>(call->fun)) {
         if (calledVar->fromWith || calledVar->level < (Level) depth)
             return false;
+        // Don't eta-reduce if the variable is declared external.
+        if (ctx.externalBindings.count(std::string(ctx.state.symbols[calledVar->name])))
+            return false;
 
         Env * env = closureEnv;
         for (Level l = calledVar->level - depth; l > 0; --l)
@@ -5064,27 +5068,60 @@ static void serializeLambdaWithClosure(SerializeContext & ctx, Value & v)
             neededBindings.emplace(name, val);
     }
 
-    if (neededBindings.empty()) {
+    // Split bindings into external (emitted as wrapper function params)
+    // and inline (serialized as let bindings).
+    std::vector<std::string> externalNames;
+    std::map<std::string, Value *> inlineBindings;
+    for (auto & [name, val] : neededBindings) {
+        if (ctx.externalBindings.count(name))
+            externalNames.push_back(name);
+        else
+            inlineBindings.emplace(name, val);
+    }
+
+    if (externalNames.empty() && inlineBindings.empty()) {
         fun->show(ctx.state.symbols, ctx.out);
         return;
     }
 
+    // Register back-references for recursive values (Nix `let` is recursive).
     BackRefMap savedBackRefs = ctx.backRefs;
-    for (auto & [name, val] : neededBindings) {
+    for (auto & [name, val] : inlineBindings) {
         ctx.state.forceValue(*val, ctx.pos);
         ctx.backRefs.emplace(val, name);
     }
 
-    ctx.out << "(let ";
-    for (auto & [name, val] : neededBindings) {
-        printIdentifier(ctx.out, name);
-        ctx.out << " = ";
-        serializeValue(ctx, *val);
-        ctx.out << "; ";
+    // Emit external bindings as a wrapper function: `({ name1, name2 }: ...)`
+    if (!externalNames.empty()) {
+        ctx.out << "({ ";
+        bool first = true;
+        for (auto & name : externalNames) {
+            if (!first)
+                ctx.out << ", ";
+            printIdentifier(ctx.out, name);
+            first = false;
+        }
+        ctx.out << " }: ";
     }
-    ctx.out << "in ";
-    fun->show(ctx.state.symbols, ctx.out);
-    ctx.out << ")";
+
+    // Emit inline bindings as let block.
+    if (!inlineBindings.empty()) {
+        ctx.out << "(let ";
+        for (auto & [name, val] : inlineBindings) {
+            printIdentifier(ctx.out, name);
+            ctx.out << " = ";
+            serializeValue(ctx, *val);
+            ctx.out << "; ";
+        }
+        ctx.out << "in ";
+        fun->show(ctx.state.symbols, ctx.out);
+        ctx.out << ")";
+    } else {
+        fun->show(ctx.state.symbols, ctx.out);
+    }
+
+    if (!externalNames.empty())
+        ctx.out << ")";
 
     ctx.backRefs = std::move(savedBackRefs);
 }
@@ -5128,6 +5165,7 @@ static void prim_serializeFunction(EvalState & state, const PosIdx pos, Value **
             .debugThrow();
 
     bool preserveCtx = false;
+    std::set<std::string> externalBindings;
     if (args[0]->type() == nAttrs) {
         auto * ctxAttr = args[0]->attrs()->get(state.symbols.create("preserveStringContext"));
         if (ctxAttr)
@@ -5147,7 +5185,7 @@ static void prim_serializeFunction(EvalState & state, const PosIdx pos, Value **
     NixStringContext context;
     std::ostringstream out;
     std::set<const void *> visited;
-    SerializeContext ctx{state, pos, out, context, visited, {}, pluginPolicy, preserveCtx};
+    SerializeContext ctx{state, pos, out, context, visited, {}, pluginPolicy, preserveCtx, std::move(externalBindings)};
     serializeValue(ctx, *fn);
 
     v.mkString(out.str(), context, state.mem);
@@ -5187,6 +5225,22 @@ static RegisterPrimOp primop_serializeFunction({
         strings with store path contexts are wrapped in
         `builtins.appendContext` calls so that contexts survive
         round-trip through `builtins.deserializeFunction`.
+      - `externalBindings` (optional, default `[]`): a list of closure
+        variable names to emit as parameters of a wrapper function
+        instead of inlining their values.  The caller provides their
+        values at deserialization time.  This avoids serializing large
+        library functions (e.g. from nixpkgs `lib`):
+
+        ```nix
+        builtins.serializeFunction {
+          fn = items: concatMapStringsSep ", " toString items;
+          externalBindings = ["concatMapStringsSep"];
+        }
+        # => "({ concatMapStringsSep }: (items: ...))"
+        # Caller provides at deserialization:
+        # (builtins.deserializeFunction s) { inherit (lib) concatMapStringsSep; }
+        ```
+
       Lambdas, primops, and partially applied primops are all supported.
 
       > **Warning**

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2642,15 +2642,31 @@ static void prim_fromJSON(EvalState & state, const PosIdx pos, Value ** args, Va
 static RegisterPrimOp primop_fromJSON({
     .name = "__fromJSON",
     .args = {"e"},
-    .doc = R"(
-      Convert a JSON string to a Nix value. For example,
+    .doc = R"doc(
+      Convert the expression *e* to a string. *e* can be:
 
-      ```nix
-      builtins.fromJSON ''{"x": [1, 2, 3], "y": null}''
-      ```
+        - A string (in which case the string is returned unmodified).
 
-      returns the value `{ x = [ 1 2 3 ]; y = null; }`.
-    )",
+        - A path (e.g., `toString /foo/bar` yields `"/foo/bar"`.
+
+        - A set containing `{ __toString = self: ...; }` or `{ outPath = ...; }`.
+
+        - An integer.
+
+        - A list, in which case the string representations of its elements
+          are joined with spaces.
+
+        - A Boolean (`false` yields `""`, `true` yields `"1"`).
+
+        - `null`, which yields the empty string.
+
+        - A function (requires the [`function-serialization`](@docroot@/development/experimental-features.md#xp-feature-function-serialization) experimental feature).
+          Lambdas produce their source representation (e.g. `toString (x: x)` yields `"(x: x)"`).
+          Primops produce their qualified `builtins.` name
+          (e.g. `toString builtins.head` yields `"builtins.head"`).
+          Partially applied primops include their arguments
+          (e.g. `toString (builtins.map builtins.head)` yields `"(builtins.map builtins.head)"`).
+    )doc",
     .impl = prim_fromJSON,
 });
 
@@ -4476,7 +4492,7 @@ static void prim_toString(EvalState & state, const PosIdx pos, Value ** args, Va
 static RegisterPrimOp primop_toString({
     .name = "toString",
     .args = {"e"},
-    .doc = R"(
+    .doc = R"doc(
       Convert the expression *e* to a string. *e* can be:
 
         - A string (in which case the string is returned unmodified).
@@ -4493,7 +4509,14 @@ static RegisterPrimOp primop_toString({
         - A Boolean (`false` yields `""`, `true` yields `"1"`).
 
         - `null`, which yields the empty string.
-    )",
+
+        - A function (requires the [`function-serialization`](@docroot@/development/experimental-features.md#xp-feature-function-serialization) experimental feature).
+          Lambdas produce their source representation (e.g. `toString (x: x)` yields `"(x: x)"`).
+          Primops produce their qualified `builtins.` name
+          (e.g. `toString builtins.head` yields `"builtins.head"`).
+          Partially applied primops include their arguments
+          (e.g. `toString (builtins.map builtins.head)` yields `"(builtins.map builtins.head)"`).
+    )doc",
     .impl = prim_toString,
 });
 

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -25,7 +25,7 @@ struct ExperimentalFeatureDetails
  * feature, we either have no issue at all if few features are not added
  * at the end of the list, or a proper merge conflict if they are.
  */
-constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::BLAKE3Hashes);
+constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::FunctionSerialization);
 
 constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails = {{
     {
@@ -278,6 +278,160 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
             Enables support for BLAKE3 hashes.
         )",
         .trackingUrl = "https://github.com/NixOS/nix/milestone/60",
+    },
+    {
+        .tag = Xp::FunctionSerialization,
+        .name = "function-serialization",
+        .description = R"(
+            Allow serializing and deserializing Nix functions.
+
+            When enabled, `builtins.toString` can coerce functions to
+            strings, and two new builtins become available:
+
+            - `builtins.serializeFunction` produces a self-contained Nix
+              expression string for a lambda, including `let` bindings
+              for captured closure variables.
+
+            - `builtins.deserializeFunction` parses a string as a Nix
+              expression that must evaluate to a function.
+
+            ## Relation to dynamic derivations
+
+            This feature serializes *pure computation* -- functions that
+            transform data.  It is useful for bundling eval-time logic
+            and captured configuration into a single string that can be
+            passed into a build sandbox and evaluated there (with
+            recursive Nix).
+
+            For the core dynamic derivations use case of constructing
+            real derivations with real store path dependencies, enable
+            `preserveStringContext` in the attrset form to emit
+            `builtins.appendContext` calls that reconstruct store path
+            contexts on deserialization.
+
+            ### What works today
+
+            The serialize/deserialize pipeline handles: closures with
+            captured configuration, dependency maps, higher-order
+            builders, partially applied primops, `lib` polyfills (via
+            eta-reduction), `with`-bound variables, recursive values,
+            and (with `preserveStringContext`) store path dependencies.
+
+            Existing approaches that this feature complements:
+            - Raw `.drv` format (no Nix evaluator needed in sandbox)
+            - Recursive Nix with a static `.nix` file + JSON data
+            - `nix-instantiate` inside the sandbox
+
+            This feature adds the ability to bundle eval-time logic and
+            data into a single string, avoiding the split between "JSON
+            data" and "static `.nix` file" in the approaches above.
+
+            ### Handling `lib` function polyfills
+
+            nixpkgs `lib` often wraps builtins in lambda polyfills for
+            backwards compatibility (e.g. `lib.head = x: builtins.head x`
+            instead of `lib.head = builtins.head`).  This poses a
+            challenge: the same logical function can be either a primop
+            or a lambda depending on the nixpkgs/Nix version, producing
+            different serialized forms.
+
+            The serializer handles this via eta-reduction: lambdas whose
+            body is a direct call to a closure variable or a `builtins.*`
+            select, with the lambda's parameters forwarded in order, are
+            reduced to the underlying function.  Three patterns are
+            detected:
+
+            - Closure variable: `let head = builtins.head; in (x: head x)`
+              serializes as `builtins.head`
+            - Direct builtin select: `x: builtins.head x` serializes as
+              `builtins.head`
+            - Multi-arg: `list: index: builtins.elemAt list index`
+              serializes as `builtins.elemAt`
+
+            This means `lib.head` and `builtins.head` produce identical
+            serialized output regardless of whether the polyfill is in
+            place.
+
+            Patterns not handled by eta-reduction:
+
+            - Wrappers that reorder, drop, or add arguments
+              (e.g. `lib.flip f a b = f b a`)
+            - Wrappers that add validation or coercion before calling
+              the underlying function
+            - Wrappers where the called function is computed dynamically
+              (e.g. via `builtins.getAttr`)
+
+            These cases serialize as full lambdas with closure bindings,
+            which is correct but produces different output than a direct
+            primop reference.  The serialized form is still valid and
+            will deserialize correctly within the same Nix version.
+
+            ### Interaction with `derivation` and `import`
+
+            The `derivation` function and other top-level constants
+            (e.g. `derivationStrict`, `import`) are available after
+            deserialization because `builtins.deserializeFunction`
+            parses in the base environment.  Functions that call
+            `derivation` round-trip correctly:
+
+            ```nix
+            let mkDrv = builtins.deserializeFunction
+              (builtins.serializeFunction (name: derivation {
+                inherit name; system = "x86_64-linux"; builder = "/bin/sh";
+              }));
+            in (mkDrv "hello").name   # => "hello"
+            ```
+
+            `import` is a primop and serializes as `builtins.import`.
+            The only issue is file availability: paths in `import`
+            calls are absolute (resolved at parse time) and must exist
+            in the deserialization environment.
+
+            ### Remaining gaps for dynamic derivations
+
+            - **No `.drv` file creation in sandbox**: deserialized
+              functions can produce derivation attrsets and even call
+              `derivation` to create them, but the resulting `.drv`
+              files can only be registered in the store via recursive
+              Nix (the restricted daemon socket, issue #8602).  This is
+              a store/scheduler feature, not an evaluator feature.
+
+            ## Known limitations
+
+            - **String context loss by default**: store path dependency
+              contexts are lost on round-trip unless
+              `preserveStringContext = true` is set in the attrset form.
+              When enabled, strings with context are wrapped in
+              `builtins.appendContext` calls in the serialized output.
+
+            - **Serialized form is not stable across Nix versions.**
+              Primops are serialized as `builtins.<name>`, which may
+              change between versions.  Eta-reduction normalizes common
+              `lib` polyfill patterns (see above), but not all
+              variations can be detected.  The format should only be
+              used within a single Nix version, not for persistent
+              storage.
+
+            - **User-provided primops** (from plugins or the flake
+              subsystem) are rejected by default at serialization time,
+              since the plugin may not be loaded in the deserialization
+              environment.  The `allowedPluginPrimOps` option accepts a
+              list of names presumed available at deserialization time.
+
+            - Float precision is limited by `std::to_string` (6 decimal
+              places).  Fixable with a higher-precision formatter, but
+              this changes float value serialization.
+
+            - Paths are serialized as absolute paths (the Nix parser
+              resolves relative paths at parse time).  If the referenced
+              file does not exist in the deserialization environment
+              (e.g. a build sandbox), operations like `import` or string
+              interpolation on the path will fail.
+
+            - `builtins.deserializeFunction` evaluates arbitrary Nix
+              expressions; only use it on trusted input.  This is
+              inherent to the string-eval approach.
+        )",
     },
 }};
 

--- a/src/libutil/include/nix/util/experimental-features.hh
+++ b/src/libutil/include/nix/util/experimental-features.hh
@@ -38,6 +38,7 @@ enum struct ExperimentalFeature {
     PipeOperators,
     ExternalBuilders,
     BLAKE3Hashes,
+    FunctionSerialization,
 };
 
 /**


### PR DESCRIPTION
## Summary

Add `builtins.serializeFunction` and `builtins.deserializeFunction` behind a new `function-serialization` experimental feature flag, enabling round-trip serialization of Nix functions including their closures.

Also extends `builtins.toString` to coerce functions to strings.

Addresses NixOS/nix#15049.

Disclaimer I used a coding agent in the creation of this patch.

/cc @roberth @Ericson2314

## Motivation

Function serialization enables:
- Debugging and logging of function values
- Dynamic code generation of `.nix` files
- Bundling eval-time logic + captured configuration into a single string for evaluation continuations (e.g. dynamic derivations via RFC 0092)

## Design

`builtins.serializeFunction` produces a self-contained Nix expression string. Closure variables are reconstructed as recursive `let` bindings. The result can be passed through `builtins.deserializeFunction` to recover a callable function.

```nix
let
  x = 1;
  serialized = builtins.serializeFunction (y: x + y);
  restored = builtins.deserializeFunction serialized;
in restored 5  # => 6
```

An attrset form provides additional control:

```nix
builtins.serializeFunction {
  fn = myFunction;
  allowedPluginPrimOps = [ "getFlake" ];
  preserveStringContext = true;
  externalBindings = [ "concatMapStringsSep" ];
}
```

## What works

- Lambdas with full closure reconstruction (nested closures, with-bound variables, recursive values via back-referenced let bindings)
- Primops as `builtins.<name>`, partially applied primops with arguments preserved
- Eta-reduction normalizes lib polyfill wrappers (`x: builtins.head x` -> `builtins.head`; also handles direct builtin selects and multi-arg wrappers)
- Plugin primop control via `allowedPluginPrimOps` (rejected by default, configurable allowlist)
- String context preservation via `preserveStringContext` (emits `builtins.appendContext` calls)
- External bindings via `externalBindings` (library functions emitted as wrapper parameters instead of inlined, keeping output small and nixpkgs-version-independent)
- derivation and other base environment names work after deserialization

## Known limitations

- String contexts lost by default (opt-in via `preserveStringContext`)
- Serialized form not stable across Nix versions
- Float precision limited by `std::to_string`
- `deserializeFunction` evaluates arbitrary expressions (inherent to approach)

Full details in the `function-serialization` experimental feature description.

## Test plan

- [x] 52 new unit tests covering all serialization features, edge cases, and dynamic derivation scenario tests
- [x] `nix eval --extra-experimental-features function-serialization --expr 'let x = 1; in builtins.serializeFunction (y: x + y)'`
- [x] `nix eval --extra-experimental-features function-serialization --expr 'let f = builtins.deserializeFunction "(x: x + 1)"; in f 41'`
- [x] Verify no test regressions without the feature enabled
