### PR TITLE
Ignore keep-{outputs,derivations} for delete

### DIFF
--- a/doc/manual/rl-next/delete-keep.md
+++ b/doc/manual/rl-next/delete-keep.md
@@ -1,0 +1,8 @@
+---
+synopsis: "Fixed a bug where keep-outputs and keep-derivations can interfere with delete commands"
+prs: [15776]
+---
+
+Setting `keep-derivations = true` and trying to delete a derivation with realised outputs would previously fail.
+Same with `keep-outputs = true` and trying to delete an output that still has derivers.
+These options no longer affect the deletion commands, and are now documented as such.

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -357,8 +357,6 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
     const auto & gcSettings = config->getLocalSettings().getGCSettings();
 
     bool shouldDelete = options.action == GCOptions::gcDeleteDead || options.action == GCOptions::gcDeleteSpecific;
-    bool keepOutputs = gcSettings.keepOutputs;
-    bool keepDerivations = gcSettings.keepDerivations;
 
     boost::unordered_flat_set<StorePath, std::hash<StorePath>> roots, dead, alive;
 
@@ -381,16 +379,6 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
     Sync<Shared> _shared;
 
     std::condition_variable wakeup;
-
-    /* Using `--ignore-liveness' with `--delete' can have unintended
-       consequences if `keep-outputs' or `keep-derivations' are true
-       (the garbage collector will recurse into deleting the outputs
-       or derivers, respectively, even if they aren't in the
-       pathsToDelete).  So disable them. */
-    if (std::holds_alternative<StorePathSet>(options.pathsToDelete) && options.ignoreLiveness) {
-        keepOutputs = false;
-        keepDerivations = false;
-    }
 
     if (shouldDelete)
         deletePath(reservedPath);
@@ -625,12 +613,23 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 alive.insert(start);
                 try {
                     StorePathSet closure;
+                    bool includeOutputs = false;
+                    bool includeDerivers = false;
+                    std::visit(
+                        overloaded{
+                            [&](const GCOptions::WholeStore &) {
+                                includeOutputs = gcSettings.keepOutputs;
+                                includeDerivers = gcSettings.keepDerivations;
+                            },
+                            [](const StorePathSet &) {},
+                        },
+                        options.pathsToDelete);
                     computeFSClosure(
                         *path,
                         closure,
                         /* flipDirection */ false,
-                        keepOutputs,
-                        keepDerivations);
+                        includeOutputs,
+                        includeDerivers);
                     for (auto & p : closure)
                         alive.insert(p);
                 } catch (InvalidPath &) {
@@ -675,22 +674,28 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 for (auto & p : i->second)
                     enqueue(p);
 
-                /* If keep-derivations is set and this is a derivation, then we only want to delete this derivation if
-                 * we can also delete all its outputs, so visit the derivation outputs. */
-                if (keepDerivations && path->isDerivation()) {
-                    for (auto & [name, maybeOutPath] : queryPartialDerivationOutputMap(*path))
-                        if (maybeOutPath && isValidPath(*maybeOutPath)
-                            && queryPathInfo(*maybeOutPath)->deriver == *path)
-                            enqueue(*maybeOutPath);
-                }
+                std::visit(
+                    overloaded{
+                        [&](const GCOptions::WholeStore &) {
+                            /* If keep-derivations is set and this is a derivation, then we only want to delete this
+                             * derivation if we can also delete all its outputs, so visit the derivation outputs. */
+                            if (gcSettings.keepDerivations && path->isDerivation())
+                                for (auto & [name, maybeOutPath] : queryPartialDerivationOutputMap(*path))
+                                    if (maybeOutPath && isValidPath(*maybeOutPath)
+                                        && queryPathInfo(*maybeOutPath)->deriver == path)
+                                        enqueue(*maybeOutPath);
 
-                /* If keep-outputs is set, we only want to delete this path if we
-                 * can also delete its derivers, so visit the derivers. */
-                if (keepOutputs) {
-                    auto derivers = queryValidDerivers(*path);
-                    for (auto & i : derivers)
-                        enqueue(i);
-                }
+                            /* If keep-outputs is set, we only want to delete this path if we
+                             * can also delete its derivers, so visit the derivers. */
+                            if (gcSettings.keepOutputs) {
+                                auto derivers = queryValidDerivers(*path);
+                                for (auto & i : derivers)
+                                    enqueue(i);
+                            }
+                        },
+                        [](const StorePathSet &) {},
+                    },
+                    options.pathsToDelete);
             }
         }
         for (auto & path : topoSortPaths(visited)) {

--- a/src/libstore/include/nix/store/local-settings.hh
+++ b/src/libstore/include/nix/store/local-settings.hh
@@ -61,6 +61,9 @@ struct GCSettings : public virtual Config
           collector still deletes store paths that are used only at build
           time (e.g., the C compiler, or source tarballs downloaded from the
           network). To prevent it from doing so, set this option to `true`.
+
+          This option only applies to garbage collection of the whole store
+          and does not affect deleting explicit paths.
         )",
         {"gc-keep-outputs"},
     };
@@ -80,6 +83,9 @@ struct GCSettings : public virtual Config
           store path was built), so by default this option is on. Turn it off
           to save a bit of disk space (or a lot if `keep-outputs` is also
           turned on).
+
+          This option only applies to garbage collection of the whole store
+          and does not affect deleting explicit paths.
         )",
         {"gc-keep-derivations"},
     };

--- a/tests/functional/delete-no-keep.sh
+++ b/tests/functional/delete-no-keep.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+TODO_NixOS
+
+deleteNoKeep() {
+    keep="$1"
+
+    clearStore
+    drvPath=$(nix-instantiate simple.nix)
+    outPath=$(nix build -f simple.nix --no-link --print-out-paths)
+
+    {
+        echo "keep-outputs = false"
+        echo "keep-derivations = false"
+        echo "keep-$keep = true"
+    } >> "$test_nix_conf"
+
+    if [[ "$keep" = "outputs" ]]; then
+        nix store delete "$outPath"
+        [[ ! -e "$outPath" ]] || fail "$outPath should have been deleted"
+    else
+        nix store delete "$drvPath"
+        [[ ! -e "$drvPath" ]] || fail "$drvPath should have been deleted"
+    fi
+}
+
+if isDaemonNewer "2.35pre"; then
+    deleteNoKeep outputs
+    deleteNoKeep derivations
+fi

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -179,6 +179,7 @@ suites = [
       'help.sh',
       'symlinks.sh',
       'external-builders.sh',
+      'delete-no-keep.sh',
     ],
     'workdir' : meson.current_source_dir(),
   },


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

`keep-outputs` and `keep-derivations` were not meant to affect delete operations (and it's very annoying when they do). This change makes them only read when using the `WholeStore` variant type.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#15727

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
