### PR TITLE
tests/functional/user-envs: fix flaky empty-shebang on darwin

### DIFF
--- a/tests/functional/user-envs.builder.sh
+++ b/tests/functional/user-envs.builder.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2154
 mkdir "$out"
 mkdir "$out"/bin
-echo "#! $shell" > "$out"/bin/"$progName"
+echo "#! $builder" > "$out"/bin/"$progName"
 # shellcheck disable=SC2154
 echo "echo $name" >> "$out"/bin/"$progName"
 chmod +x "$out"/bin/"$progName"


### PR DESCRIPTION
The builder writes `#! $shell` but `$shell` is not in the derivation
environment, producing an empty shebang. Execution then relies on
bash's ENOEXEC fallback, which intermittently yields empty output on
aarch64-darwin in the sandbox, failing at user-envs-test-case.sh:47.

Seen on Hydra nix/master:
  https://hydra.nixos.org/build/327882965
  https://hydra.nixos.org/build/327864789
  https://hydra.nixos.org/build/327864476
  https://hydra.nixos.org/build/327784794

Use `$builder` so the shebang is valid.
