### PR TITLE
libstore: don't print URL userinfo in FileTransfer diagnostics

### DIFF
--- a/src/libstore-tests/filetransfer-request.cc
+++ b/src/libstore-tests/filetransfer-request.cc
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+#include "nix/store/filetransfer.hh"
+
+namespace nix {
+
+TEST(FileTransferRequest, displayUriStripsUserinfo)
+{
+    FileTransferRequest req(VerbatimURL{std::string{"https://alice:s3cr3t@example.org:8443/path/file.toml?x=1"}});
+    // uri itself is untouched (used for CURLOPT_URL, result.urls, cache keys).
+    EXPECT_EQ(req.uri.to_string(), "https://alice:s3cr3t@example.org:8443/path/file.toml?x=1");
+    // displayUri() drops the userinfo for diagnostics.
+    EXPECT_EQ(req.displayUri(), "https://example.org:8443/path/file.toml?x=1");
+
+    FileTransferRequest plain(VerbatimURL{std::string{"https://example.org/file"}});
+    EXPECT_EQ(plain.displayUri(), "https://example.org/file");
+}
+
+} // namespace nix

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -64,6 +64,7 @@ sources = files(
   'derived-path.cc',
   'downstream-placeholder.cc',
   'dummy-store.cc',
+  'filetransfer-request.cc',
   'filetransfer-retry.cc',
   'http-binary-cache-store.cc',
   'legacy-ssh-store.cc',

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -281,7 +281,11 @@ struct curlFileTransfer : public FileTransfer
             try {
                 if (!done && enqueued)
                     fail(FileTransferError(
-                        Interrupted, {}, "%s of '%s' was interrupted", Uncolored(request.noun()), request.uri));
+                        Interrupted,
+                        {},
+                        "%s of '%s' was interrupted",
+                        Uncolored(request.noun()),
+                        request.displayUri()));
             } catch (...) {
                 ignoreExceptionInDestructor();
             }
@@ -297,7 +301,7 @@ struct curlFileTransfer : public FileTransfer
                 /* Already descriptive enough. */
             } catch (nix::Error & e) {
                 /* Add more context to the error message. */
-                e.addTrace({}, "during %s of '%s'", Uncolored(request.noun()), request.uri.to_string());
+                e.addTrace({}, "during %s of '%s'", Uncolored(request.noun()), request.displayUri());
             } catch (...) {
                 /* Can't add more context to the error. */
             }
@@ -361,7 +365,7 @@ struct curlFileTransfer : public FileTransfer
         try {
             size_t realSize = size * nmemb;
             std::string line((char *) contents, realSize);
-            printMsg(lvlVomit, "got header for '%s': %s", request.uri, trim(line));
+            printMsg(lvlVomit, "got header for '%s': %s", request.displayUri(), trim(line));
 
             static std::regex statusLine("HTTP/[^ ]+ +[0-9]+(.*)", std::regex::extended | std::regex::icase);
             if (std::smatch match; std::regex_match(line, match, statusLine)) {
@@ -450,8 +454,8 @@ struct curlFileTransfer : public FileTransfer
                     *logger,
                     lvlTalkative,
                     actFileTransfer,
-                    fmt("%s '%s'", request.verb(/*continuous=*/true), request.uri),
-                    Logger::Fields{request.uri.to_string()},
+                    fmt("%s '%s'", request.verb(/*continuous=*/true), request.displayUri()),
+                    Logger::Fields{request.displayUri()},
                     request.parentAct);
                 // Reset the start time to when we actually started the download.
                 startTime = std::chrono::steady_clock::now();
@@ -716,7 +720,7 @@ struct curlFileTransfer : public FileTransfer
             debug(
                 "finished %s of '%s'; curl status = %d, HTTP status = %d, body = %d bytes, duration = %.2f s",
                 Uncolored(request.noun()),
-                request.uri,
+                request.displayUri(),
                 code,
                 httpStatus,
                 result.bodySize,
@@ -815,14 +819,14 @@ struct curlFileTransfer : public FileTransfer
                                                                                        std::move(response),
                                                                                        "%s of '%s' was interrupted",
                                                                                        Uncolored(request.noun()),
-                                                                                       request.uri)
+                                                                                       request.displayUri())
                            : httpStatus != 0
                                ? FileTransferError(
                                      err,
                                      std::move(response),
                                      "unable to %s '%s': HTTP error %d%s",
                                      Uncolored(request.verb()),
-                                     request.uri,
+                                     request.displayUri(),
                                      httpStatus,
                                      code == CURLE_OK ? "" : fmt(" (curl error: %s)", curl_easy_strerror(code)))
                                : FileTransferError(
@@ -830,7 +834,7 @@ struct curlFileTransfer : public FileTransfer
                                      std::move(response),
                                      "unable to %s '%s': %s (%d) %s",
                                      Uncolored(request.verb()),
-                                     request.uri,
+                                     request.displayUri(),
                                      curl_easy_strerror(code),
                                      code,
                                      errbuf);
