### PR TITLE
Filter systemd socket activation sockets by name

### DIFF
--- a/src/libcmd/include/nix/cmd/unix-socket-server.hh
+++ b/src/libcmd/include/nix/cmd/unix-socket-server.hh
@@ -56,6 +56,13 @@ struct ServeUnixSocketOptions
 
 #ifndef _WIN32
     /**
+     * Name of the socket for socket activation, as included in `LISTEN_FDNAMES`
+     * Ordinarily the name of the socket unit, e.g. `nix-daemon.socket`
+     * If this field is empty, no name filtering will be performed.
+     */
+    std::string activationName = "";
+
+    /**
      * Additional file descriptor to poll. Useful for doing a self-pipe trick
      * https://cr.yp.to/docs/selfpipe.html.
      */

--- a/src/libcmd/unix/unix-socket-server.cc
+++ b/src/libcmd/unix/unix-socket-server.cc
@@ -5,6 +5,7 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/logging.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/strings.hh"
 #include "nix/util/unix-domain-socket.hh"
 #include "nix/util/util.hh"
 
@@ -65,9 +66,16 @@ PeerInfo getPeerInfo(Descriptor remote)
     if (listenFds) {
         if (getEnv("LISTEN_PID") != std::to_string(getpid()))
             throw Error("unexpected systemd environment variables");
+
+        auto fdNames = tokenizeString<std::vector<std::string>>(getEnv("LISTEN_FDNAMES").value_or(""), ":");
         auto count = string2Int<unsigned int>(*listenFds);
         assert(count);
         for (unsigned int i = 0; i < count; ++i) {
+            // Not all implementations of LISTEN_FDS will implement names,
+            // listen anyway if we do not have enough names
+            if (i < fdNames.size() && options.activationName != "" && fdNames[i] != options.activationName)
+                continue;
+
             AutoCloseFD fdSocket(SD_LISTEN_FDS_START + i);
             closeOnExec(fdSocket.get());
             listeningSockets.push_back(std::move(fdSocket));

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -285,6 +285,7 @@ static void daemonLoop(
             {
                 .socketPath = std::move(socketPath),
                 .socketMode = 0666,
+                .activationName = "nix-daemon.socket",
                 .auxiliaryFd = sigChldPipe.pipe.readSide.get(),
                 .onAuxiliaryFdPollin =
                     []() {

--- a/src/nix/unix/store-roots-daemon.cc
+++ b/src/nix/unix/store-roots-daemon.cc
@@ -44,6 +44,7 @@ struct CmdRootsDaemon : StoreConfigCommand
             {
                 .socketPath = gcSocketPath,
                 .socketMode = 0666,
+                .activationName = "nix-roots-daemon.socket",
             },
             [&](AutoCloseFD remote, std::function<void()> closeListeners) {
                 std::thread([&, remote = std::move(remote)]() mutable {


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Filtering makes it possible to differentiate different activation sockets connecting to the same daemon process. I plan to use this support to expose the varlink socket from #13768 outside the nix sandbox, within the same daemon process.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context
systemd activation provides services with a number of file descriptors in the `LISTEN_FDS` environment variable when they are started with a `.socket` unit. There is an additional less-well-documented, but still standard, environment variable called `LISTEN_FDNAMES` that provides the associated unit name for each socket. Without this filtering, the daemon could not listen on multiple sockets with different APIs, they would all use one handler.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
