### PR TITLE
Fix some code assuming that all std::string_views are NUL terminated

### DIFF
--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -77,8 +77,8 @@ TEST_F(nix_api_store_test, ReturnsValidStorePath)
 {
     StorePath * result = nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str());
     ASSERT_NE(result, nullptr);
-    ASSERT_STREQ("name", result->path.name().data());
-    ASSERT_STREQ(PATH_SUFFIX.substr(1).c_str(), result->path.to_string().data());
+    ASSERT_EQ("name", result->path.name());
+    ASSERT_EQ(PATH_SUFFIX.substr(1), result->path.to_string());
     nix_store_path_free(result);
 }
 

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -177,7 +177,7 @@ SQLiteStmt::Use::~Use()
 SQLiteStmt::Use & SQLiteStmt::Use::operator()(std::string_view value, bool notNull)
 {
     if (notNull) {
-        if (sqlite3_bind_text(stmt, curArg++, value.data(), -1, SQLITE_TRANSIENT) != SQLITE_OK)
+        if (sqlite3_bind_text(stmt, curArg++, value.data(), value.size(), SQLITE_TRANSIENT) != SQLITE_OK)
             SQLiteError::throw_(stmt.db, "binding argument");
     } else
         bind();

--- a/src/libutil-c/nix_api_util.h
+++ b/src/libutil-c/nix_api_util.h
@@ -163,6 +163,7 @@ typedef struct nix_c_context nix_c_context;
  * @brief Called to get the value of a string owned by Nix.
  *
  * The `start` data is borrowed and the function must not assume that the buffer persists after it returns.
+ * @warning Don't assume that the string is NUL-terminated.
  *
  * @param[in] start the string to copy.
  * @param[in] n the string length.

--- a/src/libutil-test-support/string_callback.cc
+++ b/src/libutil-test-support/string_callback.cc
@@ -5,7 +5,7 @@ namespace nix::testing {
 void observe_string_cb(const char * start, unsigned int n, void * user_data)
 {
     auto user_data_casted = reinterpret_cast<std::string *>(user_data);
-    *user_data_casted = std::string(start);
+    *user_data_casted = std::string(start, n);
 }
 
 } // namespace nix::testing


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

In general, std::string_view can't be assumed to have a NUL byte (that might be the case now, but it's not guaranteed and we just happen to get lucky). This fixes some of the low-hanging fruit in terms of this class of potential bugs. AFAICT it's not an issue that blows up now, but it might change if we stop storing strings as NUL terminated and it would be hard to track down all of the places where we *do* assume NUL-termination.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
