### PR TITLE
[2.31] Backport release-jobs.nix (dedicated release jobset)

### DIFF
--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       eval_id:
-        description: "Hydra evaluation ID"
+        description: "Hydra evaluation ID (from the maintenance-X.Y-release jobset)"
         required: true
         type: number
       is_latest:

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -78,24 +78,27 @@ release:
 * Create two jobsets for the release branch on Hydra:
 
   `maintenance-$VERSION` runs the full `hydraJobs` CI matrix.
-  `release-$VERSION` builds only the artifacts consumed by
+  `maintenance-$VERSION-release` builds only the artifacts consumed by
   `upload-release`, so a release can be cut without waiting on the full
-  matrix.
+  matrix. The `-release` suffix keeps the pair adjacent in Hydra's
+  alphabetical jobset list and lets scripts derive one name from the
+  other.
 
   * Clone the previous `maintenance-*` jobset, set identifier
     `maintenance-$VERSION`, description `$VERSION release branch`, flake
     URL `github:NixOS/nix/$VERSION-maintenance`.
 
-  * Clone the previous `release-*` jobset (or create a new **legacy**
-    jobset), set identifier `release-$VERSION`, description `$VERSION
-    release artifacts`, Nix expression `packaging/release-jobs.nix` in
-    input `src`, and add input `src` of type *Git checkout* pointing at
+  * Clone the previous `maintenance-*-release` jobset (or create a new
+    **legacy** jobset), set identifier `maintenance-$VERSION-release`,
+    description `$VERSION release artifacts`, Nix expression
+    `packaging/release-jobs.nix` in input `src`, and add input `src` of
+    type *Git checkout* pointing at
     `https://github.com/NixOS/nix $VERSION-maintenance`.
 
