### PR TITLE
Dirfd accessor touchups

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1173,6 +1173,7 @@ void EvalState::resetFileCache()
     importResolutionCache->clear();
     fileEvalCache->clear();
     inputCache->clear();
+    lookupPathResolved->clear();
     positions.clear();
     rootFS->invalidateCache();
 }
@@ -3269,14 +3270,28 @@ SourcePath EvalState::findFile(const LookupPath & lookupPath, const std::string_
             continue;
         auto r = *rOpt;
 
-        auto res = (r / CanonPath(suffix)).resolveSymlinks();
-        if (res.pathExists())
+        auto suffixPath = CanonPath(suffix);
+        if (auto cachedRes = getConcurrent(*rOpt->resolvedPaths, suffixPath)) {
+            if (*cachedRes)
+                return **cachedRes;
+            else
+                // Cached negative lookup.
+                continue;
+        }
+
+        auto res = (r.path / suffixPath).resolveSymlinks();
+        if (res.pathExists()) {
+            r.resolvedPaths->emplace(suffixPath, res);
             return res;
+        }
 
         // Backward compatibility hack: throw an exception if access
         // to this path is not allowed.
         if (auto accessor = res.accessor.dynamic_pointer_cast<FilteringSourceAccessor>())
             accessor->checkAccess(res.path);
+
+        // Cache negative lookups too.
+        r.resolvedPaths->emplace(suffixPath, std::nullopt);
     }
 
     if (hasPrefix(path, "nix/"))
@@ -3290,17 +3305,22 @@ SourcePath EvalState::findFile(const LookupPath & lookupPath, const std::string_
         .debugThrow();
 }
 
