### PR TITLE
Get rid of lstat cache in PosixSourceAccessor, rewrite everything with dirFds

### DIFF
--- a/src/libfetchers/filtering-source-accessor.cc
+++ b/src/libfetchers/filtering-source-accessor.cc
@@ -62,11 +62,6 @@ std::pair<CanonPath, std::optional<std::string>> FilteringSourceAccessor::getFin
     return next->getFingerprint(prefix / path);
 }
 
-void FilteringSourceAccessor::invalidateCache(const CanonPath & path)
-{
-    next->invalidateCache(prefix / path);
-}
-
 void FilteringSourceAccessor::checkAccess(const CanonPath & path)
 {
     if (!isAllowed(path))

--- a/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
+++ b/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
@@ -53,8 +53,6 @@ struct FilteringSourceAccessor : SourceAccessor
 
     std::pair<CanonPath, std::optional<std::string>> getFingerprint(const CanonPath & path) override;
 
-    void invalidateCache(const CanonPath & path) override;
-
     /**
      * Call `makeNotAllowedError` to throw a `RestrictedPathError`
      * exception if `isAllowed()` returns `false` for `path`.

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -240,26 +240,25 @@ struct MercurialInputScheme : InputScheme
                     }),
                     "\0"s);
 
-                auto actualPath = absPath(localPath);
+                /* FIXME: Check that the access to this path is allowed. */
+                auto accessor = makeFSSourceAccessor(absPath(localPath));
 
                 PathFilter filter = [&](const std::string & p) -> bool {
-                    assert(hasPrefix(p, actualPath.string()));
-                    std::string file(p, actualPath.string().size() + 1);
+                    auto cp = CanonPath(p);
+                    auto st = accessor->lstat(cp);
 
-                    auto st = lstat(p);
-
-                    if (S_ISDIR(st.st_mode)) {
-                        auto prefix = file + "/";
+                    if (st.type == SourceAccessor::tDirectory) {
+                        auto prefix = cp.rel() + "/";
                         auto i = files.lower_bound(prefix);
                         return i != files.end() && hasPrefix(*i, prefix);
                     }
 
-                    return files.count(file);
+                    return files.count(cp.rel());
                 };
 
                 return store.addToStore(
                     input.getName(),
-                    {getFSSourceAccessor(), CanonPath(actualPath.string())},
+                    {accessor, CanonPath::root},
                     ContentAddressMethod::Raw::NixArchive,
                     HashAlgorithm::SHA256,
                     {},
@@ -381,7 +380,7 @@ struct MercurialInputScheme : InputScheme
 
         deletePath(tmpDir / ".hg_archival.txt");
 
-        auto storePath = store.addToStore(name, {getFSSourceAccessor(), CanonPath(tmpDir.string())});
+        auto storePath = store.addToStore(name, {makeFSSourceAccessor(tmpDir), CanonPath::root});
 
         Attrs infoAttrs({
             {"revCount", (uint64_t) revCount},

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -863,8 +863,6 @@ LockedFlake lockFlake(
                                 CanonPath((topRef.subdir == "" ? "" : topRef.subdir + "/") + "flake.lock"),
                                 newLockFileS,
                                 commitMessage);
-
-                            flake.lockFilePath().invalidateCache();
                         }
 
                         /* Rewriting the lockfile changed the top-level

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -1,4 +1,3 @@
-#include "nix/util/posix-source-accessor.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/local-fs-store.hh"
 #include "nix/util/compression.hh"
@@ -27,13 +26,14 @@ LocalFSStore::LocalFSStore(const Config & config)
 {
 }
 
-struct LocalStoreAccessor : PosixSourceAccessor
+struct LocalStoreAccessor : SourceAccessor
 {
+    ref<SourceAccessor> accessor;
     ref<LocalFSStore> store;
     bool requireValidPath;
 
     LocalStoreAccessor(ref<LocalFSStore> store, bool requireValidPath)
-        : PosixSourceAccessor(std::filesystem::path{store->config.realStoreDir.get()})
+        : accessor(makeFSSourceAccessor(std::filesystem::path{store->config.realStoreDir.get()}))
         , store(store)
         , requireValidPath(requireValidPath)
     {
@@ -54,25 +54,61 @@ struct LocalStoreAccessor : PosixSourceAccessor
             return Stat{.type = tDirectory};
 
         requireStoreObject(path);
-        return PosixSourceAccessor::maybeLstat(path);
+        return accessor->maybeLstat(path);
+    }
+
+    Stat lstat(const CanonPath & path) override
+    {
+        /* Also allow `path` to point to the entire store, which is
+           needed for resolving symlinks. */
+        if (path.isRoot())
+            return Stat{.type = tDirectory};
+
+        requireStoreObject(path);
+        return accessor->lstat(path);
     }
 
     DirEntries readDirectory(const CanonPath & path) override
     {
         requireStoreObject(path);
-        return PosixSourceAccessor::readDirectory(path);
+        return accessor->readDirectory(path);
     }
 
     void readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback) override
     {
         requireStoreObject(path);
-        return PosixSourceAccessor::readFile(path, sink, sizeCallback);
+        return accessor->readFile(path, sink, sizeCallback);
     }
 
     std::string readLink(const CanonPath & path) override
     {
         requireStoreObject(path);
-        return PosixSourceAccessor::readLink(path);
+        return accessor->readLink(path);
+    }
+
+    std::string showPath(const CanonPath & path) override
+    {
+        return accessor->showPath(path);
+    }
+
+    std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override
+    {
+        return accessor->getPhysicalPath(path);
+    }
+
+    std::pair<CanonPath, std::optional<std::string>> getFingerprint(const CanonPath & path) override
+    {
+        return accessor->getFingerprint(path);
+    }
+
+    std::optional<time_t> getLastModified() override
+    {
+        return accessor->getLastModified();
+    }
+
+    bool pathExists(const CanonPath & path) override
+    {
+        return accessor->pathExists(path);
     }
 };
 
@@ -96,7 +132,7 @@ std::shared_ptr<SourceAccessor> LocalFSStore::getFSAccessor(const StorePath & pa
         if (!pathExists(absPath))
             return nullptr;
     }
-    return std::make_shared<PosixSourceAccessor>(std::move(absPath));
+    return makeFSSourceAccessor(std::move(absPath));
 }
 
 const std::filesystem::path LocalFSStore::drvsLogDir = "drvs";

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1077,8 +1077,7 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
                 if (info.ca) {
                     auto & specified = *info.ca;
                     auto actualHash = ({
-                        auto accessor = getFSAccessor(false);
-                        CanonPath path{info.path.to_string()};
+                        SourcePath sourcePath = requireStoreObjectAccessor(info.path, /*requireValidPath=*/false);
                         Hash h{HashAlgorithm::SHA256}; // throwaway def to appease C++
                         auto fim = specified.method.getFileIngestionMethod();
                         switch (fim) {
@@ -1088,12 +1087,12 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
                                 specified.hash.algo,
                                 std::string{info.path.hashPart()},
                             };
-                            dumpPath({accessor, path}, caSink, (FileSerialisationMethod) fim);
+                            dumpPath(sourcePath, caSink, (FileSerialisationMethod) fim);
                             h = caSink.finish().hash;
                             break;
                         }
                         case FileIngestionMethod::Git:
-                            h = git::dumpHash(specified.hash.algo, {accessor, path}).hash;
+                            h = git::dumpHash(specified.hash.algo, sourcePath).hash;
                             break;
                         }
                         ContentAddress{

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -153,13 +153,7 @@ void LocalStore::optimisePath_(
        Also note that if `path' is a symlink, then we're hashing the
        contents of the symlink (i.e. the result of readlink()), not
        the contents of the target (which may not even exist). */
-    Hash hash = ({
-        hashPath(
-            {make_ref<PosixSourceAccessor>(), CanonPath(path.string())},
-            FileSerialisationMethod::NixArchive,
-            HashAlgorithm::SHA256)
-            .hash;
-    });
+    Hash hash = hashPath(makeFSSourceAccessor(path), FileSerialisationMethod::NixArchive, HashAlgorithm::SHA256).hash;
     debug("%s has hash '%s'", PathFmt(path), hash.to_string(HashFormat::Nix32, true));
 
     /* Check if this is a known hash. */

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1713,12 +1713,11 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                     HashModuloSink caSink{outputHash.hashAlgo, oldHashPart};
                     auto fim = outputHash.method.getFileIngestionMethod();
                     dumpPath(
-                        {getFSSourceAccessor(), CanonPath(actualPath.native())}, caSink, (FileSerialisationMethod) fim);
+                        {makeFSSourceAccessor(actualPath), CanonPath::root}, caSink, (FileSerialisationMethod) fim);
                     return caSink.finish().hash;
                 }
                 case FileIngestionMethod::Git: {
-                    return git::dumpHash(outputHash.hashAlgo, {getFSSourceAccessor(), CanonPath(actualPath.native())})
-                        .hash;
+                    return git::dumpHash(outputHash.hashAlgo, {makeFSSourceAccessor(actualPath), CanonPath::root}).hash;
                 }
                 }
                 assert(false);
@@ -1740,7 +1739,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
 
             {
                 HashResult narHashAndSize = hashPath(
-                    {getFSSourceAccessor(), CanonPath(actualPath.native())},
+                    {makeFSSourceAccessor(actualPath), CanonPath::root},
                     FileSerialisationMethod::NixArchive,
                     HashAlgorithm::SHA256);
                 newInfo0.narHash = narHashAndSize.hash;
@@ -1783,7 +1782,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                             std::string{scratchPath->hashPart()}, std::string{requiredFinalPath.hashPart()});
                     rewriteOutput(outputRewrites);
                     HashResult narHashAndSize = hashPath(
-                        {getFSSourceAccessor(), CanonPath(actualPath.native())},
+                        {makeFSSourceAccessor(actualPath), CanonPath::root},
                         FileSerialisationMethod::NixArchive,
                         HashAlgorithm::SHA256);
                     ValidPathInfo newInfo0{requiredFinalPath, {store, narHashAndSize.hash}};

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1761,8 +1761,10 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                any stale writable file descriptors. Copy through the
                serialisation/deserialisation. TODO: Use copyRecursive here and
                make use of reflinking. */
-            auto source = sinkToSource([&](Sink & nextSink) { dumpPath(actualPath, nextSink); });
-            restorePath(tmpOutput, *source, store.config->getLocalSettings().fsyncStorePaths);
+            auto pathAccessor = makeFSSourceAccessor(actualPath);
+            RestoreSink restoreSink{store.config->getLocalSettings().fsyncStorePaths};
+            restoreSink.dstPath = tmpOutput;
+            copyRecursive(*pathAccessor, CanonPath::root, restoreSink, CanonPath::root);
             /* This makes it slightly harder to make sense of the control flow. The rule
                of thumb is that actualPath points to the current location of the stuff
                that we'll end up registering. */

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -34,10 +34,10 @@ PathFilter defaultPathFilter = [](const std::string &) { return true; };
 
 void SourceAccessor::dumpPath(const CanonPath & path, Sink & sink, PathFilter & filter)
 {
-    auto dumpContents = [&](const CanonPath & path) {
+    auto dumpContents = [&sink](SourceAccessor & accessor, const CanonPath & path) {
         sink << "contents";
         std::optional<uint64_t> size;
-        readFile(path, sink, [&](uint64_t _size) {
+        accessor.readFile(path, sink, [&](uint64_t _size) {
             size = _size;
             sink << _size;
         });
@@ -47,10 +47,14 @@ void SourceAccessor::dumpPath(const CanonPath & path, Sink & sink, PathFilter & 
 
     sink << narVersionMagic1;
 
-    [&, &this_(*this)](this const auto & dump, const CanonPath & path) -> void {
+    [&sink, &filter, &dumpContents](
+        this const auto & dump,
+        SourceAccessor & accessor,
+        const CanonPath & path,
+        const CanonPath & filterPath) -> void {
         checkInterrupt();
 
-        auto st = this_.lstat(path);
+        auto st = accessor.lstat(path);
 
         sink << "(";
 
@@ -58,7 +62,7 @@ void SourceAccessor::dumpPath(const CanonPath & path, Sink & sink, PathFilter & 
             sink << "type" << "regular";
             if (st.isExecutable)
                 sink << "executable" << "";
-            dumpContents(path);
+            dumpContents(accessor, path);
         }
 
         else if (st.type == tDirectory) {
@@ -67,7 +71,7 @@ void SourceAccessor::dumpPath(const CanonPath & path, Sink & sink, PathFilter & 
             /* If we're on a case-insensitive system like macOS, undo
                the case hack applied by restorePath(). */
             StringMap unhacked;
-            for (auto & i : this_.readDirectory(path))
+            for (auto & i : accessor.readDirectory(path))
                 if (archiveSettings.useCaseHack) {
                     std::string name(i.first);
                     size_t pos = i.first.find(caseHackSuffix);
@@ -81,22 +85,24 @@ void SourceAccessor::dumpPath(const CanonPath & path, Sink & sink, PathFilter & 
                 } else
                     unhacked.emplace(i.first, i.first);
 
-            for (auto & i : unhacked)
-                if (filter((path / i.first).abs())) {
-                    sink << "entry" << "(" << "name" << i.first << "node";
-                    dump(path / i.second);
-                    sink << ")";
-                }
+            accessor.readDirectory(path, [&](SourceAccessor & subdirAccessor, const CanonPath & subdirRelPath) {
+                for (auto & i : unhacked)
+                    if (filter((filterPath / i.first).abs())) {
+                        sink << "entry" << "(" << "name" << i.first << "node";
+                        dump(subdirAccessor, subdirRelPath / i.second, filterPath / i.second);
+                        sink << ")";
+                    }
+            });
         }
 
         else if (st.type == tSymlink)
-            sink << "type" << "symlink" << "target" << this_.readLink(path);
+            sink << "type" << "symlink" << "target" << accessor.readLink(path);
 
         else
             throw Error("file '%s' has an unsupported type", path);
 
         sink << ")";
-    }(path);
+    }(*this, path, path);
 }
 
 time_t dumpPathAndGetMtime(const std::filesystem::path & path, Sink & sink, PathFilter & filter)

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -101,14 +101,15 @@ void SourceAccessor::dumpPath(const CanonPath & path, Sink & sink, PathFilter & 
 
 time_t dumpPathAndGetMtime(const std::filesystem::path & path, Sink & sink, PathFilter & filter)
 {
-    auto path2 = PosixSourceAccessor::createAtRoot(path, /*trackLastModified=*/true);
+    SourcePath path2 = makeFSSourceAccessor(absPath(path), /*trackLastModified=*/true);
     path2.dumpPath(sink, filter);
     return path2.accessor->getLastModified().value();
 }
 
 void dumpPath(const std::filesystem::path & path, Sink & sink, PathFilter & filter)
 {
-    dumpPathAndGetMtime(path, sink, filter);
+    SourcePath path2 = makeFSSourceAccessor(absPath(path), /*trackLastModified=*/false);
+    path2.dumpPath(sink, filter);
 }
 
 void dumpString(std::string_view s, Sink & sink)

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -34,10 +34,12 @@ void copyRecursive(SourceAccessor & accessor, const CanonPath & from, FileSystem
     }
 
     case SourceAccessor::tDirectory: {
-        sink.createDirectory(to, [&](FileSystemObjectSink & dirSink, const CanonPath & relDirPath) {
-            for (auto & [name, _] : accessor.readDirectory(from)) {
-                copyRecursive(accessor, from / name, dirSink, relDirPath / name);
-            }
+        sink.createDirectory(to, [&](FileSystemObjectSink & dirSink, const CanonPath & relDirPathTo) {
+            accessor.readDirectory(from, [&](SourceAccessor & subdirAccessor, const CanonPath & relDirPathFrom) {
+                for (auto & [name, _] : subdirAccessor.readDirectory(relDirPathFrom)) {
+                    copyRecursive(subdirAccessor, relDirPathFrom / name, dirSink, relDirPathTo / name);
+                }
+            });
         });
         break;
     }

--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -90,6 +90,8 @@ OsString readLinkAt(Descriptor dirFd, const CanonPath & path);
  * @param flags (Unix) `O_*` flags (must not include `O_NOFOLLOW`)
  * @param mode (Unix) Mode for `O_{CREAT,TMPFILE}`
  *
+ * @param dirFdCallback Callback invoked that gets the ownership of an intermediate directory fd.
+ *
  * @pre `path.isRoot()` is false
  *
  * @throws SymlinkNotAllowed if an interior path component is a
@@ -118,12 +120,12 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
 #ifdef _WIN32
     ACCESS_MASK desiredAccess,
     ULONG createOptions,
-    ULONG createDisposition = FILE_OPEN
+    ULONG createDisposition = FILE_OPEN,
 #else
     int flags,
-    mode_t mode = 0
+    mode_t mode = 0,
 #endif
-);
+    std::function<void(AutoCloseFD dirFd, CanonPath relPath)> dirFdCallback = nullptr);
 
 #ifdef __linux__
 namespace linux {

--- a/src/libutil/include/nix/util/posix-source-accessor.hh
+++ b/src/libutil/include/nix/util/posix-source-accessor.hh
@@ -76,8 +76,6 @@ public:
 
     std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override;
 
-    void invalidateCache(const CanonPath & path) override;
-
 private:
 
     /**

--- a/src/libutil/include/nix/util/posix-source-accessor.hh
+++ b/src/libutil/include/nix/util/posix-source-accessor.hh
@@ -76,36 +76,6 @@ public:
 
     std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override;
 
-    /**
-     * Create a `PosixSourceAccessor` and `SourcePath` corresponding to
-     * some native path.
-     *
-     * @param Whether the accessor should return a non-null getLastModified.
-     * When true the accessor must be used only by a single thread.
-     *
-     * The `PosixSourceAccessor` is rooted as far up the tree as
-     * possible, (e.g. on Windows it could scoped to a drive like
-     * `C:\`). This allows more `..` parent accessing to work.
-     *
-     * @note When `path` is trusted user input, canonicalize it using
-     * `std::filesystem::canonical`, `makeParentCanonical`, `std::filesystem::weakly_canonical`, etc,
-     * as appropriate for the use case. At least weak canonicalization is
-     * required for the `SourcePath` to do anything useful at the location it
-     * points to.
-     *
-     * @note A canonicalizing behavior is not built in `createAtRoot` so that
-     * callers do not accidentally introduce symlink-related security vulnerabilities.
-     * Furthermore, `createAtRoot` does not know whether the file pointed to by
-     * `path` should be resolved if it is itself a symlink. In other words,
-     * `createAtRoot` can not decide between aforementioned `canonical`, `makeParentCanonical`, etc. for its callers.
-     *
-     * See
-     * [`std::filesystem::path::root_path`](https://en.cppreference.com/w/cpp/filesystem/path/root_path)
-     * and
-     * [`std::filesystem::path::relative_path`](https://en.cppreference.com/w/cpp/filesystem/path/relative_path).
-     */
-    static SourcePath createAtRoot(const std::filesystem::path & path, bool trackLastModified = false);
-
     void invalidateCache(const CanonPath & path) override;
 
 private:

--- a/src/libutil/include/nix/util/posix-source-accessor.hh
+++ b/src/libutil/include/nix/util/posix-source-accessor.hh
@@ -45,47 +45,4 @@ protected:
 
 } // namespace detail
 
-/**
- * A source accessor that uses the Unix filesystem.
- */
-class PosixSourceAccessor : public detail::PosixSourceAccessorBase
-{
-    /**
-     * Optional root path to prefix all operations into the native file
-     * system. This allows prepending funny things like `C:\` that
-     * `CanonPath` intentionally doesn't support.
-     */
-    const std::filesystem::path root;
-
-public:
-
-    PosixSourceAccessor();
-    PosixSourceAccessor(std::filesystem::path && root, bool trackLastModified = false);
-
-    void readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback) override;
-
-    using SourceAccessor::readFile;
-
-    bool pathExists(const CanonPath & path) override;
-
-    std::optional<Stat> maybeLstat(const CanonPath & path) override;
-
-    DirEntries readDirectory(const CanonPath & path) override;
-
-    std::string readLink(const CanonPath & path) override;
-
-    std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override;
-
-private:
-
-    /**
-     * Throw an error if `path` or any of its ancestors are symlinks.
-     */
-    void assertNoSymlinks(CanonPath path);
-
-    std::optional<PosixStat> cachedLstat(const CanonPath & path);
-
-    std::filesystem::path makeAbsPath(const CanonPath & path);
-};
-
 } // namespace nix

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -138,6 +138,22 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
      */
     virtual DirEntries readDirectory(const CanonPath & path) = 0;
 
+    /**
+     * Variation of readDirectory that receives a SourceAccessor possibly scoped to \ref dirPath.
+     * Primary meant for recursive traversal functions that would benefit from *at-style syscalls
+     * relative to a particular directory.
+     *
+     * @note Like `readFile`, this method should *not* follow symlinks.
+     * @param callback Caller-provided function invoked with a maximally deeply scoped SourceAccessor and the path that
+     * would have to be prepended to each path relative to dirPath to access a particular file with it.
+     */
+    virtual void readDirectory(
+        const CanonPath & dirPath,
+        std::function<void(SourceAccessor & subdirAccessor, const CanonPath & subdirRelPath)> callback)
+    {
+        callback(*this, dirPath);
+    }
+
     virtual std::string readLink(const CanonPath & path) = 0;
 
     virtual void dumpPath(const CanonPath & path, Sink & sink, PathFilter & filter = defaultPathFilter);

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -278,7 +278,8 @@ ref<SourceAccessor> getFSSourceAccessor();
  *
  * Symlinks in parents of `root` are resolved. Final symlink is not.
  */
-ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackLastModified = false);
+ref<SourceAccessor> makeFSSourceAccessor(
+    std::filesystem::path root, bool trackLastModified = false, FinalSymlink finalSymlink = FinalSymlink::DontFollow);
 
 /**
  * Construct an accessor that presents a "union" view of a vector of

--- a/src/libutil/include/nix/util/source-path.hh
+++ b/src/libutil/include/nix/util/source-path.hh
@@ -114,11 +114,6 @@ struct SourcePath
         return {accessor, accessor->resolveSymlinks(path, mode)};
     }
 
-    void invalidateCache() const
-    {
-        accessor->invalidateCache(path);
-    }
-
     friend class std::hash<nix::SourcePath>;
 };
 

--- a/src/libutil/mounted-source-accessor.cc
+++ b/src/libutil/mounted-source-accessor.cc
@@ -99,12 +99,6 @@ struct MountedSourceAccessorImpl : MountedSourceAccessor
         auto [accessor, subpath] = resolve(path);
         return accessor->getFingerprint(subpath);
     }
-
-    void invalidateCache(const CanonPath & path) override
-    {
-        auto [accessor, subpath] = resolve(path);
-        accessor->invalidateCache(subpath);
-    }
 };
 
 ref<MountedSourceAccessor> makeMountedSourceAccessor(std::map<CanonPath, ref<SourceAccessor>> mounts)

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -216,6 +216,8 @@ private:
 
     std::function<void(AutoCloseFD, CanonPath)> makeDirFdCallback();
 
+    AutoCloseFD openSubdirectory(const CanonPath & path);
+
 public:
     PosixDirectorySourceAccessor(
         AutoCloseFD fd, std::filesystem::path path, bool trackLastModified, unsigned dirFdCacheSize)
@@ -248,6 +250,10 @@ public:
     std::optional<Stat> maybeLstat(const CanonPath & path) override;
 
     DirEntries readDirectory(const CanonPath & path) override;
+
+    void readDirectory(
+        const CanonPath & dirPath,
+        std::function<void(SourceAccessor & subdirAccessor, const CanonPath & subdirRelPath)> callback) override;
 
     std::string readLink(const CanonPath & path) override;
 
@@ -359,7 +365,7 @@ try {
     throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
 }
 
-SourceAccessor::DirEntries PosixDirectorySourceAccessor::readDirectory(const CanonPath & path)
+AutoCloseFD PosixDirectorySourceAccessor::openSubdirectory(const CanonPath & path)
 try {
     AutoCloseFD dirFdOwning;
 
@@ -379,6 +385,14 @@ try {
         }
     }
 
+    return dirFdOwning;
+} catch (SymlinkNotAllowed & e) {
+    throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
+}
+
+SourceAccessor::DirEntries PosixDirectorySourceAccessor::readDirectory(const CanonPath & path)
+try {
+    AutoCloseFD dirFdOwning = openSubdirectory(path);
     AutoCloseDir dir(::fdopendir(dirFdOwning.get()));
     if (!dir)
         throw SysError("reading directory '%s'", showPath(path));
@@ -429,6 +443,17 @@ try {
     return entries;
 } catch (SymlinkNotAllowed & e) {
     throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
+}
+
+void PosixDirectorySourceAccessor::readDirectory(
+    const CanonPath & dirPath,
+    std::function<void(SourceAccessor & subdirAccessor, const CanonPath & subdirRelPath)> callback)
+{
+    auto fd = openSubdirectory(dirPath);
+    PosixDirectorySourceAccessor accessor{
+        std::move(fd), fsPath / dirPath.rel(), trackLastModified, /*dirFdCacheSize=*/0};
+    callback(accessor, CanonPath::root);
+    PosixSourceAccessorBase::maybeUpdateMtime(accessor.mtime);
 }
 
 std::string PosixDirectorySourceAccessor::readLink(const CanonPath & path)

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -510,11 +510,53 @@ try {
     throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
 }
 
-#endif
+#else
 
-} // namespace
+/**
+ * A source accessor that uses the Windows filesystem.
+ * @todo Should be moved into a separate file.
+ */
+class WindowsSourceAccessor : public detail::PosixSourceAccessorBase
+{
+    /**
+     * Optional root path to prefix all operations into the native file
+     * system. This allows prepending funny things like `C:\` that
+     * `CanonPath` intentionally doesn't support.
+     */
+    const std::filesystem::path root;
 
-PosixSourceAccessor::PosixSourceAccessor(std::filesystem::path && argRoot, bool trackLastModified)
+public:
+
+    WindowsSourceAccessor();
+    WindowsSourceAccessor(std::filesystem::path && root, bool trackLastModified = false);
+
+    void readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback) override;
+
+    using SourceAccessor::readFile;
+
+    bool pathExists(const CanonPath & path) override;
+
+    std::optional<Stat> maybeLstat(const CanonPath & path) override;
+
+    DirEntries readDirectory(const CanonPath & path) override;
+
+    std::string readLink(const CanonPath & path) override;
+
+    std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override;
+
+private:
+
+    /**
+     * Throw an error if `path` or any of its ancestors are symlinks.
+     */
+    void assertNoSymlinks(CanonPath path);
+
+    std::optional<PosixStat> cachedLstat(const CanonPath & path);
+
+    std::filesystem::path makeAbsPath(const CanonPath & path);
+};
+
+WindowsSourceAccessor::WindowsSourceAccessor(std::filesystem::path && argRoot, bool trackLastModified)
     : PosixSourceAccessorBase(trackLastModified)
     , root(std::move(argRoot))
 {
@@ -522,12 +564,12 @@ PosixSourceAccessor::PosixSourceAccessor(std::filesystem::path && argRoot, bool 
     displayPrefix = root.string();
 }
 
-PosixSourceAccessor::PosixSourceAccessor()
-    : PosixSourceAccessor(std::filesystem::path{})
+WindowsSourceAccessor::WindowsSourceAccessor()
+    : WindowsSourceAccessor(std::filesystem::path{})
 {
 }
 
-std::filesystem::path PosixSourceAccessor::makeAbsPath(const CanonPath & path)
+std::filesystem::path WindowsSourceAccessor::makeAbsPath(const CanonPath & path)
 {
     return root.empty()    ? (std::filesystem::path{path.abs()})
            : path.isRoot() ? /* Don't append a slash for the root of the accessor, since
@@ -537,19 +579,13 @@ std::filesystem::path PosixSourceAccessor::makeAbsPath(const CanonPath & path)
                            : root / path.rel();
 }
 
-void PosixSourceAccessor::readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback)
+void WindowsSourceAccessor::readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback)
 {
     assertNoSymlinks(path);
 
     auto ap = makeAbsPath(path);
 
-    AutoCloseFD fd = toDescriptor(open(
-        ap.string().c_str(),
-        O_RDONLY
-#ifndef _WIN32
-            | O_NOFOLLOW | O_CLOEXEC
-#endif
-        ));
+    AutoCloseFD fd = toDescriptor(open(ap.string().c_str(), O_RDONLY));
     if (!fd)
         throw SysError("opening file '%1%'", ap.string());
 
@@ -563,7 +599,7 @@ void PosixSourceAccessor::readFile(const CanonPath & path, Sink & sink, fun<void
     source.drainInto(sink, size);
 }
 
-bool PosixSourceAccessor::pathExists(const CanonPath & path)
+bool WindowsSourceAccessor::pathExists(const CanonPath & path)
 {
     if (auto parent = path.parent())
         assertNoSymlinks(*parent);
@@ -573,7 +609,7 @@ bool PosixSourceAccessor::pathExists(const CanonPath & path)
 using Cache = boost::concurrent_flat_map<std::string, std::optional<PosixStat>>;
 static Cache cache;
 
-std::optional<PosixStat> PosixSourceAccessor::cachedLstat(const CanonPath & path)
+std::optional<PosixStat> WindowsSourceAccessor::cachedLstat(const CanonPath & path)
 {
     // Note: we convert std::filesystem::path to std::string because the
     // former is not hashable on libc++.
@@ -591,7 +627,7 @@ std::optional<PosixStat> PosixSourceAccessor::cachedLstat(const CanonPath & path
     return st;
 }
 
-std::optional<SourceAccessor::Stat> PosixSourceAccessor::maybeLstat(const CanonPath & path)
+std::optional<SourceAccessor::Stat> WindowsSourceAccessor::maybeLstat(const CanonPath & path)
 {
     if (auto parent = path.parent())
         assertNoSymlinks(*parent);
@@ -603,7 +639,7 @@ std::optional<SourceAccessor::Stat> PosixSourceAccessor::maybeLstat(const CanonP
     return sourceAccessorStatFromPosixStat(*st);
 }
 
-SourceAccessor::DirEntries PosixSourceAccessor::readDirectory(const CanonPath & path)
+SourceAccessor::DirEntries WindowsSourceAccessor::readDirectory(const CanonPath & path)
 {
     assertNoSymlinks(path);
     DirEntries res;
@@ -655,19 +691,19 @@ SourceAccessor::DirEntries PosixSourceAccessor::readDirectory(const CanonPath & 
     return res;
 }
 
-std::string PosixSourceAccessor::readLink(const CanonPath & path)
+std::string WindowsSourceAccessor::readLink(const CanonPath & path)
 {
     if (auto parent = path.parent())
         assertNoSymlinks(*parent);
     return nix::readLink(makeAbsPath(path)).string();
 }
 
-std::optional<std::filesystem::path> PosixSourceAccessor::getPhysicalPath(const CanonPath & path)
+std::optional<std::filesystem::path> WindowsSourceAccessor::getPhysicalPath(const CanonPath & path)
 {
     return makeAbsPath(path);
 }
 
-void PosixSourceAccessor::assertNoSymlinks(CanonPath path)
+void WindowsSourceAccessor::assertNoSymlinks(CanonPath path)
 {
     while (!path.isRoot()) {
         auto st = cachedLstat(path);
@@ -676,6 +712,10 @@ void PosixSourceAccessor::assertNoSymlinks(CanonPath path)
         path.pop();
     }
 }
+
+#endif
+
+} // namespace
 
 ref<SourceAccessor> getFSSourceAccessor()
 {
@@ -768,9 +808,9 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackL
 
     else
         throw Error("file %1% has an unsupported type", PathFmt(root));
+#else
+    return make_ref<WindowsSourceAccessor>(std::move(root), trackLastModified);
 #endif
-
-    return make_ref<PosixSourceAccessor>(std::move(root), trackLastModified);
 }
 
 } // namespace nix

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -1,10 +1,18 @@
 #include "nix/util/posix-source-accessor.hh"
 #include "nix/util/file-system-at.hh"
+#include "nix/util/lru-cache.hh"
+#include "nix/util/sync.hh"
 #include "nix/util/memory-source-accessor.hh"
 #include "nix/util/source-path.hh"
 #include "nix/util/signals.hh"
 
 #include <boost/unordered/concurrent_flat_map.hpp>
+
+#include <atomic>
+
+#ifndef _WIN32
+#  include <sys/resource.h>
+#endif
 
 namespace nix {
 
@@ -31,8 +39,14 @@ static SourceAccessor::Stat sourceAccessorStatFromPosixStat(const PosixStat & st
 
 namespace {
 
+#ifndef _WIN32
+
+class PosixDirectorySourceAccessor;
+
 class PosixFileSourceAccessor : public detail::PosixSourceAccessorBase
 {
+    friend class PosixDirectorySourceAccessor;
+
     AutoCloseFD fd;
     std::filesystem::path fsPath;
     /**
@@ -121,6 +135,331 @@ std::string PosixFileSourceAccessor::readLink(const CanonPath & path)
         throw NotADirectory("reading symlink '%1%': %2%", showPath(path), "Not a directory");
     throw NotASymlink("path '%1%' is not a symlink", showPath(path));
 }
+
+static unsigned getGlobalDirFdCacheLimit()
+{
+    ::rlimit lim{};
+    if (::getrlimit(RLIMIT_NOFILE, &lim) == -1)
+        throw SysError("querying RLIMIT_NOFILE");
+    /* Some sane upper bound in case we have a huge rlimit. */
+    return std::min<rlim_t>(4096, lim.rlim_cur / 8);
+}
+
+class PosixDirectorySourceAccessor : public detail::PosixSourceAccessorBase
+{
+public:
+    static unsigned getGlobalFdLimit()
+    {
+        static auto res = getGlobalDirFdCacheLimit();
+        return res;
+    }
+
+    static void registerAccessor(ref<PosixDirectorySourceAccessor> accessor)
+    {
+        auto reg = globalDirFdCacheRegistry.lock();
+        std::erase_if(*reg, [](auto & maybeAccessor) { return maybeAccessor.expired(); });
+        reg->push_back(accessor.get_ptr());
+    }
+
+private:
+    AutoCloseFD dirFd;
+    std::filesystem::path fsPath;
+
+    std::shared_ptr<Sync<LRUCache<CanonPath, ref<AutoCloseFD>>>> dirFdCache;
+
+    static inline std::atomic<unsigned> globalDirFdCount = 0;
+
+    static inline Sync<std::list<std::weak_ptr<PosixDirectorySourceAccessor>>> globalDirFdCacheRegistry;
+
+    static void maybeEvictFromGlobalCaches()
+    {
+        if (globalDirFdCount.load(std::memory_order_relaxed) < getGlobalFdLimit())
+            return;
+
+        auto registry(globalDirFdCacheRegistry.lock());
+        for (auto it = registry->begin(); it != registry->end();) {
+            if (globalDirFdCount.load(std::memory_order_relaxed) < getGlobalFdLimit())
+                break;
+
+            auto accessor = it->lock();
+            if (!accessor) {
+                it = registry->erase(it);
+                continue;
+            }
+
+            /* TODO: Would be nicer if we could evict a portion of the utilised
+               cache to avoid cold-start issues. Should be fine for now. */
+            if (accessor->dirFdCache) {
+                auto cache = accessor->dirFdCache->lock();
+                globalDirFdCount.fetch_sub(cache->size(), std::memory_order_relaxed);
+                cache->clear();
+            }
+
+            ++it;
+        }
+    }
+
+    void insertIntoDirFdCache(const CanonPath & key, ref<AutoCloseFD> fd)
+    {
+        assert(dirFdCache);
+        auto cache = dirFdCache->lock();
+        auto before = cache->size();
+        cache->upsert(key, std::move(fd));
+        globalDirFdCount.fetch_add(cache->size() - before, std::memory_order_relaxed);
+    }
+
+    /**
+     * Get the parent directory of path. The second pair element might be an owning file descriptor
+     * if path.parent().isRoot() is false.
+     */
+    std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> openParent(const CanonPath & path);
+
+    std::function<void(AutoCloseFD, CanonPath)> makeDirFdCallback();
+
+public:
+    PosixDirectorySourceAccessor(
+        AutoCloseFD fd, std::filesystem::path path, bool trackLastModified, unsigned dirFdCacheSize)
+        : PosixSourceAccessorBase(trackLastModified)
+        , dirFd(std::move(fd))
+        , fsPath(std::move(path))
+    {
+        assert(fsPath.is_absolute()); /* Only used for error messages, but still nice to enforce this invariant. */
+        setPathDisplay(fsPath.generic_string());
+
+        if (dirFdCacheSize)
+            dirFdCache = std::make_shared<Sync<LRUCache<CanonPath, ref<AutoCloseFD>>>>(dirFdCacheSize);
+    }
+
+    PosixDirectorySourceAccessor(PosixDirectorySourceAccessor &&) = delete;
+    PosixDirectorySourceAccessor(const PosixDirectorySourceAccessor &) = delete;
+    PosixDirectorySourceAccessor & operator=(PosixDirectorySourceAccessor &&) = delete;
+    PosixDirectorySourceAccessor & operator=(const PosixDirectorySourceAccessor &) = delete;
+
+    ~PosixDirectorySourceAccessor()
+    {
+        if (dirFdCache) {
+            auto cache = dirFdCache->lock();
+            globalDirFdCount.fetch_sub(cache->size(), std::memory_order_relaxed);
+        }
+    }
+
+    void readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback) override;
+
+    std::optional<Stat> maybeLstat(const CanonPath & path) override;
+
+    DirEntries readDirectory(const CanonPath & path) override;
+
+    std::string readLink(const CanonPath & path) override;
+
+    std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override
+    {
+        if (path.isRoot())
+            return fsPath;
+        return std::filesystem::path(fsPath) / path.rel(); /* RHS *must* be a relative path. */
+    }
+
+    std::string showPath(const CanonPath & path) override
+    {
+        if (path.isRoot())
+            return displayPrefix; /* No trailing slash. */
+        if (displayPrefix.ends_with('/'))
+            return displayPrefix + path.rel();
+        return displayPrefix + path.abs();
+    }
+};
+
+std::function<void(AutoCloseFD, CanonPath)> PosixDirectorySourceAccessor::makeDirFdCallback()
+{
+    if (!dirFdCache)
+        return nullptr;
+
+    return [this](AutoCloseFD fd, CanonPath key) {
+        assert(fd);
+        insertIntoDirFdCache(std::move(key), make_ref<AutoCloseFD>(std::move(fd)));
+    };
+}
+
+std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> PosixDirectorySourceAccessor::openParent(const CanonPath & path)
+{
+    assert(!path.isRoot());
+    auto parent = path.parent().value();
+    if (parent.isRoot())
+        return {dirFd.get(), nullptr};
+
+    maybeEvictFromGlobalCaches();
+
+    if (dirFdCache) {
+        if (auto cachedFd = dirFdCache->lock()->get(parent)) {
+            assert((*cachedFd)->get());
+            return {(*cachedFd)->get(), *cachedFd};
+        }
+    }
+
+    AutoCloseFD parentFdOwning = openFileEnsureBeneathNoSymlinks(
+        dirFd.get(), parent, O_DIRECTORY | O_RDONLY | O_CLOEXEC, 0, makeDirFdCallback());
+
+    return {parentFdOwning.get(), make_ref<AutoCloseFD>(std::move(parentFdOwning))};
+}
+
+std::optional<SourceAccessor::Stat> PosixDirectorySourceAccessor::maybeLstat(const CanonPath & path)
+try {
+    PosixStat st;
+
+    if (path.isRoot()) {
+        /* Must never fail - we already have the file descriptor for the directory. */
+        st = nix::fstat(dirFd.get());
+    } else {
+        auto [parentFd, parentFdOwning] = openParent(path);
+        if (parentFd == INVALID_DESCRIPTOR) {
+            if (errno == ENOENT || errno == ENOTDIR)
+                return std::nullopt;
+            throw SysError("opening directory '%1%'", showPath(path.parent().value()));
+        }
+
+        if (dirFdCache && parentFdOwning) {
+            assert(*parentFdOwning);
+            insertIntoDirFdCache(path.parent().value(), ref<AutoCloseFD>(parentFdOwning));
+        }
+
+        /* We know that CanonPath returns a NUL-terminated string_view, so the use of ->data() here is safe. */
+        if (::fstatat(parentFd, path.baseName()->data(), &st, AT_SYMLINK_NOFOLLOW) == -1) {
+            if (errno == ENOENT)
+                return std::nullopt;
+            throw SysError("getting status of '%1%'", showPath(path));
+        }
+    }
+
+    maybeUpdateMtime(st.st_mtime);
+    return sourceAccessorStatFromPosixStat(st);
+} catch (SymlinkNotAllowed & e) {
+    throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
+}
+
+void PosixDirectorySourceAccessor::readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback)
+try {
+    if (path.isRoot())
+        throw NotARegularFile("'%s' is not a regular file", showPath(path));
+
+    AutoCloseFD fileFd =
+        openFileEnsureBeneathNoSymlinks(dirFd.get(), path, O_RDONLY | O_CLOEXEC, /*mode=*/0, makeDirFdCallback());
+
+    if (!fileFd) {
+        if (errno == ENOENT || errno == ENOTDIR) /* Intermediate component might not exist. */
+            throw FileNotFound("file '%s' does not exist", showPath(path));
+        throw SysError("opening '%s'", showPath(path));
+    }
+
+    auto st = nix::fstat(fileFd.get());
+    if (!S_ISREG(st.st_mode))
+        throw Error("file '%s' has an unsupported type", showPath(path));
+    PosixFileSourceAccessor fileAccessor(std::move(fileFd), fsPath / path.rel(), trackLastModified, st);
+    maybeUpdateMtime(st.st_mtime);
+    fileAccessor.readFile(CanonPath::root, sink, sizeCallback);
+} catch (SymlinkNotAllowed & e) {
+    throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
+}
+
+SourceAccessor::DirEntries PosixDirectorySourceAccessor::readDirectory(const CanonPath & path)
+try {
+    AutoCloseFD dirFdOwning;
+
+    if (path.isRoot()) {
+        /* Get a fresh file descriptor for thread-safety. */
+        dirFdOwning = ::openat(dirFd.get(), ".", O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+        if (!dirFdOwning)
+            throw SysError("opening directory '%s'", showPath(path));
+    } else {
+        dirFdOwning = openFileEnsureBeneathNoSymlinks(
+            dirFd.get(), path, O_DIRECTORY | O_RDONLY | O_CLOEXEC, /*mode=*/0, makeDirFdCallback());
+
+        if (!dirFdOwning) {
+            if (errno == ENOTDIR)
+                throw NotADirectory("'%s' is not a directory", showPath(path));
+            throw SysError("opening directory '%s'", showPath(path));
+        }
+    }
+
+    AutoCloseDir dir(::fdopendir(dirFdOwning.get()));
+    if (!dir)
+        throw SysError("reading directory '%s'", showPath(path));
+    dirFdOwning.release();
+
+    DirEntries entries;
+    const ::dirent * dirent = nullptr;
+
+    while (errno = 0, dirent = ::readdir(dir.get())) {
+        checkInterrupt();
+        std::string_view name(dirent->d_name);
+        if (name == "." || name == "..")
+            continue;
+
+        std::optional<Type> type;
+        switch (dirent->d_type) {
+        case DT_REG:
+            type = tRegular;
+            break;
+        case DT_DIR:
+            type = tDirectory;
+            break;
+        case DT_LNK:
+            type = tSymlink;
+            break;
+        case DT_CHR:
+            type = tChar;
+            break;
+        case DT_BLK:
+            type = tBlock;
+            break;
+        case DT_FIFO:
+            type = tFifo;
+            break;
+        case DT_SOCK:
+            type = tSocket;
+            break;
+        default:
+            type = std::nullopt;
+            break;
+        }
+        entries.emplace(name, type);
+    }
+
+    if (errno)
+        throw SysError("reading directory '%1%'", showPath(path));
+
+    return entries;
+} catch (SymlinkNotAllowed & e) {
+    throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
+}
+
+std::string PosixDirectorySourceAccessor::readLink(const CanonPath & path)
+try {
+    if (path.isRoot())
+        throw NotASymlink("file '%s' is not a symlink", showPath(path));
+
+    auto [parentFd, parentFdOwning] = openParent(path);
+    if (parentFd == INVALID_DESCRIPTOR) {
+        if (errno == ENOENT || errno == ENOTDIR)
+            throw FileNotFound("path '%s' does not exist", showPath(path));
+        throw SysError("opening directory '%1%'", showPath(path.parent().value()));
+    }
+
+    if (dirFdCache && parentFdOwning) {
+        assert(*parentFdOwning);
+        insertIntoDirFdCache(path.parent().value(), ref<AutoCloseFD>(parentFdOwning));
+    }
+
+    try {
+        return readLinkAt(parentFd, CanonPath(path.baseName().value()));
+    } catch (SysError & e) {
+        if (e.errNo == EINVAL)
+            throw NotASymlink("file '%s' is not a symlink", showPath(path));
+        throw;
+    }
+} catch (SymlinkNotAllowed & e) {
+    throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
+}
+
+#endif
 
 } // namespace
 
@@ -303,7 +642,7 @@ void PosixSourceAccessor::assertNoSymlinks(CanonPath path)
 
 ref<SourceAccessor> getFSSourceAccessor()
 {
-    static auto rootFS = make_ref<PosixSourceAccessor>();
+    static auto rootFS = makeFSSourceAccessor("/", /*trackLastModified=*/false);
     return rootFS;
 }
 
@@ -383,7 +722,15 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackL
     if (S_ISREG(st.st_mode))
         return make_ref<PosixFileSourceAccessor>(std::move(fd), std::move(root), trackLastModified, st);
 
-    /* TODO: Use the file descriptor for fd-relative operations on the directory. */
+    else if (S_ISDIR(st.st_mode)) {
+        auto res = make_ref<PosixDirectorySourceAccessor>(
+            std::move(fd), std::move(root), trackLastModified, PosixDirectorySourceAccessor::getGlobalFdLimit() / 8);
+        PosixDirectorySourceAccessor::registerAccessor(res);
+        return res;
+    }
+
+    else
+        throw Error("file %1% has an unsupported type", PathFmt(root));
 #endif
 
     return make_ref<PosixSourceAccessor>(std::move(root), trackLastModified);

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -3,7 +3,6 @@
 #include "nix/util/lru-cache.hh"
 #include "nix/util/sync.hh"
 #include "nix/util/memory-source-accessor.hh"
-#include "nix/util/source-path.hh"
 #include "nix/util/signals.hh"
 
 #include <boost/unordered/concurrent_flat_map.hpp>
@@ -499,15 +498,6 @@ PosixSourceAccessor::PosixSourceAccessor(std::filesystem::path && argRoot, bool 
 PosixSourceAccessor::PosixSourceAccessor()
     : PosixSourceAccessor(std::filesystem::path{})
 {
-}
-
-SourcePath PosixSourceAccessor::createAtRoot(const std::filesystem::path & path, bool trackLastModified)
-{
-    std::filesystem::path path2 = absPath(path);
-    return {
-        make_ref<PosixSourceAccessor>(path2.root_path(), trackLastModified),
-        CanonPath{path2.relative_path().string()},
-    };
 }
 
 std::filesystem::path PosixSourceAccessor::makeAbsPath(const CanonPath & path)

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -591,11 +591,6 @@ std::optional<PosixStat> PosixSourceAccessor::cachedLstat(const CanonPath & path
     return st;
 }
 
-void PosixSourceAccessor::invalidateCache(const CanonPath & path)
-{
-    cache.erase(makeAbsPath(path).string());
-}
-
 std::optional<SourceAccessor::Stat> PosixSourceAccessor::maybeLstat(const CanonPath & path)
 {
     if (auto parent = path.parent())

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -293,15 +293,42 @@ std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> PosixDirectorySourceAccessor
 
     maybeEvictFromGlobalCaches();
 
+    std::shared_ptr<AutoCloseFD> intermediateParentFd;
+    CanonPath anchor = CanonPath::root;
+
     if (dirFdCache) {
-        if (auto cachedFd = dirFdCache->lock()->get(parent)) {
-            assert((*cachedFd)->get());
-            return {(*cachedFd)->get(), *cachedFd};
+        auto cache = dirFdCache->lock();
+        auto p = parent;
+        while (true) {
+            if (auto intermediateDirFdHit = cache->get(p)) {
+                if (p == parent)
+                    return {(*intermediateDirFdHit)->get(), *intermediateDirFdHit};
+                intermediateParentFd = intermediateDirFdHit->get_ptr();
+                anchor = p;
+                break;
+            }
+            if (p.isRoot())
+                break;
+            p.pop();
         }
     }
 
-    AutoCloseFD parentFdOwning = openFileEnsureBeneathNoSymlinks(
-        dirFd.get(), parent, O_DIRECTORY | O_RDONLY | O_CLOEXEC, 0, makeDirFdCallback());
+    Descriptor startFd = intermediateParentFd ? intermediateParentFd->get() : dirFd.get();
+    CanonPath relPath = intermediateParentFd ? parent.removePrefix(anchor) : parent;
+
+    std::function<void(AutoCloseFD, CanonPath)> cb;
+    if (auto base = makeDirFdCallback()) {
+        if (intermediateParentFd) {
+            cb = [base = std::move(base), prefix = anchor](AutoCloseFD fd, CanonPath relKey) {
+                base(std::move(fd), prefix / relKey);
+            };
+        } else {
+            cb = std::move(base);
+        }
+    }
+
+    AutoCloseFD parentFdOwning =
+        openFileEnsureBeneathNoSymlinks(startFd, relPath, O_DIRECTORY | O_RDONLY | O_CLOEXEC, 0, std::move(cb));
 
     return {parentFdOwning.get(), make_ref<AutoCloseFD>(std::move(parentFdOwning))};
 }

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -661,14 +661,14 @@ ref<SourceAccessor> getFSSourceAccessor()
     return rootFS;
 }
 
-ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackLastModified)
+ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackLastModified, FinalSymlink finalSymlink)
 {
 #ifndef _WIN32
     assert(root.is_absolute());
-    AutoCloseFD fd = openFileReadonly(root, FinalSymlink::DontFollow);
+    AutoCloseFD fd = openFileReadonly(root, finalSymlink);
 
     if (!fd) {
-        if (errno != ELOOP)
+        if (finalSymlink == FinalSymlink::Follow || errno != ELOOP)
             throw NativeSysError("opening file %1%", PathFmt(root));
 
         /* A helper class that holds the symlink destination in memory. */

--- a/src/libutil/union-source-accessor.cc
+++ b/src/libutil/union-source-accessor.cc
@@ -90,12 +90,6 @@ struct UnionSourceAccessor : SourceAccessor
         }
         return {path, std::nullopt};
     }
-
-    void invalidateCache(const CanonPath & path) override
-    {
-        for (auto & accessor : accessors)
-            accessor->invalidateCache(path);
-    }
 };
 
 ref<SourceAccessor> makeUnionSourceAccessor(std::vector<ref<SourceAccessor>> && accessors)

--- a/src/libutil/unix/file-system-at.cc
+++ b/src/libutil/unix/file-system-at.cc
@@ -140,20 +140,27 @@ void unix::fchmodatTryNoFollow(Descriptor dirFd, const CanonPath & path, mode_t 
     }
 }
 
-static AutoCloseFD
-openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & path, int flags, mode_t mode)
+static AutoCloseFD openFileEnsureBeneathNoSymlinksIterative(
+    Descriptor dirFd,
+    const CanonPath & path,
+    int flags,
+    mode_t mode,
+    std::function<void(AutoCloseFD dirFd, CanonPath relPath)> dirFdCallback)
 {
     AutoCloseFD parentFd;
     auto nrComponents = std::ranges::distance(path);
     assert(nrComponents >= 1);
     auto components = std::views::take(path, nrComponents - 1); /* Everything but last component */
     auto getParentFd = [&]() { return parentFd ? parentFd.get() : dirFd; };
+    auto currentRelPath = CanonPath::root;
 
     /* This rather convoluted loop is necessary to avoid TOCTOU when validating that
        no inner path component is a symlink. */
     for (auto it = components.begin(); it != components.end(); ++it) {
         auto component = std::string(*it);                        /* Copy into a string to make NUL terminated. */
         assert(component != ".." && !component.starts_with('/')); /* In case invariant is broken somehow.. */
+        auto prevRelPath = currentRelPath;
+        currentRelPath = currentRelPath / *it;
 
         AutoCloseFD parentFd2 = ::openat(
             getParentFd(), /* First iteration uses dirFd. */
@@ -188,6 +195,9 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
             return AutoCloseFD{};
         }
 
+        if (dirFdCallback && parentFd)
+            dirFdCallback(std::move(parentFd), std::move(prevRelPath));
+
         parentFd = std::move(parentFd2);
     }
 
@@ -221,7 +231,12 @@ openFileEnsureBeneathNoSymlinksIterative(Descriptor dirFd, const CanonPath & pat
     return res;
 }
 
-AutoCloseFD openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & path, int flags, mode_t mode)
+AutoCloseFD openFileEnsureBeneathNoSymlinks(
+    Descriptor dirFd,
+    const CanonPath & path,
+    int flags,
+    mode_t mode,
+    std::function<void(AutoCloseFD dirFd, CanonPath relPath)> dirFdCallback)
 {
     /* Just in case the invariant is somehow broken. */
     assert(!path.rel().starts_with('/'));
@@ -263,7 +278,7 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(Descriptor dirFd, const CanonPath & 
     }
 #endif
 
-    return openFileEnsureBeneathNoSymlinksIterative(dirFd, path, flags, mode);
+    return openFileEnsureBeneathNoSymlinksIterative(dirFd, path, flags, mode, std::move(dirFdCallback));
 }
 
 OsString readLinkAt(Descriptor dirFd, const CanonPath & path)

--- a/src/libutil/windows/file-system-at.cc
+++ b/src/libutil/windows/file-system-at.cc
@@ -229,7 +229,13 @@ PosixStat fstat(Descriptor fd)
 }
 
 AutoCloseFD openFileEnsureBeneathNoSymlinks(
-    Descriptor dirFd, const CanonPath & path, ACCESS_MASK desiredAccess, ULONG createOptions, ULONG createDisposition)
+    Descriptor dirFd,
+    const CanonPath & path,
+    ACCESS_MASK desiredAccess,
+    ULONG createOptions,
+    ULONG createDisposition,
+    /* FIXME: Actually call this callback. */
+    [[maybe_unused]] std::function<void(AutoCloseFD dirFd, CanonPath relPath)> dirFdCallback)
 {
     assert(!path.isRoot());
     assert(!path.rel().starts_with('/')); /* Just in case the invariant is somehow broken. */

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -36,7 +36,7 @@ struct CmdAddToStore : MixDryRun, StoreCommand
         if (!namePart)
             namePart = path.filename().string();
 
-        auto sourcePath = PosixSourceAccessor::createAtRoot(makeParentCanonical(path));
+        auto sourcePath = makeFSSourceAccessor(absPath(path));
 
         auto storePath = dryRun ? store->computeStorePath(*namePart, sourcePath, caMethod, hashAlgo, {}).first
                                 : store->addToStoreSlow(*namePart, sourcePath, caMethod, hashAlgo, {}).path;

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -84,9 +84,7 @@ struct CmdHashBase : Command
                     return std::make_unique<HashSink>(hashAlgo);
             };
 
-            auto makeSourcePath = [&]() -> SourcePath {
-                return PosixSourceAccessor::createAtRoot(makeParentCanonical(path));
-            };
+            auto makeSourcePath = [&]() -> SourcePath { return makeFSSourceAccessor(absPath(path)); };
 
             Hash h{HashAlgorithm::SHA256}; // throwaway def to appease C++
             switch (mode) {

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -191,7 +191,7 @@ static void opAdd(Strings opFlags, Strings opArgs)
         throw UsageError("unknown flag");
 
     for (auto & i : opArgs) {
-        auto sourcePath = PosixSourceAccessor::createAtRoot(makeParentCanonical(i));
+        auto sourcePath = makeFSSourceAccessor(absPath(i));
         std::cout << fmt("%s\n", store->printStorePath(store->addToStore(std::string(baseNameOf(i)), sourcePath)));
     }
 }
@@ -215,7 +215,7 @@ static void opAddFixed(Strings opFlags, Strings opArgs)
     opArgs.pop_front();
 
     for (auto & i : opArgs) {
-        auto sourcePath = PosixSourceAccessor::createAtRoot(makeParentCanonical(i));
+        auto sourcePath = makeFSSourceAccessor(absPath(i));
         std::cout << fmt(
             "%s\n", store->printStorePath(store->addToStoreSlow(baseNameOf(i), sourcePath, method, hashAlgo).path));
     }

--- a/src/perl/lib/Nix/Store.xs
+++ b/src/perl/lib/Nix/Store.xs
@@ -259,7 +259,7 @@ hashPath(char * algo, int base32, char * path)
     PPCODE:
         try {
             Hash h = hashPath(
-                PosixSourceAccessor::createAtRoot(path),
+                makeFSSourceAccessor(absPath(path)),
                 FileIngestionMethod::NixArchive, parseHashAlgo(algo)).first;
             auto s = h.to_string(base32 ? HashFormat::Nix32 : HashFormat::Base16, false);
             XPUSHs(sv_2mortal(newSVpv(s.c_str(), 0)));
@@ -339,7 +339,7 @@ StoreWrapper::addToStore(char * srcPath, int recursive, char * algo)
             auto method = recursive ? ContentAddressMethod::Raw::NixArchive : ContentAddressMethod::Raw::Flat;
             auto path = THIS->store->addToStore(
                 std::string(baseNameOf(srcPath)),
-                PosixSourceAccessor::createAtRoot(srcPath),
+                makeFSSourceAccessor(absPath(srcPath)),
                 method, parseHashAlgo(algo));
             XPUSHs(sv_2mortal(newSVpv(THIS->store->printStorePath(path).c_str(), 0)));
         } catch (Error & e) {

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -35,7 +35,7 @@ nix-instantiate --eval -E "builtins.readFile ((builtins.fetchGit \"file://$TEST_
 
 # Fetch a worktree.
 unset _NIX_FORCE_HTTP
-expectStderr 0 nix eval -vvvv --impure --raw --expr "(builtins.fetchGit \"file://$TEST_ROOT/worktree\").outPath" | grepQuiet "copying '$TEST_ROOT/worktree/' to the store"
+expectStderr 0 nix eval -vvvv --impure --raw --expr "(builtins.fetchGit \"file://$TEST_ROOT/worktree\").outPath" | grepQuiet "copying '$TEST_ROOT/worktree' to the store"
 path0=$(nix eval --impure --raw --expr "(builtins.fetchGit \"file://$TEST_ROOT/worktree\").outPath")
 path0_=$(nix eval --impure --raw --expr "(builtins.fetchTree { type = \"git\"; url = \"file://$TEST_ROOT/worktree\"; }).outPath")
 [[ $path0 = "$path0_" ]]

--- a/tests/functional/lang/eval-fail-readDir-not-a-directory-1.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-not-a-directory-1.err.exp
@@ -13,4 +13,4 @@ error:
              |                 ^
             3| }
 
-       error: cannot read directory "/pwd/lang/readDir/bar": Not a directory
+       error: '/pwd/lang/readDir/bar' is not a directory

--- a/tests/functional/lang/eval-fail-readDir-not-a-directory-2.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-not-a-directory-2.err.exp
@@ -13,4 +13,4 @@ error:
              |                          ^
             3| }
 
-       error: cannot read directory "/pwd/lang/readDir/foo/git-hates-directories": Not a directory
+       error: '/pwd/lang/readDir/foo/git-hates-directories' is not a directory

--- a/tests/functional/multiple-outputs.sh
+++ b/tests/functional/multiple-outputs.sh
@@ -96,6 +96,13 @@ if nix-build multiple-outputs.nix -A cyclic --no-out-link; then
     exit 1
 fi
 
+# TODO inspect why this doesn't work with floating content-addressing
+# derivations.
+if [[ -z "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
+    expect 1 nix build -f multiple-outputs.nix invalid-output-name-1 2>&1 | grep 'contains illegal character'
+    expect 1 nix build -f multiple-outputs.nix invalid-output-name-2 2>&1 | grep 'contains illegal character'
+fi
+
 # Do a GC. This should leave an empty store.
 echo "collecting garbage..."
 rm "$TEST_ROOT"/result*
@@ -103,10 +110,3 @@ nix-store --gc --keep-derivations --keep-outputs
 nix-store --gc --print-roots
 rm -rf "$NIX_STORE_DIR"/.links
 rmdir "$NIX_STORE_DIR"
-
-# TODO inspect why this doesn't work with floating content-addressing
-# derivations.
-if [[ -z "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
-    expect 1 nix build -f multiple-outputs.nix invalid-output-name-1 2>&1 | grep 'contains illegal character'
-    expect 1 nix build -f multiple-outputs.nix invalid-output-name-2 2>&1 | grep 'contains illegal character'
-fi


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

See each individual commit for details. The goal here is to squash all TOCTOU on path traversal by actually completely banning symlink traversal via `openFileEnsureBeneathNoSymlinks`. Now dumpPath also uses a one-path-component at a time traversal callback. The strace for copyRecursive (and dumpPath would look similar) looks something like:

```
openat2(24, "8f", {flags=O_RDONLY|O_CLOEXEC|O_DIRECTORY, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 26
openat(26, ".", O_RDONLY|O_CLOEXEC|O_DIRECTORY) = 27
openat2(25, "146e0315254c855415fe3a51afef48fbd40cdf", {flags=O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, mode=0666, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 27
openat2(26, "146e0315254c855415fe3a51afef48fbd40cdf", {flags=O_RDONLY|O_CLOEXEC, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 28
openat2(25, "334ac10401e3ba122baca426285baf5e529e6a", {flags=O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, mode=0666, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 27
openat2(26, "334ac10401e3ba122baca426285baf5e529e6a", {flags=O_RDONLY|O_CLOEXEC, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 28
openat2(25, "435cffc6af828a3b69d8e1f7c27a666ecca598", {flags=O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, mode=0666, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 27
openat2(26, "435cffc6af828a3b69d8e1f7c27a666ecca598", {flags=O_RDONLY|O_CLOEXEC, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 28
openat2(25, "7e13c1f2ef3dd33c87efc1f7441363ec33216c", {flags=O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, mode=0666, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 27
```

Instead of:

```
openat2(10, "pack-823d54061f64073010f4c73702c111f9b3d6c0c8.rev", {flags=O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, mode=0666, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 11
openat(AT_FDCWD, "/nix/store/bf4vvgna8rg87h9ra626qii7ypw1j8m2-source/.git/objects/pack/pack-823d54061f64073010f4c73702c111f9b3d6c0c8.rev", O_RDONLY|O_NOFOLLOW|O_CLOEXEC) = 12
openat2(10, "pack-b0c1ae39ab6ffd5590df8c5315b28e476a9e0f01.idx", {flags=O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, mode=0666, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 11
openat(AT_FDCWD, "/nix/store/bf4vvgna8rg87h9ra626qii7ypw1j8m2-source/.git/objects/pack/pack-b0c1ae39ab6ffd5590df8c5315b28e476a9e0f01.idx", O_RDONLY|O_NOFOLLOW|O_CLOEXEC) = 12
openat2(10, "pack-b0c1ae39ab6ffd5590df8c5315b28e476a9e0f01.pack", {flags=O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, mode=0666, resolve=RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH}, 24) = 11
openat(AT_FDCWD, "/nix/store/bf4vvgna8rg87h9ra626qii7ypw1j8m2-source/.git/objects/pack/pack-b0c1ae39ab6ffd5590df8c5315b28e476a9e0f01.pack", O_RDONLY|O_NOFOLLOW|O_CLOEXEC) = 12
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
