### PR TITLE
nix search: switch to boost::regex for ~1.74x speedup

### DIFF
--- a/src/libutil-tests/hilite.cc
+++ b/src/libutil-tests/hilite.cc
@@ -7,22 +7,22 @@ namespace nix {
 
 TEST(hiliteMatches, noHighlight)
 {
-    ASSERT_STREQ(hiliteMatches("Hello, world!", std::vector<std::smatch>(), "(", ")").c_str(), "Hello, world!");
+    ASSERT_STREQ(hiliteMatches("Hello, world!", std::vector<boost::smatch>(), "(", ")").c_str(), "Hello, world!");
 }
 
 TEST(hiliteMatches, simpleHighlight)
 {
     std::string str = "Hello, world!";
-    std::regex re = std::regex("world");
-    auto matches = std::vector(std::sregex_iterator(str.begin(), str.end(), re), std::sregex_iterator());
+    boost::regex re = boost::regex("world");
+    auto matches = std::vector(boost::sregex_iterator(str.begin(), str.end(), re), boost::sregex_iterator());
     ASSERT_STREQ(hiliteMatches(str, matches, "(", ")").c_str(), "Hello, (world)!");
 }
 
 TEST(hiliteMatches, multipleMatches)
 {
     std::string str = "Hello, world, world, world, world, world, world, Hello!";
-    std::regex re = std::regex("world");
-    auto matches = std::vector(std::sregex_iterator(str.begin(), str.end(), re), std::sregex_iterator());
+    boost::regex re = boost::regex("world");
+    auto matches = std::vector(boost::sregex_iterator(str.begin(), str.end(), re), boost::sregex_iterator());
     ASSERT_STREQ(
         hiliteMatches(str, matches, "(", ")").c_str(),
         "Hello, (world), (world), (world), (world), (world), (world), Hello!");
@@ -31,10 +31,10 @@ TEST(hiliteMatches, multipleMatches)
 TEST(hiliteMatches, overlappingMatches)
 {
     std::string str = "world, Hello, world, Hello, world, Hello, world, Hello, world!";
-    std::regex re = std::regex("Hello, world");
-    std::regex re2 = std::regex("world, Hello");
-    auto v = std::vector(std::sregex_iterator(str.begin(), str.end(), re), std::sregex_iterator());
-    for (auto it = std::sregex_iterator(str.begin(), str.end(), re2); it != std::sregex_iterator(); ++it) {
+    boost::regex re = boost::regex("Hello, world");
+    boost::regex re2 = boost::regex("world, Hello");
+    auto v = std::vector(boost::sregex_iterator(str.begin(), str.end(), re), boost::sregex_iterator());
+    for (auto it = boost::sregex_iterator(str.begin(), str.end(), re2); it != boost::sregex_iterator(); ++it) {
         v.push_back(*it);
     }
     ASSERT_STREQ(
@@ -45,14 +45,14 @@ TEST(hiliteMatches, complexOverlappingMatches)
 {
     std::string str = "legacyPackages.x86_64-linux.git-crypt";
     std::vector regexes = {
-        std::regex("t-cry"),
-        std::regex("ux\\.git-cry"),
-        std::regex("git-c"),
-        std::regex("pt"),
+        boost::regex("t-cry"),
+        boost::regex("ux\\.git-cry"),
+        boost::regex("git-c"),
+        boost::regex("pt"),
     };
-    std::vector<std::smatch> matches;
+    std::vector<boost::smatch> matches;
     for (const auto & regex : regexes) {
-        for (auto it = std::sregex_iterator(str.begin(), str.end(), regex); it != std::sregex_iterator(); ++it) {
+        for (auto it = boost::sregex_iterator(str.begin(), str.end(), regex); it != boost::sregex_iterator(); ++it) {
             matches.push_back(*it);
         }
     }

--- a/src/libutil/hilite.cc
+++ b/src/libutil/hilite.cc
@@ -3,7 +3,7 @@
 namespace nix {
 
 std::string
-hiliteMatches(std::string_view s, std::vector<std::smatch> matches, std::string_view prefix, std::string_view postfix)
+hiliteMatches(std::string_view s, std::vector<boost::smatch> matches, std::string_view prefix, std::string_view postfix)
 {
     // Avoid extra work on zero matches
     if (matches.size() == 0)

--- a/src/libutil/include/nix/util/hilite.hh
+++ b/src/libutil/include/nix/util/hilite.hh
@@ -1,7 +1,7 @@
 #pragma once
 ///@file
 
-#include <regex>
+#include <boost/regex.hpp>
 #include <vector>
 #include <string>
 
@@ -14,7 +14,7 @@ namespace nix {
  * If some matches overlap, then their union will be wrapped rather
  * than the individual matches.
  */
-std::string
-hiliteMatches(std::string_view s, std::vector<std::smatch> matches, std::string_view prefix, std::string_view postfix);
+std::string hiliteMatches(
+    std::string_view s, std::vector<boost::smatch> matches, std::string_view prefix, std::string_view postfix);
 
 } // namespace nix

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -11,7 +11,7 @@
 #include "nix/util/hilite.hh"
 #include "nix/util/strings-inline.hh"
 
-#include <regex>
+#include <boost/regex.hpp>
 #include <nlohmann/json.hpp>
 
 #include "nix/util/strings.hh"
@@ -70,16 +70,16 @@ struct CmdSearch : InstallableValueCommand, MixJSON
             throw UsageError(
                 "Must provide at least one regex! To match all packages, use '%s'.", "nix search <installable> ^");
 
-        std::vector<std::regex> regexes;
-        std::vector<std::regex> excludeRegexes;
+        std::vector<boost::regex> regexes;
+        std::vector<boost::regex> excludeRegexes;
         regexes.reserve(res.size());
         excludeRegexes.reserve(excludeRes.size());
 
         for (auto & re : res)
-            regexes.push_back(std::regex(re, std::regex::extended | std::regex::icase));
+            regexes.push_back(boost::regex(re, boost::regex::extended | boost::regex::icase));
 
         for (auto & re : excludeRes)
-            excludeRegexes.emplace_back(re, std::regex::extended | std::regex::icase);
+            excludeRegexes.emplace_back(re, boost::regex::extended | boost::regex::icase);
 
         auto state = getEvalState();
 
@@ -114,30 +114,31 @@ struct CmdSearch : InstallableValueCommand, MixJSON
                     auto description = aDescription ? aDescription->getString() : "";
                     std::replace(description.begin(), description.end(), '\n', ' ');
 
-                    std::vector<std::smatch> attrPathMatches;
-                    std::vector<std::smatch> descriptionMatches;
-                    std::vector<std::smatch> nameMatches;
+                    std::vector<boost::smatch> attrPathMatches;
+                    std::vector<boost::smatch> descriptionMatches;
+                    std::vector<boost::smatch> nameMatches;
                     bool found = false;
 
                     for (auto & regex : excludeRegexes) {
-                        if (std::regex_search(attrPathStr, regex) || std::regex_search(name.name, regex)
-                            || std::regex_search(description, regex))
+                        if (boost::regex_search(attrPathStr, regex) || boost::regex_search(name.name, regex)
+                            || boost::regex_search(description, regex))
                             return;
                     }
 
                     for (auto & regex : regexes) {
                         found = false;
-                        auto addAll = [&found](std::sregex_iterator it, std::vector<std::smatch> & vec) {
-                            const auto end = std::sregex_iterator();
+                        auto addAll = [&found](boost::sregex_iterator it, std::vector<boost::smatch> & vec) {
+                            const auto end = boost::sregex_iterator();
                             while (it != end) {
                                 vec.push_back(*it++);
                                 found = true;
                             }
                         };
 
-                        addAll(std::sregex_iterator(attrPathStr.begin(), attrPathStr.end(), regex), attrPathMatches);
-                        addAll(std::sregex_iterator(name.name.begin(), name.name.end(), regex), nameMatches);
-                        addAll(std::sregex_iterator(description.begin(), description.end(), regex), descriptionMatches);
+                        addAll(boost::sregex_iterator(attrPathStr.begin(), attrPathStr.end(), regex), attrPathMatches);
+                        addAll(boost::sregex_iterator(name.name.begin(), name.name.end(), regex), nameMatches);
+                        addAll(
+                            boost::sregex_iterator(description.begin(), description.end(), regex), descriptionMatches);
 
                         if (!found)
                             break;


### PR DESCRIPTION
## Motivation

`nix search nixpkgs hello` drops from 1.40 s to 0.81 s on a warm eval cache (hyperfine, 3 warmup + 10 timed runs). User time falls by a similar fraction, so the win is real compute saved in the regex path.

Also switches `hiliteMatches` (and its tests) to `boost::smatch` so the match types stay consistent end-to-end. boost is already a public dependency of libutil, so no build wiring changes are needed.

## Context

### Other uses of boost::regex in nix;
 - #13142


### boost::regex in evaluating nixpkgs
boost::regex was supposed to be used when evaluating the nix language in #7762, but was rolled back in #9508 due to how the regex "{}" was handled. I don't think that applies here, as input to `nix search` is done by the user, while using boost::regex broke nixpkgs.

###  pre-filter for literal regex
 - #15825
I tried to pre-filter in case the search string was a literal regex, but this PR is better in that it makes the regex almost as fast as the literal regex search but also works for actual regex expressions :)

<!-- Provide context. Reference open issues if available. -->


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
