### PR TITLE
[2.34] Backport rustInstaller and bump nix-installer to 2.34.6

### DIFF
--- a/.github/actions/install-nix-action/action.yaml
+++ b/.github/actions/install-nix-action/action.yaml
@@ -4,22 +4,12 @@ inputs:
   dogfood:
     description: "Whether to use Nix installed from the latest artifact from master branch"
     required: true # Be explicit about the fact that we are using unreleased artifacts
-  experimental-installer:
-    description: "Whether to use the experimental installer to install Nix"
-    default: false
-  experimental-installer-version:
-    description: "Version of the experimental installer to use. If `latest`, the newest artifact from the default branch is used."
-    # TODO: This should probably be pinned to a release after https://github.com/NixOS/experimental-nix-installer/pull/49 lands in one
-    default: "latest"
   extra_nix_config:
     description: "Gets appended to `/etc/nix/nix.conf` if passed."
   install_url:
     description: "URL of the Nix installer"
     required: false
     default: "https://releases.nixos.org/nix/nix-2.34.6/install"
-  tarball_url:
-    description: "URL of the Nix tarball to use with the experimental installer"
-    required: false
   github_token:
     description: "Github token"
     required: true
@@ -51,74 +41,14 @@ runs:
 
         gh run download "$RUN_ID" --repo "$DOGFOOD_REPO" -n "$INSTALLER_ARTIFACT" -D "$INSTALLER_DOWNLOAD_DIR"
         echo "installer-path=file://$INSTALLER_DOWNLOAD_DIR" >> "$GITHUB_OUTPUT"
-        TARBALL_PATH="$(find "$INSTALLER_DOWNLOAD_DIR" -name 'nix*.tar.xz' -print | head -n 1)"
-        echo "tarball-path=file://$TARBALL_PATH" >> "$GITHUB_OUTPUT"
 
         echo "::notice ::Dogfooding Nix installer from master (https://github.com/$DOGFOOD_REPO/actions/runs/$RUN_ID)"
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         DOGFOOD_REPO: "NixOS/nix"
-    - name: "Gather system info for experimental installer"
-      shell: bash
-      if: ${{ inputs.experimental-installer == 'true' }}
-      run: |
-        echo "::notice Using experimental installer from $EXPERIMENTAL_INSTALLER_REPO (https://github.com/$EXPERIMENTAL_INSTALLER_REPO)"
-
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          EXPERIMENTAL_INSTALLER_SYSTEM="linux"
-          echo "EXPERIMENTAL_INSTALLER_SYSTEM=$EXPERIMENTAL_INSTALLER_SYSTEM" >> "$GITHUB_ENV"
-        elif [ "$RUNNER_OS" == "macOS" ]; then
-          EXPERIMENTAL_INSTALLER_SYSTEM="darwin"
-          echo "EXPERIMENTAL_INSTALLER_SYSTEM=$EXPERIMENTAL_INSTALLER_SYSTEM" >> "$GITHUB_ENV"
-        else
-          echo "::error ::Unsupported RUNNER_OS: $RUNNER_OS"
-          exit 1
-        fi
-
-        if [ "$RUNNER_ARCH" == "X64" ]; then
-          EXPERIMENTAL_INSTALLER_ARCH=x86_64
-          echo "EXPERIMENTAL_INSTALLER_ARCH=$EXPERIMENTAL_INSTALLER_ARCH" >> "$GITHUB_ENV"
-        elif [ "$RUNNER_ARCH" == "ARM64" ]; then
-          EXPERIMENTAL_INSTALLER_ARCH=aarch64
-          echo "EXPERIMENTAL_INSTALLER_ARCH=$EXPERIMENTAL_INSTALLER_ARCH" >> "$GITHUB_ENV"
-        else
-          echo "::error ::Unsupported RUNNER_ARCH: $RUNNER_ARCH"
-          exit 1
-        fi
-
-        echo "EXPERIMENTAL_INSTALLER_ARTIFACT=nix-installer-$EXPERIMENTAL_INSTALLER_ARCH-$EXPERIMENTAL_INSTALLER_SYSTEM" >> "$GITHUB_ENV"
-      env:
-        EXPERIMENTAL_INSTALLER_REPO: "NixOS/experimental-nix-installer"
-    - name: "Download latest experimental installer"
-      shell: bash
-      id: download-latest-experimental-installer
-      if: ${{ inputs.experimental-installer == 'true' && inputs.experimental-installer-version == 'latest' }}
-      run: |
-        RUN_ID=$(gh run list --repo "$EXPERIMENTAL_INSTALLER_REPO" --workflow ci.yml --branch main --status success --json databaseId --jq ".[0].databaseId")
-
-        EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR="$GITHUB_WORKSPACE/$EXPERIMENTAL_INSTALLER_ARTIFACT"
-        mkdir -p "$EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR"
-
-        gh run download "$RUN_ID" --repo "$EXPERIMENTAL_INSTALLER_REPO" -n "$EXPERIMENTAL_INSTALLER_ARTIFACT" -D "$EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR"
-        # Executable permissions are lost in artifacts
-        find $EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR -type f -exec chmod +x {} +
-        echo "installer-path=$EXPERIMENTAL_INSTALLER_DOWNLOAD_DIR" >> "$GITHUB_OUTPUT"
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
-        EXPERIMENTAL_INSTALLER_REPO: "NixOS/experimental-nix-installer"
     - uses: cachix/install-nix-action@c134e4c9e34bac6cab09cf239815f9339aaaf84e # v31.5.1
