### PR TITLE
[Backport 2.34-maintenance] ci: Use stable nix

### DIFF
--- a/.github/actions/install-nix-action/action.yaml
+++ b/.github/actions/install-nix-action/action.yaml
@@ -16,7 +16,7 @@ inputs:
   install_url:
     description: "URL of the Nix installer"
     required: false
-    default: "https://releases.nixos.org/nix/nix-2.32.1/install"
+    default: "https://releases.nixos.org/nix/nix-2.34.6/install"
   tarball_url:
     description: "URL of the Nix tarball to use with the experimental installer"
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       dogfood:
         description: 'Use dogfood Nix build'
         required: false
-        default: true
+        default: false
         type: boolean
 
 concurrency:
@@ -29,7 +29,7 @@ jobs:
         fetch-depth: 0
     - uses: ./.github/actions/install-nix-action
       with:
-        dogfood: ${{ github.event_name == 'workflow_dispatch' && inputs.dogfood || github.event_name != 'workflow_dispatch' }}
+        dogfood: false
         extra_nix_config:
           experimental-features = nix-command flakes
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-nix-action
         with:
-          dogfood: ${{ github.event_name == 'workflow_dispatch' && inputs.dogfood || github.event_name != 'workflow_dispatch' }}
+          dogfood: false
           extra_nix_config: experimental-features = nix-command flakes
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - run: ./ci/gha/tests/pre-commit-checks
@@ -93,7 +93,7 @@ jobs:
     - uses: ./.github/actions/install-nix-action
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        dogfood: ${{ github.event_name == 'workflow_dispatch' && inputs.dogfood || github.event_name != 'workflow_dispatch' }}
+        dogfood: false
         # The sandbox would otherwise be disabled by default on Darwin
         extra_nix_config: "sandbox = true"
     # Since ubuntu 22.30, unprivileged usernamespaces are no longer allowed to map to the root user:
@@ -150,7 +150,7 @@ jobs:
     - uses: ./.github/actions/install-nix-action
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        dogfood: ${{ github.event_name == 'workflow_dispatch' && inputs.dogfood || github.event_name != 'workflow_dispatch' }}
+        dogfood: false
     - name: Run Windows unit tests
       run: |
         nix build --file ci/gha/tests/windows.nix unitTests.nix-util-tests -L
@@ -261,7 +261,7 @@ jobs:
     - uses: ./.github/actions/install-nix-action
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        dogfood: ${{ github.event_name == 'workflow_dispatch' && inputs.dogfood || github.event_name != 'workflow_dispatch' }}
+        dogfood: false
         extra_nix_config: |
           experimental-features = flakes nix-command ca-derivations impure-derivations
           max-jobs = 1


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

We should probably have some automation for disabling dogfooding for CI on backports and auto-bumping those versions too.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
