### PR TITLE
Fix failing hydra jobs, clean up std::filesystem harder

### DIFF
--- a/nix-meson-build-support/common/clang-tidy/.clang-tidy
+++ b/nix-meson-build-support/common/clang-tidy/.clang-tidy
@@ -92,3 +92,4 @@ CheckOptions:
   # Repurpose bugprone-unsafe-functions to lint functions that we'd want to wrap.
   bugprone-unsafe-functions.CustomFunctions: >
     ::std::filesystem::create_directories, nix::createDirs, "Use nix::createDirs (it wraps exceptions)";
+    ::std::filesystem::remove_all, nix::deletePath, "Use nix::deletePath (remove_all is not TOCTOU safe)";

--- a/src/libexpr-test-support/tests/value/context.cc
+++ b/src/libexpr-test-support/tests/value/context.cc
@@ -1,6 +1,4 @@
-#ifdef __APPLE__
-#  include <exception> // Needed by rapidcheck on Darwin
-#endif
+#include <exception> // IWYU pragma: keep (Needed by rapidcheck on Darwin and FreeBSD)
 #include <rapidcheck.h>
 
 #include "nix/expr/tests/value/context.hh"

--- a/src/libexpr-tests/derived-path.cc
+++ b/src/libexpr-tests/derived-path.cc
@@ -1,8 +1,6 @@
 #include <nlohmann/json.hpp>
 #include <gtest/gtest.h>
