### PR TITLE
repl: Implemented a buffer editor keybind

### DIFF
--- a/src/libcmd/editor-for.cc
+++ b/src/libcmd/editor-for.cc
@@ -9,7 +9,8 @@ namespace nix {
 std::tuple<OsStrings, AutoCloseFD, AutoDelete> editorFor(const SourcePath & file, uint32_t line, bool readOnly)
 {
     auto path = file.getPhysicalPath();
-    OsString editor = getEnvOsNonEmpty(OS_STR("EDITOR")).value_or(OS_STR("cat"));
+    OsString editor =
+        getEnvOsNonEmpty(OS_STR("VISUAL")).value_or(getEnvOsNonEmpty(OS_STR("EDITOR")).value_or(OS_STR("cat")));
     auto args = tokenizeString<OsStrings>(editor);
     if (line > 0
         && (editor.contains(OS_STR("emacs")) || editor.contains(OS_STR("nano")) || editor.contains(OS_STR("vim"))

--- a/src/libcmd/editor-for.cc
+++ b/src/libcmd/editor-for.cc
@@ -32,7 +32,7 @@ std::tuple<OsStrings, AutoCloseFD, AutoDelete> editorFor(const SourcePath & file
 
     auto tempDir = createTempDir(defaultTempDir(), "nix-edit", 0700);
     AutoDelete autoDel(tempDir, /*recursive=*/true);
-    auto tempPath = tempDir / file2.path.baseName().value_or("nix-edit");
+    auto tempPath = tempDir / file2.path.baseName().value_or("nix-edit.nix");
 
     /* Create the file with the same name, so editors that recognise file
        extensions spin up syntax highlighting and LSPs. */

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -34,6 +34,12 @@
 #include "nix/util/processes.hh"
 #include "nix/util/strings.hh"
 
+#include <editline.h>
+#include "cmd-config-private.hh"
+#include "nix/util/memory-source-accessor.hh"
+
+#include <fstream>
+
 namespace nix {
 
 /**
@@ -82,6 +88,7 @@ struct NixRepl : AbstractNixRepl, detail::ReplCompleterMixin, gc
     NixRepl(const LookupPath & lookupPath, ref<EvalState> state, fun<AnnotatedValues()> getValues, RunNix * runNix);
     virtual ~NixRepl() = default;
 
+    void registerBinds();
     ReplExitStatus mainLoop() override;
     void initEnv() override;
 
@@ -164,9 +171,11 @@ static std::ostream & showDebugTrace(std::ostream & out, const PosTable & positi
 MakeError(IncompleteReplExpr, ParseError);
 
 static bool isFirstRepl = true;
+std::string input;
 
 ReplExitStatus NixRepl::mainLoop()
 {
+
     if (isFirstRepl) {
         std::string_view debuggerNotice = "";
         if (state->debugRepl) {
@@ -181,7 +190,7 @@ ReplExitStatus NixRepl::mainLoop()
 
     auto _guard = interacter->init(static_cast<detail::ReplCompleterMixin *>(this));
 
-    std::string input;
+    registerBinds();
 
     while (true) {
         // Hide the progress bar while waiting for user input, so that it won't interfere.
@@ -918,6 +927,62 @@ void NixRepl::runNix(const std::string & program, OsStrings args)
         throw Error(
             "Cannot run '%s' because no method of calling the Nix CLI was provided. This is a configuration problem pertaining to how this program was built. See Nix 2.25 release notes",
             program);
+}
+
+/**
+ * Opens the active buffer in an editor, allowing for a better UX, including potential LSP support, and more.
+ * Unfortunately due to how editline operates, several tradeoffs had to be made, including poor history support,
+ * having to immediately evaluate upon return, and having to leave the previous buffer as is in the scrollback buffer.
+ */
+el_status_t bufferEditor(void)
+{
+    { // Moving input to rl_line_buffer, so library functions account for it.
+        std::string rlBuffer = rl_line_buffer;
+        rl_line_buffer =
+            strdup((input + rlBuffer)
+                       .c_str()); // Why is rlBuffer and input backwards? They're appending in reverse. Why? Dunno.
+        input.clear();
+    }
+    auto memorySourceAccessor = make_ref<MemorySourceAccessor>();
+    memorySourceAccessor->root = MemorySourceAccessor::File{MemorySourceAccessor::File::Regular{
+        .executable = false,
+        .contents = rl_line_buffer,
+    }};
+    SourcePath source_path{
+        [memorySourceAccessor] { return memorySourceAccessor; }(),
+    };
+    auto [args, tempFd, delTemp] = editorFor(source_path, 0, false);
+    auto program = args.front();
+    args.pop_front(); // dropping the binary arg, it's in `program` now.
+
+    runProgram2(
+        RunOptions{
+            .program = program,
+            .lookupPath = true,
+            .args = args,
+            .isInteractive = true,
+        });
+
+    std::ifstream file(args.front());
+    std::stringstream stringBuf;
+    stringBuf << file.rdbuf();
+    std::string string = trim(stringBuf.str());
+
+    rl_line_buffer = strdup(string.c_str());
+    // We print the buffer we're actually evaluating back for end-user clarity on what is being evaluated here.
+    std::cout << '\n'
+              << string
+              << '\n'; // For whatever reason I have to put a newline on both sides, or it behaves very unpredictably...
+    return CSdone;
+}
+
+void NixRepl::registerBinds()
+{
+#if USE_READLINE
+    rl_bind_keyseq("\\C-o", bufferEditor);
+#else
+    el_bind_key(CTL('O'), bufferEditor);
+#endif
 }
 
 std::unique_ptr<AbstractNixRepl> AbstractNixRepl::create(


### PR DESCRIPTION
Ctrl + o now opens the current buffer in an editor for you to edit before evaluating.
Resolves: #15633

# Notes
This a first time contribution to cppnix from me, and I am not a huge cpp dev, so expect mistakes and issues.
Furthermore, due to existing design decisions, and the nature of `editline`, major tradeoffs and compromises had to be made, so this is by no means ideal...

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
