### PR TITLE
Don't copy flakes to the store unnecessarily (maybe 3rd time's the charm)

### DIFF
--- a/src/libcmd/installable-value.cc
+++ b/src/libcmd/installable-value.cc
@@ -54,8 +54,11 @@ InstallableValue::trySinglePathToDerivedPaths(Value & v, const PosIdx pos, std::
     }
 
     else if (v.type() == nString) {
+        auto path = state->coerceToSingleDerivedPath(pos, v, errorCtx);
+        if (auto o = std::get_if<SingleDerivedPath::Opaque>(&path.raw()))
+            state->ensureLazyPathCopied(o->path);
         return {{
-            .path = DerivedPath::fromSingle(state->coerceToSingleDerivedPath(pos, v, errorCtx)),
+            .path = DerivedPath::fromSingle(path),
             .info = make_ref<ExtraPathInfo>(),
         }};
     }

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -738,6 +738,26 @@ public:
     std::optional<std::string> tryAttrsToString(
         const PosIdx pos, Value & v, NixStringContext & context, bool coerceMore = false, bool copyToStore = true);
 
+    enum class CopyLazyPaths : bool {
+        PreserveLazy = false,
+        Copy = true,
+    };
+
+    /**
+     * For efficiency reasons, some store paths (as seen by the evaluator) in
+     * the storeFS at their content-addressed locations don't get copied to the
+     * store eagerly. This saves on needless I/O and possibly IPC if all the
+     * evaluator does is just evaluate nix expressions from those locations.
+     * This function copies such store objects to the store if they aren't already valid.
+     */
+    void ensureLazyPathCopied(const StorePath & path);
+
+    /**
+     * Ensure that all NixStringContextElem::Opaque context elements get fetched
+     * to the store.
+     */
+    void ensureLazyPathsCopied(const NixStringContext & context);
+
     /**
      * String coercion.
      *
@@ -1044,9 +1064,14 @@ public:
 
     /**
      * Coerce `v` to a path and realise it, i.e. build anything in the value's string context using `realiseContext()`.
+     * @param copyLazyPaths When encountering a lazy path (i.e. a string with Opaque context that's also "mounted" on
+     * the storeFS), fetch the store path to the store.
      */
     SourcePath realisePath(
-        const PosIdx pos, Value & v, std::optional<SymlinkResolution> resolveSymlinks = SymlinkResolution::Full);
+        const PosIdx pos,
+        Value & v,
+        std::optional<SymlinkResolution> resolveSymlinks = SymlinkResolution::Full,
+        CopyLazyPaths copyLazyPaths = CopyLazyPaths::PreserveLazy);
 
     /**
      * Realise the given string with context, and return the string with outputs instead of downstream output

--- a/src/libexpr/include/nix/expr/print-ambiguous.hh
+++ b/src/libexpr/include/nix/expr/print-ambiguous.hh
@@ -17,6 +17,12 @@ class EvalState;
  *
  * See: https://github.com/NixOS/nix/issues/9730
  */
-void printAmbiguous(EvalState & state, Value & v, std::ostream & str, std::set<const void *> * seen, size_t depth = 0);
+void printAmbiguous(
+    EvalState & state,
+    Value & v,
+    std::ostream & str,
+    std::set<const void *> * seen,
+    NixStringContext * context = nullptr,
+    size_t depth = 0);
 
 } // namespace nix

--- a/src/libexpr/include/nix/expr/print.hh
+++ b/src/libexpr/include/nix/expr/print.hh
@@ -10,6 +10,7 @@
 #include <iostream>
 
 #include "nix/util/fmt.hh"
