### PR TITLE
Add temproots in copyPaths, plus all the associated stuff

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -62,9 +62,12 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
     if (!drv->type().hasKnownOutputPaths())
         experimentalFeatureSettings.require(Xp::CaDerivations);
 
+    StorePathSet outputPaths;
     for (auto & i : drv->outputsAndOptPaths(worker.store))
         if (i.second.second)
-            worker.store.addTempRoot(*i.second.second);
+            outputPaths.insert(*i.second.second);
+
+    worker.store.addTempRoots(outputPaths);
 
     /* We don't yet have any safe way to cache an impure derivation at
        this step. */

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -326,11 +326,17 @@ static void performOp(
         auto paths = WorkerProto::Serialise<StorePathSet>::read(*store, rconn);
 
         SubstituteFlag substitute = NoSubstitute;
+        AddTempRootsFlag doAddTempRoots = NoAddTempRoots;
         if (conn.protoVersion >= WorkerProto::Version{.number = {1, 27}}) {
             substitute = readInt(conn.from) ? Substitute : NoSubstitute;
+
+            if (conn.protoVersion.features.contains(WorkerProto::featureQueryValidPathsAddTempRoots))
+                doAddTempRoots = readInt(conn.from) ? AddTempRoots : NoAddTempRoots;
         }
 
         logger->startWork();
+        if (doAddTempRoots)
+            store->addTempRoots(paths);
         if (substitute) {
             store->substitutePaths(paths);
         }

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -91,6 +91,13 @@ void LocalStore::addTempRoot(const StorePath & path)
 
     createTempRootsFile();
 
+    /* Record the store path in the temporary roots file so it will be
+       seen by a future run of the garbage collector. */
+    auto s = printStorePath(path) + '\0';
+    writeFull(_fdTempRoots.lock()->get(), s);
+
+    /* Any GC *started* past this point knows about the new temproots. */
+
     /* Open/create the global GC lock file. */
     {
         auto fdGCLock(_fdGCLock.lock());
@@ -106,8 +113,9 @@ restart:
 
     if (!gcLock.acquired) {
         /* We couldn't get a shared global GC lock, so the garbage
-           collector is running. So we have to connect to the garbage
-           collector and inform it about our root. */
+           collector is running, which may have started before we
+           wrote the new temproots. So we have to connect to the
+           garbage collector and inform it about our root. */
         auto fdRootsSocket(_fdRootsSocket.lock());
 
         if (!*fdRootsSocket) {
@@ -152,10 +160,7 @@ restart:
         }
     }
 
-    /* Record the store path in the temporary roots file so it will be
-       seen by a future run of the garbage collector. */
-    auto s = printStorePath(path) + '\0';
-    writeFull(_fdTempRoots.lock()->get(), s);
+    /* Any GC past this point knows about the new temproots. */
 }
 
 static std::string censored = "{censored}";

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -96,8 +96,16 @@ void LocalStore::addTempRoots(const StorePathSet & paths)
 
     std::string s;
 
-    for (auto & path : paths)
-        s += printStorePath(path) + '\0';
+    {
+        auto tempRootsCache(_tempRootsCache.lock());
+
+        for (auto & path : paths)
+            if (tempRootsCache->upsert(path, {}))
+                s += printStorePath(path) + '\0';
+    }
+
+    if (s.empty())
+        return;
 
     {
         auto fdTempRoots(_fdTempRoots.lock());

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -81,7 +81,7 @@ void LocalStore::createTempRootsFile()
     }
 }
 
