### PR TITLE
PosixDirectorySourceAccessor: Drop dirfd cache on resetFileCache()

### DIFF
--- a/nix-meson-build-support/common/clang-tidy/.clang-tidy
+++ b/nix-meson-build-support/common/clang-tidy/.clang-tidy
@@ -41,8 +41,6 @@ Checks:
   - -bugprone-unused-local-non-trivial-variable
   # 2 warnings - returning const& from parameter
   - -bugprone-return-const-ref-from-parameter
-  # 1 warning - unsafe C functions (e.g., getenv)
-  - -bugprone-unsafe-functions
   # 1 warning - signed char misuse
   - -bugprone-signed-char-misuse
   # 1 warning - calling parent virtual instead of override
@@ -90,3 +88,7 @@ CheckOptions:
   bugprone-reserved-identifier.AllowedIdentifiers: '__asan_default_options;__wrap___assert_fail;_SingleDerivedPathRaw;_DerivedPathRaw;_SingleBuiltPathRaw;_BuiltPathRaw'
   # Allow explicitly discarding return values with (void) cast
   bugprone-unused-return-value.AllowCastToVoid: true
+  bugprone-unsafe-functions.ReportDefaultFunctions: false
+  # Repurpose bugprone-unsafe-functions to lint functions that we'd want to wrap.
+  bugprone-unsafe-functions.CustomFunctions: >
+    ::std::filesystem::create_directories, nix::createDirs, "Use nix::createDirs (it wraps exceptions)";

