### PR TITLE
libstore: Avoid flock self-deadlock in addToStore with path locking

### DIFF
--- a/doc/manual/rl-next/pathlocks-self-deadlock.md
+++ b/doc/manual/rl-next/pathlocks-self-deadlock.md
@@ -1,0 +1,17 @@
+---
+synopsis: "Avoid `flock` self-deadlock when `addToStore` re-enters a path the current build holds"
+---
+
+When a build adds a path to the store (for example, a fixed-output or
+content-addressed derivation moving its output into place, or an `addToStore`
+call that targets the same store path the current `DerivationGoal` already
+locked), Nix would call `flock(LOCK_EX)` a second time on a freshly opened
+file descriptor for `<path>.lock`. Because Linux `flock` locks are tied to
+the open file description rather than the process, the second acquisition
+blocks against the first — a self-deadlock that manifests as a build hanging
+indefinitely on `waiting for lock on '/nix/store/...'`.
+
+`PathLocks` now tracks which real paths are held by some `PathLocks` instance
+in the current process, and the affected call sites in `LocalStore::addToStore`,
+`LocalStore::addToStoreFromDump`, and `DerivationBuilderImpl::registerOutputs`
+skip the redundant `lockPaths` when the path is already held locally.

--- a/src/libstore/include/nix/store/pathlocks.hh
+++ b/src/libstore/include/nix/store/pathlocks.hh
@@ -53,6 +53,18 @@ public:
     ~PathLocks();
     void unlock();
     void setDeletion(bool deletePaths);
+
+    /**
+     * Returns true if some `PathLocks` instance in this process currently
+     * holds the lock for `realPath` (the non-`.lock` path that
+     * `lockPaths()` would lock). Callers that re-enter the locking code
+     * for the same path (e.g. `addToStore` running on the same path the
+     * current build goal already locked) can use this to skip the
+     * redundant second lock and avoid `flock` self-deadlock — same-process
+     * flock locks held via different open file descriptions are mutually
+     * blocking on Linux.
+     */
+    static bool isHeldByThisProcess(const std::filesystem::path & realPath);
 };
 
 struct FdLock

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1050,8 +1050,13 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
 
             /* Lock the output path.  But don't lock if we're being called
                from a build hook (whose parent process already acquired a
-               lock on this path). */
-            if (!locksHeld.count(printStorePath(info.path)))
+               lock on this path), or if a `PathLocks` instance in this
+               same process is already holding the lock (e.g. the
+               derivation goal that triggered this `addToStore` call).
+               Re-locking in the latter case would self-deadlock because
+               Linux flock is per-open-file-description. */
+            if (!locksHeld.count(printStorePath(info.path))
+                && !PathLocks::isHeldByThisProcess(realPath))
                 outputLock.lockPaths({realPath});
 
             /* The path may have been created by another process in the meantime, so check again. */
