### PR TITLE
Implement new builder-rpc-v0 feature

### DIFF
--- a/doc/manual/source/store/building.md
+++ b/doc/manual/source/store/building.md
@@ -33,14 +33,14 @@ The life cycle of a build can be broken down into 3 parts:
    (Builder processes have no idea what the consumer of their standard output and error does with the pseudo-terminal master, only that they are indeed consumed so buffers do not fill up etc. and writes to each output standard stream will continue to succeed.
    In practice, Nix will store the log in `/nix/var/log/nix`)
 
-3. Processing the outputs after the builder has exited.
+3. Processing the outputs.
 
-   The builder process on exit should have left behind files for each output the derivation is supposed to produce.
-   The files must be processed to turn them into bona fide store objects.
-   If the processing succeeds, those store objects are associated with the derivation as (the results of) a successful build.
+   Traditionally, this happens only after the builder has exited: the builder process should have left behind files for each output the derivation is supposed to produce, and those files are processed to turn them into bona fide store objects.
+   Alternatively, the builder may send messages to Nix while it's running, creating filesystem objects and linking them to an output name.
+   This allows outputs to be processed concurrently during the build, allows outputs to depend on other newly created store objects, and also resolves some tricky issues with content-addressing and output-to-output references.
+   If the processing succeeds, the resulting store objects are associated with the derivation as (the results of) a successful build.
 
-Step (3) is done by Nix externally to the build itself, which is just steps (1) and (2).
-In step (3), just inert data is processed, since the builder process has exited or been killed by then.
+Step (3) is done by Nix, either externally to the build (in the traditional case, operating on the inert data left behind after the builder has exited or been killed) or concurrently with it (in the IPC case).
 Step (1) however is best described not from Nix's perspective, but from the build process's perspective.
 
 > **Explanation**
@@ -176,7 +176,11 @@ The builder is passed the arguments specified by the derivation attribute `args`
 
 ## Processing outputs
 
-If the builder exited successfully, the following steps happen in order to turn the output directories left behind by the builder into proper store objects:
+There are two methods for processing outputs.
+But first, let us cover the requirements common to both methods.
+
+Regardless of which method is used, each output must be turned into a valid store object.
+This involves two steps:
 
 - **Normalize the file permissions**
 
