### PR TITLE
libstore: Anchor all Store and StoreConfig vtables

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -22,6 +22,10 @@
 
 namespace nix {
 
+void BinaryCacheStoreConfig::anchor() {}
+
+void BinaryCacheStore::anchor() {}
+
 BinaryCacheStore::BinaryCacheStore(Config & config)
     : config{config}
 {

--- a/src/libstore/common-ssh-store-config.cc
+++ b/src/libstore/common-ssh-store-config.cc
@@ -9,6 +9,8 @@ CommonSSHStoreConfig::CommonSSHStoreConfig(const ParsedURL::Authority & authorit
 {
 }
 
+void CommonSSHStoreConfig::anchor() {}
+
 SSHMaster CommonSSHStoreConfig::createSSHMaster(bool useMaster, Descriptor logFD) const
 {
     return {

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -10,6 +10,10 @@
 
 namespace nix {
 
+void DummyStoreConfig::anchor() {}
+
+void DummyStore::anchor() {}
+
 std::string DummyStoreConfig::doc()
 {
     return
@@ -126,6 +130,10 @@ bool DummyStoreConfig::getReadOnly() const
 
 struct DummyStoreImpl : DummyStore
 {
+private:
+    void anchor() override;
+
+public:
     using Config = DummyStoreConfig;
 
     /**
@@ -377,6 +385,8 @@ struct DummyStoreImpl : DummyStore
         return wholeStoreView;
     }
 };
+
+void DummyStoreImpl::anchor() {}
 
 ref<DummyStore> DummyStore::Config::openDummyStore() const
 {

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -23,6 +23,10 @@ StringSet HttpBinaryCacheStoreConfig::uriSchemes()
     return ret;
 }
 
+void HttpBinaryCacheStoreConfig::anchor() {}
+
+void HttpBinaryCacheStore::anchor() {}
+
 HttpBinaryCacheStoreConfig::HttpBinaryCacheStoreConfig(ParsedURL _cacheUri, const Params & params)
     : StoreConfig(params, FilePathType::Unix)
     , BinaryCacheStoreConfig(params)

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -16,6 +16,10 @@ class RemoteFSAccessor;
 
 struct BinaryCacheStoreConfig : virtual StoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     BinaryCacheStoreConfig(const Params & params)
         : StoreConfig(params, FilePathType::Unix)
     {
@@ -92,6 +96,8 @@ struct alignas(8) /* Work around ASAN failures on i686-linux. */
     Config & config;
 
 private:
+    void anchor() override;
+
     std::vector<std::unique_ptr<Signer>> signers;
 
 protected:

--- a/src/libstore/include/nix/store/common-ssh-store-config.hh
+++ b/src/libstore/include/nix/store/common-ssh-store-config.hh
@@ -10,6 +10,10 @@ class SSHMaster;
 
 struct CommonSSHStoreConfig : virtual StoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     CommonSSHStoreConfig(const Params & params)
         : StoreConfig(params, FilePathType::Unix)
     {

--- a/src/libstore/include/nix/store/dummy-store-impl.hh
+++ b/src/libstore/include/nix/store/dummy-store-impl.hh
@@ -15,6 +15,10 @@ struct MemorySourceAccessor;
  */
 struct DummyStore : virtual Store
 {
+private:
+    void anchor() override;
+
+public:
     using Config = DummyStoreConfig;
 
     ref<const Config> config;

--- a/src/libstore/include/nix/store/dummy-store.hh
+++ b/src/libstore/include/nix/store/dummy-store.hh
@@ -12,6 +12,10 @@ struct DummyStore;
 
 struct DummyStoreConfig : public std::enable_shared_from_this<DummyStoreConfig>, virtual StoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     DummyStoreConfig(const Params & params)
         : StoreConfig(params, FilePathType::Unix)
     {

--- a/src/libstore/include/nix/store/gc-store.hh
+++ b/src/libstore/include/nix/store/gc-store.hh
@@ -106,6 +106,10 @@ struct GCResults
  */
 struct GcStore : public virtual Store
 {
+private:
+    void anchor() override;
+
+public:
     inline static std::string operationName = "Garbage collection";
 
     /**

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -14,6 +14,10 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
                                     virtual Store::Config,
                                     BinaryCacheStoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     HttpBinaryCacheStoreConfig(const Params & params)
         : StoreConfig(params, FilePathType::Unix)
         , BinaryCacheStoreConfig(params)
@@ -88,6 +92,8 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
 
 class HttpBinaryCacheStore : public virtual BinaryCacheStore
 {
+    void anchor() override;
+
     struct State
     {
         bool enabled = true;

--- a/src/libstore/include/nix/store/indirect-root-store.hh
+++ b/src/libstore/include/nix/store/indirect-root-store.hh
@@ -38,6 +38,10 @@ namespace nix {
  */
 struct IndirectRootStore : public virtual LocalFSStore
 {
+private:
+    void anchor() override;
+
+public:
     inline static std::string operationName = "Indirect GC roots registration";
 
     /**

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -12,6 +12,10 @@ namespace nix {
 
 struct LegacySSHStoreConfig : std::enable_shared_from_this<LegacySSHStoreConfig>, virtual CommonSSHStoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     LegacySSHStoreConfig(const Params & params)
         : StoreConfig(params, FilePathType::Unix)
         , CommonSSHStoreConfig(params)
@@ -63,6 +67,10 @@ struct LegacySSHStoreConfig : std::enable_shared_from_this<LegacySSHStoreConfig>
 
 struct LegacySSHStore : public virtual Store
 {
+private:
+    void anchor() override;
+
+public:
     using Config = LegacySSHStoreConfig;
 
     ref<const Config> config;

--- a/src/libstore/include/nix/store/local-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/local-binary-cache-store.hh
@@ -9,6 +9,10 @@ struct LocalBinaryCacheStoreConfig : std::enable_shared_from_this<LocalBinaryCac
                                      virtual Store::Config,
                                      BinaryCacheStoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     LocalBinaryCacheStoreConfig(const Params & params)
         : StoreConfig(params, FilePathType::Unix)
         , BinaryCacheStoreConfig(params)

--- a/src/libstore/include/nix/store/local-fs-store.hh
+++ b/src/libstore/include/nix/store/local-fs-store.hh
@@ -10,6 +10,8 @@ namespace nix {
 struct LocalFSStoreConfig : virtual StoreConfig
 {
 private:
+    void anchor() override;
+
     static Setting<std::optional<AbsolutePath>>
     makeRootDirSetting(LocalFSStoreConfig & self, std::optional<AbsolutePath> defaultValue)
     {
@@ -87,6 +89,10 @@ struct alignas(8) /* Work around ASAN failures on i686-linux. */
                    virtual GcStore,
                    virtual LogStore
 {
+private:
+    void anchor() override;
+
+public:
     using Config = LocalFSStoreConfig;
 
     const Config & config;

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -7,6 +7,10 @@ namespace nix {
  */
 struct LocalOverlayStoreConfig : virtual LocalStoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     LocalOverlayStoreConfig(const StringMap & params)
         : LocalOverlayStoreConfig("", params)
     {
@@ -119,6 +123,8 @@ struct LocalOverlayStore : virtual LocalStore
     LocalOverlayStore(ref<const Config>);
 
 private:
+    void anchor() override;
+
     /**
      * The store beneath us.
      *

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -35,8 +35,9 @@ struct LocalSettings;
 
 struct LocalBuildStoreConfig : virtual LocalFSStoreConfig
 {
-
 private:
+    void anchor() override;
+
     /**
       Input for computing the build directory. See `getBuildDir()`.
      */
@@ -89,6 +90,7 @@ struct LocalStoreConfig : std::enable_shared_from_this<LocalStoreConfig>,
     LocalStoreConfig(const std::filesystem::path & path, const Params & params);
 
 private:
+    void anchor() override;
 
     /**
      * An indirection so that we don't need to refer to global settings
@@ -177,6 +179,8 @@ public:
 
 class LocalStore : public virtual IndirectRootStore, public virtual GcStore
 {
+    void anchor() override;
+
 public:
 
     using Config = LocalStoreConfig;

--- a/src/libstore/include/nix/store/log-store.hh
+++ b/src/libstore/include/nix/store/log-store.hh
@@ -7,6 +7,10 @@ namespace nix {
 
 struct LogStore : public virtual Store
 {
+private:
+    void anchor() override;
+
+public:
     inline static std::string operationName = "Build log storage and retrieval";
 
     /**

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -23,6 +23,10 @@ class RemoteFSAccessor;
 
 struct RemoteStoreConfig : virtual StoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     RemoteStoreConfig(const Params & params, FilePathType pathType)
         : StoreConfig(params, pathType)
     {
@@ -44,6 +48,10 @@ struct RemoteStoreConfig : virtual StoreConfig
  */
 struct RemoteStore : public virtual Store, public virtual GcStore, public virtual LogStore
 {
+private:
+    void anchor() override;
+
+public:
     using Config = RemoteStoreConfig;
 
     const Config & config;

--- a/src/libstore/include/nix/store/ssh-store.hh
+++ b/src/libstore/include/nix/store/ssh-store.hh
@@ -12,6 +12,10 @@ struct SSHStoreConfig : std::enable_shared_from_this<SSHStoreConfig>,
                         virtual RemoteStoreConfig,
                         virtual CommonSSHStoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     SSHStoreConfig(const Params & params)
         : StoreConfig(params, FilePathType::Unix)
         , RemoteStoreConfig(params, FilePathType::Unix)
@@ -43,6 +47,10 @@ struct SSHStoreConfig : std::enable_shared_from_this<SSHStoreConfig>,
 
 struct MountedSSHStoreConfig : virtual SSHStoreConfig, virtual LocalFSStoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     MountedSSHStoreConfig(StringMap params);
     MountedSSHStoreConfig(const ParsedURL::Authority & authority, StringMap params);
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -229,6 +229,12 @@ public:
  */
 struct StoreConfig : public StoreConfigBase, public StoreDirConfig
 {
+private:
+    /* VTable anchor to avoid weak linkage of the vtable - it breaks
+       dynamic_cast across shared libraries on Darwin. */
+    virtual void anchor() = 0;
+
+public:
     using Params = StoreReference::Params;
 
     StoreConfig(const Params & params, FilePathType pathType);
@@ -380,6 +386,10 @@ struct StoreConfig : public StoreConfigBase, public StoreDirConfig
  */
 class Store : public std::enable_shared_from_this<Store>, public StoreDirConfig
 {
+    /* VTable anchor to avoid weak linkage of the vtable - it breaks
+       dynamic_cast across shared libraries on Darwin. */
+    virtual void anchor() = 0;
+
 public:
 
     using Config = StoreConfig;

--- a/src/libstore/include/nix/store/uds-remote-store.hh
+++ b/src/libstore/include/nix/store/uds-remote-store.hh
@@ -27,6 +27,10 @@ struct UDSRemoteStoreConfig : std::enable_shared_from_this<UDSRemoteStoreConfig>
                               virtual LocalFSStoreConfig,
                               virtual RemoteStoreConfig
 {
+private:
+    void anchor() override;
+
+public:
     UDSRemoteStoreConfig(const std::filesystem::path & path, const Params & params);
 
     UDSRemoteStoreConfig(const Params & params);
@@ -57,6 +61,10 @@ struct UDSRemoteStoreConfig : std::enable_shared_from_this<UDSRemoteStoreConfig>
 
 struct UDSRemoteStore : virtual IndirectRootStore, virtual RemoteStore
 {
+private:
+    void anchor() override;
+
+public:
     using Config = UDSRemoteStoreConfig;
 
     ref<const Config> config;

--- a/src/libstore/indirect-root-store.cc
+++ b/src/libstore/indirect-root-store.cc
@@ -2,6 +2,8 @@
 
 namespace nix {
 
+void IndirectRootStore::anchor() {}
+
 void IndirectRootStore::makeSymlink(const std::filesystem::path & link, const std::filesystem::path & target)
 {
     /* Create directories up to `gcRoot'. */

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -24,6 +24,8 @@ LegacySSHStoreConfig::LegacySSHStoreConfig(const ParsedURL::Authority & authorit
 {
 }
 
+void LegacySSHStoreConfig::anchor() {}
+
 std::string LegacySSHStoreConfig::doc()
 {
     return
@@ -36,6 +38,8 @@ struct LegacySSHStore::Connection : public ServeProto::BasicClientConnection
     std::unique_ptr<SSHMaster::Connection> sshConn;
     bool good = true;
 };
+
+void LegacySSHStore::anchor() {}
 
 LegacySSHStore::LegacySSHStore(ref<const Config> config)
     : Store{*config}

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -52,6 +52,10 @@ StoreReference LocalBinaryCacheStoreConfig::getReference() const
 
 struct LocalBinaryCacheStore : virtual BinaryCacheStore
 {
+private:
+    void anchor() override;
+
+public:
     using Config = LocalBinaryCacheStoreConfig;
 
     ref<Config> config;
@@ -138,6 +142,10 @@ StringSet LocalBinaryCacheStoreConfig::uriSchemes()
     else
         return {"file"};
 }
+
+void LocalBinaryCacheStoreConfig::anchor() {}
+
+void LocalBinaryCacheStore::anchor() {}
 
 ref<Store> LocalBinaryCacheStoreConfig::openStore() const
 {

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -5,6 +5,10 @@
 
 namespace nix {
 
+void LocalFSStoreConfig::anchor() {}
+
+void LocalFSStore::anchor() {}
+
 LocalFSStoreConfig::LocalFSStoreConfig(const std::filesystem::path & rootDir, const Params & params)
     : StoreConfig(params, FilePathType::Native)
     /* Default `?root` from `rootDir` if non set

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -10,6 +10,10 @@
 
 namespace nix {
 
+void LocalOverlayStoreConfig::anchor() {}
+
+void LocalOverlayStore::anchor() {}
+
 std::string LocalOverlayStoreConfig::doc()
 {
     return

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -56,6 +56,14 @@
 
 namespace nix {
 
+void LocalStoreConfig::anchor() {}
+
+void LocalBuildStoreConfig::anchor() {}
+
+void LocalStore::anchor() {}
+
+void GcStore::anchor() {}
+
 LocalStoreConfig::LocalStoreConfig(const std::filesystem::path & path, const Params & params)
     : StoreConfig(params, FilePathType::Native)
     , LocalFSStoreConfig(path, params)

--- a/src/libstore/log-store.cc
+++ b/src/libstore/log-store.cc
@@ -2,6 +2,8 @@
 
 namespace nix {
 
+void LogStore::anchor() {}
+
 std::optional<std::string> LogStore::getBuildLog(const StorePath & path)
 {
     auto maybePath = getBuildDerivationPath(path);

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -30,6 +30,8 @@
 
 namespace nix {
 
+void RemoteStoreConfig::anchor() {}
+
 /* TODO: Separate these store types into different files, give them better names */
 RemoteStore::RemoteStore(const Config & config)
     : Store{config}
@@ -58,6 +60,8 @@ RemoteStore::RemoteStore(const Config & config)
               }))
 {
 }
+
+void RemoteStore::anchor() {}
 
 ref<RemoteStore::Connection> RemoteStore::openConnectionWrapper()
 {

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -38,6 +38,10 @@ bool RestrictionContext::isAllowed(const DerivedPath & req)
  */
 struct RestrictedStore : public virtual IndirectRootStore, public virtual GcStore
 {
+private:
+    void anchor() override;
+
+public:
     ref<const LocalStore::Config> config;
 
     ref<LocalStore> next;
@@ -156,6 +160,8 @@ struct RestrictedStore : public virtual IndirectRootStore, public virtual GcStor
         return NotTrusted;
     }
 };
+
+void RestrictedStore::anchor() {}
 
 ref<Store> makeRestrictedStore(ref<LocalStore::Config> config, ref<LocalStore> next, RestrictionContext & context)
 {

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -17,6 +17,10 @@ SSHStoreConfig::SSHStoreConfig(const ParsedURL::Authority & authority, const Par
 {
 }
 
+void SSHStoreConfig::anchor() {}
+
+void MountedSSHStoreConfig::anchor() {}
+
 std::string SSHStoreConfig::doc()
 {
     return
@@ -39,6 +43,10 @@ StoreReference SSHStoreConfig::getReference() const
 struct alignas(8) /* Work around ASAN failures on i686-linux. */
     SSHStore : virtual RemoteStore
 {
+private:
+    void anchor() override;
+
+public:
     using Config = SSHStoreConfig;
 
     ref<const Config> config;
@@ -87,6 +95,8 @@ protected:
     };
 };
 
+void SSHStore::anchor() {}
+
 MountedSSHStoreConfig::MountedSSHStoreConfig(StringMap params)
     : StoreConfig(params, FilePathType::Native)
     , RemoteStoreConfig(params, FilePathType::Native)
@@ -128,6 +138,10 @@ std::string MountedSSHStoreConfig::doc()
  */
 struct MountedSSHStore : virtual SSHStore, virtual LocalFSStore
 {
+private:
+    void anchor() override;
+
+public:
     using Config = MountedSSHStoreConfig;
 
     MountedSSHStore(ref<const Config> config)
@@ -186,6 +200,8 @@ struct MountedSSHStore : virtual SSHStore, virtual LocalFSStore
         return readString(conn->from);
     }
 };
+
+void MountedSSHStore::anchor() {}
 
 ref<Store> SSHStore::Config::openStore() const
 {

--- a/src/libstore/uds-remote-store.cc
+++ b/src/libstore/uds-remote-store.cc
@@ -26,6 +26,10 @@ std::filesystem::path getDaemonSocketPath(const Store::Config & config)
         .value_or(config.getStateDir() / "daemon-socket" / "socket");
 }
 
+void UDSRemoteStoreConfig::anchor() {}
+
+void UDSRemoteStore::anchor() {}
+
 UDSRemoteStoreConfig::UDSRemoteStoreConfig(const std::filesystem::path & path, const StoreReference::Params & params)
     : Store::Config{params, FilePathType::Native}
     , LocalFSStore::Config{params}


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Classes with virtual functions defined in headers must have at least one
out-of-line definition of a virtual function (also called "key function"
[3]) to prevent having the vtable from having weak (vague [2]) linkage
and causing a bunch of headaches on Darwin.

For now this just limits to fixes for what would be required for nix-heuristic-gc,
which compiles with pybind11 which uses hidden visibility for the dylib. In the
future we'd certainly want to enable -Werror=weak-vtables to prevent such footguns.

The pattern used here is basically the same as what LLVM does [1].

[1]: https://github.com/llvm/llvm-project/blob/710c297289b751857bdc0a8677437d575b403922/clang/lib/ExtractAPI/API.cpp#L177-L200
[2]: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#vague
[3]: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#vague-vtable

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Needed to fix https://github.com/risicle/nix-heuristic-gc/pull/16 on darwin. There pybind11 links the dylib with hidden visibility and winds up with a copy of the typeinfo, so `dynamic_cast` ends up being broken.

Some references https://lists.llvm.org/pipermail/llvm-dev/2013-June/062851.html, https://stackoverflow.com/questions/23746941/what-is-the-meaning-of-clangs-wweak-vtables

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
