### PR TITLE
Run fetchers-substitute test with nix-serve-ng

### DIFF
--- a/tests/nixos/fetchers-substitute.nix
+++ b/tests/nixos/fetchers-substitute.nix
@@ -13,9 +13,9 @@
 
       networking.firewall.allowedTCPPorts = [ 5000 ];
 
-      # TODO stop using this, because it has to depend on an older version of Nix that still has the perl bindings.
       services.nix-serve = {
         enable = true;
+        package = pkgs.nix-serve-ng;
         secretKeyFile =
           let
             key = pkgs.writeTextFile {


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
The `fetchersSubstitute` test was evaulated when running `nix flake check` and has been failing since perl bindings were removed in 3b92b850bcd69d5f1afc76571ffaddc3317b3a8e.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

nix-serve-ng is a drop-in replacement for nix-serve that does not require perl. The change is transparent to nix, the actual program being tested.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
