### PR TITLE
libfetchers: support URL authority in git forge refs

### DIFF
--- a/doc/manual/rl-next/flake-ref-url-authority.md
+++ b/doc/manual/rl-next/flake-ref-url-authority.md
@@ -1,0 +1,23 @@
+---
+synopsis: Support URL authority in git forge flake refs
+issues: [6304, 7970, 11135, 14064]
+prs: [11467]
+---
+
+Git forge inputs now accept the URL authority form proposed in #6304, so
+non-default hosts can be written directly in the input URL. For example,
+`gitlab://gitlab.example.org/org/group/repo` fetches a GitLab project
+from `gitlab.example.org`, and `gitea://git.example.org/owner/repo`
+uses the Gitea-compatible archive fetcher against `git.example.org`.
+
+Built-in Git forge input schemes are provided for `github`, `gitlab`,
+`sourcehut`, `codeberg`, `gitea`, `forgejo`, `cgit`, and `bitbucket`. Branch
+and tag names can be written with `?ref=...`, while commit hashes can be written
+with `?rev=...`. The older path-ref form remains for backwards compatibility
+when the URL has no authority and no `ref`/`rev` query parameter is present.
+The `codeberg` scheme always targets `codeberg.org`; use `gitea://` or
+`forgejo://` for custom Gitea-compatible hosts.
+
+GitLab namespaces and cgit repository paths may span multiple path segments
+in query/authority form, so nested GitLab groups no longer need `%2F` in the
+owner path.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -459,7 +459,14 @@ void EvalState::checkURI(const std::string & uri0)
 
     try {
         ParsedURL uri = parseURL(uri0);
-        if (uri.scheme == "file") {
+        if (parseUrlScheme(uri.scheme).transport == "file") {
+            auto fileUri = ParsedURL{
+                .scheme = "file",
+                .authority = ParsedURL::Authority{},
+                .path = uri.path,
+            };
+            if (isAllowedURI(fileUri.to_string(), settings.allowedUris.get()))
+                return;
             if (auto rootFS2 = rootFS.dynamic_pointer_cast<AllowListSourceAccessor>())
                 rootFS2->checkAccess(CanonPath(urlPathToPath(uri.path).string()));
             return;

--- a/src/libfetchers-tests/input.cc
+++ b/src/libfetchers-tests/input.cc
@@ -64,14 +64,271 @@ INSTANTIATE_TEST_SUITE_P(
 
 namespace fetchers {
 
-class GitHubInputTest : public ::testing::Test
+class GitForgeInputTest : public ::testing::Test
 {};
 
-TEST_F(GitHubInputTest, throwOnInvalidURLParam)
+TEST_F(GitForgeInputTest, throwOnInvalidURLParam)
 {
     EXPECT_THAT(
         []() { Input::fromURL(fetchers::Settings{}, "github:a/b?tag=foo"); },
         ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("tag")));
+}
+
+TEST_F(GitForgeInputTest, builtInCodebergInputRoundTrips)
+{
+    auto input = Input::fromURL(fetchers::Settings{}, "codeberg:NixOS/nix?ref=main");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "codeberg");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "NixOS");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "nix");
+    EXPECT_EQ(input.toURLString(), "codeberg:NixOS/nix?ref=main");
+}
+
+TEST_F(GitForgeInputTest, builtInBitbucketInputRoundTrips)
+{
+    auto input = Input::fromURL(fetchers::Settings{}, "bitbucket:workspace/repo?ref=main");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "bitbucket");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "workspace");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "repo");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "ref"), "main");
+    EXPECT_EQ(input.toURLString(), "bitbucket:workspace/repo?ref=main");
+}
+
+TEST_F(GitForgeInputTest, codebergAuthorityInputFromURLIsUnsupported)
+{
+    EXPECT_THAT(
+        []() { Input::fromURL(fetchers::Settings{}, "codeberg://git.example.org/owner/repo?ref=main"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("authority is not supported")));
+}
+
+TEST_F(GitForgeInputTest, codebergHostAttrIsUnsupported)
+{
+    EXPECT_THAT(
+        []() {
+            Input::fromAttrs(
+                fetchers::Settings{},
+                {
+                    {"type", Attr("codeberg")},
+                    {"host", Attr("git.example.org")},
+                    {"owner", Attr("owner")},
+                    {"repo", Attr("repo")},
+                    {"ref", Attr("main")},
+                });
+        },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("does not support custom hosts")));
+}
+
+TEST_F(GitForgeInputTest, forgejoAuthorityInputFromURL)
+{
+    auto input = Input::fromURL(fetchers::Settings{}, "forgejo://git.example.org/owner/repo?ref=main");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "forgejo");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "host"), "git.example.org");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "owner");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "repo");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "ref"), "main");
+    EXPECT_EQ(input.toURLString(), "forgejo://git.example.org/owner/repo?ref=main");
+}
+
+TEST_F(GitForgeInputTest, forgejoAuthorityInputFromAttrs)
+{
+    auto input = Input::fromAttrs(
+        fetchers::Settings{},
+        {
+            {"type", Attr("forgejo")},
+            {"host", Attr("git.example.org")},
+            {"owner", Attr("owner")},
+            {"repo", Attr("repo")},
+            {"ref", Attr("main")},
+        });
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "forgejo");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "host"), "git.example.org");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "owner");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "repo");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "ref"), "main");
+    EXPECT_EQ(input.toURLString(), "forgejo://git.example.org/owner/repo?ref=main");
+}
+
+TEST_F(GitForgeInputTest, forgejoInputRequiresHost)
+{
+    EXPECT_THAT(
+        []() { Input::fromURL(fetchers::Settings{}, "forgejo:owner/repo?ref=main"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("requires a host")));
+}
+
+TEST_F(GitForgeInputTest, giteaAuthorityInputFromURL)
+{
+    auto input = Input::fromURL(fetchers::Settings{}, "gitea://git.example.org/owner/repo?ref=main");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "gitea");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "host"), "git.example.org");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "owner");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "repo");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "ref"), "main");
+    EXPECT_EQ(input.toURLString(), "gitea://git.example.org/owner/repo?ref=main");
+}
+
+TEST_F(GitForgeInputTest, giteaInputRequiresHost)
+{
+    EXPECT_THAT(
+        []() { Input::fromURL(fetchers::Settings{}, "gitea:owner/repo?ref=main"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("requires a host")));
+}
+
+TEST_F(GitForgeInputTest, cgitAuthorityInputFromURL)
+{
+    auto input = Input::fromURL(fetchers::Settings{}, "cgit://git.example.org/cgit/project.git?ref=main");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "cgit");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "host"), "git.example.org");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "cgit");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "project.git");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "ref"), "main");
+    EXPECT_EQ(input.toURLString(), "cgit://git.example.org/cgit/project.git?ref=main");
+}
+
+TEST_F(GitForgeInputTest, cgitAuthorityInputAllowsRootRepositoryPath)
+{
+    auto input = Input::fromURL(fetchers::Settings{}, "cgit://git.qyliss.net/pr-tracker?ref=main");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "cgit");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "host"), "git.qyliss.net");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "pr-tracker");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "ref"), "main");
+    EXPECT_EQ(input.toURLString(), "cgit://git.qyliss.net/pr-tracker?ref=main");
+}
+
+TEST_F(GitForgeInputTest, cgitAuthorityInputAllowsNestedRepositoryPaths)
+{
+    auto input = Input::fromURL(
+        fetchers::Settings{}, "cgit://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git?ref=master");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "cgit");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "host"), "git.kernel.org");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "pub/scm/linux/kernel/git/torvalds");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "linux.git");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "ref"), "master");
+    EXPECT_EQ(input.toURLString(), "cgit://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git?ref=master");
+}
+
+TEST_F(GitForgeInputTest, cgitAuthorityInputFromAttrs)
+{
+    auto input = Input::fromAttrs(
+        fetchers::Settings{},
+        {
+            {"type", Attr("cgit")},
+            {"host", Attr("git.savannah.gnu.org")},
+            {"owner", Attr("cgit")},
+            {"repo", Attr("hello.git")},
+            {"ref", Attr("main")},
+        });
+
+    EXPECT_EQ(input.toURLString(), "cgit://git.savannah.gnu.org/cgit/hello.git?ref=main");
+}
+
+TEST_F(GitForgeInputTest, cgitAuthorityInputFromAttrsAllowsRootRepositoryPath)
+{
+    auto input = Input::fromAttrs(
+        fetchers::Settings{},
+        {
+            {"type", Attr("cgit")},
+            {"host", Attr("git.qyliss.net")},
+            {"owner", Attr("")},
+            {"repo", Attr("pr-tracker")},
+            {"ref", Attr("main")},
+        });
+
+    EXPECT_EQ(input.toURLString(), "cgit://git.qyliss.net/pr-tracker?ref=main");
+}
+
+TEST_F(GitForgeInputTest, cgitInputRequiresHost)
+{
+    EXPECT_THAT(
+        []() { Input::fromURL(fetchers::Settings{}, "cgit:cgit/hello.git?ref=main"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("requires a host")));
+}
+
+TEST_F(GitForgeInputTest, gitLabAuthorityURLsAllowNestedRepositoryPaths)
+{
+    auto input = Input::fromURL(fetchers::Settings{}, "gitlab://gitlab.example.org/org/group/repo?ref=main");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "gitlab");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "host"), "gitlab.example.org");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "org/group");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "repo");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "ref"), "main");
+    EXPECT_EQ(input.toURLString(), "gitlab://gitlab.example.org/org/group/repo?ref=main");
+}
+
+TEST_F(GitForgeInputTest, gitLabAuthorityURLsRoundTripNestedRepositoryPathsWithoutRef)
+{
+    auto input = Input::fromURL(fetchers::Settings{}, "gitlab://gitlab.com/org/group/repo");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "gitlab");
+    // The default host is intentionally canonicalized away from attrs, but
+    // the nested repository path still round-trips through authority syntax.
+    EXPECT_FALSE(input.toAttrs().contains("host"));
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "org/group");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "repo");
+    EXPECT_EQ(input.toURLString(), "gitlab://gitlab.com/org/group/repo");
+}
+
+TEST_F(GitForgeInputTest, gitLabQueryRefsAllowNestedRepositoryPathsWithoutAuthority)
+{
+    auto input = Input::fromURL(fetchers::Settings{}, "gitlab:org/group/repo?ref=main");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), "org/group");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "repo");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "ref"), "main");
+    EXPECT_EQ(input.toURLString(), "gitlab:org/group/repo?ref=main");
+}
+
+TEST_F(GitForgeInputTest, gitLabAuthorityURLsAllowTopLevelGroupAndTwentyNestedSubgroups)
+{
+    const std::string owner =
+        "org/subgroup01/subgroup02/subgroup03/subgroup04/subgroup05/subgroup06/subgroup07/subgroup08/subgroup09/subgroup10/subgroup11/subgroup12/subgroup13/subgroup14/subgroup15/subgroup16/subgroup17/subgroup18/subgroup19/subgroup20";
+    auto input = Input::fromURL(fetchers::Settings{}, "gitlab://gitlab.example.org/" + owner + "/repo?ref=main");
+
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "type"), "gitlab");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "host"), "gitlab.example.org");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "owner"), owner);
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "repo"), "repo");
+    EXPECT_EQ(getStrAttr(input.toAttrs(), "ref"), "main");
+    EXPECT_EQ(input.toURLString(), "gitlab://gitlab.example.org/" + owner + "/repo?ref=main");
+}
+
+TEST_F(GitForgeInputTest, gitLabAttrsAllowTopLevelGroupAndTwentyNestedSubgroups)
+{
+    const std::string owner =
+        "org/subgroup01/subgroup02/subgroup03/subgroup04/subgroup05/subgroup06/subgroup07/subgroup08/subgroup09/subgroup10/subgroup11/subgroup12/subgroup13/subgroup14/subgroup15/subgroup16/subgroup17/subgroup18/subgroup19/subgroup20";
+    auto input = Input::fromAttrs(
+        fetchers::Settings{},
+        {
+            {"type", Attr("gitlab")},
+            {"host", Attr("gitlab.example.org")},
+            {"owner", Attr(owner)},
+            {"repo", Attr("repo")},
+            {"ref", Attr("main")},
+        });
+
+    EXPECT_EQ(input.toURLString(), "gitlab://gitlab.example.org/" + owner + "/repo?ref=main");
+}
+
+TEST_F(GitForgeInputTest, authorityURLsRejectPathRefsForNonNestedForges)
+{
+    EXPECT_THAT(
+        []() { Input::fromURL(fetchers::Settings{}, "github://git.example.org/owner/repo/main"); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("use '?ref='")));
+}
+
+TEST_F(GitForgeInputTest, customForgeInputSchemeFromURLIsUnsupported)
+{
+    EXPECT_THAT(
+        []() { Input::fromURL(fetchers::Settings{}, "gogs:owner/repo"); },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("unsupported")));
 }
 
 } // namespace fetchers

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -16,8 +16,6 @@
 
 namespace nix::fetchers {
 
-using InputSchemeMap = std::map<std::string_view, std::shared_ptr<InputScheme>>;
-
 static InputSchemeMap & inputSchemes()
 {
     static InputSchemeMap inputSchemeMap;
@@ -26,7 +24,7 @@ static InputSchemeMap & inputSchemes()
 
 void registerInputScheme(std::shared_ptr<InputScheme> && inputScheme)
 {
-    auto schemeName = inputScheme->schemeName();
+    auto schemeName = std::string{inputScheme->schemeName()};
     if (!inputSchemes().emplace(schemeName, std::move(inputScheme)).second)
         throw Error("Input scheme with name %s already registered", schemeName);
 }

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -3,7 +3,9 @@
 #include "nix/store/store-api.hh"
 #include "nix/util/types.hh"
 #include "nix/util/url-parts.hh"
+#include "nix/util/url.hh"
 #include "nix/util/git.hh"
+#include "nix/util/strings.hh"
 #include "nix/fetchers/fetchers.hh"
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/fetchers/tarball.hh"
@@ -12,6 +14,7 @@
 
 #include <optional>
 #include <nlohmann/json.hpp>
+#include <vector>
 
 namespace nix::fetchers {
 
@@ -21,9 +24,117 @@ struct DownloadUrl
     Headers headers;
 };
 
-// A github, gitlab, or sourcehut host
-const static std::string hostRegexS = "[a-zA-Z0-9.-]*"; // FIXME: check
+// A github, gitlab, sourcehut, gitea/forgejo, cgit, or bitbucket host.
+// The optional port is needed for URL-authority flake refs such as
+// gitlab://gitlab.example.org:8443/group/repo?ref=main.
+const static std::string hostRegexS = "[a-zA-Z0-9.-]+(:[0-9]+)?"; // FIXME: check
 std::regex hostRegex(hostRegexS, std::regex::ECMAScript);
+
+static std::string authorityHostWithOptionalPort(const ParsedURL::Authority & authority)
+{
+    if (authority.user || authority.password)
+        throw BadURL("URL authority for Git forge input schemes must not include user information");
+
+    auto host = authority.host;
+    if (host.empty())
+        throw BadURL("URL authority for Git forge input schemes must include a host");
+
+    if (authority.port)
+        host += fmt(":%d", *authority.port);
+
+    if (!std::regex_match(host, hostRegex))
+        throw BadURL("URL authority for Git forge input schemes contains an invalid host '%s'", host);
+
+    return host;
+}
+
+static std::string
+joinPathSegments(std::vector<std::string>::const_iterator begin, std::vector<std::string>::const_iterator end)
+{
+    std::string result;
+    for (auto i = begin; i != end; ++i) {
+        if (!result.empty())
+            result += "/";
+        result += *i;
+    }
+    return result;
+}
+
+static std::vector<std::string> splitPathSegments(const std::string & s)
+{
+    return splitString<std::vector<std::string>>(s, "/");
+}
+
+static nlohmann::json
+downloadJSON(Store & store, const Settings & settings, const std::string & url, const Headers & headers)
+{
+    auto downloadResult = downloadFile(store, settings, url, "source", headers);
+    return nlohmann::json::parse(store.requireStoreObjectAccessor(downloadResult.storePath)->readFile(CanonPath::root));
+}
+
+enum class ForgePathMode {
+    OwnerRepo,
+    NestedOwnerRepo,
+    NestedOwnerRepoAllowRootRepo,
+};
+
+enum class RefSyntax {
+    QueryOnly,
+    LegacyPathAllowed,
+};
+
+struct ForgeRepoPath
+{
+    std::string owner;
+    std::string repo;
+};
+
+static bool supportsNestedRepositoryPaths(ForgePathMode mode)
+{
+    return mode == ForgePathMode::NestedOwnerRepo || mode == ForgePathMode::NestedOwnerRepoAllowRootRepo;
+}
+
+static bool supportsRootRepositoryPath(ForgePathMode mode)
+{
+    return mode == ForgePathMode::NestedOwnerRepoAllowRootRepo;
+}
+
+static ForgeRepoPath parseForgeRepoPath(
+    const ParsedURL & url,
+    const std::vector<std::string> & path,
+    ForgePathMode mode,
+    bool hasAuthority,
+    bool hasQueryRefOrRev)
+{
+    if (path.size() < 2 && !(supportsRootRepositoryPath(mode) && hasAuthority && path.size() == 1))
+        throw BadURL("URL '%s' is invalid", url);
+
+    if (supportsRootRepositoryPath(mode) && hasAuthority && path.size() == 1)
+        return ForgeRepoPath{.owner = "", .repo = path[0]};
+
+    if (supportsNestedRepositoryPaths(mode) && (hasAuthority || hasQueryRefOrRev))
+        return ForgeRepoPath{.owner = joinPathSegments(path.begin(), std::prev(path.end())), .repo = path.back()};
+
+    return ForgeRepoPath{.owner = path[0], .repo = path[1]};
+}
+
+static std::vector<std::string>
+renderForgeRepoPath(const std::string & owner, const std::string & repo, ForgePathMode mode)
+{
+    std::vector<std::string> repoPath;
+
+    if (supportsNestedRepositoryPaths(mode)) {
+        if (!owner.empty()) {
+            auto ownerPath = splitPathSegments(owner);
+            repoPath.insert(repoPath.end(), ownerPath.begin(), ownerPath.end());
+        }
+    } else {
+        repoPath.push_back(owner);
+    }
+
+    repoPath.push_back(repo);
+    return repoPath;
+}
 
 struct GitArchiveInputScheme : InputScheme
 {
@@ -40,48 +151,92 @@ struct GitArchiveInputScheme : InputScheme
         auto path = url.pathSegments(/*skipEmpty=*/true) | std::ranges::to<std::vector<std::string>>();
 
         Attrs attrs;
+        bool hasAuthority = url.authority.has_value() && !url.authority->host.empty();
+        bool hasQueryRefOrRev = false;
 
-        auto size = path.size();
-        if (size == 3) {
-            if (std::regex_match(path[2], revRegex))
-                attrs.insert_or_assign("rev", path[2]);
-            else
-                attrs.insert_or_assign("ref", path[2]);
-        } else if (size > 3) {
-            std::string rs;
-            for (auto i = std::next(path.begin(), 2); i != path.end(); i++) {
-                rs += *i;
-                if (std::next(i) != path.end()) {
-                    rs += "/";
-                }
-            }
-            attrs.insert_or_assign("ref", rs);
-        } else if (size < 2)
-            throw BadURL("URL '%s' is invalid", url);
+        if (hasAuthority) {
+            if (!supportsURLAuthority())
+                throw BadURL("URL authority is not supported by the '%s' input scheme", schemeName());
+
+            auto authorityHost = authorityHostWithOptionalPort(*url.authority);
+            auto defaultHostValue = defaultHost();
+            if (!defaultHostValue || authorityHost != *defaultHostValue)
+                attrs.insert_or_assign("host", authorityHost);
+        }
 
         for (auto & [name, value] : url.query) {
             if (name == "rev") {
                 if (attrs.contains(name))
                     throw BadURL("URL '%s' contains multiple commit hashes", url);
                 attrs.insert_or_assign("rev", value);
+                hasQueryRefOrRev = true;
             } else if (name == "ref") {
                 if (attrs.contains(name))
                     throw BadURL("URL '%s' contains multiple branch/tag names", url);
                 attrs.insert_or_assign("ref", value);
-            } else if (name == "host")
+                hasQueryRefOrRev = true;
+            } else if (name == "host") {
+                if (!supportsURLAuthority())
+                    throw BadURL("input scheme '%s' does not support custom hosts", schemeName());
+                if (hasAuthority)
+                    throw BadURL("URL '%s' specifies the host both as URL authority and as a query parameter", url);
                 attrs.insert_or_assign("host", value);
-            else if (name == "narHash")
+            } else if (name == "narHash")
                 attrs.insert_or_assign("narHash", value);
             else
                 throw BadURL("URL '%s' contains unknown parameter '%s'", url, name);
         }
 
+        /*
+           The URL-authority form proposed in #6304 reserves path segments for
+           the repository path. Branches/tags and revisions go in the query
+           string. This matters for GitLab and cgit, where repository paths can
+           be nested: gitlab://gitlab.example.org/org/group/repo?ref=main and
+           cgit://git.example.org/pub/scm/project.git?ref=main.
+
+           Keep the old path-ref shorthand for non-authority URLs without a
+           ref/rev query parameter for backwards compatibility.
+         */
+        auto repoPath = parseForgeRepoPath(url, path, pathMode(), hasAuthority, hasQueryRefOrRev);
+        attrs.insert_or_assign("owner", repoPath.owner);
+        attrs.insert_or_assign("repo", repoPath.repo);
+
+        if (!(supportsNestedRepositoryPaths(pathMode()) && (hasAuthority || hasQueryRefOrRev)) && path.size() > 2) {
+            if (hasAuthority || hasQueryRefOrRev)
+                throw BadURL(
+                    "URL '%s' puts a branch/tag name or revision in the path; use '?ref=' or '?rev=' instead", url);
+
+            if (path.size() == 3) {
+                if (std::regex_match(path[2], revRegex))
+                    attrs.insert_or_assign("rev", path[2]);
+                else
+                    attrs.insert_or_assign("ref", path[2]);
+            } else {
+                attrs.insert_or_assign("ref", joinPathSegments(std::next(path.begin(), 2), path.end()));
+            }
+        }
+
         attrs.insert_or_assign("type", std::string{schemeName()});
-        attrs.insert_or_assign("owner", path[0]);
-        attrs.insert_or_assign("repo", path[1]);
 
         return inputFromAttrs(settings, attrs);
     }
+
+    virtual ForgePathMode pathMode() const
+    {
+        return ForgePathMode::OwnerRepo;
+    }
+
+    virtual RefSyntax refSyntax() const
+    {
+        return RefSyntax::QueryOnly;
+    }
+
+    virtual bool supportsURLAuthority() const
+    {
+        return true;
+    }
+
+    virtual std::optional<std::string> defaultHost() const = 0;
 
     const std::map<std::string, AttributeInfo> & allowedAttrs() const override
     {
@@ -142,8 +297,14 @@ struct GitArchiveInputScheme : InputScheme
         if (ref && !isLegalRefName(*ref))
             throw BadURL("input %s contains an invalid branch/tag name", attrsToJSON(attrs));
 
-        if (auto host = maybeGetStrAttr(attrs, "host"); host && !std::regex_match(*host, hostRegex))
-            throw BadURL("input %s contains an invalid instance host", attrsToJSON(attrs));
+        if (auto host = maybeGetStrAttr(attrs, "host")) {
+            if (!supportsURLAuthority())
+                throw BadURL("input scheme '%s' does not support custom hosts", schemeName());
+            if (!std::regex_match(*host, hostRegex))
+                throw BadURL("input %s contains an invalid instance host", attrsToJSON(attrs));
+        } else if (!defaultHost()) {
+            throw BadURL("input scheme '%s' requires a host", schemeName());
+        }
 
         Input input{};
         input.attrs = attrs;
@@ -156,21 +317,56 @@ struct GitArchiveInputScheme : InputScheme
         auto repo = getStrAttr(input.attrs, "repo");
         auto ref = input.getRef();
         auto rev = input.getRev();
-        std::vector<std::string> path{owner, repo};
         assert(!(ref && rev));
-        if (ref)
-            path.push_back(*ref);
-        if (rev)
-            path.push_back(rev->to_string(HashFormat::Base16, false));
+
+        auto repoPath = renderForgeRepoPath(owner, repo, pathMode());
+
+        auto host = maybeGetStrAttr(input.attrs, "host");
+        if (host && !supportsURLAuthority())
+            throw BadURL("input scheme '%s' does not support custom hosts", schemeName());
+
+        auto defaultHostValue = defaultHost();
+        if (!host && !defaultHostValue)
+            throw BadURL("input scheme '%s' requires a host", schemeName());
+
+        auto ownerHasNestedPath = supportsNestedRepositoryPaths(pathMode()) && owner.find('/') != std::string::npos;
+        auto useAuthority = supportsURLAuthority()
+                            && ((host && (!defaultHostValue || *host != *defaultHostValue))
+                                || (ownerHasNestedPath && !ref && !rev) || !defaultHostValue);
+        auto authorityHost = host ? *host : *defaultHostValue;
+
+        /* Preserve the historical canonical form for the original Git forge
+           schemes when it is unambiguous: github:owner/repo/ref rather than
+           github:owner/repo?ref=ref. New authority and nested-repository forms
+           use query parameters because their path is reserved for the
+           repository name. */
+        auto useLegacyPathRef = refSyntax() == RefSyntax::LegacyPathAllowed && !useAuthority && !ownerHasNestedPath;
+
+        std::vector<std::string> path;
+        if (useAuthority)
+            path.push_back("");
+        path.insert(path.end(), repoPath.begin(), repoPath.end());
+        if (useLegacyPathRef) {
+            if (ref)
+                path.push_back(*ref);
+            if (rev)
+                path.push_back(rev->to_string(HashFormat::Base16, false));
+        }
+
         auto url = ParsedURL{
             .scheme = std::string{schemeName()},
+            .authority = useAuthority ? std::optional<ParsedURL::Authority>{ParsedURL::Authority::parse(authorityHost)}
+                                      : std::nullopt,
             .path = path,
         };
+        if (!useLegacyPathRef) {
+            if (ref)
+                url.query.insert_or_assign("ref", *ref);
+            if (rev)
+                url.query.insert_or_assign("rev", rev->to_string(HashFormat::Base16, false));
+        }
         if (auto narHash = input.getNarHash())
             url.query.insert_or_assign("narHash", narHash->to_string(HashFormat::SRI, true));
-        auto host = maybeGetStrAttr(input.attrs, "host");
-        if (host)
-            url.query.insert_or_assign("host", *host);
         return url;
     }
 
@@ -224,7 +420,7 @@ struct GitArchiveInputScheme : InputScheme
     {
         auto owner = getStrAttr(input.attrs, "owner");
         auto repo = getStrAttr(input.attrs, "repo");
-        auto hostAndPath = fmt("%s/%s/%s", host, owner, repo);
+        auto hostAndPath = owner.empty() ? fmt("%s/%s", host, repo) : fmt("%s/%s/%s", host, owner, repo);
         return makeHeadersWithAuthTokens(settings, host, hostAndPath);
     }
 
@@ -370,33 +566,133 @@ struct GitArchiveInputScheme : InputScheme
     }
 };
 