-      if: ${{ inputs.experimental-installer != 'true' }}
       with:
         # Ternary operator in GHA: https://www.github.com/actions/runner/issues/409#issuecomment-752775072
         install_url: ${{ inputs.dogfood == 'true' && format('{0}/install', steps.download-nix-installer.outputs.installer-path) || inputs.install_url }}
         install_options: ${{ inputs.dogfood == 'true' && format('--tarball-url-prefix {0}', steps.download-nix-installer.outputs.installer-path) || '' }}
         extra_nix_config: ${{ inputs.extra_nix_config }}
-    - uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 # v20
-      if: ${{ inputs.experimental-installer == 'true' }}
-      with:
-        diagnostic-endpoint: ""
-        # TODO: It'd be nice to use `artifacts.nixos.org` for both of these, maybe through an `/experimental-installer/latest` endpoint? or `/commit/<hash>`?
-        local-root: ${{ inputs.experimental-installer-version == 'latest' && steps.download-latest-experimental-installer.outputs.installer-path || '' }}
-        source-url: ${{ inputs.experimental-installer-version != 'latest' && 'https://artifacts.nixos.org/experimental-installer/tag/${{ inputs.experimental-installer-version }}/${{ env.EXPERIMENTAL_INSTALLER_ARTIFACT }}' || '' }}
-        nix-package-url: ${{ inputs.dogfood == 'true' && steps.download-nix-installer.outputs.tarball-path || (inputs.tarball_url || '') }}
-        extra-conf: ${{ inputs.extra_nix_config }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,19 +164,19 @@ jobs:
           - scenario: on ubuntu
             runs-on: ubuntu-24.04
             os: linux
-            experimental-installer: false
+            rust-installer: false
           - scenario: on macos
             runs-on: macos-14
             os: darwin
-            experimental-installer: false
-          - scenario: on ubuntu (experimental)
+            rust-installer: false
+          - scenario: on ubuntu (rust)
             runs-on: ubuntu-24.04
             os: linux
-            experimental-installer: true
-          - scenario: on macos (experimental)
+            rust-installer: true
+          - scenario: on macos (rust)
             runs-on: macos-14
             os: darwin
-            experimental-installer: true
+            rust-installer: true
     name: installer test ${{ matrix.scenario }}
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -188,22 +188,19 @@ jobs:
         path: out
     - name: Looking up the installer tarball URL
       id: installer-tarball-url
-      run: |
-        echo "installer-url=file://$GITHUB_WORKSPACE/out" >> "$GITHUB_OUTPUT"
-        TARBALL_PATH="$(find "$GITHUB_WORKSPACE/out" -name 'nix*.tar.xz' -print | head -n 1)"
-        echo "tarball-path=file://$TARBALL_PATH" >> "$GITHUB_OUTPUT"
+      run: echo "installer-url=file://$GITHUB_WORKSPACE/out" >> "$GITHUB_OUTPUT"
     - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31.9.1
-      if: ${{ !matrix.experimental-installer }}
+      if: ${{ !matrix.rust-installer }}
       with:
         install_url: ${{ format('{0}/install', steps.installer-tarball-url.outputs.installer-url) }}
         install_options: ${{ format('--tarball-url-prefix {0}', steps.installer-tarball-url.outputs.installer-url) }}
-    - uses: ./.github/actions/install-nix-action
-      if: ${{ matrix.experimental-installer }}
-      with:
-        dogfood: false
-        experimental-installer: true
-        tarball_url: ${{ steps.installer-tarball-url.outputs.tarball-path }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run rust installer
+      if: ${{ matrix.rust-installer }}
+      run: |
+        chmod +x out/nix-installer
+        ./out/nix-installer install --no-confirm
+      env:
+        RUST_BACKTRACE: full
     - run: sudo apt install fish zsh
       if: matrix.os == 'linux'
     - run: brew install fish

--- a/ci/gha/tests/prepare-installer-for-github-actions
+++ b/ci/gha/tests/prepare-installer-for-github-actions
@@ -2,10 +2,14 @@
 
 set -euo pipefail
 
-nix build -L ".#installerScriptForGHA" ".#binaryTarball"
+nix build -L \
+  ".#installerScriptForGHA" \
+  ".#binaryTarball" \
+  ".#rustInstaller"
 
 mkdir -p out
 cp ./result/install "out/install"
 name="$(basename "$(realpath ./result-1)")"
 # everything before the first dash
 cp -r ./result-1 "out/${name%%-*}"
+cp ./result-2/bin/nix-installer "out/nix-installer"

--- a/flake.nix
+++ b/flake.nix
@@ -465,6 +465,9 @@
                 )
               )
             )
