### PR TITLE
libfetchers: verify git-lfs returns the same objects as git

### DIFF
--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -7,6 +7,7 @@
 #include "nix/util/users.hh"
 #include "nix/util/util.hh"
 #include "nix/util/hash.hh"
+#include "nix/util/json-utils.hh"
 #include "nix/store/ssh.hh"
 #include "nix/util/deleter.hh"
 
@@ -291,7 +292,8 @@ void Fetch::fetch(
 
     const auto obj = objUrls[0];
     try {
-        std::string sha256 = obj.at("oid"); // oid is also the sha256
+        // Use the committed pointer's oid/size for integrity, not server's claim
+        std::string sha256 = pointer->oid;
         std::string ourl = obj.at("actions").at("download").at("href");
         auto authHeader = [&]() -> std::optional<std::string> {
             const auto & download = obj.at("actions").at("download");
@@ -303,7 +305,20 @@ void Fetch::fetch(
                 return std::nullopt;
             return std::string(*authIt);
         }();
-        const uint64_t size = obj.at("size");
+        const uint64_t size = pointer->size;
+
+        auto objOid = getString(valueAt(getObject(obj), "oid"));
+        auto objSize = getUnsigned(valueAt(getObject(obj), "size"));
+        if (objOid != pointer->oid || objSize != pointer->size) {
+            throw Error(
+                "LFS server returned mismatched oid/size for '%s' (got oid=%s size=%d, expected oid=%s size=%d)",
+                pointerFilePath,
+                objOid,
+                objSize,
+                pointer->oid,
+                pointer->size);
+        }
+
         sizeCallback(size);
         downloadToSink(ourl, authHeader, sink, sha256, size);
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Git LFS objects should return the same OID as regular Git.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Prevents servers from returning the wrong objects, or objects with different sizes.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
