### PR TITLE
libexpr: unify toString for nan and inf

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -30,6 +30,7 @@
 #include "parser-tab.hh"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdlib>
 #include <exception>
@@ -2535,8 +2536,16 @@ BackedStringView EvalState::coerceToString(
             return "";
         if (v.type() == nInt)
             return std::to_string(v.integer().value);
-        if (v.type() == nFloat)
+        if (v.type() == nFloat) {
+            if (std::isinf(v.fpoint())) {
+                if (std::signbit(v.fpoint()))
+                    return "-inf";
+                return "inf";
+            }
+            if (std::isnan(v.fpoint()))
+                return "nan";
             return std::to_string(v.fpoint());
+        }
         if (v.type() == nNull)
             return "";
 

--- a/tests/functional/lang/eval-okay-tostring-nan.exp
+++ b/tests/functional/lang/eval-okay-tostring-nan.exp
@@ -1,0 +1,1 @@
+"nan inf -inf nan"

--- a/tests/functional/lang/eval-okay-tostring-nan.nix
+++ b/tests/functional/lang/eval-okay-tostring-nan.nix
@@ -1,0 +1,11 @@
+# Normalize nan's signbit to avoid portability issues.
+let
+  inf = 1.0e+300 * 1.0e+300;
+  nan = inf - inf;
+in
+toString [
+  nan
+  inf
+  (-inf)
+  (-nan)
+]


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

See #15652. Nix converts numbers via `std::to_string`, but its semantics are implementation-defined for nan and inf values. This leads to different behavior based on the host triple (and even libc++ vs libstdc++).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