@@ -189,15 +193,25 @@ If the builder exited successfully, the following steps happen in order to turn 
   (The name part and the [store directory path] are ignored when scanning; an input's hash part that is neither followed by a `-` nor proceeded by a `/` still scans as a reference.)
   Since these are potential runtime dependencies, Nix will register them as references of the output store object they occur in.
 
-  Nix also scans for references from one output to another in the same way, because outputs are allowed to refer to each other.
+### Traditional (post-build) processing
 
-  The outputs' references must form a [directed acyclic graph](@docroot@/glossary.md#gloss-directed-acyclic-graph).
-  (This is not a special restriction for outputs; it is true for the references of all store objects in general.)
+With the traditional method, the builder process on exit should have left behind files for each output the derivation is supposed to produce.
+The files must be processed to turn them into bona fide store objects.
+If the processing succeeds, those store objects are associated with the derivation as (the results of) a successful build.
 
-  In the case of derivations with output paths that are fixed in advance (i.e. [input-addressing] derivations, or [fixed content-addressing] derivations), the actual final store path to each output is used during the build if possible.
-  For [floating content-addressing] derivations, however, the final store path is not known in advance by definition.
-  Scratch store paths must therefore be used instead.
-  Scanning will use those scratch paths, but then any output-to-be that contains such a scanned scratch path must be rewritten to instead use the final (content-addressed) path of the output in question.
+Nix also scans for references from one output to another in the same way, because outputs are allowed to refer to each other.
+The outputs' references must form a [directed acyclic graph](@docroot@/glossary.md#gloss-directed-acyclic-graph).
+(This is not a special restriction for outputs; it is true for the references of all store objects in general.)
+
+In the case of derivations with output paths that are fixed in advance (i.e. [input-addressing] derivations, or [fixed content-addressing] derivations), the actual final store path to each output is used during the build if possible.
+For [floating content-addressing] derivations, however, the final store path is not known in advance by definition.
+Scratch store paths must therefore be used instead.
+Scanning will use those scratch paths, but then any output-to-be that contains such a scanned scratch path must be rewritten to instead use the final (content-addressed) path of the output in question.
+
+In addition to output-to-output references, rewriting is also needed to support self-references in the content-addressing case.
+An output may contain its own store path digest, which is a self-reference.
+Hash functions which are secure cannot allow the easy calculation of the quasi-fixed points needed to support self-references "natively", so instead we replace all would-be self-references with a sentinel value, and then rewrite the sentinel value to be the final store path digest.
+Superficially, this post-hashing rewriting breaks the content address, but as the self-references are easily identified, the rewriting can be inverted to yield the original hashed data, allowing verifying the content address after all.
 
 At this point, the file system data is in the proper form, and the valid acyclic reference data for each output is also calculated, so the outputs are added to the store as proper store objects.
 Additionally, those store objects (at least in the case that they are [content-addressed][content-addressing]) can be associated with the derivation in the [build trace] in the record for a successful build.
@@ -207,6 +221,50 @@ Additionally, those store objects (at least in the case that they are [content-a
 > Nix will normally clean up and remove the temporary build directory after every build, successful or unsuccessful.
 > The builder doesn't know whether Nix does or not, however, as it will have exited before the build directory is cleaned up, and it will not see any old build directory if (after a failed build) it is run again.
 > The [`--keep-failed`](@docroot@/command-ref/opt-common.md#opt-keep-failed) option can be specified to keep the build directory in the case of a failing build.
+
+### Concurrent processing via IPC
+
+With this method, the builder communicates with Nix during the build using inter-process communication (IPC).
+
+> **Implementation detail**
+>
+> The current implementation, `builder-rpc-v0`, exposes its interface over a limited form of the Nix daemon socket.
+> Builders may use it either with their own implementation of the Nix protocol, or with the `nix store add` and `nix store submit-output` commands.
+>
+> Derivations with `builder-rpc-v0` in their set of [`requiredSystemFeatures`](@docroot@/language/advanced-attributes.md#adv-attr-requiredSystemFeatures)
+> will not receive output paths in their environment, and are expected to submit all outputs with the aforementioned commands or protocol.
+
+Instead of leaving files behind for Nix to process after exit, the builder explicitly requests the daemon create store objects one at a time, then sends commands assigning output names to the just-created store objects.
+
+Scanning for references proceeds as usual for each store object creation request, but the set of potential references to be scanned is greater: it includes both all inputs (as before) and also all previously-added store objects.
+This means, if output `bar` is supposed to reference output `foo`, `foo` should be created first, and `bar` second.
+
+All store objects being created are content-addressed (there is no support for input-addressed outputs with the IPC approach).
+When a store object is created, its content address store path will be calculated by Nix and then returned in the IPC response message.
+The builder then knows what store path to use in subsequent store objects in order for reference scanning to pick them up.
+
+This overall approach has several advantages:
+
+- **No Nix-side rewriting**
+
+  For content-addressed outputs, the builder is responsible for adding outputs in reference order, using the store paths from earlier adds in later ones.
+  This avoids the fragile rewriting that would otherwise be needed to fix up output-to-output references described above.
+  The builder, unlike Nix itself, is free to leverage domain-specific knowledge to do a better job. For example it can
+
+  - uncompress, rewrite, and then recompress man pages, to not miss references hidden by compression.
+
+  - make sure to rewrite data that is to be signed, like Apple binaries, before signing that data, so as not to invalidate any signatures by mistake.
+
+- **Pipelining**
+
+  Downstream builds that only need some outputs (e.g., a "dev" or "headers" output) can start without waiting for all outputs to be ready.
+  Nix doesn't yet implement this, but it could and should.
+
+The major *disadvantage* of this approach is that it doesn't yet support self-references.
+Unlike acyclic output-to-output references, self-references fundamentally do require rewriting.
+The output-to-output case was only a challenge in the traditional case because all the outputs were submitted simultaneously, whereas the self-reference case is fundamentally challenging because of what it means for a hash function to be secure, as described above.
+Neither batched (traditional) nor serial (IPC) submission of outputs can avoid this fundamental property of secure hash functions.
+We could add support for such rewriting just for self-references, as is done for the traditional post-build processing, but we haven't yet done so as the very point of the IPC approach is to free Nix from any obligation to rewrite black-box data in unsound ways.
 
 [references]: ./store-object.md#references
 [store path digest]: ./store-path.md#digest

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -226,7 +226,7 @@ struct StaticEvalSymbols
         line, column, functor, toString, right, wrong, structuredAttrs, json, allowedReferences, allowedRequisites,
         disallowedReferences, disallowedRequisites, maxSize, maxClosureSize, builder, args, contentAddressed, impure,
         outputHash, outputHashAlgo, outputHashMode, recurseForDerivations, description, self, epsilon, startSet,
-        operator_, key, path, prefix, outputSpecified;
+        operator_, key, path, prefix, outputSpecified, requiredSystemFeatures;
 
     Expr::AstSymbols exprSymbols;
 
@@ -279,6 +279,7 @@ struct StaticEvalSymbols
             .path = alloc.create("path"),
             .prefix = alloc.create("prefix"),
             .outputSpecified = alloc.create("outputSpecified"),
+            .requiredSystemFeatures = alloc.create("requiredSystemFeatures"),
             .exprSymbols = {
                 .sub = alloc.create("__sub"),
                 .lessThan = alloc.create("__lessThan"),

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -10,8 +10,10 @@
 #include "nix/store/names.hh"
 #include "nix/store/path-references.hh"
 #include "nix/store/store-api.hh"
+#include "nix/util/configuration.hh"
 #include "nix/util/mounted-source-accessor.hh"
 #include "nix/store/build.hh"
+#include "nix/util/strings.hh"
 #include "nix/util/util.hh"
 #include "nix/util/os-string.hh"
 #include "nix/util/processes.hh"
@@ -1523,6 +1525,7 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
 
     bool contentAddressed = false;
     bool isImpure = false;
+    bool isSubmittingOutputs = false;
     std::optional<std::string> outputHash;
     std::optional<HashAlgorithm> outputHashAlgo;
     std::optional<ContentAddressMethod> ingestionMethod;
@@ -1656,6 +1659,22 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
                         handleOutputs(ss);
                         break;
                     }
+                    case EvalState::s.requiredSystemFeatures.getId(): {
+                        /* Only parsed to detect `builder-rpc-v0`; skip
+                           entirely unless the experimental feature is
+                           enabled. */
+                        if (!experimentalFeatureSettings.isEnabled(Xp::DynamicDerivations))
+                            break;
+                        state.forceList(*i->value, pos, context_below);
+                        for (auto elem : i->value->listView()) {
+                            auto name = state.forceString(*elem, context, pos, context_below);
+                            if (name == drvFeatureBuilderRpcV0) {
+                                isSubmittingOutputs = true;
+                                break;
+                            }
+                        }
+                        break;
+                    }
                     default:
                         break;
                     }
@@ -1677,6 +1696,15 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
 
                 } else {
                     auto s = state.coerceToString(pos, *i->value, context, context_below, true).toOwned();
+
+                    /* Re-interpret the attribute's value as a list of
+                       strings.
+
+                       We may wish to warn here better future-compat
+                       later, e.g. requiring that it be a list of
+                       strings without spaces to begin with. */
+                    auto forceStringList = [&] { return tokenizeString<Strings>(s); };
+
                     if (i->name == state.s.json) {
                         warnAttr(HintFmt(
                             "setting structured attributes via '__json' is deprecated, and may be disallowed in future versions of Nix. Set '__structuredAttrs = true' instead."));
@@ -1700,8 +1728,22 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
                             handleHashMode(s);
                             break;
                         case EvalState::s.outputs.getId():
-                            handleOutputs(tokenizeString<Strings>(s));
+                            handleOutputs(forceStringList());
                             break;
+                        case EvalState::s.requiredSystemFeatures.getId(): {
+                            /* Only parsed to detect `builder-rpc-v0`; skip
+                               entirely unless the experimental feature is
+                               enabled. */
+                            if (!experimentalFeatureSettings.isEnabled(Xp::DynamicDerivations))
+                                break;
+                            for (auto & name : forceStringList()) {
+                                if (name == drvFeatureBuilderRpcV0) {
+                                    isSubmittingOutputs = true;
+                                    break;
+                                }
+                            }
+                            break;
+                        }
                         default:
                             break;
                         }
@@ -1798,7 +1840,8 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
                 },
         };
 
-        drv.env["out"] = state.store->printStorePath(dof.path(*state.store, drvName, "out"));
+        if (!isSubmittingOutputs)
+            drv.env["out"] = state.store->printStorePath(dof.path(*state.store, drvName, "out"));
         drv.outputs.insert_or_assign("out", std::move(dof));
     }
 
@@ -1810,7 +1853,8 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
         auto method = ingestionMethod.value_or(ContentAddressMethod::Raw::NixArchive);
 
         for (auto & i : outputs) {
-            drv.env[i] = hashPlaceholder(i);
+            if (!isSubmittingOutputs)
+                drv.env[i] = hashPlaceholder(i);
             if (isImpure)
                 drv.outputs.insert_or_assign(
                     i,

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -886,7 +886,11 @@ Goal::Co DerivationBuildingGoal::buildLocally(
                 }
 
                 void processDaemonConnection(
-                    ref<Store> store, FdSource && from, FdSink && to, RestrictionContext & context) override
+                    ref<Store> store,
+                    FdSource && from,
+                    FdSink && to,
+                    RestrictionContext & context,
+                    daemon::RecursiveFlag recursiveFlag) override
                 {
                     /**
                      * TODO: We create a fresh Worker here because the
@@ -898,7 +902,7 @@ Goal::Co DerivationBuildingGoal::buildLocally(
                     Worker freshWorker{goal.worker.store, goal.worker.evalStore};
                     auto builder = makeRestrictedBuilder(freshWorker, context);
                     daemon::processConnection(
-                        store, std::move(from), std::move(to), NotTrusted, daemon::Recursive, builder.get_ptr());
+                        store, std::move(from), std::move(to), NotTrusted, recursiveFlag, builder.get_ptr());
                 }
             };
 

--- a/src/libstore/build/derivation-check.cc
+++ b/src/libstore/build/derivation-check.cc
@@ -1,45 +1,88 @@
 #include <queue>
 
+#include "nix/store/derivations.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/build-result.hh"
+#include "nix/util/hash.hh"
 
 #include "derivation-check.hh"
 
 namespace nix {
 
-void checkCAFixedOutput(
-    StoreDirConfig & store, const StorePath & drvPath, const DerivationOutput & outputSpec, const ValidPathInfo & info)
+void checkCAOutput(
+    StoreDirConfig & store,
+    const StorePath & drvPath,
+    const DerivationOutput & outputSpec,
+    const ValidPathInfo & info,
+    const std::string & outputName)
 {
-    if (const auto * dof = std::get_if<DerivationOutput::CAFixed>(&outputSpec.raw)) {
-        auto & wanted = dof->ca.hash;
+    std::visit(
+        overloaded{
+            [&](const DerivationOutput::CAFixed & dof) {
+                auto & wanted = dof.ca.hash;
 
-        /* Check wanted hash */
-        assert(info.ca);
-        auto & got = info.ca->hash;
-        if (wanted != got) {
-            throw BuildError(
-                BuildResult::Failure::HashMismatch,
-                "hash mismatch in fixed-output derivation '%s':\n  specified: %s\n     got:    %s",
-                store.printStorePath(drvPath),
-                wanted.to_string(HashFormat::SRI, true),
-                got.to_string(HashFormat::SRI, true));
-        }
-        if (!info.references.empty()) {
-            auto numViolations = info.references.size();
-            throw BuildError(
-                BuildResult::Failure::HashMismatch,
-                "fixed-output derivations must not reference store paths: '%s' references %d distinct paths, e.g. '%s'",
-                store.printStorePath(drvPath),
-                numViolations,
-                store.printStorePath(*info.references.begin()));
-        }
-    }
+                /* Check wanted hash */
+                assert(info.ca);
+                auto & got = info.ca->hash;
+                if (wanted != got) {
+                    throw BuildError(
+                        BuildResult::Failure::HashMismatch,
+                        "hash mismatch in fixed-output derivation '%s':\n  specified: %s\n     got:    %s",
+                        store.printStorePath(drvPath),
+                        wanted.to_string(HashFormat::SRI, true),
+                        got.to_string(HashFormat::SRI, true));
+                }
+                if (!info.references.empty()) {
+                    auto numViolations = info.references.size();
+                    throw BuildError(
+                        BuildResult::Failure::HashMismatch,
+                        "fixed-output derivations must not reference store paths: '%s' references %d distinct paths, e.g. '%s'",
+                        store.printStorePath(drvPath),
+                        numViolations,
+                        store.printStorePath(*info.references.begin()));
+                }
+            },
+            [&](const DerivationOutput::CAFloating & dof) {
+                if (!info.ca.has_value()) {
+                    throw BuildError(
+                        BuildResult::Failure::OutputRejected,
+                        "floating content-addressing derivation '%s' output '%s' (at '%s') was not content-addressed",
+                        store.printStorePath(drvPath),
+                        outputName,
+                        store.printStorePath(info.path));
+                }
+                if (info.ca->method != dof.method) {
+                    throw BuildError(
+                        BuildResult::Failure::OutputRejected,
+                        "content-addressing derivation '%s' output '%s' (at '%s') was hashed with method '%s', expected '%s'",
+                        store.printStorePath(drvPath),
+                        outputName,
+                        store.printStorePath(info.path),
+                        info.ca->method.render(),
+                        dof.method.render());
+                }
+                if (info.ca->hash.algo != dof.hashAlgo) {
+                    throw BuildError(
+                        BuildResult::Failure::OutputRejected,
+                        "content-addressing derivation '%s' output '%s' (at '%s') was hashed with algorithm '%s', expected '%s'",
+                        store.printStorePath(drvPath),
+                        outputName,
+                        store.printStorePath(info.path),
+                        printHashAlgo(info.ca->hash.algo),
+                        printHashAlgo(dof.hashAlgo));
+                }
+            },
+            [&](const DerivationOutput::Deferred & _) {},
+            [&](const DerivationOutput::Impure & _) {},
+            [&](const DerivationOutput::InputAddressed & _) {},
+        },
+        outputSpec.raw);
 }
 
 void checkOutputs(
     Store & store,
     const StorePath & drvPath,
-    const decltype(Derivation::outputs) & drvOutputs,
+    const BasicDerivation & drv,
     const decltype(DerivationOptions<StorePath>::outputChecks) & outputChecks,
     const std::map<std::string, ValidPathInfo> & outputs)
 {
@@ -53,10 +96,28 @@ void checkOutputs(
         const std::string & outputName = pair.first;
         const auto & info = pair.second;
 
-        auto * outputSpec = get(drvOutputs, outputName);
-        assert(outputSpec);
+        auto * outputSpec = get(drv.outputs, outputName);
+        if (!outputSpec) {
+            throw BuildError(
+                BuildResult::Failure::OutputRejected,
+                "builder for '%s' submitted unknown output '%s' (Valid outputs are [%s])",
+                store.printStorePath(drvPath),
+                outputName,
+                concatMapStringsSep(", ", outputs, [](auto & o) { return o.first; }));
+        }
 
-        checkCAFixedOutput(store, drvPath, *outputSpec, info);
+        if (outputPathName(drv.name, outputName) != info.path.name()) {
+            throw BuildError(
+                BuildResult::Failure::OutputRejected,
+                "derivation '%s' output '%s' (at '%s') was named '%s', expected '%s'",
+                store.printStorePath(drvPath),
+                outputName,
+                store.printStorePath(info.path),
+                info.path.name(),
+                outputPathName(drv.name, outputName));
+        }
+
+        checkCAOutput(store, drvPath, *outputSpec, info, outputName);
 
         /* Compute the closure and closure size of some output. This
            is slightly tricky because some of its references (namely
@@ -122,8 +183,6 @@ void checkOutputs(
                                 if (auto output = get(outputs, refOutputName))
                                     spec.insert(output->path);
                                 else {
-                                    std::string outputsListing =
-                                        concatMapStringsSep(", ", outputs, [](auto & o) { return o.first; });
                                     throw BuildError(
                                         BuildResult::Failure::OutputRejected,
                                         "derivation '%s' output check for '%s' contains output name '%s',"
@@ -132,7 +191,7 @@ void checkOutputs(
                                         store.printStorePath(drvPath),
                                         outputName,
                                         refOutputName,
-                                        outputsListing);
+                                        concatMapStringsSep(", ", outputs, [](auto & o) { return o.first; }));
                                 }
                             }},
                         i);

--- a/src/libstore/build/derivation-check.hh
+++ b/src/libstore/build/derivation-check.hh
@@ -8,12 +8,16 @@
 namespace nix {
 
 /**
- * If outputSpec is a CAFixed output, check that the actual output described in
- * info meets the requirements for a CAFixed output. Do nothing if outputSpec is
- * not a CAFixed output.
+ * If outputSpec is a CAFixed or CAFloating output, check that the actual output described in
+ * info meets the requirements for a CA output.
+ * Do nothing if outputSpec is not a CAFixed or CAFloating output.
  */
-void checkCAFixedOutput(
-    StoreDirConfig & store, const StorePath & drvPath, const DerivationOutput & outputSpec, const ValidPathInfo & info);
+void checkCAOutput(
+    StoreDirConfig & store,
+    const StorePath & drvPath,
+    const DerivationOutput & outputSpec,
+    const ValidPathInfo & info,
+    const std::string & outputName);
 
 /**
  * Check that outputs meets the requirements specified by the
@@ -28,7 +32,7 @@ void checkCAFixedOutput(
 void checkOutputs(
     Store & store,
     const StorePath & drvPath,
-    const decltype(Derivation::outputs) & drvOutputs,
+    const BasicDerivation & drv,
     const decltype(DerivationOptions<StorePath>::outputChecks) & drvOptions,
     const std::map<std::string, ValidPathInfo> & outputs);
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -1,4 +1,5 @@
 #include "nix/store/daemon.hh"
+#include "nix/util/configuration.hh"
 #include "nix/util/file-content-address.hh"
 #include "nix/util/signals.hh"
 #include "nix/store/worker-protocol.hh"
@@ -13,7 +14,6 @@
 #include "nix/store/indirect-root-store.hh"
 #include "nix/store/remote-store.hh"
 #include "nix/store/path-with-outputs.hh"
-#include "nix/store/submit-store.hh"
 #include "nix/util/finally.hh"
 #include "nix/util/archive.hh"
 #include "nix/store/derivations.hh"
@@ -314,6 +314,36 @@ static void performOp(
 {
     WorkerProto::ReadConn rconn(conn);
     WorkerProto::WriteConn wconn(conn);
+
+    if (recursive == daemon::RecursiveFlag::RecursiveSubmitted) {
+        // Limit valid calls to reduce opportunities for nonreproducability in builds
+        // Since this is an allowlist, it's easiest to put it at the top before the switch
+        static constexpr std::array validOperations = {
+            // All the types of "Add" should be allowed
+            WorkerProto::Op::AddToStore,
+            WorkerProto::Op::AddMultipleToStore,
+            WorkerProto::Op::AddToStoreNar,
+            WorkerProto::Op::AddToStoreScanning,
+            // SubmitOutput is designed specifically for this use case
+            WorkerProto::Op::SubmitOutput,
+            // Used by nix cli, should never change actual outputs
+            WorkerProto::Op::AddTempRoot,
+            // Used by nix cli, restricted store will prevent it from seeing derivations it shouldn't
+            WorkerProto::Op::IsValidPath,
+        };
+        if (std::ranges::find(validOperations, op) == validOperations.end()) {
+            throw Error("Operation %d not allowed inside derivation", op);
+        }
+    } else {
+        // Operations designed only for the experimental builder-rpc-v0 should never be exposed outside
+        // derivaitons that use it.
+        // AddToStoreScanning is still acceptable in ordinary recursive derivations, though.
+        // Throw the same error we do when using an unknown operation.
+        if (op == WorkerProto::Op::SubmitOutput
+            || (op == WorkerProto::Op::AddToStoreScanning && recursive == daemon::RecursiveFlag::NotRecursive)) {
+            throw Error("invalid operation %1%", op);
+        }
+    }
 
     switch (op) {
 
@@ -803,7 +833,7 @@ static void performOp(
 
         // FIXME: use some setting in recursive mode. Will need to use
         // non-global variables.
-        if (!recursive)
+        if (recursive == RecursiveFlag::NotRecursive)
             clientSettings.apply(trusted);
 
         logger->stopWork();
@@ -1025,8 +1055,9 @@ static void performOp(
         if (!conn.protoVersion.features.contains(WorkerProto::featureAddToStoreScanning))
             throw Error("Adding to store with scanning was requested, but not supported in negotiated protocol");
 
-        if (!recursive)
-            throw Error("AddToStoreScanning only valid inside a `recursive-nix` derivation builder");
+        if (recursive == daemon::RecursiveFlag::NotRecursive)
+            throw Error(
+                "AddToStoreScanning only valid within derivation with `builder-rpc-v0` or `recursive-nix` feature");
 
         auto & submitStore = require<SubmitStore>(*store);
 
@@ -1047,6 +1078,23 @@ static void performOp(
         break;
     }
 
+    case WorkerProto::Op::SubmitOutput: {
+        experimentalFeatureSettings.require(Xp::DynamicDerivations);
+        if (recursive != daemon::RecursiveFlag::RecursiveSubmitted)
+            throw Error("SubmitOutput only valid within derivation with `builder-rpc-v0` feature");
+
+        auto path = WorkerProto::Serialise<SingleDerivedPath>::read(*store, rconn);
+        auto output = WorkerProto::Serialise<OutputName>::read(*store, rconn);
+
+        auto & submitStore = require<SubmitStore>(*store);
+
+        logger->startWork();
+        submitStore.submitOutput(path, output);
+        logger->stopWork();
+        conn.to << 1;
+        break;
+    }
+
     default:
         throw Error("invalid operation %1%", op);
     }
@@ -1061,7 +1109,7 @@ void processConnection(
     std::shared_ptr<Builder> builder)
 {
 #ifndef _WIN32 // TODO need graceful async exit support on Windows?
-    auto monitor = !recursive ? std::make_unique<MonitorFdHup>(from.fd) : nullptr;
+    auto monitor = (recursive == RecursiveFlag::NotRecursive) ? std::make_unique<MonitorFdHup>(from.fd) : nullptr;
     (void) monitor; // suppress warning
     ReceiveInterrupts receiveInterrupts;
 
@@ -1080,10 +1128,16 @@ void processConnection(
         builder = store->getBuilder();
 
     /* Exchange the greeting. */
-    auto localVersion = WorkerProto::latest;
-    if (recursive) {
+    WorkerProto::Version localVersion;
+
+    if (recursive == RecursiveFlag::RecursiveSubmitted) {
+        localVersion = WorkerProto::builderRpcV0;
+    } else if (recursive == RecursiveFlag::Recursive) {
+        localVersion = WorkerProto::latest;
         localVersion.features.insert(std::string{WorkerProto::featureDisableSetOptions});
         localVersion.features.insert(std::string{WorkerProto::featureAddToStoreScanning});
+    } else {
+        localVersion = WorkerProto::latest;
     }
 
     WorkerProto::BasicServerConnection conn;
@@ -1098,7 +1152,7 @@ void processConnection(
     auto tunnelLogger = new TunnelLogger(conn.to, conn.protoVersion);
     auto prevLogger = logger;
     // FIXME
-    if (!recursive) {
+    if (recursive == RecursiveFlag::NotRecursive) {
         logger = tunnelLogger;
         applyJSONLogger();
     }

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -5,6 +5,7 @@
 #include <nlohmann/json_fwd.hpp>
 
 #include "nix/store/build-result.hh"
+#include "nix/store/daemon.hh"
 #include "nix/store/derivation-options.hh"
 #include "nix/store/build/derivation-building-misc.hh"
 #include "nix/store/derivations.hh"
@@ -145,8 +146,12 @@ struct DerivationBuilderCallbacks
      * Process a recursive Nix daemon connection, using a builder
      * that enforces the restrictions of the given context.
      */
-    virtual void
-    processDaemonConnection(ref<Store> store, FdSource && from, FdSink && to, RestrictionContext & context) = 0;
+    virtual void processDaemonConnection(
+        ref<Store> store,
+        FdSource && from,
+        FdSink && to,
+        RestrictionContext & context,
+        daemon::RecursiveFlag recursiveFlag) = 0;
 };
 
 /**

--- a/src/libstore/include/nix/store/daemon.hh
+++ b/src/libstore/include/nix/store/daemon.hh
@@ -10,7 +10,11 @@ struct Builder;
 
 namespace daemon {
 
-enum RecursiveFlag : bool { NotRecursive = false, Recursive = true };
+enum struct RecursiveFlag {
+    NotRecursive = 0,
+    Recursive = 1,
+    RecursiveSubmitted = 2,
+};
 
 void processConnection(
     ref<Store> store,

--- a/src/libstore/include/nix/store/derivations.hh
+++ b/src/libstore/include/nix/store/derivations.hh
@@ -16,6 +16,11 @@
 
 namespace nix {
 
+/**
+ * String to include in requiredSystemFeatures to enable builder-rpc-v0
+ */
+static constexpr std::string_view drvFeatureBuilderRpcV0 = "builder-rpc-v0";
+
 struct StoreDirConfig;
 
 /* Abstract syntax of derivations. */

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -114,6 +114,8 @@ public:
 
     void registerDrvOutput(const Realisation & info) override;
 
+    void submitOutput(const SingleDerivedPath & path, const OutputName & output) override;
+
     ref<const ValidPathInfo> addToStoreScanning(
         Source & dump,
         std::string_view name,

--- a/src/libstore/include/nix/store/restricted-store.hh
+++ b/src/libstore/include/nix/store/restricted-store.hh
@@ -65,6 +65,18 @@ public:
     bool isAllowed(const DerivedPath & id);
 
     /**
+     * Whether mounting dependencies inside the sandbox should happen,
+     * or if it should be entirely skipped.
+     */
+    virtual bool shouldModifySandbox() = 0;
+
+    /**
+     * Register a store path to an output name
+     * For builder-rpc-v0
+     */
+    virtual void submitOutput(const SingleDerivedPath & path, const OutputName & output) = 0;
+
+    /**
      * Add 'path' to the set of paths that may be referenced by the
      * outputs, and make it appear in the sandbox.
      */
@@ -92,7 +104,8 @@ public:
         }
 
         try {
-            addDependencyImpl(path);
+            if (shouldModifySandbox())
+                addDependencyImpl(path);
             promise.set_value();
         } catch (...) {
             /* Notify all other waiters that we are done. */

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include "nix/store/outputs-spec.hh"
 #include "nix/store/path.hh"
 #include "nix/store/derived-path.hh"
 #include "nix/util/hash.hh"

--- a/src/libstore/include/nix/store/submit-store.hh
+++ b/src/libstore/include/nix/store/submit-store.hh
@@ -14,6 +14,12 @@ public:
     inline static std::string operationName = "Submit outputs for a currently running derivation";
 
     /**
+     * Submit an output for the current derivation.
+     * Only makes sense when running within a recursive-nix derivation
+     */
+    virtual void submitOutput(const SingleDerivedPath & path, const OutputName & output) = 0;
+
+    /**
      * Add to store, scanning references.
      * Only within a recursive-nix derivation, as there would otherwise be no known
      * set of valid store paths

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -120,6 +120,12 @@ struct WorkerProto
     static const Version minimum;
 
     /**
+     * Static version for the `builder-rpc-v0` feature.
+     * Should never change, as any modification would be derivation-visible.
+     */
+    static const Version builderRpcV0;
+
+    /**
      * Feature for transmitting `UnkeyedRealisation` and `DrvOutput`
      * using drvPath (store path) instead of the old hash-based JSON format.
      */
@@ -139,6 +145,11 @@ struct WorkerProto
      * Feature for enabling the `AddToStoreScanning` operation
      */
     static constexpr std::string_view featureAddToStoreScanning = "add-to-store-scanning";
+
+    /**
+     * Feature for enabling the `SubmitOutput` operation
+     */
+    static constexpr std::string_view featureSubmitOutput = "submit-output";
 
     /**
      * A unidirectional read connection, to be used by the read half of the
@@ -264,6 +275,7 @@ enum struct WorkerProto::Op : uint64_t {
     // QueryActiveBuilds = 48, // reserved for https://github.com/NixOS/nix/pull/15979
     // AddTempRoots = 49, // reserved for https://github.com/NixOS/nix/pull/16113
     // QueryPathInfos = 50, // reserved for https://github.com/DeterminateSystems/nix-src/pull/539
+    SubmitOutput = 1000, // Only used within derivations with feature
     AddToStoreScanning = 1001,
 };
 
@@ -333,6 +345,8 @@ inline std::ostream & operator<<(std::ostream & s, WorkerProto::Op op)
 
 template<>
 DECLARE_WORKER_SERIALISER(DerivedPath);
+template<>
+DECLARE_WORKER_SERIALISER(SingleDerivedPath);
 template<>
 DECLARE_WORKER_SERIALISER(BuildResult);
 template<>

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -91,12 +91,13 @@ void RemoteStore::initConnection(Connection & conn)
         StringSink saved;
         TeeSource tee(conn.from, saved);
         try {
-            // The DisableSetOptions and `AddToStoreScanning` features aren't in the `latest` constant because it is
-            // shared with the daemon, which only adds the feature under certain conditions.
+            // The following features aren't in the `latest` constant because it is
+            // shared with the daemon, which only adds the features under certain conditions.
             // Adding is easier than removing.
             auto localVersion = WorkerProto::latest;
             localVersion.features.insert(std::string{WorkerProto::featureDisableSetOptions});
             localVersion.features.insert(std::string{WorkerProto::featureAddToStoreScanning});
+            localVersion.features.insert(std::string{WorkerProto::featureSubmitOutput});
 
             conn.protoVersion = WorkerProto::BasicClientConnection::handshake(conn.to, tee, localVersion);
             if (conn.protoVersion.number < WorkerProto::minimum.number)
@@ -504,6 +505,20 @@ void RemoteStore::registerDrvOutput(const Realisation & info)
     conn->to << WorkerProto::Op::RegisterDrvOutput;
     WorkerProto::write(*this, *conn, info);
     conn.processStderr();
+}
+
+void RemoteStore::submitOutput(const SingleDerivedPath & path, const OutputName & output)
+{
+    auto conn(getConnection());
+    if (!conn->protoVersion.features.contains(WorkerProto::featureSubmitOutput))
+        throw Error(
+            "the daemon does not support SubmitOutput, perhaps this is not in a derivation with the `builder-rpc-v0` feature?");
+
+    conn->to << WorkerProto::Op::SubmitOutput;
+    WorkerProto::Serialise<SingleDerivedPath>::write(*this, *conn, path);
+    conn->to << output;
+    conn.processStderr();
+    readInt(conn->from);
 }
 
 ref<const ValidPathInfo> RemoteStore::addToStoreScanning(

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -115,6 +115,8 @@ public:
 
     void registerDrvOutput(const Realisation & info) override;
 
+    void submitOutput(const SingleDerivedPath & path, const OutputName & output) override;
+
     ref<const ValidPathInfo> addToStoreScanning(
         Source & dump,
         std::string_view name,
@@ -282,6 +284,11 @@ void RestrictedStore::registerDrvOutput(const Realisation & info)
 // corresponds to an allowed derivation
 {
     throw Error("registerDrvOutput");
+}
+
+void RestrictedStore::submitOutput(const SingleDerivedPath & path, const OutputName & output)
+{
+    goal.submitOutput(path, output);
 }
 
 ref<const ValidPathInfo> RestrictedStore::addToStoreScanning(

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -396,8 +396,13 @@ StringSet Store::Config::getDefaultSystemFeatures()
     if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations))
         res.insert("ca-derivations");
 
-    if (experimentalFeatureSettings.isEnabled(Xp::RecursiveNix))
+    if (experimentalFeatureSettings.isEnabled(Xp::RecursiveNix)) {
         res.insert("recursive-nix");
+    }
+
+    if (experimentalFeatureSettings.isEnabled(Xp::DynamicDerivations)) {
+        res.insert(std::string{drvFeatureBuilderRpcV0});
+    }
 
     return res;
 }

--- a/src/libstore/unix/build/derivation-builder-impl.hh
+++ b/src/libstore/unix/build/derivation-builder-impl.hh
@@ -129,6 +129,15 @@ protected:
      */
     OutputPathMap scratchOutputs;
 
+    /**
+     * Whether or not derivation is using outputs submitted via recursive-nix
+     */
+    bool usingSubmitted;
+    /**
+     * Output paths from the `SubmitOutput` store command
+     */
+    Sync<OutputPathMap> submittedOutputs;
+
     const static std::filesystem::path homeDir;
 
     /**
@@ -174,6 +183,33 @@ protected:
     }
 
     bool isAllowed(const DerivedPath & req);
+
+    bool shouldModifySandbox() override
+    {
+        return !usingSubmitted;
+    }
+
+    void submitOutput(const SingleDerivedPath & path, const OutputName & output) override
+    {
+        auto submittedOutputs(this->submittedOutputs.lock());
+
+        auto * opaque = std::get_if<SingleDerivedPath::Opaque>(&path.raw());
+        if (!opaque)
+            throw Error(
+                "Attempted to submit Built path '%s' for output '%s'.\n"
+                " Only Opaque paths are supported, see https://github.com/NixOS/nix/issues/12727",
+                path.to_string(store),
+                output);
+
+        if (submittedOutputs->contains(output))
+            throw Error(
+                "Attempted to submit duplicate output '%s' (old '%s', new '%s')",
+                output,
+                store.printStorePath(*get(*submittedOutputs, output)),
+                store.printStorePath(opaque->path));
+
+        submittedOutputs->insert_or_assign(output, opaque->path);
+    };
 
     friend struct RestrictedStore;
 
@@ -366,6 +402,11 @@ private:
      */
     SingleDrvOutputs registerOutputs();
 
+    /**
+     * Check that the derivation outputs submitted by recursive-nix exist
+     * and attach them to the derivation
+     */
+    SingleDrvOutputs checkSubmittedOutputs();
 protected:
 
     /**

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1,4 +1,5 @@
 #include "nix/store/build/derivation-builder.hh"
+#include "nix/util/configuration.hh"
 #include "nix/util/file-system-at.hh"
 #include "nix/util/file-system.hh"
 #include "nix/store/local-store.hh"
@@ -210,7 +211,7 @@ SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()
        root. */
     killSandbox(true);
 
-    /* Terminate the recursive Nix daemon. */
+    /* Terminate the recursive Nix daemons. */
     stopDaemon();
 
     if (buildResult.cpuUser && buildResult.cpuSystem) {
@@ -238,9 +239,14 @@ SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()
         };
     }
 
-    /* Compute the FS closure of the outputs and register them as
-       being valid. */
-    auto builtOutputs = registerOutputs();
+    SingleDrvOutputs builtOutputs;
+    if (usingSubmitted) {
+        builtOutputs = checkSubmittedOutputs();
+    } else {
+        /* Compute the FS closure of the outputs and register them as
+           being valid. */
+        builtOutputs = registerOutputs();
+    }
 
     cleanupBuild(true);
 
@@ -468,7 +474,15 @@ std::optional<Descriptor> DerivationBuilderImpl::startBuild()
 
     /* Fire up a Nix daemon to process recursive Nix calls from the
        builder. */
-    if (drvOptions.getRequiredSystemFeatures(drv).count("recursive-nix"))
+    auto requiredFeatures = drvOptions.getRequiredSystemFeatures(drv);
+
+    usingSubmitted = requiredFeatures.count(drvFeatureBuilderRpcV0);
+
+    if (usingSubmitted && !drv.type().isCA()) {
+        throw Error("The builder-rpc-v0 feature may only be used with content-addressing derivations");
+    }
+
+    if (usingSubmitted || requiredFeatures.count("recursive-nix"))
         startDaemon();
 
     /* Run the builder. */
@@ -783,7 +797,11 @@ void DerivationBuilderImpl::initEnv()
 
 void DerivationBuilderImpl::startDaemon()
 {
-    experimentalFeatureSettings.require(Xp::RecursiveNix);
+    if (usingSubmitted) {
+        experimentalFeatureSettings.require(Xp::DynamicDerivations);
+    } else {
+        experimentalFeatureSettings.require(Xp::RecursiveNix);
+    }
 
     auto store = makeRestrictedStore(
         [&] {
@@ -806,7 +824,14 @@ void DerivationBuilderImpl::startDaemon()
 
     chownToBuilder(socketPath);
 
-    daemonThread = std::thread([this, store]() {
+    daemon::RecursiveFlag recursiveFlag;
+    if (usingSubmitted) {
+        recursiveFlag = daemon::RecursiveFlag::RecursiveSubmitted;
+    } else {
+        recursiveFlag = daemon::RecursiveFlag::Recursive;
+    }
+
+    daemonThread = std::thread([this, store, recursiveFlag]() {
         while (true) {
 
             /* Accept a connection. */
@@ -828,9 +853,10 @@ void DerivationBuilderImpl::startDaemon()
 
             auto doneFlag = make_ref<std::atomic_flag>();
 
-            auto workerThread = std::thread([this, doneFlag, store, remote{std::move(remote)}]() {
+            auto workerThread = std::thread([this, doneFlag, store, remote{std::move(remote)}, recursiveFlag]() {
                 try {
-                    miscMethods->processDaemonConnection(store, FdSource(remote.get()), FdSink(remote.get()), *this);
+                    miscMethods->processDaemonConnection(
+                        store, FdSource(remote.get()), FdSink(remote.get()), *this, recursiveFlag);
                     debug("terminated daemon connection");
                 } catch (const Interrupted &) {
                     debug("interrupted daemon connection");
@@ -1515,7 +1541,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                     PathFmt(store.toRealPath(newInfo.path)));
                 deletePath(actualPath);
                 /* Trigger the hash-mismatch error. */
-                checkCAFixedOutput(store, drvPath, *output, newInfo);
+                checkCAOutput(store, drvPath, *output, newInfo, outputName);
                 unreachable();
             }
         }
@@ -1626,7 +1652,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
 
     /* Apply output checks. This includes checking of the wanted vs got
        hash of fixed-outputs. */
-    checkOutputs(store, drvPath, drv.outputs, drvOptions.outputChecks, infos);
+    checkOutputs(store, drvPath, drv, drvOptions.outputChecks, infos);
 
     if (buildMode == bmCheck) {
         return {};
@@ -1667,6 +1693,62 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
             store.registerDrvOutput(thisRealisation);
         }
         builtOutputs.emplace(outputName, thisRealisation);
+    }
+
+    return builtOutputs;
+}
+
+SingleDrvOutputs DerivationBuilderImpl::checkSubmittedOutputs()
+{
+    // Submitted outputs from the recursive nix daemon
+    // It's fine to lock here since all other threads with the reference have been shut down.
+    auto submittedOutputs(this->submittedOutputs.lock());
+
+    SingleDrvOutputs builtOutputs;
+
+    std::map<std::string, ValidPathInfo> infos;
+
+    for (auto & [outputName, outputPath] : *submittedOutputs) {
+        infos.emplace(outputName, *store.queryPathInfo(outputPath));
+    }
+
+    // checkOutputs only performs checks that make sense for both submitting and non-submitting derivations,
+    // more verification steps needed afterward
+    checkOutputs(store, drvPath, drv, drvOptions.outputChecks, infos);
+
+    for (auto & [outputName, output] : drv.outputs) {
+        // For some reason cannot be moved to checkOutputs, needs debugging
+        if (!submittedOutputs->contains(outputName)) {
+            throw BuildError(
+                BuildResult::Failure::OutputRejected,
+                "builder for '%s' failed to submit output path for '%s'",
+                store.printStorePath(drvPath),
+                outputName);
+        }
+
+        // We should have already checked that the derivation is content-addressing in startBuild
+        // and that the outputs of a content-addressing derivation is content-addressed in checkOutputs.
+        // Add an assert here just in case, but it should never trigger.
+        assert(
+            std::get_if<DerivationOutput::CAFloating>(&output.raw)
+            || std::get_if<DerivationOutput::CAFixed>(&output.raw));
+
+        // No need to sign CA outputs, only the realisation matters
+        auto realisation = Realisation{
+            {
+                .outPath = *get(*submittedOutputs, outputName),
+            },
+            DrvOutput{
+                .drvPath = drvPath,
+                .outputName = outputName,
+            },
+        };
+
+        store.signRealisation(realisation);
+        store.registerDrvOutput(realisation);
+        builtOutputs.emplace(outputName, realisation);
+
+        // TODO: handle --check
     }
 
     return builtOutputs;

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -25,9 +25,7 @@ const WorkerProto::Version WorkerProto::latest = {
         },
     .features =
         {
-            std::string{
-                WorkerProto::featureRealisationWithPath,
-            },
+            std::string{WorkerProto::featureRealisationWithPath},
             std::string{WorkerProto::featureDeleteDeadSpecificReferrers},
         },
 };
@@ -37,6 +35,21 @@ const WorkerProto::Version WorkerProto::minimum = {
         {
             .major = 1,
             .minor = 18,
+        },
+};
+
+const WorkerProto::Version WorkerProto::builderRpcV0 = {
+    .number =
+        {
+            .major = 1,
+            .minor = 38,
+        },
+    .features =
+        {
+            std::string{WorkerProto::featureRealisationWithPath},
+            std::string{WorkerProto::featureDisableSetOptions},
+            std::string{WorkerProto::featureAddToStoreScanning},
+            std::string{WorkerProto::featureSubmitOutput},
         },
 };
 
@@ -225,6 +238,45 @@ void WorkerProto::Serialise<DerivedPath>::write(
             },
             sOrDrvPath);
     }
+}
+
+SingleDerivedPath
+WorkerProto::Serialise<SingleDerivedPath>::read(const StoreDirConfig & store, WorkerProto::ReadConn conn)
+{
+    auto tag = readNum<uint8_t>(conn.from);
+    switch (tag) {
+    case 0:
+        return SingleDerivedPath::Opaque{
+            .path = WorkerProto::Serialise<StorePath>::read(store, conn),
+        };
+    case 1: {
+        auto drvPath = make_ref<SingleDerivedPath>(WorkerProto::Serialise<SingleDerivedPath>::read(store, conn));
+        return SingleDerivedPath::Built{
+            .drvPath = std::move(drvPath),
+            .output = readString(conn.from),
+        };
+    }
+    default:
+        throw Error("Invalid tag %d for single derived path", tag);
+    }
+}
+
+void WorkerProto::Serialise<SingleDerivedPath>::write(
+    const StoreDirConfig & store, WorkerProto::WriteConn conn, const SingleDerivedPath & req)
+{
+    std::visit(
+        overloaded{
+            [&](const SingleDerivedPath::Opaque & o) {
+                conn.to << uint8_t{0};
+                WorkerProto::write(store, conn, o.path);
+            },
+            [&](const SingleDerivedPath::Built & b) {
+                conn.to << uint8_t{1};
+                WorkerProto::write(store, conn, *b.drvPath);
+                conn.to << b.output;
+            },
+        },
+        req.raw());
 }
 
 KeyedBuildResult

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -120,6 +120,7 @@ nix_sources = [ config_priv_h ] + files(
   'store-gc.cc',
   'store-info.cc',
   'store-repair.cc',
+  'store-submit-output.cc',
   'store.cc',
   'upgrade-nix.cc',
   'verify.cc',

--- a/src/nix/store-submit-output.cc
+++ b/src/nix/store-submit-output.cc
@@ -1,0 +1,46 @@
+#include "nix/cmd/command.hh"
+#include "nix/store/store-api.hh"
+#include "nix/store/store-cast.hh"
+#include "nix/store/submit-store.hh"
+
+namespace nix {
+
+struct CmdSubmitOutput : StoreCommand
+{
+    std::string path;
+    OutputName output;
+
+    CmdSubmitOutput()
+    {
+        expectArg("path", &path);
+        expectArg("output", &output);
+    }
+
+    std::string description() override
+    {
+        return "submit a store object as one of the outputs of the derivation currently being built";
+    }
+
+    std::string doc() override
+    {
+        return
+#include "store-submit-output.md"
+            ;
+    }
+
+    std::optional<ExperimentalFeature> experimentalFeature() override
+    {
+        return Xp::DynamicDerivations;
+    }
+
+    void run(ref<Store> store) override
+    {
+        auto & submitStore = require<SubmitStore>(*store);
+        auto path = SingleDerivedPath::parse(*store, this->path);
+        submitStore.submitOutput(path, output);
+    }
+};
+
+static auto rCmdSubmitOutput = registerCommand2<CmdSubmitOutput>({"store", "submit-output"});
+
+} // namespace nix

--- a/src/nix/store-submit-output.md
+++ b/src/nix/store-submit-output.md
@@ -1,0 +1,20 @@
+R""(
+
+# Examples
+
+* To submit a given [store object] as the output named `out`:
+
+  ```console
+  # nix store submit-output /nix/store/h6zs50y2662apmnbcnhnbxll76lv02yy-hello-2.12.3 out
+  ```
+
+# Description
+
+`nix store submit-output` registers a [store object] as an output of the currently-running derivation.
+
+It only functions when running inside a content-addressing derivation with the `builder-rpc-v0`
+system feature, which provides a limited daemon socket to the builder.
+Execution in any other environment will fail.
+
+[store object]: @docroot@/store/store-object.md
+)""

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -375,7 +375,8 @@ static void daemonLoop(
                         // Handle the connection.
                         auto store = storeConfig->openStore();
                         store->init();
-                        processConnection(store, FdSource(remote.get()), FdSink(remote.get()), trusted, NotRecursive);
+                        processConnection(
+                            store, FdSource(remote.get()), FdSink(remote.get()), trusted, RecursiveFlag::NotRecursive);
 
                         exit(0);
                     },
@@ -437,7 +438,8 @@ static void forwardStdioConnection(RemoteStore & store)
  */
 static void processStdioConnection(ref<Store> store, TrustedFlag trustClient)
 {
-    processConnection(store, FdSource(STDIN_FILENO), FdSink(STDOUT_FILENO), trustClient, daemon::NotRecursive);
+    processConnection(
+        store, FdSource(STDIN_FILENO), FdSink(STDOUT_FILENO), trustClient, daemon::RecursiveFlag::NotRecursive);
 }
 
 /**

--- a/tests/functional/dyn-drv/dep-built-drv-submitted.sh
+++ b/tests/functional/dyn-drv/dep-built-drv-submitted.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+# builder-rpc-v0
+requireDaemonNewerThan "2.35pre20260507"
+
+TODO_NixOS # can't enable a sandbox feature easily
+
+enableFeatures 'ca-derivations'
+restartDaemon
+
+NIX_BIN_DIR="$(dirname "$(type -p nix)")"
+export NIX_BIN_DIR
+
+nix build -L --file ./non-trivial-submitted.nix unstructured --no-link
+nix build -L --file ./non-trivial-submitted.nix structured --no-link

--- a/tests/functional/dyn-drv/meson.build
+++ b/tests/functional/dyn-drv/meson.build
@@ -10,6 +10,9 @@ suites += {
     'dep-built-drv.sh',
     'old-daemon-error-hack.sh',
     'dep-built-drv-2.sh',
+    'dep-built-drv-submitted.sh',
+    'submit-failure.sh',
+    'submit-reference.sh',
   ],
   'workdir' : meson.current_source_dir(),
 }

--- a/tests/functional/dyn-drv/non-trivial-submitted.nix
+++ b/tests/functional/dyn-drv/non-trivial-submitted.nix
@@ -1,0 +1,93 @@
+with import ./config.nix;
+
+let
+  baseAttrs = {
+    name = "build-e.drv";
+
+    requiredSystemFeatures = [ "builder-rpc-v0" ];
+
+    buildCommand = ''
+      set -e
+      set -u
+
+      if [[ ! -z "''${out+set}" ]]; then
+        echo "out variable set in builder-rpc-v0 derivation"
+        exit 1
+      fi
+
+      PATH=${builtins.getEnv "NIX_BIN_DIR"}:$PATH
+
+      export NIX_CONFIG='extra-experimental-features = nix-command ca-derivations dynamic-derivations'
+
+      declare -A deps=(
+        [a]=""
+        [b]="a"
+        [c]="a"
+        [d]="b c"
+        [e]="b c d"
+      )
+
+      # Cannot just literally include this, or Nix will think it is the
+      # *outer* derivation that's trying to refer to itself, and
+      # substitute the string too soon.
+      placeholder=$(nix eval --raw --expr 'builtins.placeholder "out"')
+
+      declare -A drvs=()
+      for word in a b c d e; do
+        inputDrvs=""
+        for dep in ''${deps[$word]}; do
+          if [[ "$inputDrvs" != "" ]]; then
+            inputDrvs+=","
+          fi
+          read -r -d "" line <<EOF || true
+          "''${drvs[$dep]}": {
+            "outputs": ["out"],
+            "dynamicOutputs": {}
+          }
+      EOF
+          inputDrvs+="$line"
+        done
+        read -r -d "" json <<EOF || true
+        {
+          "args": ["-c", "set -xeu; echo \"word env vav $word is \$$word\" >> \"\$out\""],
+          "builder": "${shell}",
+          "env": {
+            "out": "$placeholder",
+            "$word": "hello, from $word!",
+            "PATH": ${builtins.toJSON path}
+          },
+          "inputs": {
+            "drvs": {
+              $inputDrvs
+            },
+            "srcs": []
+          },
+          "name": "build-$word",
+          "outputs": {
+            "out": {
+              "method": "nar",
+              "hashAlgo": "sha256"
+            }
+          },
+          "system": "${system}",
+          "version": 4
+        }
+      EOF
+        drvPath=$(echo "$json" | nix derivation add)
+        storeDir=$(dirname "$drvPath")
+        drvs[$word]="$(basename "$drvPath")"
+      done
+      nix store submit-output "''${storeDir}/''${drvs[e]}" out
+    '';
+
+    __contentAddressed = true;
+    outputHashMode = "text";
+    outputHashAlgo = "sha256";
+  };
+
+  buildDynamic = attrs: builtins.outputOf (mkDerivation attrs).outPath "out";
+in
+{
+  unstructured = buildDynamic baseAttrs;
+  structured = buildDynamic (baseAttrs // { __structuredAttrs = true; });
+}

--- a/tests/functional/dyn-drv/submit-failure.nix
+++ b/tests/functional/dyn-drv/submit-failure.nix
@@ -1,0 +1,45 @@
+with import ./config.nix;
+
+let
+  buildSubmitting =
+    name: command:
+    mkDerivation {
+      inherit name;
+
+      requiredSystemFeatures = [ "builder-rpc-v0" ];
+
+      buildCommand = ''
+        set -e
+        set -u
+
+        PATH=${builtins.getEnv "NIX_BIN_DIR"}:$PATH
+        export NIX_CONFIG='extra-experimental-features = nix-command ca-derivations dynamic-derivations'
+
+        ${command}
+      '';
+
+      __contentAddressed = true;
+      outputHashMode = "nar";
+      outputHashAlgo = "sha256";
+
+    };
+in
+{
+  duplicate = buildSubmitting "duplicate" ''
+    mkdir a
+    echo "miao" > a/gatto
+    a="$(nix store add -n duplicate ./a)"
+    nix store submit-output "$a" out
+
+    mkdir b
+    echo "miau" > b/katze
+    b="$(nix store add -n duplicate ./b)"
+    nix store submit-output "$b" out
+  '';
+  noSubmit = buildSubmitting "no-submit" ''
+    mkdir a
+    echo "nyaa" > a/neko
+    a="$(nix store add -n no-submit ./a)"
+    # Don't run the required `nix store submit-output`
+  '';
+}

--- a/tests/functional/dyn-drv/submit-failure.sh
+++ b/tests/functional/dyn-drv/submit-failure.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+# builder-rpc-v0
+requireDaemonNewerThan "2.35pre20260507"
+
+TODO_NixOS
+
+enableFeatures 'dynamic-derivations ca-derivations'
+restartDaemon
+
+NIX_BIN_DIR="$(dirname "$(type -p nix)")"
+export NIX_BIN_DIR
+
+expectStderr 1 nix build -L --file ./submit-failure.nix noSubmit --no-link | grepQuiet "failed to submit output"
+expectStderr 1 nix build -L --file ./submit-failure.nix duplicate --no-link | grepQuiet "submit duplicate output"

--- a/tests/functional/dyn-drv/submit-reference.nix
+++ b/tests/functional/dyn-drv/submit-reference.nix
@@ -1,0 +1,45 @@
+with import ./config.nix;
+
+let
+  buildSubmitting =
+    name: command:
+    mkDerivation {
+      inherit name;
+
+      requiredSystemFeatures = [ "builder-rpc-v0" ];
+
+      buildCommand = ''
+        set -e
+        set -u
+
+        PATH=${builtins.getEnv "NIX_BIN_DIR"}:$PATH
+        export NIX_CONFIG='extra-experimental-features = nix-command ca-derivations dynamic-derivations'
+
+        ${command}
+      '';
+
+      __contentAddressed = true;
+      outputHashMode = "nar";
+      outputHashAlgo = "sha256";
+    };
+
+  dependency = buildSubmitting "dependency" ''
+    mkdir dependency
+    echo "this is a dependency" > dependency/foo
+    out="$(nix store add --scan ./dependency)"
+    nix store submit-output "$out" out
+  '';
+in
+buildSubmitting "reference" ''
+  mkdir mao
+  echo "miao" > mao/foo
+  echo "${dependency}" > mao/reference
+  mao="$(nix store add --scan ./mao)"
+
+  mkdir felis
+  echo "miau" > felis/foo
+  echo "$mao" > felis/reference
+  felis="$(nix store add --scan -n reference ./felis)"
+
+  nix store submit-output "$felis" out
+''

--- a/tests/functional/dyn-drv/submit-reference.sh
+++ b/tests/functional/dyn-drv/submit-reference.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+listReferences() {
+    nix path-info "$1" --json --json-format 2 | \
+        jq -r '.info[].references | sort | .[]'
+}
+
+# builder-rpc-v0
+requireDaemonNewerThan "2.35pre20260507"
+
+TODO_NixOS
+
+enableFeatures 'dynamic-derivations ca-derivations'
+restartDaemon
+
+NIX_BIN_DIR="$(dirname "$(type -p nix)")"
+export NIX_BIN_DIR
+
+outPath="$(nix build -L --file ./submit-reference.nix --no-link --print-out-paths)"
+
+mapfile -t rootRefs < <(listReferences "${outPath}")
+if [[ ${#rootRefs[@]} -ne 1 ]]; then
+    echo "Incorrect references for root output" >&2
+    exit 1
+fi
+
+echo "${rootRefs[0]}" | grep -- "-mao$"
+
+mapfile -t secondRefs < <(listReferences "$NIX_STORE_DIR/${rootRefs[0]}")
+if [[ ${#secondRefs[@]} -ne 1 ]]; then
+    echo "Incorrect references for other output" >&2
+    exit 1
+fi
+
+echo "${secondRefs[0]}" | grep -- "-dependency$"


### PR DESCRIPTION
Useful to submit outputs during build

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This PR adds support for creating new store objects within a derivation at runtime,
then registering them as an output.

A derivation may need to create multiple store objects if it is creating derivations to be used dynamically,
which will often contain a number of dependencies. The derivation could create a number of  derivations for dependencies, before making a single one to merge them, registering that as an output.

Registering outputs is also useful for content-addressing derivations. The builder can learn the calculated content-addressed path of one of its outputs before creating others, removing the need for any rewriting on the nix-daemon side after the derivation finishes.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes #15791

This idea was originally implemented in #13768 as a separate varlink daemon, but that required a separate client and server, not reusing any of the existing nix daemon code and protocol. In order to reduce the total implementation burden, move the work into the standard daemon.

recursive-nix has not been moving towards stabilization. This new API greatly limits the allowed nix daemon API calls within derivations when using the new `nix-daemon-registered` option in order to reduce attack surface and opportunities for non-reproducability of derivations between nix versions.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
