### PR TITLE
Add new devShell interface to nix develop

### DIFF
--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -63,6 +63,7 @@
   - [Verifying Build Reproducibility](advanced-topics/diff-hook.md)
   - [Using the `post-build-hook`](advanced-topics/post-build-hook.md)
   - [Evaluation profiler](advanced-topics/eval-profiler.md)
+  - [Development Shells](advanced-topics/development-shells.md)
 - [Command Reference](command-ref/index.md)
   - [Common Options](command-ref/opt-common.md)
   - [Common Environment Variables](command-ref/env-common.md)

--- a/doc/manual/source/advanced-topics/development-shells.md
+++ b/doc/manual/source/advanced-topics/development-shells.md
@@ -1,0 +1,92 @@
+# Development Shells
+
+`nix develop` can be used to enter a development shell for a derivation. Any derivation providing a `.devShell` attribute or having the `__isDevShell = true` attribute can be used as the target for `nix develop`.
+
+You do not need `nix develop` to enter a derivation's development shell however. You can alternatively `nix run` a derivation's `.devShell` attribute, or manually run `bin/setup` from its default output.
+
+The development shell's `meta.mainProgram` attribute should always be set to "setup".
+
+## Structure
+
+A development shell is just a derivation which provides the following files in the default output:
+
+### `bin/setup`
+
+This should be an executable file which when run provides the full interactive development shell. This can be a shell script with a `#!/path/to/posix/shell --rcfile` shebang line, or any executable.
+
+It should be capable of consuming the following environment variables:
+
+#### `NIX_DEVSHELL_VERBOSE`
+
+If this variable is set, output additional debugging information. For example, a POSIX shell may respond to this by setting `set -x`.
+
+#### `NIX_DEVSHELL_PHASE`
+
+The name of the `stdenv` phase to execute, e.g. "build". See the `--phase` option of `nix develop`.
+
+#### `NIX_DEVSHELL_COMMAND`
+
+A command to execute in place of running an interactive shell, including space-separated arguments. Each component of the command (base command and arguments) will be single-quoted. For shell scripts, this should be passed as a quoted argument to `eval`.
+
+#### `NIX_DEVSHELL_PROMPT` / `NIX_DEVSHELL_PROMPT_PREFIX` / `NIX_DEVSHELL_PROMPT_SUFFIX`
+
+Used for customizing the interactive shell's prompt. A POSIX shell should use these to set the value of the `PS1` variable.
+
+### `env`
+
+`nix print-dev-env` will output this file verbatim. Its intention is to be a sourceable shell script that provides all of the shell variables and function definitions of a derivation's build environment.
+
+Nix does not internally use this file, so it is okay to customize it for custom use cases.
+
+### `env.json`
+
+`nix print-dev-env --json` will output this file verbatim. It should have the following structure:
+
+```json
+{
+    "bashFunctions": {
+        "<fnName>": "<implementation>"
+    },
+    "variables": {
+        "<name>": {
+            "type": "<variable type>",
+            "value": "<variable value>"
+        }
+    },
+    "structuredAttrs": {
+        ".attrs.sh": "<contents>",
+        ".attrs.json": "<contents>"
+    }
+}
+```
+
+A variable's `type` can be one of:
+- `exported`: corresponds to `declare -x`
+- `var`: corresponds to `declare --`
+- `array`: `corresponds to `declare -a`
+- `associative`: `corresponds to `declare -A`
+- `unknown` (no value attribute needed)
+
+For example:
+
+```json
+{
+    "bashFunctions": {
+        "_addRpathPrefix": " \n    if [ \"${NIX_NO_SELF_RPATH:-0}\" != 1 ]; then\n        export NIX_LDFLAGS=\"-rpath $1/lib ${NIX_LDFLAGS-}\";\n    fi\n"
+    },
+    "variables": {
+        "LD": {
+            "type": "exported",
+            "value": "ld"
+        },
+        "propagatedTargetDepFiles": {
+            "type": "array",
+            "value": [
+                "propagated-target-target-deps"
+            ]
+        },
+    }
+}
+```
+
+Nix does not internally use this structure, so it is okay to customize it for custom use cases.

