### PR TITLE
fix: remove follows after git-hooks bump

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,6 @@
   # work around https://github.com/NixOS/nix/issues/7730
   inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
   inputs.git-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
-  inputs.git-hooks-nix.inputs.nixpkgs-stable.follows = "nixpkgs";
   # work around 7730 and https://github.com/NixOS/nix/issues/7807
   inputs.git-hooks-nix.inputs.flake-compat.follows = "";
   inputs.git-hooks-nix.inputs.gitignore.follows = "";


### PR DESCRIPTION
## Motivation

```
warning: input 'git-hooks-nix' has an override for a non-existent input 'nixpkgs-stable'
```

## Context

Not needed with more recent git-hooks.