### PR TITLE
Speed up evaluator, derivation printing, and base16 encoding

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -48,6 +48,7 @@
 #include <nlohmann/json.hpp>
 #include <boost/container/small_vector.hpp>
 #include <boost/unordered/concurrent_flat_map.hpp>
+#include <boost/unordered/unordered_flat_set.hpp>
 
 #include "nix/util/strings-inline.hh"
 
@@ -2289,17 +2290,18 @@ void EvalState::tryFixupBlackHolePos(Value & v, PosIdx pos)
 
 void EvalState::forceValueDeep(Value & v)
 {
-    std::set<const Value *> seen;
+    /* Only attrsets and lists can recurse cyclically, so only those need cycle
+       detection. Leaves are skipped to avoid a hash op per leaf. */
+    boost::unordered_flat_set<const Value *> seen;
 
     [&, &state(*this)](this const auto & recurse, Value & v) {
         auto _level = state.addCallDepth(v.determinePos(noPos));
 
-        if (!seen.insert(&v).second)
-            return;
-
         state.forceValue(v, v.determinePos(noPos));
 
         if (v.type() == nAttrs) {
+            if (!seen.insert(&v).second)
+                return;
             for (auto & i : *v.attrs())
                 try {
                     // If the value is a thunk, we're evaling. Otherwise no trace necessary.
@@ -2320,6 +2322,8 @@ void EvalState::forceValueDeep(Value & v)
         }
 
         else if (v.isList()) {
+            if (!seen.insert(&v).second)
+                return;
             size_t index = 0;
             for (auto v2 : v.listView())
                 try {

--- a/src/libexpr/include/nix/expr/attr-set.hh
+++ b/src/libexpr/include/nix/expr/attr-set.hh
@@ -423,13 +423,23 @@ public:
      */
     std::vector<const Attr *> lexicographicOrder(const SymbolTable & symbols) const
     {
+        /* Cache string_views once instead of re-resolving in the comparator
+           on every O(N log N) compare. */
+        struct AttrWithName
+        {
+            std::string_view sv;
+            const Attr * a;
+        };
+
+        std::vector<AttrWithName> tagged;
+        tagged.reserve(size());
+        for (const auto & a : *this)
+            tagged.push_back({symbols[a.name], &a});
+        std::ranges::sort(tagged, {}, &AttrWithName::sv);
         std::vector<const Attr *> res;
-        res.reserve(size());
-        std::ranges::transform(*this, std::back_inserter(res), [](const Attr & a) { return &a; });
-        std::ranges::sort(res, [&](const Attr * a, const Attr * b) {
-            std::string_view sa = symbols[a->name], sb = symbols[b->name];
-            return sa < sb;
-        });
+        res.reserve(tagged.size());
+        for (const auto & t : tagged)
+            res.push_back(t.a);
         return res;
     }
 

--- a/src/libstore/derivation/aterm.cc
+++ b/src/libstore/derivation/aterm.cc
@@ -13,6 +13,7 @@
 #include <boost/unordered/concurrent_flat_map.hpp>
 #include <nlohmann/json.hpp>
 #include <algorithm>
+#include <cstring>
 #include <optional>
 #include <ranges>
 
@@ -396,32 +397,46 @@ Derivation parseDerivation(
  */
 static void printString(std::string & res, std::string_view s)
 {
-    res += '"';
-    static constexpr auto chunkSize = 1024;
-    std::array<char, 2 * chunkSize + 2> buffer;
-    while (!s.empty()) {
-        auto chunk = s.substr(0, /*n=*/chunkSize);
-        s.remove_prefix(chunk.size());
-        char * buf = buffer.data();
-        char * p = buf;
-        for (auto c : chunk)
-            if (c == '\"' || c == '\\') {
-                *p++ = '\\';
-                *p++ = c;
-            } else if (c == '\n') {
-                *p++ = '\\';
+    /* Bulk-memcpy unescaped runs and handle escapes inline; write straight
+       into res via resize_and_overwrite (no zero-fill, no scratch buffer). */
+    auto oldSize = res.size();
+    res.resize_and_overwrite(oldSize + s.size() * 2 + 2, [&](char * data, size_t) -> size_t {
+        char * p = data + oldSize;
+        *p++ = '"';
+        while (!s.empty()) {
+            size_t i = 0;
+            while (i < s.size()) {
+                char c = s[i];
+                if (c == '"' || c == '\\' || c == '\n' || c == '\r' || c == '\t')
+                    break;
+                ++i;
+            }
+            if (i > 0) {
+                std::memcpy(p, s.data(), i);
+                p += i;
+            }
+            if (i == s.size())
+                break;
+            *p++ = '\\';
+            switch (s[i]) {
+            case '\n':
                 *p++ = 'n';
-            } else if (c == '\r') {
-                *p++ = '\\';
+                break;
+            case '\r':
                 *p++ = 'r';
-            } else if (c == '\t') {
-                *p++ = '\\';
+                break;
+            case '\t':
                 *p++ = 't';
-            } else
-                *p++ = c;
-        res.append(buf, p - buf);
-    }
-    res += '"';
+                break;
+            default:
+                *p++ = s[i];
+                break;
+            }
+            s.remove_prefix(i + 1);
+        }
+        *p++ = '"';
+        return p - data;
+    });
 }
 
 static void printUnquotedString(std::string & res, std::string_view s)

--- a/src/libutil/base-n.cc
+++ b/src/libutil/base-n.cc
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <string_view>
 
 #include "nix/util/array-from-string-literal.hh"
@@ -8,13 +9,24 @@ namespace nix {
 
 constexpr static const std::array<char, 16> base16Chars = "0123456789abcdef"_arrayNoNull;
 
+/* Two-char hex encoding per input byte; written via memcpy so the encoder
+   emits two characters per iteration without bounds checks. */
+constexpr static const std::array<std::array<char, 2>, 256> base16Pairs = []() {
+    std::array<std::array<char, 2>, 256> arr{};
+    for (int i = 0; i < 256; ++i) {
+        arr[i][0] = base16Chars[i >> 4];
+        arr[i][1] = base16Chars[i & 0xf];
+    }
+    return arr;
+}();
+
 std::string base16::encode(std::span<const std::byte> b)
 {
-    std::string buf;
-    buf.reserve(b.size() * 2);
+    std::string buf(b.size() * 2, '\0');
+    char * p = buf.data();
     for (size_t i = 0; i < b.size(); i++) {
-        buf.push_back(base16Chars[(uint8_t) b.data()[i] >> 4]);
-        buf.push_back(base16Chars[(uint8_t) b.data()[i] & 0x0f]);
+        std::memcpy(p, base16Pairs[static_cast<uint8_t>(b.data()[i])].data(), 2);
+        p += 2;
     }
     return buf;
 }


### PR DESCRIPTION
## Summary

Speed up four profiled hot paths in the evaluator, derivation printer, and base16 encoder.

## Benchmarks

| Change | Workload | `master` | PR | Change |
| --- | --- | ---: | ---: | ---: |
| `forceValueDeep` cycle detection | `deepSeq`, 800k four-attribute sets | 0.24 s | 0.10 s | -58% |
| `Bindings::lexicographicOrder` | 1,000 attrs | 17,587 ns | 15,714 ns | -10.7% |
| `Bindings::lexicographicOrder` | 5,000 attrs | 87,706 ns | 81,711 ns | -6.8% |
| `Bindings::lexicographicOrder` | 10,000 attrs | 175,785 ns | 158,533 ns | -9.8% |
| `base16::encode` | 32-byte input | 177 ns | 16.0 ns | -91% |
| `Derivation::unparse` | `hello.drv` | 2,188 ns | 1,708 ns | -21.9% |
| `Derivation::unparse` | `firefox.drv` | 35,826 ns | 33,814 ns | -5.6% |

Measured on an Apple M5 Pro (`aarch64-darwin`) with Clang `-O3`. Google Benchmark rows report mean CPU time over 15 repetitions with a 0.5 s minimum per repetition (30 repetitions for base16); `deepSeq` reports median wall time over 15 alternating runs. Both revisions used the same benchmark-only const-correctness fix needed to compile `BM_GetDerivationsAttrScan`.

## Testing

- `nix-expr-tests-run`
- `nix-store-tests-run`
- `nix-util-tests-run`

**AI disclosure:** Claude Code and OpenAI Codex were used for profiling, benchmarking, and review.

