### PR TITLE
Automatically generate and use a signing key

### DIFF
--- a/doc/manual/rl-next/auto-sign.md
+++ b/doc/manual/rl-next/auto-sign.md
@@ -1,0 +1,15 @@
+---
+synopsis: Automatically generate and use a signing key
+prs: [15708]
+issues: [3023]
+---
+
+Sets the default value of `secret-key-files` to /nix/var/nix/keys/secret-key, and automatically generates this keypair if it doesn't exist.
+The effect of this is that locally built paths are always signed, making it easier to trace where builds come from and to establish trust.
+The corresponding public key is stored at `/nix/var/nix/public-keys/public-key`.
+
+To prevent automatic signing of built paths, e.g., for a build farm that already has a dedicated signing flow, set `secret-key-files` to an empty value, e.g.:
+
+```
+secret-key-files =
+```

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -246,7 +246,7 @@ public:
 
     Setting<Strings> secretKeyFiles{
         this,
-        {},
+        {this->nixStateDir / "keys" / "secret-key"},
         "secret-key-files",
         R"(
           A whitespace-separated list of files containing secret (private)

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1,3 +1,4 @@
+#include "nix/util/error.hh"
 #include "nix/util/logging.hh"
 #include "nix/util/signature/local-keys.hh"
 #include "nix/util/source-accessor.hh"
@@ -1220,13 +1221,59 @@ Derivation Store::readInvalidDerivation(const StorePath & drvPath)
     return readDerivationCommon(*this, drvPath, false);
 }
 
