### PR TITLE
C API: add logger bindings

### DIFF
--- a/src/libutil-c/nix_api_util.cc
+++ b/src/libutil-c/nix_api_util.cc
@@ -1,13 +1,141 @@
 #include "nix_api_util.h"
 #include "nix/util/config-global.hh"
 #include "nix/util/error.hh"
+#include "nix/util/logging.hh"
 #include "nix_api_util_internal.h"
 #include "nix/util/util.hh"
 
+#include <boost/container/small_vector.hpp>
+
 #include <cxxabi.h>
+#include <sstream>
 #include <typeinfo>
 
 #include "nix_api_util_config.h"
+
+namespace {
+
+void collectFields(
+    boost::container::small_vector<nix_logger_field, 4> & storage,
+    boost::container::small_vector<const nix_logger_field *, 4> & cfields,
+    const nix::Logger::Fields & fields)
+{
+    storage.reserve(fields.size());
+    for (const auto & field : fields) {
+        nix_logger_field_type t;
+        nix_logger_field_value v{};
+        if (field.type == nix::Logger::Field::tString) {
+            t = NIX_LOGGER_FIELD_TYPE_STR;
+
+            nix_logger_field_value_string str;
+            str.value = field.s.data();
+            str.len = field.s.size();
+
+            v.str = str;
+        } else if (field.type == nix::Logger::Field::tInt) {
+            t = NIX_LOGGER_FIELD_TYPE_INT;
+            v.i = field.i;
+        } else {
+            nix::unreachable();
+        }
+
+        storage.push_back(
+            nix_logger_field{
+                .type = t,
+                .value = v,
+            });
+    }
+
+    cfields.reserve(storage.size());
+    for (const auto & f : storage)
+        cfields.push_back(&f);
+}
+
+/**
+ * Logger that delegates every supported method to a C callback vtable.
+ */
+class CallbackLogger final : public nix::Logger
+{
+public:
+    nix_logger vtable;
+    void * userdata;
+
+    CallbackLogger(const nix_logger & vtable, void * userdata)
+        : vtable(vtable)
+        , userdata(userdata)
+    {
+    }
+
+    ~CallbackLogger() override
+    {
+        if (vtable.destroy)
+            vtable.destroy(userdata);
+    }
+
+    void log(nix::Verbosity lvl, std::string_view s) override
+    {
+        if (!vtable.log)
+            return;
+        vtable.log(userdata, static_cast<nix_verbosity>(lvl), s.data(), s.size());
+    }
+
+    void logEI(const nix::ErrorInfo & ei) override
+    {
+        if (!vtable.log)
+            return;
+        std::ostringstream oss;
+        nix::showErrorInfo(oss, ei, nix::loggerSettings.showTrace.get());
+        auto formatted = oss.str();
+        vtable.log(userdata, static_cast<nix_verbosity>(ei.level), formatted.data(), formatted.size());
+    }
+
+    void startActivity(
+        nix::ActivityId act,
+        nix::Verbosity lvl,
+        nix::ActivityType type,
+        const std::string & s,
+        const Fields & fields,
+        nix::ActivityId parent) override
+    {
+        if (!vtable.start_activity)
+            return;
+
+        boost::container::small_vector<nix_logger_field, 4> storage;
+        boost::container::small_vector<const nix_logger_field *, 4> cfields;
+        collectFields(storage, cfields, fields);
+
+        vtable.start_activity(
+            userdata,
+            act,
+            static_cast<nix_verbosity>(lvl),
+            static_cast<nix_activity_type>(type),
+            s.c_str(),
+            s.size(),
+            cfields.data(),
+            cfields.size(),
+            parent);
+    }
+
+    void stopActivity(nix::ActivityId act) override
+    {
+        if (vtable.stop_activity)
+            vtable.stop_activity(userdata, act);
+    }
+
+    void result(nix::ActivityId act, nix::ResultType type, const Fields & fields) override
+    {
+        if (!vtable.result)
+            return;
+
+        boost::container::small_vector<nix_logger_field, 4> storage;
+        boost::container::small_vector<const nix_logger_field *, 4> cfields;
+        collectFields(storage, cfields, fields);
+
+        vtable.result(userdata, act, static_cast<nix_result_type>(type), cfields.data(), cfields.size());
+    }
+};
+
+} // namespace
 
 extern "C" {
 
@@ -171,6 +299,18 @@ nix_err nix_set_verbosity(nix_c_context * context, nix_verbosity level)
         return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "Invalid verbosity level");
     try {
         nix::verbosity = static_cast<nix::Verbosity>(level);
+    }
+    NIXC_CATCH_ERRS
+}
+
+nix_err nix_set_logger(nix_c_context * context, const nix_logger * vtable, void * userdata)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    if (vtable == nullptr)
+        return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "logger vtable is null");
+    try {
+        nix::logger = std::make_unique<CallbackLogger>(*vtable, userdata);
     }
     NIXC_CATCH_ERRS
 }

