### PR TITLE
Fix hang in derivation of CA derivations

### DIFF
--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -77,6 +77,7 @@ sources = files(
   'nar-info-disk-cache.cc',
   'nar-info.cc',
   'nix_api_store.cc',
+  'outputs-query.cc',
   'outputs-spec.cc',
   'path-info.cc',
   'path.cc',

--- a/src/libstore-tests/outputs-query.cc
+++ b/src/libstore-tests/outputs-query.cc
@@ -1,0 +1,114 @@
+// Regression tests for the functions in outputs-query.cc
+//
+// See https://github.com/NixOS/nix/issues/15713
+
+#include <gtest/gtest.h>
+
+#include "nix/store/outputs-query.hh"
+#include "nix/store/derivations.hh"
+#include "nix/store/dummy-store-impl.hh"
+#include "nix/store/realisation.hh"
+#include "nix/store/tests/libstore.hh"
+
+namespace nix {
+
+class OutputsQueryTest : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite()
+    {
+        initLibStore(false);
+    }
+
+protected:
+    EnableExperimentalFeature caFeature{"ca-derivations"};
+
+    ref<DummyStore> store = [] {
+        auto cfg = make_ref<DummyStoreConfig>(StoreReference::Params{});
+        cfg->readOnly = false;
+        return cfg->openDummyStore();
+    }();
+
+    static DerivationOutput caFloatingOutput()
+    {
+        return DerivationOutput{DerivationOutput::CAFloating{
+            .method = ContentAddressMethod::Raw::NixArchive,
+            .hashAlgo = HashAlgorithm::SHA256,
+        }};
+    }
+
+    /**
+     * Build a simple floating CA derivation with a given name and no input
+     * derivations.
+     */
+    Derivation makeLeafDrv(std::string name)
+    {
+        Derivation drv;
+        drv.name = std::move(name);
+        drv.platform = "x86_64-linux";
+        drv.builder = "/bin/sh";
+        drv.outputs = {{"out", caFloatingOutput()}};
+        return drv;
+    }
+};
+
+/**
+ * Regression test for https://github.com/NixOS/nix/issues/15713
+ *
+ * In a Fibonacci-style chain of floating CA derivations, the resolution
+ * algorithm used to call queryRealisation O(Fib(N)) times.
+ * This test verifies that memoization reduces this to O(N).
+ */
+TEST_F(OutputsQueryTest, fibonacciChainQueryCount)
+{
+    constexpr static size_t N = 10;
+    std::vector<StorePath> drvPaths;
+
+    // d0, d1: leaf derivations
+    for (int i = 0; i < 2; ++i) {
+        drvPaths.push_back(store->writeDerivation(makeLeafDrv("d" + std::to_string(i))));
+    }
+
+    // d_i depends on d_{i-1} and d_{i-2}
+    for (size_t i = 2; i <= N; ++i) {
+        Derivation drv = makeLeafDrv("d" + std::to_string(i));
+        drv.inputDrvs.map[drvPaths[i - 1]].value.insert("out");
+        drv.inputDrvs.map[drvPaths[i - 2]].value.insert("out");
+        drvPaths.push_back(store->writeDerivation(drv));
+    }
+
+    // Tracker for queryRealisation calls.
+    std::map<StorePath, int> callCounts;
+    std::map<StorePath, StorePath> outPaths;
+
+    QueryRealisationFun queryRealisation = [&](const DrvOutput & id) -> std::shared_ptr<const UnkeyedRealisation> {
+        assert(id.outputName == "out");
+        callCounts[id.drvPath]++;
+
+        // Memoize mock output paths.
+        auto it = outPaths.find(id.drvPath);
+        if (it == outPaths.end()) {
+            auto hash = hashString(HashAlgorithm::SHA1, "mock-output-" + std::to_string(outPaths.size()));
+            it = outPaths.emplace(id.drvPath, StorePath(hash, "out")).first;
+        }
+
+        return std::make_shared<UnkeyedRealisation>(UnkeyedRealisation{.outPath = it->second});
+    };
+
+    auto result = deepQueryPartialDerivationOutput(*store, drvPaths[N], "out", nullptr, queryRealisation);
+
+    ASSERT_TRUE(result);
+
+    int totalCalls = 0;
+    for (auto & [path, count] : callCounts) {
+        totalCalls += count;
+        if (count > 1)
+            ADD_FAILURE() << "Derivation at " << store->printStorePath(path) << " was queried " << count
+                          << " times (expected 1)";
+    }
+
+    // With full memoization (ResolveCache + RealisationCache), each derivation should be queried exactly once.
+    EXPECT_EQ(totalCalls, N + 1) << "queryRealisation called " << totalCalls << " times; expected exactly " << (N + 1);
+}
+
+} // namespace nix