-struct GitHubInputScheme : GitArchiveInputScheme
+enum class GitForgeScheme {
+    GitHub,
+    GitLab,
+    SourceHut,
+    Gitea,
+    CGit,
+    Bitbucket,
+};
+
+struct GitForgeSchemeInstance
 {
+    std::string scheme;
+    GitForgeScheme forge;
+    std::optional<std::string> host;
+    bool supportsAuthority = true;
+    ForgePathMode pathMode = ForgePathMode::OwnerRepo;
+    RefSyntax refSyntax = RefSyntax::QueryOnly;
+};
+
+struct GitForgeSchemeInfo
+{
+    GitForgeScheme scheme;
+    std::string name;
+    bool cloneUrlNeedsDotGit;
+};
+
+static const std::vector<GitForgeSchemeInfo> & gitForgeSchemeInfos()
+{
+    static const std::vector<GitForgeSchemeInfo> infos = {
+        GitForgeSchemeInfo{
+            .scheme = GitForgeScheme::GitHub,
+            .name = "github",
+            .cloneUrlNeedsDotGit = true,
+        },
+        GitForgeSchemeInfo{
+            .scheme = GitForgeScheme::GitLab,
+            .name = "gitlab",
+            .cloneUrlNeedsDotGit = true,
+        },
+        GitForgeSchemeInfo{
+            .scheme = GitForgeScheme::SourceHut,
+            .name = "sourcehut",
+            .cloneUrlNeedsDotGit = false,
+        },
+        GitForgeSchemeInfo{
+            .scheme = GitForgeScheme::Gitea,
+            .name = "gitea/forgejo",
+            .cloneUrlNeedsDotGit = true,
+        },
+        GitForgeSchemeInfo{
+            .scheme = GitForgeScheme::CGit,
+            .name = "cgit",
+            .cloneUrlNeedsDotGit = false,
+        },
+        GitForgeSchemeInfo{
+            .scheme = GitForgeScheme::Bitbucket,
+            .name = "bitbucket",
+            .cloneUrlNeedsDotGit = true,
+        },
+    };
+    return infos;
+}
+
+static const GitForgeSchemeInfo & gitForgeSchemeInfo(GitForgeScheme forge)
+{
+    for (auto & info : gitForgeSchemeInfos())
+        if (info.scheme == forge)
+            return info;
+    unreachable();
+}
+
+static std::string showGitForgeScheme(GitForgeScheme forge)
+{
+    return gitForgeSchemeInfo(forge).name;
+}
+
+struct GitForgeInputScheme : GitArchiveInputScheme
+{
+    GitForgeSchemeInstance config;
+
+    explicit GitForgeInputScheme(GitForgeSchemeInstance config)
+        : config(std::move(config))
+    {
+    }
+
     std::string_view schemeName() const override
     {
-        return "github";
+        return config.scheme;
     }
 
     std::string schemeDescription() const override
     {
-        // TODO
-        return "";
+        if (config.host)
+            return fmt(
+                "fetch %s repositories from %s as tarball archives", showGitForgeScheme(config.forge), *config.host);
+
+        return fmt(
+            "fetch %s repositories from a URL authority host as tarball archives", showGitForgeScheme(config.forge));
     }
 
-    std::optional<std::pair<std::string, std::string>> accessHeaderFromToken(const std::string & token) const override
+    ForgePathMode pathMode() const override
     {
-        // Github supports PAT/OAuth2 tokens and HTTP Basic
-        // Authentication.  The former simply specifies the token, the
-        // latter can use the token as the password.  Only the first
-        // is used here. See
-        // https://developer.github.com/v3/#authentication and
-        // https://docs.github.com/en/developers/apps/authorizing-oath-apps
-        return std::pair<std::string, std::string>("Authorization", fmt("token %s", token));
+        return config.pathMode;
+    }
+
+    RefSyntax refSyntax() const override
+    {
+        return config.refSyntax;
+    }
+
+    bool supportsURLAuthority() const override
+    {
+        return config.supportsAuthority;
+    }
+
+    std::optional<std::string> defaultHost() const override
+    {
+        return config.host;
     }
 
     std::string getHost(const Input & input) const
     {
-        return maybeGetStrAttr(input.attrs, "host").value_or("github.com");
+        if (auto host = maybeGetStrAttr(input.attrs, "host"))
+            return *host;
+        if (config.host)
+            return *config.host;
+        throw BadURL("input scheme '%s' requires a host", schemeName());
     }
 
     std::string getOwner(const Input & input) const
@@ -409,103 +705,150 @@ struct GitHubInputScheme : GitArchiveInputScheme
         return getStrAttr(input.attrs, "repo");
     }
 