--- a/src/libutil-c/nix_api_util.h
+++ b/src/libutil-c/nix_api_util.h
@@ -14,6 +14,8 @@
  * Also contains error handling utilities
  */
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -362,6 +364,220 @@ void nix_clear_err(nix_c_context * context);
  * @param[in] level Verbosity level
  */
 nix_err nix_set_verbosity(nix_c_context * context, nix_verbosity level);
+
+/**
+ *  @}
+ */
+
+/** @defgroup logger Logger
+ * @brief Capture Nix log output via C callbacks
+ *
+ * The functions in this section let an embedder replace Nix's global
+ * logger with one driven by user-supplied callbacks. This is the
+ * intended way to surface `builtins.trace` calls, builder output,
+ * warnings, and other diagnostic messages produced by libnixutil,
+ * libnixstore and libnixexpr to a host language.
+ *  @{
+ */
+
+/**
+ * @brief Activity identifier.
+ *
+ * `0` means "no activity" (used as the parent of top-level activities).
+ */
+typedef uint64_t nix_activity_id;
+
+/**
+ * @brief Activity type.
+ *
+ * @note Must be kept in sync with `nix::ActivityType`.
+ */
+enum nix_activity_type {
+    NIX_ACTIVITY_TYPE_NONE = 0,
+    NIX_ACTIVITY_TYPE_COPY_PATH = 100,
+    NIX_ACTIVITY_TYPE_FILE_TRANSFER = 101,
+    NIX_ACTIVITY_TYPE_REALISE = 102,
+    NIX_ACTIVITY_TYPE_COPY_PATHS = 103,
+    NIX_ACTIVITY_TYPE_BUILDS = 104,
+    NIX_ACTIVITY_TYPE_BUILD = 105,
+    NIX_ACTIVITY_TYPE_OPTIMISE_STORE = 106,
+    NIX_ACTIVITY_TYPE_VERIFY_PATHS = 107,
+    NIX_ACTIVITY_TYPE_SUBSTITUTE = 108,
+    NIX_ACTIVITY_TYPE_QUERY_PATH_INFO = 109,
+    NIX_ACTIVITY_TYPE_POST_BUILD_HOOK = 110,
+    NIX_ACTIVITY_TYPE_BUILD_WAITING = 111,
+    NIX_ACTIVITY_TYPE_FETCH_TREE = 112,
+};
+typedef enum nix_activity_type nix_activity_type;
+
+/**
+ * @brief Activity result type.
+ *
+ * @note Must be kept in sync with `nix::ResultType`.
+ */
+enum nix_result_type {
+    NIX_RESULT_TYPE_FILE_LINKED = 100,
+    NIX_RESULT_TYPE_BUILD_LOG_LINE = 101,
+    NIX_RESULT_TYPE_UNTRUSTED_PATH = 102,
+    NIX_RESULT_TYPE_CORRUPTED_PATH = 103,
+    NIX_RESULT_TYPE_SET_PHASE = 104,
+    NIX_RESULT_TYPE_PROGRESS = 105,
+    NIX_RESULT_TYPE_SET_EXPECTED = 106,
+    NIX_RESULT_TYPE_POST_BUILD_LOG_LINE = 107,
+    NIX_RESULT_TYPE_FETCH_STATUS = 108,
+    NIX_RESULT_TYPE_HASH_MISMATCH = 109,
+    NIX_RESULT_TYPE_BUILD_RESULT = 110,
+};
+typedef enum nix_result_type nix_result_type;
+
+/**
+ * @brief Logger field type.
+ *
+ * @note Must be kept in sync with `nix::Logger::Field::type`.
+ */
+enum nix_logger_field_type {
+    NIX_LOGGER_FIELD_TYPE_INT = 0,
+    NIX_LOGGER_FIELD_TYPE_STR = 1,
+};
+typedef enum nix_logger_field_type nix_logger_field_type;
+
+/**
+ * @brief String value for a logger field.
+ */
+struct nix_logger_field_value_string
+{
+    const char * value;
+    unsigned int len;
+};
+typedef struct nix_logger_field_value_string nix_logger_field_value_string;
+
+/**
+ * @brief Value held inside of a logger field.
+ */
+union nix_logger_field_value
+{
+    uint64_t i;
+    nix_logger_field_value_string str;
+};
+typedef union nix_logger_field_value nix_logger_field_value;
+
+/**
+ * @brief Logger field.
+ */
+struct nix_logger_field
+{
+    nix_logger_field_type type;
+    nix_logger_field_value value;
+};
+typedef struct nix_logger_field nix_logger_field;
+
+/**
+ * @brief Vtable of callbacks for a custom logger.
+ *
+ * Any field may be NULL, missing callbacks are treated as no-ops.
+ *
+ * @warning Callbacks may be invoked concurrently from multiple threads
+ * (notably during parallel builds). Implementations are responsible
+ * for their own synchronization.
+ *
+ * @warning Callbacks must not throw exceptions across the C boundary.
+ */
+typedef struct nix_logger
+{
+    /**
+     * @brief Ordinary log message.
+     *
+     * Receives `builtins.trace` output, warnings, errors (after
+     * formatting), and any message produced through the `printError` /
+     * `printInfo` / `debug` / etc. macros in the C++ API.
+     *
+     * @param[in] userdata The user-supplied opaque pointer.
+     * @param[in] level Verbosity level of the message.
+     * @param[in] msg Borrowed message body.
+     * @param[in] n Number of bytes in msg.
+     */
+    void (*log)(void * userdata, nix_verbosity level, const char * msg, unsigned int n);
+
+    /**
+     * @brief An activity (e.g. a build, a substitution) has started.
+     *
+     * @param[in] userdata The user-supplied opaque pointer.
+     * @param[in] activity_id Unique identifier for the new activity.
+     * @param[in] level Verbosity level associated with this activity.
+     * @param[in] type Activity type. See ::nix_activity_type.
+     * @param[in] s Borrowed description.
+     * @param[in] ns Number of bytes in s.
+     * @param[in] field Borrowed list of fields.
+     * @param[in] nf Number of fields.
+     * @param[in] parent_id ID of the parent activity, or `0` if none.
+     */
+    void (*start_activity)(
+        void * userdata,
+        nix_activity_id activity_id,
+        nix_verbosity level,
+        nix_activity_type type,
+        const char * s,
+        unsigned int ns,
+        const nix_logger_field ** fields,
+        unsigned int nf,
+        nix_activity_id parent_id);
+
+    /**
+     * @brief An activity has stopped.
+     */
+    void (*stop_activity)(void * userdata, nix_activity_id activity_id);
+
+    /**
+     * @brief An activity reported a result.
+     *
+     * Covers in particular:
+     * - ::NIX_RESULT_TYPE_BUILD_LOG_LINE - a line of builder output
+     * - ::NIX_RESULT_TYPE_POST_BUILD_LOG_LINE - a line of post-build hook output
+     * - ::NIX_RESULT_TYPE_SET_PHASE - current build phase
+     * - ::NIX_RESULT_TYPE_PROGRESS - progress in an activity
+     *
+     * @param[in] userdata The user-supplied opaque pointer.
+     * @param[in] activity_id The activity reporting this result.
+     * @param[in] type The result type.
+     * @param[in] field Borrowed list of fields.
+     * @param[in] n Number of fields.
+     */
+    void (*result)(
+        void * userdata,
+        nix_activity_id activity_id,
+        nix_result_type type,
+        const nix_logger_field ** fields,
+        unsigned int n);
+
+    /**
+     * @brief Called when the logger is destroyed.
+     *
+     * Invoked when the logger is replaced by a subsequent call to
+     * ::nix_set_logger, or when Nix's global logger is torn
+     * down at program exit. Use this to free resources owned by
+     * `userdata`.
+     */
+    void (*destroy)(void * userdata);
+} nix_logger;
+
+/**
+ * @brief Replace the global Nix logger with one driven by C callbacks.
+ *
+ * After this call, log messages, activities and supported results
+ * produced anywhere in Nix are routed to the supplied callbacks.
+ *
+ * The vtable is copied; only the function pointers it contains need to
+ * remain valid for the lifetime of the logger. `userdata` is borrowed
+ * and passed unmodified to every callback. When the logger is later
+ * destroyed (by another call to this function, or at program shutdown),
+ * `vtable->destroy(userdata)` is invoked if non-NULL.
+ *
+ * @param[out] context Optional, stores error information.
+ * @param[in] vtable Required, callback vtable.
+ * @param[in] userdata Optional opaque pointer passed to every callback.
+ * @return NIX_OK on success, an error code otherwise.
+ */
+nix_err nix_set_logger(nix_c_context * context, const nix_logger * vtable, void * userdata);
 
 /**
  *  @}

--- a/src/libutil-tests/nix_api_util.cc
+++ b/src/libutil-tests/nix_api_util.cc
@@ -1,4 +1,6 @@
 #include "nix/util/config-global.hh"
+#include "nix/util/args.hh"
+#include "nix/util/logging.hh"
 #include "nix_api_util.h"
 #include "nix/util/tests/nix_api_util.hh"
 #include "nix/util/tests/string_callback.hh"
@@ -6,6 +8,8 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "util-tests-config.hh"
 
@@ -74,6 +78,208 @@ TEST_F(nix_api_util_context, nix_err_code)
     ASSERT_EQ(nix_err_code(ctx), NIX_OK);
     nix_set_err_msg(ctx, NIX_ERR_UNKNOWN, "unknown test error");
     ASSERT_EQ(nix_err_code(ctx), NIX_ERR_UNKNOWN);
+}
+
+struct CapturedField
+{
+    nix_logger_field_type type;
+    uint64_t i = 0;
+    std::string s;
+};
+
+struct CapturedResult
+{
+    nix_activity_id id;
+    nix_result_type type;
+    std::vector<CapturedField> fields;
+};
+
+struct CapturedStart
+{
+    nix_activity_id id;
+    nix_verbosity level;
+    nix_activity_type type;
+    std::string msg;
+    std::vector<CapturedField> fields;
+    nix_activity_id parent;
+};
+
+struct CaptureCLogger
+{
+    std::vector<std::pair<nix_verbosity, std::string>> logs;
+    std::vector<CapturedStart> starts;
+    std::vector<nix_activity_id> stops;
+    std::vector<CapturedResult> results;
+    bool destroyed = false;
+};
+
+static void capture_log(void * userdata, nix_verbosity level, const char * msg, unsigned int n)
+{
+    auto * c = static_cast<CaptureCLogger *>(userdata);
+    c->logs.emplace_back(level, std::string(msg, n));
+}
+
+static void capture_start_activity(
+    void * userdata,
+    nix_activity_id id,
+    nix_verbosity level,
+    nix_activity_type type,
+    const char * s,
+    unsigned int ns,
+    const nix_logger_field ** fields,
+    unsigned int nf,
+    nix_activity_id parent)
+{
+    auto * c = static_cast<CaptureCLogger *>(userdata);
+
+    std::vector<CapturedField> vfields;
+    for (unsigned int i = 0; i < nf; ++i) {
+        const nix_logger_field * f = fields[i];
+        CapturedField cf{f->type};
+        if (f->type == NIX_LOGGER_FIELD_TYPE_INT)
+            cf.i = f->value.i;
+        else
+            cf.s = std::string(f->value.str.value, f->value.str.len);
+        vfields.push_back(std::move(cf));
+    }
+
+    c->starts.emplace_back(id, level, type, std::string(s, ns), vfields, parent);
+}
+
+static void capture_stop_activity(void * userdata, nix_activity_id id)
+{
+    auto * c = static_cast<CaptureCLogger *>(userdata);
+    c->stops.push_back(id);
+}
+
+static void capture_result(
+    void * userdata, nix_activity_id id, nix_result_type type, const nix_logger_field ** fields, unsigned int n)
+{
+    auto * c = static_cast<CaptureCLogger *>(userdata);
+    CapturedResult r{id, type, {}};
+    for (unsigned int i = 0; i < n; ++i) {
+        const nix_logger_field * f = fields[i];
+        CapturedField cf{f->type};
+        if (f->type == NIX_LOGGER_FIELD_TYPE_INT)
+            cf.i = f->value.i;
+        else
+            cf.s = std::string(f->value.str.value, f->value.str.len);
+        r.fields.push_back(std::move(cf));
+    }
+    c->results.push_back(std::move(r));
+}
+
+static void capture_destroy(void * userdata)
+{
+    auto * c = static_cast<CaptureCLogger *>(userdata);
+    c->destroyed = true;
+}
+
+const nix_logger captureLoggerVtable{
+    .log = capture_log,
+    .start_activity = capture_start_activity,
+    .stop_activity = capture_stop_activity,
+    .result = capture_result,
+    .destroy = capture_destroy,
+};
+
+class CaptureCLogging
+{
+    std::unique_ptr<nix::Logger> oldLogger;
+
+public:
+    CaptureCLogging()
+    {
+        oldLogger = std::move(nix::logger);
+    }
+
+    ~CaptureCLogging()
+    {
+        nix::logger = std::move(oldLogger);
+    }
+};
+
+TEST_F(nix_api_util_context, nix_set_logger_rejects_null_vtable)
+{
+    ASSERT_EQ(nix_set_logger(ctx, nullptr, nullptr), NIX_ERR_UNKNOWN);
+}
+
+TEST_F(nix_api_util_context, nix_set_logger_routes_log_calls)
+{
+    CaptureCLogger capture;
+    // Restore the previous logger before `capture` goes out of scope so
+    // the destroy callback runs while `capture` is still alive.
+    CaptureCLogging restoreLogger;
+
+    ASSERT_EQ(nix_set_logger(ctx, &captureLoggerVtable, &capture), NIX_OK);
+
+    nix::logger->log(nix::lvlInfo, "hello world");
+    nix::logger->warn("be careful");
+
+    ASSERT_EQ(capture.logs.size(), 2u);
+    EXPECT_EQ(capture.logs[0].first, NIX_LVL_INFO);
+    EXPECT_EQ(capture.logs[0].second, "hello world");
+    EXPECT_EQ(capture.logs[1].first, NIX_LVL_WARN);
+    // warn() prefixes "warning: " (with ANSI escapes).
+    EXPECT_NE(capture.logs[1].second.find("be careful"), std::string::npos);
+}
+
+TEST_F(nix_api_util_context, nix_set_logger_routes_activities_and_results)
+{
+    CaptureCLogger capture;
+    CaptureCLogging restoreLogger;
+
+    ASSERT_EQ(nix_set_logger(ctx, &captureLoggerVtable, &capture), NIX_OK);
+
+    nix::ActivityId actId;
+    {
+        nix::Activity act(*nix::logger, nix::lvlInfo, nix::actBuild, "building foo");
+        actId = act.id;
+        nix::logger->result(act.id, nix::resBuildLogLine, nix::Logger::Fields{"line of build output"});
+        act.progress(10, 100);
+    }
+
+    ASSERT_EQ(capture.starts.size(), 1u);
+    EXPECT_EQ(capture.starts[0].id, actId);
+    EXPECT_EQ(capture.starts[0].level, NIX_LVL_INFO);
+    EXPECT_EQ(capture.starts[0].type, NIX_ACTIVITY_TYPE_BUILD);
+    EXPECT_EQ(capture.starts[0].msg, "building foo");
+
+    ASSERT_EQ(capture.results.size(), 2u);
+
+    EXPECT_EQ(capture.results[0].id, actId);
+    EXPECT_EQ(capture.results[0].type, NIX_RESULT_TYPE_BUILD_LOG_LINE);
+    ASSERT_EQ(capture.results[0].fields.size(), 1u);
+    EXPECT_EQ(capture.results[0].fields[0].type, NIX_LOGGER_FIELD_TYPE_STR);
+    EXPECT_EQ(capture.results[0].fields[0].s, "line of build output");
+
+    EXPECT_EQ(capture.results[1].id, actId);
+    EXPECT_EQ(capture.results[1].type, NIX_RESULT_TYPE_PROGRESS);
+    ASSERT_EQ(capture.results[1].fields.size(), 4u);
+    EXPECT_EQ(capture.results[1].fields[0].type, NIX_LOGGER_FIELD_TYPE_INT);
+    EXPECT_EQ(capture.results[1].fields[0].i, 10u);
+    EXPECT_EQ(capture.results[1].fields[1].type, NIX_LOGGER_FIELD_TYPE_INT);
+    EXPECT_EQ(capture.results[1].fields[1].i, 100u);
+
+    ASSERT_EQ(capture.stops.size(), 1u);
+    EXPECT_EQ(capture.stops[0], actId);
+}
+
+TEST_F(nix_api_util_context, nix_set_logger_invokes_destroy_when_replaced)
+{
+    // Both captures must outlive `restoreLogger` so that the logger held
+    // by `nix::logger` at teardown can call destroy on a live capture.
+    CaptureCLogger capture;
+    CaptureCLogger capture2;
+    CaptureCLogging restoreLogger;
+
+    ASSERT_EQ(nix_set_logger(ctx, &captureLoggerVtable, &capture), NIX_OK);
+    EXPECT_FALSE(capture.destroyed);
+
+    // Replacing the logger must fire destroy on the old userdata.
+    ASSERT_EQ(nix_set_logger(ctx, &captureLoggerVtable, &capture2), NIX_OK);
+    EXPECT_TRUE(capture.destroyed);
+    EXPECT_FALSE(capture2.destroyed);
 }
 
 } // namespace nixC


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Closes #11036, upstreaming of https://github.com/DeterminateSystems/nix-src/pull/448

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Having Nix directly use stderr/stdout can cause problems with certain logging libraries in Rust or C. Being able to override the logger so the program integrating Nix via the C API allows for unified logging. I've tested this with Rust and it works great with tracing.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