@@ -1081,7 +1085,7 @@ struct curlFileTransfer : public FileTransfer
             }
 
             for (auto & item : incoming) {
-                debug("starting %s of '%s'", Uncolored(item->request.noun()), item->request.uri);
+                debug("starting %s of '%s'", Uncolored(item->request.noun()), item->request.displayUri());
                 item->init();
                 curl_multi_add_handle(curlm.get(), item->req);
                 item->active = true;
@@ -1133,7 +1137,7 @@ struct curlFileTransfer : public FileTransfer
     {
         if (item->request.data && item->request.uri.scheme() != "http" && item->request.uri.scheme() != "https"
             && item->request.uri.scheme() != "s3")
-            throw nix::Error("uploading to '%s' is not supported", item->request.uri.to_string());
+            throw nix::Error("uploading to '%s' is not supported", item->request.displayUri());
 
         {
             auto state(state_.lock());
@@ -1192,6 +1196,20 @@ ref<FileTransfer> getFileTransfer()
 ref<FileTransfer> makeFileTransfer(const FileTransferSettings & settings)
 {
     return makeCurlFileTransfer(settings);
+}
+
+std::string FileTransferRequest::displayUri() const
+{
+    try {
+        auto parsed = uri.parsed();
+        if (parsed.authority && parsed.authority->user) {
+            parsed.authority->user.reset();
+            parsed.authority->password.reset();
+            return parsed.to_string();
+        }
+    } catch (BadURL &) {
+    }
+    return uri.to_string();
 }
 
 void FileTransferRequest::setupForS3()
@@ -1283,7 +1301,7 @@ void FileTransfer::download(
         state->request.notify_one();
     });
 
-    request.dataCallback = [_state, uri = request.uri.to_string()](std::string_view data) -> PauseTransfer {
+    request.dataCallback = [_state, uri = request.displayUri()](std::string_view data) -> PauseTransfer {
         auto state(_state->lock());
 
         if (state->quit)

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -308,6 +308,14 @@ struct FileTransferRequest
     }
 
     /**
+     * `uri` with any userinfo (`user:password@`) stripped, for use in
+     * progress, warning and error messages so credentials embedded in
+     * the URL don't leak into logs. Returns `uri` verbatim if it can't
+     * be parsed.
+     */
+    std::string displayUri() const;
+
+    /**
      * Returns the method description for logging purposes.
      */
     std::string verb(bool continuous = false) const

--- a/tests/nixos/fetchurl.nix
+++ b/tests/nixos/fetchurl.nix
@@ -54,6 +54,14 @@ in
               echo 'foobar' > "$out/index.html"
             '';
           };
+
+          virtualHosts."auth" = {
+            basicAuth.alice = "s3cr3t";
+            root = pkgs.runCommand "nginx-root" { } ''
+              mkdir "$out"
+              echo 'authed' > "$out/index.html"
+            '';
+          };
         };
 
         security.pki.certificateFiles = [ "${goodCert}/cert.pem" ];
@@ -61,6 +69,7 @@ in
         networking.hosts."127.0.0.1" = [
           "good"
           "bad"
+          "auth"
         ];
 
         virtualisation.writableStore = true;
@@ -89,5 +98,16 @@ in
 
     # Fetching from a server with a trusted cert should work via environment variable override.
     machine.succeed("NIX_SSL_CERT_FILE=/tmp/cafile.pem nix build --no-substitute --expr 'import <nix/fetchurl.nix> { url = \"https://bad/index.html\"; hash = \"sha256-rsBwZF/lPuOzdjBZN2E08FjMM3JHyXit0Xi2zN+wAZ8=\"; }'")
+
+    # builtins.fetchurl should authenticate using userinfo from the URL.
+    out = machine.succeed("nix eval --raw --impure --no-substitute --expr 'builtins.readFile (builtins.fetchurl { url = \"http://alice:s3cr3t@auth/index.html\"; sha256 = \"sha256-67y3HalfTt2zfgMt7BwU5vkaGWcelFlR4jryIkA1dTo=\"; })'")
+    assert out == "authed\n", out
+
+    # On failure the transport-layer diagnostic must show the stripped URL,
+    # not the userinfo. (The eval trace still echoes the source expression;
+    # that is the user's own input, not a leak.)
+    err = machine.fail("nix eval --raw --impure --no-substitute --option tarball-ttl 0 --expr 'builtins.fetchurl { url = \"http://alice:wrong-secret@auth/index.html\"; sha256 = \"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"; }' 2>&1")
+    print(err)
+    assert "unable to download 'http://auth/index.html'" in err, err
   '';
 }


### PR DESCRIPTION
When a URL with embedded credentials (scheme://user:pass@host/...) is passed to builtins.fetchurl or any other downloadFile caller, the password is printed verbatim in progress, retry-warning and error messages because they all format request.uri directly:

  warning: unable to download 'http://user:SECRET@host/file': ...; retrying in 256 ms

Move the userinfo into the existing usernameAuth field in the FileTransferRequest constructor and strip it from uri. curl still receives the credentials via CURLOPT_USERNAME/PASSWORD; URLs that fail to parse are left unchanged so curl can extract userinfo from CURLOPT_URL itself as before.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