-    RefInfo getRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const override
+    struct RepoContext
+    {
+        std::string host;
+        std::string owner;
+        std::string repo;
+        Headers headers;
+    };
+
+    RepoContext getRepoContext(const Settings & settings, const Input & input) const
     {
         auto host = getHost(input);
-        auto url = fmt(
-            host == "github.com" ? "https://api.%s/repos/%s/%s/commits/%s" : "https://%s/api/v3/repos/%s/%s/commits/%s",
-            host,
-            getOwner(input),
-            getRepo(input),
-            *input.getRef());
+        return RepoContext{
+            .host = host,
+            .owner = getOwner(input),
+            .repo = getRepo(input),
+            .headers = makeHeadersWithAuthTokens(settings, host, input),
+        };
+    }
 
-        Headers headers = makeHeadersWithAuthTokens(settings, host, input);
+    static std::string repoPathForUrl(const RepoContext & ctx)
+    {
+        return ctx.owner.empty() ? ctx.repo : fmt("%s/%s", ctx.owner, ctx.repo);
+    }
 
-        auto downloadResult = downloadFile(store, settings, url, "source", headers);
-        auto json = nlohmann::json::parse(
-            store.requireStoreObjectAccessor(downloadResult.storePath)->readFile(CanonPath::root));
+    std::string revString(const Input & input) const
+    {
+        return input.getRev()->to_string(HashFormat::Base16, false);
+    }
+
+    std::optional<std::pair<std::string, std::string>> accessHeaderFromToken(const std::string & token) const override
+    {
+        switch (config.forge) {
+        case GitForgeScheme::GitHub:
+            // GitHub supports PAT/OAuth2 tokens and HTTP Basic Authentication.
+            return std::pair<std::string, std::string>("Authorization", fmt("token %s", token));
+        case GitForgeScheme::GitLab: {
+            // GitLab supports 4 kinds of authorization, two of which are
+            // relevant here: OAuth2 and PAT (Private Access Token).  The user
+            // can indicate which token is used by specifying the token as
+            // <TYPE>:<VALUE>, where type is "OAuth2" or "PAT". If the <TYPE>
+            // is unrecognized, this falls back to treating it as
+            // <HDRNAME>:<HDRVAL>.
+            auto fldsplit = token.find_first_of(':');
+            if ("OAuth2" == token.substr(0, fldsplit))
+                return std::make_pair("Authorization", fmt("Bearer %s", token.substr(fldsplit + 1)));
+            if ("PAT" == token.substr(0, fldsplit))
+                return std::make_pair("Private-token", token.substr(fldsplit + 1));
+            warn("Unrecognized GitLab token type %s", token.substr(0, fldsplit));
+            return std::make_pair(token.substr(0, fldsplit), token.substr(fldsplit + 1));
+        }
+        case GitForgeScheme::SourceHut:
+            // Note: this currently serves no purpose for private SourceHut repos
+            // because SourceHut does not allow token-authenticated tarball downloads.
+            return std::pair<std::string, std::string>("Authorization", fmt("Bearer %s", token));
+        case GitForgeScheme::Gitea:
+            return std::pair<std::string, std::string>("Authorization", fmt("token %s", token));
+        case GitForgeScheme::CGit: {
+            auto fldsplit = token.find_first_of(':');
+            if (fldsplit != std::string::npos)
+                return std::make_pair(token.substr(0, fldsplit), token.substr(fldsplit + 1));
+            return {};
+        }
+        case GitForgeScheme::Bitbucket: {
+            // Bitbucket Cloud supports OAuth/access-token authentication with
+            // Bearer tokens. Users that need app-password Basic auth can pass
+            // a complete header value as "Basic:<base64>".
+            auto fldsplit = token.find_first_of(':');
+            if (fldsplit != std::string::npos && token.substr(0, fldsplit) == "Basic")
+                return std::make_pair("Authorization", fmt("Basic %s", token.substr(fldsplit + 1)));
+            if (fldsplit != std::string::npos && token.substr(0, fldsplit) == "Bearer")
+                return std::make_pair("Authorization", fmt("Bearer %s", token.substr(fldsplit + 1)));
+            return std::make_pair("Authorization", fmt("Bearer %s", token));
+        }
+        }
+        unreachable();
+    }
+
+    RefInfo getRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const override
+    {
+        switch (config.forge) {
+        case GitForgeScheme::GitHub:
+            return getGitHubRevFromRef(settings, store, input);
+        case GitForgeScheme::GitLab:
+            return getGitLabRevFromRef(settings, store, input);
+        case GitForgeScheme::SourceHut:
+            return getSourceHutRevFromRef(settings, store, input);
+        case GitForgeScheme::Gitea:
+            return getGiteaRevFromRef(settings, store, input);
+        case GitForgeScheme::CGit:
+            return getCGitRevFromRef(settings, store, input);
+        case GitForgeScheme::Bitbucket:
+            return getBitbucketRevFromRef(settings, store, input);
+        }
+        unreachable();
+    }
+
+    DownloadUrl getDownloadUrl(const Settings & settings, const Input & input) const override
+    {
+        switch (config.forge) {
+        case GitForgeScheme::GitHub:
+            return getGitHubDownloadUrl(settings, input);
+        case GitForgeScheme::GitLab:
+            return getGitLabDownloadUrl(settings, input);
+        case GitForgeScheme::SourceHut:
+            return getSourceHutDownloadUrl(settings, input);
+        case GitForgeScheme::Gitea:
+            return getGiteaDownloadUrl(settings, input);
+        case GitForgeScheme::CGit:
+            return getCGitDownloadUrl(settings, input);
+        case GitForgeScheme::Bitbucket:
+            return getBitbucketDownloadUrl(settings, input);
+        }
+        unreachable();
+    }
+
+    RefInfo getGitHubRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const
+    {
+        auto ctx = getRepoContext(settings, input);
+        auto url =
+            fmt(ctx.host == "github.com" ? "https://api.%s/repos/%s/%s/commits/%s"
+                                         : "https://%s/api/v3/repos/%s/%s/commits/%s",
+                ctx.host,
+                ctx.owner,
+                ctx.repo,
+                *input.getRef());
+
+        auto json = downloadJSON(store, settings, url, ctx.headers);
 
         return RefInfo{
             .rev = Hash::parseAny(std::string{json["sha"]}, HashAlgorithm::SHA1),
             .treeHash = Hash::parseAny(std::string{json["commit"]["tree"]["sha"]}, HashAlgorithm::SHA1)};
     }
 
