### PR TITLE
libutil: Fix various 32 bit size_t truncations from uint64_t, fix inefficiencies in serialisation code

### DIFF
--- a/src/libutil-tests/serialise.cc
+++ b/src/libutil-tests/serialise.cc
@@ -22,4 +22,19 @@ TEST(readNum, negativeValuesSerialiseWellDefined)
     EXPECT_EQ(readNum<uint64_t>(*makeNumSource(int16_t(-1))), std::numeric_limits<uint64_t>::max());
 }
 
+TEST(readPadding, works)
+{
+    for (unsigned i = 0; i < 8; ++i)
+        EXPECT_NO_THROW(readPadding(i, *makeNumSource(0)));
+
+    for (unsigned len = 1; len < 8; ++len) {
+        EXPECT_THROW(readPadding(len, *makeNumSource(~uint64_t(0))), SerialisationError);
+        unsigned padLen = 8 - len;
+        for (unsigned byte = 0; byte < padLen; ++byte) {
+            uint64_t val = uint64_t{1} << (8 * byte);
+            EXPECT_THROW(readPadding(len, *makeNumSource(val)), SerialisationError);
+        }
+    }
+}
+
 } // namespace nix

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -146,7 +146,14 @@ static void parseContents(CreateRegularFileSink & sink, Source & source)
     sink.preallocateContents(size);
 
     if (sink.skipContents) {
-        source.skip(alignUp(size, 8));
+        uint64_t left = alignUp(size, 8);
+        /* Source::skip takes a size_t, which might be narrower on 32 bit systems, so
+           be careful around truncations. */
+        while (left) {
+            size_t toSkip = std::min<uint64_t>(left, std::numeric_limits<size_t>::max());
+            source.skip(toSkip);
+            left -= toSkip;
+        }
         return;
     }
 

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -267,6 +267,9 @@ void RestoreRegularFile::preallocateContents(uint64_t len)
 
 #if HAVE_POSIX_FALLOCATE
     if (len) {
+        if (len > std::numeric_limits<off_t>::max())
+            throw Error("cannot preallocate contents for a file because it's too large");
+
         errno = posix_fallocate(fd.get(), 0, len);
         /* Note that EINVAL may indicate that the underlying
            filesystem doesn't support preallocation (e.g. on

--- a/src/libutil/include/nix/util/serialise.hh
+++ b/src/libutil/include/nix/util/serialise.hh
@@ -567,6 +567,10 @@ inline uint64_t readLongLong(Source & source)
     return readNum<uint64_t>(source);
 }
 
+/**
+ * Read padding bytes to align `len` up to a multiple of 8. Throws
+ * SerialisationError if any padding byte is non-zero.
+ */
 void readPadding(size_t len, Source & source);
 size_t readString(char * buf, size_t max, Source & source);
 std::string readString(Source & source, size_t max = std::numeric_limits<size_t>::max());

--- a/src/libutil/include/nix/util/serialise.hh
+++ b/src/libutil/include/nix/util/serialise.hh
@@ -649,8 +649,8 @@ struct FramedSource : Source
                     auto n = readInt(from);
                     if (!n)
                         break;
-                    std::vector<char> data(n);
-                    from(data.data(), n);
+                    pending.resize(n);
+                    from(pending.data(), n);
                 }
             }
         } catch (...) {
@@ -669,11 +669,12 @@ struct FramedSource : Source
                 eof = true;
                 return 0;
             }
-            pending = std::vector<char>(len);
+            pending.resize(len);
             pos = 0;
             from(pending.data(), len);
         }
 
+        assert(pending.size() > pos); /* Sanity check. */
         auto n = std::min(len, pending.size() - pos);
         memcpy(data, pending.data() + pos, n);
         pos += n;

--- a/src/libutil/memory-source-accessor.cc
+++ b/src/libutil/memory-source-accessor.cc
@@ -234,6 +234,8 @@ void CreateMemoryRegularFile::isExecutable()
 
 void CreateMemoryRegularFile::preallocateContents(uint64_t len)
 {
+    if (len > std::numeric_limits<decltype(regularFile.contents)::size_type>::max())
+        throw Error("cannot preallocate contents for a file that is too large to fit in memory");
     regularFile.contents.reserve(len);
 }
 

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -508,12 +508,11 @@ Sink & operator<<(Sink & sink, const Error & ex)
 void readPadding(size_t len, Source & source)
 {
     if (len % 8) {
-        char zero[8];
+        uint64_t zero = 0;
         size_t n = 8 - (len % 8);
-        source(zero, n);
-        for (unsigned int i = 0; i < n; i++)
-            if (zero[i])
-                throw SerialisationError("non-zero padding");
+        source(reinterpret_cast<char *>(&zero), n);
+        if (zero)
+            throw SerialisationError("non-zero padding");
     }
 }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation


Several issues:

- Fixes some cases of `uint64_t` -> `size_t` truncation on 32 bit systems.

- Also addresses an inefficiency in `FramedSource` that meant that each chunk lead to a fresh allocation.
  Now we just reuse the existing buffer that gets resized (which doesn't reallocate if shrunk).
  
- Fixes silly codegen in `readPadding`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
