### PR TITLE
libstore: recheck free space after auto-GC lock wait

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -40,6 +40,22 @@ namespace nix {
 static std::string gcSocketPath = "gc-socket/socket";
 static std::string gcRootsDir = "gcroots";
 
+#if HAVE_STATVFS
+static uint64_t getAvailableStoreSpace(const LocalStoreConfig & config)
+{
+    static auto fakeFreeSpaceFile = getEnv("_NIX_TEST_FREE_SPACE_FILE");
+
+    if (fakeFreeSpaceFile)
+        return std::stoll(readFile(*fakeFreeSpaceFile));
+
+    struct statvfs st;
+    if (statvfs(config.realStoreDir.get().c_str(), &st))
+        throw SysError("getting filesystem info about '%s'", PathFmt(config.realStoreDir.get()));
+
+    return (uint64_t) st.f_bavail * st.f_frsize;
+}
+#endif
+
 void LocalStore::addIndirectRoot(const std::filesystem::path & path)
 {
     std::string hash = hashString(HashAlgorithm::SHA1, path.string()).to_string(HashFormat::Nix32, false);
@@ -354,9 +370,16 @@ struct GCLimitReached
 
 void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
 {
+    collectGarbage(options, results, GCTrigger::Explicit);
+}
+
+void LocalStore::collectGarbage(const GCOptions & options, GCResults & results, GCTrigger gcTrigger)
+{
     const auto & gcSettings = config->getLocalSettings().getGCSettings();
 
     bool shouldDelete = options.action == GCOptions::gcDeleteDead || options.action == GCOptions::gcDeleteSpecific;
+    auto maxFreed = options.maxFreed;
+    bool reservedPathDeleted = false;
 
     boost::unordered_flat_set<StorePath, std::hash<StorePath>> roots, dead, alive;
 
@@ -383,14 +406,49 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
 
     std::condition_variable wakeup;
 
-    if (shouldDelete)
+    if (shouldDelete && gcTrigger == GCTrigger::Explicit) {
         deletePath(reservedPath);
+        reservedPathDeleted = true;
+    }
 
     /* Acquire the global GC root. Note: we don't use fdGCLock
        here because then in auto-gc mode, another thread could
        downgrade our exclusive lock. */
-    auto fdGCLock = openGCLock();
+    auto openGCLockForGC = [&]() {
+        try {
+            return openGCLock();
+        } catch (SystemError & e) {
+            if (gcTrigger != GCTrigger::Auto || !shouldDelete || reservedPathDeleted
+                || !e.is(std::errc::no_space_on_device))
+                throw;
+
+            /* Preserve the historical emergency reserve behavior if the
+               GC lock file itself cannot be opened or created. Normal
+               auto-GC still keeps the reserve until the post-lock free-space
+               check confirms that GC is still needed. */
+            deletePath(reservedPath);
+            reservedPathDeleted = true;
+            return openGCLock();
+        }
+    };
+    auto fdGCLock = openGCLockForGC();
     FdLock gcLock(fdGCLock.get(), ltWrite, true, "waiting for the big garbage collector lock...");
+
+#if HAVE_STATVFS
+    if (gcTrigger == GCTrigger::Auto) {
+        auto avail = getAvailableStoreSpace(*config);
+        if (avail >= gcSettings.minFree || avail >= gcSettings.maxFree) {
+            printInfo("skipping auto-GC because available space is now %s", renderSize(avail));
+            return;
+        }
+
+        maxFreed = gcSettings.maxFree - avail;
+        printInfo("continuing auto-GC to free %d bytes", maxFreed);
+    }
+#endif
+
+    if (shouldDelete && gcTrigger == GCTrigger::Auto && !reservedPathDeleted)
+        deletePath(reservedPath);
 
     /* Synchronisation point to test ENOENT handling in
        addTempRoot(), see tests/gc-non-blocking.sh. */
@@ -564,8 +622,8 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
 
         results.bytesFreed += bytesFreed;
 
-        if (results.bytesFreed > options.maxFreed) {
-            printInfo("deleted more than %d bytes; stopping", options.maxFreed);
+        if (results.bytesFreed > maxFreed) {
+            printInfo("deleted more than %d bytes; stopping", maxFreed);
             throw GCLimitReached();
         }
     };
@@ -757,7 +815,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                     }
                 },
                 [&](const GCOptions::WholeStore & _) {
-                    if (options.maxFreed == 0)
+                    if (maxFreed == 0)
                         return;
 
                     switch (options.action) {
@@ -870,19 +928,6 @@ void LocalStore::autoGC(bool sync)
 #if HAVE_STATVFS
     const auto & gcSettings = config->getLocalSettings().getGCSettings();
 
-    static auto fakeFreeSpaceFile = getEnv("_NIX_TEST_FREE_SPACE_FILE");
-
-    auto getAvail = [this]() -> uint64_t {
-        if (fakeFreeSpaceFile)
-            return std::stoll(readFile(*fakeFreeSpaceFile));
-
-        struct statvfs st;
-        if (statvfs(config->realStoreDir.get().c_str(), &st))
-            throw SysError("getting filesystem info about '%s'", PathFmt(config->realStoreDir.get()));
-
-        return (uint64_t) st.f_bavail * st.f_frsize;
-    };
-
     std::shared_future<void> future;
 
     {
@@ -899,7 +944,7 @@ void LocalStore::autoGC(bool sync)
         if (now < state->lastGCCheck + std::chrono::seconds(gcSettings.minFreeCheckInterval))
             return;
 
-        auto avail = getAvail();
+        auto avail = getAvailableStoreSpace(*config);
 
         state->lastGCCheck = now;
 
@@ -914,7 +959,7 @@ void LocalStore::autoGC(bool sync)
         std::promise<void> promise;
         future = state->gcFuture = promise.get_future().share();
 
-        std::thread([promise{std::move(promise)}, this, avail, getAvail, &gcSettings]() mutable {
+        std::thread([promise{std::move(promise)}, this]() mutable {
             try {
 
                 /* Wake up any threads waiting for the auto-GC to finish. */
@@ -926,15 +971,14 @@ void LocalStore::autoGC(bool sync)
                 });
 
                 GCOptions options;
-                options.maxFreed = gcSettings.maxFree - avail;
 
-                printInfo("running auto-GC to free %d bytes", options.maxFreed);
+                printInfo("running auto-GC");
 
                 GCResults results;
 
-                collectGarbage(options, results);
+                collectGarbage(options, results, GCTrigger::Auto);
 
-                _state->lock()->availAfterGC = getAvail();
+                _state->lock()->availAfterGC = getAvailableStoreSpace(*config);
 
             } catch (...) {
                 // FIXME: we could propagate the exception to the

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -338,6 +338,13 @@ private:
 
     AutoCloseFD openGCLock();
 
+    enum class GCTrigger {
+        Explicit,
+        Auto,
+    };
+
+    void collectGarbage(const GCOptions & options, GCResults & results, GCTrigger gcTrigger);
+
 public:
 
     Roots findRoots(bool censor) override;

--- a/tests/functional/gc-auto-recheck.sh
+++ b/tests/functional/gc-auto-recheck.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+needLocalStore '"min-free" and "max-free" are daemon options'
+
+TODO_NixOS
+
+wait_for_log() {
+    local pattern=$1
+    local log=$2
+
+    for _ in {1..100}; do
+        if [[ -e "$log" ]] && grepQuiet "$pattern" "$log"; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    return 1
+}
+
+terminate_lock_holder() {
+    local pid=$1
+
+    if ! kill -0 "$pid" 2> /dev/null; then
+        return 0
+    fi
+
+    kill "$pid" 2> /dev/null || return 0
+
+    if wait "$pid"; then
+        return 0
+    else
+        local status=$?
+        if [[ "$status" -ne 143 ]]; then
+            echo "GC lock holder exited with status $status while being terminated" >&2
+        fi
+        return 0
+    fi
+}
+
+lock_holder_pid=
+
+cleanup_lock_holder() {
+    if [[ -n "$lock_holder_pid" ]]; then
+        terminate_lock_holder "$lock_holder_pid"
+        lock_holder_pid=
+    fi
+}
+
+start_gc_lock_holder() {
+    local gc_sync=$1
+    local lock_holder_log=$2
+
+    mkfifo "$gc_sync"
+
+    _NIX_TEST_GC_SYNC_2=$gc_sync nix-store --gc --print-dead -vvvvv > "$lock_holder_log" 2>&1 &
+    lock_holder_pid=$!
+
+    if ! wait_for_log "finding garbage collector roots" "$lock_holder_log"; then
+        terminate_lock_holder "$lock_holder_pid"
+        lock_holder_pid=
+        fail "GC lock holder did not reach root traversal"
+    fi
+}
+
+wait_for_auto_gc_start() {
+    local auto_gc_log=$1
+    local auto_gc_pid=$2
+    local gc_sync=$3
+
+    if ! wait_for_log "running auto-GC" "$auto_gc_log"; then
+        printf 'unlock\n' > "$gc_sync"
+        wait "$lock_holder_pid"
+        lock_holder_pid=
+        if wait "$auto_gc_pid"; then
+            :
+        else
+            local auto_gc_status=$?
+            echo "auto-GC build exited with status $auto_gc_status" >&2
+        fi
+        fail "auto-GC did not start while the global GC lock was held"
+    fi
+}
+
+write_fake_free() {
+    local bytes=$1
+
+    echo "$bytes" > "$fake_free".tmp
+    mv "$fake_free".tmp "$fake_free"
+}
+
+trap cleanup_lock_holder EXIT
+
+fake_free=$TEST_ROOT/fake-free
+export _NIX_TEST_FREE_SPACE_FILE=$fake_free
+
+expr=$(cat <<EOF
+with import ${config_nix}; mkDerivation {
+  name = "gc-recheck-after-lock";
+  buildCommand = ''
+    set -x
+    mkdir \$out
+    echo foo > \$out/bar
+  '';
+}
+EOF
+)
+
+clearStore
+write_fake_free 100
+
+nix store add-path --name garbage-recovered ./nar-access.sh > /dev/null
+
+reserved_path=$TEST_ROOT/var/nix/db/reserved
+[[ -f "$reserved_path" ]]
+
+gc_sync=$TEST_ROOT/gc-sync-recovered
+lock_holder_log=$TEST_ROOT/gc-lock-holder-recovered.log
+
+start_gc_lock_holder "$gc_sync" "$lock_holder_log"
+
+auto_gc_log=$TEST_ROOT/auto-gc-recheck-recovered.log
+nix build --impure -vvvvv -o "$TEST_ROOT"/result-recovered --expr "$expr" \
+    --min-free 1K --max-free 2K --min-free-check-interval 0 > "$auto_gc_log" 2>&1 &
+auto_gc_pid=$!
+
+wait_for_auto_gc_start "$auto_gc_log" "$auto_gc_pid" "$gc_sync"
+
+write_fake_free 4096
+printf 'unlock\n' > "$gc_sync"
+wait "$lock_holder_pid"
+lock_holder_pid=
+wait "$auto_gc_pid"
+
+grepQuiet "skipping auto-GC because available space is now" "$auto_gc_log"
+grepQuietInverse "finding garbage collector roots" "$auto_gc_log"
+[[ -f "$reserved_path" ]]
+[[ foo = $(cat "$TEST_ROOT"/result-recovered/bar) ]]
+
+clearStore
+write_fake_free 100
+
+nix store add-path --name garbage-still-low ./nar-access.sh > /dev/null
+[[ -f "$reserved_path" ]]
+
+gc_sync=$TEST_ROOT/gc-sync-still-low
+lock_holder_log=$TEST_ROOT/gc-lock-holder-still-low.log
+
+start_gc_lock_holder "$gc_sync" "$lock_holder_log"
+
+auto_gc_log=$TEST_ROOT/auto-gc-recheck-still-low.log
+nix build --impure -vvvvv -o "$TEST_ROOT"/result-still-low --expr "$expr" \
+    --min-free 3K --max-free 4K --min-free-check-interval 0 > "$auto_gc_log" 2>&1 &
+auto_gc_pid=$!
+
+wait_for_auto_gc_start "$auto_gc_log" "$auto_gc_pid" "$gc_sync"
+
+write_fake_free 2048
+printf 'unlock\n' > "$gc_sync"
+wait "$lock_holder_pid"
+lock_holder_pid=
+wait "$auto_gc_pid"
+
+grepQuiet "continuing auto-GC to free 2048 bytes" "$auto_gc_log"
+grepQuiet "finding garbage collector roots" "$auto_gc_log"
+[[ foo = $(cat "$TEST_ROOT"/result-still-low/bar) ]]

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -62,6 +62,7 @@ suites = [
       'experimental-features.sh',
       'fetchMercurial.sh',
       'gc-auto.sh',
+      'gc-auto-recheck.sh',
       'user-envs.sh',
       'user-envs-migration.sh',
       'cli-characterisation.sh',


### PR DESCRIPTION
To my surprise I haven't been able to find a GitHub issue for this.

## Motivation

Concurrent build jobs on a machine where `min-free` is triggered all run into auto-GC. The first build job starts the actual GC process while the others wait  for the global GC lock. When the first job completes and others subsequently get the lock, they should not all do unnecessary root and dead-set traversal if the first GC already recovered enough free space. Otherwise the delay for an auto-GC is proportional to the number of jobs that hit the auto-GC trigger, when it should be constant.

## Context

The circumstance surfaced on a CI environment where concurrent build jobs can be scheduled on machines where they share a store and a Nix daemon via the socket. Here they all run into the auto-GC trigger simultaneously. I've observed every concurrent job run the expensive GC traversal after they've all decided that auto-GC needed to be triggered.

## Changes

The key change is that when auto-GC is triggered, Nix checks the free space again after it acquires the GC lock. This prevents the redundant execution of the expensive GC path.

The code has been largely written with an AI agent and I'm happy to receive and respond to feedback.

As concisely summarized by the agent, the changes are:

- Share the store free-space probe between the initial auto-GC decision and the post-lock recheck.
- Route auto-GC through a trigger-aware local collectGarbage path while keeping explicit GC behavior unchanged.
- Recheck free space after acquiring the global GC lock and skip auto-GC traversal when thresholds are satisfied.
- Recompute the effective delete target from the post-lock free-space measurement when auto-GC still needs to run.
- Preserve the reserved-space file when auto-GC skips, with a no-space retry path for creating or opening the GC lock.
- Add a functional test for recovered contenders, reserve preservation, and partial recovery target recomputation.
