### PR TITLE
derivation-builder: Allow locking final output to fail for hash-mismatching FOD; plus refactor and test case

### DIFF
--- a/src/libstore/build/derivation-check.cc
+++ b/src/libstore/build/derivation-check.cc
@@ -7,6 +7,35 @@
 
 namespace nix {
 
+void checkCAFixedOutput(
+    StoreDirConfig & store, const StorePath & drvPath, const DerivationOutput & outputSpec, const ValidPathInfo & info)
+{
+    if (const auto * dof = std::get_if<DerivationOutput::CAFixed>(&outputSpec.raw)) {
+        auto & wanted = dof->ca.hash;
+
+        /* Check wanted hash */
+        assert(info.ca);
+        auto & got = info.ca->hash;
+        if (wanted != got) {
+            throw BuildError(
+                BuildResult::Failure::HashMismatch,
+                "hash mismatch in fixed-output derivation '%s':\n  specified: %s\n     got:    %s",
+                store.printStorePath(drvPath),
+                wanted.to_string(HashFormat::SRI, true),
+                got.to_string(HashFormat::SRI, true));
+        }
+        if (!info.references.empty()) {
+            auto numViolations = info.references.size();
+            throw BuildError(
+                BuildResult::Failure::HashMismatch,
+                "fixed-output derivations must not reference store paths: '%s' references %d distinct paths, e.g. '%s'",
+                store.printStorePath(drvPath),
+                numViolations,
+                store.printStorePath(*info.references.begin()));
+        }
+    }
+}
+
 void checkOutputs(
     Store & store,
     const StorePath & drvPath,
@@ -27,32 +56,7 @@ void checkOutputs(
         auto * outputSpec = get(drvOutputs, outputName);
         assert(outputSpec);
 
-        if (const auto * dof = std::get_if<DerivationOutput::CAFixed>(&outputSpec->raw)) {
-            auto & wanted = dof->ca.hash;
-
-            /* Check wanted hash */
-            assert(info.ca);
-            auto & got = info.ca->hash;
-            if (wanted != got) {
-                /* Throw an error after registering the path as
-                   valid. */
-                throw BuildError(
-                    BuildResult::Failure::HashMismatch,
-                    "hash mismatch in fixed-output derivation '%s':\n  specified: %s\n     got:    %s",
-                    store.printStorePath(drvPath),
-                    wanted.to_string(HashFormat::SRI, true),
-                    got.to_string(HashFormat::SRI, true));
-            }
-            if (!info.references.empty()) {
-                auto numViolations = info.references.size();
-                throw BuildError(
-                    BuildResult::Failure::HashMismatch,
-                    "fixed-output derivations must not reference store paths: '%s' references %d distinct paths, e.g. '%s'",
-                    store.printStorePath(drvPath),
-                    numViolations,
-                    store.printStorePath(*info.references.begin()));
-            }
-        }
+        checkCAFixedOutput(store, drvPath, *outputSpec, info);
 
         /* Compute the closure and closure size of some output. This
            is slightly tricky because some of its references (namely

--- a/src/libstore/build/derivation-check.hh
+++ b/src/libstore/build/derivation-check.hh
@@ -8,6 +8,14 @@
 namespace nix {
 
 /**
+ * If outputSpec is a CAFixed output, check that the actual output described in
+ * info meets the requirements for a CAFixed output. Do nothing if outputSpec is
+ * not a CAFixed output.
+ */
+void checkCAFixedOutput(
+    StoreDirConfig & store, const StorePath & drvPath, const DerivationOutput & outputSpec, const ValidPathInfo & info);
+
+/**
  * Check that outputs meets the requirements specified by the
  * 'outputChecks' attribute (or the legacy
  * '{allowed,disallowed}{References,Requisites}' attributes).

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1887,7 +1887,23 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         auto optFixedPath = output->path(store, drv.name, outputName);
         if (!optFixedPath || store.printStorePath(*optFixedPath) != finalDestPath) {
             assert(newInfo.ca);
-            dynamicOutputLock.lockPaths({store.toRealPath(newInfo.path)});
+
+            /* Don't wait on lock for the hash-mismatching fixed-output
+               derivation case, to avoid a deadlock in the case where a build
+               with the correct hash is in progress. */
+            bool locked = dynamicOutputLock.lockPaths({store.toRealPath(newInfo.path)}, "", !optFixedPath);
+
+            /* If we can't lock the correct path, clean up and bail now. */
+            if (!locked) {
+                debug(
+                    "failed to lock correct output path of %s, namely %s, not moving output",
+                    store.printStorePath(drvPath),
+                    PathFmt(store.toRealPath(newInfo.path)));
+                deletePath(actualPath);
+                /* Trigger the hash-mismatch error. */
+                checkCAFixedOutput(store, drvPath, *output, newInfo);
+                unreachable();
+            }
         }
 
         /* Move files, if needed */

--- a/tests/functional/fixed-slow-vs-bad.nix
+++ b/tests/functional/fixed-slow-vs-bad.nix
@@ -1,0 +1,31 @@
+with import ./config.nix;
+
+{
+  slow = mkDerivation {
+    name = "fixed";
+    outputHashMode = "flat";
+    outputHashAlgo = "sha256";
+    outputHash = builtins.hashString "sha256" "fixed";
+
+    buildCommand = ''
+      echo "slow: Started" >&2
+      echo slow-ready > /sync-fifo/fifo || echo "slow: No sync fifo, continuing" >&2
+      echo "slow: Entering infinite loop" >&2
+      while true ; do echo -n .; done
+    '';
+  };
+
+  bad = mkDerivation {
+    name = "fixed";
+    outputHashMode = "flat";
+    outputHashAlgo = "sha256";
+    outputHash = builtins.hashString "sha256" "wrong";
+
+    buildCommand = ''
+      echo "bad: Waiting for sync" >&2
+      cat /sync-fifo/fifo || echo "bad: No sync fifo, continuing" >&2
+      echo -n fixed > $out
+      echo "bad: Done" >&2
+    '';
+  };
+}

--- a/tests/functional/fixed-slow-vs-bad.sh
+++ b/tests/functional/fixed-slow-vs-bad.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+requireSandboxSupport
+
+# Requires bug fix for daemon
+requireDaemonNewerThan "2.35.0pre20260518"
+
+clearStoreIfPossible
+
+# See https://github.com/NixOS/nix/issues/15846
+#
+# `slow` is a fixed-output derivation that never finishes (which simulates a
+# slow derivation that loses the race), and `bad` is a fixed-output derivation
+# whose *correct* store path is the same as `slow`'s *declared output*. A
+# deadlock used to happen when:
+#
+# - `slow` locks the output path (A)
+# - `bad` completes
+# - `bad` locks the same output path as `slow` (B)
+# - (Never gets to happen: the output of `bad` is moved to the store path)
+#
+# In this case, we should let (B) fail and just don't try to move the output of
+# `bad`. This does mean that the output of `bad` is gone (if we don't pass
+# `--keep-going`), but the situation still makes sense since it can be explained
+# as `slow` being cancelled.
+
+sandboxArgs=()
+
+# Sandboxing is not required, but it makes the deadlock more likely to happen.
+if canUseSandbox; then
+  sandboxArgs+=(--option sandbox true)
+  sandboxArgs+=(--option sandbox-build-dir /build-non-standard)
+
+  # When using a separate test store, we need sandbox-paths to access
+  # the system store. See the same check in build.sh.
+  if ! isTestOnNixOS; then
+      sandboxArgs+=(--option extra-sandbox-paths "/nix/store")
+  fi
+
+  fifoDir="$TEST_ROOT/sync-fifo"
+  mkdir -p "$fifoDir"
+  mkfifo "$fifoDir/fifo"
+  sandboxArgs+=(--option extra-sandbox-paths "/sync-fifo=$TEST_ROOT/sync-fifo")
+fi
+
+expectStderr 1 nix build -L --max-jobs 2 "${sandboxArgs[@]}" -f fixed-slow-vs-bad.nix slow bad \
+  | grepQuiet "hash mismatch in fixed-output derivation"

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -180,6 +180,7 @@ suites = [
       'symlinks.sh',
       'external-builders.sh',
       'delete-no-keep.sh',
+      'fixed-slow-vs-bad.sh',
     ],
     'workdir' : meson.current_source_dir(),
   },


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

A slow fixed-output derivation and a fast hash-mismatching fixed-output derivation together can deadlock in `registerOutputs()` since the slow derivation has locked the output path and `registerOutputs()` is trying to lock it again when trying to write the output path.

Fix this by having the fast one not wait on the lock of the output paths in `registerOutputs()`, and if locking indeed fails, skip moving and registering the output and go directly to cleanup and throw the error. Note that this does mean the output would not be there without `--keep-going`, but that is an optimization which should give way to correctness, and can be explained as the slow derivation being cancelled before being able to write its output.

## Context

<!-- Provide context. Reference open issues if available. -->

Fixes #15846. Supersedes #15859 as this is a much simpler fix, and adds a test case.

I have confirmed with the author of #15859 that they're okay with me sending this.

Ran and passed functional tests both in NixOS and in sandbox.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Commit 1 moves a lot of code, but there should be no functional change. 

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
