### PR TITLE
config: exclude DeprecatedWarnSetting names from GlobalConfig::toKeyValue()

### DIFF
--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -15,6 +15,13 @@ struct PrimOp;
  * A deprecated bool setting that migrates to a `Setting<Diagnose>`.
  * When set to true, it emits a deprecation warning and sets the target
  * `Setting<Diagnose>` setting to `Warn`.
+ *
+ * It calls `Config::excludeSettingFromKeyValue()` after registration so
+ * that it is excluded from `GlobalConfig::toKeyValue()`. That prevents the
+ * deprecated name from being injected into `NIX_CONFIG` when nix spawns
+ * subprocesses such as post-build-hook scripts and nix repl, which would
+ * cause every nix command in those subprocesses to emit a spurious
+ * deprecation warning even though the user never set the old name.
  */
 class DeprecatedWarnSetting : public BaseSetting<bool>
 {
@@ -34,6 +41,7 @@ public:
         , targetName(targetName)
     {
         options->addSetting(this);
+        options->excludeSettingFromKeyValue(name);
     }
 
     void assign(const bool & v) override;

--- a/src/libutil/configuration.cc
+++ b/src/libutil/configuration.cc
@@ -66,6 +66,13 @@ void Config::addSetting(AbstractSetting * setting)
     }
 }
 
+void Config::excludeSettingFromKeyValue(const std::string & name)
+{
+    auto i = _settings.find(name);
+    assert(i != _settings.end());
+    i->second.excludeFromKeyValue = true;
+}
+
 AbstractConfig::AbstractConfig(StringMap initials)
     : unknownSettings(std::move(initials))
 {
@@ -88,7 +95,8 @@ void AbstractConfig::reapplyUnknownSettings()
 void Config::getSettings(std::map<std::string, SettingInfo> & res, bool overriddenOnly) const
 {
     for (const auto & opt : _settings)
-        if (!opt.second.isAlias && (!overriddenOnly || opt.second.setting->overridden)
+        if (!opt.second.isAlias && !opt.second.excludeFromKeyValue
+            && (!overriddenOnly || opt.second.setting->overridden)
             && experimentalFeatureSettings.isEnabled(opt.second.setting->experimentalFeature))
             res.emplace(opt.first, SettingInfo{opt.second.setting->to_string(), opt.second.setting->description});
 }

--- a/src/libutil/include/nix/util/configuration.hh
+++ b/src/libutil/include/nix/util/configuration.hh
@@ -146,6 +146,13 @@ public:
     {
         bool isAlias;
         AbstractSetting * setting;
+        /**
+         * If true, this setting is excluded from `getSettings()` and
+         * therefore from `GlobalConfig::toKeyValue()` / `NIX_CONFIG`,
+         * but CLI flags are still registered via `convertToArgs()`.
+         * Used by `DeprecatedWarnSetting`.
+         */
+        bool excludeFromKeyValue = false;
     };
 
     using Settings = std::map<std::string, SettingData>;
@@ -161,6 +168,13 @@ public:
     bool set(const std::string & name, const std::string & value) override;
 
     void addSetting(AbstractSetting * setting);
+
+    /**
+     * Exclude a previously-added setting from `getSettings()` and
+     * therefore from `GlobalConfig::toKeyValue()` / `NIX_CONFIG`.
+     * CLI flags (from `convertToArgs()`) are still registered.
+     */
+    void excludeSettingFromKeyValue(const std::string & name);
 
     void getSettings(std::map<std::string, SettingInfo> & res, bool overriddenOnly = false) const override;
 

--- a/tests/functional/short-path-literals.sh
+++ b/tests/functional/short-path-literals.sh
@@ -39,6 +39,23 @@ grepQuiet "relative path literal 'test/file' should be prefixed" "$TEST_ROOT/std
 NIX_CONFIG='warn-short-path-literals = true' nix eval --no-warn-short-path-literals --expr 'test/file' 2>"$TEST_ROOT"/stderr
 grepQuietInverse "relative path literal" "$TEST_ROOT/stderr"
 
+# Test: warn-short-path-literals must NOT appear in NIX_CONFIG injected into
+# post-build-hook subprocesses. If it did, every nix command in the hook would
+# emit a spurious deprecation warning even though the user never set the old name.
+NIX_CONFIG_HOOK_OUT="$TEST_ROOT/nix-config-hook-out"
+NIX_CONFIG_HOOK="$TEST_ROOT/nix-config-hook.sh"
+cat > "$NIX_CONFIG_HOOK" <<EOF
+#!/bin/sh
+printf '%s' "\$NIX_CONFIG" > $NIX_CONFIG_HOOK_OUT
+EOF
+chmod +x "$NIX_CONFIG_HOOK"
+# shellcheck disable=SC2016
+nix build --no-sandbox \
+    --option post-build-hook "$NIX_CONFIG_HOOK" \
+    --expr "derivation { name = \"t\"; system = \"$system\"; builder = \"$busybox\"; args = [\"sh\" \"-c\" \"echo > \$out\"]; }"
+grepQuietInverse "warn-short-path-literals" "$NIX_CONFIG_HOOK_OUT" \
+    || fail "warn-short-path-literals must not appear in NIX_CONFIG passed to post-build-hook"
+
 # Tests for NIX_CONFIG and setting precedence
 
 # Test: New setting via NIX_CONFIG


### PR DESCRIPTION
Fixes #15819.

Since nix 2.34 (commit `5184f844b`), every `nix` command run inside a post-build-hook emits a spurious deprecation warning:

```
warning: 'warn-short-path-literals' is deprecated, use 'lint-short-path-literals = ignore' instead
```

even when the user never set `warn-short-path-literals`. The cause: `DeprecatedWarnSetting` registers the deprecated name via `addSetting()` with `isAlias = false`, making it a primary setting. `Config::getSettings()` skips aliases but includes primary settings. `GlobalConfig::toKeyValue()` calls `getSettings()` and serialises the result into `NIX_CONFIG`. The daemon injects this into every post-build-hook subprocess environment (`derivation-goal.cc`) and into `nix repl` subprocesses (`repl.cc`). Any `nix` command in the hook reads `NIX_CONFIG`, hits `DeprecatedWarnSetting::assign()`, and fires the warning.

**Fix:** add an `excludeFromKeyValue` flag to `Config::SettingData`. When set, `getSettings()` skips the setting, removing it from `GlobalConfig::toKeyValue()` / `NIX_CONFIG`. A new `Config::excludeSettingFromKeyValue()` method (which asserts the name exists, to catch misuse) sets the flag. `DeprecatedWarnSetting` calls it immediately after `addSetting()`.

This is preferable to making the setting a true alias (`isAlias = true`), which would also drop the `--warn-short-path-literals` / `--no-warn-short-path-literals` CLI flags since `convertToArgs()` skips aliases. With `excludeFromKeyValue`, reading the setting from `nix.conf` / `NIX_CONFIG` still works and still emits the deprecation warning when explicitly set by the user; CLI flags are unaffected.

A regression test in `tests/functional/short-path-literals.sh` builds a derivation with a post-build-hook that captures `$NIX_CONFIG` and asserts `warn-short-path-literals` is absent.

> **Note:** Root cause analysis and fix were produced with the help of an AI assistant (Claude), reviewed and confirmed against the source code by the author.