### PR TITLE
repl: Make :reload robust against load failures

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -688,21 +688,19 @@ ProcessLineResult NixRepl::processLine(std::string line)
 
 void NixRepl::loadFile(const std::filesystem::path & path)
 {
-    loadedFiles.remove(path);
-    loadedFiles.push_back(path);
     Value v, v2;
     state->evalFile(lookupFileArg(*state, path.string()), v);
     state->autoCallFunction(*autoArgs, v, v2);
     addAttrsToScope(v2);
+    // Remember for :reload only on success.
+    loadedFiles.remove(path);
+    loadedFiles.push_back(path);
 }
 
 void NixRepl::loadFlake(const std::string & flakeRefS)
 {
     if (flakeRefS.empty())
         throw Error("cannot use ':load-flake' without a path specified. (Use '.' for the current working directory.)");
-
-    loadedFlakes.remove(flakeRefS);
-    loadedFlakes.push_back(flakeRefS);
 
     std::filesystem::path cwd;
     try {
@@ -730,6 +728,10 @@ void NixRepl::loadFlake(const std::string & flakeRefS)
             }),
         v);
     addAttrsToScope(v);
+
+    // Remember for :reload only on success.
+    loadedFlakes.remove(flakeRefS);
+    loadedFlakes.push_back(flakeRefS);
 }
 
 void NixRepl::initEnv()
@@ -772,28 +774,44 @@ void NixRepl::reloadFilesAndFlakes()
 
 void NixRepl::loadFiles()
 {
-    decltype(loadedFiles) old = loadedFiles;
-    loadedFiles.clear();
+    // loadFile() rebuilds loadedFiles; keep failed entries and continue.
+    decltype(loadedFiles) old;
+    std::swap(old, loadedFiles);
 
     for (auto & i : old) {
         notice("Loading %1%...", PathFmt(i));
-        loadFile(i);
+        try {
+            loadFile(i);
+        } catch (Error & e) {
+            loadedFiles.push_back(i);
+            printMsg(lvlError, e.msg());
+        }
     }
 
     for (auto & [i, what] : getValues()) {
         notice("Loading installable '%1%'...", what);
-        addAttrsToScope(*i);
+        try {
+            addAttrsToScope(*i);
+        } catch (Error & e) {
+            printMsg(lvlError, e.msg());
+        }
     }
 }
 
 void NixRepl::loadFlakes()
 {
-    Strings old = loadedFlakes;
-    loadedFlakes.clear();
+    // See loadFiles().
+    Strings old;
+    std::swap(old, loadedFlakes);
 
     for (auto & i : old) {
         notice("Loading flake '%1%'...", i);
-        loadFlake(i);
+        try {
+            loadFlake(i);
+        } catch (Error & e) {
+            loadedFlakes.push_back(i);
+            printMsg(lvlError, e.msg());
+        }
     }
 }
 

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1502,9 +1502,11 @@ ref<GitRepo> Settings::getTarballCache() const
 
 } // namespace fetchers
 
