### PR TITLE
fix(git): detect shallow boundaries in getRevCount

### DIFF
--- a/src/libfetchers-tests/git.cc
+++ b/src/libfetchers-tests/git.cc
@@ -4,6 +4,7 @@
 #include "nix/fetchers/fetchers.hh"
 #include "nix/fetchers/git-utils.hh"
 #include "nix/util/url.hh"
+#include "nix/util/tests/gmock-matchers.hh"
 
 #include <git2.h>
 #include <gtest/gtest.h>
@@ -33,7 +34,14 @@ using RefHandle = Handle<git_reference, git_reference_free>;
 using CommitHandle = Handle<git_commit, git_commit_free>;
 using SubmoduleHandle = Handle<git_submodule, git_submodule_free>;
 
-#define CHECK_LIBGIT(expr) ASSERT_TRUE((expr) >= 0) << git_error_last()
+#define CHECK_LIBGIT(expr)                                                                        \
+    do {                                                                                          \
+        int _rc = (expr);                                                                         \
+        if (_rc < 0) {                                                                            \
+            auto * _err = git_error_last();                                                       \
+            FAIL() << #expr << " failed (" << _rc << "): " << (_err ? _err->message : "unknown"); \
+        }                                                                                         \
+    } while (0)
 
 static void commitAll(git_repository * repo, const char * msg)
 {
@@ -199,6 +207,205 @@ TEST_F(GitTest, submodulePeriodSupport)
     auto [accessor, i] = input.getAccessor(settings, *store);
 
     ASSERT_EQ(accessor->readFile(CanonPath("deps/sub/lib.txt")), "hello from submodule\n");
+}
+
+TEST_F(GitTest, getRevCountShallowThrows)
+{
+    auto repoPath = tmpDir / "repo";
+
+    // Create a repo with two commits
+    RepoHandle repo;
+    {
+        git_repository * raw = nullptr;
+        CHECK_LIBGIT(git_repository_init(&raw, repoPath.string().c_str(), /*is_bare=*/0));
+        repo.reset(raw);
+    }
+    writeFile(repoPath / "file.txt", "first\n");
+    commitAll(repo.get(), "first");
+    writeFile(repoPath / "file.txt", "second\n");
+    commitAll(repo.get(), "second");
+
+    // Mark HEAD as a shallow boundary by writing .git/shallow
+    RefHandle headRef;
+    {
+        git_reference * raw = nullptr;
+        CHECK_LIBGIT(git_repository_head(&raw, repo.get()));
+        headRef.reset(raw);
+    }
+    char oidStr[GIT_OID_SHA1_HEXSIZE + 1];
+    git_oid_tostr(oidStr, sizeof(oidStr), git_reference_target(headRef.get()));
+    writeFile(repoPath / ".git" / "shallow", std::string(oidStr) + "\n");
+    headRef.reset();
+    repo.reset();
+
+    auto nixRepo = GitRepo::openRepo(repoPath, {});
+
+    ASSERT_TRUE(nixRepo->isShallow());
+
+    auto rev = nixRepo->resolveRef("HEAD");
+    // getRevCount on a shallow repo should throw, not silently return 1
+    auto expectedMsg =
+        fmt("Git commit '%s' has an incomplete history "
+            "(shallow boundary; 0 of 1 parents locally available). "
+            "To resolve this, either enable the shallow parameter in your flake URL (?shallow=1) "
+            "or set the shallow parameter to true in builtins.fetchGit, "
+            "or fetch the complete history for this branch.",
+            rev.gitRev());
+    EXPECT_THAT(
+        [&] { nixRepo->getRevCount(rev); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher(expectedMsg)));
+}
+
+TEST_F(GitTest, getRevCountShallowPartialWorks)
+{
+    auto repoPath = tmpDir / "repo";
+
+    // Create a repo: init -> A -> B on main, init -> A2 -> B2 on feature
+    RepoHandle repo;
+    {
+        git_repository * raw = nullptr;
+        CHECK_LIBGIT(git_repository_init(&raw, repoPath.string().c_str(), /*is_bare=*/0));
+        repo.reset(raw);
+    }
+    writeFile(repoPath / "file.txt", "init\n");
+    commitAll(repo.get(), "init");
+
+    writeFile(repoPath / "file.txt", "A\n");
+    commitAll(repo.get(), "A");
+    writeFile(repoPath / "file.txt", "B\n");
+    commitAll(repo.get(), "B");
+
+    // Create feature branch from init (HEAD~2)
+    git_reference * headRaw = nullptr;
+    CHECK_LIBGIT(git_repository_head(&headRaw, repo.get()));
+    RefHandle headRef(headRaw);
+
+    git_commit * headCommitRaw = nullptr;
+    CHECK_LIBGIT(git_commit_lookup(&headCommitRaw, repo.get(), git_reference_target(headRef.get())));
+    CommitHandle headCommit(headCommitRaw);
+
+    git_commit * parentRaw = nullptr;
+    CHECK_LIBGIT(git_commit_parent(&parentRaw, headCommit.get(), 0));
+    CommitHandle parent(parentRaw);
+
+    git_commit * initRaw = nullptr;
+    CHECK_LIBGIT(git_commit_parent(&initRaw, parent.get(), 0));
+    CommitHandle initCommit(initRaw);
+
+    git_reference * featureRaw = nullptr;
+    CHECK_LIBGIT(git_branch_create(&featureRaw, repo.get(), "feature", initCommit.get(), /*force=*/0));
+    RefHandle featureRef(featureRaw);
+
+    CHECK_LIBGIT(git_repository_set_head(repo.get(), "refs/heads/feature"));
+    git_checkout_options checkoutOpts = GIT_CHECKOUT_OPTIONS_INIT;
+    checkoutOpts.checkout_strategy = GIT_CHECKOUT_FORCE;
+    CHECK_LIBGIT(git_checkout_head(repo.get(), &checkoutOpts));
+
+    writeFile(repoPath / "file.txt", "A2\n");
+    commitAll(repo.get(), "A2");
+    writeFile(repoPath / "file.txt", "B2\n");
+    commitAll(repo.get(), "B2");
+
+    // Mark feature's HEAD (B2) as a shallow boundary
+    git_reference * featureHeadRaw = nullptr;
+    CHECK_LIBGIT(git_repository_head(&featureHeadRaw, repo.get()));
+    RefHandle featureHeadRef(featureHeadRaw);
+    char oidStr[GIT_OID_SHA1_HEXSIZE + 1];
+    git_oid_tostr(oidStr, sizeof(oidStr), git_reference_target(featureHeadRef.get()));
+    writeFile(repoPath / ".git" / "shallow", std::string(oidStr) + "\n");
+    featureHeadRef.reset();
+    repo.reset();
+
+    auto nixRepo = GitRepo::openRepo(repoPath, {});
+    ASSERT_TRUE(nixRepo->isShallow());
+
+    // main has complete history (init -> A -> B = 3 commits), should work
+    auto mainRev = nixRepo->resolveRef("refs/heads/main");
+    ASSERT_EQ(nixRepo->getRevCount(mainRev), 3);
+
+    // feature HEAD is at a shallow boundary, should throw
+    auto featureRev = nixRepo->resolveRef("HEAD");
+    ASSERT_THROW(nixRepo->getRevCount(featureRev), Error);
+}
+
+TEST_F(GitTest, getRevCountAuthorNamedParent)
+{
+    auto repoPath = tmpDir / "repo";
+
+    RepoHandle repo;
+    {
+        git_repository * raw = nullptr;
+        CHECK_LIBGIT(git_repository_init(&raw, repoPath.string().c_str(), /*is_bare=*/0));
+        repo.reset(raw);
+    }
+
+    // Create a commit whose author name is "parent" — this should not
+    // confuse the raw header parser into thinking there's an extra parent.
+    writeFile(repoPath / "file.txt", "hello\n");
+    IndexHandle idx;
+    {
+        git_index * raw = nullptr;
+        CHECK_LIBGIT(git_repository_index(&raw, repo.get()));
+        idx.reset(raw);
+    }
+    CHECK_LIBGIT(git_index_add_all(idx.get(), nullptr, 0, nullptr, nullptr));
+    CHECK_LIBGIT(git_index_write(idx.get()));
+
+    git_oid treeId{};
+    CHECK_LIBGIT(git_index_write_tree(&treeId, idx.get()));
+    TreeHandle tree;
+    {
+        git_tree * raw = nullptr;
+        CHECK_LIBGIT(git_tree_lookup(&raw, repo.get(), &treeId));
+        tree.reset(raw);
+    }
+
+    SigHandle sig;
+    {
+        git_signature * raw = nullptr;
+        CHECK_LIBGIT(git_signature_now(&raw, "parent", "parent@example.com"));
+        sig.reset(raw);
+    }
+
+    git_oid commitId{};
+    CHECK_LIBGIT(
+        git_commit_create_v(&commitId, repo.get(), "HEAD", sig.get(), sig.get(), nullptr, "init", tree.get(), 0));
+    CHECK_LIBGIT(git_reference_create(nullptr, repo.get(), "refs/heads/main", &commitId, true, nullptr));
+    CHECK_LIBGIT(git_repository_set_head(repo.get(), "refs/heads/main"));
+
+    auto nixRepo = GitRepo::openRepo(repoPath, {});
+    auto rev = nixRepo->resolveRef("HEAD");
+    // Root commit (no parents): rawParents should be 0 despite "parent" in author field
+    ASSERT_EQ(nixRepo->getRevCount(rev), 1);
+
+    // Add a second commit (also authored by "parent") so the first becomes a real parent.
+    // The second commit's header has rawParents==1 AND "parent" in author/committer.
+    writeFile(repoPath / "file.txt", "world\n");
+    CHECK_LIBGIT(git_index_add_all(idx.get(), nullptr, 0, nullptr, nullptr));
+    CHECK_LIBGIT(git_index_write(idx.get()));
+    git_oid treeId2{};
+    CHECK_LIBGIT(git_index_write_tree(&treeId2, idx.get()));
+    TreeHandle tree2;
+    {
+        git_tree * raw = nullptr;
+        CHECK_LIBGIT(git_tree_lookup(&raw, repo.get(), &treeId2));
+        tree2.reset(raw);
+    }
+    CommitHandle parentCommit;
+    {
+        git_commit * raw = nullptr;
+        CHECK_LIBGIT(git_commit_lookup(&raw, repo.get(), &commitId));
+        parentCommit.reset(raw);
+    }
+    const git_commit * parents[] = {parentCommit.get()};
+    git_oid commitId2{};
+    CHECK_LIBGIT(git_commit_create(
+        &commitId2, repo.get(), "HEAD", sig.get(), sig.get(), nullptr, "second", tree2.get(), 1, &parents[0]));
+    repo.reset();
+
+    nixRepo = GitRepo::openRepo(repoPath, {});
+    rev = nixRepo->resolveRef("HEAD");
+    ASSERT_EQ(nixRepo->getRevCount(rev), 2);
 }
 
 } // namespace nix::fetchers

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -414,6 +414,28 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         });
     }
 
