### PR TITLE
NAR listing: always serialize `executable` field

### DIFF
--- a/src/libutil-tests/data/nar-listing/deep.json
+++ b/src/libutil-tests/data/nar-listing/deep.json
@@ -15,6 +15,7 @@
       "type": "directory"
     },
     "foo": {
+      "executable": false,
       "size": 15,
       "type": "regular"
     }

--- a/src/libutil/memory-source-accessor/json.cc
+++ b/src/libutil/memory-source-accessor/json.cc
@@ -51,8 +51,7 @@ void adl_serializer<NarListing::Regular>::to_json(json & j, const NarListing::Re
 {
     if (r.contents.fileSize)
         j["size"] = *r.contents.fileSize;
-    if (r.executable)
-        j["executable"] = true;
+    j["executable"] = r.executable;
     if (r.contents.narOffset)
         j["narOffset"] = *r.contents.narOffset;
 }

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -276,7 +276,27 @@ nix copy --to "file://$cacheDir"?write-nar-listing=1 "$outPath"
 
 diff -u \
     <(jq -S < "$cacheDir/$(basename "$outPath" | cut -c1-32).ls") \
-    <(echo '{"version":1,"root":{"type":"directory","entries":{"bar":{"type":"regular","size":4,"narOffset":232},"link":{"type":"symlink","target":"xyzzy"}}}}' | jq -S)
+    <(jq -S <<'EOF'
+{
+  "version": 1,
+  "root": {
+    "type": "directory",
+    "entries": {
+      "bar": {
+        "type": "regular",
+        "executable": false,
+        "size": 4,
+        "narOffset": 232
+      },
+      "link": {
+        "type": "symlink",
+        "target": "xyzzy"
+      }
+    }
+  }
+}
+EOF
+    )
 
 
 # Test debug info index generation.

--- a/tests/functional/nar-access.sh
+++ b/tests/functional/nar-access.sh
@@ -37,24 +37,120 @@ cp -r "$storePath" "$invalidPath"
 expect 1 nix store cat "$invalidPath/foo/baz"
 
 # Test --json.
+
+# Shallow listing of root (no --recursive)
 diff -u \
     <(nix nar ls --json "$narFile" / | jq -S) \
-    <(echo '{"type":"directory","entries":{"foo":{},"foo-x":{},"qux":{},"zyx":{}}}' | jq -S)
+    <(jq -S <<'EOF'
+{
+  "type": "directory",
+  "entries": {
+    "foo": {},
+    "foo-x": {},
+    "qux": {},
+    "zyx": {}
+  }
+}
+EOF
+    )
+
+# Recursive listing of /foo from NAR (includes narOffset)
 diff -u \
     <(nix nar ls --json -R "$narFile" /foo | jq -S) \
-    <(echo '{"type":"directory","entries":{"bar":{"type":"regular","size":0,"narOffset":368},"baz":{"type":"regular","size":0,"narOffset":552},"data":{"type":"regular","size":58,"narOffset":736}}}' | jq -S)
+    <(jq -S <<'EOF'
+{
+  "type": "directory",
+  "entries": {
+    "bar": {
+      "type": "regular",
+      "executable": false,
+      "size": 0,
+      "narOffset": 368
+    },
+    "baz": {
+      "type": "regular",
+      "executable": false,
+      "size": 0,
+      "narOffset": 552
+    },
+    "data": {
+      "type": "regular",
+      "executable": false,
+      "size": 58,
+      "narOffset": 736
+    }
+  }
+}
+EOF
+    )
+
+# Single file from NAR
 diff -u \
     <(nix nar ls --json -R "$narFile" /foo/bar | jq -S) \
-    <(echo '{"type":"regular","size":0,"narOffset":368}' | jq -S)
+    <(jq -S <<'EOF'
+{
+  "type": "regular",
+  "executable": false,
+  "size": 0,
+  "narOffset": 368
+}
+EOF
+    )
+
+# Shallow listing from store
 diff -u \
     <(nix store ls --json "$storePath" | jq -S) \
-    <(echo '{"type":"directory","entries":{"foo":{},"foo-x":{},"qux":{},"zyx":{}}}' | jq -S)
+    <(jq -S <<'EOF'
+{
+  "type": "directory",
+  "entries": {
+    "foo": {},
+    "foo-x": {},
+    "qux": {},
+    "zyx": {}
+  }
+}
+EOF
+    )
+
+# Recursive listing from store (no narOffset)
 diff -u \
     <(nix store ls --json -R "$storePath/foo" | jq -S) \
-    <(echo '{"type":"directory","entries":{"bar":{"type":"regular","size":0},"baz":{"type":"regular","size":0},"data":{"type":"regular","size":58}}}' | jq -S)
+    <(jq -S <<'EOF'
+{
+  "type": "directory",
+  "entries": {
+    "bar": {
+      "type": "regular",
+      "executable": false,
+      "size": 0
+    },
+    "baz": {
+      "type": "regular",
+      "executable": false,
+      "size": 0
+    },
+    "data": {
+      "type": "regular",
+      "executable": false,
+      "size": 58
+    }
+  }
+}
+EOF
+    )
+
+# Single file from store
 diff -u \
-    <(nix store ls --json -R "$storePath/foo/bar"| jq -S) \
-    <(echo '{"type":"regular","size":0}' | jq -S)
+    <(nix store ls --json -R "$storePath/foo/bar" | jq -S) \
+    <(jq -S <<'EOF'
+{
+  "type": "regular",
+  "executable": false,
+  "size": 0
+}
+EOF
+    )
 
 # Test missing files.
 expect 1 nix store ls --json -R "$storePath/xyzzy" 2>&1 | grep 'does not exist'


### PR DESCRIPTION
Previously `NarListing::Regular::to_json` only included `"executable"` when true, while `MemorySourceAccessor::File::Regular::to_json` always included it. This inconsistency makes it harder for other implementations to use a single JSON definition for both — e.g. with Rust's `#[serde(derive)]` there's no way to have `skip_serializing_if` vary by generic parameter.

Always serializing the field can only help clients (they get more information), never hurt them (any correct client already handles both `true` and `false`).

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
