### PR TITLE
libexpr: add temp roots during evaluation to prevent GC races

### DIFF
--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -24,6 +24,11 @@ PackageInfo::PackageInfo(EvalState & state, ref<Store> store, const std::string 
 
     this->drvPath = drvPath;
 
+    /* Prevent GC from deleting the .drv before we read it. This
+       constructor is only called from CLI entry points (nix-build)
+       where the path originates from a previous session, so it
+       has no temp root from the current process. */
+    store->addTempRoot(drvPath);
     auto drv = store->derivationFromPath(drvPath);
 
     name = drvPath.name();

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -306,8 +306,14 @@ static void import(EvalState & state, const PosIdx pos, Value & vPath, Value * v
     auto isValidDerivationInStore = [&]() -> std::optional<StorePath> {
         if (!state.store->isStorePath(path2))
             return std::nullopt;
+        if (!isDerivation(path2))
+            return std::nullopt;
         auto storePath = state.store->parseStorePath(path2);
-        if (!(state.store->isValidPath(storePath) && isDerivation(path2)))
+        /* Add a temp root before checking validity to prevent GC
+           from deleting the path between our check and the
+           subsequent readDerivation(). */
+        state.store->addTempRoot(storePath);
+        if (!state.store->isValidPath(storePath))
             return std::nullopt;
         return storePath;
     };


### PR DESCRIPTION

## Motivation
Evaluation resolves store paths (reads `.drv` files, computes closures, extracts
output paths) that may originate from previous sessions without registering temp
roots (reading derivations from disk instead of JIT writing). This creates a
race window where GC can delete `.drv` files between evaluation resolving them
and the build phase adding its own temp roots, resulting in "No such file or
directory" errors.

Add `addTempRoot()` calls at the key points where `libexpr` reads derivations
from the store for paths that have no temp root from the current process:

- `import`: before validating and reading an imported .drv file (with
  `isDerivation` checked first to avoid unnecessary daemon round-trips for
  non-derivation imports)
- `PackageInfo` constructor: before reading a derivation for package metadata
  queries (only caller is `nix-build` for user-supplied `.drv` paths)

## Context

We're experiencing concurrent GC passes that regularly wipe `.drv`'s off of disk
when a concurrent process is halted during the eval phase, this leads to the
following when the process gets to proceed:

```
error: opening file '/nix/store/...-rust_aws-smithy-protocol-test-0.63.14.drv': No such file or directory
```

This complements #15469 — without the GC-side fix (re-checking `tempRoots`
before each deletion), `addTempRoot` at consumption sites only narrows the race
window without eliminating it.

This happens for us on: nix (Nix) 2.28.3


Now, this is my first contribution to Nix itself, so I'm not aware of any potential performance penalties in extending the set of temproots at eval-time.