### PR TITLE
Add `--also-referrers` to `nix store delete`

### DIFF
--- a/doc/manual/rl-next/closure-gc.md
+++ b/doc/manual/rl-next/closure-gc.md
@@ -1,9 +1,8 @@
 ---
 synopsis: "Added `--skip-alive` option to `nix store delete` for collecting garbage within a closure"
 issues: 7239
-prs: 15236
+prs: [15236, 15727]
 ---
 
-`nix store delete --recursive --skip-alive` can be used to collect garbage
-within a closure, in which case it will only collect the dead paths that are
-part of the closure of its arguments.
+`nix store delete --recursive --skip-alive` can be used to collect garbage within a closure, in which case it will only collect the dead paths that are part of the closure of its arguments.
+The additional option `--also-referrers` is added to support this mode, which allows referrers of paths in the closure to also be deleted.

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -746,14 +746,17 @@ static void performOp(
     case WorkerProto::Op::CollectGarbage: {
         GCOptions options;
         options.action = WorkerProto::Serialise<GCOptions::GCAction>::read(*store, rconn);
-        if (rconn.version.features.contains(WorkerProto::featureDeleteDeadSpecific)) {
+        if (rconn.version.features.contains(WorkerProto::featureDeleteDeadSpecificReferrers)) {
             options.pathsToDelete = WorkerProto::Serialise<GCOptions::GCPaths>::read(*store, rconn);
         } else {
             auto paths = WorkerProto::Serialise<StorePathSet>::read(*store, rconn);
             if (options.action != GCAction::gcDeleteSpecific && paths.empty())
                 options.pathsToDelete = GCOptions::WholeStore{};
             else
-                options.pathsToDelete = paths;
+                options.pathsToDelete = GCOptions::SpecificPaths{
+                    .paths = paths,
+                    .deleteReferrers = false,
+                };
         }
         conn.from >> options.ignoreLiveness >> options.maxFreed;
         // obsolete fields
@@ -761,8 +764,9 @@ static void performOp(
         readInt(conn.from);
         readInt(conn.from);
 
-        if (options.action == GCAction::gcDeleteDead && std::holds_alternative<StorePathSet>(options.pathsToDelete)
-            && !conn.protoVersion.features.contains(WorkerProto::featureDeleteDeadSpecific)) {
+        if (options.action == GCAction::gcDeleteDead
+            && std::holds_alternative<GCOptions::SpecificPaths>(options.pathsToDelete)
+            && !conn.protoVersion.features.contains(WorkerProto::featureDeleteDeadSpecificReferrers)) {
             throw Error(
                 "Garbage collecting specific paths requested but it is not supported by the negotiated protocol");
         }

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -361,8 +361,11 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
     boost::unordered_flat_set<StorePath, std::hash<StorePath>> roots, dead, alive;
 
     /* Return early if nothing to delete */
-    if (std::holds_alternative<StorePathSet>(options.pathsToDelete)
-        && std::get<StorePathSet>(options.pathsToDelete).empty())
+    if (std::visit(
+            overloaded{
+                [](const GCOptions::SpecificPaths & pathsToDelete) { return pathsToDelete.paths.empty(); },
+                [](const GCOptions::WholeStore & _) { return false; }},
+            options.pathsToDelete))
         return;
 
     struct Shared
@@ -621,7 +624,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                                 includeOutputs = gcSettings.keepOutputs;
                                 includeDerivers = gcSettings.keepDerivations;
                             },
-                            [](const StorePathSet &) {},
+                            [](const GCOptions::SpecificPaths &) {},
                         },
                         options.pathsToDelete);
                     computeFSClosure(
@@ -642,14 +645,22 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 return markAlive();
             }
 
-            if (std::holds_alternative<StorePathSet>(options.pathsToDelete)
-                && !std::get<StorePathSet>(options.pathsToDelete).contains(*path)) {
-                debug(
-                    "cannot delete '%s' because '%s' is not in the specified paths to delete",
-                    printStorePath(start),
-                    printStorePath(*path));
+            if (std::visit(
+                    overloaded{
+                        [&](const GCOptions::SpecificPaths & pathsToDelete) {
+                            if (!pathsToDelete.deleteReferrers && !pathsToDelete.paths.contains(*path)) {
+                                debug(
+                                    "cannot delete '%s' because '%s' is not in the specified paths to delete",
+                                    printStorePath(start),
+                                    printStorePath(*path));
+                                return true;
+                            }
+                            return false;
+                        },
+                        [](const GCOptions::WholeStore & _) { return false; },
+                    },
+                    options.pathsToDelete))
                 return;
-            }
 
             {
                 auto hashPart = path->hashPart();
@@ -693,7 +704,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                                     enqueue(i);
                             }
                         },
-                        [](const StorePathSet &) {},
+                        [](const GCOptions::SpecificPaths &) {},
                     },
                     options.pathsToDelete);
             }
