### PR TITLE
libstore: Drop queryMissing from Worker::run

### DIFF
--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -295,28 +295,11 @@ void Worker::waitForCompletion(GoalPtr goal)
 
 void Worker::run(const Goals & _topGoals)
 {
-    std::vector<nix::DerivedPath> topPaths;
-
-    for (auto & i : _topGoals) {
-        topGoals.insert(i);
-        if (auto goal = dynamic_cast<DerivationTrampolineGoal *>(i.get())) {
-            topPaths.push_back(
-                DerivedPath::Built{
-                    .drvPath = goal->drvReq,
-                    .outputs = goal->wantedOutputs,
-                });
-        } else if (auto goal = dynamic_cast<PathSubstitutionGoal *>(i.get())) {
-            topPaths.push_back(DerivedPath::Opaque{goal->storePath});
-        }
-    }
-
-    /* Call queryMissing() to efficiently query substitutes. */
-    store.queryMissing(topPaths);
-
     debug("entered goal loop");
+    for (std::shared_ptr<Goal> goal : _topGoals)
+        topGoals.insert(std::move(goal));
 
     while (1) {
-
         checkInterrupt();
 
         // TODO GC interface?


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is no longer needed, since `PathSubstitutionGoal` now queries `ValidPathInfo` asynchronously and we can start the builds right away without querying the whole closure at once. This can significantly speed up the build startup.

This was added in back in bbdf08bc0facb5157a10c794712dae7e5902be03 when pathinfo queries were done sequentially and in a blocking manner - this is not the case anymore.

The asynchronous queries don't wait for a build slot to start, so the concurrency there is not limited and all path queries can complete as the worker loop naturally. This also acts as natural rate limiting to avoid allocating too many coroutines up-front and blowing up the memory usage (which also slows down the whole build to a crawl because fork() starts taking increasingly longer to complete due large anonymous memory mappings).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
