### PR TITLE
libexpr-c: expose essential evaluator functions for derivation tree inspection

### DIFF
--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -30,6 +30,7 @@ subdir('nix-meson-build-support/subprojects')
 subdir('nix-meson-build-support/common')
 
 sources = files(
+  'nix_api_eval.cc',
   'nix_api_expr.cc',
   'nix_api_external.cc',
   'nix_api_value.cc',

--- a/src/libexpr-c/nix_api_eval.cc
+++ b/src/libexpr-c/nix_api_eval.cc
@@ -1,0 +1,85 @@
+#include <stdexcept>
+
+#include "nix/expr/eval.hh"
+#include "nix/expr/get-drvs.hh"
+
+#include "nix_api_expr.h"
+#include "nix_api_expr_internal.h"
+#include "nix_api_store.h"
+#include "nix_api_store_internal.h"
+#include "nix_api_util.h"
+#include "nix_api_util_internal.h"
+
+static const nix::Value & value_in(const nix_value * value)
+{
+    if (!value) {
+        throw std::runtime_error("nix_value is null");
+    }
+    if (!value->value || !value->value->isValid()) {
+        throw std::runtime_error("nix_value is null or uninitialized");
+    }
+    return *value->value;
+}
+
+static nix::Value & value_in(nix_value * value)
+{
+    if (!value) {
+        throw std::runtime_error("nix_value is null");
+    }
+    if (!value->value || !value->value->isValid()) {
+        throw std::runtime_error("nix_value is null or uninitialized");
+    }
+    return *value->value;
+}
+
+static const nix::Bindings * get_bindings_or_null(nix_value * autoArgs)
+{
+    if (!autoArgs) {
+        return nullptr;
+    }
+    auto & v = value_in(autoArgs);
+    if (v.type() == nix::nAttrs) {
+        return v.attrs();
+    }
+    return nullptr;
+}
+
+extern "C" {
+
+StorePath *
+nix_get_derivation(nix_c_context * context, EvalState * state, nix_value * value, bool ignoreAssertionFailures)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        auto & v = value_in(value);
+        auto maybePkg = nix::getDerivation(state->state, v, ignoreAssertionFailures);
+        if (!maybePkg) {
+            return nullptr;
+        }
+        nix::StorePath sp = maybePkg->requireDrvPath();
+        return new StorePath{std::move(sp)};
+    }
+    NIXC_CATCH_ERRS_NULL
+}
+
+nix_err nix_value_auto_call_function(
+    nix_c_context * context, EvalState * state, nix_value * auto_args, nix_value * fn_val, nix_value * result)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        auto & fn = value_in(fn_val);
+        auto & res = *result->value;
+
+        const nix::Bindings * b = get_bindings_or_null(auto_args);
+        if (b) {
+            state->state.autoCallFunction(*b, fn, res);
+        } else {
+            state->state.autoCallFunction(nix::Bindings::emptyBindings, fn, res);
+        }
+    }
+    NIXC_CATCH_ERRS
+}
+
+} // extern "C"

--- a/src/libexpr-c/nix_api_eval.cc
+++ b/src/libexpr-c/nix_api_eval.cc
@@ -8,16 +8,14 @@
 #include "nix_api_util.h"
 #include "nix_api_util_internal.h"
 
