### PR TITLE
edit: Allow opening paths that don't exist on disk in EDITOR

### DIFF
--- a/src/libcmd/editor-for.cc
+++ b/src/libcmd/editor-for.cc
@@ -1,22 +1,56 @@
 #include "nix/cmd/editor-for.hh"
 #include "nix/util/environment-variables.hh"
 #include "nix/util/source-path.hh"
+#include "nix/util/file-descriptor.hh"
+#include "nix/util/file-system.hh"
 
 namespace nix {
 
-Strings editorFor(const SourcePath & file, uint32_t line)
+std::tuple<OsStrings, AutoCloseFD, AutoDelete> editorFor(const SourcePath & file, uint32_t line, bool readOnly)
 {
     auto path = file.getPhysicalPath();
-    if (!path)
-        throw Error("cannot open '%s' in an editor because it has no physical path", file);
-    auto editor = getEnv("EDITOR").value_or("cat");
-    auto args = tokenizeString<Strings>(editor);
+    OsString editor = getEnvOsNonEmpty(OS_STR("EDITOR")).value_or(OS_STR("cat"));
+    auto args = tokenizeString<OsStrings>(editor);
     if (line > 0
-        && (editor.find("emacs") != std::string::npos || editor.find("nano") != std::string::npos
-            || editor.find("vim") != std::string::npos || editor.find("kak") != std::string::npos))
-        args.push_back(fmt("+%d", line));
-    args.push_back(path->string());
-    return args;
+        && (editor.contains(OS_STR("emacs")) || editor.contains(OS_STR("nano")) || editor.contains(OS_STR("vim"))
+            || editor.contains(OS_STR("kak"))))
+        args.push_back(string_to_os_string(fmt("+%d", line)));
+
+    if (path) {
+        args.push_back(path->native());
+        return {std::move(args), AutoCloseFD{}, AutoDelete{}};
+    }
+
+    /* Resolve symlinks when creating a temporary. That's how a regular editor
+       would behave. Also GitSourceAccessor behaves poorly with symlinks in the
+       path and fails with "«...» does not exist". */
+    auto file2 = file.resolveSymlinks();
+    auto stat = file2.lstat();
+    /* TODO: Maybe we should print a directory listing and open that instead? */
+    if (stat.type != SourceAccessor::tRegular)
+        throw Error("can't open a file %s of type '%s'", file2.to_string(), stat.typeString());
+
+    auto tempDir = createTempDir(defaultTempDir(), "nix-edit", 0700);
+    AutoDelete autoDel(tempDir, /*recursive=*/true);
+    auto tempPath = tempDir / file2.path.baseName().value_or("nix-edit");
+
+    /* Create the file with the same name, so editors that recognise file
+       extensions spin up syntax highlighting and LSPs. */
+    auto tempFd = openNewFileForWrite(
+        tempPath,
+        readOnly ? 0400 : 0600,
+        {.truncateExisting = false, .followSymlinksOnTruncate = false, .writeOnly = false});
+
+    if (!tempFd)
+        throw NativeSysError("failed to create temporary file %s", PathFmt(tempPath));
+
+    /* Copy the contents into the created copy. */
+    FdSink fileSink(tempFd.get());
+    file2.readFile(fileSink);
+    fileSink.flush();
+    args.push_back(tempPath);
+
+    return {std::move(args), std::move(tempFd), std::move(autoDel)};
 }
 
 } // namespace nix

--- a/src/libcmd/include/nix/cmd/editor-for.hh
+++ b/src/libcmd/include/nix/cmd/editor-for.hh
@@ -1,15 +1,24 @@
 #pragma once
 ///@file
 
-#include "nix/util/types.hh"
 #include "nix/util/source-path.hh"
+#include "nix/util/os-string.hh"
+#include "nix/util/file-descriptor.hh"
+#include "nix/util/file-system.hh"
 
 namespace nix {
 
 /**
  * Helper function to generate args that invoke $EDITOR on
  * filename:lineno.
+ *
+ * When file doesn't have a physical path, the contents get copied into a
+ * temporary file, and a file descriptor and RAII cleanup guard for it are
+ * returned.
+ *
+ * @param readOnly make the temporary file readonly if the file has no physical
+ * path. Ignored otherwise.
  */
-Strings editorFor(const SourcePath & file, uint32_t line);
+std::tuple<OsStrings, AutoCloseFD, AutoDelete> editorFor(const SourcePath & file, uint32_t line, bool readOnly = true);
 
 } // namespace nix

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -484,8 +484,8 @@ ProcessLineResult NixRepl::processLine(std::string line)
             }
         }();
 
-        // Open in EDITOR
-        auto args = editorFor(path, line);
+        /* Open file in EDITOR, or edit a read-only copy if the file doesn't have a physical path. */
+        auto [args, fd, autoDel] = editorFor(path, line, /*readOnly=*/true);
         auto editor = args.front();
         args.pop_front();
 
@@ -494,13 +494,16 @@ ProcessLineResult NixRepl::processLine(std::string line)
         runProgram2({
             .program = editor,
             .lookupPath = true,
-            .args = toOsStrings(std::move(args)),
+            .args = std::move(args),
             .isInteractive = true,
         });
 