+    /**
+     * Count the number of `parent` lines in a commit's raw header.
+     * This reflects the true parent count from the commit object,
+     * unaffected by shallow boundaries (unlike `git_commit_parentcount`
+     * which returns 0 for shallow boundary commits).
+     */
+    static unsigned int getRawParentCount(const git_commit * commit)
+    {
+        unsigned int count = 0;
+        const char * header = git_commit_raw_header(commit);
+        for (const char * p = header; *p;) {
+            if (strncmp(p, "parent ", 7) == 0)
+                ++count;
+            // Skip to next line
+            p = strchr(p, '\n');
+            if (!p)
+                break;
+            ++p;
+        }
+        return count;
+    }
+
     uint64_t getRevCount(const Hash & rev) override
     {
         boost::concurrent_flat_set<git_oid, std::hash<git_oid>> done;
@@ -432,18 +454,22 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
             auto _commit = lookupObject(*repo, oid, GIT_OBJECT_COMMIT);
             auto commit = (const git_commit *) &*_commit;
 
-            for (auto n : std::views::iota(0U, git_commit_parentcount(commit))) {
+            auto apiParents = git_commit_parentcount(commit);
+            auto rawParents = getRawParentCount(commit);
+            if (apiParents < rawParents)
+                throw Error(
+                    "Git commit '%s' has an incomplete history "
+                    "(shallow boundary; %u of %u parents locally available). "
+                    "To resolve this, either enable the shallow parameter in your flake URL (?shallow=1) "
+                    "or set the shallow parameter to true in builtins.fetchGit, "
+                    "or fetch the complete history for this branch.",
+                    *git_commit_id(commit),
+                    apiParents,
+                    rawParents);
+
+            for (auto n : std::views::iota(0U, apiParents)) {
                 auto parentOid = git_commit_parent_id(commit, n);
-                if (!parentOid) {
-                    throw Error(
-                        "Failed to retrieve the parent of Git commit '%s': %s. "
-                        "This may be due to an incomplete repository history. "
-                        "To resolve this, either enable the shallow parameter in your flake URL (?shallow=1) "
-                        "or add set the shallow parameter to true in builtins.fetchGit, "
-                        "or fetch the complete history for this branch.",
-                        *git_commit_id(commit),
-                        git_error_last()->message);
-                }
+                assert(parentOid);
                 if (done.insert(*parentOid))
                     pool.enqueue(std::bind(process, *parentOid));
             }


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fix a bug in `getRevCount`

Previously, `getRevCount` on a shallow clone silently returned a wrong count (only counting the commits available locally). This is because libgit2 reports parentcount as 0 for shallow boundary commits, so the walk terminates early without error.

Fix by comparing `git_commit_parentcount` (shallow-aware) against the raw commit header's parent count. When they differ, the commit is at a shallow boundary and the history is incomplete.

This is more precise than rejecting all shallow repos: a repo can be shallow for one branch while having complete history for another. Only the branches with truncated history are rejected.

## Context

- Discovered by reasoning about the lack of a certain test failure in #15772: TDD wasn't as red as it should have been
- I would recommend to also merge #15772 so that users are less likely to be faced with this error. (Users who were given wrong numbers that were not used)

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