+        // lib.optionalAttrs (self.hydraJobs.rustInstaller ? ${system}) {
+          rustInstaller = self.hydraJobs.rustInstaller.${system};
+        }
         // lib.optionalAttrs (builtins.elem system linux64BitSystems) {
           dockerImage =
             let

--- a/packaging/hydra.nix
+++ b/packaging/hydra.nix
@@ -254,6 +254,32 @@ rec {
     }
   );
 
+  # `NixOS/nix-installer` with this revision's Nix closure embedded.
+  rustInstaller =
+    lib.genAttrs
+      (
+        linux64BitSystems
+        ++ [
+          "x86_64-darwin"
+          "aarch64-darwin"
+        ]
+      )
+      (
+        system:
+        let
+          pkgs = nixpkgsFor.${system}.native;
+          # Embed the native (glibc) Nix even though the Linux installer
+          # binary is static/musl.
+          tarball = pkgs.callPackage ./rust-installer/tarball.nix {
+            nix = pkgs.nixComponents2.nix-everything;
+          };
+          builder = if pkgs.stdenv.hostPlatform.isLinux then pkgs.pkgsStatic else pkgs;
+        in
+        builder.callPackage ./rust-installer {
+          inherit tarball;
+        }
+      );
+
   # docker image with Nix inside
   dockerImage = lib.genAttrs linux64BitSystems (system: self.packages.${system}.dockerImage);
 

