### PR TITLE
packaging: disable mimalloc on FreeBSD

### DIFF
--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -17,7 +17,9 @@
   # Whether to link against mimalloc for malloc override.
   # Significantly improves evaluation performance on allocation-heavy
   # workloads (~10-15% on large evaluations).
-  withMimalloc ? !stdenv.hostPlatform.isWindows,
+  # mimalloc is disabled on FreeBSD due to a crash in nixpkgs 25.11.
+  # Once the nixpkgs flake is updated, mimalloc can be enabled again.
+  withMimalloc ? !stdenv.hostPlatform.isWindows && !stdenv.hostPlatform.isFreeBSD,
 }:
 
 let


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Due to hard-to-debug conditions, mimalloc is broken when using nixpkgs 25.11, but is fixable when using nixpkgs master. For now, disable mimalloc on FreeBSD.


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

FreeBSD support is set to be included in the next release. Without this fix FreeBSD nix will build, but it only creates segfaults when run.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
