### PR TITLE
libstore: split DerivationBuilder::unprepareBuild to fix flock self-deadlock (#15846)

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1044,8 +1044,36 @@ Goal::Co DerivationBuildingGoal::buildLocally(
     trace("build done");
 
     SingleDrvOutputs builtOutputs;
+    /* Locks acquired between the two phases of output registration.
+       Covers output store paths that `outputLocks` doesn't already
+       cover -- floating CA outputs and hash-mismatching fixed-output
+       derivations. See `DerivationBuilder::unprepareBuild`. */
+    PathLocks dynamicOutputLocks;
+    dynamicOutputLocks.setDeletion(true);
     try {
-        builtOutputs = builder->unprepareBuild();
+        auto dynamicLockPaths = builder->unprepareBuild();
+
+        /* Acquire dynamic output locks with the same try-lock +
+           coroutine yield pattern used for the pre-build locks above.
+           A blocking flock here would freeze the worker thread on a
+           lock another goal in this same daemon already holds via a
+           different file descriptor (POSIX flock is per-OFD), which is
+           exactly the deadlock reported in issue #15846. */
+        if (!dynamicLockPaths.empty() && !dynamicOutputLocks.lockPaths(dynamicLockPaths, "", false)) {
+            Activity act(
+                *logger,
+                lvlWarn,
+                actBuildWaiting,
+                fmt("waiting for lock on %s",
+                    Magenta(concatMapStringsSep(
+                        ", ", dynamicLockPaths, [](auto & p) { return "'" + p.string() + "'"; }))));
+
+            do {
+                co_await waitForAWhile();
+            } while (!dynamicOutputLocks.lockPaths(dynamicLockPaths, "", false));
+        }
+
+        builtOutputs = builder->registerOutputs();
     } catch (BuilderFailureError & e) {
         builder.reset();
         outputLocks.unlock();

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include <filesystem>
+#include <set>
 #include <nlohmann/json_fwd.hpp>
 
 #include "nix/store/build-result.hh"
@@ -166,16 +167,42 @@ struct DerivationBuilder : RestrictionContext
 
     /**
      * Tear down build environment after the builder exits (either on
-     * its own or if it is killed).
+     * its own or if it is killed), validate its exit status, and
+     * prepare outputs for registration.
      *
-     * @returns The first case indicates failure during output
-     * processing. A status code and exception are returned, providing
-     * more information. The second case indicates success, and
-     * realisations for each output of the derivation are returned.
+     * This computes the content-addressed paths of all CA outputs and
+     * canonicalises the scratch output trees. It does NOT yet move the
+     * outputs into their final store locations.
+     *
+     * @returns The set of "actual" output store paths that need to be
+     * locked before calling `registerOutputs()`. These are paths that
+     * the per-derivation output locks acquired before the build started
+     * do not already cover — namely the paths of floating CA outputs,
+     * and of fixed-output derivations whose actual content hash differs
+     * from the declared one.
+     *
+     * After this returns, the caller must acquire `PathLocks` on the
+     * returned paths (typically with a try-lock + coroutine yield retry
+     * loop, to avoid blocking the daemon's worker thread on a flock
+     * already held by another goal in the same process), and then call
+     * `registerOutputs()`.
+     *
+     * @throws BuilderFailureError
+     * @throws BuildError
+     */
+    virtual std::set<std::filesystem::path> unprepareBuild() = 0;
+
+    /**
+     * Move the prepared outputs into the store, register them as valid
+     * and apply output checks. Must be called after `unprepareBuild()`,
+     * with the caller holding `PathLocks` on the set of paths it
+     * returned.
+     *
+     * @returns realisations for each output of the derivation.
      *
      * @throws BuildError
      */
-    virtual SingleDrvOutputs unprepareBuild() = 0;
+    virtual SingleDrvOutputs registerOutputs() = 0;
 
     /**
      * Forcibly kill the child process, if any.

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -276,7 +276,9 @@ public:
 
     std::optional<Descriptor> startBuild() override;
 
-    SingleDrvOutputs unprepareBuild() override;
+    std::set<std::filesystem::path> unprepareBuild() override;
+
+    SingleDrvOutputs registerOutputs() override;
 
 protected:
 
@@ -448,10 +450,36 @@ protected:
 private:
 
     /**
-     * Check that the derivation outputs all exist and register them
-     * as valid.
+     * Per-output state computed by `unprepareBuild()` and consumed by
+     * `registerOutputs()`. We split the work into two phases so that
+     * the caller (the build goal coroutine) can acquire the dynamic
+     * output locks between them with a try-lock + yield retry loop,
+     * avoiding the same-process flock self-deadlock that happens when
+     * a sibling goal in the same daemon already holds the lock on
+     * `newInfo.path` (see issue #15846).
      */
-    SingleDrvOutputs registerOutputs();
+    struct PendingOutput
+    {
+        std::string outputName;
+        ValidPathInfo newInfo;
+        std::filesystem::path actualPath;
+        StorePathSet references;
+        AutoCloseFD tempDirFd;
+        AutoDelete delTempDir;
+    };
+
+    std::vector<PendingOutput> pendingOutputs;
+
+    /**
+     * First phase of output registration. Validates that the builder
+     * produced all expected outputs, canonicalises them, computes their
+     * content-addressed paths (for CA outputs) and stashes the result
+     * in `pendingOutputs`. Called from `unprepareBuild()`.
+     *
+     * @returns The set of "actual" output store paths that need to be
+     * locked dynamically before `registerOutputs()` runs.
+     */
+    std::set<std::filesystem::path> preRegisterOutputs();
 
 protected:
 
@@ -557,7 +585,7 @@ bool DerivationBuilderImpl::killChild()
     return ret;
 }
 
-SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()
+std::set<std::filesystem::path> DerivationBuilderImpl::unprepareBuild()
 {
     /* Since we got an EOF on the logger pipe, the builder is presumed
        to have terminated.  In fact, the builder could also have
@@ -614,13 +642,14 @@ SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()
         };
     }
 
-    /* Compute the FS closure of the outputs and register them as
-       being valid. */
-    auto builtOutputs = registerOutputs();
-
-    cleanupBuild(true);
-
-    return builtOutputs;
+    /* Compute output info and canonicalise the scratch outputs.
+       Returns the set of store paths that need to be locked
+       dynamically before `registerOutputs()` can move things into
+       place. The caller (the build goal coroutine) is expected to
+       acquire these locks with a try-lock + yield retry loop, so the
+       daemon's worker thread won't get blocked on a flock that a
+       sibling goal in the same process already holds. */
+    return preRegisterOutputs();
 }
 
 /* Move/rename path 'src' to 'dst'. Temporarily make 'src' writable if
@@ -1448,9 +1477,12 @@ void DerivationBuilderImpl::execBuilder(const Strings & args, const Strings & en
     execve(drv.builder.c_str(), stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
 }
 
-SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
+std::set<std::filesystem::path> DerivationBuilderImpl::preRegisterOutputs()
 {
-    std::map<std::string, ValidPathInfo> infos;
+    /* Output state we'll hand off to `registerOutputs()` once the
+       caller has acquired the dynamic locks we return. */
+    pendingOutputs.clear();
+    std::set<std::filesystem::path> dynamicLockPaths;
 
     /* Set of inodes seen during calls to canonicalisePathMetaData()
        for this build's outputs.  This needs to be shared between
@@ -1869,21 +1901,66 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                 NIX_WHEN_SUPPORT_ACLS(localSettings.ignoredAcls)},
             inodesSeen);
 
+        /* Update outputRewrites so the next iteration's hash rewriting
+           sees this output's final path. The previous one-pass code
+           did this at the end of the register step; we do it eagerly
+           here because the register step now happens in a separate
+           call (`registerOutputs()`) after the caller has acquired the
+           dynamic locks.
+
+           In bmCheck mode the previous code did not call `finish()`
+           for newly-built (non-AlreadyRegistered) outputs; preserve
+           that behaviour. */
+        if (buildMode != bmCheck)
+            finish(newInfo.path);
+
+        /* Determine whether the actual output path needs to be locked
+           dynamically. This happens with floating CA derivations and
+           with hash-mismatching fixed-output derivations -- i.e.,
+           cases where `newInfo.path` is not covered by the
+           per-derivation output locks the caller acquired before the
+           build started. */
+        auto finalDestPath = store.printStorePath(newInfo.path);
+        auto optFixedPath = output->path(store, drv.name, outputName);
+        if (!optFixedPath || store.printStorePath(*optFixedPath) != finalDestPath) {
+            assert(newInfo.ca);
+            dynamicLockPaths.insert(store.toRealPath(newInfo.path));
+        }
+
+        /* Stash everything `registerOutputs()` needs so it can run
+           after the caller has acquired the dynamic locks. */
+        pendingOutputs.push_back(PendingOutput{
+            .outputName = outputName,
+            .newInfo = std::move(newInfo),
+            .actualPath = std::move(actualPath),
+            .references = std::move(references),
+            .tempDirFd = std::move(tempDirFd),
+            .delTempDir = std::move(delTempDir),
+        });
+    }
+
+    return dynamicLockPaths;
+}
+
+SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
+{
+    std::map<std::string, ValidPathInfo> infos;
+
+    /* For each output prepared by `preRegisterOutputs()`, move the
+       scratch tree into its final store location and register it.
+       The caller is responsible for having acquired the dynamic locks
+       on the paths returned by `unprepareBuild()`; no flock happens
+       here. */
+    for (auto & pending : pendingOutputs) {
+        const auto & outputName = pending.outputName;
+        auto & newInfo = pending.newInfo;
+        auto & actualPath = pending.actualPath;
+        const auto & references = pending.references;
+
         /* Calculate where we'll move the output files. In the checking case we
            will leave leave them where they are, for now, rather than move to
            their usual "final destination" */
         auto finalDestPath = store.printStorePath(newInfo.path);
-
-        /* Lock final output path, if not already locked. This happens with
-           floating CA derivations and hash-mismatching fixed-output
-           derivations. */
-        PathLocks dynamicOutputLock;
-        dynamicOutputLock.setDeletion(true);
-        auto optFixedPath = output->path(store, drv.name, outputName);
-        if (!optFixedPath || store.printStorePath(*optFixedPath) != finalDestPath) {
-            assert(newInfo.ca);
-            dynamicOutputLock.lockPaths({store.toRealPath(newInfo.path)});
-        }
 
         /* Move files, if needed */
         if (store.toRealPath(newInfo.path) != actualPath) {
@@ -1967,7 +2044,8 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
             newInfo.ultimate = true;
             store.signPathInfo(newInfo);
 
-            finish(newInfo.path);
+            /* The `outputRewrites` update normally done by `finish()` was
+               performed eagerly in `preRegisterOutputs()`. */
 
             /* If it's a CA path, register it right away. This is necessary if it
                isn't statically known so that we can safely unlock the path before
@@ -1989,11 +2067,17 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         infos.emplace(outputName, std::move(newInfo));
     }
 
+    /* All scratch outputs have either been moved into the store or
+       deleted; the RAII guards in `pendingOutputs` can be released
+       now. */
+    pendingOutputs.clear();
+
     /* Apply output checks. This includes checking of the wanted vs got
        hash of fixed-outputs. */
     checkOutputs(store, drvPath, drv.outputs, drvOptions.outputChecks, infos);
 
     if (buildMode == bmCheck) {
+        cleanupBuild(true);
         return {};
     }
 
@@ -2033,6 +2117,8 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         }
         builtOutputs.emplace(outputName, thisRealisation);
     }
+
+    cleanupBuild(true);
 
     return builtOutputs;
 }

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -815,7 +815,7 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
         });
     }
 