--- a/packaging/rust-installer/default.nix
+++ b/packaging/rust-installer/default.nix
@@ -1,0 +1,64 @@
+# `NixOS/nix-installer` built with *this* Nix closure embedded, so
+# Hydra/CI can dogfood the Rust installer without the (removed)
+# `--nix-package-url` knob.
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  tarball,
+}:
+
+let
+  installerVersion = "2.34.5";
+  src = fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nix-installer";
+    tag = installerVersion;
+    hash = "sha256-+gM241qQOzQlOnP0a7d47z3iRf9+yNjbBJCLIWWNX+c=";
+  };
+in
+
+rustPlatform.buildRustPackage {
+  pname = "nix-installer";
+  version = tarball.passthru.nixVersion;
+
+  inherit src;
+
+  cargoHash = "sha256-6pt2f7wznH672L5+SkbA5GA6Sxvk1KamAf3erGqZlLU=";
+
+  doCheck = false;
+
+  env = {
+    NIX_TARBALL_PATH = "${tarball}/nix.tar.zst";
+    NIX_STORE_PATH = tarball.passthru.nixStorePath;
+    NSS_CACERT_STORE_PATH = tarball.passthru.cacertStorePath;
+    NIX_VERSION = tarball.passthru.nixVersion;
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # Drop the unused libiconv dylib the darwin stdenv injects; the
+    # binary must run before `/nix/store` exists.
+    NIX_LDFLAGS = "-dead_strip_dylibs";
+  };
+
+  postInstall = ''
+    install -m755 nix-installer.sh $out/bin/nix-installer.sh
+
+    mkdir -p $out/nix-support
+    echo "file binary-dist $out/bin/nix-installer" >> $out/nix-support/hydra-build-products
+    echo "file binary-dist $out/bin/nix-installer.sh" >> $out/nix-support/hydra-build-products
+  '';
+
+  # The binary embeds store-path strings (`NIX_STORE_PATH`, …) on
+  # purpose; don't let the reference scanner pull the whole Nix
+  # closure into this derivation's runtime closure.
+  __structuredAttrs = true;
+  unsafeDiscardReferences.out = true;
+
+  meta = {
+    description = "Rust-based Nix installer with an embedded Nix ${tarball.passthru.nixVersion}";
+    homepage = "https://github.com/NixOS/nix-installer";
+    license = lib.licenses.lgpl21Only;
+    mainProgram = "nix-installer";
+  };
+}

--- a/packaging/rust-installer/default.nix
+++ b/packaging/rust-installer/default.nix
@@ -4,61 +4,85 @@
 {
   lib,
   stdenv,
+  buildPackages,
+  runCommand,
   rustPlatform,
   fetchFromGitHub,
   tarball,
 }:
 
 let
-  installerVersion = "2.34.5";
+  installerVersion = "2.34.6";
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "nix-installer";
     tag = installerVersion;
-    hash = "sha256-+gM241qQOzQlOnP0a7d47z3iRf9+yNjbBJCLIWWNX+c=";
+    hash = "sha256-aTaz8EtHexvke7tGr5MfeKy9g7AraIAFN+dPApm+fds=";
+  };
+
+  # Bare binary: no Nix closure yet.  Appended below via `pack`, so the
+  # (expensive) Rust compile is independent of the embedded Nix and
+  # stays cacheable across Nix revisions.
+  bare = rustPlatform.buildRustPackage {
+    pname = "nix-installer-bare";
+    version = installerVersion;
+
+    inherit src;
+
+    cargoHash = "sha256-/mNXkeZVuYsqd0TiUa7bzSP4xpKh0Fqga9EpasPbrzU=";
+
+    doCheck = false;
+
+    env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+      # Drop the unused libiconv dylib the darwin stdenv injects; the
+      # binary must run before `/nix/store` exists.
+      NIX_LDFLAGS = "-dead_strip_dylibs";
+    };
+
+    postInstall = ''
+      install -m755 nix-installer.sh $out/bin/nix-installer.sh
+    '';
   };
 in
 
