### PR TITLE
derivation-builder: Set the RLIMIT_STACK to a deterministic value (8MiB)

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1328,9 +1328,32 @@ void DerivationBuilderImpl::runChild(RunChildArgs args)
         /* Close all other file descriptors. */
         unix::closeExtraFDs();
 
-        /* Disable core dumps by default. */
-        struct rlimit limit = {0, RLIM_INFINITY};
-        setrlimit(RLIMIT_CORE, &limit);
+        static constexpr auto rlimits = std::to_array({
+            /* Disable core dumps by default. */
+            std::tuple{RLIMIT_CORE, "RLIMIT_CORE", ::rlimit{0, RLIM_INFINITY}},
+            /* Set the stack size to a deterministic value. These values are the kernel default
+               and is also what's been historically used by the nix-daemon on NixOS. */
+            std::tuple{RLIMIT_STACK, "RLIMIT_STACK", ::rlimit{8 * 1024 * 1024, RLIM_INFINITY}},
+            /* FIXME: set other limits to deterministic values? Probably the most meaningful one would RLIMIT_NOFILE. */
+        });
+
+        for (const auto & [resource, name, lim] : rlimits) {
+            /* First, the happy path. Set the deterministic limit if we have the privileges for it. */
+            if (::setrlimit(resource, &lim) == 0)
+                continue;
+            if (errno != EPERM && errno != EINVAL)
+                throw SysError("setting rlimit %1%", name);
+
+            /* Otherwise set the soft limit on best-effort basis and leave the hard limit alone.
+               This isn't great for reproducibility, but oh well... */
+            ::rlimit cur{};
+            if (::getrlimit(resource, &cur) != 0)
+                throw SysError("getting rlimit %1%", name);
+
+            cur.rlim_cur = std::min(lim.rlim_cur, cur.rlim_max);
+            if (::setrlimit(resource, &cur) != 0)
+                debug("could not set rlimit %1%: %2%", name, ::strerror(errno));
+        }
 
         /* Make sure the builder inherits a predictable umask. It must not be group-writable, since registerOutputs
          * rejects those as defense-in-depth. */


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Partially addresses the FIXME by handling the stack size. On NixOS the default is 8MiB and that's what the nix-daemon is running with (and it should be relatively common with other distros since that's also the default set by the kernel [1]).

[1]: https://github.com/torvalds/linux/blob/6d35786de28116ecf78797a62b84e6bf3c45aa5a/include/uapi/linux/resource.h#L62-L66

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
