### PR TITLE
Drop experimental-installer CI since it doesn't support custom tarbal…

### DIFF
--- a/.github/actions/install-nix-action/action.yaml
+++ b/.github/actions/install-nix-action/action.yaml
@@ -4,22 +4,12 @@ inputs:
   dogfood:
     description: "Whether to use Nix installed from the latest artifact from master branch"
     required: true # Be explicit about the fact that we are using unreleased artifacts
-  experimental-installer:
-    description: "Whether to use the experimental installer to install Nix"
-    default: false
-  experimental-installer-version:
-    description: "Version of the experimental installer to use. If `latest`, the newest artifact from the default branch is used."
-    # TODO: This should probably be pinned to a release after https://github.com/NixOS/experimental-nix-installer/pull/49 lands in one
-    default: "latest"
   extra_nix_config:
     description: "Gets appended to `/etc/nix/nix.conf` if passed."
   install_url:
     description: "URL of the Nix installer"
     required: false
     default: "https://releases.nixos.org/nix/nix-2.32.1/install"
-  tarball_url:
-    description: "URL of the Nix tarball to use with the experimental installer"
-    required: false
   github_token:
     description: "Github token"
     required: true
@@ -58,54 +48,6 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         DOGFOOD_REPO: "NixOS/nix"
-    - name: "Gather system info for experimental installer"
-      shell: bash
-      if: ${{ inputs.experimental-installer == 'true' }}
-      run: |
-        echo "::notice Using experimental installer from $EXPERIMENTAL_INSTALLER_REPO (https://github.com/$EXPERIMENTAL_INSTALLER_REPO)"
-
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          EXPERIMENTAL_INSTALLER_SYSTEM="linux"
-          echo "EXPERIMENTAL_INSTALLER_SYSTEM=$EXPERIMENTAL_INSTALLER_SYSTEM" >> "$GITHUB_ENV"
-        elif [ "$RUNNER_OS" == "macOS" ]; then
-          EXPERIMENTAL_INSTALLER_SYSTEM="darwin"
-          echo "EXPERIMENTAL_INSTALLER_SYSTEM=$EXPERIMENTAL_INSTALLER_SYSTEM" >> "$GITHUB_ENV"
-        else
-          echo "::error ::Unsupported RUNNER_OS: $RUNNER_OS"
-          exit 1
-        fi
-
-        if [ "$RUNNER_ARCH" == "X64" ]; then
-          EXPERIMENTAL_INSTALLER_ARCH=x86_64
-          echo "EXPERIMENTAL_INSTALLER_ARCH=$EXPERIMENTAL_INSTALLER_ARCH" >> "$GITHUB_ENV"
-        elif [ "$RUNNER_ARCH" == "ARM64" ]; then
-          EXPERIMENTAL_INSTALLER_ARCH=aarch64
-          echo "EXPERIMENTAL_INSTALLER_ARCH=$EXPERIMENTAL_INSTALLER_ARCH" >> "$GITHUB_ENV"
-        else
-          echo "::error ::Unsupported RUNNER_ARCH: $RUNNER_ARCH"
-          exit 1
-        fi
-
-        echo "EXPERIMENTAL_INSTALLER_ARTIFACT=nix-installer-$EXPERIMENTAL_INSTALLER_ARCH-$EXPERIMENTAL_INSTALLER_SYSTEM" >> "$GITHUB_ENV"
-      env:
-        EXPERIMENTAL_INSTALLER_REPO: "NixOS/experimental-nix-installer"
-    - name: "Download latest experimental installer"
-      shell: bash
-      id: download-latest-experimental-installer
-      if: ${{ inputs.experimental-installer == 'true' && inputs.experimental-installer-version == 'latest' }}
-      run: |
-        RUN_ID=$(gh run list --repo "$EXPERIMENTAL_INSTALLER_REPO" --workflow ci.yml --branch main --status success --json databaseId --jq ".[0].databaseId")
-
-        EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR="$GITHUB_WORKSPACE/$EXPERIMENTAL_INSTALLER_ARTIFACT"
-        mkdir -p "$EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR"
-
-        gh run download "$RUN_ID" --repo "$EXPERIMENTAL_INSTALLER_REPO" -n "$EXPERIMENTAL_INSTALLER_ARTIFACT" -D "$EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR"
-        # Executable permissions are lost in artifacts
-        find $EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR -type f -exec chmod +x {} +
-        echo "installer-path=$EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR" >> "$GITHUB_OUTPUT"
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
-        EXPERIMENTAL_INSTALLER_REPO: "NixOS/experimental-nix-installer"
     - uses: cachix/install-nix-action@c134e4c9e34bac6cab09cf239815f9339aaaf84e # v31.5.1
       if: ${{ inputs.experimental-installer != 'true' }}
       with:
