### PR TITLE
feat: nix-eval-jobs via nix search

### DIFF
--- a/doc/manual/rl-next/search-calc-out-paths.md
+++ b/doc/manual/rl-next/search-calc-out-paths.md
@@ -1,0 +1,50 @@
+---
+synopsis: "`nix search` can now calculate paths, check cache availability, transform output, and stream JSON"
+---
+
+`nix search --json` now supports four new flags:
+
+- `--calc-derivation`: Includes both the output path and derivation path of each matching derivation in the JSON output. This will instantiate the derivations by writing .drv files to the store.
+- `--check-cache`: Adds a `cached` boolean field indicating whether the output path is available in a binary cache, without downloading it. Implies `--json`.
+- `--apply <expr>`: Apply a Nix function to each matching derivation to transform the output. Implies `--json`.
+- `--json-lines`: Outputs results in JSON Lines (JSONL) format, with one result per line. This enables streaming output as results are found.
+
+Example usage:
+
+```console
+# Include paths in output
+$ nix search nixpkgs hello --json --calc-derivation
+{
+  "legacyPackages.x86_64-linux.hello": {
+    "description": "Program that produces a familiar, friendly greeting",
+    "drvPath": "/nix/store/...-hello-2.12.3.drv",
+    "outPath": "/nix/store/10s5j3mfdg22k1597x580qrhprnzcjwb-hello-2.12.3",
+    "pname": "hello",
+    "version": "2.12.3"
+  }
+}
+
+# Check if packages are cached
+$ nix search nixpkgs hello --json --check-cache
+{
+  "legacyPackages.x86_64-linux.hello": {
+    "cached": true,
+    "description": "Program that produces a familiar, friendly greeting",
+    "pname": "hello",
+    "version": "2.12.3"
+  }
+}
+
+# Transform output with --apply
+$ nix search nixpkgs hello --apply 'drv: { name = drv.pname; out = drv.outPath; }'
+{
+  "legacyPackages.x86_64-linux.hello": {
+    "name": "hello",
+    "out": "/nix/store/10s5j3mfdg22k1597x580qrhprnzcjwb-hello-2.12.3"
+  }
+}
+
+# Streaming output with JSON Lines
+$ nix search nixpkgs hello --json-lines --calc-derivation
+{"legacyPackages.x86_64-linux.hello":{"description":"Program that produces a familiar, friendly greeting","drvPath":"/nix/store/...-hello-2.12.3.drv","outPath":"/nix/store/10s5j3mfdg22k1597x580qrhprnzcjwb-hello-2.12.3","pname":"hello","version":"2.12.3"}}
+```

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -10,6 +10,7 @@
 #include "nix/expr/attr-path.hh"
 #include "nix/util/hilite.hh"
 #include "nix/util/strings-inline.hh"
+#include "nix/expr/value-to-json.hh"
 
 #include <regex>
 #include <nlohmann/json.hpp>
@@ -29,6 +30,10 @@ struct CmdSearch : InstallableValueCommand, MixJSON
 {
     std::vector<std::string> res;
     std::vector<std::string> excludeRes;
+    std::optional<std::string> apply;
+    bool calcDerivation = false;
+    bool checkCache = false;
+    bool jsonLines = false;
 
     CmdSearch()
     {
@@ -40,6 +45,31 @@ struct CmdSearch : InstallableValueCommand, MixJSON
                 .description = "Hide packages whose attribute path, name or description contain *regex*.",
                 .labels = {"regex"},
                 .handler = {[this](std::string s) { excludeRes.push_back(s); }},
+            });
+        addFlag(
+            Flag{
+                .longName = "apply",
+                .description = "Apply the function *expr* to each matching derivation (implies --json).",
+                .labels = {"expr"},
+                .handler = {&apply},
+            });
+        addFlag(
+            Flag{
+                .longName = "calc-derivation",
+                .description = "Calculate output paths and derivation paths for matching derivations. This will instantiate the derivations (write .drv files to the store).",
+                .handler = {&calcDerivation, true},
+            });
+        addFlag(
+            Flag{
+                .longName = "check-cache",
+                .description = "Check if the output path is available in a binary cache without downloading. Implies --json.",
+                .handler = {&checkCache, true},
+            });
+        addFlag(
+            Flag{
+                .longName = "json-lines",
+                .description = "Output results as JSON Lines (JSONL) format, one result per line. Implies --json.",
+                .handler = {&jsonLines, true},
             });
     }
 
