### PR TITLE
fix(libstore/filetransfer): re-enable TCP keep-alive and handle S3's XML errors

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -764,7 +764,30 @@ struct curlFileTransfer : public FileTransfer
                 // We treat most errors as transient, but won't retry when hopeless
                 Error err = Transient;
 
-                if (httpStatus == HttpStatus::NotFound || httpStatus == HttpStatus::Gone
+                // S3 returns certain retryable errors as HTTP 400/500/503 with XML error codes.
+                // These take precedence over the generic HTTP status handling below.
+                // Only parse the response body on status codes where S3 XML errors can appear.
+                static const std::set<std::string> s3RetryableErrors{
+                    "RequestTimeout",     // HTTP 400 - stale connection reuse
+                    "IncompleteBody",     // HTTP 400 - network issue
+                    "InternalError",      // HTTP 500 - S3 internal failure
+                    "SlowDown",           // HTTP 503 - throttling
+                    "ServiceUnavailable", // HTTP 503 - temporary unavailability
+                };
+                // S3 error responses have the form <Error><Code>...</Code>...</Error>.
+                // Require the <Error> root to avoid matching unrelated XML with a <Code> element.
+                static std::regex s3ErrorCodeRegex("<Error>[^]*<Code>([^<]+)</Code>");
+                std::smatch s3Match;
+                bool isS3XmlStatus = httpStatus == 400 || httpStatus == 500 || httpStatus == 503;
+                auto s3ErrorCode =
+                    (isS3XmlStatus && errorSink && std::regex_search(errorSink->s, s3Match, s3ErrorCodeRegex))
+                        ? s3Match[1].str()
+                        : "";
+
+                if (s3RetryableErrors.count(s3ErrorCode)) {
+                    debug("S3 error '%s', will retry", s3ErrorCode);
+                } else if (
+                    httpStatus == HttpStatus::NotFound || httpStatus == HttpStatus::Gone
                     || code == CURLE_FILE_COULDNT_READ_FILE) {
                     // The file is definitely not there
                     err = NotFound;

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -655,6 +655,14 @@ struct curlFileTransfer : public FileTransfer
 #endif
             curl_easy_setopt(req, CURLOPT_CONNECTTIMEOUT, fileTransfer.settings.connectTimeout.get());
 
+            /* Enable TCP keepalive to detect dead connections and server closures.
+               Probes every 30s to catch network failures and idle timeouts early. */
+            curl_easy_setopt(req, CURLOPT_TCP_KEEPALIVE, 1L);
+            curl_easy_setopt(req, CURLOPT_TCP_KEEPIDLE, 30L);
+            curl_easy_setopt(req, CURLOPT_TCP_KEEPINTVL, 30L);
+            /* Don't reuse idle connections older than 90s. */
+            curl_easy_setopt(req, CURLOPT_MAXAGE_CONN, 90L);
+
             curl_easy_setopt(req, CURLOPT_LOW_SPEED_LIMIT, 1L);
             curl_easy_setopt(req, CURLOPT_LOW_SPEED_TIME, fileTransfer.settings.stalledDownloadTimeout.get());
 

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -23,6 +23,7 @@
 #include <curl/curl.h>
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <queue>
 #include <random>
@@ -767,24 +768,32 @@ struct curlFileTransfer : public FileTransfer
                 // S3 returns certain retryable errors as HTTP 400/500/503 with XML error codes.
                 // These take precedence over the generic HTTP status handling below.
                 // Only parse the response body on status codes where S3 XML errors can appear.
-                static const std::set<std::string> s3RetryableErrors{
-                    "RequestTimeout",     // HTTP 400 - stale connection reuse
-                    "IncompleteBody",     // HTTP 400 - network issue
-                    "InternalError",      // HTTP 500 - S3 internal failure
-                    "SlowDown",           // HTTP 503 - throttling
-                    "ServiceUnavailable", // HTTP 503 - temporary unavailability
-                };
+                static constexpr std::array<std::string_view, 12> s3RetryableErrors{{
+                    "IncompleteBody",       // HTTP 400 - network issue
+                    "InternalError",        // HTTP 500 - S3 internal failure
+                    "InternalFailure",      // HTTP 500 - alias for InternalError
+                    "InternalServerError",  // HTTP 500 - alias for InternalError
+                    "RequestExpired",       // HTTP 400 - clock skew / slow upload
+                    "RequestTimeout",       // HTTP 400 - stale connection reuse
+                    "RequestTimeTooSkewed", // HTTP 403 - clock drift
+                    "RequestThrottled",     // HTTP 400 - throttling variant
+                    "SlowDown",             // HTTP 503 - throttling
+                    "ServiceUnavailable",   // HTTP 503 - temporary unavailability
+                    "Throttling",           // HTTP 400 - throttling variant
+                    "ThrottledException",   // HTTP 400 - throttling variant
+                }};
                 // S3 error responses have the form <Error><Code>...</Code>...</Error>.
                 // Require the <Error> root to avoid matching unrelated XML with a <Code> element.
                 static std::regex s3ErrorCodeRegex("<Error>[^]*<Code>([^<]+)</Code>");
                 std::smatch s3Match;
-                bool isS3XmlStatus = httpStatus == 400 || httpStatus == 500 || httpStatus == 503;
+                bool isS3XmlStatus = httpStatus == 400 || httpStatus == 403 || httpStatus == 500 || httpStatus == 503;
                 auto s3ErrorCode =
                     (isS3XmlStatus && errorSink && std::regex_search(errorSink->s, s3Match, s3ErrorCodeRegex))
                         ? s3Match[1].str()
                         : "";
 
-                if (s3RetryableErrors.count(s3ErrorCode)) {
+                if (std::find(s3RetryableErrors.begin(), s3RetryableErrors.end(), s3ErrorCode)
+                    != s3RetryableErrors.end()) {
                     debug("S3 error '%s', will retry", s3ErrorCode);
                 } else if (
                     httpStatus == HttpStatus::NotFound || httpStatus == HttpStatus::Gone

--- a/tests/filetransfer-retry-backoff/test_retry_backoff.py
+++ b/tests/filetransfer-retry-backoff/test_retry_backoff.py
@@ -16,6 +16,8 @@ PAYLOAD = b"hello from flaky server\n"
 PORT = 0  # set after server starts
 fail_count = 0
 retry_after = "1"
+fail_status = 503
+fail_body = b""
 lock = threading.Lock()
 
 
@@ -27,9 +29,15 @@ class FlakyHandler(http.server.BaseHTTPRequestHandler):
             if n > 0:
                 fail_count = n - 1
         if n > 0:
-            self.send_response(503)
-            self.send_header("Retry-After", retry_after)
+            self.send_response(fail_status)
+            if fail_status == 503:
+                self.send_header("Retry-After", retry_after)
+            if fail_body:
+                self.send_header("Content-Type", "application/xml")
+                self.send_header("Content-Length", str(len(fail_body)))
             self.end_headers()
+            if fail_body:
+                self.wfile.write(fail_body)
             return
         self.send_response(200)
         self.send_header("Content-Type", "text/plain")
@@ -41,11 +49,19 @@ class FlakyHandler(http.server.BaseHTTPRequestHandler):
         pass
 
 
-def set_failures(n: int, ra: int = 1) -> None:
-    global fail_count, retry_after
+def s3_error_xml(code: str, message: str = "test") -> bytes:
+    return (f'<?xml version="1.0" encoding="UTF-8"?>'
+            f'<Error><Code>{code}</Code>'
+            f'<Message>{message}</Message></Error>').encode()
+
+
+def set_failures(n: int, ra: int = 1, status: int = 503, body: bytes = b"") -> None:
+    global fail_count, retry_after, fail_status, fail_body
     with lock:
         fail_count = n
         retry_after = str(ra)
+        fail_status = status
+        fail_body = body
 
 
 def fetch(extra_opts: str = "") -> tuple[int, str, list[int]]:
@@ -71,6 +87,7 @@ def main() -> None:
         test_retry_exhaustion()
         test_raised_retry_attempts()
         test_download_attempts_alias()
+        test_s3_xml_error_retried()
     finally:
         httpd.shutdown()
 
@@ -134,6 +151,18 @@ def test_download_attempts_alias():
 
     assert rc != 0, f"Expected failure: {out}"
     assert len(delays) == 1, f"Expected 1 retry, got {len(delays)}: {out}"
+
+
+def test_s3_xml_error_retried():
+    """HTTP 400 with S3 RequestTimeout XML error body is retried."""
+    set_failures(2, ra=0, status=400, body=s3_error_xml("RequestTimeout"))
+    rc, out, delays = fetch(
+        "--option filetransfer-retry-attempts 4 "
+        "--option filetransfer-retry-delay-rate-limited 50"
+    )
+    assert rc == 0, f"Expected success: {out}"
+    assert len(delays) == 2, f"Expected 2 retries, got {len(delays)}: {out}"
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This allows curl to detect drops from both a server (eg: S3) as well as intermediate networking. 30s is to be shorter than commonly used 60s limits on the server side. The theory is that 60s timeout on both server and client led to races that were sometimes lost.

un-reverts: https://github.com/NixOS/nix/pull/15522

## Motivation
Had connections that died and without keepalive they are not detected for a long time.