-    DownloadUrl getDownloadUrl(const Settings & settings, const Input & input) const override
+    RefInfo getGitLabRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const
     {
-        auto host = getHost(input);
-
-        Headers headers = makeHeadersWithAuthTokens(settings, host, input);
-
-        // If we have no auth headers then we default to the public archive
-        // urls so we do not run into rate limits.
-        const auto urlFmt = host != "github.com" ? "https://%s/api/v3/repos/%s/%s/tarball/%s"
-                            : headers.empty()    ? "https://%s/%s/%s/archive/%s.tar.gz"
-                                                 : "https://api.%s/repos/%s/%s/tarball/%s";
-
-        const auto url =
-            fmt(urlFmt, host, getOwner(input), getRepo(input), input.getRev()->to_string(HashFormat::Base16, false));
-
-        return DownloadUrl{parseURL(url), headers};
-    }
-
-    void clone(const Settings & settings, Store & store, const Input & input, const std::filesystem::path & destDir)
-        const override
-    {
-        auto host = getHost(input);
-        Input::fromURL(settings, fmt("git+https://%s/%s/%s.git", host, getOwner(input), getRepo(input)))
-            .applyOverrides(input.getRef(), input.getRev())
-            .clone(settings, store, destDir);
-    }
-};
-
-struct GitLabInputScheme : GitArchiveInputScheme
-{
-    std::string_view schemeName() const override
-    {
-        return "gitlab";
-    }
-
-    std::string schemeDescription() const override
-    {
-        // TODO
-        return "";
-    }
-
-    std::optional<std::pair<std::string, std::string>> accessHeaderFromToken(const std::string & token) const override
-    {
-        // Gitlab supports 4 kinds of authorization, two of which are
-        // relevant here: OAuth2 and PAT (Private Access Token).  The
-        // user can indicate which token is used by specifying the
-        // token as <TYPE>:<VALUE>, where type is "OAuth2" or "PAT".
-        // If the <TYPE> is unrecognized, this will fall back to
-        // treating this simply has <HDRNAME>:<HDRVAL>.  See
-        // https://docs.gitlab.com/12.10/ee/api/README.html#authentication
-        auto fldsplit = token.find_first_of(':');
-        // n.b. C++20 would allow: if (token.starts_with("OAuth2:")) ...
-        if ("OAuth2" == token.substr(0, fldsplit))
-            return std::make_pair("Authorization", fmt("Bearer %s", token.substr(fldsplit + 1)));
-        if ("PAT" == token.substr(0, fldsplit))
-            return std::make_pair("Private-token", token.substr(fldsplit + 1));
-        warn("Unrecognized GitLab token type %s", token.substr(0, fldsplit));
-        return std::make_pair(token.substr(0, fldsplit), token.substr(fldsplit + 1));
-    }
-
-    RefInfo getRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const override
-    {
-        auto host = maybeGetStrAttr(input.attrs, "host").value_or("gitlab.com");
-        // See rate limiting note below
+        auto ctx = getRepoContext(settings, input);
+        // See rate limiting note below.
         auto url =
-            fmt("https://%s/api/v4/projects/%s%%2F%s/repository/commits?ref_name=%s",
-                host,
-                getStrAttr(input.attrs, "owner"),
-                getStrAttr(input.attrs, "repo"),
-                *input.getRef());
+            fmt("https://%s/api/v4/projects/%s/repository/commits?ref_name=%s",
+                ctx.host,
+                percentEncode(ctx.owner + "/" + ctx.repo),
+                percentEncode(*input.getRef()));
 
-        Headers headers = makeHeadersWithAuthTokens(settings, host, input);
-
-        auto downloadResult = downloadFile(store, settings, url, "source", headers);
-        auto json = nlohmann::json::parse(
-            store.requireStoreObjectAccessor(downloadResult.storePath)->readFile(CanonPath::root));
+        auto json = downloadJSON(store, settings, url, ctx.headers);
 
         if (json.is_array() && json.size() >= 1 && json[0]["id"] != nullptr) {
             return RefInfo{.rev = Hash::parseAny(std::string(json[0]["id"]), HashAlgorithm::SHA1)};
@@ -517,82 +860,23 @@ struct GitLabInputScheme : GitArchiveInputScheme
         }
     }
 
-    DownloadUrl getDownloadUrl(const Settings & settings, const Input & input) const override
-    {
-        // This endpoint has a rate limit threshold that may be
-        // server-specific and vary based whether the user is
-        // authenticated via an accessToken or not, but the usual rate
-        // is 10 reqs/sec/ip-addr.  See
-        // https://docs.gitlab.com/ee/user/gitlab_com/index.html#gitlabcom-specific-rate-limits
-        auto host = maybeGetStrAttr(input.attrs, "host").value_or("gitlab.com");
-        auto url =
-            fmt("https://%s/api/v4/projects/%s%%2F%s/repository/archive.tar.gz?sha=%s",
-                host,
-                getStrAttr(input.attrs, "owner"),
-                getStrAttr(input.attrs, "repo"),
-                input.getRev()->to_string(HashFormat::Base16, false));
-
-        Headers headers = makeHeadersWithAuthTokens(settings, host, input);
-        return DownloadUrl{parseURL(url), headers};
-    }
-
-    void clone(const Settings & settings, Store & store, const Input & input, const std::filesystem::path & destDir)
-        const override
-    {
-        auto host = maybeGetStrAttr(input.attrs, "host").value_or("gitlab.com");
-        // FIXME: get username somewhere
-        Input::fromURL(
-            settings,
-            fmt("git+https://%s/%s/%s.git", host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo")))
-            .applyOverrides(input.getRef(), input.getRev())
-            .clone(settings, store, destDir);
-    }
-};
-
-struct SourceHutInputScheme : GitArchiveInputScheme
-{
-    std::string_view schemeName() const override
-    {
-        return "sourcehut";
-    }
-
-    std::string schemeDescription() const override
-    {
-        // TODO
-        return "";
-    }
-
-    std::optional<std::pair<std::string, std::string>> accessHeaderFromToken(const std::string & token) const override
-    {
-        // SourceHut supports both PAT and OAuth2. See
-        // https://man.sr.ht/meta.sr.ht/oauth.md
-        return std::pair<std::string, std::string>("Authorization", fmt("Bearer %s", token));
-        // Note: This currently serves no purpose, as this kind of authorization
-        // does not allow for downloading tarballs on sourcehut private repos.
-        // Once it is implemented, however, should work as expected.
-    }
-
-    RefInfo getRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const override
+    RefInfo getSourceHutRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const
     {
         // TODO: In the future, when the sourcehut graphql API is implemented for mercurial
         // and with anonymous access, this method should use it instead.
 
         auto ref = *input.getRef();
-
-        auto host = maybeGetStrAttr(input.attrs, "host").value_or("git.sr.ht");
-        auto base_url =
-            fmt("https://%s/%s/%s", host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo"));
-
-        Headers headers = makeHeadersWithAuthTokens(settings, host, input);
+        auto ctx = getRepoContext(settings, input);
+        auto base_url = fmt("https://%s/%s", ctx.host, repoPathForUrl(ctx));
 
         std::string refUri;
         if (ref == "HEAD") {
-            auto downloadFileResult = downloadFile(store, settings, fmt("%s/HEAD", base_url), "source", headers);
+            auto downloadFileResult = downloadFile(store, settings, fmt("%s/HEAD", base_url), "source", ctx.headers);
             auto contents = store.requireStoreObjectAccessor(downloadFileResult.storePath)->readFile(CanonPath::root);
 
             auto remoteLine = git::parseLsRemoteLine(getLine(contents).first);
             if (!remoteLine) {
-                throw BadURL("in '%d', couldn't resolve HEAD ref '%d'", input.to_string(), ref);
+                throw BadURL("in '%s', couldn't resolve HEAD ref '%s'", input.to_string(), ref);
             }
             refUri = remoteLine->target;
         } else {
@@ -600,7 +884,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         }
         std::regex refRegex(refUri);
 
-        auto downloadFileResult = downloadFile(store, settings, fmt("%s/info/refs", base_url), "source", headers);
+        auto downloadFileResult = downloadFile(store, settings, fmt("%s/info/refs", base_url), "source", ctx.headers);
         auto contents = store.requireStoreObjectAccessor(downloadFileResult.storePath)->readFile(CanonPath::root);
         std::istringstream is(contents);
 
@@ -613,39 +897,226 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         }
 
         if (!id)
-            throw BadURL("in '%d', couldn't find ref '%d'", input.to_string(), ref);
+            throw BadURL("in '%s', couldn't find ref '%s'", input.to_string(), ref);
 
         return RefInfo{.rev = Hash::parseAny(*id, HashAlgorithm::SHA1)};
     }
 
-    DownloadUrl getDownloadUrl(const Settings & settings, const Input & input) const override
+    RefInfo getCGitRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const
     {
-        auto host = maybeGetStrAttr(input.attrs, "host").value_or("git.sr.ht");
-        auto url =
-            fmt("https://%s/%s/%s/archive/%s.tar.gz",
-                host,
-                getStrAttr(input.attrs, "owner"),
-                getStrAttr(input.attrs, "repo"),
-                input.getRev()->to_string(HashFormat::Base16, false));
+        return getSourceHutRevFromRef(settings, store, input);
+    }
 
-        Headers headers = makeHeadersWithAuthTokens(settings, host, input);
-        return DownloadUrl{parseURL(url), headers};
+    RefInfo getGiteaRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const
+    {
+        auto ctx = getRepoContext(settings, input);
+        auto ref = *input.getRef();
+
+        if (ref == "HEAD") {
+            auto repoJson = downloadJSON(
+                store, settings, fmt("https://%s/api/v1/repos/%s/%s", ctx.host, ctx.owner, ctx.repo), ctx.headers);
+
+            auto defaultBranch = repoJson.find("default_branch");
+            if (defaultBranch == repoJson.end() || !defaultBranch->is_string()
+                || defaultBranch->get<std::string>().empty())
+                throw Error("Gitea API response for '%s/%s' did not include a default branch", ctx.owner, ctx.repo);
+
+            ref = defaultBranch->get<std::string>();
+        }
+
+        auto json = downloadJSON(
+            store,
+            settings,
+            fmt("https://%s/api/v1/repos/%s/%s/commits?sha=%s&limit=1",
+                ctx.host,
+                ctx.owner,
+                ctx.repo,
+                percentEncode(ref)),
+            ctx.headers);
+
+        if (!json.is_array() || json.empty() || !json[0].contains("sha"))
+            throw Error("No commits returned by Gitea API for ref '%s' in '%s/%s'", ref, ctx.owner, ctx.repo);
+
+        std::optional<Hash> treeHash;
+        if (json[0].contains("commit") && json[0]["commit"].contains("tree")
+            && json[0]["commit"]["tree"].contains("sha"))
+            treeHash = Hash::parseAny(std::string{json[0]["commit"]["tree"]["sha"]}, HashAlgorithm::SHA1);
+
+        return RefInfo{.rev = Hash::parseAny(std::string{json[0]["sha"]}, HashAlgorithm::SHA1), .treeHash = treeHash};
+    }
+
+    RefInfo getBitbucketRevFromRef(const Settings & settings, nix::Store & store, const Input & input) const
+    {
+        auto ctx = getRepoContext(settings, input);
+        auto ref = *input.getRef();
+
+        auto apiHost = ctx.host == "bitbucket.org" ? "api.bitbucket.org" : ctx.host;
+
+        if (ref == "HEAD") {
+            auto repoJson = downloadJSON(
+                store, settings, fmt("https://%s/2.0/repositories/%s/%s", apiHost, ctx.owner, ctx.repo), ctx.headers);
+
+            if (!repoJson.contains("mainbranch") || !repoJson["mainbranch"].contains("name")
+                || !repoJson["mainbranch"]["name"].is_string()
+                || repoJson["mainbranch"]["name"].get<std::string>().empty())
+                throw Error("Bitbucket API response for '%s/%s' did not include a main branch", ctx.owner, ctx.repo);
+
+            ref = repoJson["mainbranch"]["name"].get<std::string>();
+        }
+
+        auto json = downloadJSON(
+            store,
+            settings,
+            fmt("https://%s/2.0/repositories/%s/%s/commits/%s?pagelen=1",
+                apiHost,
+                ctx.owner,
+                ctx.repo,
+                percentEncode(ref)),
+            ctx.headers);
+
+        if (!json.contains("values") || !json["values"].is_array() || json["values"].empty()
+            || !json["values"][0].contains("hash"))
+            throw Error("No commits returned by Bitbucket API for ref '%s' in '%s/%s'", ref, ctx.owner, ctx.repo);
+
+        return RefInfo{.rev = Hash::parseAny(std::string{json["values"][0]["hash"]}, HashAlgorithm::SHA1)};
+    }
+
+    DownloadUrl getGitHubDownloadUrl(const Settings & settings, const Input & input) const
+    {
+        auto ctx = getRepoContext(settings, input);
+
+        // If we have no auth headers then we default to the public archive
+        // URLs so we do not run into rate limits.
+        const auto urlFmt = ctx.host != "github.com" ? "https://%s/api/v3/repos/%s/%s/tarball/%s"
+                            : ctx.headers.empty()    ? "https://%s/%s/%s/archive/%s.tar.gz"
+                                                     : "https://api.%s/repos/%s/%s/tarball/%s";
+
+        const auto url = fmt(urlFmt, ctx.host, ctx.owner, ctx.repo, revString(input));
+
+        return DownloadUrl{parseURL(url), ctx.headers};
+    }
+
+    DownloadUrl getGitLabDownloadUrl(const Settings & settings, const Input & input) const
+    {
+        // This endpoint has a rate limit threshold that may be server-specific
+        // and vary based whether the user is authenticated via an accessToken
+        // or not, but the usual rate is 10 reqs/sec/ip-addr. See
+        // https://docs.gitlab.com/ee/user/gitlab_com/index.html#gitlabcom-specific-rate-limits
+        auto ctx = getRepoContext(settings, input);
+        auto url =
+            fmt("https://%s/api/v4/projects/%s/repository/archive.tar.gz?sha=%s",
+                ctx.host,
+                percentEncode(ctx.owner + "/" + ctx.repo),
+                revString(input));
+
+        return DownloadUrl{parseURL(url), ctx.headers};
+    }
+
+    DownloadUrl getArchiveDotTarGzDownloadUrl(const Settings & settings, const Input & input) const
+    {
+        auto ctx = getRepoContext(settings, input);
+        auto url = fmt("https://%s/%s/%s/archive/%s.tar.gz", ctx.host, ctx.owner, ctx.repo, revString(input));
+
+        return DownloadUrl{parseURL(url), ctx.headers};
+    }
+
+    DownloadUrl getSourceHutDownloadUrl(const Settings & settings, const Input & input) const
+    {
+        return getArchiveDotTarGzDownloadUrl(settings, input);
+    }
+
+    DownloadUrl getGiteaDownloadUrl(const Settings & settings, const Input & input) const
+    {
+        return getArchiveDotTarGzDownloadUrl(settings, input);
+    }
+
+    static std::string cgitSnapshotBasename(const std::string & repo)
+    {
+        if (repo.size() >= 4 && repo.compare(repo.size() - 4, 4, ".git") == 0)
+            return repo.substr(0, repo.size() - 4);
+        return repo;
+    }
+
+    DownloadUrl getCGitDownloadUrl(const Settings & settings, const Input & input) const
+    {
+        auto ctx = getRepoContext(settings, input);
+        auto url =
+            fmt("https://%s/%s/snapshot/%s-%s.tar.gz",
+                ctx.host,
+                repoPathForUrl(ctx),
+                cgitSnapshotBasename(ctx.repo),
+                revString(input));
+
+        return DownloadUrl{parseURL(url), ctx.headers};
+    }
+
+    DownloadUrl getBitbucketDownloadUrl(const Settings & settings, const Input & input) const
+    {
+        auto ctx = getRepoContext(settings, input);
+        auto url = fmt("https://%s/%s/%s/get/%s.zip", ctx.host, ctx.owner, ctx.repo, revString(input));
+
+        return DownloadUrl{parseURL(url), ctx.headers};
     }
 
     void clone(const Settings & settings, Store & store, const Input & input, const std::filesystem::path & destDir)
         const override
     {
-        auto host = maybeGetStrAttr(input.attrs, "host").value_or("git.sr.ht");
-        Input::fromURL(
-            settings,
-            fmt("git+https://%s/%s/%s", host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo")))
+        auto ctx = getRepoContext(settings, input);
+        auto cloneRepo = gitForgeSchemeInfo(config.forge).cloneUrlNeedsDotGit ? fmt("%s.git", ctx.repo) : ctx.repo;
+        auto clonePath = ctx.owner.empty() ? cloneRepo : fmt("%s/%s", ctx.owner, cloneRepo);
+        auto cloneUrl = fmt("git+https://%s/%s", ctx.host, clonePath);
+
+        Input::fromURL(settings, cloneUrl)
             .applyOverrides(input.getRef(), input.getRev())
             .clone(settings, store, destDir);
     }
 };
 
-static auto rGitHubInputScheme = OnStartup([] { registerInputScheme(std::make_unique<GitHubInputScheme>()); });
-static auto rGitLabInputScheme = OnStartup([] { registerInputScheme(std::make_unique<GitLabInputScheme>()); });
-static auto rSourceHutInputScheme = OnStartup([] { registerInputScheme(std::make_unique<SourceHutInputScheme>()); });
+static std::vector<GitForgeSchemeInstance> defaultGitForgeInputSchemeConfigs()
+{
+    return {
+        GitForgeSchemeInstance{
+            .scheme = "github",
+            .forge = GitForgeScheme::GitHub,
+            .host = "github.com",
+            .refSyntax = RefSyntax::LegacyPathAllowed,
+        },
+        GitForgeSchemeInstance{
+            .scheme = "gitlab",
+            .forge = GitForgeScheme::GitLab,
+            .host = "gitlab.com",
+            .pathMode = ForgePathMode::NestedOwnerRepo,
+            .refSyntax = RefSyntax::LegacyPathAllowed,
+        },
+        GitForgeSchemeInstance{
+            .scheme = "sourcehut",
+            .forge = GitForgeScheme::SourceHut,
+            .host = "git.sr.ht",
+            .refSyntax = RefSyntax::LegacyPathAllowed,
+        },
+        GitForgeSchemeInstance{
+            .scheme = "codeberg",
+            .forge = GitForgeScheme::Gitea,
+            .host = "codeberg.org",
+            .supportsAuthority = false,
+        },
+        GitForgeSchemeInstance{.scheme = "gitea", .forge = GitForgeScheme::Gitea},
+        GitForgeSchemeInstance{.scheme = "forgejo", .forge = GitForgeScheme::Gitea},
+        GitForgeSchemeInstance{
+            .scheme = "cgit",
+            .forge = GitForgeScheme::CGit,
+            .pathMode = ForgePathMode::NestedOwnerRepoAllowRootRepo,
+        },
+        GitForgeSchemeInstance{.scheme = "bitbucket", .forge = GitForgeScheme::Bitbucket, .host = "bitbucket.org"},
+    };
+}
+
+static void registerDefaultGitForgeInputSchemes()
+{
+    for (auto & config : defaultGitForgeInputSchemeConfigs())
+        registerInputScheme(std::make_shared<GitForgeInputScheme>(std::move(config)));
+}
+
+static auto rGitForgeInputSchemes = OnStartup([] { registerDefaultGitForgeInputSchemes(); });
 
 } // namespace nix::fetchers

--- a/src/libfetchers/include/nix/fetchers/fetchers.hh
+++ b/src/libfetchers/include/nix/fetchers/fetchers.hh
@@ -277,7 +277,7 @@ struct InputScheme
 
 void registerInputScheme(std::shared_ptr<InputScheme> && fetcher);
 
-using InputSchemeMap = std::map<std::string_view, std::shared_ptr<InputScheme>>;
+using InputSchemeMap = std::map<std::string, std::shared_ptr<InputScheme>, std::less<>>;
 
 /**
  * Use this for docs, not for finding a specific scheme

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -225,8 +225,6 @@ struct MercurialInputScheme : InputScheme
                 if (settings.warnDirty)
                     warn("Mercurial tree '%s' is unclean", PathFmt{localPath});
 
-                input.attrs.insert_or_assign("ref", chomp(runHg({OS_STR("branch"), OS_STR("-R"), localPath.native()})));
-
                 auto files = tokenizeString<StringSet>(
                     runHg({
                         OS_STR("status"),
@@ -401,6 +399,9 @@ struct MercurialInputScheme : InputScheme
 
         auto storePath = fetchToStore(settings, store, input);
         auto accessor = store.requireStoreObjectAccessor(storePath);
+
+        if (!input.getRev())
+            accessor->fingerprint = store.queryPathInfo(storePath)->narHash.to_string(HashFormat::SRI, true);
 
         accessor->setPathDisplay("«" + input.to_string() + "»");
 

--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -98,6 +98,21 @@ TEST(parseFlakeRef, GitArchiveInput)
     }
 }
 
+TEST(parseFlakeRef, GitArchiveInputKnownSchemeBadURLDoesNotFallBackToPath)
+{
+    experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
+
+    fetchers::Settings fetchSettings;
+
+    EXPECT_THROW(parseFlakeRef(fetchSettings, "github://git.example.org/owner/repo/main"), Error);
+    EXPECT_THROW(parseFlakeRef(fetchSettings, "codeberg://git.example.org/owner/repo?ref=main"), Error);
+    EXPECT_THROW(parseFlakeRef(fetchSettings, "github://git.example.org/owner/repo?host=other.example.org"), Error);
+    EXPECT_THROW(parseFlakeRef(fetchSettings, "cgit://git.example.org?ref=main"), Error);
+    EXPECT_THROW(parseFlakeRef(fetchSettings, "cgit:///repo?ref=main"), Error);
+    EXPECT_THROW(parseFlakeRef(fetchSettings, "gitea:///owner/repo?ref=main"), Error);
+    EXPECT_THROW(parseFlakeRef(fetchSettings, "forgejo:///owner/repo?ref=main"), Error);
+}
+
 struct InputFromURLTestCase
 {
     std::string url;
@@ -255,6 +270,54 @@ INSTANTIATE_TEST_SUITE_P(
                 },
             .description = "github_ref_slashes_in_path_everywhere",
             .expectedUrl = "github:ownerB/repoA/branchC",
+        },
+        InputFromURLTestCase{
+            .url = "github://github.com/owner/repo?ref=main",
+            .attrs =
+                {
+                    {"type", Attr("github")},
+                    {"owner", Attr("owner")},
+                    {"repo", Attr("repo")},
+                    {"ref", Attr("main")},
+                },
+            .description = "github_default_authority_canonicalizes_to_legacy_path_ref",
+            .expectedUrl = "github:owner/repo/main",
+        },
+        InputFromURLTestCase{
+            .url = "gitlab://gitlab.com/org/repo?ref=main",
+            .attrs =
+                {
+                    {"type", Attr("gitlab")},
+                    {"owner", Attr("org")},
+                    {"repo", Attr("repo")},
+                    {"ref", Attr("main")},
+                },
+            .description = "gitlab_default_authority_canonicalizes_to_legacy_path_ref",
+            .expectedUrl = "gitlab:org/repo/main",
+        },
+        InputFromURLTestCase{
+            .url = "sourcehut://git.sr.ht/~user/repo?ref=main",
+            .attrs =
+                {
+                    {"type", Attr("sourcehut")},
+                    {"owner", Attr("~user")},
+                    {"repo", Attr("repo")},
+                    {"ref", Attr("main")},
+                },
+            .description = "sourcehut_default_authority_canonicalizes_to_legacy_path_ref",
+            .expectedUrl = "sourcehut:~user/repo/main",
+        },
+        InputFromURLTestCase{
+            .url = "bitbucket://bitbucket.org/workspace/repo?ref=main",
+            .attrs =
+                {
+                    {"type", Attr("bitbucket")},
+                    {"owner", Attr("workspace")},
+                    {"repo", Attr("repo")},
+                    {"ref", Attr("main")},
+                },
+            .description = "bitbucket_default_authority_canonicalizes_to_shorthand_query_ref",
+            .expectedUrl = "bitbucket:workspace/repo?ref=main",
         },
         InputFromURLTestCase{
             // FIXME: Subgroups in gitlab URLs are busted. This double-encoding

--- a/src/libflake-tests/url-name.cc
+++ b/src/libflake-tests/url-name.cc
@@ -42,6 +42,13 @@ TEST(getNameFromURL, getNameFromURL)
     ASSERT_EQ(getNameFromURL(parseURL("sourcehut:NixOS/nix")), "nix");
     ASSERT_EQ(getNameFromURL(parseURL("sourcehut:cachix/devenv/main#packages.x86_64-linux.default")), "devenv");
 
+    ASSERT_EQ(getNameFromURL(parseURL("codeberg:forgejo/forgejo?ref=v1.22.0")), "forgejo");
+    ASSERT_EQ(getNameFromURL(parseURL("forgejo://git.example.org/owner/project?ref=main")), "project");
+    ASSERT_EQ(getNameFromURL(parseURL("gitea://git.example.org/owner/project?ref=main")), "project");
+    ASSERT_EQ(
+        getNameFromURL(parseURL("cgit://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git?ref=master")),
+        "linux.git");
+
     ASSERT_EQ(getNameFromURL(parseURL("git://github.com/edolstra/dwarffs")), "dwarffs");
     ASSERT_EQ(getNameFromURL(parseURL("git://github.com/edolstra/nix-warez?dir=blender")), "blender");
     ASSERT_EQ(getNameFromURL(parseURL("git+file:///home/user/project")), "project");

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -248,8 +248,16 @@ std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
     const std::optional<std::filesystem::path> & baseDir,
     bool isFlake)
 {
+    ParsedURL parsed;
     try {
-        auto parsed = parseURL(url, /*lenient=*/true);
+        parsed = parseURL(url, /*lenient=*/true);
+    } catch (BadURL &) {
+        return std::nullopt;
+    }
+
+    const bool hasInputScheme = fetchers::getAllInputSchemes().contains(parsed.scheme);
+
+    try {
         if (baseDir && (parsed.scheme == "path" || parsed.scheme == "git+file")) {
             /* Here we know that the path must not contain encoded '/' or NUL bytes. */
             auto path = urlPathToPath(parsed.path);
@@ -258,6 +266,8 @@ std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
         }
         return fromParsedURL(fetchSettings, std::move(parsed), isFlake);
     } catch (BadURL &) {
+        if (hasInputScheme)
+            throw;
         return std::nullopt;
     }
 }

