### PR TITLE
StoreDirConfig::parseStorePath(), canonPath(): Don't crash on empty paths

### DIFF
--- a/src/libstore/store-dir-config.cc
+++ b/src/libstore/store-dir-config.cc
@@ -8,6 +8,8 @@ namespace nix {
 
 StorePath StoreDirConfig::parseStorePath(std::string_view path) const
 {
+    if (path.empty())
+        throw BadStorePath("empty path is not a valid store path");
     // On Windows, `/nix/store` is not a canonical path. More broadly it
     // is unclear whether this function should be using the native
     // notion of a canonical path at all. For example, it makes to

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -114,7 +114,7 @@ TEST(canonPath, requiresAbsolutePath)
     ASSERT_ANY_THROW(canonPath("."sv));
     ASSERT_ANY_THROW(canonPath(".."sv));
     ASSERT_ANY_THROW(canonPath("../"sv));
-    ASSERT_DEATH({ canonPath(""sv); }, "!path.empty\\(\\)");
+    ASSERT_ANY_THROW(canonPath(""sv));
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -95,7 +95,8 @@ absPath(const std::filesystem::path & path0, const std::filesystem::path * dir, 
 
 std::filesystem::path canonPath(const std::filesystem::path & path, bool resolveSymlinks)
 {
-    assert(!path.empty());
+    if (path.empty())
+        throw Error("cannot canonicalise an empty path");
 
     if (!path.is_absolute())
         throw Error("not an absolute path: %s", PathFmt(path));


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
