### PR TITLE
fetchClosure: Add temproot before checking path

### DIFF
--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -23,6 +23,8 @@ static void runFetchClosureWithRewrite(
     const std::optional<StorePath> & toPathMaybe,
     Value & v)
 {
+    if (toPathMaybe)
+        state.store->addTempRoot(*toPathMaybe);
 
     // establish toPath or throw
 
@@ -74,6 +76,7 @@ static void runFetchClosureWithRewrite(
 static void runFetchClosureWithContentAddressedPath(
     EvalState & state, const PosIdx pos, Store & fromStore, const StorePath & fromPath, Value & v)
 {
+    state.store->addTempRoot(fromPath);
 
     if (!state.store->isValidPath(fromPath))
         copyClosure(fromStore, *state.store, RealisedPath::Set{fromPath});
@@ -103,6 +106,7 @@ static void runFetchClosureWithContentAddressedPath(
 static void runFetchClosureWithInputAddressedPath(
     EvalState & state, const PosIdx pos, Store & fromStore, const StorePath & fromPath, Value & v)
 {
+    state.store->addTempRoot(fromPath);
 
     if (!state.store->isValidPath(fromPath))
         copyClosure(fromStore, *state.store, RealisedPath::Set{fromPath});


### PR DESCRIPTION
This avoids the fetched path from getting garbage collected if it is already valid.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

GC "race" whack-a-mole

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

Just changing `if (!isValidPath(...)) copyClosure(...);` into `copyClosure(...);` would also work but it would lose out on the fast path in the (common?) case of re-evaluating the same expressions multiple times with the `toPath` still valid.

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