--- a/src/libflake/url-name.cc
+++ b/src/libflake/url-name.cc
@@ -1,6 +1,7 @@
 #include <regex>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "nix/flake/url-name.hh"
 #include "nix/util/strings.hh"
@@ -13,8 +14,7 @@ static const std::regex
     lastAttributeRegex("^((?:" + attributeNamePattern + "\\.)*)(" + attributeNamePattern + ")(\\^.*)?$");
 static const std::string pathSegmentPattern("[a-zA-Z0-9_-]+");
 static const std::regex lastPathSegmentRegex(".*/(" + pathSegmentPattern + ")");
-static const std::regex secondPathSegmentRegex("(?:" + pathSegmentPattern + ")/(" + pathSegmentPattern + ")(?:/.*)?");
-static const std::regex gitProviderRegex("github|gitlab|sourcehut");
+static const std::regex gitProviderRegex("github|gitlab|sourcehut|codeberg|gitea|forgejo|cgit|bitbucket");
 static const std::regex gitSchemeRegex("git($|\\+.*)");
 
 std::optional<std::string> getNameFromURL(const ParsedURL & url)
@@ -31,14 +31,30 @@ std::optional<std::string> getNameFromURL(const ParsedURL & url)
         return match.str(2);
     }
 
+    /* If this is a github/gitlab/sourcehut/codeberg/gitea/forgejo/cgit/bitbucket flake, use the repo name.
+       Legacy path-ref shorthand stores owner/repo/ref as path segments, while
+       authority refs and GitLab refs that use query ref/rev reserve all path
+       segments for the repository path. */
+    if (std::regex_match(url.scheme, gitProviderRegex)) {
+        auto segments = url.pathSegments(/*skipEmpty=*/true) | std::ranges::to<std::vector<std::string>>();
+        if (std::ranges::empty(segments))
+            return {};
+
+        auto hasAuthorityHost = url.authority.has_value() && !url.authority->host.empty();
+        auto hasQueryRefOrRev = url.query.count("ref") > 0 || url.query.count("rev") > 0;
+        if (hasAuthorityHost || ((url.scheme == "gitlab" || url.scheme == "cgit") && hasQueryRefOrRev))
+            return std::string{segments.back()};
+
+        if (segments.size() >= 2)
+            return std::string{segments[1]};
+
+        return std::string{segments.back()};
+    }
+
     /* This is not right, because special chars like slashes within the
        path fragments should be percent encoded, but I don't think any
        of the regexes above care. */
     auto path = concatStringsSep("/", url.path);
