### PR TITLE
libutil: skip fork in long-path bind/connect on FreeBSD and Linux

### DIFF
--- a/src/libutil-tests/unix/unix-domain-socket.cc
+++ b/src/libutil-tests/unix/unix-domain-socket.cc
@@ -1,12 +1,18 @@
 #include <gtest/gtest.h>
 
 #include "nix/util/file-descriptor.hh"
+#include "nix/util/file-system.hh"
 #include "nix/util/processes.hh"
 #include "nix/util/unix-domain-socket.hh"
 
 #include <algorithm>
+#include <filesystem>
+#include <poll.h>
+#include <span>
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 namespace nix {
 
@@ -122,6 +128,120 @@ TEST(MessageWithFds, datagramEmptyData)
     int status = pid.wait();
     EXPECT_TRUE(WIFEXITED(status));
     EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+namespace {
+
+std::filesystem::path buildDeepDir(const std::filesystem::path & root, size_t targetLen)
+{
+    std::filesystem::path cur = root;
+    while (cur.string().size() < targetLen) {
+        cur /= "deeper-segment-padding";
+        std::filesystem::create_directory(cur);
+    }
+    return cur;
+}
+
+// This listens at sockPath and has a forked child connect and write one byte. If
+// the child can't connect, the readyPipe wakes the poll so accept doesn't hang.
+void runRoundtrip(const std::filesystem::path & sockPath)
+{
+    auto listenFd = createUnixDomainSocket(sockPath, 0600);
+
+    Pipe readyPipe;
+    readyPipe.create();
+
+    Pid pid = startProcess([&] {
+        readyPipe.readSide.close();
+        int rc = 1;
+        try {
+            auto clientFd = connect(sockPath);
+            std::byte msg{'x'};
+            if (write(clientFd.get(), std::span{&msg, 1}, false) != 1)
+                rc = 2;
+            else
+                rc = 0;
+        } catch (...) {
+            rc = 3;
+        }
+        std::byte done{static_cast<std::byte>(rc)};
+        (void) write(readyPipe.writeSide.get(), std::span{&done, 1}, false);
+        _exit(rc);
+    });
+    readyPipe.writeSide.close();
+
+    // Multiplex accept and the readyPipe so a child failure doesn't hang.
+    pollfd pfds[2] = {
+        {.fd = toSocket(listenFd.get()), .events = POLLIN, .revents = 0},
+        {.fd = readyPipe.readSide.get(), .events = POLLIN, .revents = 0},
+    };
+    ASSERT_GT(poll(pfds, 2, 5000), 0) << "timed out waiting for client";
+    ASSERT_TRUE(pfds[0].revents & POLLIN) << "child signalled failure before connecting";
+
+    int conn = accept(toSocket(listenFd.get()), nullptr, nullptr);
+    ASSERT_NE(conn, -1);
+    AutoCloseFD connFd(conn);
+
+    std::byte buf{};
+    ASSERT_EQ(read(connFd.get(), std::span{&buf, 1}), size_t{1});
+    EXPECT_EQ(std::to_integer<char>(buf), 'x');
+
+    int status = pid.wait();
+    EXPECT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+} // namespace
+
+class UnixDomainSocketLongPath : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        tmp = createTempDir();
+    }
+
+    void TearDown() override
+    {
+        nix::deletePath(tmp);
+    }
+
+    std::filesystem::path tmp;
+};
+
+TEST_F(UnixDomainSocketLongPath, bindConnectRoundtrip)
+{
+    // The full path exceeds sun_path.
+    constexpr size_t targetLen = sizeof(sockaddr_un::sun_path) + 50;
+    auto deepDir = buildDeepDir(tmp, targetLen);
+    auto sockPath = deepDir / "s";
+    ASSERT_GT(sockPath.string().size(), sizeof(sockaddr_un::sun_path));
+
+    runRoundtrip(sockPath);
+}
+
+TEST_F(UnixDomainSocketLongPath, bindRejectsTooLongBasename)
+{
+    // A basename over sun_path cannot be rescued by chdir or dirfd tricks.
+    std::string base(sizeof(sockaddr_un::sun_path), 'a');
+    auto sockPath = tmp / base;
+
+    auto fd = createUnixDomainSocket();
+    EXPECT_THROW(bind(toSocket(fd.get()), sockPath), Error);
+}
+
+TEST_F(UnixDomainSocketLongPath, nearLimitBasenameRoundtrip)
+{
+    // A basename close to the sun_path limit. The roundtrip works on both platforms,
+    // but it forces Linux through the fork+chdir fallback while FreeBSD stays on bindat.
+    auto deepDir = buildDeepDir(tmp, sizeof(sockaddr_un::sun_path));
+    std::string base(sizeof(sockaddr_un::sun_path) - 4, 'b');
+    auto sockPath = deepDir / base;
+
+    ASSERT_GT(sockPath.string().size(), sizeof(sockaddr_un::sun_path));
+    ASSERT_LT(base.size() + 1, sizeof(sockaddr_un::sun_path));
+
+    runRoundtrip(sockPath);
 }
 
 } // namespace nix

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -31,10 +31,20 @@ check_funcs = [
     'posix_fallocate',
     'Optionally used to preallocate files to be large enough before writing to them.',
   ],
