### PR TITLE
linux-derivation-builder: Also block *listxattr

### DIFF
--- a/doc/manual/rl-next/seccomp-block-listxattr.md
+++ b/doc/manual/rl-next/seccomp-block-listxattr.md
@@ -1,0 +1,10 @@
+---
+synopsis: "Linux sandbox: also block `listxattr` syscalls"
+prs: [15743]
+---
+
+The Linux sandbox now also returns `ENOTSUP` for `listxattr`,
+`llistxattr` and `flistxattr`, matching the existing treatment of
+`getxattr`/`setxattr`/`removexattr`. This prevents host xattrs (e.g.
+`security.selinux`) from leaking into builds and fixes tools such as
+`mkfs.ubifs` that probe xattr support via `listxattr`.

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -116,7 +116,10 @@ static void setupSeccomp(const LocalSettings & localSettings)
     /* Prevent builders from using EAs or ACLs. Not all filesystems
        support these, and they're not allowed in the Nix store because
        they're not representable in the NAR serialisation. */
-    if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(getxattr), 0) != 0
+    if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(listxattr), 0) != 0
+        || seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(llistxattr), 0) != 0
+        || seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(flistxattr), 0) != 0
+        || seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(getxattr), 0) != 0
         || seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(lgetxattr), 0) != 0
         || seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(fgetxattr), 0) != 0
         || seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(setxattr), 0) != 0


### PR DESCRIPTION
Not blocking *listxattr not only leaks information from the host filesystem (e.g. leaks the fact that SELinux is enabled through the presence of security.selinux in the xattrs) but can confuse applications that assume that if *listxattr succeeds, xattrs are supported. For example, mkfs.ubifs will call llistxattr to get a list of attributes with a check for errno == EOPNOTSUPP to detect xattrs being unsupported. If that succeeds and it finds xattrs (which it will on an SELinux system), it calls lgetxattr on the individual attributes, which fails, causing mkfs.ubifs to fail.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
