### PR TITLE
tests/functional/json: fix script(1) invocation for util-linux 2.42

### DIFF
--- a/tests/functional/json.sh
+++ b/tests/functional/json.sh
@@ -51,7 +51,7 @@ if type script &>/dev/null; then
     if [[ $acceptsCommandFlag -eq 0 ]]; then
       script -e -q /dev/null "$@"
     else
-      script -e -q /dev/null -c "$(shellEscapeArray "$@")"
+      script -e -q -c "$(shellEscapeArray "$@")" /dev/null
     fi
   }
   runScript nix eval --json --expr "{ a.b.c = true; }" > "$TEST_HOME/actual.json"


### PR DESCRIPTION
util-linux 2.42 (commit util-linux/util-linux@7268e79b) added `+` to the getopt string of `script(1)`, so option parsing stops at the first non-option argument. The previous `script -e -q /dev/null -c CMD` ordering therefore treats `-c CMD` as extra positional arguments and fails with `unexpected number of arguments`.

Place all options before the `<file>` argument, which works on both old and new util-linux.

Upstream restored permutation in util-linux/util-linux@70507ab9ea, but that fix is not in 2.42.x releases yet.