### PR TITLE
Document how to use addTempRoot() in a race-free way

### DIFF
--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -82,6 +82,7 @@ std::pair<StorePath, Hash> fetchToStore2(
     auto [storePath, hash] =
         mode == FetchMode::DryRun
             ? [&]() {
+                  // FIXME: we may have already computed this above.
                   auto [storePath, hash] =
                       store.computeStorePath(name, path, method, HashAlgorithm::SHA256, {}, filter2);
                   debug(

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -816,6 +816,47 @@ public:
     /**
      * Add a store path as a temporary root of the garbage collector.
      * The root disappears as soon as we exit.
+     * Before exiting, if you want to avoid the path being GC'ed, you either have to make it a permanent root using
+     * `LocalFSStore::addPermRoot()`, or make sure it's reachable from a permanent root (e.g. by adding it as a
+     * reference of a reachable path).
+     *
+     * To avoid races, you should call either this function or `LocalFSStore::addPermRoot()` *before* creating and using
+     * a store path, e.g.
+     *
+     * ```c++
+     * auto path = store.computeStorePath(...);
+     * store->addTempRoot(path);
+     * if (!store->isValidPath(path))
+     *     store->addToStore(...);
+     * ```
+     *
+     * By contrast, registering a root just before *using* a path is not sufficient to prevent GC races. For
+     * instance, don't do this:
+     *
+     * ```c++
+     * store->addTempRoot(path);
+     * auto drv = store->readDerivation(path);
+     * ```
+     *
+     * since the path may be GC'ed just before the call to `addTempRoot()`.
+     *
+     * Note that `addToStore()` implicitly calls `addTempRoot()`, so you don't need to call it yourself if you're
+     * calling `addToStore()` unconditionally.
+     *
+     * It is generally the responsibility of the caller of Nix APIs and CLI tools to ensure that paths are reachable by
+     * the garbage collector. For example, `buildPath(drvPath)` does not need to register *drvPath* as a GC root, since
+     * that's the responsibility of the caller, and it would be too late for `buildPath()` to do so anyway. Thus, this
+     * can race:
+     * ```console
+     * drv=$(nix-instantiate foo.nix)
+     * nix-store -r $drv
+     * ```
+     * whereas this is safe:
+     * ```console
+     * nix-instantiate foo.nix --add-root ./drv
+     * nix-store -r ./drv
+     * ```
+     *
      */
     virtual void addTempRoot(const StorePath & path)
     {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This has come up fairly often lately so let's document how to use the root registration APIs safely.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