-
-    /* If this is a github/gitlab/sourcehut flake, use the repo name */
-    if (std::regex_match(url.scheme, gitProviderRegex) && std::regex_match(path, match, secondPathSegmentRegex))
-        return match.str(1);
 
     /* If it is a regular git flake, use the directory name */
     if (std::regex_match(url.scheme, gitSchemeRegex) && std::regex_match(path, match, lastPathSegmentRegex))

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -312,22 +312,25 @@ Currently the `type` attribute can be one of the following:
   The URL syntax for `github` flakes is:
 
   ```
-  github:<owner>/<repo>(/<rev-or-ref>)?(\?<params>)?
+  github:<owner>/<repo>(\?<params>)?
+  github://<host>/<owner>/<repo>(\?<params>)?
   ```
 
-  `<rev-or-ref>` specifies the name of a branch or tag (`ref`), or a
-  commit hash (`rev`). Note that unlike Git, GitHub allows fetching by
-  commit hash without specifying a branch or tag.
+  Branch or tag names are specified with `ref`; commit hashes are specified
+  with `rev`. Note that unlike Git, GitHub allows fetching by commit hash
+  without specifying a branch or tag. The old path form
+  `github:<owner>/<repo>/<rev-or-ref>` is still accepted for compatibility,
+  but new URLs should use `?ref=` or `?rev=`.
 