-rustPlatform.buildRustPackage {
-  pname = "nix-installer";
-  version = tarball.passthru.nixVersion;
+runCommand "nix-installer-${tarball.passthru.nixVersion}"
+  {
+    nativeBuildInputs = [
+      buildPackages.python3
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      buildPackages.darwin.sigtool
+      buildPackages.darwin.cctools
+    ];
 
-  inherit src;
+    # The appended payload contains store-path strings on purpose; don't
+    # let the reference scanner pull the whole Nix closure into this
+    # derivation's runtime closure.
+    __structuredAttrs = true;
+    unsafeDiscardReferences.out = true;
 
-  cargoHash = "sha256-6pt2f7wznH672L5+SkbA5GA6Sxvk1KamAf3erGqZlLU=";
+    passthru = { inherit bare; };
 
-  doCheck = false;
-
-  env = {
-    NIX_TARBALL_PATH = "${tarball}/nix.tar.zst";
-    NIX_STORE_PATH = tarball.passthru.nixStorePath;
-    NSS_CACERT_STORE_PATH = tarball.passthru.cacertStorePath;
-    NIX_VERSION = tarball.passthru.nixVersion;
+    meta = {
+      description = "Rust-based Nix installer with an embedded Nix ${tarball.passthru.nixVersion}";
+      homepage = "https://github.com/NixOS/nix-installer";
+      license = lib.licenses.lgpl21Only;
+      mainProgram = "nix-installer";
+    };
   }
-  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    # Drop the unused libiconv dylib the darwin stdenv injects; the
-    # binary must run before `/nix/store` exists.
-    NIX_LDFLAGS = "-dead_strip_dylibs";
-  };
+  ''
+    mkdir -p $out/bin $out/nix-support
 
-  postInstall = ''
-    install -m755 nix-installer.sh $out/bin/nix-installer.sh
+    python3 ${src}/scripts/pack \
+      --input ${bare}/bin/nix-installer \
+      --tarball ${tarball}/nix.tar.zst \
+      --nix-store-path ${tarball.passthru.nixStorePath} \
+      --cacert-store-path ${tarball.passthru.cacertStorePath} \
+      --nix-version ${tarball.passthru.nixVersion} \
+      --output $out/bin/nix-installer
 
-    mkdir -p $out/nix-support
+    install -m755 ${bare}/bin/nix-installer.sh $out/bin/nix-installer.sh
+
     echo "file binary-dist $out/bin/nix-installer" >> $out/nix-support/hydra-build-products
     echo "file binary-dist $out/bin/nix-installer.sh" >> $out/nix-support/hydra-build-products
-  '';
-
-  # The binary embeds store-path strings (`NIX_STORE_PATH`, …) on
-  # purpose; don't let the reference scanner pull the whole Nix
-  # closure into this derivation's runtime closure.
-  __structuredAttrs = true;
-  unsafeDiscardReferences.out = true;
-
-  meta = {
-    description = "Rust-based Nix installer with an embedded Nix ${tarball.passthru.nixVersion}";
-    homepage = "https://github.com/NixOS/nix-installer";
-    license = lib.licenses.lgpl21Only;
-    mainProgram = "nix-installer";
-  };
-}
+  ''

--- a/packaging/rust-installer/tarball.nix
+++ b/packaging/rust-installer/tarball.nix
@@ -1,0 +1,50 @@
+# Zstd-compressed Nix closure in the layout expected by
+# `NixOS/nix-installer` (`include_bytes!` at build time).
+{
+  lib,
+  stdenv,
+  runCommand,
+  buildPackages,
+  zstd,
+  nix,
+  cacert,
+}:
+
+let
+  installerClosureInfo = buildPackages.closureInfo {
+    rootPaths = [
+      nix
+      cacert
+    ];
+  };
+in
+
+runCommand "nix-installer-tarball-${nix.version}"
+  {
+    nativeBuildInputs = [ zstd ];
+
+    passthru = {
+      nixStorePath = nix.outPath;
+      cacertStorePath = cacert.outPath;
+      nixVersion = nix.version;
+    };
+  }
+  ''
+    mkdir -p $out
+
+    dir=nix-${nix.version}-${stdenv.hostPlatform.system}
+
+    cp ${installerClosureInfo}/registration $TMPDIR/reginfo
+
+    tar cf - \
+      --sort=name \
+      --owner=0 --group=0 --mode=u+rw,uga+r \
+      --mtime='1970-01-01' \
+      --absolute-names \
+      --hard-dereference \
+      --transform "s,$TMPDIR/reginfo,$dir/.reginfo," \
+      --transform "s,$NIX_STORE,$dir/store,S" \
+      $TMPDIR/reginfo \
+      $(cat ${installerClosureInfo}/store-paths) \
+      | zstd -19 -T1 -o $out/nix.tar.zst
+  ''


### PR DESCRIPTION
Backport of 7cdf3bad7 + b12be692c, plus a bump to nix-installer 2.34.6.

2.34.6 dropped `build.rs`/`env!()` embedding in favour of appending the closure via `scripts/pack` post-build, so the Rust compile is independent of the embedded Nix and stays cacheable across revisions; the packaging is adapted accordingly.