--- a/packaging/hydra.nix
+++ b/packaging/hydra.nix
@@ -218,6 +218,8 @@ rec {
       tidyScope = pkgs.nixComponents2.overrideScope (
         self: super: {
           withClangTidy = true;
+          # clang-tidy doesn't seem to like unity builds.
+          withUnityBuild = false;
           # nix-everything is built via callPackage (not the layer system), so
           # enableClangTidyLayer's doCheck=false doesn't reach it. Set it here
           # so checkInputs (the *-tests.tests.run derivations) aren't pulled in.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1172,6 +1172,7 @@ void EvalState::resetFileCache()
     fileEvalCache->clear();
     inputCache->clear();
     positions.clear();
+    rootFS->invalidateCache();
 }
 
 void EvalState::eval(Expr * e, Value & v)

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -815,7 +815,7 @@ struct GitInputScheme : InputScheme
             repoDir = cacheDir;
             repoInfo.gitDir = ".";
 
-            std::filesystem::create_directories(cacheDir.parent_path());
+            createDirs(cacheDir.parent_path());
             PathLocks cacheDirLock({cacheDir.string()});
 
             auto repo = GitRepo::openRepo(cacheDir, {.create = true, .bare = true});

--- a/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
+++ b/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
@@ -53,6 +53,11 @@ struct FilteringSourceAccessor : SourceAccessor
 
     std::pair<CanonPath, std::optional<std::string>> getFingerprint(const CanonPath & path) override;
 
+    void invalidateCache() override
+    {
+        next->invalidateCache();
+    }
+
     /**
      * Call `makeNotAllowedError` to throw a `RestrictedPathError`
      * exception if `isAllowed()` returns `false` for `path`.

--- a/src/libstore-tests/register-valid-paths-bench.cc
+++ b/src/libstore-tests/register-valid-paths-bench.cc
@@ -22,7 +22,7 @@ static void BM_RegisterValidPathsDerivations(benchmark::State & state)
 
         auto tmpRoot = createTempDir();
         auto realStoreDir = tmpRoot / "nix/store";
-        std::filesystem::create_directories(realStoreDir);
+        createDirs(realStoreDir);
 
         std::shared_ptr<Store> store = openStore(fmt("local?root=%s", tmpRoot.string()));
         auto localStore = std::dynamic_pointer_cast<LocalStore>(store);

--- a/src/libutil-test-support/include/nix/util/tests/characterization.hh
+++ b/src/libutil-test-support/include/nix/util/tests/characterization.hh
@@ -60,7 +60,7 @@ struct CharacterizationTest : virtual ::testing::Test
         auto got = test();
 
         if (testAccept()) {
-            std::filesystem::create_directories(file.parent_path());
+            createDirs(file.parent_path());
             writeFile2(file, got);
             GTEST_SKIP() << "Updating golden master " << file;
         } else {

--- a/src/libutil-test-support/include/nix/util/tests/json-characterization.hh
+++ b/src/libutil-test-support/include/nix/util/tests/json-characterization.hh
@@ -73,7 +73,7 @@ void checkpointJson(CharacterizationTest & test, std::string_view testStem, cons
     json gotJson = static_cast<json>(got);
 
     if (testAccept()) {
-        std::filesystem::create_directories(file.parent_path());
+        createDirs(file.parent_path());
         writeFile(file, gotJson.dump(2) + "\n");
         ADD_FAILURE() << "Updating golden master " << file;
     } else {
@@ -98,7 +98,7 @@ void checkpointJson(CharacterizationTest & test, std::string_view testStem, cons
     json gotJson = static_cast<json>(*got);
 
     if (testAccept()) {
-        std::filesystem::create_directories(file.parent_path());
+        createDirs(file.parent_path());
         writeFile(file, gotJson.dump(2) + "\n");
         ADD_FAILURE() << "Updating golden master " << file;
     } else {

--- a/src/libutil-tests/source-accessor.cc
+++ b/src/libutil-tests/source-accessor.cc
@@ -138,6 +138,32 @@ TEST_F(FSSourceAccessorTest, works)
     }
 }
 
+TEST_F(FSSourceAccessorTest, invalidateCacheDropsStaleDirFds)
+{
+#ifdef _WIN32
+    GTEST_SKIP() << "fd-based accessor is Unix-only";
+#endif
+    auto accessor = makeFSSourceAccessor(tmpDir);
+
+    createDirs(tmpDir / "a" / "b");
+    writeFile(tmpDir / "a" / "b" / "f", "old");
+
+    EXPECT_TRUE(accessor->pathExists(CanonPath("a/b/f")));
+
+    deletePath(tmpDir / "a" / "b");
+    createDirs(tmpDir / "a" / "b");
+    writeFile(tmpDir / "a" / "b" / "g", "new");
+    createSymlink("g", tmpDir / "a" / "b" / "l");
+
+    accessor->invalidateCache();
+
+    EXPECT_FALSE(accessor->pathExists(CanonPath("a/b/f")));
+    EXPECT_TRUE(accessor->pathExists(CanonPath("a/b/g")));
+    EXPECT_THAT(accessor, HasContents(CanonPath("a/b/g"), "new"));
+    EXPECT_THAT(accessor, HasDirectory(CanonPath("a/b"), (std::set<std::string>{"g", "l"})));
+    EXPECT_THAT(accessor, HasSymlink(CanonPath("a/b/l"), "g"));
+}
+
 /* ----------------------------------------------------------------------------
  * RestoreSink non-directory at root (no dirFd)
  * --------------------------------------------------------------------------*/

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -393,7 +393,7 @@ void createDir(const std::filesystem::path & path, mode_t mode)
 void createDirs(const std::filesystem::path & path)
 {
     try {
-        std::filesystem::create_directories(path);
+        std::filesystem::create_directories(path); // NOLINT(bugprone-unsafe-functions)
     } catch (std::filesystem::filesystem_error & e) {
         throw SystemError(e.code(), "creating directory %1%", PathFmt(path));
     }

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -231,9 +231,10 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
     }
 
     /**
-     * Invalidate any cached value the accessor may have for the specified path.
+     * Drop any cached state that could go stale across external filesystem
+     * mutation (e.g. cached directory fds).
      */
-    virtual void invalidateCache(const CanonPath & path) {}
+    virtual void invalidateCache() {}
 };
 
 /**

--- a/src/libutil/mounted-source-accessor.cc
+++ b/src/libutil/mounted-source-accessor.cc
@@ -73,6 +73,11 @@ struct MountedSourceAccessorImpl : MountedSourceAccessor
         }
     }
 
+    void invalidateCache() override
+    {
+        mounts.visit_all([](auto & kv) { kv.second->invalidateCache(); });
+    }
+
     std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override
     {
         auto [accessor, subpath] = resolve(path);

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -238,9 +238,15 @@ public:
 
     ~PosixDirectorySourceAccessor()
     {
+        invalidateCache();
+    }
+
+    void invalidateCache() override
+    {
         if (dirFdCache) {
             auto cache = dirFdCache->lock();
             globalDirFdCount.fetch_sub(cache->size(), std::memory_order_relaxed);
+            cache->clear();
         }
     }
 

--- a/src/libutil/union-source-accessor.cc
+++ b/src/libutil/union-source-accessor.cc
@@ -69,6 +69,12 @@ struct UnionSourceAccessor : SourceAccessor
         return SourceAccessor::showPath(path);
     }
 
+    void invalidateCache() override
+    {
+        for (auto & accessor : accessors)
+            accessor->invalidateCache();
+    }
+
     std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override
     {
         for (auto & accessor : accessors) {


### PR DESCRIPTION
The dirfd cache can hold an fd to a directory that has since been removed and recreated; `*at()` through it then reports phantom ENOENT. In `nix repl`, after replacing a directory (e.g. `git checkout`) and `:r`, `pathExists` returns false / `readFile` errors for files that exist. Pre-#15718 returned the new content.

Repurpose the now-unused `invalidateCache()` virtual to clear the dirfd LRU and call it from `EvalState::resetFileCache()`, the existing "filesystem may have changed" hook used by `:l`/`:r`/`:e` and the C API.