### PR TITLE
Fix MonitorFdHup 100% CPU spin and unresponsive daemon workers

### DIFF
--- a/src/libutil-tests/monitorfdhup.cc
+++ b/src/libutil-tests/monitorfdhup.cc
@@ -15,9 +15,11 @@ namespace nix {
 // which sets a process-global flag.  We must clear it after each
 // test so subsequent tests that call checkInterrupt() are not
 // poisoned.
-class MonitorFdHupTest : public ::testing::Test {
+class MonitorFdHupTest : public ::testing::Test
+{
 protected:
-    void TearDown() override {
+    void TearDown() override
+    {
         setInterrupted(false);
     }
 };

--- a/src/libutil-tests/monitorfdhup.cc
+++ b/src/libutil-tests/monitorfdhup.cc
@@ -2,6 +2,7 @@
 #if !defined(_WIN32) && !defined(__CYGWIN__)
 
 #  include "nix/util/monitor-fd.hh"
+#  include "nix/util/signals.hh"
 
 #  include <sys/file.h>
 #  include <sys/socket.h>
@@ -9,7 +10,19 @@
 #  include <gtest/gtest.h>
 
 namespace nix {
-TEST(MonitorFdHup, shouldNotBlock)
+
+// MonitorFdHup calls triggerInterrupt() when it detects a hangup,
+// which sets a process-global flag.  We must clear it after each
+// test so subsequent tests that call checkInterrupt() are not
+// poisoned.
+class MonitorFdHupTest : public ::testing::Test {
+protected:
+    void TearDown() override {
+        setInterrupted(false);
+    }
+};
+
+TEST_F(MonitorFdHupTest, shouldNotBlock)
 {
     Pipe p;
     p.create();
@@ -20,7 +33,7 @@ TEST(MonitorFdHup, shouldNotBlock)
     }
 }
 
-TEST(MonitorFdHup, shouldExitOnPeerClose)
+TEST_F(MonitorFdHupTest, shouldExitOnPeerClose)
 {
     // When the peer end of a socket is closed, MonitorFdHup should
     // detect the hangup and exit its poll loop promptly.
@@ -52,7 +65,7 @@ TEST(MonitorFdHup, shouldExitOnPeerClose)
 // MonitorFdHup must handle this without spinning.
 // On macOS, kqueue is used instead of poll, and registering a
 // closed fd with kevent fails differently.
-TEST(MonitorFdHup, shouldExitOnInvalidFd)
+TEST_F(MonitorFdHupTest, shouldExitOnInvalidFd)
 {
     // Close the fd before creating MonitorFdHup.
     // The poll loop should see POLLNVAL on the first poll() call
@@ -82,7 +95,7 @@ TEST(MonitorFdHup, shouldExitOnInvalidFd)
 }
 #  endif
 
-TEST(MonitorFdHup, shouldExitOnShutdown)
+TEST_F(MonitorFdHupTest, shouldExitOnShutdown)
 {
     // When the peer calls shutdown(SHUT_RDWR), MonitorFdHup should
     // detect the condition and exit.

--- a/src/libutil-tests/monitorfdhup.cc
+++ b/src/libutil-tests/monitorfdhup.cc
@@ -4,6 +4,8 @@
 #  include "nix/util/monitor-fd.hh"
 
 #  include <sys/file.h>
+#  include <sys/socket.h>
+#  include <chrono>
 #  include <gtest/gtest.h>
 
 namespace nix {
@@ -17,6 +19,90 @@ TEST(MonitorFdHup, shouldNotBlock)
         MonitorFdHup monitor(p.readSide.get());
     }
 }
+
+TEST(MonitorFdHup, shouldExitOnPeerClose)
+{
+    // When the peer end of a socket is closed, MonitorFdHup should
+    // detect the hangup and exit its poll loop promptly.
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    AutoCloseFD our(fds[0]);
+    AutoCloseFD peer(fds[1]);
+
+    auto start = std::chrono::steady_clock::now();
+    {
+        MonitorFdHup monitor(our.get());
+        // Close the peer end — delivers POLLHUP to our end.
+        peer.close();
+        // Small delay to let the monitor thread see it.
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        // Destructor joins the thread — should return immediately
+        // since the thread already exited on POLLHUP.
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+    // Should complete well under 1 second.  If the thread is spinning
+    // it would still complete (destructor closes notifyPipe) but after
+    // a measurable delay from the spin consuming CPU.
+    EXPECT_LT(ms, 1000);
+}
+
+#  ifndef __APPLE__
+// On Linux, poll() returns POLLNVAL for a closed/invalid fd.
+// MonitorFdHup must handle this without spinning.
+// On macOS, kqueue is used instead of poll, and registering a
+// closed fd with kevent fails differently.
+TEST(MonitorFdHup, shouldExitOnInvalidFd)
+{
+    // Close the fd before creating MonitorFdHup.
+    // The poll loop should see POLLNVAL on the first poll() call
+    // and exit immediately via the POLLHUP|POLLERR|POLLNVAL check.
+    Pipe p;
+    p.create();
+    int fd = p.readSide.get();
+    p.readSide.close();
+
+    auto start = std::chrono::steady_clock::now();
+    {
+        MonitorFdHup monitor(fd);
+        // Give the thread a moment to run and (hopefully) exit.
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        // Destructor joins.  If the thread is spinning on POLLNVAL
+        // without our fix, it would still be alive and only exit
+        // when the destructor closes notifyPipe.  The spin would
+        // be visible as high CPU, though the join would succeed.
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+    // Should complete promptly.  Without the POLLNVAL fix, the thread
+    // spins at ~2M iterations/sec until the destructor breaks it out,
+    // but it still completes — the test is mainly documenting that
+    // this code path is exercised.
+    EXPECT_LT(ms, 1000);
+}
+#  endif
+
+TEST(MonitorFdHup, shouldExitOnShutdown)
+{
+    // When the peer calls shutdown(SHUT_RDWR), MonitorFdHup should
+    // detect the condition and exit.
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    AutoCloseFD our(fds[0]);
+    AutoCloseFD peer(fds[1]);
+
+    auto start = std::chrono::steady_clock::now();
+    {
+        MonitorFdHup monitor(our.get());
+        // Shut down the peer — on most platforms this delivers POLLHUP.
+        shutdown(peer.get(), SHUT_RDWR);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+    EXPECT_LT(ms, 1000);
+}
+
 } // namespace nix
 
 #endif

--- a/src/libutil/unix/include/nix/util/monitor-fd.hh
+++ b/src/libutil/unix/include/nix/util/monitor-fd.hh
@@ -116,13 +116,22 @@ inline void MonitorFdHup::runThread(int watchFd, int notifyFd)
             }
         }
 
-        if (fds[0].revents & POLLHUP) {
+        // Treat any terminal event on the monitored fd as
+        // disconnection.  POLLERR and POLLNVAL are delivered
+        // regardless of the requested events mask (per POSIX)
+        // and indicate a broken or invalid fd.  If we only
+        // check POLLHUP, a socket in an error state (POLLERR
+        // without POLLHUP) causes a tight 100% CPU spin since
+        // poll() returns immediately on every call.
+        if (fds[0].revents & (POLLHUP | POLLERR | POLLNVAL)) {
             unix::triggerInterrupt();
             break;
         }
 
-        if (fds[1].revents & POLLHUP) {
-            // Notify pipe closed, exit thread
+        // The notifyPipe is used by ~MonitorFdHup to signal
+        // the thread to exit.  Do NOT call triggerInterrupt()
+        // here — this is the normal destruction path.
+        if (fds[1].revents & (POLLHUP | POLLERR | POLLNVAL)) {
             break;
         }
     }

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -331,6 +331,13 @@ static void daemonLoop(
                         if (setsid() == -1)
                             throw SysError("creating a new session");
 
+                        // The parent's signal handler thread (which calls
+                        // sigwait) does not survive fork().  Start a new
+                        // one so that SIGTERM/SIGINT are routed through
+                        // triggerInterrupt() for a graceful shutdown
+                        // instead of being permanently blocked.
+                        unix::startSignalHandlerThread();
+
                         // Restore normal handling of SIGCHLD.
                         setSigChldAction(false);
 


### PR DESCRIPTION
## Summary

- **MonitorFdHup poll loop**: Also check `POLLERR` and `POLLNVAL` (not just `POLLHUP`) when detecting client disconnection. Per POSIX, these events are always delivered regardless of the requested events mask. A socket in an error state (`POLLERR` without `POLLHUP`) causes `poll()` to return immediately on every call, creating a tight 100% CPU spin loop.
- **Forked daemon workers deaf to SIGTERM**: The parent's `sigwait` thread does not survive `fork()`, but the child inherits `SIGTERM` blocked in the signal mask. Call `startSignalHandlerThread()` in the forked child so signals are properly routed through `triggerInterrupt()`.

These two bugs combine to create daemon worker processes that spin at 100% CPU and cannot be killed with `SIGTERM` (only `SIGKILL` works).

Note: the `POLLERR`/`POLLNVAL` fix only applies to the non-macOS (`poll`-based) path since the macOS path already uses `kqueue` with `EV_EOF`.

Closes #1573 (partial — addresses the daemon worker spin)

## Test plan

- [ ] Verify daemon workers exit cleanly when a client disconnects normally
- [ ] Verify daemon workers don't spin at 100% CPU when a client socket enters an error state
- [ ] Verify `SIGTERM` properly terminates forked daemon workers
- [ ] Check that the notify pipe destruction path still works (no spurious interrupts)