-  You can also specify `host` as a parameter, to point to a custom GitHub
-  Enterprise server.
+  You can also specify a custom GitHub Enterprise server as the URL authority.
+  The older `host` query parameter is still accepted for compatibility.
 
   Some examples:
 
   * `github:edolstra/dwarffs`
-  * `github:edolstra/dwarffs/unstable`
-  * `github:edolstra/dwarffs/d3f2baba8f425779026c6ec04021b2e927f61e31`
-  * `github:internal/project?host=company-github.example.org`
+  * `github:edolstra/dwarffs?ref=unstable`
+  * `github:edolstra/dwarffs?rev=d3f2baba8f425779026c6ec04021b2e927f61e31`
+  * `github://company-github.example.org/internal/project`
 
 * `gitlab`: Similar to `github`, is a more efficient way to fetch
   GitLab repositories. The following attributes are required:
@@ -340,25 +343,33 @@ Currently the `type` attribute can be one of the following:
 
   The URL syntax for `gitlab` flakes is:
 
-  `gitlab:<owner>/<repo>(/<rev-or-ref>)?(\?<params>)?`
+  ```
+  gitlab:<owner-or-namespace>/<repo>(\?<params>)?
+  gitlab://<host>/<owner-or-namespace>/<repo>(\?<params>)?
+  ```
 