-std::optional<SourcePath> EvalState::resolveLookupPathPath(const LookupPath::Path & value0, bool initAccessControl)
+std::shared_ptr<EvalState::LookupPathResolvedState>
+EvalState::resolveLookupPathPath(const LookupPath::Path & value0, bool initAccessControl)
 {
     auto & value = value0.s;
     if (auto cached = getConcurrent(*lookupPathResolved, value))
         return *cached;
 
-    auto finish = [&](std::optional<SourcePath> res) {
-        if (res)
-            debug("resolved search path element '%s' to '%s'", value, *res);
-        else
+    auto finish = [&](std::optional<SourcePath> maybePath) {
+        std::shared_ptr<LookupPathResolvedState> res;
+        if (maybePath) {
+            debug("resolved search path element '%s' to '%s'", value, *maybePath);
+            res = std::make_shared<LookupPathResolvedState>(
+                *maybePath, make_ref<decltype(LookupPathResolvedState::resolvedPaths)::element_type>());
+        } else {
             debug("failed to resolve search path element '%s'", value);
+        }
         lookupPathResolved->emplace(std::string(value), res);
         return res;
     };

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -277,6 +277,8 @@ EvalState::EvalState(
            mounted fetchTree. */
         auto accessor = settings.pureEval ? storeFS.cast<SourceAccessor>()
                                           : makeUnionSourceAccessor({getFSSourceAccessor(), storeFS});
+        /* Cache positive lstat/readlink results to speed up resolveSymlinks. */
+        accessor = makeCachingSourceAccessor(accessor);
 
         /* Apply access control if needed. */
         if (settings.restrictEval || settings.pureEval)

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -489,7 +489,15 @@ private:
 
     LookupPath lookupPath;
 
-    const ref<boost::concurrent_flat_map<std::string, std::optional<SourcePath>, StringViewHash, std::equal_to<>>>
+    struct LookupPathResolvedState
+    {
+        SourcePath path;
+        const ref<boost::concurrent_flat_map<CanonPath, std::optional<SourcePath>>> resolvedPaths;
+    };
+
+    const ref<
+        boost::
+            concurrent_flat_map<std::string, std::shared_ptr<LookupPathResolvedState>, StringViewHash, std::equal_to<>>>
         lookupPathResolved;
 
     /**
@@ -626,9 +634,10 @@ public:
      *
      * If the specified search path element is a URI, download it.
      *
-     * If it is not found, return `std::nullopt`.
+     * If it is not found, return `nullptr`.
      */
-    std::optional<SourcePath> resolveLookupPathPath(const LookupPath::Path & elem, bool initAccessControl = false);
+    std::shared_ptr<LookupPathResolvedState>
+    resolveLookupPathPath(const LookupPath::Path & elem, bool initAccessControl = false);
 
     /**
      * Evaluate an expression to normal form

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -74,6 +74,14 @@ struct LocalStoreAccessor : SourceAccessor
         return accessor->readDirectory(path);
     }
 
+    void readDirectory(
+        const CanonPath & dirPath,
+        std::function<void(SourceAccessor & subdirAccessor, const CanonPath & subdirRelPath)> callback) override
+    {
+        requireStoreObject(dirPath);
+        return accessor->readDirectory(dirPath, std::move(callback));
+    }
+
     void readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback) override
     {
         requireStoreObject(path);

--- a/src/libutil/caching-source-accessor.cc
+++ b/src/libutil/caching-source-accessor.cc
@@ -1,0 +1,102 @@
+#include "nix/util/source-accessor.hh"
+
+#include <boost/unordered/concurrent_flat_map.hpp>
+
+namespace nix {
+
+class CachingSourceAccessor : public SourceAccessor
+{
+    ref<SourceAccessor> next;
+
+    boost::concurrent_flat_map<CanonPath, Stat> lstatCache;
+    boost::concurrent_flat_map<CanonPath, std::string> readLinkCache;
+
+public:
+    CachingSourceAccessor(ref<SourceAccessor> next_)
+        : next(std::move(next_))
+    {
+        displayPrefix.clear();
+    }
+
+    void readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback) override
+    {
+        next->readFile(path, sink, sizeCallback);
+    }
+
+    std::optional<Stat> maybeLstat(const CanonPath & path) override
+    {
+        if (auto res = getConcurrent(lstatCache, path))
+            return *res;
+
+        auto st = next->maybeLstat(path);
+        if (!st)
+            return std::nullopt;
+
+        /* Never evict, the evaluator better keep positive lookups cached. */
+        lstatCache.emplace(path, *st);
+        return st;
+    }
+
+    Stat lstat(const CanonPath & path) override
+    {
+        if (auto res = getConcurrent(lstatCache, path))
+            return *res;
+
+        auto st = next->lstat(path);
+        /* Never evict, the evaluator better keep positive lookups cached. */
+        lstatCache.emplace(path, st);
+        return st;
+    }
+
+    DirEntries readDirectory(const CanonPath & path) override
+    {
+        return next->readDirectory(path);
+    }
+
+    void readDirectory(
+        const CanonPath & dirPath,
+        std::function<void(SourceAccessor & subdirAccessor, const CanonPath & subdirRelPath)> callback) override
+    {
+        return next->readDirectory(dirPath, std::move(callback));
+    }
+
+    std::string readLink(const CanonPath & path) override
+    {
+        if (auto res = getConcurrent(readLinkCache, path))
+            return *res;
+
+        auto target = next->readLink(path);
+        /* Never evict, the evaluator better keep positive lookups cached. */
+        readLinkCache.emplace(path, target);
+        return target;
+    }
+
+    std::string showPath(const CanonPath & path) override
+    {
+        return next->showPath(path);
+    }
+
+    void invalidateCache() override
+    {
+        lstatCache.clear();
+        readLinkCache.clear();
+        next->invalidateCache();
+    }
+
+    std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override
+    {
+        return next->getPhysicalPath(path);
+    }
+
+    std::pair<CanonPath, std::optional<std::string>> getFingerprint(const CanonPath & path) override
+    {
+        return next->getFingerprint(path);
+    }
+};
+
+ref<SourceAccessor> makeCachingSourceAccessor(ref<SourceAccessor> next)
+{
+    return make_ref<CachingSourceAccessor>(std::move(next));
+}
+
+} // namespace nix

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -288,4 +288,10 @@ ref<SourceAccessor> makeFSSourceAccessor(
  */
 ref<SourceAccessor> makeUnionSourceAccessor(std::vector<ref<SourceAccessor>> && accessors);
 
+/**
+ * Make a wrapper source accessor that caches positive lookup results.
+ * Useful for the evaluator which already assumes a mostly immutable view of the filesystem.
+ */
+ref<SourceAccessor> makeCachingSourceAccessor(ref<SourceAccessor> next);
+
 } // namespace nix

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -136,6 +136,7 @@ sources = [ config_priv_h ] + files(
   'base-n.cc',
   'base-nix-32.cc',
   'bump-memory-resource.cc',
+  'caching-source-accessor.cc',
   'canon-path.cc',
   'compression-algo.cc',
   'compression-settings.cc',

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -208,6 +208,13 @@ private:
     }
 
     /**
+     * Helper for opening the parent directory used for other FD-relative operations down the line.
+     * Also caches the resulting dirFd. Throws FileNotFound if some intermediate directory or the parent
+     * doesn't exist.
+     */
+    std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> openParentAndUpsert(const CanonPath & path, bool ignoreMissing);
+
+    /**
      * Get the parent directory of path. The second pair element might be an owning file descriptor
      * if path.parent().isRoot() is false.
      */
@@ -343,25 +350,39 @@ std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> PosixDirectorySourceAccessor
     }
 }
 
