### PR TITLE
libutil: use connectat and bindat on freebsd instead

### DIFF
--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -109,13 +109,20 @@ bindConnectProcHelper(std::string_view operationName, auto && operation, Socket 
 void bind(Socket fd, const std::filesystem::path & path)
 {
     tryUnlink(path);
-
+#ifdef __FreeBSD__
+    bindConnectProcHelper("bind", ::bindat, fd, path.string());
+#else
     bindConnectProcHelper("bind", ::bind, fd, path.string());
-}
+#endif
+} // namespace nix
 
 void connect(Socket fd, const std::filesystem::path & path)
 {
+#ifdef __FreeBSD__
+    bindConnectProcHelper("connect", ::connectat, fd, path.string());
+#else
     bindConnectProcHelper("connect", ::connect, fd, path.string());
+#endif
 }
 
 AutoCloseFD connect(const std::filesystem::path & path)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

#15739

The motivation is with freebsd `connectat` and `bindat` when parse `AT_FDCWD` it acts like normal [`connect(2)`][connect] & [`bind(2)`][bind] however without it works like the [`connect(2)`][connect] & [`bind(2)`][bind] however: 
- It is limited to sockets in the PF_LOCAL domain.
- If the file path stored in the sun_path field	of the sock-addr_un structure is a relative path, it is located relative to the directory associated with the file descriptor fd.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Issues: #15739
- Docs: 
    - https://man.freebsd.org/cgi/man.cgi?query=connectat 
    - https://man.freebsd.org/cgi/man.cgi?query=bindat

### Alternatives

- Use [`connect(2)`][connect] and [`bind(2)`][bind] without the benfits.
- [Write a wrapper that does what `connectat` and `bindat` do under the hood which is more complex](#motivation)


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 

[connect]: https://man.freebsd.org/cgi/man.cgi?query=connect
[bind]: https://man.freebsd.org/cgi/man.cgi?query=bind