-* Wait for the `release-$VERSION` jobset to evaluate and build. If
-  impatient, go to the evaluation and select `Actions -> Bump builds to
-  front of queue`. The aggregate job `release` turns green once every
-  required artifact is available.
+* Wait for the `maintenance-$VERSION-release` jobset to evaluate and
+  build. If impatient, go to the evaluation and select `Actions -> Bump
+  builds to front of queue`. The aggregate job `release` turns green
+  once every required artifact is available.
 
 * When the release jobset evaluation has succeeded building, take note of
   the evaluation ID (e.g. `1780832` in
@@ -173,8 +176,9 @@ release:
   $ git push
   ```
 
-* Wait for the desired evaluation of the `release-$VERSION` jobset to
-  finish building (the `release` aggregate job is the gating signal).
+* Wait for the desired evaluation of the `maintenance-XX.YY-release`
+  jobset to finish building (the `release` aggregate job is the gating
+  signal).
 
 * Tag the release
 

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -75,27 +75,30 @@ release:
   $ git push --set-upstream origin $VERSION-maintenance
   ```
 
-* Create a jobset for the release branch on Hydra as follows:
+* Create two jobsets for the release branch on Hydra:
 
-  * Go to the jobset of the previous release
-  (e.g. https://hydra.nixos.org/jobset/nix/maintenance-2.11).
+  `maintenance-$VERSION` runs the full `hydraJobs` CI matrix.
+  `release-$VERSION` builds only the artifacts consumed by
+  `upload-release`, so a release can be cut without waiting on the full
+  matrix.
 
-  * Select `Actions -> Clone this jobset`.
+  * Clone the previous `maintenance-*` jobset, set identifier
+    `maintenance-$VERSION`, description `$VERSION release branch`, flake
+    URL `github:NixOS/nix/$VERSION-maintenance`.
 
-  * Set identifier to `maintenance-$VERSION`.
+  * Clone the previous `release-*` jobset (or create a new **legacy**
+    jobset), set identifier `release-$VERSION`, description `$VERSION
+    release artifacts`, Nix expression `packaging/release-jobs.nix` in
+    input `src`, and add input `src` of type *Git checkout* pointing at
+    `https://github.com/NixOS/nix $VERSION-maintenance`.
 
-  * Set description to `$VERSION release branch`.
+* Wait for the `release-$VERSION` jobset to evaluate and build. If
+  impatient, go to the evaluation and select `Actions -> Bump builds to
+  front of queue`. The aggregate job `release` turns green once every
+  required artifact is available.
 
-  * Set flake URL to `github:NixOS/nix/$VERSION-maintenance`.
-
-  * Hit `Create jobset`.
-
-* Wait for the new jobset to evaluate and build. If impatient, go to
-  the evaluation and select `Actions -> Bump builds to front of
-  queue`.
-
-* When the jobset evaluation has succeeded building, take note of the
-  evaluation ID (e.g. `1780832` in
+* When the release jobset evaluation has succeeded building, take note of
+  the evaluation ID (e.g. `1780832` in
   `https://hydra.nixos.org/eval/1780832`).
 
 * Tag the release:
@@ -170,8 +173,8 @@ release:
   $ git push
   ```
 
-* Wait for the desired evaluation of the maintenance jobset to finish
-  building.
+* Wait for the desired evaluation of the `release-$VERSION` jobset to
+  finish building (the `release` aggregate job is the gating signal).
 
 * Tag the release
 

--- a/maintainers/upload-release.pl
+++ b/maintainers/upload-release.pl
@@ -64,7 +64,13 @@ my $evalInfo = decode_json(fetch($evalUrl, 'application/json'));
 #print Dumper($evalInfo);
 my $flakeUrl = $evalInfo->{flake};
 my $flakeInfo = decode_json(`nix flake metadata --json "$flakeUrl"` or die) if $flakeUrl;
-my $nixRev = ($flakeInfo ? $flakeInfo->{revision} : $evalInfo->{jobsetevalinputs}->{nix}->{revision}) or die;
+# Flake jobsets (`maintenance-X.Y`) expose the rev via the flake URL.
+# The release-artifacts jobset (`maintenance-X.Y-release`) is a legacy
+# jobset whose checkout is passed in as input `src`.
+my $nixRev = ($flakeInfo
+              ? $flakeInfo->{revision}
+              : $evalInfo->{jobsetevalinputs}->{src}->{revision}
+                // $evalInfo->{jobsetevalinputs}->{nix}->{revision}) or die;
 
 my $buildInfo = decode_json(fetch("$evalUrl/job/build.nix-everything.x86_64-linux", 'application/json'));
 #print Dumper($buildInfo);

--- a/packaging/release-jobs.nix
+++ b/packaging/release-jobs.nix
@@ -1,0 +1,76 @@
+# Hydra jobset containing only the artifacts consumed by
+# `maintainers/upload-release.{pl,py}`, so a release can be cut without
+# waiting on the full `hydraJobs` CI matrix.
+#
+# Evaluated as a legacy (non-flake) jobset because Hydra hard-codes flake
+# jobsets to `outputs.hydraJobs`; we re-enter the flake via
+# `builtins.getFlake` so derivations stay identical to the flake jobset
+# and share builds through the binary cache.
+#
+# Hydra jobset configuration:
+#   Type:            Legacy
+#   Nix expression:  packaging/release-jobs.nix in input `src`
+#   Inputs:
+#     src  (Git checkout)  https://github.com/NixOS/nix <branch>
+{
+  src ? {
+    outPath = ./..;
+  },
+}:
+let
+  # Fetch by GitHub ref rather than the bare store path Hydra hands us,
+  # so `rev`/`lastModified` (and thus the version suffix) match the flake
+  # jobset and derivations are shared.
+  flake = builtins.getFlake (
+    if src ? rev then
+      "github:NixOS/nix/${src.rev}"
+    else
+      # Local evaluation / testing.
+      builtins.unsafeDiscardStringContext (toString src)
+  );
+  inherit (flake) hydraJobs;
+  inherit (flake.inputs.nixpkgs) lib;
+
+  jobs = {
+    # `nix-everything` per system: provides the store paths for
+    # `fallback-paths.nix` and (on x86_64-linux) the rendered manual via
+    # its `doc` output.
+    build.nix-everything = hydraJobs.build.nix-everything;
+    buildCross.nix-everything.riscv64-unknown-linux-gnu =
+      hydraJobs.buildCross.nix-everything.riscv64-unknown-linux-gnu;
+
+    inherit (hydraJobs)
+      manual
+      binaryTarball
+      binaryTarballCross
+      installerScript
+      installerScriptForGHA
+      dockerImage
+      ;
+
+    # Aggregate gating job: green ⇒ every artifact the upload script
+    # needs is available.  `upload-release` can wait on this single job
+    # instead of the whole evaluation.  Constituents are referenced by
+    # job *name* so that an evaluation failure in one of them does not
+    # take down the aggregate's own evaluation.
+    release = flake.inputs.nixpkgs.legacyPackages.x86_64-linux.releaseTools.aggregate {
+      name = "nix-release-${flake.packages.x86_64-linux.nix-everything.version}";
+      meta.description = "Artifacts required for a Nix release";
+      constituents =
+        let
+          collectJobNames =
+            prefix: x:
+            if lib.isDerivation x then
+              [ prefix ]
+            else if lib.isAttrs x then
+              lib.concatLists (
+                lib.mapAttrsToList (n: collectJobNames (if prefix == "" then n else "${prefix}.${n}")) x
+              )
+            else
+              [ ];
+        in
+        collectJobNames "" (builtins.removeAttrs jobs [ "release" ]);
+    };
+  };
+in
+jobs

--- a/packaging/release-jobs.nix
+++ b/packaging/release-jobs.nix
@@ -8,6 +8,7 @@
 # and share builds through the binary cache.
 #
 # Hydra jobset configuration:
+#   Identifier:      maintenance-<X.Y>-release
 #   Type:            Legacy
 #   Nix expression:  packaging/release-jobs.nix in input `src`
 #   Inputs:
@@ -36,7 +37,13 @@ let
     # `fallback-paths.nix` and (on x86_64-linux) the rendered manual via
     # its `doc` output.
     build.nix-everything = hydraJobs.build.nix-everything;
-    buildCross.nix-everything = hydraJobs.buildCross.nix-everything;
+    buildCross.nix-everything = {
+      # Only the cross targets that end up in `fallback-paths.nix`.
+      inherit (hydraJobs.buildCross.nix-everything)
+        riscv64-unknown-linux-gnu
+        x86_64-unknown-freebsd
+        ;
+    };
 
     inherit (hydraJobs)
       manual

--- a/packaging/release-jobs.nix
+++ b/packaging/release-jobs.nix
@@ -1,5 +1,5 @@
 # Hydra jobset containing only the artifacts consumed by
-# `maintainers/upload-release.{pl,py}`, so a release can be cut without
+# `maintainers/upload-release.pl`, so a release can be cut without
 # waiting on the full `hydraJobs` CI matrix.
 #
 # Evaluated as a legacy (non-flake) jobset because Hydra hard-codes flake
@@ -36,8 +36,7 @@ let
     # `fallback-paths.nix` and (on x86_64-linux) the rendered manual via
     # its `doc` output.
     build.nix-everything = hydraJobs.build.nix-everything;
-    buildCross.nix-everything.riscv64-unknown-linux-gnu =
-      hydraJobs.buildCross.nix-everything.riscv64-unknown-linux-gnu;
+    buildCross.nix-everything = hydraJobs.buildCross.nix-everything;
 
     inherit (hydraJobs)
       manual

--- a/packaging/release-jobs.nix
+++ b/packaging/release-jobs.nix
@@ -41,7 +41,6 @@ let
       # Only the cross targets that end up in `fallback-paths.nix`.
       inherit (hydraJobs.buildCross.nix-everything)
         riscv64-unknown-linux-gnu
-        x86_64-unknown-freebsd
         ;
     };
 


### PR DESCRIPTION
Backport of #15640 / f4bde1f72d, e069dae4ef, e0f3115214 to `2.31-maintenance`.

Enables the `maintenance-2.31-release` Hydra jobset (`packaging/release-jobs.nix`), which currently fails to evaluate because the file was never backported.