### PR TITLE
Add redirect for language/values.html

### DIFF
--- a/doc/manual/source/_redirects
+++ b/doc/manual/source/_redirects
@@ -36,6 +36,7 @@
 /expressions/language-values /language/values 301!
 /expressions/* /language/:splat 301!
 /language/values /language/types 301!
+/language/values.html /language/types 301!
 /language/constructs /language/syntax 301!
 /language/builtin-constants /language/builtins 301!
 


### PR DESCRIPTION
## Motivation

`/language/values.html` does not currently redirect, while `/language/values` does.

This causes inconsistency and can lead to broken links.

## Context

Adds a redirect rule so that `/language/values.html` also redirects to `/language/types`.

This matches the behavior of `/language/values`.