### PR TITLE
fix(libexpr): avoid dangling markdown breaks in lambda docs

### DIFF
--- a/src/libexpr-tests/eval.cc
+++ b/src/libexpr-tests/eval.cc
@@ -174,6 +174,24 @@ TEST_F(EvalStateTest, getBuiltin_fail)
     ASSERT_THROW(state.getBuiltin("nonexistent"), EvalError);
 }
 
+TEST_F(EvalStateTest, getDoc_namedLambdaWithoutPosition_omitsTrailingBackslash)
+{
+    Env env{.up = nullptr, .values = {}};
+    ExprInt body(0);
+    ExprLambda lambda(noPos, createSymbol("a"), &body);
+    Value value;
+
+    lambda.setName(createSymbol("puppy"));
+    value.mkLambda(&env, &lambda);
+
+    auto doc = state.getDoc(value);
+
+    ASSERT_TRUE(doc.has_value());
+    ASSERT_FALSE(doc->pos);
+    ASSERT_EQ(doc->name, std::optional<std::string>{"puppy"});
+    ASSERT_STREQ(doc->doc, "Function `puppy`");
+}
+
 class PureEvalTest : public LibExprTest
 {
 public:

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -606,8 +606,6 @@ std::optional<EvalState::Doc> EvalState::getDoc(Value & v)
             s << "Function `" << name << "`";
             if (pos)
                 s << "\\\n  … ";
-            else
-                s << "\\\n";
         }
         if (pos) {
             s << "defined at " << pos;


### PR DESCRIPTION
This PR fixes `:doc` showing a trailing `\` for named lambdas that don't have a source position.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
