### PR TITLE
Fix typos in all .md, .sh, .nix files

### DIFF
--- a/doc/manual/remove_before_wrapper.py
+++ b/doc/manual/remove_before_wrapper.py
@@ -22,7 +22,7 @@ def main():
     shutil.rmtree(output, ignore_errors=True)
     shutil.rmtree(output_temp, ignore_errors=True)
 
-    # Execute nix command with `--write-to` tempary output
+    # Execute nix command with `--write-to` temporary output
     nix_command_write_to = nix_command + ['--write-to', output_temp]
     subprocess.run(nix_command_write_to, check=True)
 

--- a/doc/manual/source/command-ref/env-common.md
+++ b/doc/manual/source/command-ref/env-common.md
@@ -160,7 +160,7 @@ When [`use-xdg-base-directories`] is enabled, the configuration directory is res
 
 Likewise for the state and cache directories.
 
-## Miscellanous environment variables
+## Miscellaneous environment variables
 
 - <span id="env-IN_NIX_SHELL">[`IN_NIX_SHELL`](#env-IN_NIX_SHELL)</span>
 

--- a/doc/manual/source/protocols/json/schema/build-trace-entry-v3.yaml
+++ b/doc/manual/source/protocols/json/schema/build-trace-entry-v3.yaml
@@ -40,7 +40,7 @@ additionalProperties: false
     title: Build Trace Key
     description: |
       A [build trace entry](@docroot@/store/build-trace.md) is a key-value pair.
-      This is the "key" part, refering to a derivation and output.
+      This is the "key" part, referring to a derivation and output.
     type: object
     required:
       - drvPath

--- a/doc/manual/source/release-notes/rl-2.30.md
+++ b/doc/manual/source/release-notes/rl-2.30.md
@@ -13,7 +13,7 @@
 - Deprecate manually making structured attrs using the `__json` attribute [#13220](https://github.com/NixOS/nix/pull/13220)
 
   The proper way to create a derivation using [structured attrs] in the Nix language is by using `__structuredAttrs = true` with [`builtins.derivation`].
-  However, by exploiting how structured attrs are implementated, it has also been possible to create them by setting the `__json` environment variable to a serialized JSON string.
+  However, by exploiting how structured attrs are implemented, it has also been possible to create them by setting the `__json` environment variable to a serialized JSON string.
   This sneaky alternative method is now deprecated, and may be disallowed in future versions of Nix.
 
   [structured attrs]: @docroot@/language/advanced-attributes.md#adv-attr-structuredAttrs

--- a/doc/manual/source/release-notes/rl-2.32.md
+++ b/doc/manual/source/release-notes/rl-2.32.md
@@ -8,7 +8,7 @@
 
 - Derivation JSON format now uses store path basenames only [#13570](https://github.com/NixOS/nix/issues/13570) [#13980](https://github.com/NixOS/nix/pull/13980)
 
-  Experience with many JSON frameworks (e.g. nlohmann/json in C++, Serde in Rust, and Aeson in Haskell) has shown that the use of the store directory in JSON formats is an impediment to systematic JSON formats, because it requires the serializer/deserializer to take an extra paramater (the store directory).
+  Experience with many JSON frameworks (e.g. nlohmann/json in C++, Serde in Rust, and Aeson in Haskell) has shown that the use of the store directory in JSON formats is an impediment to systematic JSON formats, because it requires the serializer/deserializer to take an extra parameter (the store directory).
 
   We ultimately want to rectify this issue with all JSON formats to the extent allowed by our stability promises. To start with, we are changing the JSON format for derivations because the `nix derivation` commands are — in addition to being formally unstable — less widely used than other unstable commands.
 

--- a/doc/manual/source/store/file-system-object.md
+++ b/doc/manual/source/store/file-system-object.md
@@ -19,7 +19,7 @@ Every file system object is one of the following:
    In general, Nix does not assign any semantics to symbolic links.
    Certain operations however, may make additional assumptions and attempt to use the target to find another file system object.
 
-   > See [the Wikpedia article on symbolic links](https://en.m.wikipedia.org/wiki/Symbolic_link) for background information if you are unfamiliar with this Unix concept.
+   > See [the Wikipedia article on symbolic links](https://en.m.wikipedia.org/wiki/Symbolic_link) for background information if you are unfamiliar with this Unix concept.
 
 File system objects and their children form a tree.
 A bare file or symlink can be a root file system object.

--- a/doc/manual/theme/head.hbs
+++ b/doc/manual/theme/head.hbs
@@ -11,5 +11,5 @@ MathJax = {
   }
 };
 </script>
-<!-- Load a newer versino of MathJax than mdbook does by default, and which in particular has working relative paths for the "bussproofs" extension. -->
+<!-- Load a newer version of MathJax than mdbook does by default, and which in particular has working relative paths for the "bussproofs" extension. -->
 <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.0.1/es5/tex-mml-chtml.js"></script>

--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontBuild = true;
 
   /**
-    `doCheck` controles whether tests are added as build gate for the combined package.
+    `doCheck` controls whether tests are added as build gate for the combined package.
     This includes both the unit tests and the functional tests, but not the
     integration tests that run in CI (the flake's `hydraJobs` and some of the `checks`).
   */

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -832,8 +832,8 @@ EOF
         # TODO: should probably alert the user if this is disabled?
         _sudo "to launch the Nix volume mounter" \
             launchctl bootstrap system "$NIX_VOLUME_MOUNTD_DEST" || true
-        # TODO: confirm whether kickstart is necessesary?
-        # I feel a little superstitous, but it can guard
+        # TODO: confirm whether kickstart is necessary?
+        # I feel a little superstitious, but it can guard
         # against multiple problems (doesn't start, old
         # version still running for some reason...)
         _sudo "to launch the Nix volume mounter" \

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -270,7 +270,7 @@ _diff() {
         printf -v CHANGED_GROUP_FORMAT "%b" "${GREEN}%>${RED}%<${ESC}"
         diff --changed-group-format="$CHANGED_GROUP_FORMAT" "$@"
     else
-    # simple colorized diff comatible w/ pre `--color` versions
+    # simple colorized diff compatible w/ pre `--color` versions
         diff --unchanged-group-format="$_UNCHANGED_GRP_FMT" --old-line-format="$_OLD_LINE_FMT" --new-line-format="$_NEW_LINE_FMT" --unchanged-line-format="  %L" "$@"
     fi
 }
@@ -961,7 +961,7 @@ configure_shell_profile() {
 cert_in_store() {
     # in a subshell
     # - change into the cert-file dir
-    # - get the phyiscal pwd
+    # - get the physical pwd
     # and test if this path is in the Nix store
     [[ "$(cd -- "$(dirname "$NIX_SSL_CERT_FILE")" && exec pwd -P)" == "$NIX_ROOT/store/"* ]]
 }

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -44,7 +44,7 @@ cacheDir2="$TEST_ROOT/binary+cache"
 nix copy --to "file://$cacheDir2" "$outPath" && [[ -d "$cacheDir2" ]]
 
 basicDownloadTests() {
-    # No uploading tests bcause upload with force HTTP doesn't work.
+    # No uploading tests because upload with force HTTP doesn't work.
 
     # By default, a binary cache doesn't support "nix-env -qas", but does
     # support installation.

--- a/tests/functional/build-delete.sh
+++ b/tests/functional/build-delete.sh
@@ -44,7 +44,7 @@ issue_6572_dependent_outputs() {
 
     # Make sure that 'nix build' tracks input-outputs correctly when a single output is already present.
     if [[ -n "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
-        # Resolved derivations interferre with the deletion
+        # Resolved derivations interfere with the deletion
         nix-store --delete "${NIX_STORE_DIR}"/*.drv
     fi
     nix-store --delete "$(jq -r <"$TEST_ROOT"/a.json .[0].outputs.second)"

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -53,7 +53,7 @@ nix build -f multiple-outputs.nix --json nothing-to-install --no-link | jq --exi
     (.outputs | keys == ["out"]))
 '
 
-# But not when it's overriden.
+# But not when it's overridden.
 nix build -f multiple-outputs.nix --json e^a_a --no-link
 nix build -f multiple-outputs.nix --json e^a_a --no-link | jq --exit-status '
   (.[0] |
@@ -67,7 +67,7 @@ nix build -f multiple-outputs.nix --json 'e^*' --no-link | jq --exit-status '
     (.outputs | keys == ["a_a", "b", "c"]))
 '
 
-# test buidling from non-drv attr path
+# test building from non-drv attr path
 
 nix build -f multiple-outputs.nix --json 'e.a_a.outPath' --no-link | jq --exit-status '
   (.[0] |

--- a/tests/functional/characterisation-test-infra.sh
+++ b/tests/functional/characterisation-test-infra.sh
@@ -19,14 +19,14 @@ cp "$TEST_ROOT/got" "$TEST_ROOT/expected"
   (( "$badDiff" == 0 ))
 )
 
-# matches empty, non-existant file is the same as empty file
+# matches empty, non-existent file is the same as empty file
 echo -n > "$TEST_ROOT/got"
 (
   diffAndAcceptInner test "$TEST_ROOT/got" "$TEST_ROOT/does-not-exist"
   (( "$badDiff" == 0 ))
 )
 
-# doesn't matches non-empty, non-existant file is the same as empty file
+# doesn't matches non-empty, non-existent file is the same as empty file
 echo Hi! > "$TEST_ROOT/got"
 (
   diffAndAcceptInner test "$TEST_ROOT/got" "$TEST_ROOT/does-not-exist"
@@ -64,7 +64,7 @@ echo Bye! > "$TEST_ROOT/expected"
   (( "$badDiff" == 0 ))
 )
 
-# _NIX_TEST_ACCEPT matches empty, non-existant file not created
+# _NIX_TEST_ACCEPT matches empty, non-existent file not created
 echo -n > "$TEST_ROOT/got"
 (
   _NIX_TEST_ACCEPT=1 diffAndAcceptInner test "$TEST_ROOT/got" "$TEST_ROOT/does-not-exists"

--- a/tests/functional/common/functions.sh
+++ b/tests/functional/common/functions.sh
@@ -101,7 +101,7 @@ killDaemon() {
       die "killDaemon: not supported when testing on NixOS. Is it really needed? If so add conditionals; e.g. if ! isTestOnNixOS; then ..."
     fi
 
-    # Don't fail trying to stop a non-existant daemon twice.
+    # Don't fail trying to stop a non-existent daemon twice.
     if [[ "${_NIX_TEST_DAEMON_PID-}" == '' ]]; then
         return
     fi

--- a/tests/functional/dyn-drv/eval-outputOf.sh
+++ b/tests/functional/dyn-drv/eval-outputOf.sh
@@ -34,7 +34,7 @@ testStaticHello () {
              (assert a == b; null))'
 }
 
-# Test with a regular old input-addresed derivation
+# Test with a regular old input-addressed derivation
 #
 # `builtins.outputOf` works without ca-derivations and doesn't create a
 # placeholder but just returns the output path.

--- a/tests/functional/fetchTree-file.sh
+++ b/tests/functional/fetchTree-file.sh
@@ -76,12 +76,12 @@ EOF
     # For backwards compatibility, flake inputs that correspond to the
     # old 'tarball' fetcher should still have their type set to 'tarball'
     assert (nodes.tarball_default_unpack.locked.type == "tarball");
-    # Unless explicitely specified, the 'unpack' parameter shouldn’t appear here
+    # Unless explicitly specified, the 'unpack' parameter shouldn’t appear here
     # because that would break older Nix versions
     assert (!nodes.tarball_default_unpack.locked ? unpack);
     assert (nodes.tarball_default_unpack.locked.narHash == "$input_directory_hash");
 
-    # Explicitely passing the unpack parameter should enforce the desired behavior
+    # Explicitly passing the unpack parameter should enforce the desired behavior
     assert (nodes.no_ext_explicit_unpack.locked.narHash == nodes.tarball_default_unpack.locked.narHash);
     assert (nodes.tarball_explicit_no_unpack.locked.narHash == nodes.no_ext_default_no_unpack.locked.narHash);
 

--- a/tests/functional/flakes/develop.sh
+++ b/tests/functional/flakes/develop.sh
@@ -66,7 +66,7 @@ echo "\$ENVVAR"
 EOF
 )" ]]
 
-# Test wether `--keep-env-var` keeps the environment variable.
+# Test whether `--keep-env-var` keeps the environment variable.
 (
   expect='BAR'
   got="$(FOO='BAR' nix develop --ignore-env --keep-env-var FOO --no-write-lock-file .#hello <<EOF
@@ -76,7 +76,7 @@ EOF
   [[ "$got" == "$expect" ]]
 )
 
-# Test wether duplicate `--keep-env-var` keeps the environment variable.
+# Test whether duplicate `--keep-env-var` keeps the environment variable.
 (
   expect='BAR'
   got="$(FOO='BAR' nix develop --ignore-env --keep-env-var FOO --keep-env-var FOO --no-write-lock-file .#hello <<EOF
@@ -86,7 +86,7 @@ EOF
   [[ "$got" == "$expect" ]]
 )
 
-# Test wether `--set-env-var` sets the environment variable.
+# Test whether `--set-env-var` sets the environment variable.
 (
   expect='BAR'
   got="$(nix develop --ignore-env --set-env-var FOO 'BAR' --no-write-lock-file .#hello <<EOF
@@ -125,11 +125,11 @@ expectStderr 1 nix develop --keep-env-var FOO .#hello |
 expectStderr 1 nix develop --ignore-env --unset-env-var FOO .#hello |
   grepQuiet "error: --unset-env-var does not make sense with --ignore-env"
 
-# Test wether multiple occurances of `--set-env-var` throws.
+# Test whether multiple occurrences of `--set-env-var` throws.
 expectStderr 1 nix develop --set-env-var FOO 'BAR' --set-env-var FOO 'BLA' --no-write-lock-file .#hello |
   grepQuiet "error: Duplicate definition of environment variable 'FOO' with '--set-env-var' is ambiguous"
 
-# Test wether similar `--unset-env-var` and `--set-env-var` throws.
+# Test whether similar `--unset-env-var` and `--set-env-var` throws.
 expectStderr 1 nix develop --set-env-var FOO 'BAR' --unset-env-var FOO --no-write-lock-file .#hello |
   grepQuiet "error: Cannot unset environment variable 'FOO' that is set with '--set-env-var'"
 

--- a/tests/functional/flakes/follow-paths.sh
+++ b/tests/functional/flakes/follow-paths.sh
@@ -153,7 +153,7 @@ nix flake lock "$flakeFollowsA"
 
 [[ $(nix eval --json "$flakeFollowsA"#e) = 123 ]]
 
-# Non-existant follows should print a warning.
+# Non-existent follows should print a warning.
 cat >"$flakeFollowsA"/flake.nix <<EOF
 {
     description = "Flake A";

--- a/tests/functional/flakes/relative-paths.sh
+++ b/tests/functional/flakes/relative-paths.sh
@@ -65,7 +65,7 @@ git -C "$rootFlake" add flake.nix sub2/flake.nix
 
 [[ $(nix eval "$subflake2#y") = 15 ]]
 
-# Make sure that this still works after commiting the lock file.
+# Make sure that this still works after committing the lock file.
 git -C "$rootFlake" add sub2/flake.lock
 [[ $(nix eval "$subflake2#y") = 15 ]]
 

--- a/tests/functional/gc-closure.sh
+++ b/tests/functional/gc-closure.sh
@@ -15,7 +15,7 @@ nix_gc_closure() {
     input2_out=$(printf "%s" "$input2" | head -n1)
     input2_out2=$(printf "%s" "$input2" | tail -n1)
     top=$(nix build -f dependencies2.nix --no-link --print-out-paths)
-    somthing_else=$(nix store add-path ./dependencies2.nix)
+    something_else=$(nix store add-path ./dependencies2.nix)
 
     if isDaemonNewer "2.35pre"; then
         if [[ "$extraArg" != "--also-referrers" ]] && ! "$ensureNoDeleteReferrer"; then
@@ -27,7 +27,7 @@ nix_gc_closure() {
         [[ ! -e "$top" ]] || fail "top should have been deleted"
         [[ -e "$input0" ]] || fail "input0 is a gc root, shouldn't have been deleted"
         [[ -e "$input1" ]] || fail "input1 is not in the closure of top, it shouldn't have been deleted"
-        [[ -e "$somthing_else" ]] || fail "somthing_else is not in the closure of top, it shouldn't have been deleted"
+        [[ -e "$something_else" ]] || fail "something_else is not in the closure of top, it shouldn't have been deleted"
         if [[ "$extraArg" = "--also-referrers" ]]; then
             [[ ! -e "$input2_out" ]] || fail "input2_out is part of top's closure and we can delete dead referrers, it should have been deleted"
         elif "$ensureNoDeleteReferrer"; then

--- a/tests/functional/lang-gc.sh
+++ b/tests/functional/lang-gc.sh
@@ -9,7 +9,7 @@ source common.sh
 
 set -o pipefail
 
-skipTest "Too memory instensive for CI. Attempt to reduce memory usage was unsuccessful, because it made detection of the bug unreliable."
+skipTest "Too memory intensive for CI. Attempt to reduce memory usage was unsuccessful, because it made detection of the bug unreliable."
 
 # Regression test for #11141. The stack pointer corrector assigned the base
 # instead of the top (which resides at the low end of the stack). Sounds confusing?

--- a/tests/functional/linux-sandbox.sh
+++ b/tests/functional/linux-sandbox.sh
@@ -41,7 +41,7 @@ nix-sandbox-build dependencies.nix --check
 # Test that sandboxed builds with --check and -K can move .check directory to store
 nix-sandbox-build check.nix -A nondeterministic
 
-# `100 + 4` means non-determinstic, see doc/manual/source/command-ref/status-build-failure.md
+# `100 + 4` means non-deterministic, see doc/manual/source/command-ref/status-build-failure.md
 expectStderr 104 nix-sandbox-build check.nix -A nondeterministic --check -K > "$TEST_ROOT"/log
 grepQuietInverse 'error: renaming' "$TEST_ROOT"/log
 grepQuiet 'may not be deterministic' "$TEST_ROOT"/log

--- a/tests/functional/read-only-store.sh
+++ b/tests/functional/read-only-store.sh
@@ -4,7 +4,7 @@ source common.sh
 
 enableFeatures "read-only-local-store"
 
-needLocalStore "cannot open store read-only when daemon has already opened it writeable"
+needLocalStore "cannot open store read-only when daemon has already opened it writable"
 
 TODO_NixOS
 

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -145,7 +145,7 @@ foo + baz
 ' "3" \
     ./flake ./flake\#bar --experimental-features 'flakes'
 
-# Test the `:reload` mechansim with flakes:
+# Test the `:reload` mechanism with flakes:
 # - Eval `./flake#changingThing`
 # - Modify the flake
 # - Re-eval it

--- a/tests/functional/simple.sh
+++ b/tests/functional/simple.sh
@@ -20,7 +20,7 @@ text=$(cat "$outPath/hello")
 TODO_NixOS
 
 # Directed delete: $outPath is not reachable from a root, so it should
-# be deleteable.
+# be deletable.
 nix-store --delete "$outPath"
 [[ ! -e $outPath/hello ]]
 

--- a/tests/functional/structured-attrs.sh
+++ b/tests/functional/structured-attrs.sh
@@ -26,7 +26,7 @@ TODO_NixOS # following line fails.
 
 # `nix develop` is a slightly special way of dealing with environment vars, it parses
 # these from a shell-file exported from a derivation. This is to test especially `outputs`
-# (which is an associative array in thsi case) being fine.
+# (which is an associative array in this case) being fine.
 # shellcheck disable=SC2016
 nix develop -f structured-attrs-shell.nix -c bash -c 'test -n "$out"'
 

--- a/tests/functional/suggestions.sh
+++ b/tests/functional/suggestions.sh
@@ -30,7 +30,7 @@ EOF
 # Probable typo in the requested attribute path. Suggest some close possibilities
 NIX_BUILD_STDERR_WITH_SUGGESTIONS=$(! nix build .\#fob 2>&1 1>/dev/null)
 [[ "$NIX_BUILD_STDERR_WITH_SUGGESTIONS" =~ "Did you mean one of fo1, fo2, foo or fooo?" ]] || \
-    fail "The nix build stderr should suggest the three closest possiblities"
+    fail "The nix build stderr should suggest the three closest possibilities"
 
 # None of the possible attributes is close to `bar`, so shouldn’t suggest anything
 NIX_BUILD_STDERR_WITH_NO_CLOSE_SUGGESTION=$(! nix build .\#bar 2>&1 1>/dev/null)
@@ -39,8 +39,8 @@ NIX_BUILD_STDERR_WITH_NO_CLOSE_SUGGESTION=$(! nix build .\#bar 2>&1 1>/dev/null)
 
 NIX_EVAL_STDERR_WITH_SUGGESTIONS=$(! nix build --impure --expr '(builtins.getFlake (builtins.toPath ./.)).packages.'"$system"'.fob' 2>&1 1>/dev/null)
 [[ "$NIX_EVAL_STDERR_WITH_SUGGESTIONS" =~ "Did you mean one of fo1, fo2, foo or fooo?" ]] || \
-    fail "The evaluator should suggest the three closest possiblities"
+    fail "The evaluator should suggest the three closest possibilities"
 
 NIX_EVAL_STDERR_WITH_SUGGESTIONS=$(! nix build --impure --expr '({ foo }: foo) { foo = 1; fob = 2; }' 2>&1 1>/dev/null)
 [[ "$NIX_EVAL_STDERR_WITH_SUGGESTIONS" =~ "Did you mean foo?" ]] || \
-    fail "The evaluator should suggest the three closest possiblities"
+    fail "The evaluator should suggest the three closest possibilities"

--- a/tests/nixos/ca-fd-leak/sender.c
+++ b/tests/nixos/ca-fd-leak/sender.c
@@ -62,6 +62,6 @@ int main(int argc, char ** argv)
     int buf;
 
     // Wait for the server to close the socket, implying that it has
-    // received the commmand.
+    // received the command.
     recv(sock, (void *) &buf, sizeof(int), 0);
 }

--- a/tests/nixos/fetch-git/test-cases/lfs/default.nix
+++ b/tests/nixos/fetch-git/test-cases/lfs/default.nix
@@ -172,7 +172,7 @@
         f"did not set lfs, yet lfs-enrolled file is {file_size_default}b (>= 1KiB), probably bad default value"
 
     with subtest("Use as flake input"):
-      # May seem reduntant, but this has minor differences compared to raw
+      # May seem redundant, but this has minor differences compared to raw
       # fetchGit which caused failures before
       with TemporaryDirectory() as tempdir:
         client.succeed(f"mkdir -p {tempdir}")


### PR DESCRIPTION
Also fixes one typo in each of the
"remove_before_wrapper.py"
"build-trace-entry-v3.yaml"
"head.hbs"
"sender.c"
files

This PR only touches text in comments and `"`strings`"` with the only exception of `tests/functional/gc-closure.sh` where i renamed a variable (`$somthing_else` -> `$something_else`).

The typos were picked using [`typos`](https://github.com/crate-ci/typos) and i manually changed text, filtering out false-positives.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