@@ -62,8 +92,13 @@ struct CmdSearch : InstallableValueCommand, MixJSON
 
     void run(ref<Store> store, ref<InstallableValue> installable) override
     {
-        settings.readOnlyMode = true;
-        evalSettings.enableImportFromDerivation.setDefault(false);
+        // Disable IFD by default for performance, but allow override via --option
+        if (!evalSettings.enableImportFromDerivation.isOverridden())
+            evalSettings.enableImportFromDerivation = false;
+
+        // By default, run in read-only mode for performance (don't instantiate drvs).
+        // But if --calc-derivation or IFD is enabled, we need to allow instantiation.
+        settings.readOnlyMode = !calcDerivation && !evalSettings.enableImportFromDerivation;
 
         // Recommend "^" here instead of ".*" due to differences in resulting highlighting
         if (res.empty())
@@ -83,9 +118,20 @@ struct CmdSearch : InstallableValueCommand, MixJSON
 
         auto state = getEvalState();
 
+        // --json-lines, --apply, and --check-cache imply --json
+        if (jsonLines || apply || checkCache)
+            json = true;
+
         std::optional<nlohmann::json> jsonOut;
-        if (json)
+        if (json && !jsonLines)
             jsonOut = json::object();
+
+        // Parse apply expression once if provided
+        Value * vApply = nullptr;
+        if (apply) {
+            vApply = state->allocValue();
+            state->eval(state->parseExprFromString(*apply, state->rootPath(".")), *vApply);
+        }
 
         uint64_t results = 0;
 
@@ -95,7 +141,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
             auto attrPathS = state->symbols.resolve({attrPath});
             auto attrPathStr = attrPath.to_string(*state);
 
-            Activity act(*logger, lvlInfo, actUnknown, fmt("evaluating '%s'", attrPathStr));
+            Activity act(*logger, json ? lvlDebug : lvlInfo, actUnknown, fmt("evaluating '%s'", attrPathStr));
             try {
                 auto recurse = [&]() {
                     for (const auto & attr : cursor.getAttrs()) {
@@ -146,11 +192,82 @@ struct CmdSearch : InstallableValueCommand, MixJSON
                     if (found) {
                         results++;
                         if (json) {
-                            (*jsonOut)[attrPathStr] = {
-                                {"pname", name.name},
-                                {"version", name.version},
-                                {"description", description},
-                            };
+                            nlohmann::json jsonEntry;
+
+                            if (vApply) {
+                                try {
+                                    // Get the derivation value and apply the user's function
+                                    auto & v = cursor.forceValue();
+                                    auto vRes = state->allocValue();
+                                    state->callFunction(*vApply, v, *vRes, noPos);
+
+                                    // Convert result to JSON
+                                    NixStringContext context;
+                                    jsonEntry = printValueAsJSON(*state, true, *vRes, noPos, context, false);
+                                } catch (Error & e) {
+                                    // If apply fails, output error information
+                                    jsonEntry = json::object({
+                                        {"pname", name.name},
+                                        {"version", name.version},
+                                        {"description", description},
+                                        {"applyError", e.msg()},
+                                    });
+                                }
+                            } else {
+                                // Default output: pname, version, description
+                                jsonEntry = json::object({
+                                    {"pname", name.name},
+                                    {"version", name.version},
+                                    {"description", description},
+                                });
+
+                                if (calcDerivation) {
+                                    try {
+                                        // Calculate both outPath and drvPath
+                                        // This will instantiate the derivation (write .drv file)
+                                        auto aOutPath = cursor.maybeGetAttr(state->s.outPath);
+                                        if (aOutPath) {
+                                            auto outPathStr = aOutPath->getString();
+                                            jsonEntry["outPath"] = outPathStr;
+                                        }
+
+                                        auto drvPath = cursor.forceDerivation();
+                                        jsonEntry["drvPath"] = state->store->printStorePath(drvPath);
+                                    } catch (Error & e) {
+                                        jsonEntry["derivationError"] = e.msg();
+                                    }
+                                }
+
+                                if (checkCache) {
+                                    try {
+                                        // Get outPath without instantiating
+                                        auto aOutPath = cursor.maybeGetAttr(state->s.outPath);
+                                        if (aOutPath) {
+                                            auto outPathStr = aOutPath->getString();
+                                            auto outPath = state->store->parseStorePath(outPathStr);
+
+                                            // Check if path is substitutable (cached)
+                                            StorePathSet paths{outPath};
+                                            auto substitutable = state->store->querySubstitutablePaths(paths);
+                                            jsonEntry["cached"] = substitutable.count(outPath) > 0;
+                                        } else {
+                                            jsonEntry["cached"] = false;
+                                        }
+                                    } catch (Error & e) {
+                                        // If we can't check, mark as unknown
+                                        jsonEntry["cached"] = false;
+                                    }
+                                }
+                            }
+
+                            if (jsonLines) {
+                                // Output as JSON Lines (one JSON object per line)
+                                auto jsonLine = json::object();
+                                jsonLine[attrPathStr] = jsonEntry;
+                                logger->cout("%s", jsonLine.dump());
+                            } else {
+                                (*jsonOut)[attrPathStr] = jsonEntry;
+                            }
                         } else {
                             if (results > 1)
                                 logger->cout("");
@@ -188,7 +305,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
         for (auto & cursor : installable->getCursors(*state))
             visit(*cursor, cursor->getAttrPath(), true);
 
-        if (json)
+        if (json && !jsonLines)
             printJSON(*jsonOut);
 
         if (!json && !results)

--- a/tests/functional/search.sh
+++ b/tests/functional/search.sh
@@ -49,3 +49,45 @@ e=$'\x1b' # grep doesn't support \e, \033 or even \x1b
 (( $(nix search -f search.nix foo ^ --exclude 'foo|bar' | grep -Ec 'foo|bar') == 0 ))
 (( $(nix search -f search.nix foo ^ -e foo --exclude bar | grep -Ec 'foo|bar') == 0 ))
 [[ $(nix search -f search.nix '' ^ -e bar --json | jq -c 'keys') == '["foo","hello"]' ]]
+
+## Tests for --calc-derivation
+
+# Check that --calc-derivation adds both outPath and drvPath to JSON output
+[[ -n $(nix search -f search.nix '' hello --json --calc-derivation | jq -r '.hello.outPath') ]]
+[[ -n $(nix search -f search.nix '' hello --json --calc-derivation | jq -r '.hello.drvPath') ]]
+
+# Check that without --calc-derivation, paths are not present
+[[ $(nix search -f search.nix '' hello --json | jq 'has("hello") and (.hello | has("outPath") | not) and (.hello | has("drvPath") | not)') == 'true' ]]
+
+# Check that other fields are still present with --calc-derivation
+[[ $(nix search -f search.nix '' hello --json --calc-derivation | jq 'has("hello") and (.hello | has("pname")) and (.hello | has("version")) and (.hello | has("description"))') == 'true' ]]
+
+## Tests for --json-lines
+
+# Check that --json-lines outputs one JSON object per line
+(( $(nix search -f search.nix '' ^ --json-lines | wc -l) == 3 ))
+
+# Check that each line is valid JSON
+nix search -f search.nix '' hello --json-lines | jq -e 'has("hello")'
+
+# Check that --json-lines works with --calc-derivation
+[[ -n $(nix search -f search.nix '' hello --json-lines --calc-derivation | jq -r '.hello.outPath') ]]
+
+## Tests for --apply
+
+# Check that --apply works for simple transformations
+[[ $(nix search -f search.nix '' hello --apply 'drv: { drvName = drv.name; }' | jq -r '.hello.drvName') == 'hello-0.1' ]]
+
+# Check that --apply can access outPath
+[[ -n $(nix search -f search.nix '' hello --apply 'drv: { out = drv.outPath; }' | jq -r '.hello.out') ]]
+
+# Check that --apply can transform derivation attributes
+[[ $(nix search -f search.nix '' hello --apply 'drv: { name = drv.name; type = drv.type; }' | jq 'has("hello") and (.hello | has("name")) and (.hello | has("type"))') == 'true' ]]
+
+## Tests for --check-cache
+
+# Check that --check-cache adds cached field
+[[ $(nix search -f search.nix '' hello --json --check-cache | jq 'has("hello") and (.hello | has("cached"))') == 'true' ]]
+
+# Check that cached field is a boolean
+[[ $(nix search -f search.nix '' hello --json --check-cache | jq '.hello.cached | type') == '"boolean"' ]]


### PR DESCRIPTION
Overall: I'm trying to explore ways to make the Nix's CI experience better. More control over what is evaluated, built, and fetched.

## nix search, eval cache, nix-eval-jobs, oh my!

Spent some token $$$ (Claude Sonnet 4.5) trying to bring nix-eval-jobs functionality to Nix. This is pretty close. Uses existing `nix search` machinery for most of it and adds some customization. Nothing in the design here is set in stone, but to showcase what is possible. A huge benefit of this is that search can leverage the **eval cache!**!!! Subsequent calls are speedy! Even initial run seems quite fast considering we're not throwing multiple workers at it.

It might even be better for this to become its own command. Thoughts? Consolidate the formats?

There are some differences in the traversal, needs some investigation:
```bash
./result/bin/nix search nixpkgs . --json-lines --calc-derivation | wc -l
107476

vs.
nix-eval-jobs --flake github:NixOS/nixpkgs#legacyPackages.x86_64-linux | wc -l
112066
```

###  Fun stuff
 - `--json-lines`: stream just like nix-eval-jobs
```bash
  $ nix search nixpkgs 'python.*requests' --json-lines
  {"legacyPackages.x86_64-linux.python311Packages.requests":{"description":"Python HTTP library","pname":"requests","version":"2.31.0"}}
  {"legacyPackages.x86_64-linux.python312Packages.requests":{"description":"Python HTTP library","pname":"requests","version":"2.31.0"}}
  {"legacyPackages.x86_64-linux.python310Packages.requests":{"description":"Python HTTP library","pname":"requests","version":"2.31.0"}}
```

 - `--calc-derivation`: adds outPath and drvPath to the output, this is more expensive eval than normal
```json
  $ nix search nixpkgs '\.hello$' --json --calc-derivation --json-lines
{"legacyPackages.x86_64-linux.haskellPackages.hello":{"description":"Hello World, an example package","drvPath":"/nix/store/9k7398z2g9jnfyqbmkjn649771jbapcm-hello-1.0.0.2.drv","outPath":"/nix/store/p7nlns9mxkscagcw3vlb37yll0zaqn5n-hello-1.0.0.2","pname":"hello","version":"1.0.0.2"}}
{"legacyPackages.x86_64-linux.hello":{"description":"Program that produces a familiar, friendly greeting","drvPath":"/nix/store/7mdg60drrnh0wq1j8hmmbhll47czm107-hello-2.12.3.drv","outPath":"/nix/store/10s5j3mfdg22k1597x580qrhprnzcjwb-hello-2.12.3","pname":"hello","version":"2.12.3"}}
{"legacyPackages.x86_64-linux.tests.arrayUtilities.getRunpathEntries.hello":{"description":"","drvPath":"/nix/store/fghayk5b782x5xh3m6jy4pb82z75q7ka-hello.drv","outPath":"/nix/store/gsvfswazmd4492lrm9n45iiycx9bcwvm-hello","pname":"hello","version":""}}
{"legacyPackages.x86_64-linux.tests.haskell.ghcWithPackages.hello":{"description":"Glasgow Haskell Compiler","drvPath":"/nix/store/67jikrmyrqp38ybxfksbz2wnw2p3plmz-ghc-9.10.3-with-packages.drv","outPath":"/nix/store/27lwfd0mx2xb7a24m2kj4vgiv3akgff6-ghc-9.10.3-with-packages","pname":"ghc","version":"9.10.3-with-packages"}}
{"legacyPackages.x86_64-linux.vdrPlugins.hello":{"description":"","drvPath":"/nix/store/7iyb3xw9kncw53x676lh3gmlai9a5av4-hello-2.8.1.drv","outPath":"/nix/store/k7gzhv0yibxsdvqr2
```
  
  - `--apply`: Very similar to `nix eval`'s apply, probably should be in many other commands

```json
  $ nix search nixpkgs hello --apply 'drv: { name = drv.name; out = drv.outPath; }'
  {
    "legacyPackages.x86_64-linux.hello": {
      "name": "hello-2.12.3",
      "out": "/nix/store/10s5j3mfdg22k1597x580qrhprnzcjwb-hello-2.12.3"
    }
  }
```


 - `--check-cache`: 
 ```json
nix search nixpkgs '\.matlab$' --json --check-cache
{
  "legacyPackages.x86_64-linux.haskellPackages.matlab": {
    "cached": false,
    "description": "Matlab bindings and interface",
    "pname": "matlab",
    "version": "0.3.0.0"
  },
  "legacyPackages.x86_64-linux.vimPlugins.nvim-treesitter-parsers.matlab": {
    "cached": true,
    "description": "Tree-sitter grammar for matlab",
    "pname": "vimplugin-nvim-treesitter-grammar-matlab",
    "version": "0.0.0+rev=c2390a5"
  }
}
```

Additional stuff:
  - IFD override: allow-import-from-derivation can now be overridden via --option
  - Error reporting: failed eval in apply goes into JSON output instead of silently failing
  - can we avoid instantiating drv's, but still calculating outPaths?