+static Sync<std::map<std::filesystem::path, GitRepo::WorkdirInfo>> workdirInfoCache_;
+
 GitRepo::WorkdirInfo GitRepo::getCachedWorkdirInfo(const std::filesystem::path & path)
 {
-    static Sync<std::map<std::filesystem::path, WorkdirInfo>> _cache;
+    auto & _cache = workdirInfoCache_;
     {
         auto cache(_cache.lock());
         auto i = cache->find(path);
@@ -1514,6 +1516,11 @@ GitRepo::WorkdirInfo GitRepo::getCachedWorkdirInfo(const std::filesystem::path &
     auto workdirInfo = GitRepo::openRepo(path, {})->getWorkdirInfo();
     _cache.lock()->emplace(path, workdirInfo);
     return workdirInfo;
+}
+
+void GitRepo::invalidateWorkdirInfoCache()
+{
+    workdirInfoCache_.lock()->clear();
 }
 
 bool isLegalRefName(const std::string & refName)

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -88,6 +88,9 @@ struct GitRepo
 
     static WorkdirInfo getCachedWorkdirInfo(const std::filesystem::path & path);
 
+    /* Drop all entries from the getCachedWorkdirInfo() cache. */
+    static void invalidateWorkdirInfoCache();
+
     /* Get the ref that HEAD points to. */
     virtual std::optional<std::string> getWorkdirRef() = 0;
 

--- a/src/libfetchers/input-cache.cc
+++ b/src/libfetchers/input-cache.cc
@@ -1,4 +1,5 @@
 #include "nix/fetchers/input-cache.hh"
+#include "nix/fetchers/git-utils.hh"
 #include "nix/fetchers/registry.hh"
 #include "nix/util/sync.hh"
 
@@ -65,6 +66,10 @@ struct InputCacheImpl : InputCache
     void clear() override
     {
         cache_.lock()->clear();
+        /* The workdir info cache has the same "per evaluation" lifetime
+           as the input cache, so flush it here as well so that e.g.
+           `:reload` in `nix repl` picks up changes in git work trees. */
+        GitRepo::invalidateWorkdirInfoCache();
     }
 };
 

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -281,6 +281,38 @@ exec 3>&- # Close fifo
 wait $repl_pid # Wait for process to finish
 grep -q "afterChange" repl_output
 
+# Regression: `:reload` on a flake loaded from a *git* work tree must pick up
+# uncommitted changes. Guards against the per-process workdir-info cache
+# pinning the tree to the rev seen on first load.
+if [[ $(type -p git) ]]; then
+    createGitRepo gitflake
+    cat > gitflake/flake.nix <<EOF
+{ outputs = { self }: { changingThing = "beforeChange"; }; }
+EOF
+    git -C gitflake add flake.nix
+    git -C gitflake commit -m init
+
+    rm -f repl_fifo repl_output
+    mkfifo repl_fifo
+    touch repl_output
+    nix repl ./gitflake --experimental-features 'flakes' < repl_fifo >> repl_output 2>&1 &
+    repl_pid=$!
+    exec 3>repl_fifo
+    echo "changingThing" >&3
+    for _ in $(seq 1 1000); do
+        grep -q "beforeChange" repl_output && break
+        sleep 0.1
+    done
+    grep -q "beforeChange" repl_output || fail "git flake didn't load"
+    sed -i 's/beforeChange/afterChange/' gitflake/flake.nix
+    echo ":reload" >&3
+    echo "changingThing" >&3
+    echo "exit" >&3
+    exec 3>&-
+    wait $repl_pid
+    grep -q "afterChange" repl_output || fail ":reload didn't pick up git work tree change"
+fi
+
 # Regression: a failed `:l` / `:lf` must not be remembered for `:reload`,
 # and an error in one loaded file must not drop later ones from the reload list.
 cat > reloadA.nix <<EOF

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -281,6 +281,30 @@ exec 3>&- # Close fifo
 wait $repl_pid # Wait for process to finish
 grep -q "afterChange" repl_output
 
+# Regression: a failed `:l` / `:lf` must not be remembered for `:reload`,
+# and an error in one loaded file must not drop later ones from the reload list.
+cat > reloadA.nix <<EOF
+{ fromA = 1; }
+EOF
+cat > reloadB.nix <<EOF
+{ fromB = 2; }
+EOF
+testReplResponseNoRegex '
+:l reloadA.nix
+:l ./does-not-exist.nix
+:l reloadB.nix
+:r
+fromA + fromB
+' '3'
+# Same for flakes.
+testReplResponseNoRegex '
+:lf ./does-not-exist-flake
+:lf ./flake
+:r
+foo
+' '1' \
+    --experimental-features 'flakes'
+
 # Test recursive printing and formatting
 # Normal output should print attributes in lexicographical order non-recursively
 testReplResponseNoRegex '


### PR DESCRIPTION
Previously a failing :l/:lf was recorded before evaluation, so a typo'd path or broken flake ref would be retried on every :reload. Worse, :reload cleared the file/flake lists up front and rebuilt them while iterating, so the first error aborted the loop and silently dropped all later entries (and skipped CLI installables and flakes entirely).

Record loaded files/flakes only after they actually load, and during reload catch errors per entry so one broken file no longer wipes out the rest of the session.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