--- a/doc/manual/source/advanced-topics/development-shells.md
+++ b/doc/manual/source/advanced-topics/development-shells.md
@@ -1,0 +1,97 @@
+# Development Shells
+
+This page is a deep dive into the expression interface behind [`nix develop`] and [`nix print-dev-env`].
+Visit those pages for an introduction and how to use development shells.
+
+## Discovery
+
+Any derivation providing a `.devShell` attribute or having the `__isDevShell = true` attribute can be used as the target for `nix develop`.
+You do not need `nix develop` to enter a derivation's development shell however. You can alternatively `nix run` a derivation's `.devShell` attribute, or manually run `bin/run-shell` from its default output.
+
+The development shell's `meta.mainProgram` attribute should always be set to "run-shell".
+
+## Structure
+
+A development shell is just a derivation which provides the following files in the default output:
+
+### `bin/run-shell`
+
+This should be an executable file which when run provides the full interactive development shell. This can be a shell script with a `#!/path/to/posix/shell --rcfile` shebang line, or any executable.
+
+It should be capable of consuming the following environment variables:
+
+#### `NIX_DEVSHELL_VERBOSE`
+
+If this variable is set, output additional debugging information. For example, a POSIX shell may respond to this by setting `set -x`.
+
+#### `NIX_DEVSHELL_PHASE`
+
+The name of the `stdenv` phase to execute, e.g. "build". See the `--phase` option of `nix develop`.
+
+#### `NIX_DEVSHELL_COMMAND`
+
+A command to execute in place of running an interactive shell, including space-separated arguments. Each component of the command (base command and arguments) will be single-quoted. For shell scripts, this should be passed as a quoted argument to `eval`.
+
+#### `NIX_DEVSHELL_PROMPT` / `NIX_DEVSHELL_PROMPT_PREFIX` / `NIX_DEVSHELL_PROMPT_SUFFIX`
+
+Used for customizing the interactive shell's prompt. A POSIX shell should use these to set the value of the `PS1` variable.
+
+### `env`
+
+`nix print-dev-env` will output this file verbatim. Its intention is to be a sourceable shell script that provides all of the shell variables and function definitions of a derivation's build environment.
+
+Nix does not internally use this file, so it is okay to customize it for custom use cases.
+
+### `env.json`
+
+`nix print-dev-env --json` will output this file verbatim.
+Conventionally it has following structure, but since Nix does not consume this file it can be customized:
+
+```json
+{
+    "bashFunctions": {
+        "<fnName>": "<implementation>"
+    },
+    "variables": {
+        "<name>": {
+            "type": "<variable type>",
+            "value": "<variable value>"
+        }
+    },
+    "structuredAttrs": {
+        ".attrs.sh": "<contents>",
+        ".attrs.json": "<contents>"
+    }
+}
+```
+
+A variable's `type` can be one of:
+- `exported`: corresponds to `declare -x`
+- `var`: corresponds to `declare --`
+- `array`: `corresponds to `declare -a`
+- `associative`: `corresponds to `declare -A`
+- `unknown` (no value attribute needed)
+
+For example:
+
+```json
+{
+    "bashFunctions": {
+        "_addRpathPrefix": " \n    if [ \"${NIX_NO_SELF_RPATH:-0}\" != 1 ]; then\n        export NIX_LDFLAGS=\"-rpath $1/lib ${NIX_LDFLAGS-}\";\n    fi\n"
+    },
+    "variables": {
+        "LD": {
+            "type": "exported",
+            "value": "ld"
+        },
+        "propagatedTargetDepFiles": {
+            "type": "array",
+            "value": [
+                "propagated-target-target-deps"
+            ]
+        },
+    }
+}
+```
+
+Nix does not internally use this structure, so it is okay to customize it for custom use cases.

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -226,7 +226,7 @@ struct StaticEvalSymbols
         line, column, functor, toString, right, wrong, structuredAttrs, json, allowedReferences, allowedRequisites,
         disallowedReferences, disallowedRequisites, maxSize, maxClosureSize, builder, args, contentAddressed, impure,
         outputHash, outputHashAlgo, outputHashMode, recurseForDerivations, description, self, epsilon, startSet,
-        operator_, key, path, prefix, outputSpecified;
+        operator_, key, path, prefix, outputSpecified, devShell, isDevShell;
 
     Expr::AstSymbols exprSymbols;
 
@@ -279,6 +279,8 @@ struct StaticEvalSymbols
             .path = alloc.create("path"),
             .prefix = alloc.create("prefix"),
             .outputSpecified = alloc.create("outputSpecified"),
+            .devShell = alloc.create("devShell"),
+            .isDevShell = alloc.create("__isDevShell"),
             .exprSymbols = {
                 .sub = alloc.create("__sub"),
                 .lessThan = alloc.create("__lessThan"),

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -264,7 +264,7 @@ struct StaticEvalSymbols
         line, column, functor, toString, right, wrong, structuredAttrs, json, allowedReferences, allowedRequisites,
         disallowedReferences, disallowedRequisites, maxSize, maxClosureSize, builder, args, contentAddressed, impure,
         outputHash, outputHashAlgo, outputHashMode, recurseForDerivations, description, self, epsilon, startSet,
-        operator_, key, path, prefix, outputSpecified, requiredSystemFeatures;
+        operator_, key, path, prefix, outputSpecified, requiredSystemFeatures, devShell, isDevShell;
 
     Expr::AstSymbols exprSymbols;
 
@@ -318,6 +318,8 @@ struct StaticEvalSymbols
             .prefix = alloc.create("prefix"),
             .outputSpecified = alloc.create("outputSpecified"),
             .requiredSystemFeatures = alloc.create("requiredSystemFeatures"),
+            .devShell = alloc.create("devShell"),
+            .isDevShell = alloc.create("__isDevShell"),
             .exprSymbols = {
                 .sub = alloc.create("__sub"),
                 .lessThan = alloc.create("__lessThan"),

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -1,4 +1,6 @@
 #include "nix/cmd/command.hh"
+#include "nix/cmd/installable-value.hh"
+#include "nix/expr/eval-cache.hh"
 #include "nix/util/config-global.hh"
 #include "nix/expr/eval.hh"
 #include "nix/cmd/installable-flake.hh"
@@ -9,6 +11,7 @@
 #include "nix/store/outputs-spec.hh"
 #include "nix/store/outputs-query.hh"
 #include "nix/store/derivations.hh"
+#include "nix/util/error.hh"
 
 #ifndef _WIN32 // TODO re-enable on Windows
 #  include "run.hh"
@@ -18,6 +21,7 @@
 #include <sstream>
 #include <nlohmann/json.hpp>
 #include <algorithm>
+#include <optional>
 
 #include "nix/util/strings.hh"
 
@@ -506,6 +510,57 @@ struct Common : InstallableCommand, MixProfile
             shellOutPath,
         };
     }
+
+    /**
+     * Checks if installable has a `.devShell` attribute, or is itself a devshell.
+     * @return A pair of: the StorePath of either or nullopt if neither, and the system.
+     */
+    std::pair<std::optional<StorePath>, std::string> maybeGetDevShell(ref<Store> store, ref<Installable> installable)
+    {
+        auto evalStore = getEvalStore();
+
+        std::string system;
+
+        auto state = getEvalState();
+        bool isDevShell = false;
+        std::optional<ref<eval_cache::AttrCursor>> cursor = std::nullopt;
+        try {
+            auto installableValue = InstallableValue::require(installable);
+            cursor = installableValue->getCursor(*state);
+            auto isDevShellAttr = (*cursor)->maybeGetAttr(state->s.isDevShell);
+            if (isDevShellAttr) {
+                isDevShell = isDevShellAttr->getBool();
+                system = (*cursor)->getAttr(state->s.system)->getString();
+            }
+        } catch (UsageError &) {
+            isDevShell = false;
+        }
+
+        std::optional<StorePath> devShell = std::nullopt;
+        if (isDevShell) {
+            devShell = Installable::toStorePath(evalStore, store, Realise::Outputs, OperateOn::Output, installable);
+        } else {
+            auto devShellAttr = cursor ? (*cursor)->maybeGetAttr(state->s.devShell) : nullptr;
+            if (devShellAttr) {
+                auto devShellDrvPath = devShellAttr->forceDerivation();
+                system = devShellAttr->getAttr(state->s.system)->getString();
+
+                store->buildPaths(
+                    {DerivedPath::Built{
+                        .drvPath = makeConstantStorePathRef(devShellDrvPath),
+                        .outputs = OutputsSpec::All{},
+                    }},
+                    bmNormal,
+                    evalStore);
+
+                auto path = deepQueryPartialDerivationOutput(*store, devShellDrvPath, "out", evalStore.get());
+                assert(path);
+                devShell = *path;
+            }
+        }
+
+        return {devShell, system};
+    }
 };
 
 struct CmdDevelop : Common, MixEnvironment
