### PR TITLE
Lazy revCount

### DIFF
--- a/src/libexpr-tests/lazy-fetcher-attr.cc
+++ b/src/libexpr-tests/lazy-fetcher-attr.cc
@@ -1,0 +1,100 @@
+#include <gtest/gtest.h>
+
+#include "nix/expr/fetch-tree.hh"
+#include "nix/expr/tests/libexpr.hh"
+#include "nix/fetchers/attrs.hh"
+#include "nix/fetchers/fetchers.hh"
+#include "nix/store/path.hh"
+
+namespace nix {
+
+class LazyFetcherAttrTest : public LibExprTest
+{
+protected:
+    StorePath dummyPath()
+    {
+        return StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-test"};
+    }
+};
+
+TEST_F(LazyFetcherAttrTest, nonLazyAttrProducesImmediateValue)
+{
+    fetchers::Input input;
+    input.attrs.insert_or_assign("type", std::string("git"));
+    input.attrs.insert_or_assign("revCount", uint64_t(5));
+
+    Value v;
+    emitTreeAttrs(state, dummyPath(), input, v, false, false);
+    state.forceValue(v, noPos);
+
+    auto * rcAttr = v.attrs()->get(state.symbols.create("revCount"));
+    ASSERT_NE(rcAttr, nullptr);
+    state.forceValue(*rcAttr->value, noPos);
+    EXPECT_EQ(rcAttr->value->integer().value, 5);
+}
+
+TEST_F(LazyFetcherAttrTest, lazyAttrProducesThunk)
+{
+    int calls = 0;
+    fetchers::Input input;
+    input.attrs.insert_or_assign("type", std::string("git"));
+    input.attrs.insert_or_assign(
+        "revCount",
+        fetchers::LazyAttr(
+            make_ref<fetchers::LazyAttrComputation>(
+                fetchers::LazyAttrComputation{.compute = [&calls]() -> fetchers::ResolvedAttr {
+                    calls++;
+                    return uint64_t(42);
+                }})));
+
+    Value v;
+    emitTreeAttrs(state, dummyPath(), input, v, false, false);
+    state.forceValue(v, noPos);
+
+    auto * rcAttr = v.attrs()->get(state.symbols.create("revCount"));
+    ASSERT_NE(rcAttr, nullptr);
+
+    // Not yet forced, so the lazy function should not have been called
+    EXPECT_EQ(calls, 0);
+
+    // Force the thunk
+    state.forceValue(*rcAttr->value, noPos);
+    EXPECT_EQ(rcAttr->value->integer().value, 42);
+    EXPECT_EQ(calls, 1);
+}
+
+TEST_F(LazyFetcherAttrTest, lazyFunctionOnlyCalledOnAccess)
+{
+    int calls = 0;
+    fetchers::Input input;
+    input.attrs.insert_or_assign("type", std::string("git"));
+    input.attrs.insert_or_assign("lastModified", uint64_t(1000));
+    input.attrs.insert_or_assign(
+        "revCount",
+        fetchers::LazyAttr(
+            make_ref<fetchers::LazyAttrComputation>(
+                fetchers::LazyAttrComputation{.compute = [&calls]() -> fetchers::ResolvedAttr {
+                    calls++;
+                    return uint64_t(99);
+                }})));
+
+    Value v;
+    emitTreeAttrs(state, dummyPath(), input, v, false, false);
+    state.forceValue(v, noPos);
+
+    // Access lastModified, so should not trigger lazy revCount
+    auto * lmAttr = v.attrs()->get(state.symbols.create("lastModified"));
+    ASSERT_NE(lmAttr, nullptr);
+    state.forceValue(*lmAttr->value, noPos);
+    EXPECT_EQ(lmAttr->value->integer().value, 1000);
+    EXPECT_EQ(calls, 0);
+
+    // Now access revCount
+    auto * rcAttr = v.attrs()->get(state.symbols.create("revCount"));
+    ASSERT_NE(rcAttr, nullptr);
+    state.forceValue(*rcAttr->value, noPos);
+    EXPECT_EQ(rcAttr->value->integer().value, 99);
+    EXPECT_EQ(calls, 1);
+}
+
+} // namespace nix