-#ifdef __APPLE__
-#  include <exception> // Needed by rapidcheck on Darwin
-#endif
+#include <exception> // IWYU pragma: keep (Needed by rapidcheck on Darwin and FreeBSD)
 #include <rapidcheck/gtest.h>
 
 #include "nix/store/tests/derived-path.hh"

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -226,7 +226,7 @@ static git_packbuilder_progress PACKBUILDER_PROGRESS_CHECK_INTERRUPT = &packBuil
 
 static void initRepoAtomically(std::filesystem::path & path, GitRepo::Options options)
 {
-    if (pathExists(path.string()))
+    if (pathExists(path))
         return;
 
     if (!options.create)
@@ -570,7 +570,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
         /* Get submodule info. */
         auto modulesFile = path / ".gitmodules";
-        if (pathExists(modulesFile.string()))
+        if (pathExists(modulesFile))
             info.submodules = parseSubmodules(modulesFile);
 
         return info;

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -1098,7 +1098,7 @@ struct GitInputScheme : InputScheme
                 for (auto & file : repoInfo.workdirInfo.dirtyFiles) {
                     writeString("modified:", hashSink);
                     writeString(file.abs(), hashSink);
-                    dumpPath((*repoPath / file.rel()).string(), hashSink);
+                    dumpPath(*repoPath / file.rel(), hashSink);
                 }
                 for (auto & file : repoInfo.workdirInfo.deletedFiles) {
                     writeString("deleted:", hashSink);

--- a/src/libstore-test-support/derived-path.cc
+++ b/src/libstore-test-support/derived-path.cc
@@ -1,7 +1,4 @@
-
-#ifdef __APPLE__
-#  include <exception> // Needed by rapidcheck on Darwin
-#endif
+#include <exception> // IWYU pragma: keep (Needed by rapidcheck on Darwin and FreeBSD)
 #include <rapidcheck.h>
 
 #include "nix/store/tests/derived-path.hh"

--- a/src/libstore-test-support/include/nix/store/tests/nix_api_store.hh
+++ b/src/libstore-test-support/include/nix/store/tests/nix_api_store.hh
@@ -22,13 +22,10 @@ public:
     };
 
     ~nix_api_store_test_base() override
-    {
-        if (exists(std::filesystem::path{nixDir})) {
-            for (auto & path : std::filesystem::recursive_directory_iterator(nixDir)) {
-                std::filesystem::permissions(path, std::filesystem::perms::owner_all);
-            }
-            std::filesystem::remove_all(nixDir);
-        }
+    try {
+        nix::deletePath(nixDir);
+    } catch (...) {
+        nix::ignoreExceptionInDestructor();
     }
 
     std::string nixDir;

--- a/src/libstore-test-support/include/nix/store/tests/outputs-spec.hh
+++ b/src/libstore-test-support/include/nix/store/tests/outputs-spec.hh
@@ -1,7 +1,7 @@
 #pragma once
 ///@file
 
-#include <exception> // Needed by rapidcheck on Darwin
+#include <exception> // IWYU pragma: keep (Needed by rapidcheck on Darwin and FreeBSD)
 #include <rapidcheck/gen/Arbitrary.h>
 
 #include "nix/store/outputs-spec.hh"

--- a/src/libstore-test-support/path.cc
+++ b/src/libstore-test-support/path.cc
@@ -1,6 +1,4 @@
-#ifdef __APPLE__
-#  include <exception> // Needed by rapidcheck on Darwin
-#endif
+#include <exception> // IWYU pragma: keep (Needed by rapidcheck on Darwin and FreeBSD)
 
 #include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck.h>

--- a/src/libstore-tests/register-valid-paths-bench.cc
+++ b/src/libstore-tests/register-valid-paths-bench.cc
@@ -66,7 +66,7 @@ static void BM_RegisterValidPathsDerivations(benchmark::State & state)
         state.PauseTiming();
         localStore.reset();
         store.reset();
-        std::filesystem::remove_all(tmpRoot);
+        deletePath(tmpRoot);
         state.ResumeTiming();
     }
 

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -262,7 +262,7 @@ LocalStore::VerificationResult LocalOverlayStore::verifyAllValidPaths(RepairFlag
     StorePathSet done;
 
     auto existsInStoreDir = [&](const StorePath & storePath) {
-        return pathExists((config->realStoreDir.get() / storePath.to_string()).string());
+        return pathExists(config->realStoreDir.get() / storePath.to_string());
     };
 
     bool errors = false;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1365,7 +1365,7 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
                 printError(
                     "link %s was modified! expected hash %s, got '%s'", PathFmt(link.path()), name.string(), hash);
                 if (repair) {
-                    std::filesystem::remove(link.path());
+                    unlinkIfExists(link.path());
                     printInfo("removed link %s", PathFmt(link.path()));
                 } else {
                     errors = true;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1207,7 +1207,7 @@ StorePath LocalStore::addToStoreFromDump(
         delTempDir = std::make_unique<AutoDelete>(tempDir);
         tempPath = tempDir / "x";
 
-        restorePath(tempPath.string(), bothSource, dumpMethod, localSettings.fsyncStorePaths);
+        restorePath(tempPath, bothSource, dumpMethod, localSettings.fsyncStorePaths);
 
         dumpBuffer.reset();
         dump = {};
@@ -1260,7 +1260,7 @@ StorePath LocalStore::addToStoreFromDump(
                 }
             } else {
                 /* Move the temporary path we restored above. */
-                moveFile(tempPath.string(), realPath);
+                moveFile(tempPath, realPath);
             }
 
             /* For computing the nar hash. In recursive SHA-256 mode, this
@@ -1311,7 +1311,7 @@ std::pair<std::filesystem::path, AutoCloseFD> LocalStore::createTempDirInStore()
             continue;
         }
         lockedByUs = lockFile(tmpDirFd.get(), ltWrite, true);
-    } while (!pathExists(tmpDirFn.string()) || !lockedByUs);
+    } while (!pathExists(tmpDirFn) || !lockedByUs);
     return {tmpDirFn, std::move(tmpDirFd)};
 }
 

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -164,7 +164,7 @@ void LocalStore::optimisePath_(
     std::filesystem::path linkPath = std::filesystem::path{linksDir} / hash.to_string(HashFormat::Nix32, false);
 
     /* Maybe delete the link, if it has been corrupted. */
-    if (std::filesystem::exists(std::filesystem::symlink_status(linkPath))) {
+    if (pathExists(linkPath)) {
         auto stLink = lstat(linkPath);
         if (st.st_size != stLink.st_size || (repair && hash != ({
                                                            hashPath(
@@ -178,11 +178,11 @@ void LocalStore::optimisePath_(
             warn(
                 "There may be more corrupted paths."
                 "\nYou should run `nix-store --verify --check-contents --repair` to fix them all");
-            std::filesystem::remove(linkPath);
+            unlinkIfExists(linkPath);
         }
     }
 
-    if (!std::filesystem::exists(std::filesystem::symlink_status(linkPath))) {
+    if (!pathExists(linkPath)) {
         /* Nope, create a hard link in the links directory. */
         try {
             std::filesystem::create_hard_link(path, linkPath);

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -7,6 +7,10 @@
 
 #include <cstdlib>
 #include <cstring>
+#ifdef __APPLE__
+#  include <regex>
+#endif
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -95,19 +95,10 @@ std::filesystem::path createGeneration(LocalFSStore & store, std::filesystem::pa
     return generation;
 }
 
-static void removeFile(const std::filesystem::path & path)
-{
-    try {
-        std::filesystem::remove(path);
-    } catch (std::filesystem::filesystem_error & e) {
-        throw SystemError(e.code(), "removing file %1%", PathFmt(path));
-    }
-}
-
 void deleteGeneration(const std::filesystem::path & profile, GenerationNumber gen)
 {
     std::filesystem::path generation = makeName(profile, gen);
-    removeFile(generation);
+    unlinkIfExists(generation);
 }
 
 /**

--- a/src/libutil-test-support/hash.cc
+++ b/src/libutil-test-support/hash.cc
@@ -1,6 +1,4 @@
-#ifdef __APPLE__
-#  include <exception> // Needed by rapidcheck on Darwin
-#endif
+#include <exception> // IWYU pragma: keep (Needed by rapidcheck on Darwin and FreeBSD)
 #include <rapidcheck.h>
 
 #include "nix/util/hash.hh"

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -257,20 +257,6 @@ TEST(pathExists, bogusPathDoesNotExist)
 }
 
 /* ----------------------------------------------------------------------------
- * makeParentCanonical
- * --------------------------------------------------------------------------*/
-
-TEST(makeParentCanonical, noParent)
-{
-    ASSERT_EQ(makeParentCanonical("file"), absPath(std::filesystem::path("file")));
-}
-
-TEST(makeParentCanonical, root)
-{
-    ASSERT_EQ(makeParentCanonical(FS_ROOT), FS_ROOT_NO_TRAILING_SLASH);
-}
-
-/* ----------------------------------------------------------------------------
  * chmodIfNeeded
  * --------------------------------------------------------------------------*/
 

--- a/src/libutil-tests/unix/file-system-at.cc
+++ b/src/libutil-tests/unix/file-system-at.cc
@@ -42,8 +42,6 @@ TEST(fchmodatTryNoFollow, works)
     auto dirFd = openDirectory(tmpDir, FinalSymlink::Follow);
     ASSERT_TRUE(dirFd);
 
-    struct ::stat st;
-
     using nix::testing::ThrowsSysError;
 
     /* Check that symlinks are not followed and targets are not changed.
@@ -82,22 +80,18 @@ TEST(fchmodatTryNoFollow, works)
     };
 
     expectSymlinkChmod("filelink", 0777);
-    ASSERT_EQ(stat((tmpDir / "file").c_str(), &st), 0);
-    EXPECT_EQ(st.st_mode & 0777, 0644);
+    ASSERT_EQ(stat(tmpDir / "file").st_mode & 0777, 0644);
 
     expectSymlinkChmod("dirlink", 0777);
-    ASSERT_EQ(stat((tmpDir / "dir").c_str(), &st), 0);
-    EXPECT_EQ(st.st_mode & 0777, 0755);
+    ASSERT_EQ(stat(tmpDir / "dir").st_mode & 0777, 0755);
 
     /* Check fchmodatTryNoFollow works on regular files and directories. */
 
     EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), CanonPath("file"), 0600));
-    ASSERT_EQ(stat((tmpDir / "file").c_str(), &st), 0);
-    EXPECT_EQ(st.st_mode & 0777, 0600);
+    ASSERT_EQ(stat(tmpDir / "file").st_mode & 0777, 0600);
 
     EXPECT_NO_THROW(fchmodatTryNoFollow(dirFd.get(), CanonPath("dir"), 0700));
-    ASSERT_EQ(stat((tmpDir / "dir").c_str(), &st), 0);
-    EXPECT_EQ(st.st_mode & 0777, 0700);
+    ASSERT_EQ(stat(tmpDir / "dir").st_mode & 0777, 0700);
 
     EXPECT_THAT([&] { fchmodatTryNoFollow(dirFd.get(), CanonPath("nonexistent"), 0600); }, ThrowsSysError(ENOENT));
 }

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -660,21 +660,6 @@ bool isExecutableFileAmbient(const std::filesystem::path & exe)
                   == 0;
 }
 
-std::filesystem::path makeParentCanonical(const std::filesystem::path & rawPath)
-{
-    std::filesystem::path path(absPath(rawPath));
-    try {
-        auto parent = path.parent_path();
-        if (parent == path) {
-            // `path` is a root directory => trivially canonical
-            return parent;
-        }
-        return std::filesystem::canonical(parent) / path.filename();
-    } catch (std::filesystem::filesystem_error & e) {
-        throw SystemError(e.code(), "canonicalising parent path of %1%", PathFmt(path));
-    }
-}
-
 void chmod(const std::filesystem::path & path, mode_t mode)
 {
     if (

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -679,6 +679,14 @@ void chmod(const std::filesystem::path & path, mode_t mode)
 #  define UNLINK_PROC ::unlink
 #endif
 
+void unlinkIfExists(const std::filesystem::path & path)
+{
+    if (UNLINK_PROC(path.c_str()) == -1) {
+        if (errno != ENOENT)
+            throw SysError("removing %s", PathFmt(path));
+    }
+}
+
 void unlink(const std::filesystem::path & path)
 {
     if (UNLINK_PROC(path.c_str()) == -1)

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -160,23 +160,6 @@ std::optional<PosixStat> maybeStat(const std::filesystem::path & path);
 bool pathExists(const std::filesystem::path & path);
 
 /**
- * Canonicalize a path except for the last component.
- *
- * This is useful for getting the canonical location of a symlink.
- *
- * Consider the case where `foo/l` is a symlink. `canonical("foo/l")` will
- * resolve the symlink `l` to its target.
- * `makeParentCanonical("foo/l")` will not resolve the symlink `l` to its target,
- * but does ensure that the returned parent part of the path, `foo` is resolved
- * to `canonical("foo")`, and can therefore be retrieved without traversing any
- * symlinks.
- *
- * If a relative path is passed, it will be made absolute, so that the parent
- * can always be canonicalized.
- */
-std::filesystem::path makeParentCanonical(const std::filesystem::path & path);
-
-/**
  * A version of pathExists that returns false on a permission error.
  * Useful for inferring default paths across directories that might not
  * be readable.

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -515,6 +515,13 @@ void chown(const std::filesystem::path & path, uid_t owner, gid_t group);
 void unlink(const std::filesystem::path & path);
 
 /**
+ * Remove a file, throwing an exception on error. ENOENT is ignored.
+ *
+ * @param path Path to the file to remove.
+ */
+void unlinkIfExists(const std::filesystem::path & path);
+
+/**
  * Try to remove a file, ignoring errors.
  *
  * @param path Path to the file to try to remove.

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -77,7 +77,7 @@ std::filesystem::path defaultTempDir()
 void deletePath(const std::filesystem::path & path)
 {
     std::error_code ec;
-    std::filesystem::remove_all(path, ec);
+    std::filesystem::remove_all(path, ec); // NOLINT(bugprone-unsafe-functions)
     if (ec && ec != std::errc::no_such_file_or_directory)
         throw SysError(ec.default_error_condition().value(), "recursively deleting %1%", PathFmt(path));
 }

--- a/src/nix/dump-path.cc
+++ b/src/nix/dump-path.cc
@@ -61,7 +61,7 @@ struct CmdDumpPath2 : Command
     void run() override
     {
         auto sink = getNarSink();
-        dumpPath(path.string(), sink);
+        dumpPath(path, sink);
         sink.flush();
     }
 };

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -125,7 +125,7 @@ struct ProfileManifest
         auto manifestPath = profile / "manifest.json";
 
         if (std::filesystem::exists(manifestPath)) {
-            auto json = nlohmann::json::parse(readFile(manifestPath.string()));
+            auto json = nlohmann::json::parse(readFile(manifestPath));
 
             auto version = json.value("version", 0);
             std::string sUrl;
@@ -248,13 +248,13 @@ struct ProfileManifest
             }
         }
 
-        buildProfile(tempDir.string(), std::move(pkgs));
+        buildProfile(tempDir, std::move(pkgs));
 
         writeFile(tempDir / "manifest.json", toJSON(*store).dump());
 
         /* Add the symlink tree to the store. */
         StringSink sink;
-        dumpPath(tempDir.string(), sink);
+        dumpPath(tempDir, sink);
 
         auto narHash = hashString(HashAlgorithm::SHA256, sink.s);
 

--- a/tests/functional/flakes/edit.sh
+++ b/tests/functional/flakes/edit.sh
@@ -9,4 +9,3 @@ nix edit "$flake1Dir#" | grepQuiet simple.builder.sh
 tar --exclude=".git*" -czf "$TEST_ROOT"/flake1Dir.tar.gz -C "$(dirname "$flake1Dir")" "$(basename "$flake1Dir")"
 # Test that editing a file from a tarball flake works and the file is readonly.
 nix edit "file://$TEST_ROOT/flake1Dir.tar.gz" | grepQuiet simple.builder.sh
-EDITOR='test ! -w' nix edit "file://$TEST_ROOT/flake1Dir.tar.gz"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

* Cleanups up redundant .string() calls in a bunch of places, now that the functions accept a `std::filesystem::path`.
* Fixes https://hydra.nixos.org/build/326607395/nixlog/1, https://hydra.nixos.org/build/326734471/nixlog/1 cc @lisanna-dettwyler. Header cleanup was too agressive.
* Fixes functional_root tests - writability check doesn't work with CAP_DAC_OVERRIDE.
* Bans `std::filesystem::remove_all` via a clang-tidy rule - we have `deletePath` instead.
* Replaces mistaken `std::filesystem::remove` where `unlink` is enough.
* `exists(symlink_status())` -> `pathExists`
* Removes now dead `makeParentCanonical`. 

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
