### PR TITLE
fix: avoid redundant queries in GC markAlive

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -360,7 +360,8 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
     bool keepOutputs = gcSettings.keepOutputs;
     bool keepDerivations = gcSettings.keepDerivations;
 
-    boost::unordered_flat_set<StorePath, std::hash<StorePath>> roots, dead, alive;
+    boost::unordered_flat_set<StorePath, std::hash<StorePath>> roots, dead;
+    StorePathSet alive;
 
     /* Return early if nothing to delete */
     if (std::holds_alternative<StorePathSet>(options.pathsToDelete)
@@ -622,15 +623,12 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 alive.insert(*path);
                 alive.insert(start);
                 try {
-                    StorePathSet closure;
                     computeFSClosure(
                         *path,
-                        closure,
+                        alive,
                         /* flipDirection */ false,
                         keepOutputs,
                         keepDerivations);
-                    for (auto & p : closure)
-                        alive.insert(p);
                 } catch (InvalidPath &) {
                 }
             };


### PR DESCRIPTION
`computeFSClosure` was called with a fresh empty set each time, so `computeClosure`'s insert-dedup could not skip paths whose closures had already been explored.

`StorePathSet` might be slightly slower than `unordered_flat_set`, but this should be easily offset by the reduced I/O.

I've have not measured the performance.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
