### PR TITLE
Only bump the RLIMIT_STACK limit in EvalState constructor

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -42,6 +42,7 @@
 #include <fstream>
 #include <functional>
 #include <ranges>
+#include <mutex>
 
 #include <nlohmann/json.hpp>
 #include <boost/container/small_vector.hpp>
@@ -314,6 +315,17 @@ EvalState::EvalState(
 #endif
     , staticBaseEnv{std::make_shared<StaticEnv>(nullptr, nullptr)}
 {
+#ifndef _WIN32
+    static std::once_flag stackSizeBumped;
+    std::call_once(stackSizeBumped, []() {
+        // Increase the default stack size for the evaluator and for
+        // libstdc++'s std::regex.
+        // This used to be 64 MiB, but macOS as deployed on GitHub Actions has a
+        // hard limit slightly under that, so we round it down a bit.
+        nix::ensureStackSizeAtLeast(60 * 1024 * 1024);
+    });
+#endif
+
     corepkgsFS->setPathDisplay("<nix", ">");
     internalFS->setPathDisplay("«nix-internal»", "");
 

--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -58,7 +58,7 @@ unsigned int getMaxCPU()
 #ifndef _WIN32
 size_t savedStackSize = 0;
 
-void setStackSize(size_t stackSize)
+void ensureStackSizeAtLeast(size_t stackSize)
 {
     struct rlimit limit;
     if (getrlimit(RLIMIT_STACK, &limit) == 0 && static_cast<size_t>(limit.rlim_cur) < stackSize) {

--- a/src/libutil/include/nix/util/current-process.hh
+++ b/src/libutil/include/nix/util/current-process.hh
@@ -27,9 +27,10 @@ unsigned int getMaxCPU();
 // It does not seem possible to dynamically change stack size on Windows.
 #ifndef _WIN32
 /**
- * Change the stack size.
+ * Increase the RLIMIT_STACK rlimit if it is currently smaller than `stackSize`.
+ * @note Not thread safe. Calls to this should be wrapped in a std::call_once.
  */
-void setStackSize(size_t stackSize);
+void ensureStackSizeAtLeast(size_t stackSize);
 #endif
 
 /**

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -597,13 +597,5 @@ int main(int argc, char ** argv)
 {
     // The CLI has a more detailed version than the libraries; see nixVersion.
     nix::nixVersion = NIX_CLI_VERSION;
-#ifndef _WIN32
-    // Increase the default stack size for the evaluator and for
-    // libstdc++'s std::regex.
-    // This used to be 64 MiB, but macOS as deployed on GitHub Actions has a
-    // hard limit slightly under that, so we round it down a bit.
-    nix::setStackSize(60 * 1024 * 1024);
-#endif
-
     return nix::handleExceptions(argv[0], [&]() { nix::mainWrapped(argc, argv); });
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

For regular commands like `nix store add` we have no reason to bump the stack size. I've seen pthread_create fail in nix-ninja with ENOMEM.

This is a cross-port of https://gerrit.lix.systems/c/lix/+/5053.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