-void LocalStore::addTempRoot(const StorePath & path)
+void LocalStore::addTempRoots(const StorePathSet & paths)
 {
     if (config->readOnly) {
         debug(
@@ -91,10 +91,22 @@ void LocalStore::addTempRoot(const StorePath & path)
 
     createTempRootsFile();
 
-    /* Record the store path in the temporary roots file so it will be
+    /* Record the store paths in the temporary roots file so they will be
        seen by a future run of the garbage collector. */
-    auto s = printStorePath(path) + '\0';
-    writeFull(_fdTempRoots.lock()->get(), s);
+
+    std::string s;
+
+    for (auto & path : paths)
+        s += printStorePath(path) + '\0';
+
+    {
+        auto fdTempRoots(_fdTempRoots.lock());
+
+        /* This might not be atomic, but that's fine. Writes go in-order, and if
+           we partially write a store path, findTempRoots() will just ignore it,
+           and we'll send it the new temproots below if it's still running. */
+        writeFull(fdTempRoots->get(), s);
+    }
 
     /* Any GC *started* past this point knows about the new temproots. */
 
@@ -138,12 +150,14 @@ restart:
         }
 
         try {
-            debug("sending GC root '%s'", printStorePath(path));
-            writeFull(fdRootsSocket->get(), printStorePath(path) + "\n", false);
-            char c;
-            readFull(fdRootsSocket->get(), &c, 1);
-            assert(c == '1');
-            debug("got ack for GC root '%s'", printStorePath(path));
+            for (auto & path : paths) {
+                debug("sending GC root '%s'", printStorePath(path));
+                writeFull(fdRootsSocket->get(), printStorePath(path) + "\n", false);
+                char c;
+                readFull(fdRootsSocket->get(), &c, 1);
+                assert(c == '1');
+                debug("got ack for GC root '%s'", printStorePath(path));
+            }
         } catch (SystemError & e) {
             /* The garbage collector may have exited, so we need to
                restart. */

--- a/src/libstore/include/nix/store/gc-store.hh
+++ b/src/libstore/include/nix/store/gc-store.hh
@@ -97,7 +97,7 @@ struct GCResults
  *
  * The notion of GC roots actually not part of this class.
  *
- *  - The base `Store` class has `Store::addTempRoot()` because for a store
+ *  - The base `Store` class has `Store::addTempRoots()` because for a store
  *    that doesn't support garbage collection at all, a temporary GC root is
  *    safely implementable as no-op.
  *

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -189,17 +189,10 @@ public:
         bool includeOutputs = false,
         bool includeDerivers = false) override;
 
-    StorePathSet queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute = NoSubstitute) override;
-
-    /**
-     * Custom variation that atomically creates temp locks on the remote
-     * side.
-     *
-     * This exists to prevent a race where the remote host
-     * garbage-collects paths that are already there. Optionally, ask
-     * the remote host to substitute missing paths.
-     */
-    StorePathSet queryValidPaths(const StorePathSet & paths, bool lock, SubstituteFlag maybeSubstitute = NoSubstitute);
+    StorePathSet queryValidPaths(
+        const StorePathSet & paths,
+        SubstituteFlag maybeSubstitute = NoSubstitute,
+        AddTempRootsFlag maybeAddTempRoots = NoAddTempRoots) override;
 
     void connect() override;
 

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <future>
 #include <string>
+#include <variant>
 #include <boost/unordered/unordered_flat_set.hpp>
 
 namespace nix {
@@ -324,6 +325,8 @@ private:
      * Connection to the garbage collector.
      */
     Sync<AutoCloseFD> _fdRootsSocket;
+
+    Sync<LRUCache<StorePath, std::monostate>> _tempRootsCache;
 
 public:
 

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -304,7 +304,7 @@ public:
         const StorePathSet & references,
         RepairFlag repair) override;
 
-    void addTempRoot(const StorePath & path) override;
+    void addTempRoots(const StorePathSet & paths) override;
 
 private:
 

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -272,7 +272,10 @@ public:
 
     bool isValidPathUncached(const StorePath & path) override;
 
-    StorePathSet queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute = NoSubstitute) override;
+    StorePathSet queryValidPaths(
+        const StorePathSet & paths,
+        SubstituteFlag maybeSubstitute = NoSubstitute,
+        AddTempRootsFlag maybeAddTempRoots = NoAddTempRoots) override;
 
     StorePathSet queryAllValidPaths() override;
 

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -126,7 +126,7 @@ public:
 
     void ensurePath(const StorePath & path) override;
 
-    void addTempRoot(const StorePath & path) override;
+    void addTempRoots(const StorePathSet & paths) override;
 
     Roots findRoots(bool censor) override;
 

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -62,7 +62,10 @@ public:
 
     bool isValidPathUncached(const StorePath & path) override;
 
