### PR TITLE
fix: allow for fallback when installable resolution fails

### DIFF
--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -6,6 +6,7 @@
 #include "nix/cmd/common-eval-args.hh"
 #include "nix/expr/eval-inline.hh"
 #include "nix/expr/eval.hh"
+#include "nix/expr/eval-error.hh"
 #include "nix/flake/flake.hh"
 #include "nix/expr/eval-cache.hh"
 
@@ -159,11 +160,16 @@ std::vector<ref<eval_cache::AttrCursor>> InstallableFlake::getCursors(EvalState 
     for (auto & attrPath : attrPaths) {
         debug("trying flake output attribute '%s'", attrPath);
 
-        auto attr = root->findAlongAttrPath(AttrPath::parse(state, attrPath));
-        if (attr) {
-            res.push_back(ref(*attr));
-        } else {
-            suggestions += attr.getSuggestions();
+        try {
+            auto attr = root->findAlongAttrPath(AttrPath::parse(state, attrPath));
+            if (attr) {
+                res.push_back(ref(*attr));
+            } else {
+                suggestions += attr.getSuggestions();
+            }
+        } catch (TypeError & e) {
+            debug("error resolving attribute '%s': %s", attrPath, e.msg());
+            // Continue to next attribute path
         }
     }
 

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -35,6 +35,7 @@ suites += {
     'old-lockfiles.sh',
     'trace-ifd.sh',
     'get-flake.sh',
+    'type-error-fallback.sh',
   ],
   'workdir' : meson.current_source_dir(),
 }

--- a/tests/functional/flakes/type-error-fallback.sh
+++ b/tests/functional/flakes/type-error-fallback.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+source ./common.sh
+
+# Test that attribute path resolution correctly handles TypeError fallback
+# when packages.*.foo is a string but legacyPackages.*.foo is an attrset
+
+flakeDir=$TEST_ROOT/type-error-fallback
+
+mkdir -p "$flakeDir"
+cat > "$flakeDir"/flake.nix <<EOF
+{
+    outputs = { self }: {
+        # packages.*.hello is a string (not a path, just a string value)
+        packages.$system.hello = "packages-hello";
+
+        # legacyPackages.*.hello is an attrset with .out
+        legacyPackages.$system.hello = {
+            type = "derivation";
+            out = "legacyPackages-hello-out";
+            outputName = "out";
+        };
+    };
+}
+EOF
+
+# Test 1: #hello should pick packages (the string)
+result=$(nix eval --impure --raw "$flakeDir#hello")
+[[ "$result" == "packages-hello" ]]
+
+# Test 2: #hello.out should fallback to legacyPackages after TypeError
+# (because packages.hello is a string, not an attrset with .out)
+result=$(nix eval --impure --raw "$flakeDir#hello.out")
+[[ "$result" == "legacyPackages-hello-out" ]]
+
+# Test 3: Explicitly accessing packages.*.hello.out should fail
+# (when directly specified, no fallback happens)
+expect 1 nix eval --impure "$flakeDir#packages.$system.hello.out" 2>&1 | \
+    grepQuiet "does not provide attribute"
+
+# Test 4: Explicitly accessing legacyPackages.*.hello.out should succeed
+result=$(nix eval --impure --raw "$flakeDir#legacyPackages.$system.hello.out")
+[[ "$result" == "legacyPackages-hello-out" ]]


### PR DESCRIPTION
## Motivation
```nix
{
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
  outputs = _: {
     packages.x86_64-linux.hello = _.nixpkgs.legacyPackages.x86_64-linux.hello.outPath;
     legacyPackages.x86_64-linux.hello = _.nixpkgs.legacyPackages.x86_64-linux.hello;
  };
}
```
```shell
$ nix build .#hello --print-out-paths
/nix/store/10s5j3mfdg22k1597x580qrhprnzcjwb-hello-2.12.3
$ nix build .#hello.out --print-out-paths
error: 'packages.x86_64-linux.hello' is not an attribute set
```

"hello.out" is not valid in the packages attrset, thus should be skipped during resolution

## Context

This comes up when there are scoped devShells or packages that are also exposed in legacyPackages with the same name. 