### PR TITLE
libstore: Plug thread safety issues in recursive-nix

### DIFF
--- a/src/libstore/include/nix/store/restricted-store.hh
+++ b/src/libstore/include/nix/store/restricted-store.hh
@@ -2,6 +2,9 @@
 ///@file
 
 #include "nix/store/store-api.hh"
+#include "nix/util/sync.hh"
+
+#include <future>
 
 namespace nix {
 
@@ -28,15 +31,20 @@ struct RestrictionContext
      */
     virtual const StorePathSet & originalPaths() = 0;
 
-    /**
-     * Paths that were added via recursive Nix calls.
-     */
-    StorePathSet addedPaths;
+    struct State
+    {
+        /**
+         * Paths that were added via recursive Nix calls.
+         */
+        std::map<StorePath, std::shared_future<void>> addedPaths;
 
-    /**
-     * Realisations that were added via recursive Nix calls.
-     */
-    std::set<DrvOutput> addedDrvOutputs;
+        /**
+         * Realisations that were added via recursive Nix calls.
+         */
+        std::set<DrvOutput> addedDrvOutputs;
+    };
+
+    Sync<State> state_;
 
     /**
      * Recursive Nix calls are only allowed to build or realize paths
@@ -56,7 +64,33 @@ struct RestrictionContext
     {
         if (isAllowed(path))
             return;
-        addDependencyImpl(path);
+
+        std::promise<void> promise;
+
+        auto [future, shouldAdd] = [&]() -> std::pair<std::shared_future<void>, bool> {
+            auto state(state_.lock());
+            if (auto iter = state->addedPaths.find(path); iter != state->addedPaths.end()) {
+                return {iter->second, false};
+            }
+            auto [iter2, _] = state->addedPaths.emplace(path, promise.get_future().share());
+            return {iter2->second, true};
+        }();
+
+        /* Another daemon worker thread already started adding the dependency. Just wait for it
+           to complete. */
+        if (!shouldAdd) {
+            future.get();
+            return;
+        }
+
+        try {
+            addDependencyImpl(path);
+            promise.set_value();
+        } catch (...) {
+            /* Notify all other waiters that we are done. */
+            promise.set_exception(std::current_exception());
+            throw;
+        }
     }
 
     virtual ~RestrictionContext() = default;

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -167,8 +167,11 @@ StorePathSet RestrictedStore::queryAllValidPaths()
     StorePathSet paths;
     for (auto & p : goal.originalPaths())
         paths.insert(p);
-    for (auto & p : goal.addedPaths)
-        paths.insert(p);
+    for (auto & [p, future] : goal.state_.lock()->addedPaths) {
+        /* Only report the paths that have finished materialising in the sandbox. */
+        if (future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+            paths.insert(p);
+    }
     return paths;
 }
 
@@ -300,8 +303,12 @@ std::vector<KeyedBuildResult> RestrictedStore::buildPathsWithResults(
     next->computeFSClosure(newPaths, closure);
     for (auto & path : closure)
         goal.addDependency(path);
-    for (auto & real : newRealisations)
-        goal.addedDrvOutputs.insert(real.id);
+
+    {
+        auto state(goal.state_.lock());
+        for (auto & real : newRealisations)
+            state->addedDrvOutputs.insert(real.id);
+    }
 
     return results;
 }

--- a/src/libstore/unix/build/chroot-derivation-builder.cc
+++ b/src/libstore/unix/build/chroot-derivation-builder.cc
@@ -131,8 +131,6 @@ struct ChrootDerivationBuilder : virtual DerivationBuilderImpl
 
     std::pair<std::filesystem::path, std::filesystem::path> addDependencyPrep(const StorePath & path)
     {
-        DerivationBuilderImpl::addDependencyImpl(path);
-
         debug("materialising '%s' in the sandbox", store.printStorePath(path));
 
         std::filesystem::path source = store.toRealPath(path);

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -238,12 +238,18 @@ protected:
 
     bool isAllowed(const StorePath & path) override
     {
-        return inputPaths.count(path) || addedPaths.count(path);
+        if (inputPaths.count(path))
+            return true;
+        auto state(state_.lock());
+        auto iter = state->addedPaths.find(path);
+        if (iter == state->addedPaths.end())
+            return false;
+        return iter->second.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
     }
 
     bool isAllowed(const DrvOutput & id) override
     {
-        return addedDrvOutputs.count(id);
+        return state_.lock()->addedDrvOutputs.count(id);
     }
 
     bool isAllowed(const DerivedPath & req);
@@ -1165,7 +1171,7 @@ void DerivationBuilderImpl::startDaemon()
         ref<LocalStore>(std::dynamic_pointer_cast<LocalStore>(this->store.shared_from_this())),
         *this);
 
-    addedPaths.clear();
+    state_.lock()->addedPaths.clear();
 
     auto socketName = ".nix-socket";
     std::filesystem::path socketPath = tmpDir / socketName;
@@ -1246,10 +1252,7 @@ void DerivationBuilderImpl::stopDaemon()
     daemonSocket.close();
 }
 
-void DerivationBuilderImpl::addDependencyImpl(const StorePath & path)
-{
-    addedPaths.insert(path);
-}
+void DerivationBuilderImpl::addDependencyImpl(const StorePath & path) {}
 
 void DerivationBuilderImpl::chownToBuilder(const std::filesystem::path & path)
 {
@@ -1434,7 +1437,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         referenceablePaths.insert(p);
     for (auto & i : scratchOutputs)
         referenceablePaths.insert(i.second);
-    for (auto & p : addedPaths)
+    for (auto & [p, _] : state_.lock()->addedPaths)
         referenceablePaths.insert(p);
 
     /* Check whether the output paths were created, and make all


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Access to addedPaths/addedDrvOutputs was completely unsynchronised.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Haven't yet been able to reproduce issues with this with thread sanitizers. The implementations seems kinda correct, but not 100% sure.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
