### PR TITLE
fix `assert ==` tech debt and add better error messages

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1221,6 +1221,11 @@ void Expr::eval(EvalState & state, Env & env, Value & v)
     unreachable();
 }
 
+void Expr::evalAssert(EvalState & state, Env & env, Value & v)
+{
+    eval(state, env, v);
+}
+
 void ExprInt::eval(EvalState & state, Env & env, Value & v)
 {
     v = this->v;
@@ -1865,25 +1870,23 @@ void ExprIf::eval(EvalState & state, Env & env, Value & v)
 
 void ExprAssert::eval(EvalState & state, Env & env, Value & v)
 {
-    if (!state.evalBool(env, cond, pos, "in the condition of the assert statement")) {
+    Value condVal;
+    try {
+        cond->evalAssert(state, env, condVal);
+    } catch (Error & e) {
         std::ostringstream out;
         cond->show(state.symbols, out);
-        auto exprStr = out.view();
-
-        if (auto eq = dynamic_cast<ExprOpEq *>(cond)) {
-            try {
-                Value v1;
-                eq->e1->eval(state, env, v1);
-                Value v2;
-                eq->e2->eval(state, env, v2);
-                state.eqValues<true>(v1, v2, eq->pos, "in an equality assertion");
-            } catch (AssertionError & e) {
-                e.addTrace(state.positions[pos], "while evaluating the condition of the assertion '%s'", exprStr);
-                throw;
-            }
-        }
-
-        state.error<AssertionError>("assertion '%1%' failed", exprStr).atPos(pos).withFrame(env, *this).debugThrow();
+        e.addTrace(state.positions[pos], "while evaluating the condition of the assertion '%s'", out.view());
+        throw;
+    }
+    // Fallback for evalAssert calls that produce a false value without
+    // throwing — e.g. boolean operators (&&, ->) where no sub-expression
+    // triggered an assertion error, or expressions without an evalAssert
+    // override.
+    if (!state.forceBool(condVal, pos, "in the condition of the assert statement")) {
+        std::ostringstream out;
+        cond->show(state.symbols, out);
+        state.error<AssertionError>("assertion '%1%' failed", out.view()).atPos(pos).withFrame(env, *this).debugThrow();
     }
     body->eval(state, env, v);
 }
@@ -1893,13 +1896,25 @@ void ExprOpNot::eval(EvalState & state, Env & env, Value & v)
     v.mkBool(!state.evalBool(env, e, getPos(), "in the argument of the not operator")); // XXX: FIXME: !
 }
 
-void ExprOpEq::eval(EvalState & state, Env & env, Value & v)
+template<bool IsAssert>
+void ExprOpEq::evalImpl(EvalState & state, Env & env, Value & v)
 {
     Value v1;
     e1->eval(state, env, v1);
     Value v2;
     e2->eval(state, env, v2);
-    v.mkBool(state.eqValues(v1, v2, pos, "while testing two values for equality"));
+    v.mkBool(state.eqValues<IsAssert>(
+        v1, v2, pos, IsAssert ? "in an equality assertion" : "while testing two values for equality"));
+}
+
+void ExprOpEq::eval(EvalState & state, Env & env, Value & v)
+{
+    evalImpl<false>(state, env, v);
+}
+
+void ExprOpEq::evalAssert(EvalState & state, Env & env, Value & v)
+{
+    evalImpl<true>(state, env, v);
 }
 
 void ExprOpNEq::eval(EvalState & state, Env & env, Value & v)

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1876,7 +1876,7 @@ void ExprAssert::eval(EvalState & state, Env & env, Value & v)
                 eq->e1->eval(state, env, v1);
                 Value v2;
                 eq->e2->eval(state, env, v2);
-                state.assertEqValues(v1, v2, eq->pos, "in an equality assertion");
+                state.eqValues<true>(v1, v2, eq->pos, "in an equality assertion");
             } catch (AssertionError & e) {
                 e.addTrace(state.positions[pos], "while evaluating the condition of the assertion '%s'", exprStr);
                 throw;
@@ -2702,220 +2702,12 @@ SingleDerivedPath EvalState::coerceToSingleDerivedPath(const PosIdx pos, Value &
     return derivedPath;
 }
 
-// NOTE: This implementation must match eqValues!
-// We accept this burden because informative error messages for
-// `assert a == b; x` are critical for our users' testing UX.
-void EvalState::assertEqValues(Value & v1, Value & v2, const PosIdx pos, std::string_view errorCtx)
-{
-    auto _level = addCallDepth(pos);
-
-    // This implementation must match eqValues.
-    forceValue(v1, pos);
-    forceValue(v2, pos);
-
-    if (&v1 == &v2)
-        return;
-
-    // Special case type-compatibility between float and int
-    if ((v1.type() == nInt || v1.type() == nFloat) && (v2.type() == nInt || v2.type() == nFloat)) {
-        if (eqValues(v1, v2, pos, errorCtx)) {
-            return;
-        } else {
-            error<AssertionError>(
-                "%s with value '%s' is not equal to %s with value '%s'",
-                showType(v1),
-                ValuePrinter(*this, v1, errorPrintOptions),
-                showType(v2),
-                ValuePrinter(*this, v2, errorPrintOptions))
-                .debugThrow();
-        }
-    }
-
-    if (v1.type() != v2.type()) {
-        error<AssertionError>(
-            "%s of value '%s' is not equal to %s of value '%s'",
-            showType(v1),
-            ValuePrinter(*this, v1, errorPrintOptions),
-            showType(v2),
-            ValuePrinter(*this, v2, errorPrintOptions))
-            .debugThrow();
-    }
-
-    switch (v1.type()) {
-    case nInt:
-        if (v1.integer() != v2.integer()) {
-            error<AssertionError>("integer '%d' is not equal to integer '%d'", v1.integer(), v2.integer()).debugThrow();
-        }
-        return;
-
-    case nBool:
-        if (v1.boolean() != v2.boolean()) {
-            error<AssertionError>(
-                "boolean '%s' is not equal to boolean '%s'",
-                ValuePrinter(*this, v1, errorPrintOptions),
-                ValuePrinter(*this, v2, errorPrintOptions))
-                .debugThrow();
-        }
-        return;
-
-    case nString:
-        if (v1.string_view() != v2.string_view()) {
-            error<AssertionError>(
-                "string '%s' is not equal to string '%s'",
-                ValuePrinter(*this, v1, errorPrintOptions),
-                ValuePrinter(*this, v2, errorPrintOptions))
-                .debugThrow();
-        }
-        return;
-
-    case nPath:
-        if (v1.pathAccessor() != v2.pathAccessor()) {
-            error<AssertionError>(
-                "path '%s' is not equal to path '%s' because their accessors are different",
-                ValuePrinter(*this, v1, errorPrintOptions),
-                ValuePrinter(*this, v2, errorPrintOptions))
-                .debugThrow();
-        }
-        if (v1.pathStrView() != v2.pathStrView()) {
-            error<AssertionError>(
-                "path '%s' is not equal to path '%s'",
-                ValuePrinter(*this, v1, errorPrintOptions),
-                ValuePrinter(*this, v2, errorPrintOptions))
-                .debugThrow();
-        }
-        return;
-
-    case nNull:
-        return;
-
-    case nList:
-        if (v1.listSize() != v2.listSize()) {
-            error<AssertionError>(
-                "list of size '%d' is not equal to list of size '%d', left hand side is '%s', right hand side is '%s'",
-                v1.listSize(),
-                v2.listSize(),
-                ValuePrinter(*this, v1, errorPrintOptions),
-                ValuePrinter(*this, v2, errorPrintOptions))
-                .debugThrow();
-        }
-        for (size_t n = 0; n < v1.listSize(); ++n) {
-            try {
-                assertEqValues(*v1.listView()[n], *v2.listView()[n], pos, errorCtx);
-            } catch (Error & e) {
-                e.addTrace(positions[pos], "while comparing list element %d", n);
-                throw;
-            }
-        }
-        return;
-
-    case nAttrs: {
-        if (isDerivation(v1) && isDerivation(v2)) {
-            auto i = v1.attrs()->get(s.outPath);
-            auto j = v2.attrs()->get(s.outPath);
-            if (i && j) {
-                try {
-                    assertEqValues(*i->value, *j->value, pos, errorCtx);
-                    return;
-                } catch (Error & e) {
-                    e.addTrace(positions[pos], "while comparing a derivation by its '%s' attribute", "outPath");
-                    throw;
-                }
-                assert(false);
-            }
-        }
-
-        if (v1.attrs()->size() != v2.attrs()->size()) {
-            error<AssertionError>(
-                "attribute names of attribute set '%s' differs from attribute set '%s'",
-                ValuePrinter(*this, v1, errorPrintOptions),
-                ValuePrinter(*this, v2, errorPrintOptions))
-                .debugThrow();
-        }
-
-        // Like normal comparison, we compare the attributes in non-deterministic Symbol index order.
-        // This function is called when eqValues has found a difference, so to reliably
-        // report about its result, we should follow in its literal footsteps and not
-        // try anything fancy that could lead to an error.
-        Bindings::const_iterator i, j;
-        for (i = v1.attrs()->begin(), j = v2.attrs()->begin(); i != v1.attrs()->end(); ++i, ++j) {
-            if (i->name != j->name) {
-                // A difference in a sorted list means that one attribute is not contained in the other, but we don't
-                // know which. Let's find out. Could use <, but this is more clear.
-                if (!v2.attrs()->get(i->name)) {
-                    error<AssertionError>(
-                        "attribute name '%s' is contained in '%s', but not in '%s'",
-                        symbols[i->name],
-                        ValuePrinter(*this, v1, errorPrintOptions),
-                        ValuePrinter(*this, v2, errorPrintOptions))
-                        .debugThrow();
-                }
-                if (!v1.attrs()->get(j->name)) {
-                    error<AssertionError>(
-                        "attribute name '%s' is missing in '%s', but is contained in '%s'",
-                        symbols[j->name],
-                        ValuePrinter(*this, v1, errorPrintOptions),
-                        ValuePrinter(*this, v2, errorPrintOptions))
-                        .debugThrow();
-                }
-                assert(false);
-            }
-            try {
-                assertEqValues(*i->value, *j->value, pos, errorCtx);
-            } catch (Error & e) {
-                // The order of traces is reversed, so this presents as
-                //  where left hand side is
-                //    at <pos>
-                //  where right hand side is
-                //    at <pos>
-                //  while comparing attribute '<name>'
-                if (j->pos != noPos)
-                    e.addTrace(positions[j->pos], "where right hand side is");
-                if (i->pos != noPos)
-                    e.addTrace(positions[i->pos], "where left hand side is");
-                e.addTrace(positions[pos], "while comparing attribute '%s'", symbols[i->name]);
-                throw;
-            }
-        }
-        return;
-    }
-
-    case nFunction:
-        error<AssertionError>("distinct functions and immediate comparisons of identical functions compare as unequal")
-            .debugThrow();
-
-    case nExternal:
-        if (!(*v1.external() == *v2.external())) {
-            error<AssertionError>(
-                "external value '%s' is not equal to external value '%s'",
-                ValuePrinter(*this, v1, errorPrintOptions),
-                ValuePrinter(*this, v2, errorPrintOptions))
-                .debugThrow();
-        }
-        return;
-
-    case nFloat:
-        // !!!
-        if (!(v1.fpoint() == v2.fpoint())) {
-            error<AssertionError>("float '%f' is not equal to float '%f'", v1.fpoint(), v2.fpoint()).debugThrow();
-        }
-        return;
-
-    // Cannot be returned by forceValue().
-    case nThunk:
-    case nFailed:
-        unreachable();
-
-    default: // Note that we pass compiler flags that should make `default:` unreachable.
-        // Also note that this probably ran after `eqValues`, which implements
-        // the same logic more efficiently (without having to unwind stacks),
-        // so maybe `assertEqValues` and `eqValues` are out of sync. Check it for solutions.
-        error<EvalError>("assertEqValues: cannot compare %1% with %2%", showType(v1), showType(v2))
-            .withTrace(pos, errorCtx)
-            .panic();
-    }
-}
-
-// This implementation must match assertEqValues
+// Two equivalence implementations, one for simple `==` and one for
+// `assert e1 == e2`.
+//
+// NOTE: eqValues must return equivalently regardless of IsAssert
+//       (where throwing `AssertionError` is like returning `false`)
+template<bool IsAssert>
 bool EvalState::eqValues(Value & v1, Value & v2, const PosIdx pos, std::string_view errorCtx)
 {
     auto _level = addCallDepth(pos);
@@ -2929,40 +2721,118 @@ bool EvalState::eqValues(Value & v1, Value & v2, const PosIdx pos, std::string_v
     if (&v1 == &v2)
         return true;
 
-    // Special case type-compatibility between float and int
-    if (v1.type() == nInt && v2.type() == nFloat)
-        return v1.integer().value == v2.fpoint();
-    if (v1.type() == nFloat && v2.type() == nInt)
-        return v1.fpoint() == v2.integer().value;
+    // Special case type-compatibility between float and int.
+    // The difference in conditionals *inside* is intentional.
+    if constexpr (IsAssert) {
+        // Broad condition to augment all cases
+        if ((v1.type() == nInt || v1.type() == nFloat) && (v2.type() == nInt || v2.type() == nFloat)) {
+            if (eqValues<false>(v1, v2, pos, errorCtx))
+                return true;
+            error<AssertionError>(
+                "%s with value '%s' is not equal to %s with value '%s'",
+                showType(v1),
+                ValuePrinter(*this, v1, errorPrintOptions),
+                showType(v2),
+                ValuePrinter(*this, v2, errorPrintOptions))
+                .debugThrow();
+        }
+    } else {
+        // Narrower condition to take care of heterogenous `==`.
+        // Homogenous `==` is handled in the switch below.
+        if (v1.type() == nInt && v2.type() == nFloat)
+            return v1.integer().value == v2.fpoint();
+        if (v1.type() == nFloat && v2.type() == nInt)
+            return v1.fpoint() == v2.integer().value;
+    }
 
     // All other types are not compatible with each other.
-    if (v1.type() != v2.type())
+    if (v1.type() != v2.type()) {
+        if constexpr (IsAssert)
+            error<AssertionError>(
+                "%s of value '%s' is not equal to %s of value '%s'",
+                showType(v1),
+                ValuePrinter(*this, v1, errorPrintOptions),
+                showType(v2),
+                ValuePrinter(*this, v2, errorPrintOptions))
+                .debugThrow();
         return false;
+    }
 
     switch (v1.type()) {
     case nInt:
-        return v1.integer() == v2.integer();
+        if (v1.integer() == v2.integer())
+            return true;
+        if constexpr (IsAssert)
+            error<AssertionError>("integer '%d' is not equal to integer '%d'", v1.integer(), v2.integer()).debugThrow();
+        return false;
 
     case nBool:
-        return v1.boolean() == v2.boolean();
+        if (v1.boolean() == v2.boolean())
+            return true;
+        if constexpr (IsAssert)
+            error<AssertionError>(
+                "boolean '%s' is not equal to boolean '%s'",
+                ValuePrinter(*this, v1, errorPrintOptions),
+                ValuePrinter(*this, v2, errorPrintOptions))
+                .debugThrow();
+        return false;
 
     case nString:
-        return v1.string_view() == v2.string_view();
+        if (v1.string_view() == v2.string_view())
+            return true;
+        if constexpr (IsAssert)
+            error<AssertionError>(
+                "string '%s' is not equal to string '%s'",
+                ValuePrinter(*this, v1, errorPrintOptions),
+                ValuePrinter(*this, v2, errorPrintOptions))
+                .debugThrow();
+        return false;
 
     case nPath:
-        return
-            // FIXME: compare accessors by their fingerprint.
-            v1.pathAccessor() == v2.pathAccessor() && v1.pathStrView() == v2.pathStrView();
+        // FIXME: compare accessors by their fingerprint.
+        if (v1.pathAccessor() != v2.pathAccessor()) {
+            if constexpr (IsAssert)
+                error<AssertionError>(
+                    "path '%s' is not equal to path '%s' because their accessors are different",
+                    ValuePrinter(*this, v1, errorPrintOptions),
+                    ValuePrinter(*this, v2, errorPrintOptions))
+                    .debugThrow();
+            return false;
+        }
+        if (v1.pathStrView() == v2.pathStrView())
+            return true;
+        if constexpr (IsAssert)
+            error<AssertionError>(
+                "path '%s' is not equal to path '%s'",
+                ValuePrinter(*this, v1, errorPrintOptions),
+                ValuePrinter(*this, v2, errorPrintOptions))
+                .debugThrow();
+        return false;
 
     case nNull:
         return true;
 
     case nList:
-        if (v1.listSize() != v2.listSize())
+        if (v1.listSize() != v2.listSize()) {
+            if constexpr (IsAssert)
+                error<AssertionError>(
+                    "list of size '%d' is not equal to list of size '%d', left hand side is '%s', right hand side is '%s'",
+                    v1.listSize(),
+                    v2.listSize(),
+                    ValuePrinter(*this, v1, errorPrintOptions),
+                    ValuePrinter(*this, v2, errorPrintOptions))
+                    .debugThrow();
             return false;
-        for (size_t n = 0; n < v1.listSize(); ++n)
-            if (!eqValues(*v1.listView()[n], *v2.listView()[n], pos, errorCtx))
-                return false;
+        }
+        for (size_t n = 0; n < v1.listSize(); ++n) {
+            try {
+                if (!eqValues<IsAssert>(*v1.listView()[n], *v2.listView()[n], pos, errorCtx))
+                    return false;
+            } catch (Error & e) {
+                e.addTrace(positions[pos], "while comparing list element %d", n);
+                throw;
+            }
+        }
         return true;
 
     case nAttrs: {
@@ -2971,32 +2841,102 @@ bool EvalState::eqValues(Value & v1, Value & v2, const PosIdx pos, std::string_v
         if (isDerivation(v1) && isDerivation(v2)) {
             auto i = v1.attrs()->get(s.outPath);
             auto j = v2.attrs()->get(s.outPath);
-            if (i && j)
-                return eqValues(*i->value, *j->value, pos, errorCtx);
+            if (i && j) {
+                try {
+                    return eqValues<IsAssert>(*i->value, *j->value, pos, errorCtx);
+                } catch (Error & e) {
+                    e.addTrace(positions[pos], "while comparing a derivation by its '%s' attribute", "outPath");
+                    throw;
+                }
+            }
         }
 
-        if (v1.attrs()->size() != v2.attrs()->size())
+        if (v1.attrs()->size() != v2.attrs()->size()) {
+            if constexpr (IsAssert)
+                error<AssertionError>(
+                    "attribute names of attribute set '%s' differs from attribute set '%s'",
+                    ValuePrinter(*this, v1, errorPrintOptions),
+                    ValuePrinter(*this, v2, errorPrintOptions))
+                    .debugThrow();
             return false;
+        }
 
         /* Otherwise, compare the attributes one by one. */
         Bindings::const_iterator i, j;
-        for (i = v1.attrs()->begin(), j = v2.attrs()->begin(); i != v1.attrs()->end(); ++i, ++j)
-            if (i->name != j->name || !eqValues(*i->value, *j->value, pos, errorCtx))
-                return false;
-
+        for (i = v1.attrs()->begin(), j = v2.attrs()->begin(); i != v1.attrs()->end(); ++i, ++j) {
+            if constexpr (IsAssert) {
+                if (i->name != j->name) {
+                    // A difference in a sorted list means that one attribute is not contained in the other, but we
+                    // don't know which. Let's find out. Could use <, but this is more clear.
+                    if (!v2.attrs()->get(i->name)) {
+                        error<AssertionError>(
+                            "attribute name '%s' is contained in '%s', but not in '%s'",
+                            symbols[i->name],
+                            ValuePrinter(*this, v1, errorPrintOptions),
+                            ValuePrinter(*this, v2, errorPrintOptions))
+                            .debugThrow();
+                    }
+                    if (!v1.attrs()->get(j->name)) {
+                        error<AssertionError>(
+                            "attribute name '%s' is missing in '%s', but is contained in '%s'",
+                            symbols[j->name],
+                            ValuePrinter(*this, v1, errorPrintOptions),
+                            ValuePrinter(*this, v2, errorPrintOptions))
+                            .debugThrow();
+                    }
+                    assert(false);
+                }
+                try {
+                    if (!eqValues<IsAssert>(*i->value, *j->value, pos, errorCtx))
+                        return false;
+                } catch (Error & e) {
+                    // The order of traces is reversed, so this presents as
+                    //  where left hand side is
+                    //    at <pos>
+                    //  where right hand side is
+                    //    at <pos>
+                    //  while comparing attribute '<name>'
+                    if (j->pos != noPos)
+                        e.addTrace(positions[j->pos], "where right hand side is");
+                    if (i->pos != noPos)
+                        e.addTrace(positions[i->pos], "where left hand side is");
+                    e.addTrace(positions[pos], "while comparing attribute '%s'", symbols[i->name]);
+                    throw;
+                }
+            } else {
+                if (i->name != j->name || !eqValues<IsAssert>(*i->value, *j->value, pos, errorCtx))
+                    return false;
+            }
+        }
         return true;
     }
 
     /* Functions are incomparable. */
     case nFunction:
+        if constexpr (IsAssert)
+            error<AssertionError>(
+                "distinct functions and immediate comparisons of identical functions compare as unequal")
+                .debugThrow();
         return false;
 
     case nExternal:
-        return *v1.external() == *v2.external();
+        if (*v1.external() == *v2.external())
+            return true;
+        if constexpr (IsAssert)
+            error<AssertionError>(
+                "external value '%s' is not equal to external value '%s'",
+                ValuePrinter(*this, v1, errorPrintOptions),
+                ValuePrinter(*this, v2, errorPrintOptions))
+                .debugThrow();
+        return false;
 
     case nFloat:
         // !!!
-        return v1.fpoint() == v2.fpoint();
+        if (v1.fpoint() == v2.fpoint())
+            return true;
+        if constexpr (IsAssert)
+            error<AssertionError>("float '%f' is not equal to float '%f'", v1.fpoint(), v2.fpoint()).debugThrow();
+        return false;
 
     // Cannot be returned by forceValue().
     case nThunk:
@@ -3009,6 +2949,9 @@ bool EvalState::eqValues(Value & v1, Value & v2, const PosIdx pos, std::string_v
             .panic();
     }
 }
+
+template bool EvalState::eqValues<false>(Value &, Value &, const PosIdx, std::string_view);
+template bool EvalState::eqValues<true>(Value &, Value &, const PosIdx, std::string_view);
 
 bool EvalState::fullGC()
 {

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1355,7 +1355,8 @@ void ExprAttrs::eval(EvalState & state, Env & env, Value & v)
     v.mkAttrs(sort ? bindings.finish() : bindings.alreadySorted());
 }
 
-void ExprLet::eval(EvalState & state, Env & env, Value & v)
+template<bool IsAssert>
+void ExprLet::evalImpl(EvalState & state, Env & env, Value & v)
 {
     /* Create a new environment that contains the attributes in this
        `let'. */
@@ -1376,7 +1377,21 @@ void ExprLet::eval(EvalState & state, Env & env, Value & v)
                    ? makeDebugTraceStacker(state, *this, env2, getPos(), "while evaluating a '%1%' expression", "let")
                    : nullptr;
 
-    body->eval(state, env2, v);
+    if constexpr (IsAssert) {
+        body->evalAssert(state, env2, v);
+    } else {
+        body->eval(state, env2, v);
+    }
+}
+
+void ExprLet::eval(EvalState & state, Env & env, Value & v)
+{
+    evalImpl<false>(state, env, v);
+}
+
+void ExprLet::evalAssert(EvalState & state, Env & env, Value & v)
+{
+    evalImpl<true>(state, env, v);
 }
 
 void ExprList::eval(EvalState & state, Env & env, Value & v)

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1948,6 +1948,24 @@ void ExprOpAnd::eval(EvalState & state, Env & env, Value & v)
         && state.evalBool(env, e2, pos, "in the right operand of the AND (&&) operator"));
 }
 
+void ExprOpAnd::evalAssert(EvalState & state, Env & env, Value & v)
+{
+    try {
+        e1->evalAssert(state, env, v);
+    } catch (Error & e) {
+        e.addTrace(state.positions[pos], "while evaluating the left operand of the && operator");
+        throw;
+    }
+    if (state.forceBool(v, pos, "in the left operand of the AND (&&) operator")) {
+        try {
+            e2->evalAssert(state, env, v);
+        } catch (Error & e) {
+            e.addTrace(state.positions[pos], "while evaluating the right operand of the && operator");
+            throw;
+        }
+    }
+}
+
 void ExprOpOr::eval(EvalState & state, Env & env, Value & v)
 {
     v.mkBool(
@@ -1960,6 +1978,21 @@ void ExprOpImpl::eval(EvalState & state, Env & env, Value & v)
     v.mkBool(
         !state.evalBool(env, e1, pos, "in the left operand of the IMPL (->) operator")
         || state.evalBool(env, e2, pos, "in the right operand of the IMPL (->) operator"));
+}
+
+void ExprOpImpl::evalAssert(EvalState & state, Env & env, Value & v)
+{
+    e1->eval(state, env, v);
+    if (state.forceBool(v, pos, "in the left operand of the IMPL (->) operator")) {
+        try {
+            e2->evalAssert(state, env, v);
+        } catch (Error & e) {
+            e.addTrace(state.positions[pos], "while evaluating the right operand of the -> operator");
+            throw;
+        }
+    } else {
+        v.mkBool(true);
+    }
 }
 
 void ExprOpUpdate::eval(EvalState & state, Value & v, Value & v1, Value & v2)

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -940,17 +940,12 @@ public:
     /**
      * Do a deep equality test between two values.  That is, list
      * elements and attributes are compared recursively.
-     */
-    bool eqValues(Value & v1, Value & v2, const PosIdx pos, std::string_view errorCtx);
-
-    /**
-     * Like `eqValues`, but throws an `AssertionError` if not equal.
      *
-     * WARNING:
-     * Callers should call `eqValues` first and report if `assertEqValues` behaves
-     * incorrectly. (e.g. if it doesn't throw if eqValues returns false or vice versa)
+     * When IsAssert is true, may throw an AssertionError on mismatch
+     * instead of returning false.  This improves assert error messages.
      */
-    void assertEqValues(Value & v1, Value & v2, const PosIdx pos, std::string_view errorCtx);
+    template<bool IsAssert = false>
+    bool eqValues(Value & v1, Value & v2, const PosIdx pos, std::string_view errorCtx);
 
     bool isFunctor(const Value & fun) const;
 

--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -643,7 +643,11 @@ struct ExprLet : Expr
     ExprLet(ExprAttrs * attrs, Expr * body)
         : attrs(attrs)
         , body(body) {};
+    void evalAssert(EvalState & state, Env & env, Value & v) override;
     COMMON_METHODS
+private:
+    template<bool IsAssert>
+    void evalImpl(EvalState & state, Env & env, Value & v);
 };
 
 struct ExprWith : Expr

--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -118,6 +118,14 @@ struct Expr
     virtual void eval(EvalState & state, Env & env, Value & v);
 
     /**
+     * Like eval, but may throw a detailed assertion error instead of
+     * producing a false value.  The default delegates to eval.
+     * Subclasses are encouraged to override this to improve assert
+     * error messages.
+     */
+    virtual void evalAssert(EvalState & state, Env & env, Value & v);
+
+    /**
      * Create a thunk for the delayed computation of the given expression
      * in the given environment. But if the expression is a variable,
      * then look it up right away. This significantly reduces the number
@@ -741,7 +749,14 @@ struct ExprOpNot : Expr
         MakeBinOpMembers(name, s) \
     }
 
-MakeBinOp(ExprOpEq, "==");
+struct ExprOpEq : Expr
+{
+    MakeBinOpMembers(ExprOpEq, "==") void evalAssert(EvalState & state, Env & env, Value & v) override;
+private:
+    template<bool IsAssert>
+    void evalImpl(EvalState & state, Env & env, Value & v);
+};
+
 MakeBinOp(ExprOpNEq, "!=");
 MakeBinOp(ExprOpAnd, "&&");
 MakeBinOp(ExprOpOr, "||");

--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -762,9 +762,19 @@ private:
 };
 
 MakeBinOp(ExprOpNEq, "!=");
-MakeBinOp(ExprOpAnd, "&&");
+
+struct ExprOpAnd : Expr
+{
+    MakeBinOpMembers(ExprOpAnd, "&&") void evalAssert(EvalState & state, Env & env, Value & v) override;
+};
+
 MakeBinOp(ExprOpOr, "||");
-MakeBinOp(ExprOpImpl, "->");
+
+struct ExprOpImpl : Expr
+{
+    MakeBinOpMembers(ExprOpImpl, "->") void evalAssert(EvalState & state, Env & env, Value & v) override;
+};
+
 MakeBinOp(ExprOpConcatLists, "++");
 
 struct ExprOpUpdate : Expr

--- a/tests/functional/lang/eval-fail-assert-and-equal-lhs.err.exp
+++ b/tests/functional/lang/eval-fail-assert-and-equal-lhs.err.exp
@@ -1,0 +1,14 @@
+error:
+       … while evaluating the condition of the assertion '((1 == 2) && (3 == 3))'
+         at /pwd/lang/eval-fail-assert-and-equal-lhs.nix:1:1:
+            1| assert 1 == 2 && 3 == 3;
+             | ^
+            2| abort "unreachable"
+
+       … while evaluating the left operand of the && operator
+         at /pwd/lang/eval-fail-assert-and-equal-lhs.nix:1:15:
+            1| assert 1 == 2 && 3 == 3;
+             |               ^
+            2| abort "unreachable"
+
+       error: an integer with value '1' is not equal to an integer with value '2'

--- a/tests/functional/lang/eval-fail-assert-and-equal-lhs.nix
+++ b/tests/functional/lang/eval-fail-assert-and-equal-lhs.nix
@@ -1,0 +1,2 @@
+assert 1 == 2 && 3 == 3;
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert-and-equal.err.exp
+++ b/tests/functional/lang/eval-fail-assert-and-equal.err.exp
@@ -1,0 +1,14 @@
+error:
+       … while evaluating the condition of the assertion '((1 == 1) && (2 == 3))'
+         at /pwd/lang/eval-fail-assert-and-equal.nix:1:1:
+            1| assert 1 == 1 && 2 == 3;
+             | ^
+            2| abort "unreachable"
+
+       … while evaluating the right operand of the && operator
+         at /pwd/lang/eval-fail-assert-and-equal.nix:1:15:
+            1| assert 1 == 1 && 2 == 3;
+             |               ^
+            2| abort "unreachable"
+
+       error: an integer with value '2' is not equal to an integer with value '3'

--- a/tests/functional/lang/eval-fail-assert-and-equal.nix
+++ b/tests/functional/lang/eval-fail-assert-and-equal.nix
@@ -1,0 +1,2 @@
+assert 1 == 1 && 2 == 3;
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert-impl-equal.err.exp
+++ b/tests/functional/lang/eval-fail-assert-impl-equal.err.exp
@@ -1,0 +1,14 @@
+error:
+       … while evaluating the condition of the assertion '(true -> (2 == 3))'
+         at /pwd/lang/eval-fail-assert-impl-equal.nix:1:1:
+            1| assert true -> 2 == 3;
+             | ^
+            2| abort "unreachable"
+
+       … while evaluating the right operand of the -> operator
+         at /pwd/lang/eval-fail-assert-impl-equal.nix:1:13:
+            1| assert true -> 2 == 3;
+             |             ^
+            2| abort "unreachable"
+
+       error: an integer with value '2' is not equal to an integer with value '3'

--- a/tests/functional/lang/eval-fail-assert-impl-equal.nix
+++ b/tests/functional/lang/eval-fail-assert-impl-equal.nix
@@ -1,0 +1,2 @@
+assert true -> 2 == 3;
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert-let-equal-attrs.err.exp
+++ b/tests/functional/lang/eval-fail-assert-let-equal-attrs.err.exp
@@ -1,0 +1,24 @@
+error:
+       … while evaluating the condition of the assertion '(let x = { b = 1; }; y = { b = 2; }; in (x == y))'
+         at /pwd/lang/eval-fail-assert-let-equal-attrs.nix:1:1:
+            1| assert
+             | ^
+            2|   let
+
+       … while comparing attribute 'b'
+
+       … where left hand side is
+         at /pwd/lang/eval-fail-assert-let-equal-attrs.nix:4:7:
+            3|     x = {
+            4|       b = 1;
+             |       ^
+            5|     };
+
+       … where right hand side is
+         at /pwd/lang/eval-fail-assert-let-equal-attrs.nix:7:7:
+            6|     y = {
+            7|       b = 2;
+             |       ^
+            8|     };
+
+       error: an integer with value '1' is not equal to an integer with value '2'

--- a/tests/functional/lang/eval-fail-assert-let-equal-attrs.nix
+++ b/tests/functional/lang/eval-fail-assert-let-equal-attrs.nix
@@ -1,0 +1,11 @@
+assert
+  let
+    x = {
+      b = 1;
+    };
+    y = {
+      b = 2;
+    };
+  in
+  x == y;
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert-let-equal-ints.err.exp
+++ b/tests/functional/lang/eval-fail-assert-let-equal-ints.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while evaluating the condition of the assertion '(let x = 1; y = 2; in (x == y))'
+         at /pwd/lang/eval-fail-assert-let-equal-ints.nix:1:1:
+            1| assert
+             | ^
+            2|   let
+
+       error: an integer with value '1' is not equal to an integer with value '2'

--- a/tests/functional/lang/eval-fail-assert-let-equal-ints.nix
+++ b/tests/functional/lang/eval-fail-assert-let-equal-ints.nix
@@ -1,0 +1,7 @@
+assert
+  let
+    x = 1;
+    y = 2;
+  in
+  x == y;
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert-let-equal-type.err.exp
+++ b/tests/functional/lang/eval-fail-assert-let-equal-type.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while evaluating the condition of the assertion '(let a = false; b = null; in (a == b))'
+         at /pwd/lang/eval-fail-assert-let-equal-type.nix:1:1:
+            1| assert
+             | ^
+            2|   let
+
+       error: a Boolean of value 'false' is not equal to null of value 'null'

--- a/tests/functional/lang/eval-fail-assert-let-equal-type.nix
+++ b/tests/functional/lang/eval-fail-assert-let-equal-type.nix
@@ -1,0 +1,7 @@
+assert
+  let
+    a = false;
+    b = null;
+  in
+  a == b;
+abort "unreachable"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

- Solve the tech debt I introduced in https://github.com/NixOS/nix/pull/11043
- Improve error messages by reporting differences for all expressions `e<n>` in
```nix
assert let ... in e1;
assert e2 && e3;
assert ... -> e4;
...
```

as well as arbitrary nestings of those constructs.

## Context

- Solve the tech debt I introduced in https://github.com/NixOS/nix/pull/11043
- Closes #15790

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