+#include "nix/expr/value/context.hh"
 #include "nix/expr/print-options.hh"
 
 namespace nix {
@@ -64,7 +65,12 @@ bool isReservedKeyword(const std::string_view str);
  */
 std::ostream & printIdentifier(std::ostream & o, std::string_view s);
 
-void printValue(EvalState & state, std::ostream & str, Value & v, PrintOptions options = PrintOptions{});
+void printValue(
+    EvalState & state,
+    std::ostream & str,
+    Value & v,
+    PrintOptions options = PrintOptions{},
+    NixStringContext * context = nullptr);
 
 /**
  * A partially-applied form of `printValue` which can be formatted using `<<`
@@ -77,12 +83,15 @@ private:
     EvalState & state;
     Value & value;
     PrintOptions options;
+    NixStringContext * context;
 
 public:
-    ValuePrinter(EvalState & state, Value & value, PrintOptions options = PrintOptions{})
+    ValuePrinter(
+        EvalState & state, Value & value, PrintOptions options = PrintOptions{}, NixStringContext * context = nullptr)
         : state(state)
         , value(value)
         , options(options)
+        , context(context)
     {
     }
 };

--- a/src/libexpr/paths.cc
+++ b/src/libexpr/paths.cc
@@ -22,10 +22,55 @@ SourcePath EvalState::storePath(const StorePath & path)
     return {rootFS, CanonPath{store->printStorePath(path)}};
 }
 
+void EvalState::ensureLazyPathCopied(const StorePath & path)
+{
+    if (settings.isReadOnly())
+        return;
+
+    auto mount = storeFS->getMount(CanonPath(store->printStorePath(path)));
+    if (!mount)
+        return;
+
+    /* TODO: We could memoise this in-memory if necessary. */
+    auto storePath = fetchToStore(
+        fetchSettings,
+        *store,
+        SourcePath{ref(mount)},
+        /* Force a copy. mountInput does a dryRun to just calculate the storePath and narHash. */
+        FetchMode::Copy,
+        path.name());
+
+    /* Catch hash mismatches more loudly. This is more likely caused by unsound
+       caching of different accessor types that fetch the same repo with
+       the same git revision, but with different kinds of accessors (think
+       tarball-based fetchers vs local/remote git accessors). */
+    if (storePath != path) {
+        panic(fmt(
+            "hashed store path computed by the evaluator ('%1%') does not match what was computed when copying to the store ('%2%'), this is a bug",
+            store->printStorePath(path),
+            store->printStorePath(storePath)));
+    }
+}
+
+void EvalState::ensureLazyPathsCopied(const NixStringContext & context)
+{
+    for (const auto & c : context)
+        if (auto * o = std::get_if<NixStringContextElem::Opaque>(&c.raw))
+            /* TODO: This could be done in parallel. */
+            ensureLazyPathCopied(o->path);
+}
+
 StorePath
 EvalState::mountInput(fetchers::Input & input, const fetchers::Input & originalInput, ref<SourceAccessor> accessor)
 {
-    auto [storePath, narHash] = fetchToStore2(fetchSettings, *store, accessor, FetchMode::Copy, input.getName());
+    /* To mount the input, dryRun is sufficient. We still compute the narHash (to check for mismatches) and the store
+       path to figure out where to mount it. TODO: This could be relaxed in the future by making outPath and narHash
+       lazier. Good code that doesn't do `toString ./.` or otherwise inspects the outPath string and only uses it for
+       doing relative imports does not even require computing the store path. That is a big invasive change though and
+       would require having a special "LazyStorePathString" thunk. narHash also doesn't need to be computed eagerly in
+       case it's not actually specified (like during local development with a dirty tree) - in that case narHash could
+       also become a lazy app/thunk that shares the state with the storePath delayed computation. */
+    auto [storePath, narHash] = fetchToStore2(fetchSettings, *store, accessor, FetchMode::DryRun, input.getName());
 
     allowPath(storePath); // FIXME: should just whitelist the entire virtual store
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -10,6 +10,7 @@
 #include "nix/store/names.hh"
 #include "nix/store/path-references.hh"
 #include "nix/store/store-api.hh"
+#include "nix/util/mounted-source-accessor.hh"
 #include "nix/util/util.hh"
 #include "nix/util/os-string.hh"
 #include "nix/util/processes.hh"
@@ -63,7 +64,7 @@ std::string EvalState::realiseString(Value & s, StorePathSet * storePathsOutMayb
     nix::NixStringContext stringContext;
     auto rawStr = coerceToString(pos, s, stringContext, "while realising a string").toOwned();
     auto rewrites = realiseContext(stringContext, storePathsOutMaybe, isIFD);
-
+    ensureLazyPathsCopied(stringContext);
     return nix::rewriteStrings(rawStr, rewrites);
 }
 
@@ -88,7 +89,11 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
                     ensureValid(b.drvPath->getBaseStorePath());
                 },
                 [&](const NixStringContextElem::Opaque & o) {
-                    ensureValid(o.path);
+                    /* If the path happens to be mounted on the storeFS, that means it's lazy path string and would get
+                       copied to the store on-demand (when referenced in a derivation). The string is equal to final
+                       store path where the store object would end up (the path is hashed before mounting). */
+                    if (!storeFS->getMount(CanonPath(store->printStorePath(o.path))))
+                        ensureValid(o.path);
                     if (maybePathsOut)
                         maybePathsOut->emplace(o.path);
                 },