@@ -1247,7 +1252,12 @@ StorePath LocalStore::addToStoreFromDump(
 
         auto realPath = toRealPath(dstPath);
 
-        PathLocks outputLock({realPath});
+        /* Skip locking if a `PathLocks` instance in this same process is
+           already holding the lock for `realPath` — re-locking would
+           self-deadlock on Linux flock (per-open-file-description). */
+        PathLocks outputLock;
+        if (!PathLocks::isHeldByThisProcess(realPath))
+            outputLock.lockPaths({realPath});
 
         /* The path may have been created by another process in the meantime, so check again. */
         if (repair || !isValidPathUncached(dstPath)) {

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -2,6 +2,7 @@
 #include "nix/util/file-system-at.hh"
 #include "nix/util/file-system.hh"
 #include "nix/store/local-store.hh"
+#include "nix/store/pathlocks.hh"
 #include "nix/util/processes.hh"
 #include "nix/store/builtins.hh"
 #include "nix/store/path-references.hh"
@@ -1854,7 +1855,12 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         auto optFixedPath = output->path(store, drv.name, outputName);
         if (!optFixedPath || store.printStorePath(*optFixedPath) != finalDestPath) {
             assert(newInfo.ca);
-            dynamicOutputLock.lockPaths({store.toRealPath(newInfo.path)});
+            /* Skip if a `PathLocks` instance in this process already holds
+               the lock — re-locking via a separate fd would self-deadlock
+               on Linux flock (per-open-file-description). */
+            auto realPath = store.toRealPath(newInfo.path);
+            if (!PathLocks::isHeldByThisProcess(realPath))
+                dynamicOutputLock.lockPaths({realPath});
         }
 
         /* Move files, if needed */

--- a/src/libstore/unix/pathlocks.cc
+++ b/src/libstore/unix/pathlocks.cc
@@ -1,9 +1,11 @@
 #include "nix/store/pathlocks.hh"
 #include "nix/util/file-system-at.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/sync.hh"
 
 #include <cerrno>
 #include <cstdlib>
+#include <set>
 
 #include <fcntl.h>
 #include <sys/types.h>
@@ -11,6 +13,22 @@
 #include <sys/file.h>
 
 namespace nix {
+
+/* Tracks paths currently locked by some `PathLocks` instance in this
+   process. Used by `addToStore` to skip a second `flock(LOCK_EX)` on a
+   path the caller already holds, which would otherwise self-deadlock
+   because Linux flock is per-open-file-description. */
+static Sync<std::set<std::filesystem::path>> & heldRealPaths()
+{
+    static Sync<std::set<std::filesystem::path>> s;
+    return s;
+}
+
+bool PathLocks::isHeldByThisProcess(const std::filesystem::path & realPath)
+{
+    auto held(heldRealPaths().lock());
+    return held->count(realPath) > 0;
+}
 
 AutoCloseFD openLockFile(const std::filesystem::path & path, bool create)
 {
@@ -121,6 +139,17 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
                 break;
         }
 
+        /* Register the (real, non-`.lock`) path as held by this process
+           so `addToStore` can detect re-entry and skip a self-deadlocking
+           second `flock`. Done before `fds.push_back` so that if the
+           push throws (e.g. `bad_alloc`), `isHeldByThisProcess` still
+           reports the kernel-held flock and re-entrant callers won't
+           attempt a second, deadlocking acquisition. */
+        {
+            auto held(heldRealPaths().lock());
+            held->insert(path);
+        }
+
         /* Use borrow so that the descriptor isn't closed. */
         fds.push_back(FDPair(fd.release(), lockPath));
     }
@@ -138,6 +167,15 @@ void PathLocks::unlock()
             printError("error (ignored): cannot close lock file on %1%", PathFmt(i.second));
 
         debug("lock released on %1%", PathFmt(i.second));
+
+        /* Mirror the insert in `lockPaths()`: derive the real path from
+           `lockPath` by stripping the trailing `.lock`. */
+        auto realPath = i.second;
+        realPath.replace_extension();
+        {
+            auto held(heldRealPaths().lock());
+            held->erase(realPath);
+        }
     }
 
     fds.clear();


### PR DESCRIPTION
  > ⚠️ **Disclosure**: This pull request — including the patch, commit message,
  > and this description — was drafted with the assistance of an LLM.
  > A human author has reviewed the change and is responsible for its
  > correctness, but reviewers should be aware of the AI involvement when
  > evaluating reasoning, comments, and edge-case coverage.

  ## Motivation

  A build can hang indefinitely on `waiting for lock on '/nix/store/...'` when
  the same Nix process re-enters the path-locking code for a path it already
  holds. Concretely:

  - `LocalStore::addToStore` / `addToStoreFromDump` running on a path whose
    outer lock is owned by a `DerivationGoal` in the same process; and
  - `DerivationBuilderImpl::registerOutputs` taking a `dynamicOutputLock` for
    a CA / floating-output path it already locked earlier.

  Each re-entry opens a fresh fd on `<path>.lock` and calls `flock(LOCK_EX)`.
  Linux `flock` locks are tied to the open file description, not the process,
  so the second acquisition blocks against the fd the outer `PathLocks` is
  still holding — a textbook self-deadlock.

  The existing escape hatch (`Worker::locksHeld`, populated from
  `NIX_HELD_LOCKS`) only covers the build-hook case where a child process
  inherits the parent's lock list. It does not cover same-process re-entry.

  ## Context

  Strategy:

  - Add a process-wide registry (`Sync<std::set<fs::path>>`) of paths
    currently held by some `PathLocks` instance, populated in `lockPaths()`
    and drained in `unlock()`.
  - Expose `PathLocks::isHeldByThisProcess(realPath)`.
  - Three call sites that can re-enter — `addToStore`, `addToStoreFromDump`,
    and `registerOutputs` — consult it and skip `lockPaths` when the path is
    already locally held. Outer `PathLocks` ownership is unchanged, so the
    flock is still released exactly once when the original holder is destroyed.

  Reading order for the diff:

  1. `src/libstore/include/nix/store/pathlocks.hh` — public API addition.
  2. `src/libstore/unix/pathlocks.cc` — registry + insert/erase in
     `lockPaths`/`unlock`.
  3. `src/libstore/local-store.cc` and
     `src/libstore/unix/build/derivation-builder.cc` — call sites that opt out
     of the redundant lock.

  Known limitation: the registry is only wired up in the POSIX
  `pathlocks.cc`. Windows `LockFileEx` has similar per-handle semantics and
  would benefit from the same treatment, but that is left for a follow-up; the
  Windows build will currently fail to link until `isHeldByThisProcess` is
  also defined there. Happy to fold the Windows side into this PR if reviewers
  prefer.

  No tests are added — reliably reproducing a self-deadlock in functional
  tests requires either deterministic scheduling hooks or a timeout-based
  check, both of which felt out of scope for the fix itself. Pointers to a
  preferred testing pattern in the project would be welcome.