+std::pair<Descriptor, std::shared_ptr<AutoCloseFD>>
+PosixDirectorySourceAccessor::openParentAndUpsert(const CanonPath & path, bool ignoreMissing)
+{
+    auto [parentFd, parentFdOwning] = openParent(path);
+    if (parentFd == INVALID_DESCRIPTOR) {
+        if (errno == ENOENT || errno == ENOTDIR) /* Intermediate component might not exist. */ {
+            if (ignoreMissing)
+                return {INVALID_DESCRIPTOR, {}};
+            else
+                throw FileNotFound("path '%s' does not exist", showPath(path));
+        }
+        throw SysError("opening directory '%1%'", showPath(path.parent().value()));
+    }
+
+    if (dirFdCache && parentFdOwning) {
+        assert(*parentFdOwning);
+        insertIntoDirFdCache(path.parent().value(), ref<AutoCloseFD>(parentFdOwning));
+    }
+
+    return {parentFd, parentFdOwning};
+}
+
 std::optional<SourceAccessor::Stat> PosixDirectorySourceAccessor::maybeLstat(const CanonPath & path)
-try {
+{
     PosixStat st;
 
     if (path.isRoot()) {
         /* Must never fail - we already have the file descriptor for the directory. */
         st = nix::fstat(dirFd.get());
     } else {
-        auto [parentFd, parentFdOwning] = openParent(path);
-        if (parentFd == INVALID_DESCRIPTOR) {
-            if (errno == ENOENT || errno == ENOTDIR)
-                return std::nullopt;
-            throw SysError("opening directory '%1%'", showPath(path.parent().value()));
-        }
-
-        if (dirFdCache && parentFdOwning) {
-            assert(*parentFdOwning);
-            insertIntoDirFdCache(path.parent().value(), ref<AutoCloseFD>(parentFdOwning));
-        }
+        auto [parentFd, parentFdOwning] = openParentAndUpsert(path, /*ignoreMissing=*/true);
+        if (parentFd == INVALID_DESCRIPTOR)
+            return std::nullopt;
 
         /* We know that CanonPath returns a NUL-terminated string_view, so the use of ->data() here is safe. */
         if (::fstatat(parentFd, path.baseName()->data(), &st, AT_SYMLINK_NOFOLLOW) == -1) {
@@ -373,20 +394,26 @@ try {
 
     maybeUpdateMtime(st.st_mtime);
     return sourceAccessorStatFromPosixStat(st);
-} catch (SymlinkNotAllowed & e) {
-    throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
 }
 
 void PosixDirectorySourceAccessor::readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback)
-try {
+{
     if (path.isRoot())
         throw NotARegularFile("'%s' is not a regular file", showPath(path));
 
-    AutoCloseFD fileFd =
-        openFileEnsureBeneathNoSymlinks(dirFd.get(), path, O_RDONLY | O_CLOEXEC, /*mode=*/0, makeDirFdCallback());
+    /* TODO: We can do better when we have openat2. */
+    auto [parentFd, parentFdOwning] = openParentAndUpsert(path, /*ignoreMissing=*/false);
+    AutoCloseFD fileFd;
+
+    try {
+        fileFd = openFileEnsureBeneathNoSymlinks(parentFd, path.baseName().value(), O_RDONLY | O_CLOEXEC);
+    } catch (SymlinkNotAllowed & e) {
+        auto parent = path.parent().value();
+        throw SymlinkNotAllowed(parent / e.path, "path '%s' is a symlink", showPath(parent / e.path));
+    }
 
     if (!fileFd) {
-        if (errno == ENOENT || errno == ENOTDIR) /* Intermediate component might not exist. */
+        if (errno == ENOENT)
             throw FileNotFound("file '%s' does not exist", showPath(path));
         throw SysError("opening '%s'", showPath(path));
     }
@@ -397,12 +424,10 @@ try {
     PosixFileSourceAccessor fileAccessor(std::move(fileFd), fsPath / path.rel(), trackLastModified, st);
     maybeUpdateMtime(st.st_mtime);
     fileAccessor.readFile(CanonPath::root, sink, sizeCallback);
-} catch (SymlinkNotAllowed & e) {
-    throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
 }
 
 AutoCloseFD PosixDirectorySourceAccessor::openSubdirectory(const CanonPath & path)
-try {
+{
     AutoCloseFD dirFdOwning;
 
     if (path.isRoot()) {
@@ -411,8 +436,16 @@ try {
         if (!dirFdOwning)
             throw SysError("opening directory '%s'", showPath(path));
     } else {
-        dirFdOwning = openFileEnsureBeneathNoSymlinks(
-            dirFd.get(), path, O_DIRECTORY | O_RDONLY | O_CLOEXEC, /*mode=*/0, makeDirFdCallback());
+        /* TODO: We can do better when we have openat2. */
+        auto [parentFd, parentFdOwning] = openParentAndUpsert(path, /*ignoreMissing=*/false);
+
+        try {
+            dirFdOwning =
+                openFileEnsureBeneathNoSymlinks(parentFd, path.baseName().value(), O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+        } catch (SymlinkNotAllowed & e) {
+            auto parent = path.parent().value();
+            throw SymlinkNotAllowed(parent / e.path, "path '%s' is a symlink", showPath(parent / e.path));
+        }
 
         if (!dirFdOwning) {
             if (errno == ENOTDIR)
@@ -422,8 +455,6 @@ try {
     }
 
     return dirFdOwning;
-} catch (SymlinkNotAllowed & e) {
-    throw SymlinkNotAllowed(e.path, "path '%s' is a symlink", showPath(e.path));
 }
 
 SourceAccessor::DirEntries PosixDirectorySourceAccessor::readDirectory(const CanonPath & path)
@@ -497,17 +528,7 @@ try {
     if (path.isRoot())
         throw NotASymlink("file '%s' is not a symlink", showPath(path));
 
-    auto [parentFd, parentFdOwning] = openParent(path);
-    if (parentFd == INVALID_DESCRIPTOR) {
-        if (errno == ENOENT || errno == ENOTDIR)
-            throw FileNotFound("path '%s' does not exist", showPath(path));
-        throw SysError("opening directory '%1%'", showPath(path.parent().value()));
-    }
-
-    if (dirFdCache && parentFdOwning) {
-        assert(*parentFdOwning);
-        insertIntoDirFdCache(path.parent().value(), ref<AutoCloseFD>(parentFdOwning));
-    }
+    auto [parentFd, parentFdOwning] = openParentAndUpsert(path, /*ignoreMissing=*/false);
 
     try {
         return readLinkAt(parentFd, CanonPath(path.baseName().value()));

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -333,10 +333,14 @@ std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> PosixDirectorySourceAccessor
         }
     }
 
-    AutoCloseFD parentFdOwning =
-        openFileEnsureBeneathNoSymlinks(startFd, relPath, O_DIRECTORY | O_RDONLY | O_CLOEXEC, 0, std::move(cb));
-
-    return {parentFdOwning.get(), make_ref<AutoCloseFD>(std::move(parentFdOwning))};
+    try {
+        AutoCloseFD parentFdOwning =
+            openFileEnsureBeneathNoSymlinks(startFd, relPath, O_DIRECTORY | O_RDONLY | O_CLOEXEC, 0, std::move(cb));
+        return {parentFdOwning.get(), make_ref<AutoCloseFD>(std::move(parentFdOwning))};
+    } catch (SymlinkNotAllowed & e) {
+        /* Need to fixup the error message to include the actual path relative to the (possibly) cached fd. */
+        throw SymlinkNotAllowed(anchor / e.path, "path '%s' is a symlink", showPath(anchor / e.path));
+    }
 }
 
 std::optional<SourceAccessor::Stat> PosixDirectorySourceAccessor::maybeLstat(const CanonPath & path)

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -346,7 +346,7 @@ std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> PosixDirectorySourceAccessor
         return {parentFdOwning.get(), make_ref<AutoCloseFD>(std::move(parentFdOwning))};
     } catch (SymlinkNotAllowed & e) {
         /* Need to fixup the error message to include the actual path relative to the (possibly) cached fd. */
-        throw SymlinkNotAllowed(anchor / e.path, "path '%s' is a symlink", showPath(anchor / e.path));
+        throw SymlinkNotAllowed(anchor / e.path, "path '%s' (or its ancestor) is a symlink", showPath(anchor / e.path));
     }
 }
 
@@ -420,7 +420,7 @@ void PosixDirectorySourceAccessor::readFile(const CanonPath & path, Sink & sink,
 
     auto st = nix::fstat(fileFd.get());
     if (!S_ISREG(st.st_mode))
-        throw Error("file '%s' has an unsupported type", showPath(path));
+        throw NotARegularFile("file '%s' is not a regular file", showPath(path));
     PosixFileSourceAccessor fileAccessor(std::move(fileFd), fsPath / path.rel(), trackLastModified, st);
     maybeUpdateMtime(st.st_mtime);
     fileAccessor.readFile(CanonPath::root, sink, sizeCallback);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Improves the dirFd cache efficiency from https://github.com/NixOS/nix/pull/15718 and fixes some SymlinkNotAllowed error message issues I missed (first commit).
Also re-adds a caching accessor solely for the purposes of the evaluator, since resolveSymlinks() can do quite a bit of lookups. Note that this doesn't apply to the store layer, where we do care about not having a cache.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
