### PR TITLE
manual: Update Names section to exclude indented strings and URIs

### DIFF
--- a/doc/manual/source/language/identifiers.md
+++ b/doc/manual/source/language/identifiers.md
@@ -16,7 +16,7 @@ An *identifier* is an [ASCII](https://en.wikipedia.org/wiki/ASCII) character seq
 
 # Names
 
-A *name* can be written as an [identifier](#identifiers) or a [string literal](./string-literals.md).
+A *name* can be written as an [identifier](#identifiers) or a [double-quoted string literal](./string-literals.md).
 
 > **Syntax**
 >


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

Stating that names can be "double-quoted string literals" rather than any string literals removes potential confusion.

## Motivation

Reading the Nix 2.28.7 reference manual suggests attribute names are allowed to be string literals, which includes indented string literals and URIs, but this doesn't seem to be the case.

I did my tests with `nix (Nix) 2.31.4`. Creating files as in the snippets below and then running `nix-instantiate --eval <snippet-file>`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Indented strings and URIs are string literals but they are not allowed as names for attrsets, `let` or `inherit`. The following snippets illustrate that they lead to syntax errors.

```
==> examples/ind_str-attr.nix <==
{
  ''indented string'' = "error: syntax error, unexpected IND_STRING_OPEN, expecting INHERIT";
}

==> examples/ind_str-inherit.nix <==
{ inherit ({ "non-indented string" = "error: syntax error, unexpected IND_STRING_OPEN"; })
    ''non-indented string'';
}

==> examples/ind_str-let.nix <==
let
  ''indented string'' = "error: syntax error, unexpected URI, expecting IN_KW or INHERIT";
in
  true

==> examples/uri-attr.nix <==
{
  http://example.org/foo.tar.bz2 = "error: syntax error, unexpected URI, expecting INHERIT";
}

==> examples/uri-inherit.nix <==
{ inherit ({ "http://example.org/foo.tar.bz2" = "error: syntax error, unexpected URI"; })
    http://example.org/foo.tar.bz2;
}

==> examples/uri-let.nix <==
let
  http://example.org/foo.tar.bz2 = "error: syntax error, unexpected URI, expecting IN_KW or INHERIT";
in
  true
```


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
