### PR TITLE
libexpr: Avoid a call to builtins.getAttr in builtins.derivation

### DIFF
--- a/src/libexpr/primops/derivation.nix
+++ b/src/libexpr/primops/derivation.nix
@@ -46,7 +46,7 @@ let
   outputToAttrListElement = outputName: {
     name = outputName;
     value = commonAttrs // {
-      outPath = builtins.getAttr outputName strict;
+      outPath = strict.${outputName};
       drvPath = strict.drvPath;
       type = "derivation";
       inherit outputName;

--- a/tests/functional/lang/eval-fail-derivation-name.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-name.err.exp
@@ -2,15 +2,8 @@ error:
        … while evaluating the attribute 'outPath'
          at «nix-internal»/derivation-internal.nix:<number>:<number>:
      <number>|     value = commonAttrs // {
-     <number>|       outPath = builtins.getAttr outputName strict;
+     <number>|       outPath = strict.${outputName};
              |       ^
-     <number>|       drvPath = strict.drvPath;
-
-       … while calling the 'getAttr' builtin
-         at «nix-internal»/derivation-internal.nix:<number>:<number>:
-     <number>|     value = commonAttrs // {
-     <number>|       outPath = builtins.getAttr outputName strict;
-             |                 ^
      <number>|       drvPath = strict.drvPath;
 
        … while calling the 'derivationStrict' builtin

--- a/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
@@ -2,15 +2,8 @@ error:
        … while evaluating the attribute 'outPath'
          at «nix-internal»/derivation-internal.nix:50:7:
            49|     value = commonAttrs // {
-           50|       outPath = builtins.getAttr outputName strict;
+           50|       outPath = strict.${outputName};
              |       ^
-           51|       drvPath = strict.drvPath;
-
-       … while calling the 'getAttr' builtin
-         at «nix-internal»/derivation-internal.nix:50:17:
-           49|     value = commonAttrs // {
-           50|       outPath = builtins.getAttr outputName strict;
-             |                 ^
            51|       drvPath = strict.drvPath;
 
        … while calling the 'derivationStrict' builtin
@@ -37,7 +30,7 @@ error:
              |                                                                       ^
            13|     in
 
-       (9994 duplicate frames omitted)
+       (9995 duplicate frames omitted)
 
        … while evaluating attribute 'head'
          at /pwd/lang/eval-fail-derivation-structuredAttrs-stack-overflow.nix:12:66:


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Currently the profiling output contains a frame for the internal `getAttr` call. By using the attribute access form instead of the builtin this frame can be avoided. This makes for more readable profiling output.
Additionally this brings down `nrPrimOpCalls` from 411021 to 403705 for `nix-instantiate '<nixpkgs>' -A firefox`.

Profiling output as seen before on the left, and after on the right. Note that the `getAttr` frames around calls to `derivationStrict` are now gone.

<img width="1920" height="1045" alt="flame" src="https://github.com/user-attachments/assets/9ebf0792-0b96-43e8-8586-2c5b32c30087" />


## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