@@ -585,177 +640,236 @@ struct CmdDevelop : Common, MixEnvironment
 
     void run(ref<Store> store, ref<Installable> installable) override
     {
-        auto [buildEnvironment, gcroot] = getBuildEnvironment(store, installable);
-
-        auto [rcFileFd, rcFilePath] = createTempFile("nix-shell");
-
-        AutoDelete tmpDir(createTempDir("", "nix-develop"), true);
-
-        auto script = makeRcScript(store, buildEnvironment, tmpDir);
-
-        if (verbosity >= lvlDebug)
-            script += "set -x\n";
-
-        script += fmt("command rm -f '%s'\n", rcFilePath.string());
-
-        if (phase) {
-            if (!command.empty())
-                throw UsageError("you cannot use both '--command' and '--phase'");
-            // FIXME: foundMakefile is set by buildPhase, need to get
-            // rid of that.
-            script += fmt("foundMakefile=1\n");
-            script +=
-                fmt("if declare -f runPhase >/dev/null; then\n"
-                    "  runPhase %1%Phase\n"
-                    "else\n"
-                    "  runHook %1%Phase\n"
-                    "fi\n",
-                    *phase);
-        }
-
-        else if (!command.empty()) {
-            std::vector<std::string> args;
-            args.reserve(command.size());
-            for (const auto & s : command)
-                args.push_back(escapeShellArgAlways(s));
-            script += fmt("exec %s\n", concatStringsSep(" ", args));
-        }
-
-        else {
-            script = "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;\nshopt -u expand_aliases\n" + script
-                     + "\nshopt -s expand_aliases\n";
-            if (developSettings.bashPrompt != "")
-                script += fmt("[ -n \"$PS1\" ] && PS1=%s;\n", escapeShellArgAlways(developSettings.bashPrompt.get()));
-            if (developSettings.bashPromptPrefix != "")
-                script +=
-                    fmt("[ -n \"$PS1\" ] && PS1=%s\"$PS1\";\n",
-                        escapeShellArgAlways(developSettings.bashPromptPrefix.get()));
-            if (developSettings.bashPromptSuffix != "")
-                script +=
-                    fmt("[ -n \"$PS1\" ] && PS1+=%s;\n", escapeShellArgAlways(developSettings.bashPromptSuffix.get()));
-        }
+        std::filesystem::path program;
+        Strings args;
 
         setEnviron();
-        // prevent garbage collection until shell exits
-        setEnv("NIX_GCROOT", store->printStorePath(gcroot).c_str());
 
-        std::filesystem::path shell = "bash";
-        bool foundInteractive = false;
+        auto [devShell, devShellSystem] = maybeGetDevShell(store, installable);
 
-        try {
-            auto state = getEvalState();
+        std::string system;
+        AutoDelete tmpDir;
 
-            auto nixpkgsLockFlags = lockFlags;
-            nixpkgsLockFlags.inputOverrides = {};
-            nixpkgsLockFlags.inputUpdates = {};
+        if (devShell) {
+            // prevent garbage collection until shell exits
+            setEnv("NIX_GCROOT", store->printStorePath(*devShell).c_str());
 
-            auto nixpkgs = defaultNixpkgsFlakeRef();
-            if (auto * i = dynamic_cast<const InstallableFlake *>(&*installable))
-                nixpkgs = i->nixpkgsFlakeRef();
-
-            auto bashInstallable = make_ref<InstallableFlake>(
-                nullptr, //< Don't barf when the command is run with --arg/--argstr
-                state,
-                std::move(nixpkgs),
-                "bashInteractive",
-                ExtendedOutputsSpec::Default(),
-                Strings{},
-                Strings{"legacyPackages." + settings.thisSystem.get() + "."},
-                nixpkgsLockFlags);
-
-            for (auto & path : Installable::toStorePathSet(
-                     getEvalStore(), store, Realise::Outputs, OperateOn::Output, {bashInstallable})) {
-                auto s = store->printStorePath(path) + "/bin/bash";
-                if (pathExists(s)) {
-                    shell = s;
-                    foundInteractive = true;
-                    break;
+            if (verbosity >= lvlDebug)
+                setEnv("NIX_DEVSHELL_VERBOSE", "1");
+            if (phase) {
+                setEnv("NIX_DEVSHELL_PHASE", phase->c_str());
+                // Need to chdir since phases assume in flake directory
+                // chdir if installable is a flake of type git+file or path
+                auto installableFlake = installable.dynamic_pointer_cast<InstallableFlake>();
+                if (installableFlake) {
+                    auto sourcePath = installableFlake->getLockedFlake()->flake.resolvedRef.input.getSourcePath();
+                    if (sourcePath) {
+                        setEnv("NIX_DEVSHELL_PHASE_SRCPATH", sourcePath->c_str());
+                    }
                 }
+            } else if (!command.empty()) {
+                std::vector<std::string> args;
+                args.reserve(command.size());
+                for (const auto & s : command)
+                    args.push_back(escapeShellArgAlways(s));
+                setEnv("NIX_DEVSHELL_COMMAND", concatStringsSep(" ", args).c_str());
+            } else {
+                setEnv("NIX_DEVSHELL_PROMPT", developSettings.bashPrompt.get().c_str());
+                setEnv("NIX_DEVSHELL_PROMPT_PREFIX", developSettings.bashPromptPrefix.get().c_str());
+                setEnv("NIX_DEVSHELL_PROMPT_SUFFIX", developSettings.bashPromptSuffix.get().c_str());
             }
 
-            if (!foundInteractive)
-                throw Error("package 'nixpkgs#bashInteractive' does not provide a 'bin/bash'");
+            program = std::filesystem::path(store->printStorePath(*devShell)) / "bin" / "run-shell";
+            if (!std::filesystem::exists(program))
+                throw Error("%s's devShell does not provide bin/run-shell");
 
-        } catch (Error &) {
-            ignoreExceptionExceptInterrupt();
-        }
+            system = devShellSystem;
+        } else {
+            /* Legacy devshell path */
 
-        // Override SHELL with the one chosen for this environment.
-        // This is to make sure the system shell doesn't leak into the build environment.
-        setEnvOs(OS_STR("SHELL"), shell.c_str());
-        /* See: https://github.com/NixOS/nix/issues/5873
-           Format via .string() and not PathFmt intentionally. */
-        script += fmt("SHELL=\"%s\"\n", shell.string());
-        if (foundInteractive)
-            script += fmt("PATH=\"%s${PATH:+:$PATH}\"\n", std::filesystem::path(shell).parent_path().string());
-        writeFull(rcFileFd.get(), script);
+            auto [buildEnvironment, gcroot] = getBuildEnvironment(store, installable);
+
+            auto [rcFileFd, rcFilePath] = createTempFile("nix-shell");
+
+            tmpDir = createTempDir("", "nix-develop");
+
+            auto script = makeRcScript(store, buildEnvironment, tmpDir);
+
+            if (verbosity >= lvlDebug)
+                script += "set -x\n";
+
+            script += fmt("command rm -f '%s'\n", rcFilePath.string());
+
+            if (phase) {
+                if (!command.empty())
+                    throw UsageError("you cannot use both '--command' and '--phase'");
+                // FIXME: foundMakefile is set by buildPhase, need to get
+                // rid of that.
+                script += fmt("foundMakefile=1\n");
+                script += fmt("runHook %1%Phase\n", *phase);
+            }
+
+            else if (!command.empty()) {
+                std::vector<std::string> args;
+                args.reserve(command.size());
+                for (const auto & s : command)
+                    args.push_back(escapeShellArgAlways(s));
+                script += fmt("exec %s\n", concatStringsSep(" ", args));
+            }
+
+            else {
+                script = "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;\nshopt -u expand_aliases\n" + script
+                         + "\nshopt -s expand_aliases\n";
+                if (developSettings.bashPrompt != "")
+                    script +=
+                        fmt("[ -n \"$PS1\" ] && PS1=%s;\n", escapeShellArgAlways(developSettings.bashPrompt.get()));
+                if (developSettings.bashPromptPrefix != "")
+                    script +=
+                        fmt("[ -n \"$PS1\" ] && PS1=%s\"$PS1\";\n",
+                            escapeShellArgAlways(developSettings.bashPromptPrefix.get()));
+                if (developSettings.bashPromptSuffix != "")
+                    script += fmt(
+                        "[ -n \"$PS1\" ] && PS1+=%s;\n", escapeShellArgAlways(developSettings.bashPromptSuffix.get()));
+            }
+
+            // prevent garbage collection until shell exits
+            setEnv("NIX_GCROOT", store->printStorePath(gcroot).c_str());
+
+            std::filesystem::path shell = "bash";
+            bool foundInteractive = false;
+
+            try {
+                auto state = getEvalState();
+
+                auto nixpkgsLockFlags = lockFlags;
+                nixpkgsLockFlags.inputOverrides = {};
+                nixpkgsLockFlags.inputUpdates = {};
+
+                auto nixpkgs = defaultNixpkgsFlakeRef();
+                if (auto * i = dynamic_cast<const InstallableFlake *>(&*installable))
+                    nixpkgs = i->nixpkgsFlakeRef();
+
+                auto bashInstallable = make_ref<InstallableFlake>(
+                    nullptr, //< Don't barf when the command is run with --arg/--argstr
+                    state,
+                    std::move(nixpkgs),
+                    "bashInteractive",
+                    ExtendedOutputsSpec::Default(),
+                    Strings{},
+                    Strings{"legacyPackages." + settings.thisSystem.get() + "."},
+                    nixpkgsLockFlags);
+
+                for (auto & path : Installable::toStorePathSet(
+                         getEvalStore(), store, Realise::Outputs, OperateOn::Output, {bashInstallable})) {
+                    auto s = store->printStorePath(path) + "/bin/bash";
+                    if (pathExists(s)) {
+                        shell = s;
+                        foundInteractive = true;
+                        break;
+                    }
+                }
+
+                if (!foundInteractive)
+                    throw Error("package 'nixpkgs#bashInteractive' does not provide a 'bin/bash'");
+
+            } catch (Error &) {
+                ignoreExceptionExceptInterrupt();
+            }
+
+            program = shell;
+
+            // Override SHELL with the one chosen for this environment.
+            // This is to make sure the system shell doesn't leak into the build environment.
+            setEnvOs(OS_STR("SHELL"), shell.c_str());
+            /* See: https://github.com/NixOS/nix/issues/5873
+            Format via .string() and not PathFmt intentionally. */
+            script += fmt("SHELL=\"%s\"\n", shell.string());
+            if (foundInteractive)
+                script += fmt("PATH=\"%s${PATH:+:$PATH}\"\n", std::filesystem::path(shell).parent_path().string());
+            writeFull(rcFileFd.get(), script);
 
 #ifdef _WIN32 // TODO re-enable on Windows
-        throw UnimplementedError("Cannot yet spawn processes on Windows");
+            throw UnimplementedError("Cannot yet spawn processes on Windows");
 #else
-        // If running a phase or single command, don't want an interactive shell running after
-        // Ctrl-C, so don't pass --rcfile
-        auto args = phase || !command.empty() ? Strings{shell.filename().string(), rcFilePath}
-                                              : Strings{shell.filename().string(), "--rcfile", rcFilePath};
+            // If running a phase or single command, don't want an interactive shell running after
+            // Ctrl-C, so don't pass --rcfile
+            args = phase || !command.empty() ? Strings{shell.filename().string(), rcFilePath}
+                                             : Strings{shell.filename().string(), "--rcfile", rcFilePath};
 
-        // Need to chdir since phases assume in flake directory
-        if (phase) {
-            // chdir if installable is a flake of type git+file or path
-            auto installableFlake = installable.dynamic_pointer_cast<InstallableFlake>();
-            if (installableFlake) {
-                auto sourcePath = installableFlake->getLockedFlake()->flake.resolvedRef.input.getSourcePath();
-                if (sourcePath) {
-                    if (chdir(sourcePath->c_str()) == -1) {
-                        throw SysError("chdir to %s failed", PathFmt(*sourcePath));
+            // Need to chdir since phases assume in flake directory
+            if (phase) {
+                // chdir if installable is a flake of type git+file or path
+                auto installableFlake = installable.dynamic_pointer_cast<InstallableFlake>();
+                if (installableFlake) {
+                    auto sourcePath = installableFlake->getLockedFlake()->flake.resolvedRef.input.getSourcePath();
+                    if (sourcePath) {
+                        if (chdir(sourcePath->c_str()) == -1) {
+                            throw SysError("chdir to %s failed", PathFmt(*sourcePath));
+                        }
                     }
                 }
             }
+
+            system = buildEnvironment.getSystem();
         }
 
         // Release our references to eval caches to ensure they are persisted to disk, because
         // we are about to exec out of this process without running C++ destructors.
         getEvalState()->evalCaches.clear();
 
-        execProgramInStore(store, UseLookupPath::Use, shell, args, buildEnvironment.getSystem());
+        execProgramInStore(store, UseLookupPath::Use, program, args, system);
 #endif
-    }
-};
-
-struct CmdPrintDevEnv : Common, MixJSON
-{
-    std::string description() override
-    {
-        return "print shell code that can be sourced by bash to reproduce the build environment of a derivation";
-    }
-
-    std::string doc() override
-    {
-        return
-#include "print-dev-env.md"
-            ;
-    }
-
-    Category category() override
-    {
-        return catUtility;
-    }
-
-    void run(ref<Store> store, ref<Installable> installable) override
-    {
-        auto buildEnvironment = getBuildEnvironment(store, installable).first;
-
-        logger->stop();
-
-        if (json) {
-            printJSON(buildEnvironment.toJSON());
-        } else {
-            AutoDelete tmpDir(createTempDir("", "nix-dev-env"), true);
-            logger->writeToStdout(makeRcScript(store, buildEnvironment, tmpDir));
         }
-    }
-};
+    };
 
-static auto rCmdPrintDevEnv = registerCommand<CmdPrintDevEnv>("print-dev-env");
-static auto rCmdDevelop = registerCommand<CmdDevelop>("develop");
+    struct CmdPrintDevEnv : Common, MixJSON
+    {
+        std::string description() override
+        {
+            return "print shell code that can be sourced by bash to reproduce the build environment of a derivation";
+        }
+
+        std::string doc() override
+        {
+            return
+#include "print-dev-env.md"
+                ;
+        }
+
+        Category category() override
+        {
+            return catUtility;
+        }
+
+        void run(ref<Store> store, ref<Installable> installable) override
+        {
+            auto devShell = maybeGetDevShell(store, installable).first;
+
+            if (devShell) {
+                auto file = std::filesystem::path(store->printStorePath(*devShell)) / (json ? "env.json" : "env");
+                if (!std::filesystem::exists(file))
+                    throw Error("%s's devShell does not provide %s", installable->what(), file.filename().string());
+
+                logger->stop();
+                logger->writeToStdout(readFile(file));
+            } else {
+                /* Legacy devshell path*/
+
+                auto buildEnvironment = getBuildEnvironment(store, installable).first;
+
+                logger->stop();
+
+                if (json) {
+                    printJSON(buildEnvironment.toJSON());
+                } else {
+                    AutoDelete tmpDir(createTempDir("", "nix-dev-env"), true);
+                    logger->writeToStdout(makeRcScript(store, buildEnvironment, tmpDir));
+                }
+            }
+        }
+    };
+
+    static auto rCmdPrintDevEnv = registerCommand<CmdPrintDevEnv>("print-dev-env");
+    static auto rCmdDevelop = registerCommand<CmdDevelop>("develop");
 
 } // namespace nix

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -1,4 +1,6 @@
 #include "nix/cmd/command.hh"
+#include "nix/cmd/installable-value.hh"
+#include "nix/expr/eval-cache.hh"
 #include "nix/util/config-global.hh"
 #include "nix/expr/eval.hh"
 #include "nix/cmd/installable-flake.hh"
@@ -10,6 +12,8 @@
 #include "nix/store/outputs-spec.hh"
 #include "nix/store/outputs-query.hh"
 #include "nix/store/derivations.hh"
+#include "nix/util/error.hh"
+#include "nix/util/logging.hh"
 
 #ifndef _WIN32 // TODO re-enable on Windows
 #  include "run.hh"
@@ -19,6 +23,7 @@
 #include <sstream>
 #include <nlohmann/json.hpp>
 #include <algorithm>
+#include <optional>
 
 #include "nix/util/strings.hh"
 
@@ -506,6 +511,56 @@ struct Common : InstallableCommand, MixProfile
             shellOutPath,
         };
     }
+
+    /**
+     * Checks if installable has a `.devShell` attribute, or is itself a devshell.
+     * @return A pair of: the StorePath of either or nullopt if neither, and the system.
+     */
+    std::pair<std::optional<StorePath>, std::string> maybeGetDevShell(ref<Store> store, ref<Installable> installable)
+    {
+        auto evalStore = getEvalStore();
+
+        std::string system;
+
+        auto state = getEvalState();
+        bool isDevShell = false;
+        std::optional<ref<eval_cache::AttrCursor>> cursor = std::nullopt;
+        try {
+            auto installableValue = InstallableValue::require(installable);
+            cursor = installableValue->getCursor(*state, AutoCall::Yes);
+            auto isDevShellAttr = (*cursor)->maybeGetAttr(state->s.isDevShell);
+            if (isDevShellAttr) {
+                isDevShell = isDevShellAttr->getBool();
+                system = (*cursor)->getAttr(state->s.system)->getString();
+            }
+        } catch (UsageError &) {
+            isDevShell = false;
+        }
+
+        std::optional<StorePath> devShell = std::nullopt;
+        if (isDevShell) {
+            devShell = Installable::toStorePath(evalStore, store, Realise::Outputs, OperateOn::Output, installable);
+        } else {
+            auto devShellAttr = cursor ? (*cursor)->maybeGetAttr(state->s.devShell) : nullptr;
+            if (devShellAttr) {
+                auto devShellDrvPath = devShellAttr->forceDerivation();
+                system = devShellAttr->getAttr(state->s.system)->getString();
+
+                store->getBuilder(evalStore)->buildPaths(
+                    {DerivedPath::Built{
+                        .drvPath = makeConstantStorePathRef(devShellDrvPath),
+                        .outputs = OutputsSpec::All{},
+                    }},
+                    bmNormal);
+
+                auto path = deepQueryPartialDerivationOutput(*store, devShellDrvPath, "out", evalStore.get());
+                assert(path);
+                devShell = *path;
+            }
+        }
+
+        return {devShell, system};
+    }
 };
 
 struct CmdDevelop : Common, MixEnvironment