-static const nix::Bindings * get_bindings_or_null(nix_value * autoArgs)
+static const nix::Bindings & get_bindings_or_empty(nix::EvalState & state, nix_value * autoArgs)
 {
     if (!autoArgs) {
-        return nullptr;
+        return nix::Bindings::emptyBindings;
     }
     auto & v = check_value_in(autoArgs);
-    if (v.type() == nix::nAttrs) {
-        return v.attrs();
-    }
-    return nullptr;
+    state.forceAttrs(v, nix::noPos, "while evaluating automatic function arguments");
+    return *v.attrs();
 }
 
 extern "C" {
@@ -46,14 +44,10 @@ nix_err nix_value_auto_call_function(
         context->last_err_code = NIX_OK;
     try {
         auto & fn = check_value_in(fn_val);
-        auto & res = *result->value;
+        auto & res = check_value_not_null(result);
 
-        const nix::Bindings * b = get_bindings_or_null(auto_args);
-        if (b) {
-            state->state.autoCallFunction(*b, fn, res);
-        } else {
-            state->state.autoCallFunction(nix::Bindings::emptyBindings, fn, res);
-        }
+        auto & b = get_bindings_or_empty(state->state, auto_args);
+        state->state.autoCallFunction(b, fn, res);
     }
     NIXC_CATCH_ERRS
 }

--- a/src/libexpr-c/nix_api_eval.cc
+++ b/src/libexpr-c/nix_api_eval.cc
@@ -1,5 +1,3 @@
-#include <stdexcept>
-
 #include "nix/expr/eval.hh"
 #include "nix/expr/get-drvs.hh"
 
@@ -10,34 +8,12 @@
 #include "nix_api_util.h"
 #include "nix_api_util_internal.h"
 
-static const nix::Value & value_in(const nix_value * value)
-{
-    if (!value) {
-        throw std::runtime_error("nix_value is null");
-    }
-    if (!value->value || !value->value->isValid()) {
-        throw std::runtime_error("nix_value is null or uninitialized");
-    }
-    return *value->value;
-}
-
-static nix::Value & value_in(nix_value * value)
-{
-    if (!value) {
-        throw std::runtime_error("nix_value is null");
-    }
-    if (!value->value || !value->value->isValid()) {
-        throw std::runtime_error("nix_value is null or uninitialized");
-    }
-    return *value->value;
-}
-
 static const nix::Bindings * get_bindings_or_null(nix_value * autoArgs)
 {
     if (!autoArgs) {
         return nullptr;
     }
-    auto & v = value_in(autoArgs);
+    auto & v = check_value_in(autoArgs);
     if (v.type() == nix::nAttrs) {
         return v.attrs();
     }
@@ -52,7 +28,7 @@ nix_get_derivation(nix_c_context * context, EvalState * state, nix_value * value
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = value_in(value);
+        auto & v = check_value_in(value);
         auto maybePkg = nix::getDerivation(state->state, v, ignoreAssertionFailures);
         if (!maybePkg) {
             return nullptr;
@@ -69,7 +45,7 @@ nix_err nix_value_auto_call_function(
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & fn = value_in(fn_val);
+        auto & fn = check_value_in(fn_val);
         auto & res = *result->value;
 
         const nix::Bindings * b = get_bindings_or_null(auto_args);

--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -342,6 +342,51 @@ void nix_gc_register_finalizer(void * obj, void * cd, void (*finalizer)(void * o
 
 /** @} */ // doxygen group GC
 
+/** @addtogroup libexpr_eval
+ * @ingroup libexpr
+ * @brief Higher-level evaluation helpers
+ * @{
+ */
+
+/**
+ * @brief Attempt to interpret a Nix value as a derivation.
+ *
+ * If the value represents a derivation, returns its drvPath. Returns NULL
+ * (without setting an error) when the value is not a derivation and the
+ * caller should recurse into its attributes instead.
+ *
+ * Derivation metadata (name, system, outputs, meta) can be queried from
+ * the value itself using the existing attrset accessors
+ * (nix_get_attr_byname, nix_get_string, etc.).
+ *
+ * @param[out] context Optional, stores error information. Check
+ *  last_err_code to distinguish NULL-from-error from NULL-as-not-derivation.
+ * @param[in] state The evaluation state.
+ * @param[in] value The value to inspect.
+ * @param[in] ignoreAssertionFailures Whether to ignore AssertionErrors
+ *  in the derivation's meta evaluation.
+ * @return A new StorePath, or NULL. Free with nix_store_path_free().
+ */
+StorePath *
+nix_get_derivation(nix_c_context * context, EvalState * state, nix_value * value, bool ignoreAssertionFailures);
+
+/**
+ * @brief Auto-call a function with auto-args (the --arg / --argstr pattern).
+ *
+ * This corresponds to nix::EvalState::autoCallFunction.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] state The evaluation state.
+ * @param[in] auto_args An attrset value containing auto-args, or NULL for
+ *  empty.
+ * @param[in] fn_val The function to call.
+ * @param[out] result Pre-allocated nix_value to receive the result.
+ */
+nix_err nix_value_auto_call_function(
+    nix_c_context * context, EvalState * state, nix_value * auto_args, nix_value * fn_val, nix_value * result);
+
+/** @} */ // doxygen group libexpr_eval
+
 // cffi end
 #ifdef __cplusplus
 }

--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -355,8 +355,7 @@ void nix_gc_register_finalizer(void * obj, void * cd, void (*finalizer)(void * o
  * Forces @p value and inspects it. The value is considered a derivation when it
  * is an attribute set whose `type` attribute is the string `"derivation"`; in
  * that case its `drvPath` attribute is parsed and returned. Otherwise NULL is
- * returned without recording an error, which signals that the caller should
- * treat @p value as an ordinary attribute set (e.g. recurse into it).
+ * returned without recording an error.
  *
  * Only the derivation path is returned. Other metadata (`name`, `system`,
  * outputs, `meta`, ...) lives on @p value itself and can be read with the
@@ -380,7 +379,9 @@ nix_get_derivation(nix_c_context * context, EvalState * state, nix_value * value
 /**
  * @brief Call a function, drawing its arguments from an attribute set.
  *
- * Forces @p fn_val and writes its application into @p result:
+ * Forces @p fn_val and writes the application result into @p result. The result
+ * is not forced; call nix_value_force() to evaluate it before inspecting the
+ * final value.
  *
  * - If @p fn_val is a function that takes a set of named arguments
  *   (e.g. `{ a, b ? 1 }: ...`), it is called with an attribute set assembled

--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -342,45 +342,62 @@ void nix_gc_register_finalizer(void * obj, void * cd, void (*finalizer)(void * o
 
 /** @} */ // doxygen group GC
 
-/** @addtogroup libexpr_eval
+/** @defgroup libexpr_eval Evaluation
  * @ingroup libexpr
  * @brief Higher-level evaluation helpers
  * @{
  */
 
 /**
- * @brief Attempt to interpret a Nix value as a derivation.
+ * @brief Determine whether a Nix value is a derivation and, if so, return its
+ *        store derivation path.
  *
- * If the value represents a derivation, returns its drvPath. Returns NULL
- * (without setting an error) when the value is not a derivation and the
- * caller should recurse into its attributes instead.
+ * Forces @p value and inspects it. The value is considered a derivation when it
+ * is an attribute set whose `type` attribute is the string `"derivation"`; in
+ * that case its `drvPath` attribute is parsed and returned. Otherwise NULL is
+ * returned without recording an error, which signals that the caller should
+ * treat @p value as an ordinary attribute set (e.g. recurse into it).
  *
- * Derivation metadata (name, system, outputs, meta) can be queried from
- * the value itself using the existing attrset accessors
- * (nix_get_attr_byname, nix_get_string, etc.).
+ * Only the derivation path is returned. Other metadata (`name`, `system`,
+ * outputs, `meta`, ...) lives on @p value itself and can be read with the
+ * attribute-set accessors such as nix_get_attr_byname() and nix_get_string().
  *
- * @param[out] context Optional, stores error information. Check
- *  last_err_code to distinguish NULL-from-error from NULL-as-not-derivation.
+ * @param[out] context Optional, stores error information. On a NULL return,
+ *  inspect the error code via nix_err_code() to tell the two NULL cases apart:
+ *  NIX_OK means @p value is simply not a derivation, any other code means
+ *  inspection failed. See @ref errors.
  * @param[in] state The evaluation state.
- * @param[in] value The value to inspect.
- * @param[in] ignoreAssertionFailures Whether to ignore AssertionErrors
- *  in the derivation's meta evaluation.
- * @return A new StorePath, or NULL. Free with nix_store_path_free().
+ * @param[in] value The value to inspect. It is forced by this call.
+ * @param[in] ignoreAssertionFailures If true, an assertion failure raised while
+ *  forcing @p value is treated as "not a derivation" (NULL is returned without
+ *  an error) rather than being reported as an error.
+ * @return A newly allocated StorePath holding the derivation path, or NULL.
+ *  Free a non-NULL result with nix_store_path_free().
  */
 StorePath *
 nix_get_derivation(nix_c_context * context, EvalState * state, nix_value * value, bool ignoreAssertionFailures);
 
 /**
- * @brief Auto-call a function with auto-args (the --arg / --argstr pattern).
+ * @brief Call a function, drawing its arguments from an attribute set.
  *
- * This corresponds to nix::EvalState::autoCallFunction.
+ * Forces @p fn_val and writes its application into @p result:
+ *
+ * - If @p fn_val is a function that takes a set of named arguments
+ *   (e.g. `{ a, b ? 1 }: ...`), it is called with an attribute set assembled
+ *   from @p auto_args: each named argument is taken from @p auto_args when
+ *   present; an argument absent from @p auto_args falls back to its default;
+ *   an argument that is both absent and has no default is an error.
+ * - Otherwise @p fn_val is copied into @p result unchanged. This includes any
+ *   non-function value as well as a function that takes a single unnamed
+ *   argument (e.g. `x: ...`), since there are no named arguments to supply.
  *
  * @param[out] context Optional, stores error information
  * @param[in] state The evaluation state.
- * @param[in] auto_args An attrset value containing auto-args, or NULL for
- *  empty.
- * @param[in] fn_val The function to call.
- * @param[out] result Pre-allocated nix_value to receive the result.
+ * @param[in] auto_args Attribute set value supplying the named arguments, or
+ *  NULL to supply none.
+ * @param[in] fn_val The value to call.
+ * @param[out] result Pre-allocated nix_value that receives the result.
+ * @return NIX_OK if the call was successful, an error code otherwise.
  */
 nix_err nix_value_auto_call_function(
     nix_c_context * context, EvalState * state, nix_value * auto_args, nix_value * fn_val, nix_value * result);

--- a/src/libexpr-c/nix_api_expr_internal.h
+++ b/src/libexpr-c/nix_api_expr_internal.h
@@ -2,6 +2,7 @@
 #define NIX_API_EXPR_INTERNAL_H
 
 #include <memory>
+#include <stdexcept>
 
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/expr/eval.hh"
@@ -73,5 +74,36 @@ struct nix_realised_string
 };
 
 } // extern "C"
+
+// Shared helpers for validating nix_value [in] parameters across libexpr-c translation units.
+inline const nix::Value & check_value_not_null(const nix_value * value)
+{
+    if (!value || !value->value)
+        throw std::runtime_error("nix_value is null");
+    return *value->value;
+}
+
+inline nix::Value & check_value_not_null(nix_value * value)
+{
+    if (!value || !value->value)
+        throw std::runtime_error("nix_value is null");
+    return *value->value;
+}
+
+inline const nix::Value & check_value_in(const nix_value * value)
+{
+    auto & v = check_value_not_null(value);
+    if (!v.isValid())
+        throw std::runtime_error("Uninitialized nix_value");
+    return v;
+}
+
+inline nix::Value & check_value_in(nix_value * value)
+{
+    auto & v = check_value_not_null(value);
+    if (!v.isValid())
+        throw std::runtime_error("Uninitialized nix_value");
+    return v;
+}
 
 #endif // NIX_API_EXPR_INTERNAL_H

--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -12,41 +12,6 @@
 #include "nix_api_store_internal.h"
 #include "nix_api_value.h"
 
-// Internal helper functions to check [in] and [out] `Value *` parameters
-static const nix::Value & check_value_not_null(const nix_value * value)
-{
-    if (!value) {
-        throw std::runtime_error("nix_value is null");
-    }
-    return *value->value;
-}
-
-static nix::Value & check_value_not_null(nix_value * value)
-{
-    if (!value) {
-        throw std::runtime_error("nix_value is null");
-    }
-    return *value->value;
-}
-
-static const nix::Value & check_value_in(const nix_value * value)
-{
-    auto & v = check_value_not_null(value);
-    if (!v.isValid()) {
-        throw std::runtime_error("Uninitialized nix_value");
-    }
-    return v;
-}
-
-static nix::Value & check_value_in(nix_value * value)
-{
-    auto & v = check_value_not_null(value);
-    if (!v.isValid()) {
-        throw std::runtime_error("Uninitialized nix_value");
-    }
-    return v;
-}
-
 static nix::Value & check_value_out(nix_value * value)
 {
     auto & v = check_value_not_null(value);

--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -53,6 +53,7 @@ sources = files(
   'json.cc',
   'lazy-fetcher-attr.cc',
   'main.cc',
+  'nix_api_eval.cc',
   'nix_api_expr.cc',
   'nix_api_external.cc',
   'nix_api_value.cc',

--- a/src/libexpr-tests/nix_api_eval.cc
+++ b/src/libexpr-tests/nix_api_eval.cc
@@ -1,0 +1,212 @@
+#include "nix_api_store.h"
+#include "nix_api_util.h"
+#include "nix_api_expr.h"
+#include "nix_api_value.h"
+
+#include "nix/expr/tests/nix_api_expr.hh"
+#include "nix/util/tests/string_callback.hh"
+#include "nix/util/tests/gmock-matchers.hh"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace nixC {
+
+// nix_get_derivation
+
+TEST_F(nix_api_expr_test, nix_get_derivation_returns_drv_path)
+{
+    auto expr = R"(derivation { name = "myname"; builder = "mybuilder"; system = "mysystem"; })";
+    nix_expr_eval_from_string(ctx, state, expr, ".", value);
+    assert_ctx_ok();
+
+    StorePath * drvPath = nix_get_derivation(ctx, state, value, false);
+    assert_ctx_ok();
+    ASSERT_NE(nullptr, drvPath);
+
+    std::string name;
+    nix_store_path_name(drvPath, OBSERVE_STRING(name));
+    EXPECT_THAT(name, ::testing::HasSubstr("myname"));
+    EXPECT_THAT(name, ::testing::EndsWith(".drv"));
+
+    nix_store_path_free(drvPath);
+}
+
+TEST_F(nix_api_expr_test, nix_get_derivation_non_derivation_returns_null_without_error)
+{
+    nix_expr_eval_from_string(ctx, state, "{ a = 1; }", ".", value);
+    assert_ctx_ok();
+
+    StorePath * drvPath = nix_get_derivation(ctx, state, value, false);
+    // Not a derivation: NULL with no error recorded, so the caller can tell
+    // this apart from a genuine failure.
+    ASSERT_EQ(nullptr, drvPath);
+    ASSERT_EQ(NIX_OK, nix_err_code(ctx));
+}
+
+TEST_F(nix_api_expr_test, nix_get_derivation_non_attrset_returns_null_without_error)
+{
+    nix_expr_eval_from_string(ctx, state, "42", ".", value);
+    assert_ctx_ok();
+
+    StorePath * drvPath = nix_get_derivation(ctx, state, value, false);
+    ASSERT_EQ(nullptr, drvPath);
+    ASSERT_EQ(NIX_OK, nix_err_code(ctx));
+}
+
+TEST_F(nix_api_expr_test, nix_get_derivation_null_value_is_error)
+{
+    StorePath * drvPath = nix_get_derivation(ctx, state, nullptr, false);
+    ASSERT_EQ(nullptr, drvPath);
+    ASSERT_NE(NIX_OK, nix_err_code(ctx));
+}
+
+// A derivation-shaped attribute set whose `name` throws an assertion only when
+// forced. The outer set is already WHNF, so nix_get_derivation is what triggers
+// the failure (while reading the name), exercising the assertion handling.
+static constexpr const char * ASSERTING_DRV = R"({ type = "derivation"; name = assert false; "myname"; })";
+
+TEST_F(nix_api_expr_test, nix_get_derivation_assertion_ignored)
+{
+    nix_expr_eval_from_string(ctx, state, ASSERTING_DRV, ".", value);
+    assert_ctx_ok();
+
+    // With ignoreAssertionFailures = true the assertion is swallowed and the
+    // value is reported as "not a derivation": NULL with no error.
+    StorePath * drvPath = nix_get_derivation(ctx, state, value, true);
+    ASSERT_EQ(nullptr, drvPath);
+    ASSERT_EQ(NIX_OK, nix_err_code(ctx));
+}
+
+TEST_F(nix_api_expr_test, nix_get_derivation_assertion_propagated)
+{
+    nix_expr_eval_from_string(ctx, state, ASSERTING_DRV, ".", value);
+    assert_ctx_ok();
+
+    // With ignoreAssertionFailures = false the assertion surfaces as an error.
+    StorePath * drvPath = nix_get_derivation(ctx, state, value, false);
+    ASSERT_EQ(nullptr, drvPath);
+    ASSERT_EQ(NIX_ERR_NIX_ERROR, nix_err_code(ctx));
+    ASSERT_THAT(nix_err_msg(nullptr, ctx, nullptr), ::testing::HasSubstr("assert"));
+}
+
+// nix_value_auto_call_function
+
+TEST_F(nix_api_expr_test, nix_value_auto_call_function_supplies_args)
+{
+    nix_expr_eval_from_string(ctx, state, "{ a, b }: a + b", ".", value);
+    assert_ctx_ok();
+
+    nix_value * args = nix_alloc_value(ctx, state);
+    nix_expr_eval_from_string(ctx, state, "{ a = 1; b = 2; }", ".", args);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    nix_value_auto_call_function(ctx, state, args, value, result);
+    assert_ctx_ok();
+
+    ASSERT_EQ(3, nix_get_int(ctx, result));
+
+    nix_gc_decref(ctx, args);
+    nix_gc_decref(ctx, result);
+}
+
+TEST_F(nix_api_expr_test, nix_value_auto_call_function_uses_defaults)
+{
+    nix_expr_eval_from_string(ctx, state, "{ a, b ? 10 }: a + b", ".", value);
+    assert_ctx_ok();
+
+    nix_value * args = nix_alloc_value(ctx, state);
+    nix_expr_eval_from_string(ctx, state, "{ a = 5; }", ".", args);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    nix_value_auto_call_function(ctx, state, args, value, result);
+    assert_ctx_ok();
+
+    ASSERT_EQ(15, nix_get_int(ctx, result));
+
+    nix_gc_decref(ctx, args);
+    nix_gc_decref(ctx, result);
+}
+
+TEST_F(nix_api_expr_test, nix_value_auto_call_function_null_args_uses_defaults)
+{
+    nix_expr_eval_from_string(ctx, state, "{ a ? 7 }: a", ".", value);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    // NULL auto_args supplies no arguments; every formal must then have a
+    // default.
+    nix_value_auto_call_function(ctx, state, nullptr, value, result);
+    assert_ctx_ok();
+
+    ASSERT_EQ(7, nix_get_int(ctx, result));
+
+    nix_gc_decref(ctx, result);
+}
+
+TEST_F(nix_api_expr_test, nix_value_auto_call_function_missing_arg_is_error)
+{
+    nix_expr_eval_from_string(ctx, state, "{ a, b }: a + b", ".", value);
+    assert_ctx_ok();
+
+    nix_value * args = nix_alloc_value(ctx, state);
+    nix_expr_eval_from_string(ctx, state, "{ a = 1; }", ".", args);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    // 'b' has neither a supplied value nor a default. The argument name in the
+    // message is colorized, so use the ANSI-stripping matcher to assert on it.
+    nix_value_auto_call_function(ctx, state, args, value, result);
+    ASSERT_EQ(NIX_ERR_NIX_ERROR, nix_err_code(ctx));
+    ASSERT_THAT(
+        nix_err_msg(nullptr, ctx, nullptr),
+        ::nix::testing::HasSubstrIgnoreANSIMatcher(
+            "cannot evaluate a function that has an argument without a value ('b')"));
+
+    nix_gc_decref(ctx, args);
+    nix_gc_decref(ctx, result);
+}
+
+TEST_F(nix_api_expr_test, nix_value_auto_call_function_non_function_passthrough)
+{
+    nix_expr_eval_from_string(ctx, state, "42", ".", value);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    // A non-function value is returned unchanged.
+    nix_value_auto_call_function(ctx, state, nullptr, value, result);
+    assert_ctx_ok();
+
+    ASSERT_EQ(42, nix_get_int(ctx, result));
+
+    nix_gc_decref(ctx, result);
+}
+
+TEST_F(nix_api_expr_test, nix_value_auto_call_function_single_arg_lambda_passthrough)
+{
+    nix_expr_eval_from_string(ctx, state, "x: x + 1", ".", value);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    // A function taking a single unnamed argument has no named arguments to
+    // fill, so it is returned unchanged rather than being called.
+    nix_value_auto_call_function(ctx, state, nullptr, value, result);
+    assert_ctx_ok();
+
+    ASSERT_EQ(NIX_TYPE_FUNCTION, nix_get_type(ctx, result));
+
+    nix_gc_decref(ctx, result);
+}
+
+TEST_F(nix_api_expr_test, nix_value_auto_call_function_null_fn_is_error)
+{
+    nix_value * result = nix_alloc_value(ctx, state);
+    nix_value_auto_call_function(ctx, state, nullptr, nullptr, result);
+    ASSERT_NE(NIX_OK, nix_err_code(ctx));
+
+    nix_gc_decref(ctx, result);
+}
+
+} // namespace nixC

--- a/src/libexpr-tests/nix_api_eval.cc
+++ b/src/libexpr-tests/nix_api_eval.cc
@@ -130,6 +130,53 @@ TEST_F(nix_api_expr_test, nix_value_auto_call_function_uses_defaults)
     nix_gc_decref(ctx, result);
 }
 
+TEST_F(nix_api_expr_test, nix_value_auto_call_function_forces_auto_args)
+{
+    nix_expr_eval_from_string(ctx, state, "{ a }: a + 1", ".", value);
+    assert_ctx_ok();
+
+    nix_value * identity = nix_alloc_value(ctx, state);
+    nix_expr_eval_from_string(ctx, state, "x: x", ".", identity);
+    assert_ctx_ok();
+
+    nix_value * attrs = nix_alloc_value(ctx, state);
+    nix_expr_eval_from_string(ctx, state, "{ a = 4; }", ".", attrs);
+    assert_ctx_ok();
+
+    nix_value * args = nix_alloc_value(ctx, state);
+    nix_init_apply(ctx, args, identity, attrs);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    nix_value_auto_call_function(ctx, state, args, value, result);
+    assert_ctx_ok();
+
+    ASSERT_EQ(5, nix_get_int(ctx, result));
+
+    nix_gc_decref(ctx, identity);
+    nix_gc_decref(ctx, attrs);
+    nix_gc_decref(ctx, args);
+    nix_gc_decref(ctx, result);
+}
+
+TEST_F(nix_api_expr_test, nix_value_auto_call_function_non_attr_auto_args_is_error)
+{
+    nix_expr_eval_from_string(ctx, state, "{ a ? 7 }: a", ".", value);
+    assert_ctx_ok();
+
+    nix_value * args = nix_alloc_value(ctx, state);
+    nix_init_int(ctx, args, 42);
+    assert_ctx_ok();
+
+    nix_value * result = nix_alloc_value(ctx, state);
+    nix_value_auto_call_function(ctx, state, args, value, result);
+    ASSERT_EQ(NIX_ERR_NIX_ERROR, nix_err_code(ctx));
+    ASSERT_THAT(nix_err_msg(nullptr, ctx, nullptr), ::nix::testing::HasSubstrIgnoreANSIMatcher("expected a set"));
+
+    nix_gc_decref(ctx, args);
+    nix_gc_decref(ctx, result);
+}
+
 TEST_F(nix_api_expr_test, nix_value_auto_call_function_null_args_uses_defaults)
 {
     nix_expr_eval_from_string(ctx, state, "{ a ? 7 }: a", ".", value);


### PR DESCRIPTION
## Motivation

I maintain a set of Rust bindings for Nix that interact with the evaluator
through FFI. While looking to create a `nix-eval-jobs` replacement I've noticed
that it depends heavily on C++ APIs that are not a part of stable C bindings.
This effectively blocks efforts to build external tooling (such as but not
limited to a Rust-based nix-eval-jobs replacement) that interacts with the
evaluator through FFI. Furthermore, other external tools also call internal C++
APIs like `nix::getDerivation`, `nix::findAlongAttrPath`,
`EvalState::autoCallFunction`, and `nix::printValueAsJSON` because the stable C
bindings lack equivalents. This forces consumers to link against unstable
headers that shift between Nix versions, which I find to be making maintenance
brittle. In the light of recent work on the C API, expanding the C API surface
to cover these four operations allows downstream tooling to migrate to stable
bindings and, in turn, enables pure-FFI consumers without any new internal
linkage. This is not all, of course, but I think it's a good start.

## Context

nix-eval-jobs (`src/worker.cc`, `src/drv.cc`) is the canonical consumer. It
evaluates Nix attribute sets in parallel, inspecting each value to determine
whether it is a derivation (recurse vs. emit JSON) and serializing the result.
Conversely, every other piece of derivation metadata nix-eval-jobs extracts
(name, system, output names, meta) is a plain attribute lookup on the forced
attrset, already covered by `nix_get_attr_byname`, `nix_get_string`,
`nix_get_attrs_size`, and `nix_get_attr_name_byidx`.

This is a non-trivial change (obviously, new public API surface) but not
invasive as no existing behavior is altered. 250~ lines added across one new .cc
file and one small addition to the public header. My implementation strategy is
relevatively simple: four new functions now live in a new `nix_api_eval.cc`
translation unit that was also added to meson.build. Each follows the
established C API conventions; error reporting through `nix_c_context` with
`last_err_code`, `EvalState*` wrapping the internal `nix::EvalState&`, and
`NIXC_CATCH_ERRS` / `NIXC_CATCH_ERRS_NULL` macros for exception-to-error-code
translation.

Initially I've wrapped `nix::PackageInfo` in an opaque `nix_package_info` handle
and exposed typed query functions (queryName, querySystem, queryOutputs,
queryMeta, etc.). I've since dropped this approach because every one of those
accessors reduces to an attrset key lookup on the forced derivation value. Those
are operations the existing C API (`nix_get_attr_byname`, `nix_get_string`,
`nix_get_attrs_size`) already supports. Pulling `PackageInfo` into the stable
ABI would also couple the C API to a C++ type whose signature can drift between
Nix versions, which I think would be defeating the purpose of the stable
bindings. The latest design I've settled on
`keeps`nix_get_derivation`returning a plain`StorePath*`, and leaves derivation
introspection to the caller via the attrset API.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
