### PR TITLE
Add AddDerivationJson worker protocol request

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -1,4 +1,5 @@
 #include "nix/store/daemon.hh"
+#include "nix/util/serialise.hh"
 #include "nix/util/signals.hh"
 #include "nix/store/worker-protocol.hh"
 #include "nix/store/worker-protocol-connection.hh"
@@ -1025,6 +1026,18 @@ static void performOp(
         conn.to << 1;
         break;
     }
+
+    case WorkerProto::Op::AddDerivationJson: {
+        auto s = readString(conn.from);
+
+        logger->startWork();
+        auto drv = Derivation::parseJsonAndValidate(*store, nlohmann::json::parse(s));
+        auto drvPath = store->writeDerivation(drv);
+        logger->stopWork();
+
+        WorkerProto::write(*store, conn, drvPath);
+        break;
+    };
 
     default:
         throw Error("invalid operation %1%", op);

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -251,6 +251,8 @@ enum struct WorkerProto::Op : uint64_t {
     AddBuildLog = 45,
     BuildPathsWithResults = 46,
     AddPermRoot = 47,
+    // SubmitOutput = 48, // See PR #15793
+    AddDerivationJson = 49,
 };
 
 struct WorkerProto::ClientHandshakeInfo


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
ATerm is a nix-specific format, and there are few implementations available.  While this is not a problem when using libstore with its well-tested ATerm implementation, users may want to write their own implementations of the worker protocol to submit derivations (especially when making dynamic derivations with #15793).

There is already a common method of serializing derivations with JSON, which has support in many languages, so add a new call that can be used to add a JSON derivation.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

No test has been added as yet because it is challenging to write. There should not be any need to use the new rpc call in `libstore`, but calling it requires the protected function `getConnection`.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
