### PR TITLE
[2.33] Backport release-jobs.nix (dedicated release jobset)

### DIFF
--- a/.github/actions/install-nix-action/action.yaml
+++ b/.github/actions/install-nix-action/action.yaml
@@ -4,22 +4,12 @@ inputs:
   dogfood:
     description: "Whether to use Nix installed from the latest artifact from master branch"
     required: true # Be explicit about the fact that we are using unreleased artifacts
-  experimental-installer:
-    description: "Whether to use the experimental installer to install Nix"
-    default: false
-  experimental-installer-version:
-    description: "Version of the experimental installer to use. If `latest`, the newest artifact from the default branch is used."
-    # TODO: This should probably be pinned to a release after https://github.com/NixOS/experimental-nix-installer/pull/49 lands in one
-    default: "latest"
   extra_nix_config:
     description: "Gets appended to `/etc/nix/nix.conf` if passed."
   install_url:
     description: "URL of the Nix installer"
     required: false
     default: "https://releases.nixos.org/nix/nix-2.34.6/install"
-  tarball_url:
-    description: "URL of the Nix tarball to use with the experimental installer"
-    required: false
   github_token:
     description: "Github token"
     required: true
@@ -51,74 +41,14 @@ runs:
 
         gh run download "$RUN_ID" --repo "$DOGFOOD_REPO" -n "$INSTALLER_ARTIFACT" -D "$INSTALLER_DOWNLOAD_DIR"
         echo "installer-path=file://$INSTALLER_DOWNLOAD_DIR" >> "$GITHUB_OUTPUT"
-        TARBALL_PATH="$(find "$INSTALLER_DOWNLOAD_DIR" -name 'nix*.tar.xz' -print | head -n 1)"
-        echo "tarball-path=file://$TARBALL_PATH" >> "$GITHUB_OUTPUT"
 
         echo "::notice ::Dogfooding Nix installer from master (https://github.com/$DOGFOOD_REPO/actions/runs/$RUN_ID)"
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         DOGFOOD_REPO: "NixOS/nix"
-    - name: "Gather system info for experimental installer"
-      shell: bash
-      if: ${{ inputs.experimental-installer == 'true' }}
-      run: |
-        echo "::notice Using experimental installer from $EXPERIMENTAL_INSTALLER_REPO (https://github.com/$EXPERIMENTAL_INSTALLER_REPO)"
-
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          EXPERIMENTAL_INSTALLER_SYSTEM="linux"
-          echo "EXPERIMENTAL_INSTALLER_SYSTEM=$EXPERIMENTAL_INSTALLER_SYSTEM" >> "$GITHUB_ENV"
-        elif [ "$RUNNER_OS" == "macOS" ]; then
-          EXPERIMENTAL_INSTALLER_SYSTEM="darwin"
-          echo "EXPERIMENTAL_INSTALLER_SYSTEM=$EXPERIMENTAL_INSTALLER_SYSTEM" >> "$GITHUB_ENV"
-        else
-          echo "::error ::Unsupported RUNNER_OS: $RUNNER_OS"
-          exit 1
-        fi
-
-        if [ "$RUNNER_ARCH" == "X64" ]; then
-          EXPERIMENTAL_INSTALLER_ARCH=x86_64
-          echo "EXPERIMENTAL_INSTALLER_ARCH=$EXPERIMENTAL_INSTALLER_ARCH" >> "$GITHUB_ENV"
-        elif [ "$RUNNER_ARCH" == "ARM64" ]; then
-          EXPERIMENTAL_INSTALLER_ARCH=aarch64
-          echo "EXPERIMENTAL_INSTALLER_ARCH=$EXPERIMENTAL_INSTALLER_ARCH" >> "$GITHUB_ENV"
-        else
-          echo "::error ::Unsupported RUNNER_ARCH: $RUNNER_ARCH"
-          exit 1
-        fi
-
-        echo "EXPERIMENTAL_INSTALLER_ARTIFACT=nix-installer-$EXPERIMENTAL_INSTALLER_ARCH-$EXPERIMENTAL_INSTALLER_SYSTEM" >> "$GITHUB_ENV"
-      env:
-        EXPERIMENTAL_INSTALLER_REPO: "NixOS/experimental-nix-installer"
-    - name: "Download latest experimental installer"
-      shell: bash
-      id: download-latest-experimental-installer
-      if: ${{ inputs.experimental-installer == 'true' && inputs.experimental-installer-version == 'latest' }}
-      run: |
-        RUN_ID=$(gh run list --repo "$EXPERIMENTAL_INSTALLER_REPO" --workflow ci.yml --branch main --status success --json databaseId --jq ".[0].databaseId")
-
-        EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR="$GITHUB_WORKSPACE/$EXPERIMENTAL_INSTALLER_ARTIFACT"
-        mkdir -p "$EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR"
-
-        gh run download "$RUN_ID" --repo "$EXPERIMENTAL_INSTALLER_REPO" -n "$EXPERIMENTAL_INSTALLER_ARTIFACT" -D "$EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR"
-        # Executable permissions are lost in artifacts
-        find $EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR -type f -exec chmod +x {} +
-        echo "installer-path=$EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR" >> "$GITHUB_OUTPUT"
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
-        EXPERIMENTAL_INSTALLER_REPO: "NixOS/experimental-nix-installer"
     - uses: cachix/install-nix-action@c134e4c9e34bac6cab09cf239815f9339aaaf84e # v31.5.1