--- a/src/libstore/include/nix/store/realisation.hh
+++ b/src/libstore/include/nix/store/realisation.hh
@@ -4,6 +4,7 @@
 #include <variant>
 
 #include "nix/util/hash.hh"
+#include "nix/util/std-hash.hh"
 #include "nix/store/path.hh"
 #include "nix/store/derived-path.hh"
 #include <nlohmann/json_fwd.hpp>
@@ -175,6 +176,26 @@ public:
         const StorePath & drvPathResolved,
         const OutputName & outputName);
 };
+
+} // namespace nix
+
+template<>
+struct std::hash<nix::DrvOutput>
+{
+    std::size_t operator()(const nix::DrvOutput & id) const noexcept
+    {
+        std::size_t h = 0;
+        nix::hash_combine(h, id.drvPath, id.outputName);
+        return h;
+    }
+};
+
+namespace nix {
+
+inline std::size_t hash_value(const DrvOutput & id)
+{
+    return std::hash<DrvOutput>{}(id);
+}
 
 } // namespace nix
 

--- a/src/libstore/outputs-query.cc
+++ b/src/libstore/outputs-query.cc
@@ -10,6 +10,13 @@ namespace nix {
 namespace {
 
 /**
+ * Cache mapping an unresolved drv path to its resolved (Derivation, StorePath)
+ * pair. Shared across a single top-level resolution call to prevent exponential
+ * re-traversal of the closure when many derivations share the same dependencies.
+ */
+using ResolveCache = boost::unordered_flat_map<StorePath, std::pair<Derivation, StorePath>>;
+
+/**
  * Cache mapping a resolved derivation output to its realisation output path.
  */
 using RealisationCache = boost::unordered_flat_map<DrvOutput, std::optional<StorePath>>;
@@ -21,6 +28,7 @@ static std::optional<StorePath> deepQueryPartialDerivationOutputImpl(
     const std::string & outputName,
     Store * evalStore_,
     QueryRealisationFun & queryRealisation,
+    ResolveCache & cache,
     RealisationCache & resCache);
 
 /**
@@ -37,24 +45,31 @@ static std::optional<StorePath> resolveSingleDerivedPath(
     const SingleDerivedPath & path,
     Store * evalStore_,
     QueryRealisationFun & queryRealisation,
+    ResolveCache & cache,
     RealisationCache & resCache)
 {
     return std::visit(
         overloaded{
             [](const SingleDerivedPath::Opaque & opaque) -> std::optional<StorePath> { return opaque.path; },
             [&](const SingleDerivedPath::Built & built) -> std::optional<StorePath> {
-                auto innerPath = resolveSingleDerivedPath(store, *built.drvPath, evalStore_, queryRealisation, resCache);
+                auto innerPath =
+                    resolveSingleDerivedPath(store, *built.drvPath, evalStore_, queryRealisation, cache, resCache);
                 if (!innerPath)
                     return std::nullopt;
                 return deepQueryPartialDerivationOutputImpl(
-                    store, *innerPath, built.output, evalStore_, queryRealisation, resCache);
+                    store, *innerPath, built.output, evalStore_, queryRealisation, cache, resCache);
             },
         },
         path.raw());
 }
 
 /**
- * Resolve a derivation and compute its store path.
+ * Resolve a derivation and compute its store path, with memoization.
+ *
+ * Results are stored in `cache` (keyed on the unresolved `drvPath`) so that
+ * each derivation in the closure is resolved at most once per top-level call,
+ * preventing the exponential re-traversal that would otherwise occur for
+ * content-addressed derivation closures.
  *
  * @param queryRealisation must already be initialized (not empty)
  */
@@ -63,8 +78,13 @@ static std::pair<Derivation, StorePath> resolveDerivation(
     const StorePath & drvPath,
     Store * evalStore_,
     QueryRealisationFun & queryRealisation,
+    ResolveCache & cache,
     RealisationCache & resCache)
 {
+    auto it = cache.find(drvPath);
+    if (it != cache.end())
+        return it->second;
+
     auto & evalStore = evalStore_ ? *evalStore_ : store;
 
     Derivation drv = evalStore.readInvalidDerivation(drvPath);
@@ -78,18 +98,20 @@ static std::pair<Derivation, StorePath> resolveDerivation(
             [&](ref<const SingleDerivedPath> depDrvPath,
                 const std::string & depOutputName) -> std::optional<StorePath> {
                 auto concreteDrvPath =
-                    resolveSingleDerivedPath(store, *depDrvPath, evalStore_, queryRealisation, resCache);
+                    resolveSingleDerivedPath(store, *depDrvPath, evalStore_, queryRealisation, cache, resCache);
                 if (!concreteDrvPath)
                     return std::nullopt;
                 return deepQueryPartialDerivationOutputImpl(
-                    store, *concreteDrvPath, depOutputName, evalStore_, queryRealisation, resCache);
+                    store, *concreteDrvPath, depOutputName, evalStore_, queryRealisation, cache, resCache);
             });
         if (resolvedDrv)
             drv = Derivation{*resolvedDrv};
     }
 
     auto resolvedDrvPath = computeStorePath(store, drv);
-    return {std::move(drv), std::move(resolvedDrvPath)};
+    auto result = std::make_pair(drv, resolvedDrvPath);
+    cache.emplace(drvPath, result);
+    return result;
 }
 
 void queryPartialDerivationOutputMapCA(
@@ -125,7 +147,7 @@ void queryPartialDerivationOutputMapCA(
 
 /**
  * Internal implementation of deepQueryPartialDerivationOutput that accepts a
- * shared RealisationCache, allowing memoization of realisation queries across recursive calls.
+ * shared ResolveCache and RealisationCache, allowing memoization across recursive calls.
  */
 static std::optional<StorePath> deepQueryPartialDerivationOutputImpl(
     Store & store,
@@ -133,6 +155,7 @@ static std::optional<StorePath> deepQueryPartialDerivationOutputImpl(
     const std::string & outputName,
     Store * evalStore_,
     QueryRealisationFun & queryRealisation,
+    ResolveCache & cache,
     RealisationCache & resCache)
 {
     auto & evalStore = evalStore_ ? *evalStore_ : store;
@@ -141,7 +164,7 @@ static std::optional<StorePath> deepQueryPartialDerivationOutputImpl(
     if (staticResult || !experimentalFeatureSettings.isEnabled(Xp::CaDerivations))
         return staticResult;
 
-    auto [drv, resolvedDrvPath] = resolveDerivation(store, drvPath, evalStore_, queryRealisation, resCache);
+    auto [drv, resolvedDrvPath] = resolveDerivation(store, drvPath, evalStore_, queryRealisation, cache, resCache);
 
     if (drv.outputs.count(outputName) == 0)
         throw Error("derivation '%s' does not have an output named '%s'", store.printStorePath(drvPath), outputName);
@@ -183,8 +206,9 @@ std::map<std::string, std::optional<StorePath>> deepQueryPartialDerivationOutput
     if (!experimentalFeatureSettings.isEnabled(Xp::CaDerivations))
         return outputs;
 
+    ResolveCache cache;
     RealisationCache resCache;
-    auto [drv, resolvedDrvPath] = resolveDerivation(store, drvPath, evalStore_, queryRealisation, resCache);
+    auto [drv, resolvedDrvPath] = resolveDerivation(store, drvPath, evalStore_, queryRealisation, cache, resCache);
     queryPartialDerivationOutputMapCA(store, resolvedDrvPath, drv, outputs, queryRealisation, resCache);
 
     return outputs;
@@ -213,9 +237,10 @@ std::optional<StorePath> deepQueryPartialDerivationOutput(
     if (!queryRealisation)
         queryRealisation = [&store](const DrvOutput & o) { return store.queryRealisation(o); };
 
+    ResolveCache cache;
     RealisationCache resCache;
     return deepQueryPartialDerivationOutputImpl(
-        store, drvPath, outputName, evalStore_, queryRealisation, resCache);
+        store, drvPath, outputName, evalStore_, queryRealisation, cache, resCache);
 }
 
 } // namespace nix

--- a/src/libstore/outputs-query.cc
+++ b/src/libstore/outputs-query.cc
@@ -3,7 +3,25 @@
 #include "nix/store/realisation.hh"
 #include "nix/util/util.hh"
 
+#include <boost/unordered/unordered_flat_map.hpp>
+
 namespace nix {
+
+namespace {
+
+/**
+ * Cache mapping a resolved derivation output to its realisation output path.
+ */
+using RealisationCache = boost::unordered_flat_map<DrvOutput, std::optional<StorePath>>;
+
+/* Forward declaration so resolveSingleDerivedPath can call it. */
+static std::optional<StorePath> deepQueryPartialDerivationOutputImpl(
+    Store & store,
+    const StorePath & drvPath,
+    const std::string & outputName,
+    Store * evalStore_,
+    QueryRealisationFun & queryRealisation,
+    RealisationCache & resCache);
 
 /**
  * Resolve a `SingleDerivedPath` to a concrete store path.
@@ -15,16 +33,21 @@ namespace nix {
  * @param queryRealisation must already be initialized (not empty)
  */
 static std::optional<StorePath> resolveSingleDerivedPath(
-    Store & store, const SingleDerivedPath & path, Store * evalStore_, QueryRealisationFun & queryRealisation)
+    Store & store,
+    const SingleDerivedPath & path,
+    Store * evalStore_,
+    QueryRealisationFun & queryRealisation,
+    RealisationCache & resCache)
 {
     return std::visit(
         overloaded{
             [](const SingleDerivedPath::Opaque & opaque) -> std::optional<StorePath> { return opaque.path; },
             [&](const SingleDerivedPath::Built & built) -> std::optional<StorePath> {
-                auto innerPath = resolveSingleDerivedPath(store, *built.drvPath, evalStore_, queryRealisation);
+                auto innerPath = resolveSingleDerivedPath(store, *built.drvPath, evalStore_, queryRealisation, resCache);
                 if (!innerPath)
                     return std::nullopt;
-                return deepQueryPartialDerivationOutput(store, *innerPath, built.output, evalStore_, queryRealisation);
+                return deepQueryPartialDerivationOutputImpl(
+                    store, *innerPath, built.output, evalStore_, queryRealisation, resCache);
             },
         },
         path.raw());
@@ -35,8 +58,12 @@ static std::optional<StorePath> resolveSingleDerivedPath(
  *
  * @param queryRealisation must already be initialized (not empty)
  */
-static std::pair<Derivation, StorePath>
-resolveDerivation(Store & store, const StorePath & drvPath, Store * evalStore_, QueryRealisationFun & queryRealisation)
+static std::pair<Derivation, StorePath> resolveDerivation(
+    Store & store,
+    const StorePath & drvPath,
+    Store * evalStore_,
+    QueryRealisationFun & queryRealisation,
+    RealisationCache & resCache)
 {
     auto & evalStore = evalStore_ ? *evalStore_ : store;
 
@@ -50,11 +77,12 @@ resolveDerivation(Store & store, const StorePath & drvPath, Store * evalStore_, 
             store,
             [&](ref<const SingleDerivedPath> depDrvPath,
                 const std::string & depOutputName) -> std::optional<StorePath> {
-                auto concreteDrvPath = resolveSingleDerivedPath(store, *depDrvPath, evalStore_, queryRealisation);
+                auto concreteDrvPath =
+                    resolveSingleDerivedPath(store, *depDrvPath, evalStore_, queryRealisation, resCache);
                 if (!concreteDrvPath)
                     return std::nullopt;
-                return deepQueryPartialDerivationOutput(
-                    store, *concreteDrvPath, depOutputName, evalStore_, queryRealisation);
+                return deepQueryPartialDerivationOutputImpl(
+                    store, *concreteDrvPath, depOutputName, evalStore_, queryRealisation, resCache);
             });
         if (resolvedDrv)
             drv = Derivation{*resolvedDrv};
@@ -69,19 +97,77 @@ void queryPartialDerivationOutputMapCA(
     const StorePath & drvPath,
     const BasicDerivation & drv,
     std::map<std::string, std::optional<StorePath>> & outputs,
-    QueryRealisationFun queryRealisation)
+    QueryRealisationFun queryRealisation,
+    RealisationCache & resCache)
 {
     if (!queryRealisation)
         queryRealisation = [&store](const DrvOutput & o) { return store.queryRealisation(o); };
 
     for (auto & [outputName, _] : drv.outputs) {
-        auto realisation = queryRealisation(DrvOutput{drvPath, outputName});
-        if (realisation) {
-            outputs.insert_or_assign(outputName, realisation->outPath);
+        DrvOutput id{drvPath, outputName};
+        auto it = resCache.find(id);
+        if (it != resCache.end()) {
+            outputs.insert_or_assign(outputName, it->second);
+            continue;
+        }
+
+        auto realisation = queryRealisation(id);
+        std::optional<StorePath> outPath = realisation ? std::optional{realisation->outPath} : std::nullopt;
+        resCache.emplace(id, outPath);
+
+        if (outPath) {
+            outputs.insert_or_assign(outputName, *outPath);
         } else {
             outputs.insert({outputName, std::nullopt});
         }
     }
+}
+
+/**
+ * Internal implementation of deepQueryPartialDerivationOutput that accepts a
+ * shared RealisationCache, allowing memoization of realisation queries across recursive calls.
+ */
+static std::optional<StorePath> deepQueryPartialDerivationOutputImpl(
+    Store & store,
+    const StorePath & drvPath,
+    const std::string & outputName,
+    Store * evalStore_,
+    QueryRealisationFun & queryRealisation,
+    RealisationCache & resCache)
+{
+    auto & evalStore = evalStore_ ? *evalStore_ : store;
+
+    auto staticResult = evalStore.queryStaticPartialDerivationOutput(drvPath, outputName);
+    if (staticResult || !experimentalFeatureSettings.isEnabled(Xp::CaDerivations))
+        return staticResult;
+
+    auto [drv, resolvedDrvPath] = resolveDerivation(store, drvPath, evalStore_, queryRealisation, resCache);
+
+    if (drv.outputs.count(outputName) == 0)
+        throw Error("derivation '%s' does not have an output named '%s'", store.printStorePath(drvPath), outputName);
+
+    DrvOutput id{resolvedDrvPath, outputName};
+    auto it = resCache.find(id);
+    if (it != resCache.end())
+        return it->second;
+
+    auto realisation = queryRealisation(id);
+    std::optional<StorePath> outPath = realisation ? std::optional{realisation->outPath} : std::nullopt;
+    resCache.emplace(id, outPath);
+    return outPath;
+}
+
+} // namespace
+
+void queryPartialDerivationOutputMapCA(
+    Store & store,
+    const StorePath & drvPath,
+    const BasicDerivation & drv,
+    std::map<std::string, std::optional<StorePath>> & outputs,
+    QueryRealisationFun queryRealisation)
+{
+    RealisationCache resCache;
+    queryPartialDerivationOutputMapCA(store, drvPath, drv, outputs, queryRealisation, resCache);
 }
 
 std::map<std::string, std::optional<StorePath>> deepQueryPartialDerivationOutputMap(
@@ -97,8 +183,9 @@ std::map<std::string, std::optional<StorePath>> deepQueryPartialDerivationOutput
     if (!experimentalFeatureSettings.isEnabled(Xp::CaDerivations))
         return outputs;
 
-    auto [drv, resolvedDrvPath] = resolveDerivation(store, drvPath, evalStore_, queryRealisation);
-    queryPartialDerivationOutputMapCA(store, resolvedDrvPath, drv, outputs, queryRealisation);
+    RealisationCache resCache;
+    auto [drv, resolvedDrvPath] = resolveDerivation(store, drvPath, evalStore_, queryRealisation, resCache);
+    queryPartialDerivationOutputMapCA(store, resolvedDrvPath, drv, outputs, queryRealisation, resCache);
 
     return outputs;
 }
@@ -123,22 +210,12 @@ std::optional<StorePath> deepQueryPartialDerivationOutput(
     Store * evalStore_,
     QueryRealisationFun queryRealisation)
 {
-    auto & evalStore = evalStore_ ? *evalStore_ : store;
-
     if (!queryRealisation)
         queryRealisation = [&store](const DrvOutput & o) { return store.queryRealisation(o); };
 
-    auto staticResult = evalStore.queryStaticPartialDerivationOutput(drvPath, outputName);
-    if (staticResult || !experimentalFeatureSettings.isEnabled(Xp::CaDerivations))
-        return staticResult;
-
-    auto [drv, resolvedDrvPath] = resolveDerivation(store, drvPath, evalStore_, queryRealisation);
-
-    if (drv.outputs.count(outputName) == 0)
-        throw Error("derivation '%s' does not have an output named '%s'", store.printStorePath(drvPath), outputName);
-
-    auto realisation = queryRealisation(DrvOutput{resolvedDrvPath, outputName});
-    return realisation ? std::optional{realisation->outPath} : std::nullopt;
+    RealisationCache resCache;
+    return deepQueryPartialDerivationOutputImpl(
+        store, drvPath, outputName, evalStore_, queryRealisation, resCache);
 }
 
 } // namespace nix


### PR DESCRIPTION
Closes: #15713 

## Motivation

Bug found in #15713 that hangs the nix command when ca-derivations are enabled. This PR significantly speeds up the command so that it doesn't hang.

## Context

Bug introduced in 57c83a18320d38830cc630b738e9b2156df204a1. Friendly ping @Ericson2314, could you take a look?

Fixed by adding memoization in `outputs-query.cc`. The memoization is per-call, so if there are many calls then there's no memoization between the calls.