@@ -113,12 +55,3 @@ runs:
         install_url: ${{ inputs.dogfood == 'true' && format('{0}/install', steps.download-nix-installer.outputs.installer-path) || inputs.install_url }}
         install_options: ${{ inputs.dogfood == 'true' && format('--tarball-url-prefix {0}', steps.download-nix-installer.outputs.installer-path) || '' }}
         extra_nix_config: ${{ inputs.extra_nix_config }}
-    - uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 # v20
-      if: ${{ inputs.experimental-installer == 'true' }}
-      with:
-        diagnostic-endpoint: ""
-        # TODO: It'd be nice to use `artifacts.nixos.org` for both of these, maybe through an `/experimental-installer/latest` endpoint? or `/commit/<hash>`?
-        local-root: ${{ inputs.experimental-installer-version == 'latest' && steps.download-latest-experimental-installer.outputs.installer-path || '' }}
-        source-url: ${{ inputs.experimental-installer-version != 'latest' && 'https://artifacts.nixos.org/experimental-installer/tag/${{ inputs.experimental-installer-version }}/${{ env.EXPERIMENTAL_INSTALLER_ARTIFACT }}' || '' }}
-        nix-package-url: ${{ inputs.dogfood == 'true' && steps.download-nix-installer.outputs.tarball-path || (inputs.tarball_url || '') }}
-        extra-conf: ${{ inputs.extra_nix_config }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,19 +164,9 @@ jobs:
           - scenario: on ubuntu
             runs-on: ubuntu-24.04
             os: linux
-            experimental-installer: false
           - scenario: on macos
             runs-on: macos-14
             os: darwin
-            experimental-installer: false
-          - scenario: on ubuntu (experimental)
-            runs-on: ubuntu-24.04
-            os: linux
-            experimental-installer: true
-          - scenario: on macos (experimental)
-            runs-on: macos-14
-            os: darwin
-            experimental-installer: true
     name: installer test ${{ matrix.scenario }}
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -193,17 +183,9 @@ jobs:
         TARBALL_PATH="$(find "$GITHUB_WORKSPACE/out" -name 'nix*.tar.xz' -print | head -n 1)"
         echo "tarball-path=file://$TARBALL_PATH" >> "$GITHUB_OUTPUT"
     - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
-      if: ${{ !matrix.experimental-installer }}
       with:
         install_url: ${{ format('{0}/install', steps.installer-tarball-url.outputs.installer-url) }}
         install_options: ${{ format('--tarball-url-prefix {0}', steps.installer-tarball-url.outputs.installer-url) }}
-    - uses: ./.github/actions/install-nix-action
-      if: ${{ matrix.experimental-installer }}
-      with:
-        dogfood: false
-        experimental-installer: true
-        tarball_url: ${{ steps.installer-tarball-url.outputs.tarball-path }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
     - run: sudo apt install fish zsh
       if: matrix.os == 'linux'
     - run: brew install fish


### PR DESCRIPTION
…ls anymore

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The artifacts are gone now + support for installing from a custom tarball anymore (NIX_INSTALLER_NIX_PACKAGE_URL/--nix-package-url have been dropped completely).

@Mic92, what's the way we could use the new installer in nix CI without rebuilding it? Using file:// URLs was pretty helpful for our testing I think.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