@@ -585,177 +640,239 @@ struct CmdDevelop : Common, MixEnvironment
 
     void run(ref<Store> store, ref<Installable> installable) override
     {
-        auto [buildEnvironment, gcroot] = getBuildEnvironment(store, installable);
-
-        auto [rcFileFd, rcFilePath] = createTempFile("nix-shell");
-
-        AutoDelete tmpDir(createTempDir("", "nix-develop"), true);
-
-        auto script = makeRcScript(store, buildEnvironment, tmpDir);
-
-        if (verbosity >= lvlDebug)
-            script += "set -x\n";
-
-        script += fmt("command rm -f '%s'\n", rcFilePath.string());
-
-        if (phase) {
-            if (!command.empty())
-                throw UsageError("you cannot use both '--command' and '--phase'");
-            // FIXME: foundMakefile is set by buildPhase, need to get
-            // rid of that.
-            script += fmt("foundMakefile=1\n");
-            script +=
-                fmt("if declare -f runPhase >/dev/null; then\n"
-                    "  runPhase %1%Phase\n"
-                    "else\n"
-                    "  runHook %1%Phase\n"
-                    "fi\n",
-                    *phase);
-        }
-
-        else if (!command.empty()) {
-            std::vector<std::string> args;
-            args.reserve(command.size());
-            for (const auto & s : command)
-                args.push_back(escapeShellArgAlways(s));
-            script += fmt("exec %s\n", concatStringsSep(" ", args));
-        }
-
-        else {
-            script = "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;\nshopt -u expand_aliases\n" + script
-                     + "\nshopt -s expand_aliases\n";
-            if (developSettings.bashPrompt != "")
-                script += fmt("[ -n \"$PS1\" ] && PS1=%s;\n", escapeShellArgAlways(developSettings.bashPrompt.get()));
-            if (developSettings.bashPromptPrefix != "")
-                script +=
-                    fmt("[ -n \"$PS1\" ] && PS1=%s\"$PS1\";\n",
-                        escapeShellArgAlways(developSettings.bashPromptPrefix.get()));
-            if (developSettings.bashPromptSuffix != "")
-                script +=
-                    fmt("[ -n \"$PS1\" ] && PS1+=%s;\n", escapeShellArgAlways(developSettings.bashPromptSuffix.get()));
-        }
+        std::filesystem::path program;
+        Strings args;
 
         setEnviron();
-        // prevent garbage collection until shell exits
-        setEnv("NIX_GCROOT", store->printStorePath(gcroot).c_str());
 
-        std::filesystem::path shell = "bash";
-        bool foundInteractive = false;
+        auto [devShell, devShellSystem] = maybeGetDevShell(store, installable);
 
-        try {
-            auto state = getEvalState();
+        std::string system;
+        AutoDelete tmpDir = createTempDir("", "nix-develop");
 
-            auto nixpkgsLockFlags = lockFlags;
-            nixpkgsLockFlags.inputOverrides = {};
-            nixpkgsLockFlags.inputUpdates = {};
+        if (devShell) {
+            // prevent garbage collection until shell exits
+            setEnv("NIX_GCROOT", store->printStorePath(*devShell).c_str());
 
-            auto nixpkgs = defaultNixpkgsFlakeRef();
-            if (auto * i = dynamic_cast<const InstallableFlake *>(&*installable))
-                nixpkgs = i->nixpkgsFlakeRef();
+            setEnv("NIX_BUILD_TOP", tmpDir.path().c_str());
 
-            auto bashInstallable = make_ref<InstallableFlake>(
-                nullptr, //< Don't barf when the command is run with --arg/--argstr
-                state,
-                std::move(nixpkgs),
-                "bashInteractive",
-                ExtendedOutputsSpec::Default(),
-                Strings{},
-                Strings{"legacyPackages." + settings.thisSystem.get() + "."},
-                nixpkgsLockFlags);
-
-            for (auto & path : Installable::toStorePathSet(
-                     getEvalStore(), store, Realise::Outputs, OperateOn::Output, {bashInstallable})) {
-                auto s = store->printStorePath(path) + "/bin/bash";
-                if (pathExists(s)) {
-                    shell = s;
-                    foundInteractive = true;
-                    break;
+            if (verbosity >= lvlDebug)
+                setEnv("NIX_DEVSHELL_VERBOSE", "1");
+            if (phase) {
+                setEnv("NIX_DEVSHELL_PHASE", phase->c_str());
+                // Need to chdir since phases assume in flake directory
+                // chdir if installable is a flake of type git+file or path
+                auto installableFlake = installable.dynamic_pointer_cast<InstallableFlake>();
+                if (installableFlake) {
+                    auto sourcePath = installableFlake->getLockedFlake()->flake.resolvedRef.input.getSourcePath();
+                    if (sourcePath) {
+                        setEnv("NIX_DEVSHELL_PHASE_SRCPATH", sourcePath->c_str());
+                    }
                 }
+            } else if (!command.empty()) {
+                std::vector<std::string> args;
+                args.reserve(command.size());
+                for (const auto & s : command)
+                    args.push_back(escapeShellArgAlways(s));
+                setEnv("NIX_DEVSHELL_COMMAND", concatStringsSep(" ", args).c_str());
+            } else {
+                setEnv("NIX_DEVSHELL_PROMPT", developSettings.bashPrompt.get().c_str());
+                setEnv("NIX_DEVSHELL_PROMPT_PREFIX", developSettings.bashPromptPrefix.get().c_str());
+                setEnv("NIX_DEVSHELL_PROMPT_SUFFIX", developSettings.bashPromptSuffix.get().c_str());
             }
 
-            if (!foundInteractive)
-                throw Error("package 'nixpkgs#bashInteractive' does not provide a 'bin/bash'");
+            program = std::filesystem::path(store->printStorePath(*devShell)) / "bin" / "run-shell";
+            if (!std::filesystem::exists(program))
+                throw Error("%s's devShell does not provide bin/run-shell");
 
-        } catch (Error &) {
-            ignoreExceptionExceptInterrupt();
-        }
+            system = devShellSystem;
+        } else {
+            /* Legacy devshell path */
 
-        // Override SHELL with the one chosen for this environment.
-        // This is to make sure the system shell doesn't leak into the build environment.
-        setEnvOs(OS_STR("SHELL"), shell.c_str());
-        /* See: https://github.com/NixOS/nix/issues/5873
-           Format via .string() and not PathFmt intentionally. */
-        script += fmt("SHELL=\"%s\"\n", shell.string());
-        if (foundInteractive)
-            script += fmt("PATH=\"%s${PATH:+:$PATH}\"\n", std::filesystem::path(shell).parent_path().string());
-        writeFull(rcFileFd.get(), script);
+            printInfo(
+                "provided installable does not have a `devShell` attribute and `__isDevShell` is not set to true, falling back to legacy shell generation");
+
+            auto [buildEnvironment, gcroot] = getBuildEnvironment(store, installable);
+
+            auto [rcFileFd, rcFilePath] = createTempFile("nix-shell");
+
+            auto script = makeRcScript(store, buildEnvironment, tmpDir);
+
+            if (verbosity >= lvlDebug)
+                script += "set -x\n";
+
+            script += fmt("command rm -f '%s'\n", rcFilePath.string());
+
+            if (phase) {
+                if (!command.empty())
+                    throw UsageError("you cannot use both '--command' and '--phase'");
+                // FIXME: foundMakefile is set by buildPhase, need to get
+                // rid of that.
+                script += fmt("foundMakefile=1\n");
+                script += fmt("runHook %1%Phase\n", *phase);
+            }
+
+            else if (!command.empty()) {
+                std::vector<std::string> args;
+                args.reserve(command.size());
+                for (const auto & s : command)
+                    args.push_back(escapeShellArgAlways(s));
+                script += fmt("exec %s\n", concatStringsSep(" ", args));
+            }
+
+            else {
+                script = "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;\nshopt -u expand_aliases\n" + script
+                         + "\nshopt -s expand_aliases\n";
+                if (developSettings.bashPrompt != "")
+                    script +=
+                        fmt("[ -n \"$PS1\" ] && PS1=%s;\n", escapeShellArgAlways(developSettings.bashPrompt.get()));
+                if (developSettings.bashPromptPrefix != "")
+                    script +=
+                        fmt("[ -n \"$PS1\" ] && PS1=%s\"$PS1\";\n",
+                            escapeShellArgAlways(developSettings.bashPromptPrefix.get()));
+                if (developSettings.bashPromptSuffix != "")
+                    script += fmt(
+                        "[ -n \"$PS1\" ] && PS1+=%s;\n", escapeShellArgAlways(developSettings.bashPromptSuffix.get()));
+            }
+
+            // prevent garbage collection until shell exits
+            setEnv("NIX_GCROOT", store->printStorePath(gcroot).c_str());
+
+            std::filesystem::path shell = "bash";
+            bool foundInteractive = false;
+
+            try {
+                auto state = getEvalState();
+
+                auto nixpkgsLockFlags = lockFlags;
+                nixpkgsLockFlags.inputOverrides = {};
+                nixpkgsLockFlags.inputUpdates = {};
+
+                auto nixpkgs = defaultNixpkgsFlakeRef();
+                if (auto * i = dynamic_cast<const InstallableFlake *>(&*installable))
+                    nixpkgs = i->nixpkgsFlakeRef();
+
+                auto bashInstallable = make_ref<InstallableFlake>(
+                    nullptr, //< Don't barf when the command is run with --arg/--argstr
+                    state,
+                    std::move(nixpkgs),
+                    "bashInteractive",
+                    ExtendedOutputsSpec::Default(),
+                    Strings{},
+                    Strings{"legacyPackages." + settings.thisSystem.get() + "."},
+                    nixpkgsLockFlags);
+
+                for (auto & path : Installable::toStorePathSet(
+                         getEvalStore(), store, Realise::Outputs, OperateOn::Output, {bashInstallable})) {
+                    auto s = store->printStorePath(path) + "/bin/bash";
+                    if (pathExists(s)) {
+                        shell = s;
+                        foundInteractive = true;
+                        break;
+                    }
+                }
+
+                if (!foundInteractive)
+                    throw Error("package 'nixpkgs#bashInteractive' does not provide a 'bin/bash'");
+
+            } catch (Error &) {
+                ignoreExceptionExceptInterrupt();
+            }
+
+            program = shell;
+
+            // Override SHELL with the one chosen for this environment.
+            // This is to make sure the system shell doesn't leak into the build environment.
+            setEnvOs(OS_STR("SHELL"), shell.c_str());
+            /* See: https://github.com/NixOS/nix/issues/5873
+            Format via .string() and not PathFmt intentionally. */
+            script += fmt("SHELL=\"%s\"\n", shell.string());
+            if (foundInteractive)
+                script += fmt("PATH=\"%s${PATH:+:$PATH}\"\n", std::filesystem::path(shell).parent_path().string());
+            writeFull(rcFileFd.get(), script);
 
 #ifdef _WIN32 // TODO re-enable on Windows
-        throw UnimplementedError("Cannot yet spawn processes on Windows");
+            throw UnimplementedError("Cannot yet spawn processes on Windows");
 #else
-        // If running a phase or single command, don't want an interactive shell running after
-        // Ctrl-C, so don't pass --rcfile
-        auto args = phase || !command.empty() ? Strings{shell.filename().string(), rcFilePath}
-                                              : Strings{shell.filename().string(), "--rcfile", rcFilePath};
+            // If running a phase or single command, don't want an interactive shell running after
+            // Ctrl-C, so don't pass --rcfile
+            args = phase || !command.empty() ? Strings{shell.filename().string(), rcFilePath}
+                                             : Strings{shell.filename().string(), "--rcfile", rcFilePath};
 
-        // Need to chdir since phases assume in flake directory
-        if (phase) {
-            // chdir if installable is a flake of type git+file or path
-            auto installableFlake = installable.dynamic_pointer_cast<InstallableFlake>();
-            if (installableFlake) {
-                auto sourcePath = installableFlake->getLockedFlake()->flake.resolvedRef.input.getSourcePath();
-                if (sourcePath) {
-                    if (chdir(sourcePath->c_str()) == -1) {
-                        throw SysError("chdir to %s failed", PathFmt(*sourcePath));
+            // Need to chdir since phases assume in flake directory
+            if (phase) {
+                // chdir if installable is a flake of type git+file or path
+                auto installableFlake = installable.dynamic_pointer_cast<InstallableFlake>();
+                if (installableFlake) {
+                    auto sourcePath = installableFlake->getLockedFlake()->flake.resolvedRef.input.getSourcePath();
+                    if (sourcePath) {
+                        if (chdir(sourcePath->c_str()) == -1) {
+                            throw SysError("chdir to %s failed", PathFmt(*sourcePath));
+                        }
                     }
                 }
             }
+
+            system = buildEnvironment.getSystem();
         }
 
         // Release our references to eval caches to ensure they are persisted to disk, because
         // we are about to exec out of this process without running C++ destructors.
         getEvalState()->evalCaches.clear();
 
-        execProgramInStore(store, UseLookupPath::Use, shell, args, buildEnvironment.getSystem());
+        execProgramInStore(store, UseLookupPath::Use, program, args, system);
 #endif
-    }
-};
-
-struct CmdPrintDevEnv : Common, MixJSON
-{
-    std::string description() override
-    {
-        return "print shell code that can be sourced by bash to reproduce the build environment of a derivation";
-    }
-
-    std::string doc() override
-    {
-        return
-#include "print-dev-env.md"
-            ;
-    }
-
-    Category category() override
-    {
-        return catUtility;
-    }
-
-    void run(ref<Store> store, ref<Installable> installable) override
-    {
-        auto buildEnvironment = getBuildEnvironment(store, installable).first;
-
-        logger->stop();
-
-        if (json) {
-            printJSON(buildEnvironment.toJSON());
-        } else {
-            AutoDelete tmpDir(createTempDir("", "nix-dev-env"), true);
-            logger->writeToStdout(makeRcScript(store, buildEnvironment, tmpDir));
         }
-    }
-};
+    };
 
-static auto rCmdPrintDevEnv = registerCommand<CmdPrintDevEnv>("print-dev-env");
-static auto rCmdDevelop = registerCommand<CmdDevelop>("develop");
+    struct CmdPrintDevEnv : Common, MixJSON
+    {
+        std::string description() override
+        {
+            return "print shell code that can be sourced by bash to reproduce the build environment of a derivation";
+        }
+
+        std::string doc() override
+        {
+            return
+#include "print-dev-env.md"
+                ;
+        }
+
+        Category category() override
+        {
+            return catUtility;
+        }
+
+        void run(ref<Store> store, ref<Installable> installable) override
+        {
+            auto devShell = maybeGetDevShell(store, installable).first;
+
+            if (devShell) {
+                auto file = std::filesystem::path(store->printStorePath(*devShell)) / (json ? "env.json" : "env");
+                if (!std::filesystem::exists(file))
+                    throw Error("%s's devShell does not provide %s", installable->what(), file.filename().string());
+
+                logger->stop();
+                logger->writeToStdout(readFile(file));
+            } else {
+                /* Legacy devshell path*/
+
+                auto buildEnvironment = getBuildEnvironment(store, installable).first;
+
+                logger->stop();
+
+                if (json) {
+                    printJSON(buildEnvironment.toJSON());
+                } else {
+                    AutoDelete tmpDir(createTempDir("", "nix-dev-env"), true);
+                    logger->writeToStdout(makeRcScript(store, buildEnvironment, tmpDir));
+                }
+            }
+        }
+    };
+
+    static auto rCmdPrintDevEnv = registerCommand<CmdPrintDevEnv>("print-dev-env");
+    static auto rCmdDevelop = registerCommand<CmdDevelop>("develop");
 
 } // namespace nix


### PR DESCRIPTION
A derivation can set the `__isDevShell` attribute to indicate to `nix develop` that it is a dev shell. Alternatively, it can provide a `devShell` attribute that `nix develop` will automatically use. Otherwise, fall back to the legacy behavior.

Closes #7501

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

The current devshell implementation in `nix develop` has a lot of implicit dependencies on stdenv's internals. This and the linked change move all of this logic into nixpkgs where it belongs.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Corresponding change in nixpkgs: https://github.com/NixOS/nixpkgs/pull/509697

Disabling whitespace diff is highly recommended for reading this change.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
