### PR TITLE
libexpr: save some performance in builtins.derivation

### DIFF
--- a/src/libexpr/primops/derivation.nix
+++ b/src/libexpr/primops/derivation.nix
@@ -35,27 +35,43 @@ drvAttrs@{
   ...
 }:
 
-let
+# Special-case the happy path, performing as little work as possible when the
+# only output is out
+if !drvAttrs ? outputs || outputs == defaultOutputs then
+  let
+    strict = derivationStrict drvAttrs;
 
-  strict = derivationStrict drvAttrs;
-
-  commonAttrs =
-    drvAttrs
-    // (listToAttrs outputsList)
-    // {
-      all = map (x: x.value) outputsList;
+    self = drvAttrs // {
       inherit drvAttrs;
-      drvPath = strict.drvPath;
       type = "derivation";
+      all = [ self ];
+      drvPath = strict.drvPath;
+      outPath = strict.out;
+      out = self;
+      outputName = "out";
     };
+  in
+  self
+else
+  let
+    strict = derivationStrict drvAttrs;
 
-  outputsList = map (outputName: {
-    name = outputName;
-    value = commonAttrs // {
-      outPath = strict.${outputName};
-      inherit outputName;
-    };
-  }) outputs;
+    commonAttrs =
+      drvAttrs
+      // (listToAttrs outputsList)
+      // {
+        all = map (x: x.value) outputsList;
+        inherit drvAttrs;
+        drvPath = strict.drvPath;
+        type = "derivation";
+      };
 
-in
-(head outputsList).value
+    outputsList = map (outputName: {
+      name = outputName;
+      value = commonAttrs // {
+        outPath = strict.${outputName};
+        inherit outputName;
+      };
+    }) outputs;
+  in
+  (head outputsList).value

--- a/src/libexpr/primops/derivation.nix
+++ b/src/libexpr/primops/derivation.nix
@@ -26,6 +26,9 @@
   Note that `derivation` is very bare-bones, and provides almost no commands during the build.
   Most likely, you'll want to use functions like `stdenv.mkDerivation` in Nixpkgs to set up a basic environment.
 */
+let
+  inherit (builtins) listToAttrs head;
+in
 drvAttrs@{
   outputs ? [ "out" ],
   ...
@@ -37,7 +40,7 @@ let
 
   commonAttrs =
     drvAttrs
-    // (builtins.listToAttrs outputsList)
+    // (listToAttrs outputsList)
     // {
       all = map (x: x.value) outputsList;
       inherit drvAttrs;
@@ -54,4 +57,4 @@ let
   }) outputs;
 
 in
-(builtins.head outputsList).value
+(head outputsList).value

--- a/src/libexpr/primops/derivation.nix
+++ b/src/libexpr/primops/derivation.nix
@@ -28,9 +28,10 @@
 */
 let
   inherit (builtins) listToAttrs head;
+  defaultOutputs = [ "out" ];
 in
 drvAttrs@{
-  outputs ? [ "out" ],
+  outputs ? defaultOutputs,
   ...
 }:
 

--- a/src/libexpr/primops/derivation.nix
+++ b/src/libexpr/primops/derivation.nix
@@ -43,7 +43,7 @@ let
       inherit drvAttrs;
     };
 
-  outputToAttrListElement = outputName: {
+  outputsList = map (outputName: {
     name = outputName;
     value = commonAttrs // {
       outPath = strict.${outputName};
@@ -51,9 +51,7 @@ let
       type = "derivation";
       inherit outputName;
     };
-  };
-
-  outputsList = map outputToAttrListElement outputs;
+  }) outputs;
 
 in
 (builtins.head outputsList).value

--- a/src/libexpr/primops/derivation.nix
+++ b/src/libexpr/primops/derivation.nix
@@ -44,14 +44,14 @@ let
     // {
       all = map (x: x.value) outputsList;
       inherit drvAttrs;
+      drvPath = strict.drvPath;
+      type = "derivation";
     };
 
   outputsList = map (outputName: {
     name = outputName;
     value = commonAttrs // {
       outPath = strict.${outputName};
-      drvPath = strict.drvPath;
-      type = "derivation";
       inherit outputName;
     };
   }) outputs;

--- a/tests/functional/lang/eval-fail-derivation-name.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-name.err.exp
@@ -1,16 +1,16 @@
 error:
        … while evaluating the attribute 'outPath'
          at «nix-internal»/derivation-internal.nix:<number>:<number>:
-     <number>|     value = commonAttrs // {
-     <number>|       outPath = strict.${outputName};
+     <number>|       drvPath = strict.drvPath;
+     <number>|       outPath = strict.out;
              |       ^
-     <number>|       inherit outputName;
+     <number>|       out = self;
 
        … while calling the 'derivationStrict' builtin
          at «nix-internal»/derivation-internal.nix:<number>:<number>:
-     <number>|
-     <number>|   strict = derivationStrict drvAttrs;
-             |            ^
+     <number>|   let
+     <number>|     strict = derivationStrict drvAttrs;
+             |              ^
      <number>|
 
        … while evaluating derivation '~jiggle~'

--- a/tests/functional/lang/eval-fail-derivation-name.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-name.err.exp
@@ -4,7 +4,7 @@ error:
      <number>|     value = commonAttrs // {
      <number>|       outPath = strict.${outputName};
              |       ^