+static std::list<std::filesystem::path> getDefaultSecretKeys()
+{
+    const auto secretKeyDir = settings.nixStateDir / "keys";
+    const auto publicKeyDir = settings.nixStateDir / "public-keys";
+    const auto defaultSecretKeyFile = secretKeyDir / "secret-key";
+    const auto defaultPublicKeyFile = publicKeyDir / "public-key";
+
+    auto tryGenerateDefaults = [&]() {
+        if (pathExists(defaultSecretKeyFile))
+            return true;
+        try {
+            if (!pathExists(secretKeyDir))
+                createDir(secretKeyDir, S_IRUSR | S_IWUSR | S_IEXEC);
+            if (!pathExists(publicKeyDir))
+                createDir(publicKeyDir, S_IRUSR | S_IWUSR | S_IEXEC | S_IRGRP | S_IROTH);
+        } catch (SystemError & e) {
+            printError("warning: cannot generate default keypair: %s, skipping signing with default key", e.what());
+            return false;
+        }
+        if (pathExists(defaultPublicKeyFile)) {
+            printError(
+                "warning: cannot generate default keypair because a public key already exists at %s, skipping signing with default key",
+                defaultPublicKeyFile.string());
+            return false;
+        }
+        auto secretKey = SecretKey::generate(getHostName());
+        try {
+            writeFile(defaultSecretKeyFile, secretKey.to_string(), S_IRUSR | S_IWUSR);
+            writeFile(defaultPublicKeyFile, secretKey.toPublicKey().to_string(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+        } catch (Error & e) {
+            printError("warning: cannot generate default keypair: %s, skipping signing with default key", e.what());
+            deletePath(defaultSecretKeyFile);
+            deletePath(defaultPublicKeyFile);
+        }
+        return true;
+    };
+
+    std::list<std::filesystem::path> keys;
+
+    for (const auto & keyFile : settings.secretKeyFiles.get()) {
+        if (keyFile == defaultSecretKeyFile && !tryGenerateDefaults())
+            continue;
+        keys.push_back(keyFile);
+    }
+
+    return keys;
+}
+
 void Store::signPathInfo(ValidPathInfo & info)
 {
     // FIXME: keep secret keys in memory.
 
-    auto secretKeyFiles = settings.secretKeyFiles;
-
-    for (auto & secretKeyFile : secretKeyFiles.get()) {
+    for (auto & secretKeyFile : getDefaultSecretKeys()) {
         SecretKey secretKey(readFile(secretKeyFile));
         LocalSigner signer(std::move(secretKey));
         info.sign(*this, signer);
@@ -1237,9 +1284,7 @@ void Store::signRealisation(Realisation & realisation)
 {
     // FIXME: keep secret keys in memory.
 
-    auto secretKeyFiles = settings.secretKeyFiles;
-
-    for (auto & secretKeyFile : secretKeyFiles.get()) {
+    for (auto & secretKeyFile : getDefaultSecretKeys()) {
         SecretKey secretKey(readFile(secretKeyFile));
         LocalSigner signer(std::move(secretKey));
         realisation.sign(realisation.id, signer);

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -268,6 +268,11 @@ std::string stripIndentation(std::string_view s);
 std::pair<std::string_view, std::string_view> getLine(std::string_view s);
 
 /**
+ * Gets our hostname in a cross-platform way.
+ */
+std::string getHostName();
+
+/**
  * Get a pointer to the contents of a `std::optional` if it is set, or a
  * null pointer otherise.
  *

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -7,6 +7,7 @@
 
 #include <sodium.h>
 #include <boost/lexical_cast.hpp>
+#include <boost/asio/ip/host_name.hpp>
 #include <stdint.h>
 
 #ifdef NDEBUG
@@ -297,6 +298,11 @@ std::pair<std::string_view, std::string_view> getLine(std::string_view s)
             line = line.substr(0, line.size() - 1);
         return {line, s.substr(newline + 1)};
     }
+}
+
+std::string getHostName()
+{
+    return boost::asio::ip::host_name();
 }
 
 } // namespace nix

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -14,7 +14,7 @@ nix-instantiate --store "file://$cacheDir" dependencies.nix
 # Create the binary cache.
 clearStore
 clearCache
-outPath=$(nix-build dependencies.nix --no-out-link)
+outPath=$(nix-build dependencies.nix --no-out-link --secret-key-files "")
 depPath=$(nix-build dependencies.nix -A input0_drv --no-out-link)
 
 nix copy --to "file://$cacheDir" "$outPath"

--- a/tests/functional/build-remote-trustless.sh
+++ b/tests/functional/build-remote-trustless.sh
@@ -12,6 +12,8 @@ unset NIX_STORE_DIR
 
 remoteDir=$TEST_ROOT/remote
 
+echo "secret-key-files =" >> "$test_nix_conf"
+
 # Note: ssh{-ng}://localhost bypasses ssh. See tests/functional/build-remote.sh for
 # more details.
 nix-build "$file" -o "$TEST_ROOT/result" --max-jobs 0 \

--- a/tests/functional/signing.sh
+++ b/tests/functional/signing.sh
@@ -34,7 +34,7 @@ nix store verify -r "$outPath" --sigs-needed 2 --trusted-public-keys "$pk1 $pk2"
 nix store verify --all --sigs-needed 2 --trusted-public-keys "$pk1 $pk2"
 
 # Build something unsigned.
-outPath2=$(nix-build simple.nix --no-out-link)
+outPath2=$(nix-build simple.nix --no-out-link --secret-key-files "")
 
 nix store verify -r "$outPath"
 
@@ -54,6 +54,12 @@ expect 2 nix store verify -r "$outPath2" --sigs-needed 1 --trusted-public-keys "
 nix store sign --key-file "$TEST_ROOT"/sk1 "$outPath2"
 
 nix store verify -r "$outPath2" --sigs-needed 1 --trusted-public-keys "$pk1"
+
+# Test default signing
+if isDaemonNewer "2.35pre"; then
+    outPath3=$(nix-build simple2.nix --no-out-link)
+    nix store verify -r "$outPath3" --sigs-needed 1
+fi
 
 # Build something content-addressed.
 outPathCA=$(IMPURE_VAR1=foo IMPURE_VAR2=bar nix-build ./fixed.nix -A good.0 --no-out-link)

--- a/tests/functional/simple2.nix
+++ b/tests/functional/simple2.nix
@@ -1,0 +1,9 @@
+with import ./config.nix;
+
+mkDerivation {
+  name = "simple2";
+  builder = ./simple.builder.sh;
+  PATH = "";
+  goodPath = path;
+  meta.position = "${__curPos.file}:${toString __curPos.line}";
+}


### PR DESCRIPTION
Sets the default value of `secret-key-files` to `/nix/var/nix/keys/secret-key`, and automatically generates this keypair if it doesn't exist. The effect of this is that locally built paths are always signed, making it easier to trace where builds come from and to establish trust. The corresponding public key is stored at `/nix/var/nix/public-keys/public-key`.

Closes #3023

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

In addition to enabling tracing of what machine built what store path, this makes a future `--target-store` flag more usable, because you can obtain and add the automatically-generated public key of the remote store rather than having to manually generate and configure a new key.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#3023

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
