### PR TITLE
release: name artifact jobsets maintenance-X.Y-release

### DIFF
--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       eval_id:
-        description: "Hydra evaluation ID"
+        description: "Hydra evaluation ID (from the maintenance-X.Y-release jobset)"
         required: true
         type: number
       is_latest:

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -84,24 +84,27 @@ release:
 * Create two jobsets for the release branch on Hydra:
 
   `maintenance-$VERSION` runs the full `hydraJobs` CI matrix.
-  `release-$VERSION` builds only the artifacts consumed by
+  `maintenance-$VERSION-release` builds only the artifacts consumed by
   `upload-release`, so a release can be cut without waiting on the full
-  matrix.
+  matrix. The `-release` suffix keeps the pair adjacent in Hydra's
+  alphabetical jobset list and lets scripts derive one name from the
+  other.
 
   * Clone the previous `maintenance-*` jobset, set identifier
     `maintenance-$VERSION`, description `$VERSION release branch`, flake
     URL `github:NixOS/nix/$VERSION-maintenance`.
 
-  * Clone the previous `release-*` jobset (or create a new **legacy**
-    jobset), set identifier `release-$VERSION`, description `$VERSION
-    release artifacts`, Nix expression `packaging/release-jobs.nix` in
-    input `src`, and add input `src` of type *Git checkout* pointing at
+  * Clone the previous `maintenance-*-release` jobset (or create a new
+    **legacy** jobset), set identifier `maintenance-$VERSION-release`,
+    description `$VERSION release artifacts`, Nix expression
+    `packaging/release-jobs.nix` in input `src`, and add input `src` of
+    type *Git checkout* pointing at
     `https://github.com/NixOS/nix $VERSION-maintenance`.
 
-* Wait for the `release-$VERSION` jobset to evaluate and build. If
-  impatient, go to the evaluation and select `Actions -> Bump builds to
-  front of queue`. The aggregate job `release` turns green once every
-  required artifact is available.
+* Wait for the `maintenance-$VERSION-release` jobset to evaluate and
+  build. If impatient, go to the evaluation and select `Actions -> Bump
+  builds to front of queue`. The aggregate job `release` turns green
+  once every required artifact is available.
 
 * When the release jobset evaluation has succeeded building, take note of
   the evaluation ID (e.g. `1780832` in
@@ -177,8 +180,9 @@ release:
   $ git push
   ```
 
-* Wait for the desired evaluation of the `release-$VERSION` jobset to
-  finish building (the `release` aggregate job is the gating signal).
+* Wait for the desired evaluation of the `maintenance-XX.YY-release`
+  jobset to finish building (the `release` aggregate job is the gating
+  signal).
 
 * Tag the release
 

--- a/maintainers/upload-release.pl
+++ b/maintainers/upload-release.pl
@@ -64,7 +64,13 @@ my $evalInfo = decode_json(fetch($evalUrl, 'application/json'));
 #print Dumper($evalInfo);
 my $flakeUrl = $evalInfo->{flake};
 my $flakeInfo = decode_json(`nix flake metadata --json "$flakeUrl"` or die) if $flakeUrl;
-my $nixRev = ($flakeInfo ? $flakeInfo->{revision} : $evalInfo->{jobsetevalinputs}->{nix}->{revision}) or die;
+# Flake jobsets (`maintenance-X.Y`) expose the rev via the flake URL.
+# The release-artifacts jobset (`maintenance-X.Y-release`) is a legacy
+# jobset whose checkout is passed in as input `src`.
+my $nixRev = ($flakeInfo
+              ? $flakeInfo->{revision}
+              : $evalInfo->{jobsetevalinputs}->{src}->{revision}
+                // $evalInfo->{jobsetevalinputs}->{nix}->{revision}) or die;
 
 my $buildInfo = decode_json(fetch("$evalUrl/job/build.nix-everything.x86_64-linux", 'application/json'));
 #print Dumper($buildInfo);

--- a/packaging/release-jobs.nix
+++ b/packaging/release-jobs.nix
@@ -8,6 +8,7 @@
 # and share builds through the binary cache.
 #
 # Hydra jobset configuration:
+#   Identifier:      maintenance-<X.Y>-release
 #   Type:            Legacy
 #   Nix expression:  packaging/release-jobs.nix in input `src`
 #   Inputs:
@@ -36,7 +37,13 @@ let
     # `fallback-paths.nix` and (on x86_64-linux) the rendered manual via
     # its `doc` output.
     build.nix-everything = hydraJobs.build.nix-everything;
-    buildCross.nix-everything = hydraJobs.buildCross.nix-everything;
+    buildCross.nix-everything = {
+      # Only the cross targets that end up in `fallback-paths.nix`.
+      inherit (hydraJobs.buildCross.nix-everything)
+        riscv64-unknown-linux-gnu
+        x86_64-unknown-freebsd
+        ;
+    };
 
     inherit (hydraJobs)
       manual


### PR DESCRIPTION
Need to create those jobsets as well in hydra...

Suffixing the existing maintenance-X.Y identifier keeps the full-CI and release-artifact jobsets adjacent in Hydra's alphabetical list and lets tooling derive one name from the other, whereas a parallel release-X.Y namespace scatters the pair and leaves no obvious slot for master.

Teach upload-release.pl to read the git revision from the legacy `src` input so it works against evaluations of the new jobset, and trim buildCross in release-jobs.nix to the two targets fallback-paths.nix actually consumes so the artifact jobset stays minimal.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