-    SingleDrvOutputs unprepareBuild() override
+    std::set<std::filesystem::path> unprepareBuild() override
     {
         sandboxMountNamespace = -1;
         sandboxUserNamespace = -1;


### PR DESCRIPTION
## Motivation

Fixes #15846.

`PathLocks::lockPaths` uses `flock(2)`, whose locks are associated with the
open file description rather than the process. When a goal running
`registerOutputs` tries to flock the actual output path while a sibling
goal in the same daemon already holds that path's lock via a different
open file description, the flock blocks even though both file descriptors
live in the same process. Because `registerOutputs` runs synchronously
from the build goal coroutine, that flock freezes the daemon's worker
thread; the sibling goal can no longer make progress (its builder's
stdout pipe fills and the build blocks on write), and the daemon
deadlocks. The reporter's `lsof` shows the same `-source.lock` file open
on two file descriptors of one process — the smoking gun for this
pattern.

## Approach

Split `DerivationBuilder` output registration into two phases so the
dynamic output locks can be acquired from the goal coroutine, where a
non-blocking try-lock can yield instead of blocking the worker:

- `unprepareBuild()` tears down the build environment, validates the
  builder exit status, canonicalises the scratch outputs and computes
  their content-addressed paths. It now returns the set of output store
  paths that the per-derivation pre-build locks do not already cover
  (floating CA outputs, and fixed-output derivations whose actual hash
  differs from the declared one). It no longer moves outputs.

- `registerOutputs()` moves the prepared outputs into the store,
  registers them as valid, and applies output checks. The caller is
  responsible for holding `PathLocks` on the paths returned by
  `unprepareBuild()`.

`DerivationBuildingGoal::buildLocally` acquires the dynamic output locks
between the two calls using the same try-lock + `co_await
waitForAWhile()` retry pattern already used for the pre-build locks in
`acquireResources`. The worker thread yields the coroutine instead of
blocking on flock, so any sibling goal holding the lock can progress and
release it.

The set of paths locked, and the order in which they are locked, is
unchanged versus the pre-existing code; only the call site (and thus
the blocking discipline) moves.

## Notes on behavioural preservation

- The `finish()` call that updates `outputRewrites` for subsequent
  iterations now runs at the end of phase 1 (before the move) instead of
  at the end of phase 2 (after the move). The update is guarded with
  `if (buildMode != bmCheck)` so that bmCheck does not call `finish()`
  for newly-built outputs, matching the prior behaviour.

- Per-output state that previously lived in the third loop's stack frame
  (`newInfo`, `actualPath`, `references`, `tempDirFd`, `delTempDir`) is
  stashed on the builder as `pendingOutputs`. The RAII guards are
  cleared after the move loop in phase 2 (success) or by the
  `DerivationBuilder` destructor (failure paths).

- `ChrootLinuxDerivationBuilder::unprepareBuild` is updated to the new
  signature; its namespace-reset behaviour is preserved.

- I deliberately avoided fcntl OFD locks: they have the same per-OFD
  semantics as `flock` and would not fix the in-process collision.
  Plain POSIX `F_SETLK` is process-wide but has well-known "close any fd
  drops all locks" semantics that interact badly with how `PathLocks`
  manages file descriptors. Moving the lock acquisition into the
  coroutine seemed like the smallest principled fix.

## Test plan

- [x] `nix build` on the patched tree builds clean. The full test suite
  derivations (`nix-store-tests-run`, `nix-expr-tests-run`,
  `nix-flake-tests-run`, `nix-fetchers-tests-run`,
  `nix-functional-tests-...`) all build green.
- [x] The reproducer from #15846 (`nix build -j3
  'github:RazYang/nix_deadlock'`) no longer hangs. Three fetchers whose
  declared and actual hashes disagree now serialise at the dynamic-lock
  stage instead of deadlocking the worker thread.
- [ ] Reviewers, I'd especially appreciate eyes on:
    1. The `finish()` re-timing in phase 1 vs phase 2 (`derivation-builder.cc`
       in the third loop). I believe the bmCheck guard preserves the prior
       semantics exactly, but a second opinion would be welcome.
    2. Whether the public `DerivationBuilder` interface change
       (`unprepareBuild()` return type, new `registerOutputs()`) is
       acceptable, or whether you'd prefer a non-breaking internal
       refactor with a wrapper. Only `ChrootLinuxDerivationBuilder`
       overrides this in-tree.

## Known follow-up

A pre-existing benign `error (ignored): cannot rename: Permission denied`
from `ChrootDerivationBuilder::cleanupBuild`'s rescue-rename loop becomes
visible after this fix (it was previously masked by the deadlock — the
build never reached the post-build cleanup path). The rescue path uses an
`initialOutputs` snapshot of validity rather than querying the store, so
on a successful build it still tries to rename the newly-built outputs
over their (now-registered) destinations. The build result is unaffected
and the error is logged with the `(ignored)` prefix. Happy to address it
as a follow-up commit on this PR or as a separate PR — let me know which
you'd prefer.

---

## Disclosure

Parts of this change were drafted with the assistance of an LLM (Anthropic
Claude, via Claude Code). The LLM helped with: navigating the existing
`registerOutputs` body to find a clean split point, drafting the
two-phase API, and explaining the `flock(2)` per-OFD semantics that
caused the original deadlock.

All architectural decisions, the choice between candidate fixes,
behavioural-preservation reasoning, build/test verification, and the
final code were reviewed and verified by me. The reproducer is mine; the
backtrace and `lsof` evidence in the linked issue are real and were
captured before this work began. I am responsible for the correctness of
the patch.
