### PR TITLE
More memory optimisations for the Worker, cleanups

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -764,9 +764,9 @@ Goal::Co DerivationBuildingGoal::buildWithHook(
         } else if (std::get_if<ChildEOF>(&event)) {
             buildLog->flush();
             break;
-        } else if (auto * timeout = std::get_if<TimedOut>(&event)) {
+        } else if (auto * timeout = std::get_if<std::unique_ptr<TimedOut>>(&event)) {
             hook.reset();
-            co_return doneFailure(std::move(*timeout));
+            co_return doneFailure(std::move(**timeout));
         }
     }
 
@@ -1035,9 +1035,9 @@ Goal::Co DerivationBuildingGoal::buildLocally(
         } else if (std::get_if<ChildEOF>(&event)) {
             buildLog->flush();
             break;
-        } else if (auto * timeout = std::get_if<TimedOut>(&event)) {
+        } else if (auto * timeout = std::get_if<std::unique_ptr<TimedOut>>(&event)) {
             builder->killChild();
-            co_return doneFailure(std::move(*timeout));
+            co_return doneFailure(std::move(**timeout));
         }
     }
 

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -144,11 +144,9 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
                 worker.store.printStorePath(drvPath));
     }
 
-    auto resolutionGoal = worker.makeDerivationResolutionGoal(drvPath, *drv, buildMode);
-    {
-        Goals waitees{resolutionGoal};
-        co_await await(std::move(waitees));
-    }
+    auto resolutionGoal = worker.makeDerivationResolutionGoal(drvPath, drv, buildMode);
+    co_await await({resolutionGoal});
+
     if (nrFailed != 0) {
         co_return doneFailure({BuildResult::Failure::DependencyFailed, "Build failed due to failed dependency"});
     }
@@ -219,6 +217,9 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
             assert(false);
     }
 
+    /* We don't need it any more and don't want to hold on to it while suspended. */
+    resolutionGoal.reset();
+
     /* Give up on substitution for the output we want, actually build this derivation */
 
     auto g = worker.makeDerivationBuildingGoal(drvPath, drv, buildMode, storeDerivation);
@@ -226,11 +227,7 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
     /* We will finish with it ourselves, as if we were the derivational goal. */
     g->preserveFailure = true;
 
-    {
-        Goals waitees;
-        waitees.insert(g);
-        co_await await(std::move(waitees));
-    }
+    co_await await({g});
 
     trace("outer build done");
 

--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -22,23 +22,16 @@ std::string DerivationResolutionGoal::key()
     return "dc$" + std::string(drvPath.name()) + "$" + worker.store.printStorePath(drvPath);
 }
 
