### PR TITLE
libstore: Use member fileTransfer instead of global getFileTransfer()…

### DIFF
--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -322,7 +322,7 @@ std::string S3BinaryCacheStore::createMultipartUpload(
         std::move(headers->begin(), headers->end(), std::back_inserter(req.headers));
     }
 
-    auto result = getFileTransfer()->enqueueFileTransfer(req).get();
+    auto result = fileTransfer->enqueueFileTransfer(req).get();
 
     std::regex uploadIdRegex("<UploadId>([^<]+)</UploadId>");
     std::smatch match;
@@ -353,7 +353,7 @@ S3BinaryCacheStore::uploadPart(std::string_view key, std::string_view uploadId, 
     req.data = {payload};
     req.mimeType = "application/octet-stream";
 
-    auto result = getFileTransfer()->enqueueFileTransfer(req).get();
+    auto result = fileTransfer->enqueueFileTransfer(req).get();
 
     if (result.etag.empty()) {
         throw Error("S3 UploadPart response missing ETag for part %d", partNumber);
@@ -374,7 +374,7 @@ void S3BinaryCacheStore::abortMultipartUpload(std::string_view key, std::string_
         req.uri = VerbatimURL(url);
         req.method = HttpMethod::Delete;
 
-        getFileTransfer()->enqueueFileTransfer(req).get();
+        fileTransfer->enqueueFileTransfer(req).get();
     } catch (...) {
         ignoreExceptionInDestructor();
     }
@@ -407,7 +407,7 @@ void S3BinaryCacheStore::completeMultipartUpload(
     req.data = {payload};
     req.mimeType = "text/xml";
 
-    getFileTransfer()->enqueueFileTransfer(req).get();
+    fileTransfer->enqueueFileTransfer(req).get();
 
     debug("S3 multipart upload completed: %d parts uploaded for '%s'", partEtags.size(), key);
 }


### PR DESCRIPTION
… in the s3 store

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Ideally we'd get rid of the global file transfer object altogether and this moves us in that direction. fileTransfer was already a member of the HttpBinaryCacheStore, so just use that instead. In practice it pointed to the same singleton object though (it's primarily used for tests now).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
