### PR TITLE
doc: add documentation to __addErrorContext primop

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1047,7 +1047,35 @@ static void prim_addErrorContext(EvalState & state, const PosIdx pos, Value ** a
 static RegisterPrimOp primop_addErrorContext(
     PrimOp{
         .name = "__addErrorContext",
+        .args = {"context", "value"},
         .arity = 2,
+        .doc = R"(
+            Evaluate *context*, which can be coerced to a string,
+            and append it to any error or stack traces displayed while evaluating *value*.
+            Then return *value*.
+
+            This function is useful for providing helpful context in complex Nix expressions
+            when the evaluation of *value* fails.
+            The additional context is applied when evaluating *value* itself fails,
+            not when attributes or elements of *value* are evaluated.
+
+            For example, the module system from nixpkgs uses this to show
+            the relevant information about the options that were evaluating
+            when an error occurs.
+
+            ```nix-repl
+            nix-repl> addErrorContext "while evaluating foo" (throw "bar")
+            error:
+                   … while evaluating foo
+
+                   … while calling the 'throw' builtin
+                     at «string»:1:56:
+                        1| with builtins; addErrorContext "while evaluating foo" (throw "bar")
+                         |                                                        ^
+
+                   error: bar
+            ```
+        )",
         // The normal trace item is redundant
         .addTrace = false,
         .impl = prim_addErrorContext,


### PR DESCRIPTION
This adds .args and .doc fields to the primop registration for __addErrorContext, making it appear in the builtins reference manual.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

more documentation -> more good

The issue is known since 2017 & I really think this function should be documented as it is helpful for making your own Nix expressions easier to debug.

## Context

<!-- Provide context. Reference open issues if available. -->
fixes #1609

I tried to use a similar documentation format already used on similar "side-effect" wrappers like `warn`.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