-/**
- * Used for `inputGoals` local variable below
- */
-struct value_comparison
-{
-    template<typename T>
-    bool operator()(const ref<T> & lhs, const ref<T> & rhs) const
-    {
-        return *lhs < *rhs;
-    }
-};
-
 Goal::Co DerivationResolutionGoal::resolveDerivation()
 {
     Goals waitees;
 
-    std::map<ref<const SingleDerivedPath>, GoalPtr, value_comparison> inputGoals;
+    using ValueComparison = decltype([]<typename T>(const ref<T> & lhs, const ref<T> & rhs) {
+        /* Compare the values, not the pointers themselves. */
+        return *lhs < *rhs;
+    });
+
+    std::map<ref<const SingleDerivedPath>, GoalPtr, ValueComparison> inputGoals;
 
     auto addWaiteeDerivedPath = [&worker = worker, buildMode = buildMode, &waitees, &inputGoals](
                                     this const auto & self,

--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -7,10 +7,10 @@
 namespace nix {
 
 DerivationResolutionGoal::DerivationResolutionGoal(
-    const StorePath & drvPath, const Derivation & drv, Worker & worker, BuildMode buildMode)
+    const StorePath & drvPath, ref<const Derivation> drv, Worker & worker, BuildMode buildMode)
     : Goal(worker, resolveDerivation())
     , drvPath(drvPath)
-    , drv{std::make_unique<Derivation>(drv)}
+    , drv(std::move(drv))
     , buildMode{buildMode}
 {
     name = fmt("resolving derivation '%s'", worker.store.printStorePath(drvPath));

--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -40,42 +40,38 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
 
     std::map<ref<const SingleDerivedPath>, GoalPtr, value_comparison> inputGoals;
 
-    {
-        std::function<void(ref<const SingleDerivedPath>, const DerivedPathMap<StringSet>::ChildNode &)>
-            addWaiteeDerivedPath;
-
-        addWaiteeDerivedPath = [&](ref<const SingleDerivedPath> inputDrv,
-                                   const DerivedPathMap<StringSet>::ChildNode & inputNode) {
-            if (!inputNode.value.empty()) {
-                auto g = worker.makeGoal(
-                    DerivedPath::Built{
-                        .drvPath = inputDrv,
-                        .outputs = inputNode.value,
-                    },
-                    buildMode == bmRepair ? bmRepair : bmNormal);
-                inputGoals.insert_or_assign(inputDrv, g);
-                waitees.insert(std::move(g));
-            }
-            for (const auto & [outputName, childNode] : inputNode.childMap)
-                addWaiteeDerivedPath(
-                    make_ref<SingleDerivedPath>(SingleDerivedPath::Built{inputDrv, outputName}), childNode);
-        };
-
-        for (const auto & [inputDrvPath, inputNode] : drv->inputDrvs.map) {
-            /* Ensure that pure, non-fixed-output derivations don't
-               depend on impure derivations. */
-            if (experimentalFeatureSettings.isEnabled(Xp::ImpureDerivations) && !drv->type().isImpure()
-                && !drv->type().isFixed()) {
-                auto inputDrv = worker.evalStore.readDerivation(inputDrvPath);
-                if (inputDrv.type().isImpure())
-                    throw Error(
-                        "pure derivation '%s' depends on impure derivation '%s'",
-                        worker.store.printStorePath(drvPath),
-                        worker.store.printStorePath(inputDrvPath));
-            }
-
-            addWaiteeDerivedPath(makeConstantStorePathRef(inputDrvPath), inputNode);
+    auto addWaiteeDerivedPath = [&worker = worker, buildMode = buildMode, &waitees, &inputGoals](
+                                    this const auto & self,
+                                    ref<const SingleDerivedPath> inputDrv,
+                                    const DerivedPathMap<StringSet>::ChildNode & inputNode) -> void {
+        if (!inputNode.value.empty()) {
+            auto g = worker.makeGoal(
+                DerivedPath::Built{
+                    .drvPath = inputDrv,
+                    .outputs = inputNode.value,
+                },
+                buildMode == bmRepair ? bmRepair : bmNormal);
+            inputGoals.insert_or_assign(inputDrv, g);
+            waitees.insert(std::move(g));
         }
+        for (const auto & [outputName, childNode] : inputNode.childMap)
+            self(make_ref<SingleDerivedPath>(SingleDerivedPath::Built{inputDrv, outputName}), childNode);
+    };
+
+    for (const auto & [inputDrvPath, inputNode] : drv->inputDrvs.map) {
+        /* Ensure that pure, non-fixed-output derivations don't
+           depend on impure derivations. */
+        if (experimentalFeatureSettings.isEnabled(Xp::ImpureDerivations) && !drv->type().isImpure()
+            && !drv->type().isFixed()) {
+            auto inputDrv = worker.evalStore.readDerivation(inputDrvPath);
+            if (inputDrv.type().isImpure())
+                throw Error(
+                    "pure derivation '%s' depends on impure derivation '%s'",
+                    worker.store.printStorePath(drvPath),
+                    worker.store.printStorePath(inputDrvPath));
+        }
+
+        addWaiteeDerivedPath(makeConstantStorePathRef(inputDrvPath), inputNode);
     }
 
     co_await await(std::move(waitees));

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -65,10 +65,15 @@ Co::Co(Co && rhs)
     rhs.handle = nullptr;
 }
 
-void Co::operator=(Co && rhs)
+Co & Co::operator=(Co && rhs)
 {
-    this->handle = rhs.handle;
+    if (handle) {
+        handle.promise().alive = false;
+        handle.destroy();
+    }
+    handle = rhs.handle;
     rhs.handle = nullptr;
+    return *this;
 }
 
 Co::~Co()

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -12,16 +12,15 @@ TimedOut::TimedOut(time_t maxDuration)
 
 using Co = nix::Goal::Co;
 using promise_type = nix::Goal::promise_type;
-using ChildEvents = decltype(promise_type::childEvents);
 
-void ChildEvents::pushChildEvent(ChildOutput event)
+void Goal::ChildEvents::pushChildEvent(ChildOutput event)
 {
     if (childTimeout)
         return; // Already timed out, ignore
     childOutputs.push(std::move(event));
 }
 
-void ChildEvents::pushChildEvent(ChildEOF event)
+void Goal::ChildEvents::pushChildEvent(ChildEOF event)
 {
     if (childTimeout)
         return; // Already timed out, ignore
@@ -29,20 +28,20 @@ void ChildEvents::pushChildEvent(ChildEOF event)
     childEOF = std::move(event);
 }
 
-void ChildEvents::pushChildEvent(TimedOut event)
+void Goal::ChildEvents::pushChildEvent(TimedOut event)
 {
     // Timeout is immediate - flush pending events
     childOutputs = {};
     childEOF.reset();
-    childTimeout = std::move(event);
+    childTimeout = std::make_unique<TimedOut>(std::move(event));
 }
 
-bool ChildEvents::hasChildEvent() const
+bool Goal::ChildEvents::hasChildEvent() const
 {
     return !childOutputs.empty() || childEOF || childTimeout;
 }
 
-Goal::ChildEvent ChildEvents::popChildEvent()
+Goal::ChildEvent Goal::ChildEvents::popChildEvent()
 {
     if (!childOutputs.empty()) {
         auto event = std::move(childOutputs.front());
@@ -52,7 +51,7 @@ Goal::ChildEvent ChildEvents::popChildEvent()
     if (childEOF)
         return *std::exchange(childEOF, std::nullopt);
     if (childTimeout)
-        return *std::exchange(childTimeout, std::nullopt);
+        return std::exchange(childTimeout, nullptr);
     unreachable();
 }
 
@@ -278,22 +277,19 @@ void Goal::work()
 
 void Goal::handleChildOutput(Descriptor fd, std::string_view data)
 {
-    assert(top_co);
-    top_co->handle.promise().childEvents.pushChildEvent(ChildOutput{fd, std::string{data}});
+    childEvents.pushChildEvent(ChildOutput{fd, std::string{data}});
     worker.wakeUp(shared_from_this());
 }
 
 void Goal::handleEOF(Descriptor fd)
 {
-    assert(top_co);
-    top_co->handle.promise().childEvents.pushChildEvent(ChildEOF{fd});
+    childEvents.pushChildEvent(ChildEOF{fd});
     worker.wakeUp(shared_from_this());
 }
 
 void Goal::timedOut(TimedOut && ex)
 {
-    assert(top_co);
-    top_co->handle.promise().childEvents.pushChildEvent(std::move(ex));
+    childEvents.pushChildEvent(std::move(ex));
     worker.wakeUp(shared_from_this());
 }
 

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -104,7 +104,7 @@ std::shared_ptr<DerivationGoal> Worker::makeDerivationGoal(
 }
 
 std::shared_ptr<DerivationResolutionGoal>
-Worker::makeDerivationResolutionGoal(const StorePath & drvPath, const Derivation & drv, BuildMode buildMode)
+Worker::makeDerivationResolutionGoal(const StorePath & drvPath, ref<const Derivation> drv, BuildMode buildMode)
 {
     return initGoalIfNeeded(derivationResolutionGoals[drvPath], drvPath, drv, *this, buildMode);
 }

--- a/src/libstore/include/nix/store/build/derivation-resolution-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-resolution-goal.hh
@@ -37,7 +37,8 @@ struct DerivationResolutionGoal : public Goal
 {
     friend class Worker;
 
-    DerivationResolutionGoal(const StorePath & drvPath, const Derivation & drv, Worker & worker, BuildMode buildMode);
+    DerivationResolutionGoal(
+        const StorePath & drvPath, ref<const Derivation> drv, Worker & worker, BuildMode buildMode);
 
     /**
      * If the derivation needed to be resolved, this is resulting
@@ -55,7 +56,7 @@ private:
     /**
      * The derivation stored at drvPath.
      */
-    std::unique_ptr<Derivation> drv;
+    ref<const Derivation> drv;
 
     /**
      * The remainder is state held during the build.

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -233,8 +233,10 @@ public:
 
         explicit Co(handle_type handle)
             : handle(handle) {};
-        void operator=(Co &&);
+        Co & operator=(Co &&);
         Co(Co && rhs);
+        Co & operator=(const Co &) = delete;
+        Co(const Co & rhs) = delete;
         ~Co();
 
         bool await_ready()

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -74,7 +74,43 @@ enum struct JobCategory {
 
 struct Goal : public std::enable_shared_from_this<Goal>
 {
+    /**
+     * Event types for child process communication, delivered via coroutines.
+     */
+    struct ChildOutput
+    {
+        Descriptor fd;
+        std::string data;
+    };
+
+    struct ChildEOF
+    {
+        Descriptor fd;
+    };
+
+    using ChildEvent = std::variant<ChildOutput, ChildEOF, std::unique_ptr<TimedOut>>;
+
 private:
+    class ChildEvents
+    {
+        /**
+         * Structured queue of child events:
+         * - outputs: stream of data from child
+         * - eof: optional end-of-stream marker
+         * - timeout: optional timeout that flushes/overrides other events
+         */
+        std::queue<ChildOutput> childOutputs;
+        std::optional<ChildEOF> childEOF;
+        std::unique_ptr<TimedOut> childTimeout;
+
+    public:
+        void pushChildEvent(ChildOutput event);
+        void pushChildEvent(ChildEOF event);
+        void pushChildEvent(TimedOut event);
+        bool hasChildEvent() const;
+        ChildEvent popChildEvent();
+    };
+
     /**
      * Goals that this goal is waiting for.
      */
@@ -84,6 +120,8 @@ private:
      * Memoised result of key().
      */
     std::optional<std::string> cachedKey;
+
+    ChildEvents childEvents;
 
 public:
     typedef enum { ecBusy, ecSuccess, ecFailed, ecNoSubstituters } ExitCode;
@@ -151,22 +189,6 @@ public:
 
         friend Goal;
     };
-
-    /**
-     * Event types for child process communication, delivered via coroutines.
-     */
-    struct ChildOutput
-    {
-        Descriptor fd;
-        std::string data;
-    };
-
-    struct ChildEOF
-    {
-        Descriptor fd;
-    };
-
-    using ChildEvent = std::variant<ChildOutput, ChildEOF, TimedOut>;
 
     /**
      * Tag type for `co_await`-ing child events.
@@ -321,28 +343,6 @@ public:
          */
         bool alive = true;
 
-        class
-        {
-            /**
-             * Structured queue of child events:
-             * - outputs: stream of data from child
-             * - eof: optional end-of-stream marker
-             * - timeout: optional timeout that flushes/overrides other events
-             */
-            std::queue<ChildOutput> childOutputs;
-            std::optional<ChildEOF> childEOF;
-            std::optional<TimedOut> childTimeout;
-
-        public:
-
-            void pushChildEvent(ChildOutput event);
-            void pushChildEvent(ChildEOF event);
-            void pushChildEvent(TimedOut event);
-            bool hasChildEvent() const;
-            ChildEvent popChildEvent();
-
-        } childEvents;
-
         /**
          * The awaiter used by @ref final_suspend.
          */
@@ -450,7 +450,7 @@ public:
 
             bool await_ready()
             {
-                assert(!promise.childEvents.hasChildEvent());
+                assert(!promise.goal->childEvents.hasChildEvent());
                 return false;
             }
 
@@ -478,7 +478,7 @@ public:
 
             bool await_ready()
             {
-                return handle && handle.promise().childEvents.hasChildEvent();
+                return handle && handle.promise().goal->childEvents.hasChildEvent();
             }
 
             void await_suspend(handle_type h)
@@ -489,7 +489,7 @@ public:
             ChildEvent await_resume()
             {
                 assert(handle);
-                return handle.promise().childEvents.popChildEvent();
+                return handle.promise().goal->childEvents.popChildEvent();
             }
         };
 

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -265,7 +265,7 @@ public:
      * @ref DerivationResolutionGoal "derivation resolution goal"
      */
     std::shared_ptr<DerivationResolutionGoal>
-    makeDerivationResolutionGoal(const StorePath & drvPath, const Derivation & drv, BuildMode buildMode);
+    makeDerivationResolutionGoal(const StorePath & drvPath, ref<const Derivation> drv, BuildMode buildMode);
 
     /**
      * @ref DerivationBuildingGoal "derivation building goal"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Several things. Derivation is the primary memory hog in the build loop, with
the total memory usage getting into gigabytes just to hold the derivations
in memory. Previously I've optimised most goals to share a single ref<const Derivation>,
but turns out I missed DerivationResolutionGoal.

Also fixes a bug in the move assignment of Goal::Co that didn't destroy the coroutine
frame of the Goal being moved into.

Just the first commit lowers the memory usage of the build loop by 25% in my tests
(from 4.2G -> 3.2G) on a 70k derivation closure.

Some cleanups and other memory reductions:

- ChildEvents has no business being in the coroutines promise type - it bloats
it unnecessarily. The whole promise type was like 500 bytes just because it
stored TimedOut inline - now it's behind a unique_ptr as it should have been.
Shaves off like 300MB of memory usage on my stress-testing benchmark.

- Replace std::function with a `deducing this` recursive lambda.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
