### PR TITLE
Fix instructions to disable unit tests when building from source

### DIFF
--- a/doc/manual/source/installation/prerequisites-source.md
+++ b/doc/manual/source/installation/prerequisites-source.md
@@ -74,7 +74,7 @@
     This is an optional dependency and can be disabled
     by providing a `--disable-cpuid` to the `configure` script.
 
-  - Unless `./configure --disable-unit-tests` is specified, GoogleTest (GTest) and
+  - Unless `meson setup build -Dunit-tests=false` is specified, GoogleTest (GTest) and
     RapidCheck are required, which are available at
     <https://google.github.io/googletest/> and
     <https://github.com/emil-e/rapidcheck> respectively.


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The current documentation is incorrect. If you want to disable unit tests when building from source, the current instructions direct you to `./configure --disable-unit-tests` which is no longer up to date.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Expanding upon https://github.com/NixOS/nix/pull/14949 in updating the build instructions to reflect meson.

Specifically addresses a question in a comment from: https://github.com/NixOS/nix/issues/12852

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
