### PR TITLE
fix concurrent localstore migrations

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -584,7 +584,7 @@ void LocalStore::upgradeDBSchema(State & state)
         debug("executing Nix database schema migration '%s'...", migrationName);
 
         SQLiteTxn txn(state.db);
-        state.db.exec(stmt + fmt(";\ninsert into SchemaMigrations values('%s')", migrationName));
+        state.db.exec(stmt + fmt(";\ninsert or ignore into SchemaMigrations values('%s')", migrationName));
         txn.commit();
 
         schemaMigrations.insert(migrationName);


### PR DESCRIPTION
## Motivation

This solves #15693 , a race condition when spawning multiple nix builds quickly.

## Context

The race condition comes about from [code added last month](https://github.com/NixOS/nix/commit/5286c0477d77fb919df890324d3a510a199f450e#diff-766e649c52f1b2f334ad2788aa2230b88b0a7cdd2799529c6125462960b145e0R610) of applying a LocalStore migration whenever it doesn't exist, and two nix builds can try to do it at the same time. The actual fail is on trying to insert into the migration table that the migration actually happened, because the migration name is a primary key and can't be inserted twice.

The solution is to use `insert or ignore`, instead of just `insert`, on migration names. Then even if one nix build manages to sneak in before another, it's ok if the migration is already registered as happened.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