@@ -158,7 +163,8 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
     return res;
 }
 
-SourcePath EvalState::realisePath(const PosIdx pos, Value & v, std::optional<SymlinkResolution> resolveSymlinks)
+SourcePath EvalState::realisePath(
+    const PosIdx pos, Value & v, std::optional<SymlinkResolution> resolveSymlinks, CopyLazyPaths copyLazyPaths)
 {
     NixStringContext context;
 
@@ -167,6 +173,8 @@ SourcePath EvalState::realisePath(const PosIdx pos, Value & v, std::optional<Sym
     try {
         if (!context.empty() && path.accessor == rootFS) {
             auto rewrites = realiseContext(context);
+            if (copyLazyPaths == CopyLazyPaths::Copy)
+                ensureLazyPathsCopied(context);
             path = {path.accessor, CanonPath(rewriteStrings(path.path.abs(), rewrites))};
         }
         return resolveSymlinks ? path.resolveSymlinks(*resolveSymlinks) : path;
@@ -441,10 +449,11 @@ static RegisterPrimOp primop_import(
 /* !!! Should we pass the Pos or the file name too? */
 extern "C" typedef void (*ValueInitializer)(EvalState & state, Value & v);
 
-/* Load a ValueInitializer from a DSO and return whatever it initializes */
+/* Load a ValueInitializer from a DSO and return whatever it initializes. FIXME: This doesn't
+   work with chroot stores. */
 void prim_importNative(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
-    auto path = state.realisePath(pos, *args[0]);
+    auto path = state.realisePath(pos, *args[0], SymlinkResolution::Full, EvalState::CopyLazyPaths::Copy);
 
     std::string sym(
         state.forceStringNoCtx(*args[1], pos, "while evaluating the second argument passed to builtins.importNative"));
@@ -471,7 +480,7 @@ void prim_importNative(EvalState & state, const PosIdx pos, Value ** args, Value
     /* We don't dlclose because v may be a primop referencing a function in the shared object file */
 }
 
-/* Execute a program and parse its output */
+/* Execute a program and parse its output. FIXME: This doesn't work with chroot stores. */
 void prim_exec(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
     state.forceList(*args[0], pos, "while evaluating the first argument passed to builtins.exec");
@@ -509,6 +518,7 @@ void prim_exec(EvalState & state, const PosIdx pos, Value ** args, Value & v)
             .debugThrow();
     }
 
+    state.ensureLazyPathsCopied(context);
     auto output = runProgram(program, true, toOsStrings(std::move(commandArgs)));
     Expr * parsed;
     try {
@@ -1726,7 +1736,10 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
                 [&](const NixStringContextElem::Built & b) {
                     drv.inputDrvs.ensureSlot(*b.drvPath).value.insert(b.output);
                 },
-                [&](const NixStringContextElem::Opaque & o) { drv.inputSrcs.insert(o.path); },
+                [&](const NixStringContextElem::Opaque & o) {
+                    state.ensureLazyPathCopied(o.path);
+                    drv.inputSrcs.insert(o.path);
+                },
             },
             c.raw);
     }
@@ -1930,6 +1943,10 @@ static void prim_storePath(EvalState & state, const PosIdx pos, Value ** args, V
     auto path =
         state.coerceToPath(pos, *args[0], context, "while evaluating the first argument passed to 'builtins.storePath'")
             .path;
+    /* Here we are leaving the realm of the rootFS accessor and must actually fetch to the store.
+       TODO: This could probably get optimised to avoid the fetching altogether to short-circuit when the path
+       is already mounted on storeFS. */
+    state.ensureLazyPathsCopied(context);
     /* Resolve symlinks in ‘path’, unless ‘path’ itself is a symlink
        directly in the store.  The latter condition is necessary so
        e.g. nix-push does the right thing. */
@@ -2666,9 +2683,10 @@ static void prim_toFile(EvalState & state, const PosIdx pos, Value ** args, Valu
     StorePathSet refs;
 
     for (auto c : context) {
-        if (auto p = std::get_if<NixStringContextElem::Opaque>(&c.raw))
+        if (auto p = std::get_if<NixStringContextElem::Opaque>(&c.raw)) {
+            state.ensureLazyPathCopied(p->path);
             refs.insert(p->path);
-        else
+        } else
             state
                 .error<EvalError>(
                     "files created by %1% may not reference derivations, but %2% references %3%",

--- a/src/libexpr/print-ambiguous.cc
+++ b/src/libexpr/print-ambiguous.cc
@@ -7,7 +7,13 @@
 namespace nix {
 
 // See: https://github.com/NixOS/nix/issues/9730
-void printAmbiguous(EvalState & state, Value & v, std::ostream & str, std::set<const void *> * seen, size_t depth)
+void printAmbiguous(
+    EvalState & state,
+    Value & v,
+    std::ostream & str,
+    std::set<const void *> * seen,
+    NixStringContext * context,
+    size_t depth)
 {
     checkInterrupt();
 
@@ -22,6 +28,8 @@ void printAmbiguous(EvalState & state, Value & v, std::ostream & str, std::set<c
         break;
     case nString:
         printLiteralString(str, v.string_view());
+        if (context)
+            copyContext(v, *context);
         break;
     case nPath:
         str << v.path().to_string(); // !!! escaping?
@@ -36,7 +44,7 @@ void printAmbiguous(EvalState & state, Value & v, std::ostream & str, std::set<c
             str << "{ ";
             for (auto & i : v.attrs()->lexicographicOrder(state.symbols)) {
                 str << state.symbols[i->name] << " = ";
-                printAmbiguous(state, *i->value, str, seen, depth + 1);
+                printAmbiguous(state, *i->value, str, seen, context, depth + 1);
                 str << "; ";
             }
             str << "}";
@@ -52,7 +60,7 @@ void printAmbiguous(EvalState & state, Value & v, std::ostream & str, std::set<c
             str << "[ ";
             for (auto v2 : v.listView()) {
                 if (v2)
-                    printAmbiguous(state, *v2, str, seen, depth + 1);
+                    printAmbiguous(state, *v2, str, seen, context, depth + 1);
                 else
                     str << "(nullptr)";
                 str << " ";

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -162,6 +162,7 @@ private:
     std::ostream & output;
     EvalState & state;
     PrintOptions options;
+    NixStringContext * context;
     std::optional<ValuesSeen> seen;
     size_t totalAttrsPrinted = 0;
     size_t totalListItemsPrinted = 0;
@@ -577,9 +578,12 @@ private:
                 printBool(v);
                 break;
 
-            case nString:
+            case nString: {
                 printString(v);
+                if (context)
+                    copyContext(v, *context);
                 break;
+            }
 
             case nPath:
                 printPath(v);
@@ -632,10 +636,11 @@ private:
     }
 
 public:
-    Printer(std::ostream & output, EvalState & state, PrintOptions options)
+    Printer(std::ostream & output, EvalState & state, PrintOptions options, NixStringContext * context)
         : output(output)
         , state(state)
         , options(options)
+        , context(context)
     {
     }
 
@@ -656,14 +661,14 @@ public:
     }
 };
 
-void printValue(EvalState & state, std::ostream & output, Value & v, PrintOptions options)
+void printValue(EvalState & state, std::ostream & output, Value & v, PrintOptions options, NixStringContext * context)
 {
-    Printer(output, state, options).print(v);
+    Printer(output, state, options, context).print(v);
 }
 
 std::ostream & operator<<(std::ostream & output, const ValuePrinter & printer)
 {
-    printValue(printer.state, output, printer.value, printer.options);
+    printValue(printer.state, output, printer.value, printer.options, printer.context);
     return output;
 }
 

--- a/src/libflake/flake-primops.cc
+++ b/src/libflake/flake-primops.cc
@@ -42,7 +42,6 @@ PrimOp getFlake(const Settings & settings)
             auto path = state.realisePath(pos, *args[0]);
             callFlake(state, lockFlake(settings, state, path, lockFlags), v);
         } else {
-            NixStringContext context;
             std::string flakeRefS(
                 state.forceStringNoCtx(*args[0], pos, "while evaluating the argument passed to builtins.getFlake"));
 

--- a/src/libflake/flake-primops.cc
+++ b/src/libflake/flake-primops.cc
@@ -19,10 +19,12 @@
 #include "nix/fetchers/fetchers.hh"
 #include "nix/util/error.hh"
 #include "nix/util/experimental-features.hh"
+#include "nix/util/mounted-source-accessor.hh"
 #include "nix/util/pos-idx.hh"
 #include "nix/util/pos-table.hh"
 #include "nix/util/types.hh"
 #include "nix/util/util.hh"
+#include "nix/store/store-api.hh"
 
 namespace nix::flake::primops {
 
@@ -51,6 +53,21 @@ PrimOp getFlake(const Settings & settings)
                     "cannot call 'getFlake' on unlocked flake reference '%s', at %s (use --impure to override)",
                     flakeRefS,
                     state.positions[pos]);
+
+            /* Backwards compatibility: since flakes used to be copied to the store eagerly, some users
+               relied on being able to do builtins.getFlake on a flakeref with discarded string context.
+               So if a flake input has a physical source path that is inside the store, first try to look it up in the
+               storeFS. */
+            if (auto sourcePath = flakeRef.input.getSourcePath();
+                flakeRef.input.getType() == "path" && sourcePath && state.store->isInStore(sourcePath->string())) {
+                auto [storePath, subPath] = state.store->toStorePath(sourcePath->string());
+                if (auto mount = state.storeFS->getMount(CanonPath(state.store->printStorePath(storePath)))) {
+                    auto path = state.storePath(storePath) / CanonPath(subPath);
+                    if (!flakeRef.subdir.empty())
+                        path = path / flakeRef.subdir;
+                    return callFlake(state, lockFlake(settings, state, path, lockFlags), v);
+                }
+            }
 
             callFlake(state, lockFlake(settings, state, flakeRef, lockFlags), v);
         }

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -95,6 +95,8 @@ UnresolvedApp InstallableValue::toApp(EvalState & state)
                     c.raw));
         }
 
+        state.ensureLazyPathsCopied(context);
+
         return UnresolvedApp{App{
             .context = std::move(context2),
             .program = program,

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -83,10 +83,10 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
 
             [&](this const auto & recurse, Value & v, const PosIdx pos, const std::filesystem::path & path) -> void {
                 state->forceValue(v, pos);
-                if (v.type() == nString)
-                    // FIXME: disallow strings with contexts?
+                if (v.type() == nString) {
+                    copyContext(v, context);
                     writeFile(path, v.string_view());
-                else if (v.type() == nAttrs) {
+                } else if (v.type() == nAttrs) {
                     [[maybe_unused]] bool directoryCreated = std::filesystem::create_directory(path);
                     // Directory should not already exist
                     assert(directoryCreated);
@@ -110,9 +110,8 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
 
         else if (raw) {
             logger->stop();
-            writeFull(
-                getStandardOutput(),
-                *state->coerceToString(noPos, *v, context, "while generating the eval command output"));
+            auto string = state->coerceToString(noPos, *v, context, "while generating the eval command output");
+            writeFull(getStandardOutput(), *string);
         }
 
         else if (json) {
@@ -120,8 +119,11 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
         }
 
         else {
-            logger->cout("%s", ValuePrinter(*state, *v, PrintOptions{.force = true, .derivationPaths = true}));
+            ValuePrinter printer(*state, *v, PrintOptions{.force = true, .derivationPaths = true}, &context);
+            logger->cout("%s", printer);
         }
+
+        state->ensureLazyPathsCopied(context);
     }
 };
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -7,6 +7,7 @@
 #include "nix/expr/get-drvs.hh"
 #include "nix/util/os-string.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/mounted-source-accessor.hh"
 #include "nix/store/store-open.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/outputs-spec.hh"
@@ -215,8 +216,10 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
         auto lockedFlake = lockFlake();
         auto & flake = lockedFlake.flake;
 
-        // Currently, all flakes are in the Nix store via the rootFS accessor.
-        auto storePath = store->printStorePath(store->toStorePath(flake.path.path.abs()).first);
+        /* Flakes do not get copied to the store, but are instead mounted at
+           their expected store paths in storeFS. Querying metadata does not
+           force copying to the store, as one would expect. */
+        auto storePath = store->toStorePath(flake.path.path.abs()).first;
 
         if (json) {
             nlohmann::json j;
@@ -238,7 +241,7 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
                 j["revCount"] = *revCount;
             if (auto lastModified = flake.lockedRef.input.getLastModified())
                 j["lastModified"] = *lastModified;
-            j["path"] = storePath;
+            j["path"] = store->printStorePath(storePath);
             j["locks"] = lockedFlake.lockFile.toJSON().first;
             if (auto fingerprint = lockedFlake.getFingerprint(*store, fetchSettings))
                 j["fingerprint"] = fingerprint->to_string(HashFormat::Base16, false);
@@ -249,7 +252,7 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
                 logger->cout(ANSI_BOLD "Locked URL:" ANSI_NORMAL "    %s", flake.lockedRef.to_string());
             if (flake.description)
                 logger->cout(ANSI_BOLD "Description:" ANSI_NORMAL "   %s", *flake.description);
-            logger->cout(ANSI_BOLD "Path:" ANSI_NORMAL "          %s", storePath);
+            logger->cout(ANSI_BOLD "Path:" ANSI_NORMAL "          %s", store->printStorePath(storePath));
             if (auto rev = flake.lockedRef.input.getRev())
                 logger->cout(ANSI_BOLD "Revision:" ANSI_NORMAL "      %s", rev->to_string(HashFormat::Base16, false));
             if (auto dirtyRev = fetchers::maybeGetStrAttr(flake.lockedRef.toAttrs(), "dirtyRev"))

--- a/src/nix/nix-instantiate/nix-instantiate.cc
+++ b/src/nix/nix-instantiate/nix-instantiate.cc
@@ -66,7 +66,7 @@ void processExpr(
                 if (strict)
                     state.forceValueDeep(vRes);
                 std::set<const void *> seen;
-                printAmbiguous(state, vRes, std::cout, &seen);
+                printAmbiguous(state, vRes, std::cout, &seen, &context);
                 std::cout << std::endl;
             }
         } else {
@@ -94,6 +94,8 @@ void processExpr(
                 std::cout << fmt("%s%s\n", drvPathS, (outputName != "out" ? "!" + outputName : ""));
             }
         }
+
+        state.ensureLazyPathsCopied(context);
     }
 }
 

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -69,7 +69,6 @@ nix flake metadata "$flake1Dir" | grepQuiet 'URL:.*flake1.*'
 # Test 'nix flake metadata --json'.
 json=$(nix flake metadata flake1 --json | jq .)
 [[ $(echo "$json" | jq -r .description) = 'Bla bla' ]]
-[[ -d $(echo "$json" | jq -r .path) ]]
 [[ $(echo "$json" | jq -r .lastModified) = $(git -C "$flake1Dir" log -n1 --format=%ct) ]]
 hash1=$(echo "$json" | jq -r .revision)
 [[ -n $(echo "$json" | jq -r .fingerprint) ]]


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

3rd time's the charm!

This builds on top of https://github.com/NixOS/nix/pull/14050 to
actually make flakes get lazily copied to the store. This repurposes
a slightly less lazy (but also more deterministic) approach than
determinate nix has taken. We do still pay to cost of hashing an input
once to compute the store path and narHash daemon-client-side. This
could be improved in follow-ups in case we don't actually need to check
the narHash (like during local development).

We need certain backwards compatibility hacks for getFlake with a discarded string
context, those are similar to what detnix does.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
