### PR TITLE
libstore: avoid `$out.tmp` collision during hash rewriting (#15839)

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1673,7 +1673,12 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                     dumpPath(actualPath, rsink);
                     rsink.flush();
                 });
-                std::filesystem::path tmpPath = actualPath.native() + ".tmp";
+                /* Put the temporary copy in a directory inaccessible to the builder.
+                   actualPath might point inside the build chroot, which is controlled
+                   by the derivation builder. */
+                auto [rewriteTempDir, rewriteTempDirFd] = store.createTempDirInStore();
+                AutoDelete delRewriteTempDir(rewriteTempDir);
+                std::filesystem::path tmpPath = rewriteTempDir / "x";
                 restorePath(tmpPath, *source);
                 deletePath(actualPath);
                 movePath(tmpPath, actualPath);


### PR DESCRIPTION
Fixes #15839

This is @xokdvium's propoposed fix, write into a fresh dir created outside the builder's reach via `LocalStore::createTempDirInStore()`.

I include a commit with the unit test that I used to replicate the bug and then use to prove that the bug had been fixed, but its use maybe limited now that the bug has been fixed - we're not likely to regress and get the same bug again :) If you want me to drop the unit test, let me know.

Claude assisted in making this PR.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 