-        // Reload right after exiting the editor
-        state->resetFileCache();
-        reloadFilesAndFlakes();
+        /* If we had to open a temporary read-only file, there's no need to
+           reload (no files could have changed anyway). */
+        if (!fd) {
+            state->resetFileCache();
+            reloadFilesAndFlakes();
+        }
     }
 
     else if (command == ":t") {

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -232,6 +232,10 @@ struct OpenNewFileForWriteParams
      * Whether to follow symlinks if @ref truncateExisting is true.
      */
     bool followSymlinksOnTruncate:1 = false;
+    /**
+     * Whether to open the newly created file as write-only.
+     */
+    bool writeOnly:1 = true;
 };
 
 /**

--- a/src/libutil/include/nix/util/os-string.hh
+++ b/src/libutil/include/nix/util/os-string.hh
@@ -104,4 +104,14 @@ inline OsStrings toOsStrings(std::list<std::string> ss)
 #  define OS_STR(s) L##s
 #endif
 
+#ifdef _WIN32
+
+template<class C>
+C tokenizeString(OsStringView s, OsStringView separators = OS_STR(" \t\n\r"));
+
+extern template std::list<OsString> tokenizeString(OsStringView s, OsStringView separators);
+extern template std::vector<OsString> tokenizeString(OsStringView s, OsStringView separators);
+
+#endif
+
 } // namespace nix

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -37,7 +37,7 @@ AutoCloseFD openFileReadonly(const std::filesystem::path & path, FinalSymlink fi
 
 AutoCloseFD openNewFileForWrite(const std::filesystem::path & path, mode_t mode, OpenNewFileForWriteParams params)
 {
-    auto flags = O_WRONLY | O_CREAT | O_CLOEXEC;
+    auto flags = (params.writeOnly ? O_WRONLY : O_RDWR) | O_CREAT | O_CLOEXEC;
     if (params.truncateExisting) {
         flags |= O_TRUNC;
         if (!params.followSymlinksOnTruncate)

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -57,7 +57,7 @@ openNewFileForWrite(const std::filesystem::path & path, [[maybe_unused]] mode_t 
 {
     return AutoCloseFD{CreateFileW(
         path.c_str(),
-        GENERIC_WRITE,
+        GENERIC_WRITE | (params.writeOnly ? 0 : GENERIC_READ),
         FILE_SHARE_READ | FILE_SHARE_DELETE,
         /*lpSecurityAttributes=*/nullptr,
         params.truncateExisting ? CREATE_ALWAYS : CREATE_NEW, /* TODO: Reparse points. */

--- a/src/libutil/windows/os-string.cc
+++ b/src/libutil/windows/os-string.cc
@@ -4,6 +4,7 @@
 #include <locale>
 
 #include "nix/util/os-string.hh"
+#include "nix/util/strings-inline.hh"
 
 namespace nix {
 
@@ -28,5 +29,18 @@ OsString string_to_os_string(std::string s)
 {
     return string_to_os_string(std::string_view{s});
 }
+
+#ifdef _WIN32
+
+template<class C>
+C tokenizeString(OsStringView s, OsStringView separators)
+{
+    return basicTokenizeString<C, OsChar>(s, separators);
+}
+
+template std::list<OsString> tokenizeString(OsStringView s, OsStringView separators);
+template std::vector<OsString> tokenizeString(OsStringView s, OsStringView separators);
+
+#endif
 
 } // namespace nix

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -44,16 +44,17 @@ struct CmdEdit : InstallableValueCommand
 
         logger->stop();
 
-        auto args = editorFor(file, line);
+        auto [args, tempFd, delTemp] = editorFor(file, line, /*readOnly=*/true);
+        auto program = args.front();
+        args.pop_front();
 
-        restoreProcessContext();
-
-        execvp(args.front().c_str(), stringsToCharPtrs(args).data());
-
-        std::string command;
-        for (const auto & arg : args)
-            command += " '" + arg + "'";
-        throw SysError("cannot run command%s", command);
+        runProgram2(
+            RunOptions{
+                .program = program,
+                .lookupPath = true,
+                .args = std::move(args),
+                .isInteractive = true,
+            });
     }
 };
 

--- a/tests/functional/flakes/edit.sh
+++ b/tests/functional/flakes/edit.sh
@@ -6,3 +6,7 @@ createFlake1
 
 export EDITOR=cat
 nix edit "$flake1Dir#" | grepQuiet simple.builder.sh
+tar --exclude=".git*" -czf "$TEST_ROOT"/flake1Dir.tar.gz -C "$(dirname "$flake1Dir")" "$(basename "$flake1Dir")"
+# Test that editing a file from a tarball flake works and the file is readonly.
+nix edit "file://$TEST_ROOT/flake1Dir.tar.gz" | grepQuiet simple.builder.sh
+EDITOR='test ! -w' nix edit "file://$TEST_ROOT/flake1Dir.tar.gz"

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -381,6 +381,9 @@ import $testDir/lang/parse-fail-eof-pos.nix
 " \
 '.*error: syntax error, unexpected end of file.*'
 
+EDITOR='cat' nix repl <<< ':e derivation' 2>&1 | grepQuiet 'derivationStrict'
+EDITOR='cat' nix repl <<< ':e <nix/fetchurl.nix>' 2>&1 | grepQuiet 'builtin:fetchurl'
+
 # TODO: move init to characterisation/framework.sh
 badDiff=0
 badExitCode=0


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Since https://github.com/NixOS/nix/pull/14050 we now mount over the store paths in the rootFS accessor in the evaluator. This broke :e and nix edit on something like `:e "${outPath}/src/nix-manual/utils.nix"` when having the `github:nixos/nix` flake loaded in a `--pure-eval` repl. `nix edit` was also broken similarly with: `because it has no physical path`.

For regular files, we can copy the outputs into a temporary read-only file and open that instead. For directories, we could open a directory listing in the editor, but I haven't implemented that here. Copying the whole directory tree seems a bit wasteful to me, so we can't truthfully mimic the old behavior of `:e` on directories (that editors usually allow the user to traverse when opened).

This also implements some infrastructure for getting a writable file descriptor for the file that would get edited - I intend to use it for https://github.com/NixOS/nix/issues/15633.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context


This got reported by @bryango in https://github.com/NixOS/nix/pull/14050#issuecomment-3682935969.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