-      if: ${{ inputs.experimental-installer != 'true' }}
       with:
         # Ternary operator in GHA: https://www.github.com/actions/runner/issues/409#issuecomment-752775072
         install_url: ${{ inputs.dogfood == 'true' && format('{0}/install', steps.download-nix-installer.outputs.installer-path) || inputs.install_url }}
         install_options: ${{ inputs.dogfood == 'true' && format('--tarball-url-prefix {0}', steps.download-nix-installer.outputs.installer-path) || '' }}
         extra_nix_config: ${{ inputs.extra_nix_config }}
-    - uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 # v20
-      if: ${{ inputs.experimental-installer == 'true' }}
-      with:
-        diagnostic-endpoint: ""
-        # TODO: It'd be nice to use `artifacts.nixos.org` for both of these, maybe through an `/experimental-installer/latest` endpoint? or `/commit/<hash>`?
-        local-root: ${{ inputs.experimental-installer-version == 'latest' && steps.download-latest-experimental-installer.outputs.installer-path || '' }}
-        source-url: ${{ inputs.experimental-installer-version != 'latest' && 'https://artifacts.nixos.org/experimental-installer/tag/${{ inputs.experimental-installer-version }}/${{ env.EXPERIMENTAL_INSTALLER_ARTIFACT }}' || '' }}
-        nix-package-url: ${{ inputs.dogfood == 'true' && steps.download-nix-installer.outputs.tarball-path || (inputs.tarball_url || '') }}
-        extra-conf: ${{ inputs.extra_nix_config }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,19 +146,9 @@ jobs:
           - scenario: on ubuntu
             runs-on: ubuntu-24.04
             os: linux
-            experimental-installer: false
           - scenario: on macos
             runs-on: macos-14
             os: darwin
-            experimental-installer: false
-          - scenario: on ubuntu (experimental)
-            runs-on: ubuntu-24.04
-            os: linux
-            experimental-installer: true
-          - scenario: on macos (experimental)
-            runs-on: macos-14
-            os: darwin
-            experimental-installer: true
     name: installer test ${{ matrix.scenario }}
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -170,22 +160,11 @@ jobs:
         path: out
     - name: Looking up the installer tarball URL
       id: installer-tarball-url
-      run: |
-        echo "installer-url=file://$GITHUB_WORKSPACE/out" >> "$GITHUB_OUTPUT"
-        TARBALL_PATH="$(find "$GITHUB_WORKSPACE/out" -name 'nix*.tar.xz' -print | head -n 1)"
-        echo "tarball-path=file://$TARBALL_PATH" >> "$GITHUB_OUTPUT"
+      run: echo "installer-url=file://$GITHUB_WORKSPACE/out" >> "$GITHUB_OUTPUT"
     - uses: cachix/install-nix-action@0b0e072294b088b73964f1d72dfdac0951439dbd # v31.8.4
-      if: ${{ !matrix.experimental-installer }}
       with:
         install_url: ${{ format('{0}/install', steps.installer-tarball-url.outputs.installer-url) }}
         install_options: ${{ format('--tarball-url-prefix {0}', steps.installer-tarball-url.outputs.installer-url) }}
-    - uses: ./.github/actions/install-nix-action
-      if: ${{ matrix.experimental-installer }}
-      with:
-        dogfood: false
-        experimental-installer: true
-        tarball_url: ${{ steps.installer-tarball-url.outputs.tarball-path }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
     - run: sudo apt install fish zsh
       if: matrix.os == 'linux'
     - run: brew install fish

--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       eval_id:
-        description: "Hydra evaluation ID"
+        description: "Hydra evaluation ID (from the maintenance-X.Y-release jobset)"
         required: true
         type: number
       is_latest:

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -81,27 +81,30 @@ release:
   $ git push --set-upstream origin $VERSION-maintenance
   ```
 
-* Create a jobset for the release branch on Hydra as follows:
+* Create two jobsets for the release branch on Hydra:
 
-  * Go to the jobset of the previous release
-  (e.g. https://hydra.nixos.org/jobset/nix/maintenance-2.11).
+  `maintenance-$VERSION` runs the full `hydraJobs` CI matrix.
+  `release-$VERSION` builds only the artifacts consumed by
+  `upload-release`, so a release can be cut without waiting on the full
+  matrix.
 
-  * Select `Actions -> Clone this jobset`.
+  * Clone the previous `maintenance-*` jobset, set identifier
+    `maintenance-$VERSION`, description `$VERSION release branch`, flake
+    URL `github:NixOS/nix/$VERSION-maintenance`.
 
-  * Set identifier to `maintenance-$VERSION`.
+  * Clone the previous `release-*` jobset (or create a new **legacy**
+    jobset), set identifier `release-$VERSION`, description `$VERSION
+    release artifacts`, Nix expression `packaging/release-jobs.nix` in
+    input `src`, and add input `src` of type *Git checkout* pointing at
+    `https://github.com/NixOS/nix $VERSION-maintenance`.
 
-  * Set description to `$VERSION release branch`.
+* Wait for the `release-$VERSION` jobset to evaluate and build. If
+  impatient, go to the evaluation and select `Actions -> Bump builds to
+  front of queue`. The aggregate job `release` turns green once every
+  required artifact is available.
 
-  * Set flake URL to `github:NixOS/nix/$VERSION-maintenance`.
-
-  * Hit `Create jobset`.
-
-* Wait for the new jobset to evaluate and build. If impatient, go to
-  the evaluation and select `Actions -> Bump builds to front of
-  queue`.
-
-* When the jobset evaluation has succeeded building, take note of the
-  evaluation ID (e.g. `1780832` in
+* When the release jobset evaluation has succeeded building, take note of
+  the evaluation ID (e.g. `1780832` in
   `https://hydra.nixos.org/eval/1780832`).
 
 * Tag the release:
@@ -174,8 +177,8 @@ release:
   $ git push
   ```
 
-* Wait for the desired evaluation of the maintenance jobset to finish
-  building.
+* Wait for the desired evaluation of the `release-$VERSION` jobset to
+  finish building (the `release` aggregate job is the gating signal).
 
 * Tag the release
 

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -84,24 +84,27 @@ release:
 * Create two jobsets for the release branch on Hydra:
 
   `maintenance-$VERSION` runs the full `hydraJobs` CI matrix.
-  `release-$VERSION` builds only the artifacts consumed by
+  `maintenance-$VERSION-release` builds only the artifacts consumed by
   `upload-release`, so a release can be cut without waiting on the full
-  matrix.
+  matrix. The `-release` suffix keeps the pair adjacent in Hydra's
+  alphabetical jobset list and lets scripts derive one name from the
+  other.
 
   * Clone the previous `maintenance-*` jobset, set identifier
     `maintenance-$VERSION`, description `$VERSION release branch`, flake
     URL `github:NixOS/nix/$VERSION-maintenance`.
 
-  * Clone the previous `release-*` jobset (or create a new **legacy**
-    jobset), set identifier `release-$VERSION`, description `$VERSION
-    release artifacts`, Nix expression `packaging/release-jobs.nix` in
-    input `src`, and add input `src` of type *Git checkout* pointing at
+  * Clone the previous `maintenance-*-release` jobset (or create a new
+    **legacy** jobset), set identifier `maintenance-$VERSION-release`,
+    description `$VERSION release artifacts`, Nix expression
+    `packaging/release-jobs.nix` in input `src`, and add input `src` of
+    type *Git checkout* pointing at
     `https://github.com/NixOS/nix $VERSION-maintenance`.
 
-* Wait for the `release-$VERSION` jobset to evaluate and build. If
-  impatient, go to the evaluation and select `Actions -> Bump builds to
-  front of queue`. The aggregate job `release` turns green once every
-  required artifact is available.
+* Wait for the `maintenance-$VERSION-release` jobset to evaluate and
+  build. If impatient, go to the evaluation and select `Actions -> Bump
+  builds to front of queue`. The aggregate job `release` turns green
+  once every required artifact is available.
 
 * When the release jobset evaluation has succeeded building, take note of
   the evaluation ID (e.g. `1780832` in
@@ -177,8 +180,9 @@ release:
   $ git push
   ```
 
-* Wait for the desired evaluation of the `release-$VERSION` jobset to
-  finish building (the `release` aggregate job is the gating signal).
+* Wait for the desired evaluation of the `maintenance-XX.YY-release`
+  jobset to finish building (the `release` aggregate job is the gating
+  signal).
 
 * Tag the release
 

--- a/maintainers/upload-release.pl
+++ b/maintainers/upload-release.pl
@@ -64,7 +64,13 @@ my $evalInfo = decode_json(fetch($evalUrl, 'application/json'));
 #print Dumper($evalInfo);
 my $flakeUrl = $evalInfo->{flake};
 my $flakeInfo = decode_json(`nix flake metadata --json "$flakeUrl"` or die) if $flakeUrl;
-my $nixRev = ($flakeInfo ? $flakeInfo->{revision} : $evalInfo->{jobsetevalinputs}->{nix}->{revision}) or die;
+# Flake jobsets (`maintenance-X.Y`) expose the rev via the flake URL.
+# The release-artifacts jobset (`maintenance-X.Y-release`) is a legacy
+# jobset whose checkout is passed in as input `src`.
+my $nixRev = ($flakeInfo
+              ? $flakeInfo->{revision}
+              : $evalInfo->{jobsetevalinputs}->{src}->{revision}
+                // $evalInfo->{jobsetevalinputs}->{nix}->{revision}) or die;
 
 my $buildInfo = decode_json(fetch("$evalUrl/job/build.nix-everything.x86_64-linux", 'application/json'));
 #print Dumper($buildInfo);

--- a/packaging/release-jobs.nix
+++ b/packaging/release-jobs.nix
@@ -1,0 +1,76 @@
+# Hydra jobset containing only the artifacts consumed by
+# `maintainers/upload-release.{pl,py}`, so a release can be cut without
+# waiting on the full `hydraJobs` CI matrix.
+#
+# Evaluated as a legacy (non-flake) jobset because Hydra hard-codes flake
+# jobsets to `outputs.hydraJobs`; we re-enter the flake via
+# `builtins.getFlake` so derivations stay identical to the flake jobset
+# and share builds through the binary cache.
+#
+# Hydra jobset configuration:
+#   Type:            Legacy
+#   Nix expression:  packaging/release-jobs.nix in input `src`
+#   Inputs:
+#     src  (Git checkout)  https://github.com/NixOS/nix <branch>
+{
+  src ? {
+    outPath = ./..;
+  },
+}:
+let
+  # Fetch by GitHub ref rather than the bare store path Hydra hands us,
+  # so `rev`/`lastModified` (and thus the version suffix) match the flake
+  # jobset and derivations are shared.
+  flake = builtins.getFlake (
+    if src ? rev then
+      "github:NixOS/nix/${src.rev}"
+    else
+      # Local evaluation / testing.
+      builtins.unsafeDiscardStringContext (toString src)
+  );
+  inherit (flake) hydraJobs;
+  inherit (flake.inputs.nixpkgs) lib;
+
+  jobs = {
+    # `nix-everything` per system: provides the store paths for
+    # `fallback-paths.nix` and (on x86_64-linux) the rendered manual via
+    # its `doc` output.
+    build.nix-everything = hydraJobs.build.nix-everything;
+    buildCross.nix-everything.riscv64-unknown-linux-gnu =
+      hydraJobs.buildCross.nix-everything.riscv64-unknown-linux-gnu;
+
+    inherit (hydraJobs)
+      manual
+      binaryTarball
+      binaryTarballCross
+      installerScript
+      installerScriptForGHA
+      dockerImage
+      ;
+
+    # Aggregate gating job: green ⇒ every artifact the upload script
+    # needs is available.  `upload-release` can wait on this single job
+    # instead of the whole evaluation.  Constituents are referenced by
+    # job *name* so that an evaluation failure in one of them does not
+    # take down the aggregate's own evaluation.
+    release = flake.inputs.nixpkgs.legacyPackages.x86_64-linux.releaseTools.aggregate {
+      name = "nix-release-${flake.packages.x86_64-linux.nix-everything.version}";
+      meta.description = "Artifacts required for a Nix release";
+      constituents =
+        let
+          collectJobNames =
+            prefix: x:
+            if lib.isDerivation x then
+              [ prefix ]
+            else if lib.isAttrs x then
+              lib.concatLists (
+                lib.mapAttrsToList (n: collectJobNames (if prefix == "" then n else "${prefix}.${n}")) x
+              )
+            else
+              [ ];
+        in
+        collectJobNames "" (builtins.removeAttrs jobs [ "release" ]);
+    };
+  };
+in
+jobs

--- a/packaging/release-jobs.nix
+++ b/packaging/release-jobs.nix
@@ -8,6 +8,7 @@
 # and share builds through the binary cache.
 #
 # Hydra jobset configuration:
+#   Identifier:      maintenance-<X.Y>-release
 #   Type:            Legacy
 #   Nix expression:  packaging/release-jobs.nix in input `src`
 #   Inputs:
@@ -36,7 +37,13 @@ let
     # `fallback-paths.nix` and (on x86_64-linux) the rendered manual via
     # its `doc` output.
     build.nix-everything = hydraJobs.build.nix-everything;
-    buildCross.nix-everything = hydraJobs.buildCross.nix-everything;
+    buildCross.nix-everything = {
+      # Only the cross targets that end up in `fallback-paths.nix`.
+      inherit (hydraJobs.buildCross.nix-everything)
+        riscv64-unknown-linux-gnu
+        x86_64-unknown-freebsd
+        ;
+    };
 
     inherit (hydraJobs)
       manual

--- a/packaging/release-jobs.nix
+++ b/packaging/release-jobs.nix
@@ -1,5 +1,5 @@
 # Hydra jobset containing only the artifacts consumed by
-# `maintainers/upload-release.{pl,py}`, so a release can be cut without
+# `maintainers/upload-release.pl`, so a release can be cut without
 # waiting on the full `hydraJobs` CI matrix.
 #
 # Evaluated as a legacy (non-flake) jobset because Hydra hard-codes flake
@@ -36,8 +36,7 @@ let
     # `fallback-paths.nix` and (on x86_64-linux) the rendered manual via
     # its `doc` output.
     build.nix-everything = hydraJobs.build.nix-everything;
-    buildCross.nix-everything.riscv64-unknown-linux-gnu =
-      hydraJobs.buildCross.nix-everything.riscv64-unknown-linux-gnu;
+    buildCross.nix-everything = hydraJobs.buildCross.nix-everything;
 
     inherit (hydraJobs)
       manual

--- a/packaging/release-jobs.nix
+++ b/packaging/release-jobs.nix
@@ -41,7 +41,6 @@ let
       # Only the cross targets that end up in `fallback-paths.nix`.
       inherit (hydraJobs.buildCross.nix-everything)
         riscv64-unknown-linux-gnu
-        x86_64-unknown-freebsd
         ;
     };
 


### PR DESCRIPTION
Backport of #15640 / f4bde1f72d, e069dae4ef, e0f3115214 to `2.33-maintenance`.

Enables the `maintenance-2.33-release` Hydra jobset (`packaging/release-jobs.nix`), which currently fails to evaluate because the file was never backported.