### PR TITLE
derivaton-builder: Reap recursive-nix daemon worker threads early

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -41,6 +41,8 @@
 #include <pwd.h>
 #include <grp.h>
 #include <iostream>
+#include <list>
+#include <atomic>
 
 #include "nix/util/strings.hh"
 #include "nix/util/signals.hh"
@@ -226,10 +228,16 @@ protected:
      */
     std::thread daemonThread;
 
+    struct DaemonWorkerState
+    {
+        std::thread thread;
+        ref<std::atomic_flag> done;
+    };
+
     /**
      * The daemon worker threads.
      */
-    std::vector<std::thread> daemonWorkerThreads;
+    std::list<DaemonWorkerState> daemonWorkerThreads;
 
     const StorePathSet & originalPaths() override
     {
@@ -1201,19 +1209,41 @@ void DerivationBuilderImpl::startDaemon()
 
             debug("received daemon connection");
 
-            auto workerThread = std::thread([store, remote{std::move(remote)}]() {
+            auto doneFlag = make_ref<std::atomic_flag>();
+
+            auto workerThread = std::thread([doneFlag, store, remote{std::move(remote)}]() {
                 try {
                     daemon::processConnection(
                         store, FdSource(remote.get()), FdSink(remote.get()), NotTrusted, daemon::Recursive);
                     debug("terminated daemon connection");
                 } catch (const Interrupted &) {
                     debug("interrupted daemon connection");
-                } catch (SystemError &) {
+                } catch (...) {
+                    /* Swallow all exceptions to avoid crashing the the process (exceptions that escape from the thread
+                     * trigger std::terminate()). */
                     ignoreExceptionExceptInterrupt();
                 }
+
+                doneFlag->test_and_set(std::memory_order_relaxed);
             });
 
-            daemonWorkerThreads.push_back(std::move(workerThread));
+            daemonWorkerThreads.push_back(
+                DaemonWorkerState{
+                    .thread = std::move(workerThread),
+                    .done = std::move(doneFlag),
+                });
+
+            /* Prune threads eagerly to free up resources. Ideally we'd also limit the number of concurrent workers. */
+            for (auto it = daemonWorkerThreads.begin(), end = daemonWorkerThreads.end(); it != end;) {
+                auto & state = *it;
+                auto & thread = state.thread;
+                if (state.done->test(std::memory_order_relaxed) && thread.joinable()) {
+                    thread.join();
+                    it = daemonWorkerThreads.erase(it);
+                } else {
+                    ++it;
+                }
+            }
         }
 
         debug("daemon shutting down");
@@ -1242,9 +1272,7 @@ void DerivationBuilderImpl::stopDaemon()
     if (daemonThread.joinable())
         daemonThread.join();
 
-    // FIXME: should prune worker threads more quickly.
-    // FIXME: shutdown the client socket to speed up worker termination.
-    for (auto & thread : daemonWorkerThreads)
+    for (auto & [thread, doneFlag] : daemonWorkerThreads)
         thread.join();
     daemonWorkerThreads.clear();
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Not reaping threads early on leads to resource exhaustion when handling a lot of connection (like in nix-ninja). Ideally this would all just be async coroutine code so that we didn't have to spawn threads to handle connections, but it's a long-term goal.

Fixes ENOMEM errors when building nix via nix-ninja.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
