### PR TITLE
libstore: add parallel-store-jobs setting

### DIFF
--- a/doc/manual/rl-next/parallel-store-jobs.md
+++ b/doc/manual/rl-next/parallel-store-jobs.md
@@ -1,0 +1,30 @@
+---
+synopsis: New `parallel-store-jobs` setting to oversubscribe store-path worker pools
+prs: []
+---
+
+Two `ThreadPool` instances that drive batch operations over store paths were
+previously hardcoded to `std::thread::hardware_concurrency()`:
+
+- `Store::queryValidPaths` — the bulk path-validity check that runs at the
+  start of `nix copy` (one HEAD request per path against the destination).
+- `Store::addMultipleToStore`'s `processGraph` workers — the upload/copy
+  workers that actually push NARs to a remote store.
+
+For I/O-bound workloads — most notably, uploading large closures to a remote
+binary cache over a high-latency link — these workers spend the vast majority
+of their time waiting on network round-trips, so the core count is the wrong
+ceiling. Capping concurrency at `hardware_concurrency()` leaves substantial
+network bandwidth on the table even when `http-connections` is set much
+higher.
+
+The new `parallel-store-jobs` setting gives operators a single knob to control
+both pools. Default is `0`, which preserves the existing
+`hardware_concurrency()` behavior — no change for anyone who doesn't set it.
+
+```
+nix copy --to s3://my-cache?... --option parallel-store-jobs 64
+```
+
+is a possible setting for evaluator instances pushing closures to S3/GCS,
+where each thread is mostly waiting on RTT.

--- a/src/libstore/include/nix/store/worker-settings.hh
+++ b/src/libstore/include/nix/store/worker-settings.hh
@@ -81,6 +81,20 @@ public:
         )",
         {"substitution-max-jobs"}};
 
+    Setting<unsigned int> parallelStoreJobs{
+        this,
+        0,
+        "parallel-store-jobs",
+        R"(
+          Number of worker threads used for batch operations over store paths
+          (querying path validity in bulk, and processing the path graph during
+          `nix copy`). `0` (the default) uses the number of available CPU cores.
+
+          Increase this for I/O-bound workloads — most notably, uploading to a
+          remote binary cache — where threads spend most of their time waiting
+          on network round-trips rather than CPU.
+        )"};
+
     Setting<time_t> maxSilentTime{
         this,
         0,

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -260,7 +260,9 @@ void Store::addMultipleToStore(PathsSource && pathsToCopy, Activity & act, Repai
 
             nrDone++;
             showProgress();
-        });
+        },
+        /*discoverNodes=*/false,
+        settings.getWorkerSettings().parallelStoreJobs);
 }
 
 /*
@@ -738,7 +740,7 @@ StorePathSet Store::queryValidPaths(const StorePathSet & paths, SubstituteFlag m
     Sync<State> state_(State{paths.size(), StorePathSet()});
 
     std::condition_variable wakeup;
-    ThreadPool pool;
+    ThreadPool pool(settings.getWorkerSettings().parallelStoreJobs);
 
     auto doQuery = [&](const StorePath & path) {
         checkInterrupt();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Two `ThreadPool` instances inside `libstore` that drive batch operations over store paths are hardcoded to `std::thread::hardware_concurrency()`:

- `Store::queryValidPaths` — the bulk path-validity check that fires at the start of `nix copy` (one HEAD per path against the destination store).
- `Store::addMultipleToStore`'s `processGraph` workers — the upload/copy workers that push NARs to a remote store.

These pools are I/O-bound when the destination is a remote binary cache: each worker spends the vast majority of its wall time blocked on network round-trips. The core count is simply the wrong ceiling for I/O-bound work.

## Change

Adds a new `parallel-store-jobs` setting in `WorkerSettings` that controls the size of both pools. Default of `0` falls through to the existing `ThreadPool::ThreadPool` `hardware_concurrency()` fallback, so this is a no-op for anyone who doesn't set it.

`nix copy --to s3://my-cache?... --option parallel-store-jobs 64` is the kind of setting that could be appropriate for an instance uploading large closures to a remote cache.

## Why a new setting and not `max-substitution-jobs`?

`max-substitution-jobs` governs the parallelism of *fetching* paths from substituters (the `PathSubstitutionGoal` worker pool), not the `queryValidPaths`/`processGraph` pools touched here.

## Backwards compatibility

None broken. Default behavior is unchanged.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