-    StorePathSet queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute = NoSubstitute) override;
+    StorePathSet queryValidPaths(
+        const StorePathSet & paths,
+        SubstituteFlag maybeSubstitute = NoSubstitute,
+        AddTempRootsFlag maybeAddTempRoots = NoAddTempRoots) override;
 
     StorePathSet queryAllValidPaths() override;
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -859,9 +859,18 @@ public:
      * ```
      *
      */
-    virtual void addTempRoot(const StorePath & path)
+    void addTempRoot(const StorePath & path)
     {
-        debug("not creating temporary root, store doesn't support GC");
+        addTempRoots({path});
+    }
+
+    /**
+     * Add multiple store paths as temporary roots of the garbage collector.
+     * The roots disappears as soon as we exit.
+     */
+    virtual void addTempRoots(const StorePathSet & paths)
+    {
+        debug("not creating temporary roots, store doesn't support GC");
     }
 
     /**

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -50,6 +50,8 @@ enum CheckSigsFlag : bool { NoCheckSigs = false, CheckSigs = true };
 
 enum SubstituteFlag : bool { NoSubstitute = false, Substitute = true };
 
+enum AddTempRootsFlag : bool { NoAddTempRoots = false, AddTempRoots = true };
+
 enum BuildMode : uint8_t { bmNormal, bmRepair, bmCheck };
 
 enum TrustedFlag : bool { NotTrusted = false, Trusted = true };
@@ -486,9 +488,12 @@ public:
 
     /**
      * Query which of the given paths is valid. Optionally, try to
-     * substitute missing paths.
+     * substitute missing paths and/or add paths as temproots.
      */
-    virtual StorePathSet queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute = NoSubstitute);
+    virtual StorePathSet queryValidPaths(
+        const StorePathSet & paths,
+        SubstituteFlag maybeSubstitute = NoSubstitute,
+        AddTempRootsFlag maybeAddTempRoots = NoAddTempRoots);
 
     /**
      * Query the set of all valid paths. Note that for some store

--- a/src/libstore/include/nix/store/worker-protocol-connection.hh
+++ b/src/libstore/include/nix/store/worker-protocol-connection.hh
@@ -100,7 +100,8 @@ struct WorkerProto::BasicClientConnection : WorkerProto::BasicConnection
         const StoreDirConfig & remoteStore,
         bool * daemonException,
         const StorePathSet & paths,
-        SubstituteFlag maybeSubstitute);
+        SubstituteFlag maybeSubstitute,
+        AddTempRootsFlag maybeAddTempRoots);
 
     std::optional<UnkeyedValidPathInfo>
     queryPathInfo(const StoreDirConfig & store, bool * daemonException, const StorePath & path);

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -136,6 +136,11 @@ struct WorkerProto
     static constexpr std::string_view featureDisableSetOptions = "disable-set-options";
 
     /**
+     * Feature for optionally adding temproots during QueryValidPaths
+     */
+    static constexpr std::string_view featureQueryValidPathsAddTempRoots = "query-valid-paths-add-temp-roots";
+
+    /**
      * A unidirectional read connection, to be used by the read half of the
      * canonical serializers below.
      */

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -274,16 +274,11 @@ void LegacySSHStore::computeFSClosure(
         out.insert(i);
 }
 
-StorePathSet LegacySSHStore::queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute)
+StorePathSet LegacySSHStore::queryValidPaths(
+    const StorePathSet & paths, SubstituteFlag maybeSubstitute, AddTempRootsFlag maybeAddTempRoots)
 {
     auto conn(connections->get());
-    return conn->queryValidPaths(*this, false, paths, maybeSubstitute);
-}
-
-StorePathSet LegacySSHStore::queryValidPaths(const StorePathSet & paths, bool lock, SubstituteFlag maybeSubstitute)
-{
-    auto conn(connections->get());
-    return conn->queryValidPaths(*this, lock, paths, maybeSubstitute);
+    return conn->queryValidPaths(*this, maybeAddTempRoots, paths, maybeSubstitute);
 }
 
 void LegacySSHStore::connect()

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -130,6 +130,7 @@ LocalStore::LocalStore(ref<const Config> config)
     , schemaPath(dbDir / "schema")
     , tempRootsDir(config->stateDir.get() / "temproots")
     , fnTempRoots(tempRootsDir / std::to_string(getpid()))
+    , _tempRootsCache(256)
 {
     auto state(_state->lock());
     state->stmts = std::make_unique<State::Stmts>();

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -842,8 +842,12 @@ bool LocalStore::isValidPathUncached(const StorePath & path)
     return retrySQLite<bool>([&]() { return isValidPath_(*_state->lock(), path); });
 }
 
-StorePathSet LocalStore::queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute)
+StorePathSet LocalStore::queryValidPaths(
+    const StorePathSet & paths, SubstituteFlag maybeSubstitute, AddTempRootsFlag maybeAddTempRoots)
 {
+    if (maybeAddTempRoots)
+        addTempRoots(paths);
+
     StorePathSet res;
     for (auto & i : paths)
         if (isValidPath(i))

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -190,11 +190,8 @@ bool RemoteStore::isValidPathUncached(const StorePath & path)
 StorePathSet RemoteStore::queryValidPaths(
     const StorePathSet & paths, SubstituteFlag maybeSubstitute, AddTempRootsFlag maybeAddTempRoots)
 {
-    if (maybeAddTempRoots)
-        addTempRoots(paths);
-
     auto conn(getConnection());
-    return conn->queryValidPaths(*this, &conn.daemonException, paths, maybeSubstitute);
+    return conn->queryValidPaths(*this, &conn.daemonException, paths, maybeSubstitute, maybeAddTempRoots);
 }
 
 StorePathSet RemoteStore::queryAllValidPaths()

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -187,8 +187,12 @@ bool RemoteStore::isValidPathUncached(const StorePath & path)
     return readInt(conn->from);
 }
 
-StorePathSet RemoteStore::queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute)
+StorePathSet RemoteStore::queryValidPaths(
+    const StorePathSet & paths, SubstituteFlag maybeSubstitute, AddTempRootsFlag maybeAddTempRoots)
 {
+    if (maybeAddTempRoots)
+        addTempRoots(paths);
+
     auto conn(getConnection());
     return conn->queryValidPaths(*this, &conn.daemonException, paths, maybeSubstitute);
 }

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -668,10 +668,13 @@ void RemoteStore::ensurePath(const StorePath & path)
     readInt(conn->from);
 }
 
-void RemoteStore::addTempRoot(const StorePath & path)
+void RemoteStore::addTempRoots(const StorePathSet & paths)
 {
     auto conn(getConnection());
-    conn->addTempRoot(*this, &conn.daemonException, path);
+
+    /* Unclear if adding a new operation would be worthwhile */
+    for (auto & path : paths)
+        conn->addTempRoot(*this, &conn.daemonException, path);
 }
 
 Roots RemoteStore::findRoots(bool censor)

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -129,7 +129,7 @@ public:
         unsupported("buildDerivation");
     }
 
-    void addTempRoot(const StorePath & path) override {}
+    void addTempRoots(const StorePathSet & paths) override {}
 
     void addIndirectRoot(const std::filesystem::path & path) override {}
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1015,7 +1015,7 @@ std::map<StorePath, StorePath> copyPaths(
     CheckSigsFlag checkSigs,
     SubstituteFlag substitute)
 {
-    auto valid = dstStore.queryValidPaths(storePaths, substitute);
+    auto valid = dstStore.queryValidPaths(storePaths, substitute, AddTempRoots);
 
     StorePathSet missing;
     for (auto & path : storePaths)

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -740,8 +740,12 @@ void Store::substitutePaths(const StorePathSet & paths)
         }
 }
 
-StorePathSet Store::queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute)
+StorePathSet
+Store::queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute, AddTempRootsFlag maybeAddTempRoots)
 {
+    if (maybeAddTempRoots)
+        addTempRoots(paths);
+
     struct State
     {
         size_t left;

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -265,13 +265,20 @@ std::optional<UnkeyedValidPathInfo> WorkerProto::BasicClientConnection::queryPat
 }
 
 StorePathSet WorkerProto::BasicClientConnection::queryValidPaths(
-    const StoreDirConfig & store, bool * daemonException, const StorePathSet & paths, SubstituteFlag maybeSubstitute)
+    const StoreDirConfig & store,
+    bool * daemonException,
+    const StorePathSet & paths,
+    SubstituteFlag maybeSubstitute,
+    AddTempRootsFlag maybeAddTempRoots)
 {
     assert((protoVersion >= WorkerProto::Version{.number = {1, 12}}));
     to << WorkerProto::Op::QueryValidPaths;
     WorkerProto::write(store, *this, paths);
     if (protoVersion >= WorkerProto::Version{.number = {1, 27}}) {
         to << maybeSubstitute;
+
+        if (protoVersion.features.contains(WorkerProto::featureQueryValidPathsAddTempRoots))
+            to << maybeAddTempRoots;
     }
     processStderr(daemonException);
     return WorkerProto::Serialise<StorePathSet>::read(store, *this);

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -29,6 +29,9 @@ const WorkerProto::Version WorkerProto::latest = {
                 WorkerProto::featureRealisationWithPath,
             },
             std::string{WorkerProto::featureDeleteDeadSpecificReferrers},
+            std::string{
+                WorkerProto::featureQueryValidPathsAddTempRoots,
+            },
         },
 };
 

--- a/src/libutil-tests/lru-cache.cc
+++ b/src/libutil-tests/lru-cache.cc
@@ -90,6 +90,40 @@ TEST(LRUCache, overwriteOldestWhenCapacityIsReached)
     ASSERT_EQ(c.get("another").value(), "whatever");
 }
 
+TEST(LRUCache, upsertReturnValue)
+{
+    LRUCache<std::string, std::string> c(10);
+    ASSERT_EQ(c.upsert("one", "eins"), true);
+    ASSERT_EQ(c.upsert("two", "zwei"), true);
+    ASSERT_EQ(c.upsert("one", "uno"), false);
+    ASSERT_EQ(c.upsert("two", "dos"), false);
+    ASSERT_EQ(c.upsert("three", "drei"), true);
+}
+
+TEST(LRUCache, upsertReturnValueEdgeCases)
+{
+    LRUCache<std::string, std::string> c(3);
+    ASSERT_EQ(c.upsert("one", "eins"), true);
+    ASSERT_EQ(c.upsert("two", "zwei"), true);
+    ASSERT_EQ(c.upsert("three", "drei"), true);
+
+    /* does not exceed capacity */
+    ASSERT_EQ(c.upsert("one", "uno"), false);
+
+    /* exceeds capacity */
+    ASSERT_EQ(c.upsert("another", "whatever"), true);
+
+    /* retired */
+    ASSERT_EQ(c.upsert("two", "dos"), true);
+}
+
+TEST(LRUCache, upsertReturnValueZeroCapacity)
+{
+    LRUCache<std::string, std::string> c(0);
+    ASSERT_EQ(c.upsert("one", "eins"), true);
+    ASSERT_EQ(c.upsert("one", "uno"), true);
+}
+
 /* ----------------------------------------------------------------------------
  * clear
  * --------------------------------------------------------------------------*/

--- a/src/libutil/include/nix/util/lru-cache.hh
+++ b/src/libutil/include/nix/util/lru-cache.hh
@@ -54,14 +54,17 @@ public:
 
     /**
      * Insert or upsert an item in the cache.
+     *
+     * @returns true iff the key was not in the cache previously
      */
     template<typename K>
-    void upsert(const K & key, const Value & value)
+    bool upsert(const K & key, const Value & value)
     {
+        /* As if inserted and immediately retired */
         if (capacity == 0)
-            return;
+            return true;
 
-        erase(key);
+        bool existing = erase(key);
 
         if (data.size() >= capacity) {
             /**
@@ -79,6 +82,8 @@ public:
         auto j = lru.insert(lru.end(), i);
 
         i->second.first.it = j;
+
+        return !existing;
     }
 
     template<typename K>

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -954,8 +954,7 @@ static void opServe(Strings opFlags, Strings opArgs)
             bool substitute = readInt(in);
             auto paths = ServeProto::Serialise<StorePathSet>::read(*store, rconn);
             if (lock && writeAllowed)
-                for (auto & path : paths)
-                    store->addTempRoot(path);
+                store->addTempRoots(paths);
 
             if (substitute && writeAllowed) {
                 store->substitutePaths(paths);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

GC "race" whack-a-mole.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

Fixes, hopefully, #1970. Supersedes #15613. Originally discussed in #15616 but split out.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

Make `copyPaths` add the copied paths as temproots, but hopefully in a better manner than individually rooting every single path:

- Change the `Store::addTempRoot` virtual method to a batched `Store::addTempRoots` method, with the original one remaining as a non-virtual helper. Implement `LocalStore::addTempRoots` as writing out temproots in a batch. Also add an LRU cache for `LocalStore::addTempRoots`. `RemoteStore::addTempRoots` is just a loop.
- Add `AddTempRootsFlag` to `Store::queryValidPaths`
- In `copyPaths`, set `AddTempRootsFlag` while calling `queryValidPaths`
- Finally, add a `AddTempRootsFlag` flag worker protocol operation `QueryValidPaths`, and use that in `RemoteStore::queryValidPaths`. This requires a new daemon on the remote side, in exchange for (hopefully) better performance.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

Adding a flag to worker protocol `QueryValidPaths` is somewhat unorthogonal, but it was how it's done in the legacy SSH store, and I do think it still makes sense to do in `QueryValidPaths` in the worker protocol since it closes a TOCTOU for the result of list of valid paths, if needed by the caller. I haven't added a batch `AddTempRoots` worker protocol operation since it doesn't seem to be needed.

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Also note that

- The first commit "libstore: gc: Write temproot before trying the GC lock" is theoretically a standalone fix, but it's included here since the code is changed later by the batch `LocalStore::addTempRoots` code. Including it makes the later commit make more sense.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