+  [
+    'bindat',
+    'Avoids forking when binding AF_UNIX sockets with paths longer than sun_path.',
+    '#include <sys/socket.h>',
+  ],
+  [
+    'connectat',
+    'Avoids forking when connecting AF_UNIX sockets with paths longer than sun_path.',
+    '#include <sys/socket.h>',
+  ],
 ]
 foreach funcspec : check_funcs
   define_name = 'HAVE_' + funcspec[0].underscorify().to_upper()
-  define_value = cxx.has_function(funcspec[0]).to_int()
+  define_value = cxx.has_function(funcspec[0], prefix : funcspec.get(2, '')).to_int()
   configdata_priv.set(define_name, define_value, description : funcspec[1])
 endforeach
 

--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -1,3 +1,5 @@
+#include "util-config-private.hh"
+
 #include "nix/util/file-system.hh"
 #include "nix/util/unix-domain-socket.hh"
 #include "nix/util/util.hh"
@@ -9,6 +11,7 @@
 #  include <winsock2.h>
 #  include <afunix.h>
 #else
+#  include <fcntl.h>
 #  include <sys/socket.h>
 #  include <sys/un.h>
 #  include "nix/util/processes.hh"
@@ -49,12 +52,84 @@ AutoCloseFD createUnixDomainSocket(const std::filesystem::path & path, mode_t mo
     return fdSocket;
 }
 
+#if HAVE_BINDAT && HAVE_CONNECTAT
+constexpr auto bindAt = ::bindat;
+constexpr auto connectAt = ::connectat;
+#else
+constexpr auto bindAt = nullptr;
+constexpr auto connectAt = nullptr;
+#endif
+
+#ifndef _WIN32
+
 /**
- * Use string for path, because no `struct sockaddr_un` variant supports native wide character paths.
+ * Tries the dirfd-anchored fast path for a socket whose absolute path
+ * overflows sun_path. Returns false when the path can't be handled this way,
+ * leaving the caller to fall back to the fork+chdir helper.
+ *
+ * For this case, FreeBSD has bindat and connectat. Linux doesn't, but
+ * its /proc/self/fd/<N>/<base> magic symlink lets plain bind and connect reach
+ * the same place by resolving through an open dirfd.
  */