-  `<rev-or-ref>` works the same as `github`. Either a branch or tag name
-  (`ref`), or a commit hash (`rev`) can be specified.
+  Branch or tag names are specified with `ref`; commit hashes are specified
+  with `rev`. The old path form `gitlab:<owner>/<repo>/<rev-or-ref>` is still
+  accepted for compatibility when no URL authority and no `ref`/`rev` query
+  parameter are present.
 
-  Since GitLab allows for self-hosting, you can specify `host` as
-  a parameter, to point to any instances other than `gitlab.com`.
+  Since GitLab allows for self-hosting, you can specify instances other than
+  `gitlab.com` as the URL authority. The older `host` query parameter is still
+  accepted for compatibility.
 
   Some examples:
 
   * `gitlab:veloren/veloren`
-  * `gitlab:veloren/veloren/master`
-  * `gitlab:veloren/veloren/80a4d7f13492d916e47d6195be23acae8001985a`
-  * `gitlab:openldap/openldap?host=git.openldap.org`
+  * `gitlab:veloren/veloren?ref=master`
+  * `gitlab:veloren/veloren?rev=80a4d7f13492d916e47d6195be23acae8001985a`
+  * `gitlab://git.openldap.org/openldap/openldap`
 
-  When accessing a project in a (nested) subgroup, make sure to URL-encode any
-  slashes, i.e. replace `/` with `%2F`:
+  Nested GitLab groups can be written directly in the path when using the
+  URL-authority form, or when using a `ref`/`rev` query parameter:
 
-  * `gitlab:veloren%2Fdev/rfcs`
+  * `gitlab://gitlab.com/veloren/dev/rfcs`
+  * `gitlab:veloren/dev/rfcs?ref=main`
+  * `gitlab://gitlab.example.org/org/group/subgroup/project?ref=main`
 
 * `sourcehut`: Similar to `github`, is a more efficient way to fetch
   SourceHut repositories. The following attributes are required:
@@ -371,13 +382,18 @@ Currently the `type` attribute can be one of the following:
 
   The URL syntax for `sourcehut` flakes is:
 
-  `sourcehut:<owner>/<repo>(/<rev-or-ref>)?(\?<params>)?`
+  ```
+  sourcehut:<owner>/<repo>(\?<params>)?
+  sourcehut://<host>/<owner>/<repo>(\?<params>)?
+  ```
 
-  `<rev-or-ref>` works the same as `github`. Either a branch or tag name
-  (`ref`), or a commit hash (`rev`) can be specified.
+  Branch or tag names are specified with `ref`; commit hashes are specified
+  with `rev`. The old path form `sourcehut:<owner>/<repo>/<rev-or-ref>` is
+  still accepted for compatibility.
 
-  Since SourceHut allows for self-hosting, you can specify `host` as
-  a parameter, to point to any instances other than `git.sr.ht`.
+  Since SourceHut allows for self-hosting, you can specify instances other than
+  `git.sr.ht` as the URL authority. The older `host` query parameter is still
+  accepted for compatibility.
 
   Currently, `ref` name resolution only works for Git repositories.
   You can refer to Mercurial repositories by simply changing `host` to
@@ -387,10 +403,123 @@ Currently the `type` attribute can be one of the following:
   Some examples:
 
   * `sourcehut:~misterio/nix-colors`
-  * `sourcehut:~misterio/nix-colors/main`
-  * `sourcehut:~misterio/nix-colors?host=git.example.org`
-  * `sourcehut:~misterio/nix-colors/182b4b8709b8ffe4e9774a4c5d6877bf6bb9a21c`
-  * `sourcehut:~misterio/nix-colors/21c1a380a6915d890d408e9f22203436a35bb2de?host=hg.sr.ht`
+  * `sourcehut:~misterio/nix-colors?ref=main`
+  * `sourcehut://git.example.org/~misterio/nix-colors`
+  * `sourcehut:~misterio/nix-colors?rev=182b4b8709b8ffe4e9774a4c5d6877bf6bb9a21c`
+  * `sourcehut://hg.sr.ht/~misterio/nix-colors?rev=21c1a380a6915d890d408e9f22203436a35bb2de`
+
+* `codeberg`: Similar to `github`, is a more efficient way to fetch
+  Codeberg repositories through the Gitea-compatible archive fetcher.
+  The following attributes are required:
+
+  * `owner`: The owner of the repository.
+
+  * `repo`: The name of the repository.
+
+  These are downloaded as tarball archives.
+
+  The URL syntax for `codeberg` flakes is:
+
+  ```
+  codeberg:<owner>/<repo>(\?<params>)?
+  ```
+
+  Branch or tag names are specified with `ref`; commit hashes are specified
+  with `rev`. The old path form `codeberg:<owner>/<repo>/<rev-or-ref>` is
+  still accepted for compatibility.
+
+  The `codeberg` scheme always targets `codeberg.org`. For another
+  Gitea/Forgejo-compatible host, use the `gitea` or `forgejo` URL authority
+  schemes, for example `gitea://git.example.org/owner/repo?ref=main` or
+  `forgejo://git.example.org/owner/repo?ref=main`.
+
+  Some examples:
+
+  * `codeberg:forgejo/forgejo`
+  * `codeberg:forgejo/forgejo?ref=v1.22.0`
+  * `gitea://git.example.org/internal/project?ref=main`
+
+* `gitea` and `forgejo`: Similar to `codeberg`, these are more efficient
+  ways to fetch repositories from Gitea-compatible and Forgejo-compatible
+  hosts. The following attributes are required:
+
+  * `host`: The Gitea or Forgejo instance host.
+
+  * `owner`: The owner of the repository.
+
+  * `repo`: The name of the repository.
+
+  These are downloaded as tarball archives.
+
+  The URL syntax for `gitea` and `forgejo` flakes is:
+
+  ```
+  gitea://<host>/<owner>/<repo>(\?<params>)?
+  forgejo://<host>/<owner>/<repo>(\?<params>)?
+  ```
+
+  Branch or tag names are specified with `ref`; commit hashes are specified
+  with `rev`. The repository host must be written as the URL authority.
+
+  Some examples:
+
+  * `gitea://git.example.org/owner/repo`
+  * `gitea://git.example.org/owner/repo?ref=main`
+  * `forgejo://git.example.org/owner/repo?rev=d3f2baba8f425779026c6ec04021b2e927f61e31`
+
+* `cgit`: Similar to `sourcehut`, this is a more efficient way to fetch
+  repositories from cgit hosts. The following attributes are required:
+
+  * `host`: The cgit instance host.
+
+  * `owner`: The repository path prefix, if any.
+
+  * `repo`: The final repository path segment.
+
+  These are downloaded as tarball archives.
+
+  The URL syntax for `cgit` flakes is:
+
+  ```
+  cgit://<host>/<repo>(\?<params>)?
+  cgit://<host>/<path-prefix>/<repo>(\?<params>)?
+  ```
+
+  Branch or tag names are specified with `ref`; commit hashes are specified
+  with `rev`. The repository host must be written as the URL authority.
+  Repository paths may span multiple path segments.
+
+  Some examples:
+
+  * `cgit://git.qyliss.net/pr-tracker?ref=main`
+  * `cgit://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git?ref=master`
+  * `cgit://git.savannah.gnu.org/cgit/hello.git?rev=d3f2baba8f425779026c6ec04021b2e927f61e31`
+
+* `bitbucket`: Similar to `github`, is a more efficient way to fetch
+  Bitbucket Cloud repositories through archive downloads. The following
+  attributes are required:
+
+  * `owner`: The workspace containing the repository.
+
+  * `repo`: The repository slug.
+
+  These are downloaded as tarball archives.
+
+  The URL syntax for `bitbucket` flakes is:
+
+  ```
+  bitbucket:<owner>/<repo>(\?<params>)?
+  bitbucket://<host>/<owner>/<repo>(\?<params>)?
+  ```
+
+  Branch or tag names are specified with `ref`; commit hashes are specified
+  with `rev`. The old path form `bitbucket:<owner>/<repo>/<rev-or-ref>` is
+  still accepted for compatibility.
+
+  Some examples:
+
+  * `bitbucket:workspace/project`
+  * `bitbucket:workspace/project?ref=main`
 
 # Flake format
 


### PR DESCRIPTION
Accept git forge flake refs in the URL-authority form from issue #6304.

The implementation supports RFC 3986-style authority for forge hosts and uses query refs for authority/nested forms, but it intentionally preserves legacy path-ref canonicalization for some default-host forge schemes. Therefore it does not yet fully implement the stricter proposal that refs and revisions should be removed from URL paths across all schemes.

Co-Authored-By: Tilman Andre Mix <tilmanmixyz@proton.me>
Co-Authored-By: Sefa Eyeoglu <contact@scrumplex.net>
Co-Authored-By: Seth Flynn <getchoo@tuta.io>

Closes: #14064 #7970 #11135 #11467

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This attempts to move towards the input ref proposal in #6304, previous 

## Context

Issues #14064 #7970 #11135 #11467. Move scheme-specific behaviour to a forge instance table, with default host, authority support, path and ref syntax. Tries to not duplicate to much logic. The change isn't really invasive since it preserves old behaviour.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
