### PR TITLE
tests: filter 'waiting for' messages in nix-profile test

### DIFF
--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -225,6 +225,7 @@ diff -u <(
     nix --offline profile install "$flake2Dir" 2>&1 1> /dev/null \
         | grep -vE "^warning: " \
         | grep -vE "^error \(ignored\): " \
+        | grep -vE "^waiting for " \
         || true
 ) <(cat << EOF
 error: An existing package already provides the following file:


### PR DESCRIPTION
The 'waiting for another Nix process to finish fetching input' message appears nondeterministically, causing the diff comparison to fail.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fix flaky test.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- More instances of this problem might exist.

- Message introduced in https://github.com/NixOS/nix/pull/15644

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