-static void
-bindConnectProcHelper(std::string_view operationName, auto && operation, Socket fd, const std::string & path)
+static bool tryBindConnectAtDir(
+    [[maybe_unused]] std::string_view operationName,
+    [[maybe_unused]] auto && operation,
+    [[maybe_unused]] auto && operationAt,
+    [[maybe_unused]] Socket fd,
+    [[maybe_unused]] const std::filesystem::path & path)
 {
+#  if (HAVE_BINDAT && HAVE_CONNECTAT) || defined(__linux__)
+    auto base = path.filename();
+
+    struct sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    auto * psaddr = reinterpret_cast<struct sockaddr *>(&addr);
+
+    if (base.native().size() + 1 >= sizeof(addr.sun_path))
+        throw Error("socket path '%s' is too long", PathFmt(path));
+
+    // O_PATH opens the directory as a path-resolution-only handle, with no read permission needed.
+    AutoCloseFD dirfd = ::open(path.parent_path().c_str(), O_PATH | O_DIRECTORY | O_CLOEXEC);
+    if (!dirfd)
+        return false;
+
+#    if HAVE_BINDAT && HAVE_CONNECTAT
+    memcpy(addr.sun_path, base.c_str(), base.native().size() + 1);
+    if (operationAt(dirfd.get(), fd, psaddr, sizeof(addr)) == -1)
+        throw SysError("cannot %s to socket at '%s'", operationName, PathFmt(path));
+    return true;
+#    else // __linux__
+    // A long basename plus a multi-digit dirfd can push this past sun_path even when the
+    // basename alone fits, so fall back to fork+chdir for that pathological case.
+    auto proc = std::filesystem::path("/proc/self/fd") / std::to_string(dirfd.get()) / base;
+    if (proc.native().size() + 1 >= sizeof(addr.sun_path))
+        return false;
+    memcpy(addr.sun_path, proc.c_str(), proc.native().size() + 1);
+    if (operation(fd, psaddr, sizeof(addr)) == -1) {
+        // /proc not being mounted is the case where fork+chdir remains useful.
+        if (errno == ENOENT || errno == ENOTDIR)
+            return false;
+        throw SysError("cannot %s to socket at '%s'", operationName, PathFmt(path));
+    }
+    return true;
+#    endif
+#  else
+    return false;
+#  endif
+}
+
+#endif // !_WIN32
+
+static void bindConnectProcHelper(
+    std::string_view operationName,
+    auto && operation,
+    [[maybe_unused]] auto && operationAt,
+    Socket fd,
+    const std::filesystem::path & path)
+{
+    // No `struct sockaddr_un` variant supports native wide character paths.
+    auto pathStr = path.string();
+
     struct sockaddr_un addr;
     addr.sun_family = AF_UNIX;
 
@@ -65,24 +140,27 @@ bindConnectProcHelper(std::string_view operationName, auto && operation, Socket 
     // special case.
     auto * psaddr = reinterpret_cast<struct sockaddr *>(&addr);
 
-    if (path.size() + 1 >= sizeof(addr.sun_path)) {
+    if (pathStr.size() + 1 >= sizeof(addr.sun_path)) {
 #ifdef _WIN32
-        throw Error("cannot %s to socket at '%s': path is too long", operationName, path);
+        throw Error("cannot %s to socket at '%s': path is too long", operationName, pathStr);
 #else
+        if (tryBindConnectAtDir(operationName, operation, operationAt, fd, path))
+            return;
+
         Pipe pipe;
         pipe.create();
         Pid pid = startProcess([&] {
             try {
                 pipe.readSide.close();
-                auto dir = std::filesystem::path(path).parent_path();
-                if (chdir(dir.string().c_str()) == -1)
+                auto dir = path.parent_path();
+                if (chdir(dir.c_str()) == -1)
                     throw SysError("chdir to %s failed", PathFmt(dir));
-                std::string base(baseNameOf(path));
-                if (base.size() + 1 >= sizeof(addr.sun_path))
-                    throw Error("socket path '%s' is too long", base);
-                memcpy(addr.sun_path, base.c_str(), base.size() + 1);
+                auto base = path.filename();
+                if (base.native().size() + 1 >= sizeof(addr.sun_path))
+                    throw Error("socket path '%s' is too long", PathFmt(path));
+                memcpy(addr.sun_path, base.c_str(), base.native().size() + 1);
                 if (operation(fd, psaddr, sizeof(addr)) == -1)
-                    throw SysError("cannot %s to socket at '%s'", operationName, path);
+                    throw SysError("cannot %s to socket at '%s'", operationName, PathFmt(path));
                 writeFull(pipe.writeSide.get(), "0\n");
             } catch (SysError & e) {
                 writeFull(pipe.writeSide.get(), fmt("%d\n", e.errNo));
@@ -93,29 +171,28 @@ bindConnectProcHelper(std::string_view operationName, auto && operation, Socket 
         pipe.writeSide.close();
         auto errNo = string2Int<int>(chomp(drainFD(pipe.readSide.get())));
         if (!errNo || *errNo == -1)
-            throw Error("cannot %s to socket at '%s'", operationName, path);
+            throw Error("cannot %s to socket at '%s'", operationName, PathFmt(path));
         else if (*errNo > 0) {
             errno = *errNo;
-            throw SysError("cannot %s to socket at '%s'", operationName, path);
+            throw SysError("cannot %s to socket at '%s'", operationName, PathFmt(path));
         }
 #endif
     } else {
-        memcpy(addr.sun_path, path.c_str(), path.size() + 1);
+        memcpy(addr.sun_path, pathStr.c_str(), pathStr.size() + 1);
         if (operation(fd, psaddr, sizeof(addr)) == -1)
-            throw SysError("cannot %s to socket at '%s'", operationName, path);
+            throw SysError("cannot %s to socket at '%s'", operationName, PathFmt(path));
     }
 }
 
 void bind(Socket fd, const std::filesystem::path & path)
 {
     tryUnlink(path);
-
-    bindConnectProcHelper("bind", ::bind, fd, path.string());
+    bindConnectProcHelper("bind", ::bind, bindAt, fd, path);
 }
 
 void connect(Socket fd, const std::filesystem::path & path)
 {
-    bindConnectProcHelper("connect", ::connect, fd, path.string());
+    bindConnectProcHelper("connect", ::connect, connectAt, fd, path);
 }
 
 AutoCloseFD connect(const std::filesystem::path & path)

--- a/tests/functional/long-socket-path.sh
+++ b/tests/functional/long-socket-path.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+# Long AF_UNIX socket paths must not break the daemon's bind nor the client's
+# connect, even when the absolute path exceeds sockaddr_un::sun_path.
+
+# This test requires control of the daemon's socket path.
+isTestOnNixOS && skipTest "this test manages its own daemon socket path"
+
+requireDaemonNewerThan "2.0"
+
+needLocalStore "the daemon socket path is part of this test"
+
+# Build a path well past Linux's 108-byte sun_path.
+deep="$TEST_ROOT/$(printf 'padding-segment-/%.0s' {1..10})z"
+sock="$deep/d.sock"
+mkdir -p "$deep"
+
+killDaemon
+export NIX_DAEMON_SOCKET_PATH=$sock
+startDaemon
+
+out=$(nix --extra-experimental-features nix-command store ping 2>&1)
+echo "$out" | grep -q 'Store URL' || fail "unexpected ping output: $out"
+
+killDaemon

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -129,6 +129,7 @@ suites = [
       'legacy-ssh-store.sh',
       'linux-sandbox.sh',
       'logging.sh',
+      'long-socket-path.sh',
       'make-content-addressed.sh',
       'misc.sh',
       'multiple-outputs-substitute-failure.sh',


### PR DESCRIPTION
- Fixes #15739

## Motivation

Currently, `bindConnectProcHelper` forks a subprocess for every `AF_UNIX` bind or connect whose path exceeds `sockaddr_un::sun_path`, just to chdir into the parent and operate on the basename.

## Context

FreeBSD's bindat/connectat and Linux's /proc/self/fd magic symlink let us anchor a dirfd directly and skip the subprocess, but the fork helper stays as the fallback when neither is available.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
