### PR TITLE
Use limit from macOS kernel instead of hardcoded

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -21,6 +21,9 @@
 #ifndef _WIN32
 #  include <sys/resource.h>
 #endif
+#ifdef __APPLE__
+#  include <sys/sysctl.h>
+#endif
 #ifdef __linux__
 #  include <features.h>
 #endif
@@ -132,15 +135,26 @@ void bumpFileLimit()
     if (getrlimit(RLIMIT_NOFILE, &limit) != 0)
         return;
 
-    if (limit.rlim_cur < limit.rlim_max) {
-        // Some software misbehaves really bad when we try to raise the
-        // limit to RLIM_INFINITY, so cap the limit at the 1048576 limit used
-        // by the daemon.
-        //
-        // GNU patch < 2.8 crashes with **** out of memory, which breaks in nixpkgs darwin bootstrap tools.
-        // This was fixed in:
-        // https://cgit.git.savannah.gnu.org/cgit/patch.git/commit/?id=61d7788b83b302207a67b82786f4fd79e3538f30
-        limit.rlim_cur = std::min(limit.rlim_max, rlim_t(1048576));
+    rlim_t target = limit.rlim_max;
+
+#  ifdef __APPLE__
+    // On macOS the hard limit is typically RLIM_INFINITY, but
+    // setting rlim_cur to that causes problems: child processes
+    // (e.g. GNU patch in the Nix sandbox) may allocate memory
+    // proportional to the fd limit and OOM. Use the kernel's
+    // per-process file limit instead, which is the effective cap.
+    //
+    // GNU patch < 2.8 crashes with **** out of memory, which breaks in nixpkgs darwin bootstrap tools.
+    // This was fixed in:
+    // https://cgit.git.savannah.gnu.org/cgit/patch.git/commit/?id=61d7788b83b302207a67b82786f4fd79e3538f30
+    int maxfiles;
+    size_t len = sizeof(maxfiles);
+    if (sysctlbyname("kern.maxfilesperproc", &maxfiles, &len, nullptr, 0) == 0)
+        target = maxfiles;
+#  endif
+
+    if (limit.rlim_cur < target) {
+        limit.rlim_cur = target;
         // Ignore errors, this is best effort.
         setrlimit(RLIMIT_NOFILE, &limit);
     }


### PR DESCRIPTION
## Motivation

Refactor of https://github.com/NixOS/nix/pull/15663 to get the actual per-process file limit from the macOS kernel rather than a hardcoded limit

I ensured that this commit does not cause GNU patch to OOM using:

```
$ nix build -L nixpkgs/13043924aaa7375ce482ebe2494338e058282925#stdenv.__bootPackages.stdenv.__bootPackages.patchutils --rebuild
```

## Context

https://github.com/NixOS/nix/issues/15619

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 

cc @xokdvium 