@@ -719,7 +730,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
         /* Either delete all garbage paths, or just the specified paths. */
         std::visit(
             overloaded{
-                [&](const StorePathSet & paths) {
+                [&](const GCOptions::SpecificPaths & pathsToDelete) {
                     switch (options.action) {
                     case GCOptions::gcDeleteDead:
                         printInfo("deleting garbage within specified paths...");
@@ -732,7 +743,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                         printInfo("determining live/dead paths...");
                     }
 
-                    for (auto & i : paths) {
+                    for (auto & i : pathsToDelete.paths) {
                         maybeDeleteReferrersClosure(i);
 
                         if (options.action == GCOptions::gcDeleteSpecific && !dead.contains(i))

--- a/src/libstore/include/nix/store/gc-store.hh
+++ b/src/libstore/include/nix/store/gc-store.hh
@@ -42,6 +42,16 @@ struct GCOptions
     struct WholeStore
     {};
 
+    struct SpecificPaths
+    {
+        StorePathSet paths;
+
+        /**
+         * Allow dead referrers of candidate paths to also be deleted.
+         */
+        bool deleteReferrers = false;
+    };
+
     GCAction action{gcDeleteDead};
 
     /**
@@ -55,7 +65,7 @@ struct GCOptions
     /**
      * The paths from which to delete.
      */
-    using GCPaths = std::variant<WholeStore, StorePathSet>;
+    using GCPaths = std::variant<WholeStore, SpecificPaths>;
     GCPaths pathsToDelete;
 
     /**

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -126,9 +126,9 @@ struct WorkerProto
     static constexpr std::string_view featureRealisationWithPath = "realisation-with-path-not-hash";
 
     /**
-     * Feature for garbage collecting a specific set of paths.
+     * Feature for garbage collecting a specific set of paths and deleting referrers.
      */
-    static constexpr std::string_view featureDeleteDeadSpecific = "delete-dead-specific";
+    static constexpr std::string_view featureDeleteDeadSpecificReferrers = "delete-dead-specific-referrers";
 
     /**
      * A unidirectional read connection, to be used by the read half of the
@@ -345,6 +345,10 @@ template<>
 DECLARE_WORKER_SERIALISER(std::optional<std::chrono::microseconds>);
 template<>
 DECLARE_WORKER_SERIALISER(WorkerProto::ClientHandshakeInfo);
+
+template<>
+DECLARE_WORKER_SERIALISER(GCOptions::SpecificPaths);
+
 template<>
 DECLARE_WORKER_SERIALISER(GCOptions::GCPaths);
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -686,18 +686,23 @@ void RemoteStore::collectGarbage(const GCOptions & options, GCResults & results)
 {
     auto conn(getConnection());
 
-    if (conn->protoVersion.features.contains(WorkerProto::featureDeleteDeadSpecific)) {
+    bool supportsDeleteSpecificReferrers =
+        conn->protoVersion.features.contains(WorkerProto::featureDeleteDeadSpecificReferrers);
+
+    if (supportsDeleteSpecificReferrers) {
         conn->to << WorkerProto::Op::CollectGarbage;
         WorkerProto::write(*this, *conn, options.action);
         WorkerProto::write(*this, *conn, options.pathsToDelete);
     } else {
         auto paths = std::visit(
             overloaded{
-                [&](const StorePathSet & paths) {
+                [&](const GCOptions::SpecificPaths & paths) {
                     if (options.action != GCOptions::gcDeleteSpecific)
                         throw Error(
                             "Your daemon version is too old to support garbage collecting a specific set of paths");
-                    return paths;
+                    if (paths.deleteReferrers)
+                        throw Error("Your daemon version is too old to support deleting referrers.");
+                    return paths.paths;
                 },
                 [](const GCOptions::WholeStore & _) { return StorePathSet{}; },
             },
@@ -706,6 +711,7 @@ void RemoteStore::collectGarbage(const GCOptions & options, GCResults & results)
         WorkerProto::write(*this, *conn, options.action);
         WorkerProto::write(*this, *conn, paths);
     }
+
     conn->to << options.ignoreLiveness
              << options.maxFreed
              /* removed options */

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -28,7 +28,7 @@ const WorkerProto::Version WorkerProto::latest = {
             std::string{
                 WorkerProto::featureRealisationWithPath,
             },
-            std::string{WorkerProto::featureDeleteDeadSpecific},
+            std::string{WorkerProto::featureDeleteDeadSpecificReferrers},
         },
 };
 
@@ -533,13 +533,29 @@ void WorkerProto::Serialise<Realisation>::write(const StoreDirConfig & store, Wr
     WorkerProto::write(store, conn, static_cast<const UnkeyedRealisation &>(info));
 }
 
+GCOptions::SpecificPaths
+WorkerProto::Serialise<GCOptions::SpecificPaths>::read(const StoreDirConfig & store, ReadConn conn)
+{
+    GCOptions::SpecificPaths paths;
+    paths.paths = WorkerProto::Serialise<StorePathSet>::read(store, conn);
+    conn.from >> paths.deleteReferrers;
+    return paths;
+}
+
+void WorkerProto::Serialise<GCOptions::SpecificPaths>::write(
+    const StoreDirConfig & store, WriteConn conn, const GCOptions::SpecificPaths & paths)
+{
+    WorkerProto::write(store, conn, paths.paths);
+    conn.to << paths.deleteReferrers;
+}
+
 GCOptions::GCPaths WorkerProto::Serialise<GCOptions::GCPaths>::read(const StoreDirConfig & store, ReadConn conn)
 {
     uint8_t wholeStore;
     conn.from >> wholeStore;
     switch (wholeStore) {
     case 0:
-        return WorkerProto::Serialise<StorePathSet>::read(store, conn);
+        return WorkerProto::Serialise<GCOptions::SpecificPaths>::read(store, conn);
     case 1:
         return GCOptions::WholeStore{};
     default:
@@ -552,7 +568,7 @@ void WorkerProto::Serialise<GCOptions::GCPaths>::write(
 {
     std::visit(
         overloaded{
-            [&](const StorePathSet paths) {
+            [&](const GCOptions::SpecificPaths paths) {
                 conn.to << uint8_t{0};
                 WorkerProto::write(store, conn, paths);
             },

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -727,7 +727,9 @@ static void opDelete(Strings opFlags, Strings opArgs)
     StorePathSet paths;
     for (auto & i : opArgs)
         paths.insert(store->followLinksToStorePath(i));
-    options.pathsToDelete = std::move(paths);
+    options.pathsToDelete = GCOptions::SpecificPaths{
+        .paths = std::move(paths),
+    };
 
     auto & gcStore = require<GcStore>(*store);
 

--- a/src/nix/store-delete.cc
+++ b/src/nix/store-delete.cc
@@ -9,6 +9,7 @@ namespace nix {
 struct CmdStoreDelete : StorePathsCommand
 {
     GCOptions options{.action = GCOptions::gcDeleteSpecific};
+    bool deleteReferrers = false;
 
     CmdStoreDelete()
     {
@@ -24,6 +25,12 @@ struct CmdStoreDelete : StorePathsCommand
             .description =
                 "Do not emit errors when attempting to delete something that is still alive, useful with --recursive.",
             .handler = {&options.action, GCOptions::gcDeleteDead},
+        });
+
+        addFlag({
+            .longName = "also-referrers",
+            .description = "Also allow deletion of any referrers of the specified paths.",
+            .handler = {&deleteReferrers, true},
         });
     }
 
@@ -46,7 +53,10 @@ struct CmdStoreDelete : StorePathsCommand
         StorePathSet paths;
         for (auto & path : storePaths)
             paths.insert(path);
-        options.pathsToDelete = std::move(paths);
+        options.pathsToDelete = GCOptions::SpecificPaths{
+            .paths = std::move(paths),
+            .deleteReferrers = deleteReferrers,
+        };
 
         GCResults results;
         Finally printer([&] { printFreed(false, results); });

--- a/src/nix/store-delete.md
+++ b/src/nix/store-delete.md
@@ -8,6 +8,18 @@ R""(
   # nix store delete /nix/store/fdhrijyv3670djsgprx596nn89iwlj2s-hello-2.10
   ```
 
+* Garbage collect a closure:
+
+  ```console
+  # nix store delete --recursive --skip-alive nixpkgs#hello
+  ```
+
+* Garbage collect a closure including dead referrers of the closure:
+
+  ```console
+  # nix store delete --recursive --skip-alive --also-referrers nixpkgs#hello
+  ```
+
 # Description
 
 This command deletes the store paths specified by [*installables*](./nix.md#installables),

--- a/tests/functional/dependencies2.nix
+++ b/tests/functional/dependencies2.nix
@@ -1,0 +1,39 @@
+with import ./config.nix;
+
+let
+
+  input0 = mkDerivation {
+    name = "dependencies-input-0";
+    buildCommand = "mkdir $out; echo foo > $out/bar";
+  };
+
+  input1 = mkDerivation {
+    name = "dependencies-input-1";
+    buildCommand = "mkdir $out; echo FOO > $out/foo";
+  };
+
+  input2 = mkDerivation {
+    name = "dependencies-input-2";
+    buildCommand = ''
+      mkdir $out
+      echo BAR > $out/bar
+      echo ${input0} > $out/input0
+      echo "$out" > $out2
+    '';
+    outputs = [
+      "out"
+      "out2"
+    ];
+  };
+
+in
+mkDerivation {
+  name = "dependencies-top";
+  builder = ./dependencies.builder0.sh + "/FOOBAR/../.";
+  input1 = input1 + "/.";
+  input2 = "${input2}/.";
+  input1_drv = input1;
+  input2_drv = input2;
+  input0_drv = input0;
+  meta.description = "Random test package";
+}

--- a/tests/functional/gc-closure.sh
+++ b/tests/functional/gc-closure.sh
@@ -5,25 +5,43 @@ source common.sh
 TODO_NixOS
 
 nix_gc_closure() {
+    ensureNoDeleteReferrer="${1}"
+    extraArg="${2:-""}"
     clearStore
-    nix build -f dependencies.nix input0_drv --out-link "$TEST_ROOT/gc-root"
+    nix build -f dependencies2.nix input0_drv --out-link "$TEST_ROOT/gc-root"
     input0=$(realpath "$TEST_ROOT/gc-root")
-    input1=$(nix build -f dependencies.nix input1_drv --no-link --print-out-paths)
-    input2=$(nix build -f dependencies.nix input2_drv --no-link --print-out-paths)
-    top=$(nix build -f dependencies.nix --no-link --print-out-paths)
-    somthing_else=$(nix store add-path ./dependencies.nix)
+    input1=$(nix build -f dependencies2.nix input1_drv --no-link --print-out-paths)
+    input2=$(nix build -f dependencies2.nix input2_drv --no-link --print-out-paths)
+    input2_out=$(printf "%s" "$input2" | head -n1)
+    input2_out2=$(printf "%s" "$input2" | tail -n1)
+    top=$(nix build -f dependencies2.nix --no-link --print-out-paths)
+    somthing_else=$(nix store add-path ./dependencies2.nix)
 
     if isDaemonNewer "2.35pre"; then
+        if [[ "$extraArg" != "--also-referrers" ]] && ! "$ensureNoDeleteReferrer"; then
+            nix store delete "$input2_out2"
+        fi
         # Check that nix store delete --recursive --skip-alive is best-effort (doesn't fail when some paths in the closure are alive)
-        nix store delete --recursive --skip-alive "$top"
+        # shellcheck disable=SC2086 # we want $extraArg to expand to nothing if unset
+        nix store delete --recursive --skip-alive $extraArg "$top"
         [[ ! -e "$top" ]] || fail "top should have been deleted"
         [[ -e "$input0" ]] || fail "input0 is a gc root, shouldn't have been deleted"
-        [[ ! -e "$input2" ]] || fail "input2 is not a gc root and is part of top's closure, it should have been deleted"
         [[ -e "$input1" ]] || fail "input1 is not in the closure of top, it shouldn't have been deleted"
         [[ -e "$somthing_else" ]] || fail "somthing_else is not in the closure of top, it shouldn't have been deleted"
+        if [[ "$extraArg" = "--also-referrers" ]]; then
+            [[ ! -e "$input2_out" ]] || fail "input2_out is part of top's closure and we can delete dead referrers, it should have been deleted"
+        elif "$ensureNoDeleteReferrer"; then
+            [[ -e "$input2_out" ]] || fail "input2_out is part of top's closure but we can't delete dead referrers, it shouldn't have been deleted"
+        else
+            [[ ! -e "$input2_out" ]] || fail "input2_out is not a gc root, is part of top's closure, and has no referrers, it should have been deleted"
+        fi
+    elif [[ "$extraArg" = "--also-referrers" ]]; then
+        expectStderr 1 nix store delete --recursive --also-referrers "$top" | grepQuiet "Your daemon version is too old to support deleting referrers"
     else
         expectStderr 1 nix store delete --recursive --skip-alive "$top" | grepQuiet "Your daemon version is too old to support garbage collecting a specific set of paths"
     fi
 }
 
-nix_gc_closure
+nix_gc_closure false
+nix_gc_closure true
+nix_gc_closure false --also-referrers


### PR DESCRIPTION
This makes deleting paths more ergonomic.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

If you build `hello` from scratch, it'll also build `glibc` and `glibc-static` (an output of glibc). `glibc-static` depends on `glibc`, but is not part of `hello`'s closure. This normally prevents deletion of `glibc`, but using this flag allows `glibc-static` to also be deleted as long as it is dead, allowing deletion of `glibc` as well.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Lix currently does this by default: https://git.lix.systems/lix-project/lix/issues/495

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
