### PR TITLE
manual: update nix-shell documentation to exclude ruby

### DIFF
--- a/doc/manual/source/command-ref/nix-shell.md
+++ b/doc/manual/source/command-ref/nix-shell.md
@@ -327,4 +327,4 @@ runCommand "dummy" { buildInputs = [ python3 python3Packages.prettytable ]; } ""
 The script's file name is passed as the first argument to the interpreter specified by the `-i` flag.
 
 Aside from the very first line, which is a directive to the operating system, the additional `#! nix-shell` lines do not need to be at the beginning of the file.
-This allows wrapping them in block comments for languages where `#` does not start a comment, such as ECMAScript, Erlang, PHP, or Ruby.
+This allows wrapping them in block comments for languages where `#` does not start a comment, such as ECMAScript, Erlang, or PHP.


### PR DESCRIPTION
a `#` starts a comment in ruby:

https://docs.ruby-lang.org/en/master/syntax/comments_rdoc.html

I suspect this was originally written referring to its block comment style but its inclusion in the list as one where `#` "does not start a comment" is misleading.

## Motivation

I was reading the `nix-shell` man page and got confused why Ruby was included in the list of languages where `#` does not start a comment. This made me second guess that I actually understood the `nix-shell` behavior described.

## Context

I checked the issue tracker and didn't see reference of this. Thank you for nix!

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