-     <number>|       drvPath = strict.drvPath;
+     <number>|       inherit outputName;
 
        … while calling the 'derivationStrict' builtin
          at «nix-internal»/derivation-internal.nix:<number>:<number>:

--- a/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
@@ -1,17 +1,17 @@
 error:
        … while evaluating the attribute 'outPath'
-         at «nix-internal»/derivation-internal.nix:56:7:
-           55|     value = commonAttrs // {
-           56|       outPath = strict.${outputName};
+         at «nix-internal»/derivation-internal.nix:50:7:
+           49|       drvPath = strict.drvPath;
+           50|       outPath = strict.out;
              |       ^
-           57|       inherit outputName;
+           51|       out = self;
 
        … while calling the 'derivationStrict' builtin
-         at «nix-internal»/derivation-internal.nix:41:12:
-           40|
-           41|   strict = derivationStrict drvAttrs;
-             |            ^
-           42|
+         at «nix-internal»/derivation-internal.nix:43:14:
+           42|   let
+           43|     strict = derivationStrict drvAttrs;
+             |              ^
+           44|
 
        … while evaluating derivation 'test'
          whose name attribute is located at /pwd/lang/eval-fail-derivation-structuredAttrs-stack-overflow.nix:5:3

--- a/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
@@ -1,17 +1,17 @@
 error:
        … while evaluating the attribute 'outPath'
-         at «nix-internal»/derivation-internal.nix:50:7:
-           49|     value = commonAttrs // {
-           50|       outPath = strict.${outputName};
+         at «nix-internal»/derivation-internal.nix:53:7:
+           52|     value = commonAttrs // {
+           53|       outPath = strict.${outputName};
              |       ^
-           51|       drvPath = strict.drvPath;
+           54|       drvPath = strict.drvPath;
 
        … while calling the 'derivationStrict' builtin
-         at «nix-internal»/derivation-internal.nix:37:12:
-           36|
-           37|   strict = derivationStrict drvAttrs;
+         at «nix-internal»/derivation-internal.nix:40:12:
+           39|
+           40|   strict = derivationStrict drvAttrs;
              |            ^
-           38|
+           41|
 
        … while evaluating derivation 'test'
          whose name attribute is located at /pwd/lang/eval-fail-derivation-structuredAttrs-stack-overflow.nix:5:3

--- a/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
@@ -1,17 +1,17 @@
 error:
        … while evaluating the attribute 'outPath'
-         at «nix-internal»/derivation-internal.nix:55:7:
-           54|     value = commonAttrs // {
-           55|       outPath = strict.${outputName};
+         at «nix-internal»/derivation-internal.nix:56:7:
+           55|     value = commonAttrs // {
+           56|       outPath = strict.${outputName};
              |       ^
-           56|       inherit outputName;
+           57|       inherit outputName;
 
        … while calling the 'derivationStrict' builtin
-         at «nix-internal»/derivation-internal.nix:40:12:
-           39|
-           40|   strict = derivationStrict drvAttrs;
+         at «nix-internal»/derivation-internal.nix:41:12:
+           40|
+           41|   strict = derivationStrict drvAttrs;
              |            ^
-           41|
+           42|
 
        … while evaluating derivation 'test'
          whose name attribute is located at /pwd/lang/eval-fail-derivation-structuredAttrs-stack-overflow.nix:5:3

--- a/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
@@ -1,10 +1,10 @@
 error:
        … while evaluating the attribute 'outPath'
-         at «nix-internal»/derivation-internal.nix:53:7:
-           52|     value = commonAttrs // {
-           53|       outPath = strict.${outputName};
+         at «nix-internal»/derivation-internal.nix:55:7:
+           54|     value = commonAttrs // {
+           55|       outPath = strict.${outputName};
              |       ^
-           54|       drvPath = strict.drvPath;
+           56|       inherit outputName;
 
        … while calling the 'derivationStrict' builtin
          at «nix-internal»/derivation-internal.nix:40:12:


### PR DESCRIPTION
Saves two lookups and an environment definition on every single call to builtins.derivation.

Building firefox from nixpkgs, here's the stats diff for the first commit (comparing the output of NIX_SHOW_STATS, null = unchanged):
```json
{
  "attrset": {
    "lookups": null,
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": "-0%"
  },
  "memory": {
    "envs": "-0.31%",
    "list": null,
    "sets": null,
    "symbols": "-0%",
    "values": null,
    "total": "-0.03%"
  },
  "speed": {
    "primops": null,
    "functionCalls": null,
    "thunksMade": null,
    "thunksAvoided": "-0.61%"
  }
}
```
And for the second commit:
```json
{
  "attrset": {
    "lookups": "-2.95%",
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": "+0%"
  },
  "memory": {
    "envs": "+0%",
    "list": null,
    "sets": null,
    "symbols": null,
    "values": "+0%",
    "total": "+0%"
  },
  "speed": {
    "primops": null,
    "functionCalls": null,
    "thunksMade": "+0%",
    "thunksAvoided": "+0%"
  }
}
```
Likely minor improvement in real-time, but since it's such a critical function, we should squeeze every bit of performance out of it that we can.
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
