### PR TITLE
libstore: fix `auto-allocate-uids` for non-sandboxed builds

### DIFF
--- a/doc/manual/rl-next/auto-allocate-uids-no-sandbox.md
+++ b/doc/manual/rl-next/auto-allocate-uids-no-sandbox.md
@@ -1,0 +1,18 @@
+---
+synopsis: "`auto-allocate-uids`: fall back to `build-users-group` for non-sandboxed builds"
+issues: [9761]
+---
+
+When `auto-allocate-uids` is enabled, builds that cannot be sandboxed
+(e.g. derivations with `__noChroot = true`, or when `sandbox = false`)
+previously ran as an auto-allocated UID with no entry in the host's
+`/etc/passwd`. This caused `whoami`, `getpwuid()`, `podman`, `ssh` and
+similar tools to fail inside such builds, breaking nixpkgs packages like
+`spago-legacy`, `generic-stack-builder` and `xcodeenv`.
+
+Auto-allocated UIDs only make sense inside a user namespace where Nix
+fabricates `/etc/passwd`. For non-sandboxed builds, Nix now falls back
+to a regular `nixbld` user from `build-users-group` if one is
+configured. If neither sandboxing nor `build-users-group` is available,
+the build fails with a clear error instead of silently running as an
+unknown UID.

--- a/src/libstore/unix/user-lock.cc
+++ b/src/libstore/unix/user-lock.cc
@@ -218,6 +218,23 @@ std::unique_ptr<UserLock> acquireUserLock(
     const std::filesystem::path & stateDir, const LocalSettings & localSettings, uid_t nrIds, bool useUserNamespace)
 {
     if (auto * uidSettings = localSettings.getAutoAllocateUidSettings()) {
+        /* Auto-allocated UIDs only work inside a user namespace where Nix
+           can fabricate `/etc/passwd`. For non-sandboxed builds (e.g.
+           `__noChroot = true`), fall back to a regular `nixbld` user from
+           `build-users-group` if one is configured. */
+        if (!useUserNamespace) {
+            if (localSettings.buildUsersGroup != "") {
+                auto userPoolDir = stateDir / "userpool";
+                createDirs(userPoolDir);
+                return SimpleUserLock::acquire(userPoolDir, localSettings.buildUsersGroup);
+            }
+            throw Error(
+                "the 'auto-allocate-uids' setting cannot be used for builds that are not sandboxed "
+                "(e.g. derivations with '__noChroot = true' or with 'sandbox = false'), "
+                "because the auto-allocated UID has no entry in '/etc/passwd' outside the sandbox; "
+                "either enable sandboxing for this build or configure 'build-users-group' "
+                "to provide a fallback build user");
+        }
         auto userPoolDir = stateDir / "userpool2";
         createDirs(userPoolDir);
         return AutoUserLock::acquire(userPoolDir, localSettings.buildUsersGroup, nrIds, useUserNamespace, *uidSettings);


### PR DESCRIPTION
## Motivation

Allow unsandboxed builds using `auto-allocate-uids` to fall back to `nixbld` users.

Closes #9761.

## Context

Where `auto-allocate-uids` is enabled, builds that cannot be sandboxed (e.g. derivations with `__noChroot = true`, or with `sandbox = false`) were `setuid`'d to an auto-allocated UID with no entry in the host's `/etc/passwd`. `/etc/passwd` is only fabricated inside the chroot, so outside the user namespace `whoami`, `getpwuid()`, `podman` and `ssh` all fail, breaking nixpkgs packages like `spago-legacy`, `generic-stack-builder` and `xcodeenv`.

Auto-allocated UIDs only make sense inside a user namespace where Nix controls `/etc/passwd`. For non-sandboxed builds, fall back to a real `nixbld` user via `build-users-group` if one is configured; otherwise fail with a clear error pointing at sandboxing or `build-users-group` rather than silently running as an unknown UID.

Disclaimer: I used a coding agent in the creation of this patch.
