### PR TITLE
Hide/unhide cursor in the progress bar logger

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -2,8 +2,10 @@
 #include "nix/util/terminal.hh"
 #include "nix/util/sync.hh"
 #include "nix/util/signals.hh"
-#include "nix/store/store-api.hh"
+#include "nix/store/path.hh"
+#include "nix/util/file-system.hh"
 #include "nix/store/names.hh"
+#include "nix/util/util.hh"
 
 #include <map>
 #include <thread>
@@ -13,17 +15,19 @@
 
 namespace nix {
 
+namespace {
+
 static std::string_view getS(const std::vector<Logger::Field> & fields, size_t n)
 {
-    assert(n < fields.size());
-    assert(fields[n].type == Logger::Field::tString);
+    if (n >= fields.size() || fields[n].type != Logger::Field::tString)
+        throw Error("could not get expected log field of type 'string' at index %d", n);
     return fields[n].s;
 }
 
 static uint64_t getI(const std::vector<Logger::Field> & fields, size_t n)
 {
-    assert(n < fields.size());
-    assert(fields[n].type == Logger::Field::tInt);
+    if (n >= fields.size() || fields[n].type != Logger::Field::tInt)
+        throw Error("could not get expected log field of type 'int' at index %d", n);
     return fields[n].i;
 }
 
@@ -34,10 +38,17 @@ static std::string_view storePathToName(std::string_view path)
     return i == std::string::npos ? base.substr(0, 0) : base.substr(i + 1);
 }
 
-class ProgressBar : public Logger
+static std::string_view storePathToNameWithoutDrvSuffix(std::string_view path)
+{
+    auto res = storePathToName(path);
+    if (hasSuffix(res, drvExtension))
+        res.remove_suffix(drvExtension.size());
+    return res;
+}
+
+class ProgressBar final : public Logger
 {
 private:
-
     struct ActInfo
     {
         std::string s, lastLine, phase;
@@ -223,9 +234,7 @@ public:
         state->activitiesByType[type].its.emplace(act, i);
 
         if (type == actBuild) {
-            std::string name(storePathToName(getS(fields, 0)));
-            if (hasSuffix(name, ".drv"))
-                name = name.substr(0, name.size() - 4);
+            auto name = storePathToNameWithoutDrvSuffix(getS(fields, 0));
             i->s = fmt("building " ANSI_BOLD "%s" ANSI_NORMAL, name);
             auto machineName = getS(fields, 1);
             if (machineName != "")
@@ -250,9 +259,7 @@ public:
         }
 
         if (type == actPostBuildHook) {
-            auto name = storePathToName(getS(fields, 0));
-            if (hasSuffix(name, ".drv"))
-                name = name.substr(0, name.size() - 4);
+            auto name = storePathToNameWithoutDrvSuffix(getS(fields, 0));
             i->s = fmt("post-build " ANSI_BOLD "%s" ANSI_NORMAL, name);
             i->name = DrvName(name).name;
         }
@@ -686,6 +693,8 @@ public:
         this->printBuildLogs = printBuildLogs;
     }
 };
+
+} // namespace
 
 std::unique_ptr<Logger> makeProgressBar()
 {

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -107,6 +107,18 @@ private:
 
     std::unique_ptr<InterruptCallback> interruptCallback;
 
+    void hideCursorIfNeeded() const
+    {
+        if (isTTY)
+            writeToStderr("\e[?25l");
+    }
+
+    void unhideCursorIfNeeded() const
+    {
+        if (isTTY)
+            writeToStderr("\e[?25h");
+    }
+
 public:
 
     ProgressBar(bool isTTY)
@@ -116,6 +128,7 @@ public:
             redraw("\rshutting down\e[K");
         }))
     {
+        hideCursorIfNeeded();
         state_.lock()->active = isTTY;
         updateThread = std::thread([&]() {
             auto state(state_.lock());
@@ -142,6 +155,7 @@ public:
             if (state->active) {
                 state->active = false;
                 clearProgressDisplay();
+                unhideCursorIfNeeded();
                 updateCV.notify_one();
                 quitCV.notify_one();
             }
@@ -159,8 +173,10 @@ public:
             return;
         }
 
-        if (state->active)
+        if (state->active) {
             clearProgressDisplay();
+            unhideCursorIfNeeded();
+        }
     }
 
     void resume() override
@@ -173,8 +189,10 @@ public:
             state->suspensions--;
         }
         if (state->suspensions == 0) {
-            if (state->active)
+            if (state->active) {
                 clearProgressDisplay();
+                hideCursorIfNeeded();
+            }
             state->haveUpdate = true;
             updateCV.notify_one();
         }
@@ -681,7 +699,9 @@ public:
             return {};
         invalidateRedrawCache();
         std::cerr << fmt("\r\e[K%s ", msg);
+        unhideCursorIfNeeded();
         auto s = trim(readLine(getStandardInput(), true));
+        hideCursorIfNeeded();
         if (s.size() != 1)
             return {};
         draw(*state);

--- a/src/libutil/tee-logger.cc
+++ b/src/libutil/tee-logger.cc
@@ -2,10 +2,13 @@
 
 namespace nix {
 
-struct TeeLogger : Logger
+namespace {
+
+class TeeLogger final : public Logger
 {
     std::vector<std::unique_ptr<Logger>> loggers;
 
+public:
     TeeLogger(std::vector<std::unique_ptr<Logger>> && loggers)
         : loggers(std::move(loggers))
     {
@@ -93,6 +96,8 @@ struct TeeLogger : Logger
             logger->setPrintBuildLogs(printBuildLogs);
     }
 };
+
+} // namespace
 
 std::unique_ptr<Logger>
 makeTeeLogger(std::unique_ptr<Logger> mainLogger, std::vector<std::unique_ptr<Logger>> && extraLoggers)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Small cleanup + hide/unhide of the cursor in the bar logger. I was looking a bit into resurrecting our bar logger improvements from https://github.com/NixOS/nix/pull/4296 and this these are some small issues I found while trying to do that.

Also deduplicates some code in the progress-bar.cc and sprinkles anonymous namespaces on top to appease Wweak-vtables.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