--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -51,6 +51,7 @@ sources = files(
   'error_traces.cc',
   'eval.cc',
   'json.cc',
+  'lazy-fetcher-attr.cc',
   'main.cc',
   'nix_api_expr.cc',
   'nix_api_external.cc',

--- a/src/libexpr/include/nix/expr/fetch-tree.hh
+++ b/src/libexpr/include/nix/expr/fetch-tree.hh
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "nix/expr/eval.hh"
+
+namespace nix {
+
+/**
+ * Convert a libfetchers `Input` to libexpr `Value`.
+ */
+void emitTreeAttrs(
+    EvalState & state,
+    const StorePath & storePath,
+    const fetchers::Input & input,
+    Value & v,
+    bool emptyRevFallback = false,
+    bool forceDirty = false);
+
+} // namespace nix

--- a/src/libexpr/include/nix/expr/meson.build
+++ b/src/libexpr/include/nix/expr/meson.build
@@ -20,6 +20,7 @@ headers = [ config_pub_h ] + files(
   'eval-profiler.hh',
   'eval-settings.hh',
   'eval.hh',
+  'fetch-tree.hh',
   'function-trace.hh',
   'gc-small-vector.hh',
   'get-drvs.hh',

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -1,7 +1,9 @@
+#include "nix/expr/value.hh"
 #include "nix/fetchers/attrs.hh"
 #include "nix/expr/primops.hh"
 #include "nix/expr/eval-inline.hh"
 #include "nix/expr/eval-settings.hh"
+#include "nix/expr/fetch-tree.hh"
 #include "nix/store/store-api.hh"
 #include "nix/fetchers/fetchers.hh"
 #include "nix/store/filetransfer.hh"
@@ -18,6 +20,95 @@
 #include <iomanip>
 
 namespace nix {
+
+/**
+ * Adapter for putting libfetchers data into a thunk closure.
+ * Used as the argument to prim_forceLazyFetcherAttr in a lazy apply thunk.
+ */
+class LazyFetcherAttr : public ExternalValueBase, public gc_cleanup
+{
+    fetchers::LazyAttr lazy;
+
+public:
+    LazyFetcherAttr(fetchers::LazyAttr lazy)
+        : lazy(std::move(lazy))
+    {
+    }
+
+    fetchers::ResolvedAttr force()
+    {
+        return lazy->compute();
+    }
+
+protected:
+    std::ostream & print(std::ostream & str) const override
+    {
+        unreachable();
+    }
+
+public:
+    std::string showType() const override
+    {
+        unreachable();
+    }
+
+    std::string typeOf() const override
+    {
+        unreachable();
+    }
+};
+
+/**
+ * Initialize a `Value` from a resolved fetcher attribute.
+ */
+static void resolvedAttrToValue(EvalState & state, Value & v, const fetchers::ResolvedAttr & resolved)
+{
+    std::visit(
+        overloaded{
+            [&](const std::string & s) { v.mkString(s, state.mem); },
+            [&](uint64_t n) { v.mkInt(n); },
+            [&](const Explicit<bool> & b) { v.mkBool(b.t); },
+        },
+        resolved);
+}
+
+/**
+ * internal primop: Force a LazyFetcherAttr external value.
+ */
+static void prim_forceLazyFetcherAttr(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+{
+    Value & arg = *args[0];
+
+    state.forceValue(arg, pos);
+    // We only construct this primop with LazyFetcherAttr preapplied.
+    assert(arg.type() == nExternal);
+    auto * ext = dynamic_cast<LazyFetcherAttr *>(args[0]->external());
+    assert(ext);
+
+    resolvedAttrToValue(state, v, ext->force());
+}
+
+/**
+ * Emit a lazy thunk for a LazyAttr: mkApp(primop, externalValue).
+ */
+static void emitLazyAttrThunk(EvalState & state, const fetchers::LazyAttr & lazyAttr, Value & dest)
+{
+    // not user-callable (unregistered, internal)
+    static PrimOp forcePrimOp{
+        .name = "__forceLazyFetcherAttr",
+        .arity = 1,
+        .impl = prim_forceLazyFetcherAttr,
+        .internal = true,
+    };
+
+    auto * vExt = state.allocValue();
+    vExt->mkExternal(new LazyFetcherAttr(lazyAttr));
+
+    auto * vPrimOp = state.allocValue();
+    vPrimOp->mkPrimOp(&forcePrimOp);
+
+    dest.mkApp(vPrimOp, vExt);
+}
 
 void emitTreeAttrs(
     EvalState & state,
@@ -51,7 +142,9 @@ void emitTreeAttrs(
             attrs.alloc("shortRev").mkString(emptyHash.gitShortRev(), state.mem);
         }
 
-        if (auto revCount = input.getRevCount())
+        if (auto revCount = maybeGetLazyAttr(input.attrs, "revCount"))
+            emitLazyAttrThunk(state, *revCount, attrs.alloc("revCount"));
+        else if (auto revCount = input.getRevCount())
             attrs.alloc("revCount").mkInt(*revCount);
         else if (emptyRevFallback)
             attrs.alloc("revCount").mkInt(0);

--- a/src/libfetchers-tests/attrs.cc
+++ b/src/libfetchers-tests/attrs.cc
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+
+#include "nix/fetchers/attrs.hh"
+
+#include <nlohmann/json.hpp>
+
+namespace nix::fetchers {
+
+TEST(LazyAttr, resolveToInt)
+{
+    Attrs attrs;
+    attrs.insert_or_assign(
+        "count", LazyAttr(make_ref<LazyAttrComputation>(LazyAttrComputation{.compute = []() -> ResolvedAttr {
+            return uint64_t(42);
+        }})));
+    EXPECT_EQ(maybeGetIntAttr(attrs, "count"), 42);
+}
+
+TEST(LazyAttr, resolveToString)
+{
+    Attrs attrs;
+    attrs.insert_or_assign(
+        "name", LazyAttr(make_ref<LazyAttrComputation>(LazyAttrComputation{.compute = []() -> ResolvedAttr {
+            return std::string("hello");
+        }})));
+    EXPECT_EQ(maybeGetStrAttr(attrs, "name"), "hello");
+}
+
+TEST(LazyAttr, resolveToBool)
+{
+    Attrs attrs;
+    attrs.insert_or_assign(
+        "flag", LazyAttr(make_ref<LazyAttrComputation>(LazyAttrComputation{.compute = []() -> ResolvedAttr {
+            return Explicit<bool>{true};
+        }})));
+    EXPECT_EQ(maybeGetBoolAttr(attrs, "flag"), true);
+}
+
+TEST(LazyAttr, attrsToJSONForcesLazy)
+{
+    Attrs attrs;
+    attrs.insert_or_assign(
+        "x", LazyAttr(make_ref<LazyAttrComputation>(LazyAttrComputation{.compute = []() -> ResolvedAttr {
+            return uint64_t(99);
+        }})));
+    auto json = attrsToJSON(attrs);
+    EXPECT_EQ(json["x"], 99);
+}
+
+TEST(LazyAttr, attrsToQueryForcesLazy)
+{
+    Attrs attrs;
+    attrs.insert_or_assign(
+        "v", LazyAttr(make_ref<LazyAttrComputation>(LazyAttrComputation{.compute = []() -> ResolvedAttr {
+            return std::string("val");
+        }})));
+    auto query = attrsToQuery(attrs);
+    EXPECT_EQ(query.at("v"), "val");
+}
+
+TEST(LazyAttr, notCalledUntilForced)
+{
+    int calls = 0;
+    Attrs attrs;
+    attrs.insert_or_assign(
+        "lazy", LazyAttr(make_ref<LazyAttrComputation>(LazyAttrComputation{.compute = [&calls]() -> ResolvedAttr {
+            calls++;
+            return uint64_t(1);
+        }})));
+    EXPECT_EQ(calls, 0);
+    maybeGetIntAttr(attrs, "lazy");
+    EXPECT_EQ(calls, 1);
+}
+
+} // namespace nix::fetchers

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -40,6 +40,7 @@ subdir('nix-meson-build-support/common')
 
 sources = files(
   'access-tokens.cc',
+  'attrs.cc',
   'git-utils.cc',
   'git.cc',
   'input.cc',

--- a/src/libfetchers/attrs.cc
+++ b/src/libfetchers/attrs.cc
@@ -4,6 +4,18 @@
 
 namespace nix::fetchers {
 
+ResolvedAttr forceAttr(const Attr & attr)
+{
+    return std::visit(
+        overloaded{
+            [](const LazyAttr & lazy) -> ResolvedAttr { return lazy->compute(); },
+            [](const std::string & v) -> ResolvedAttr { return v; },
+            [](uint64_t v) -> ResolvedAttr { return v; },
+            [](const Explicit<bool> & v) -> ResolvedAttr { return v; },
+        },
+        attr);
+}
+
 Attrs jsonToAttrs(const nlohmann::json & json)
 {
     Attrs attrs;
@@ -26,11 +38,12 @@ nlohmann::json attrsToJSON(const Attrs & attrs)
 {
     nlohmann::json json;
     for (auto & attr : attrs) {
-        if (auto v = std::get_if<uint64_t>(&attr.second)) {
+        auto resolved = forceAttr(attr.second);
+        if (auto v = std::get_if<uint64_t>(&resolved)) {
             json[attr.first] = *v;
-        } else if (auto v = std::get_if<std::string>(&attr.second)) {
+        } else if (auto v = std::get_if<std::string>(&resolved)) {
             json[attr.first] = *v;
-        } else if (auto v = std::get_if<Explicit<bool>>(&attr.second)) {
+        } else if (auto v = std::get_if<Explicit<bool>>(&resolved)) {
             json[attr.first] = v->t;
         } else
             unreachable();
@@ -43,7 +56,8 @@ std::optional<std::string> maybeGetStrAttr(const Attrs & attrs, const std::strin
     auto i = attrs.find(name);
     if (i == attrs.end())
         return {};
-    if (auto v = std::get_if<std::string>(&i->second))
+    auto resolved = forceAttr(i->second);
+    if (auto v = std::get_if<std::string>(&resolved))
         return *v;
     throw Error("input attribute '%s' is not a string %s", name, attrsToJSON(attrs).dump());
 }
@@ -61,7 +75,8 @@ std::optional<uint64_t> maybeGetIntAttr(const Attrs & attrs, const std::string &
     auto i = attrs.find(name);
     if (i == attrs.end())
         return {};
-    if (auto v = std::get_if<uint64_t>(&i->second))
+    auto resolved = forceAttr(i->second);
+    if (auto v = std::get_if<uint64_t>(&resolved))
         return *v;
     throw Error("input attribute '%s' is not an integer", name);
 }
@@ -79,7 +94,8 @@ std::optional<bool> maybeGetBoolAttr(const Attrs & attrs, const std::string & na
     auto i = attrs.find(name);
     if (i == attrs.end())
         return {};
-    if (auto v = std::get_if<Explicit<bool>>(&i->second))
+    auto resolved = forceAttr(i->second);
+    if (auto v = std::get_if<Explicit<bool>>(&resolved))
         return v->t;
     throw Error("input attribute '%s' is not a Boolean", name);
 }
@@ -96,11 +112,12 @@ StringMap attrsToQuery(const Attrs & attrs)
 {
     StringMap query;
     for (auto & attr : attrs) {
-        if (auto v = std::get_if<uint64_t>(&attr.second)) {
+        auto resolved = forceAttr(attr.second);
+        if (auto v = std::get_if<uint64_t>(&resolved)) {
             query.insert_or_assign(attr.first, fmt("%d", *v));
-        } else if (auto v = std::get_if<std::string>(&attr.second)) {
+        } else if (auto v = std::get_if<std::string>(&resolved)) {
             query.insert_or_assign(attr.first, *v);
-        } else if (auto v = std::get_if<Explicit<bool>>(&attr.second)) {
+        } else if (auto v = std::get_if<Explicit<bool>>(&resolved)) {
             query.insert_or_assign(attr.first, v->t ? "1" : "0");
         } else
             unreachable();

--- a/src/libfetchers/attrs.cc
+++ b/src/libfetchers/attrs.cc
@@ -51,6 +51,16 @@ nlohmann::json attrsToJSON(const Attrs & attrs)
     return json;
 }
 
+std::optional<LazyAttr> maybeGetLazyAttr(const Attrs & attrs, const std::string & name)
+{
+    auto i = attrs.find(name);
+    if (i == attrs.end())
+        return {};
+    if (auto v = std::get_if<LazyAttr>(&i->second))
+        return *v;
+    return {};
+}
+
 std::optional<std::string> maybeGetStrAttr(const Attrs & attrs, const std::string & name)
 {
     auto i = attrs.find(name);

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -13,6 +13,7 @@
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/util/json-utils.hh"
 #include "nix/util/archive.hh"
+#include "nix/util/memo.hh"
 #include "nix/util/mounted-source-accessor.hh"
 
 #include <sys/time.h>
@@ -162,6 +163,13 @@ std::vector<PublicKey> getPublicKeys(const Attrs & attrs)
 } // end namespace
 
 static const Hash nullRev{HashAlgorithm::SHA1};
+
+static LazyAttr makeLazyAttr(fun<ResolvedAttr()> compute)
+{
+    return make_ref<LazyAttrComputation>(LazyAttrComputation{
+        .compute = memo<ResolvedAttr>(std::move(compute)),
+    });
+}
 
 struct GitInputScheme : InputScheme
 {
@@ -723,14 +731,12 @@ struct GitInputScheme : InputScheme
     }
 
     uint64_t getRevCount(
-        const Settings & settings,
-        const RepoInfo & repoInfo,
-        const std::filesystem::path & repoDir,
-        const Hash & rev) const
+        ref<Cache> cache, const RepoInfo & repoInfo, const std::filesystem::path & repoDir, const Hash & rev) const
     {
-        Cache::Key key{"gitRevCount", {{"rev", rev.gitRev()}}};
+        if (GitRepo::openRepo(repoDir, {})->isShallow())
+            throw Error("'%s' is a shallow Git repository, so 'revCount' is not available", repoInfo.locationToArg());
 
-        auto cache = settings.getCache();
+        Cache::Key key{"gitRevCount", {{"rev", rev.gitRev()}}};
 
         if (auto revCountAttrs = cache->lookup(key))
             return getIntAttr(*revCountAttrs, "revCount");
@@ -743,6 +749,18 @@ struct GitInputScheme : InputScheme
         cache->upsert(key, Attrs{{"revCount", revCount}});
 
         return revCount;
+    }
+
+    LazyAttr lazyRevCount(
+        const Settings & settings,
+        const RepoInfo & repoInfo,
+        const std::filesystem::path & repoDir,
+        const Hash & rev) const
+    {
+        auto cache = settings.getCache();
+        return makeLazyAttr([this, cache, repoInfo, repoDir, rev]() -> ResolvedAttr {
+            return getRevCount(cache, repoInfo, repoDir, rev);
+        });
     }
 
     std::string getDefaultRef(const Settings & settings, const RepoInfo & repoInfo, bool shallow) const
@@ -891,13 +909,6 @@ struct GitInputScheme : InputScheme
 
         auto repo = GitRepo::openRepo(repoDir, {});
 
-        auto isShallow = repo->isShallow();
-
-        if (isShallow && !getShallowAttr(input))
-            throw Error(
-                "'%s' is a shallow Git repository, but shallow repositories are only allowed when `shallow = true;` is specified",
-                repoInfo.locationToArg());
-
         // FIXME: check whether rev is an ancestor of ref?
 
         auto rev = *input.getRev();
@@ -911,7 +922,7 @@ struct GitInputScheme : InputScheme
         if (!getShallowAttr(input)) {
             /* Like lastModified, skip revCount if supplied by the caller. */
             if (!input.attrs.contains("revCount"))
-                input.attrs.insert_or_assign("revCount", getRevCount(settings, repoInfo, repoDir, rev));
+                input.attrs.insert_or_assign("revCount", lazyRevCount(settings, repoInfo, repoDir, rev));
         }
 
         printTalkative("using revision %s of repo '%s'", rev.gitRev(), repoInfo.locationToArg());
@@ -1033,8 +1044,11 @@ struct GitInputScheme : InputScheme
 
             input.attrs.insert_or_assign("rev", rev.gitRev());
             if (!getShallowAttr(input)) {
-                input.attrs.insert_or_assign(
-                    "revCount", rev == nullRev ? 0 : getRevCount(settings, repoInfo, repoPath, rev));
+                if (rev == nullRev) {
+                    input.attrs.insert_or_assign("revCount", uint64_t(0));
+                } else {
+                    input.attrs.insert_or_assign("revCount", lazyRevCount(settings, repoInfo, repoPath, rev));
+                }
             }
 
             verifyCommit(input, repo);

--- a/src/libfetchers/include/nix/fetchers/attrs.hh
+++ b/src/libfetchers/include/nix/fetchers/attrs.hh
@@ -45,6 +45,11 @@ typedef std::map<std::string, Attr> Attrs;
  */
 ResolvedAttr forceAttr(const Attr & attr);
 
+/**
+ * Retrieve an attr, but only if it's a LazyAttr.
+ */
+std::optional<LazyAttr> maybeGetLazyAttr(const Attrs & attrs, const std::string & name);
+
 Attrs jsonToAttrs(const nlohmann::json & json);
 
 nlohmann::json attrsToJSON(const Attrs & attrs);

--- a/src/libfetchers/include/nix/fetchers/attrs.hh
+++ b/src/libfetchers/include/nix/fetchers/attrs.hh
@@ -3,6 +3,8 @@
 
 #include "nix/util/types.hh"
 #include "nix/util/hash.hh"
+#include "nix/util/ref.hh"
+#include "nix/util/fun.hh"
 
 #include <variant>
 
@@ -12,7 +14,24 @@
 
 namespace nix::fetchers {
 
-typedef std::variant<std::string, uint64_t, Explicit<bool>> Attr;
+/**
+ * The resolved (non-lazy) subset of attribute value types.
+ */
+using ResolvedAttr = std::variant<std::string, uint64_t, Explicit<bool>>;
+
+/**
+ * A deferred attribute computation.  Wrapping in `ref<>` gives
+ * pointer-identity equality/ordering, which is correct: two lazy
+ * attrs are equal iff they are the same computation.
+ */
+struct LazyAttrComputation
+{
+    fun<ResolvedAttr()> compute;
+};
+
+using LazyAttr = ref<LazyAttrComputation>;
+
+using Attr = std::variant<std::string, uint64_t, Explicit<bool>, LazyAttr>;
 
 /**
  * An `Attrs` can be thought of a JSON object restricted or simplified
@@ -20,6 +39,11 @@ typedef std::variant<std::string, uint64_t, Explicit<bool>> Attr;
  * and also not containing any `null`s.
  */
 typedef std::map<std::string, Attr> Attrs;
+
+/**
+ * Force a potentially lazy attribute to its resolved value.
+ */
+ResolvedAttr forceAttr(const Attr & attr);
 
 Attrs jsonToAttrs(const nlohmann::json & json);
 

--- a/src/libflake/flake-primops.cc
+++ b/src/libflake/flake-primops.cc
@@ -105,12 +105,13 @@ static void prim_parseFlakeRef(EvalState & state, const PosIdx pos, Value ** arg
     for (const auto & [key, value] : attrs) {
         auto s = state.symbols.create(key);
         auto & vv = binds.alloc(s);
+        auto resolved = forceAttr(value);
         std::visit(
             overloaded{
                 [&vv, &state](const std::string & value) { vv.mkString(value, state.mem); },
                 [&vv](const uint64_t & value) { vv.mkInt(value); },
                 [&vv](const Explicit<bool> & value) { vv.mkBool(value.t); }},
-            value);
+            resolved);
     }
     v.mkAttrs(binds);
 }

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -991,9 +991,13 @@ std::optional<Fingerprint> LockedFlake::getFingerprint(Store & store, const fetc
 
     /* Include revCount and lastModified because they're not
        necessarily implied by the content fingerprint (e.g. for
-       tarball flakes) but can influence the evaluation result. */
-    if (auto revCount = flake.lockedRef.input.getRevCount())
-        *fingerprint += fmt(";revCount=%d", *revCount);
+       tarball flakes) but can influence the evaluation result.
+       For revCount, we only include its presence (not its value)
+       because the value is functionally determined by rev, which
+       is already part of the fingerprint. This avoids forcing a
+       lazy revCount computation. */
+    if (flake.lockedRef.input.attrs.contains("revCount"))
+        *fingerprint += ";hasRevCount";
     if (auto lastModified = flake.lockedRef.input.getLastModified())
         *fingerprint += fmt(";lastModified=%d", *lastModified);
 

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -989,15 +989,24 @@ std::optional<Fingerprint> LockedFlake::getFingerprint(Store & store, const fetc
 
     *fingerprint += fmt(";%s;%s", flake.lockedRef.subdir, lockFile);
 
-    /* Include revCount and lastModified because they're not
-       necessarily implied by the content fingerprint (e.g. for
-       tarball flakes) but can influence the evaluation result.
-       For revCount, we only include its presence (not its value)
-       because the value is functionally determined by rev, which
-       is already part of the fingerprint. This avoids forcing a
-       lazy revCount computation. */
-    if (flake.lockedRef.input.attrs.contains("revCount"))
-        *fingerprint += ";hasRevCount";
+    if (auto revCount = get(flake.lockedRef.input.attrs, "revCount")) {
+        if (std::get_if<fetchers::LazyAttr>(revCount)) {
+            /* A lazy revCount is computed by the fetcher, so its
+               value is functionally determined by `rev`. We only
+               need to record its presence, not force its value.
+
+               This means a lazy and a concrete revCount that would
+               resolve to the same value produce different
+               fingerprints, sacrificing some cache hits to avoid
+               the cost of forcing. */
+            *fingerprint += ";hasRevCount";
+        } else if (auto n = flake.lockedRef.input.getRevCount()) {
+            /* A concrete revCount comes from a lockfile or explicit
+               user input. The fetcher passes it through as-is, so
+               it can affect evaluation and must be fingerprinted. */
+            *fingerprint += fmt(";revCount=%d", *n);
+        }
+    }
     if (auto lastModified = flake.lockedRef.input.getLastModified())
         *fingerprint += fmt(";lastModified=%d", *lastModified);
 

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -38,6 +38,7 @@
 #include "nix/fetchers/input-cache.hh"
 #include "nix/expr/attr-set.hh"
 #include "nix/expr/eval-error.hh"
+#include "nix/expr/fetch-tree.hh"
 #include "nix/expr/nixexpr.hh"
 #include "nix/expr/symbol-table.hh"
 #include "nix/expr/value.hh"

--- a/src/libflake/include/nix/flake/flake.hh
+++ b/src/libflake/include/nix/flake/flake.hh
@@ -233,14 +233,6 @@ ref<eval_cache::EvalCache> openEvalCache(EvalState & state, ref<const LockedFlak
 
 } // namespace flake
 
-void emitTreeAttrs(
-    EvalState & state,
-    const StorePath & storePath,
-    const fetchers::Input & input,
-    Value & v,
-    bool emptyRevFallback = false,
-    bool forceDirty = false);
-
 /**
  * An internal builtin similar to `fetchTree`, except that it
  * always treats the input as final (i.e. no attributes can be

--- a/src/libutil-tests/memo.cc
+++ b/src/libutil-tests/memo.cc
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <string>
+
+#include "nix/util/memo.hh"
+
+namespace nix {
+
+TEST(memo, computesOnce)
+{
+    int calls = 0;
+    fun<int()> f = memo<int>([&calls]() -> int {
+        calls++;
+        return 42;
+    });
+    EXPECT_EQ(f(), 42);
+    EXPECT_EQ(f(), 42);
+    EXPECT_EQ(f(), 42);
+    EXPECT_EQ(calls, 1);
+}
+
+TEST(memo, copiesShareCache)
+{
+    int calls = 0;
+    fun<int()> f = memo<int>([&calls]() -> int {
+        calls++;
+        return 7;
+    });
+    auto g = f;
+    EXPECT_EQ(f(), 7);
+    EXPECT_EQ(g(), 7);
+    EXPECT_EQ(calls, 1);
+}
+
+TEST(memo, worksWithString)
+{
+    int calls = 0;
+    fun<std::string()> f = memo<std::string>([&calls]() -> std::string {
+        calls++;
+        return "hello";
+    });
+    EXPECT_EQ(f(), "hello");
+    EXPECT_EQ(f(), "hello");
+    EXPECT_EQ(calls, 1);
+}
+
+} // namespace nix

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -79,6 +79,7 @@ sources = files(
   'json-utils.cc',
   'logging.cc',
   'lru-cache.cc',
+  'memo.cc',
   'memory-source-accessor.cc',
   'monitorfdhup.cc',
   'nar-listing.cc',

--- a/src/libutil/include/nix/util/fun.hh
+++ b/src/libutil/include/nix/util/fun.hh
@@ -1,6 +1,5 @@
 #pragma once
 ///@file
-// Tests in: src/libutil-tests/fun.cc
 
 #include <functional>
 #include <stdexcept>

--- a/src/libutil/include/nix/util/memo.hh
+++ b/src/libutil/include/nix/util/memo.hh
@@ -1,0 +1,40 @@
+#pragma once
+///@file
+
+#include "nix/util/fun.hh"
+
+#include <memory>
+#include <mutex>
+#include <optional>
+
+namespace nix {
+
+/**
+ * Memoize a `fun<T()>`.
+ *
+ * Copies of the returned `fun` share the same cache.
+ * Thread-safe.
+ */
+template<typename T>
+fun<T()> memo(fun<T()> f)
+{
+    struct State
+    {
+        fun<T()> compute;
+        std::once_flag flag;
+        std::optional<T> cached;
+
+        explicit State(fun<T()> compute)
+            : compute(std::move(compute))
+        {
+        }
+    };
+
+    auto state = std::shared_ptr<State>(new State(std::move(f)));
+    return [state]() -> T {
+        std::call_once(state->flag, [&]() { state->cached.emplace(state->compute()); });
+        return *state->cached;
+    };
+}
+
+} // namespace nix

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -60,6 +60,7 @@ headers = [ config_pub_h ] + files(
   'json-utils.hh',
   'logging.hh',
   'lru-cache.hh',
+  'memo.hh',
   'memory-source-accessor.hh',
   'mounted-source-accessor.hh',
   'muxable-pipe.hh',

--- a/tests/functional/fetchGitShallow.sh
+++ b/tests/functional/fetchGitShallow.sh
@@ -29,9 +29,11 @@ git -C "$TEST_ROOT/shallow-parent" commit -m "Branch commit"
 # Make a shallow clone (depth=1)
 git clone --depth 1 "file://$TEST_ROOT/shallow-parent" "$TEST_ROOT/shallow-clone"
 
-# Test 1: Fetching a shallow repo shouldn't work by default, because we can't
-# return a revCount.
-(! nix eval --impure --raw --expr "(builtins.fetchGit { url = \"$TEST_ROOT/shallow-clone\"; ref = \"dev\"; }).outPath")
+# Test 1: Fetching a shallow repo succeeds for outPath because revCount is lazy.
+path1=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"$TEST_ROOT/shallow-clone\"; ref = \"dev\"; }).outPath")
+[[ -d "$path1" ]]
+# But accessing revCount on a shallow clone fails.
+(! nix eval --impure --expr "(builtins.fetchGit { url = \"$TEST_ROOT/shallow-clone\"; ref = \"dev\"; }).revCount" 2>/dev/null)
 
 # Test 2: But you can request a shallow clone, which won't return a revCount.
 path=$(nix eval --impure --raw --expr "(builtins.fetchTree { type = \"git\"; url = \"file://$TEST_ROOT/shallow-clone\"; ref = \"dev\"; shallow = true; }).outPath")

--- a/tests/functional/fetchGitShallow.sh
+++ b/tests/functional/fetchGitShallow.sh
@@ -65,3 +65,32 @@ fi
 # Verify that we can shallow fetch the worktree
 git -C "$TEST_ROOT/shallow-worktree" rev-list --count HEAD >/dev/null
 nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$TEST_ROOT/shallow-worktree\"; shallow = true; }).rev"
+
+# Test 5: nix build --dry-run on a shallow clone must not force revCount.
+# The flake fingerprint must not eagerly evaluate revCount, because that
+# would fail (or produce wrong results) on shallow clones.
+# Nor should it generate a complete lock file that serializes the root node.
+# We remove the parent repo to ensure that a future improvement that
+# tries to fetch missing history can't paper over the issue.
+createGitRepo "$TEST_ROOT/shallow-build-parent"
+echo "" > "$TEST_ROOT/shallow-build-parent/file.txt"
+git -C "$TEST_ROOT/shallow-build-parent" add file.txt
+git -C "$TEST_ROOT/shallow-build-parent" commit -m "first"
+cat > "$TEST_ROOT/shallow-build-parent/flake.nix" <<EOF
+{
+  outputs = { self }: {
+    packages.$system.default =
+      derivation {
+        name = "test";
+        system = "$system";
+        builder = "/bin/sh";
+        args = [ "-c" "echo ok > \\\$out" ];
+      };
+  };
+}
+EOF
+git -C "$TEST_ROOT/shallow-build-parent" add flake.nix
+git -C "$TEST_ROOT/shallow-build-parent" commit -m "add flake"
+git clone --depth 1 "file://$TEST_ROOT/shallow-build-parent" "$TEST_ROOT/shallow-build-clone"
+rm -rf "$TEST_ROOT/shallow-build-parent"
+nix build --dry-run "git+file://$TEST_ROOT/shallow-build-clone"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

1. Few exprs need `revCount`, so let's only fetch it when needed.
   (or when serializing the lock)
2. Current Nix has a bug where `nix build git+file:///path/to/repo` would go `getAccessorFromWorkdir` and fail to throw the revcount error, returning a number that's too low instead. I'm unsure whether the CLI should infer `shallow = true;`, but I'm open to the idea if users need it. For now I've kept it simple and "pure" for what that's worth.

## Context

Written partially at OceanSprint 2026

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
