### PR TITLE
Fix segfault by using a shared_ptr for logger

### DIFF
--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -66,7 +66,7 @@ InstallableFlake::InstallableFlake(
 
 DerivedPathsWithInfo InstallableFlake::toDerivedPaths()
 {
-    Activity act(*logger, lvlTalkative, actUnknown, fmt("evaluating derivation '%s'", what()));
+    Activity act(logger, lvlTalkative, actUnknown, fmt("evaluating derivation '%s'", what()));
 
     auto attr = getCursor(*state);
 

--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -32,7 +32,7 @@ public:
 
 class CaptureLogging
 {
-    std::unique_ptr<Logger> oldLogger;
+    std::shared_ptr<Logger> oldLogger;
 public:
     CaptureLogging()
     {

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -3243,7 +3243,7 @@ Expr * EvalState::parseStdin()
     // NOTE this method (and parseExprFromString) must take care to *fully copy* their
     // input into their respective Pos::Origin until the parser stops overwriting its
     // input data.
-    // Activity act(*logger, lvlTalkative, "parsing standard input");
+    // Activity act(logger, lvlTalkative, "parsing standard input");
     auto buffer = drainFD(0);
     // drainFD should have left some extra space for terminators
     buffer.append("\0\0", 2);

--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -72,7 +72,7 @@ std::pair<StorePath, Hash> fetchToStore2(
     }
 
     Activity act(
-        *logger,
+        logger,
         lvlChatty,
         actUnknown,
         fmt(mode == FetchMode::DryRun ? "hashing '%s'" : "copying '%s' to the store", path));

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -502,7 +502,7 @@ void InputScheme::clone(
 
     auto [accessor, input2] = getAccessor(settings, store, input);
 
-    Activity act(*logger, lvlTalkative, actUnknown, fmt("copying '%s' to %s...", input2.to_string(), PathFmt(destDir)));
+    Activity act(logger, lvlTalkative, actUnknown, fmt("copying '%s' to %s...", input2.to_string(), PathFmt(destDir)));
 
     RestoreSink sink(/*startFsync=*/false);
     sink.dstPath = destDir;

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -630,7 +630,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
     void fetch(const std::string & url, const std::string & refspec, bool shallow) override
     {
-        Activity act(*logger, lvlTalkative, actFetchTree, fmt("fetching Git repository '%s'", url));
+        Activity act(logger, lvlTalkative, actFetchTree, fmt("fetching Git repository '%s'", url));
 
         // TODO: implement git-credential helper support (preferably via libgit2, which as of 2024-01 does not support
         // that)

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -742,7 +742,7 @@ struct GitInputScheme : InputScheme
             return getIntAttr(*revCountAttrs, "revCount");
 
         Activity act(
-            *logger, lvlChatty, actUnknown, fmt("getting Git revision count of '%s'", repoInfo.locationToArg()));
+            logger, lvlChatty, actUnknown, fmt("getting Git revision count of '%s'", repoInfo.locationToArg()));
 
         auto revCount = GitRepo::openRepo(repoDir, {})->getRevCount(rev);
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -303,7 +303,7 @@ struct GitArchiveInputScheme : InputScheme
         });
 
         auto act = std::make_unique<Activity>(
-            *logger, lvlInfo, actUnknown, fmt("unpacking '%s' into the Git cache", input.to_string()));
+            logger, lvlInfo, actUnknown, fmt("unpacking '%s' into the Git cache", input.to_string()));
 
         TarArchive archive{*source};
         auto tarballCache = settings.getTarballCache();

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -323,7 +323,7 @@ struct MercurialInputScheme : InputScheme
                             }))
                          .second
                      == "1")) {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("fetching Mercurial repository '%s'", actualUrl));
+            Activity act(logger, lvlTalkative, actUnknown, fmt("fetching Mercurial repository '%s'", actualUrl));
 
             if (pathExists(cacheDir)) {
                 try {

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -154,7 +154,7 @@ struct PathInputScheme : InputScheme
 
         time_t mtime = 0;
         if (!storePath || storePath->name() != "source" || !store.isValidPath(*storePath)) {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying %s to the store", PathFmt(absPath)));
+            Activity act(logger, lvlTalkative, actUnknown, fmt("copying %s to the store", PathFmt(absPath)));
             // FIXME: try to substitute storePath.
             auto src = sinkToSource(
                 [&](Sink & sink) { mtime = dumpPathAndGetMtime(absPath.string(), sink, defaultPathFilter); });

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -165,7 +165,7 @@ static DownloadTarballResult downloadTarball_(
 
     // TODO: fall back to cached value if download fails.
 
-    auto act = std::make_unique<Activity>(*logger, lvlInfo, actUnknown, fmt("unpacking '%s' into the Git cache", url));
+    auto act = std::make_unique<Activity>(logger, lvlInfo, actUnknown, fmt("unpacking '%s' into the Git cache", url));
 
     AutoDelete cleanupTemp;
 

--- a/src/libmain/include/nix/main/progress-bar.hh
+++ b/src/libmain/include/nix/main/progress-bar.hh
@@ -5,6 +5,6 @@
 
 namespace nix {
 
-std::unique_ptr<Logger> makeProgressBar();
+std::shared_ptr<Logger> makeProgressBar();
 
 }

--- a/src/libmain/loggers.cc
+++ b/src/libmain/loggers.cc
@@ -21,7 +21,7 @@ LogFormat parseLogFormat(const std::string & logFormatStr)
     throw Error("option 'log-format' has an invalid value '%s'", logFormatStr);
 }
 
-std::unique_ptr<Logger> makeDefaultLogger()
+std::shared_ptr<Logger> makeDefaultLogger()
 {
     switch (defaultLogFormat) {
     case LogFormat::raw:

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -716,9 +716,9 @@ public:
 
 } // namespace
 
-std::unique_ptr<Logger> makeProgressBar()
+std::shared_ptr<Logger> makeProgressBar()
 {
-    return std::make_unique<ProgressBar>(isTTY());
+    return std::make_shared<ProgressBar>(isTTY());
 }
 
 } // namespace nix

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -445,7 +445,7 @@ void BinaryCacheStore::queryPathInfoUncached(
         auto uri = config.getReference().render(/*FIXME withParams=*/false);
         auto storePathS = printStorePath(storePath);
         auto act = std::make_shared<Activity>(
-            *logger,
+            logger,
             lvlTalkative,
             actQueryPathInfo,
             fmt("querying info about '%s' on '%s'", storePathS, uri),

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -110,7 +110,7 @@ struct PostBuildHookState
     std::unique_ptr<Pipe> out;
     Pid pid;
 
-    PostBuildHookState(Logger & logger, const std::string hook, const std::string drvPath)
+    PostBuildHookState(std::shared_ptr<Logger>, const std::string hook, const std::string drvPath)
         : hook(hook)
         , act(logger,
               lvlTalkative,
@@ -134,7 +134,7 @@ struct PostBuildHookState
 static std::unique_ptr<PostBuildHookState> runPostBuildHook(
     const WorkerSettings & workerSettings,
     const StoreDirConfig & store,
-    Logger & logger,
+    std::shared_ptr<Logger> logger,
     const StorePath & drvPath,
     const StorePathSet & outputPaths);
 
@@ -465,7 +465,7 @@ Goal::Co DerivationBuildingGoal::tryToBuild(StorePathSet inputPaths)
 
         if (!outputLocks.lockPaths(lockFiles, "", false)) {
             Activity act(
-                *logger,
+                logger,
                 lvlWarn,
                 actBuildWaiting,
                 fmt("waiting for lock on %s",
@@ -539,7 +539,7 @@ Goal::Co DerivationBuildingGoal::tryToBuild(StorePathSet inputPaths)
             // First attempt was postponed. Retry in a loop with an activity
             // that lives until accept or decline.
             Activity act(
-                *logger,
+                logger,
                 lvlWarn,
                 actBuildWaiting,
                 fmt("waiting for a machine to build '%s'", Magenta(worker.store.printStorePath(drvPath))));
@@ -700,7 +700,7 @@ Goal::Co DerivationBuildingGoal::buildWithHook(
     std::unique_ptr<BuildLog> buildLog = std::make_unique<BuildLog>(
         worker.settings.logLines,
         std::make_unique<Activity>(
-            *logger,
+            logger,
             lvlInfo,
             actBuild,
             msg,
@@ -829,7 +829,7 @@ Goal::Co DerivationBuildingGoal::buildWithHook(
         outputPaths.insert(output.outPath);
 
     if (worker.settings.postBuildHook.get() != "") {
-        auto hookState = runPostBuildHook(worker.settings, worker.store, *logger, drvPath, outputPaths);
+        auto hookState = runPostBuildHook(worker.settings, worker.store, logger, drvPath, outputPaths);
         worker.childStarted(shared_from_this(), {hookState->out->readSide.get()}, false, false);
         while (true) {
             auto event = co_await WaitForChildEvent{};
@@ -884,7 +884,7 @@ Goal::Co DerivationBuildingGoal::buildLocally(
         buildLog = std::make_unique<BuildLog>(
             worker.settings.logLines,
             std::make_unique<Activity>(
-                *logger, lvlInfo, actBuild, msg, Logger::Fields{worker.store.printStorePath(drvPath), "", 1, 1}));
+                logger, lvlInfo, actBuild, msg, Logger::Fields{worker.store.printStorePath(drvPath), "", 1, 1}));
         mcRunningBuilds = std::make_unique<MaintainCount<uint64_t>>(worker.runningBuilds);
         worker.updateProgress();
     };
@@ -1000,7 +1000,7 @@ Goal::Co DerivationBuildingGoal::buildLocally(
         } else {
             if (!actLock)
                 actLock = std::make_unique<Activity>(
-                    *logger,
+                    logger,
                     lvlWarn,
                     actBuildWaiting,
                     fmt("waiting for a free build user ID for '%s'", Magenta(worker.store.printStorePath(drvPath))));
@@ -1073,7 +1073,7 @@ Goal::Co DerivationBuildingGoal::buildLocally(
         }
 
         if (worker.settings.postBuildHook.get() != "") {
-            auto hookState = runPostBuildHook(worker.settings, worker.store, *logger, drvPath, outputPaths);
+            auto hookState = runPostBuildHook(worker.settings, worker.store, logger, drvPath, outputPaths);
             worker.childStarted(shared_from_this(), {hookState->out->readSide.get()}, false, false);
             while (true) {
                 auto event = co_await WaitForChildEvent{};
@@ -1101,7 +1101,7 @@ Goal::Co DerivationBuildingGoal::buildLocally(
 static std::unique_ptr<PostBuildHookState> runPostBuildHook(
     const WorkerSettings & workerSettings,
     const StoreDirConfig & store,
-    Logger & logger,
+    std::shared_ptr<Logger> logger,
     const StorePath & drvPath,
     const StorePathSet & outputPaths)
 {

--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -140,7 +140,7 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
                     worker.store.printStorePath(drvPath),
                     worker.store.printStorePath(pathResolved));
             act = std::make_unique<Activity>(
-                *logger,
+                logger,
                 lvlInfo,
                 actBuildWaiting,
                 msg,

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -228,7 +228,7 @@ Goal::Co PathSubstitutionGoal::tryToRun(
                 return;
 
             Activity act(
-                *logger,
+                logger,
                 actSubstitute,
                 Logger::Fields{workerStore->printStorePath(storePath), sub->config.getHumanReadableURI()});
             PushActivity pact(act.id);

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -19,9 +19,9 @@ namespace nix {
 Worker::Worker(Store & store, Store & evalStore)
     /* Can't use make_ref, because the constructor is private. */
     : wakerState(ref<Waker>(new Waker{}))
-    , act(*logger, actRealise)
-    , actDerivations(*logger, actBuilds)
-    , actSubstitutions(*logger, actCopyPaths)
+    , act(logger, actRealise)
+    , actDerivations(logger, actBuilds)
+    , actSubstitutions(logger, actCopyPaths)
 #ifdef _WIN32
     , ioport{CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0)}
 #endif

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -1049,11 +1049,9 @@ void processConnection(ref<Store> store, FdSource && from, FdSink && to, Trusted
 
     auto tunnelLogger_ = std::make_unique<TunnelLogger>(conn.to, conn.protoVersion);
     auto tunnelLogger = tunnelLogger_.get();
-    std::unique_ptr<Logger> prevLogger_;
     auto prevLogger = logger.get();
     // FIXME
     if (!recursive) {
-        prevLogger_ = std::move(logger);
         logger = std::move(tunnelLogger_);
         applyJSONLogger();
     }

--- a/src/libstore/export-import.cc
+++ b/src/libstore/export-import.cc
@@ -69,7 +69,7 @@ StorePaths importPaths(Store & store, Source & source, CheckSigsFlag checkSigs)
 
         auto path = store.parseStorePath(readString(source));
 
-        // Activity act(*logger, lvlInfo, "importing path '%s'", info.path);
+        // Activity act(logger, lvlInfo, "importing path '%s'", info.path);
 
         auto references = CommonProto::Serialise<StorePathSet>::read(store, CommonProto::ReadConn{.from = source});
         auto deriver = readString(source);

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -452,7 +452,7 @@ struct curlFileTransfer : public FileTransfer
         {
             if (!_act) {
                 _act = std::make_unique<Activity>(
-                    *logger,
+                    logger,
                     lvlTalkative,
                     actFileTransfer,
                     fmt("%s '%s'", request.verb(/*continuous=*/true), request.displayUri()),

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -239,7 +239,7 @@ void LocalOverlayStore::deleteStorePath(const std::filesystem::path & path, uint
 
 void LocalOverlayStore::optimiseStore()
 {
-    Activity act(*logger, actOptimiseStore);
+    Activity act(logger, actOptimiseStore);
 
     // Note for LocalOverlayStore, queryAllValidPaths only returns paths in upper layer
     auto paths = queryAllValidPaths();

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -178,7 +178,7 @@ static void collectDerivedPaths(
 
 MissingPaths Store::queryMissing(const std::vector<DerivedPath> & targets)
 {
-    Activity act(*logger, lvlDebug, actUnknown, "querying info about missing paths");
+    Activity act(logger, lvlDebug, actUnknown, "querying info about missing paths");
 
     MissingPaths res;
 

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -285,7 +285,7 @@ void LocalStore::optimisePath_(
 
 void LocalStore::optimiseStore(OptimiseStats & stats)
 {
-    Activity act(*logger, actOptimiseStore);
+    Activity act(logger, actOptimiseStore);
 
     auto paths = queryAllValidPaths();
     InodeHash inodeHash = loadInodeHash();
@@ -299,7 +299,7 @@ void LocalStore::optimiseStore(OptimiseStats & stats)
         if (!isValidPath(i))
             continue; /* path was GC'ed, probably */
         {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("optimising path '%s'", printStorePath(i)));
+            Activity act(logger, lvlTalkative, actUnknown, fmt("optimising path '%s'", printStorePath(i)));
             optimisePath_(&act, stats, config->realStoreDir.get() / i.to_string(), inodeHash, NoRepair);
         }
         done++;

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -898,7 +898,7 @@ void copyStorePath(
     const auto & dstCfg = dstStore.config;
     auto storePathS = srcStore.printStorePath(storePath);
     Activity act(
-        *logger,
+        logger,
         lvlInfo,
         actCopyPath,
         makeCopyPathMessage(srcCfg, dstCfg, storePathS),
@@ -1008,7 +1008,7 @@ std::map<StorePath, StorePath> copyPaths(
     if (missing.empty())
         return {};
 
-    Activity act(*logger, lvlInfo, actCopyPaths, fmt("copying %d paths", missing.size()));
+    Activity act(logger, lvlInfo, actCopyPaths, fmt("copying %d paths", missing.size()));
 
     // In the general case, `addMultipleToStore` requires a sorted list of
     // store paths to add, so sort them right now
@@ -1056,7 +1056,7 @@ std::map<StorePath, StorePath> copyPaths(
             const auto & dstCfg = dstStore.config;
             auto storePathS = srcStore.printStorePath(missingPath);
             Activity act(
-                *logger,
+                logger,
                 lvlInfo,
                 actCopyPath,
                 makeCopyPathMessage(srcCfg, dstCfg, storePathS),

--- a/src/libutil/include/nix/util/logging.hh
+++ b/src/libutil/include/nix/util/logging.hh
@@ -193,12 +193,12 @@ void setCurActivity(const ActivityId activityId);
 
 struct Activity
 {
-    Logger & logger;
+    std::shared_ptr<Logger> logger;
 
     const ActivityId id;
 
     Activity(
-        Logger & logger,
+        std::shared_ptr<Logger> logger,
         Verbosity lvl,
         ActivityType type,
         const std::string & s = "",
@@ -206,7 +206,10 @@ struct Activity
         ActivityId parent = getCurActivity());
 
     Activity(
-        Logger & logger, ActivityType type, const Logger::Fields & fields = {}, ActivityId parent = getCurActivity())
+        std::shared_ptr<Logger> logger,
+        ActivityType type,
+        const Logger::Fields & fields = {},
+        ActivityId parent = getCurActivity())
         : Activity(logger, lvlError, type, "", fields, parent) {};
 
     Activity(const Activity & act) = delete;
@@ -233,7 +236,7 @@ struct Activity
 
     void result(ResultType type, const Logger::Fields & fields) const
     {
-        logger.result(id, type, fields);
+        logger->result(id, type, fields);
     }
 
     friend class Logger;
@@ -255,21 +258,21 @@ struct PushActivity
     }
 };
 
-extern std::unique_ptr<Logger> logger;
+extern std::shared_ptr<Logger> logger;
 
-std::unique_ptr<Logger> makeSimpleLogger(bool printBuildLogs = true);
+std::shared_ptr<Logger> makeSimpleLogger(bool printBuildLogs = true);
 
 /**
  * Create a logger that sends log messages to `mainLogger` and the
  * list of loggers in `extraLoggers`. Only `mainLogger` is used for
  * writing to stdout and getting user input.
  */
-std::unique_ptr<Logger>
-makeTeeLogger(std::unique_ptr<Logger> mainLogger, std::vector<std::unique_ptr<Logger>> && extraLoggers);
+std::shared_ptr<Logger>
+makeTeeLogger(std::shared_ptr<Logger> mainLogger, std::vector<std::shared_ptr<Logger>> && extraLoggers);
 
-std::unique_ptr<Logger> makeJSONLogger(Descriptor fd, bool includeNixPrefix = true);
+std::shared_ptr<Logger> makeJSONLogger(Descriptor fd, bool includeNixPrefix = true);
 
-std::unique_ptr<Logger> makeJSONLogger(const std::filesystem::path & path, bool includeNixPrefix = true);
+std::shared_ptr<Logger> makeJSONLogger(const std::filesystem::path & path, bool includeNixPrefix = true);
 
 void applyJSONLogger();
 

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -30,7 +30,7 @@ void setCurActivity(const ActivityId activityId)
     curActivity = activityId;
 }
 
-std::unique_ptr<Logger> logger = makeSimpleLogger(true);
+std::shared_ptr<Logger> logger = makeSimpleLogger(true);
 
 void Logger::warn(const std::string & msg)
 {
@@ -165,9 +165,9 @@ void writeToStderr(std::string_view s)
     writeFullLogging(getStandardError(), s);
 }
 
-std::unique_ptr<Logger> makeSimpleLogger(bool printBuildLogs)
+std::shared_ptr<Logger> makeSimpleLogger(bool printBuildLogs)
 {
-    return std::make_unique<SimpleLogger>(printBuildLogs);
+    return std::make_shared<SimpleLogger>(printBuildLogs);
 }
 
 std::atomic<uint64_t> nextId{0};
@@ -182,7 +182,7 @@ static uint64_t getPid()
 }
 
 Activity::Activity(
-    Logger & logger,
+    std::shared_ptr<Logger> logger,
     Verbosity lvl,
     ActivityType type,
     const std::string & s,
@@ -191,7 +191,7 @@ Activity::Activity(
     : logger(logger)
     , id(nextId++ + (((uint64_t) getPid()) << 32))
 {
-    logger.startActivity(id, lvl, type, s, fields, parent);
+    logger->startActivity(id, lvl, type, s, fields, parent);
 }
 
 void to_json(nlohmann::json & json, std::shared_ptr<const Pos> pos)
@@ -341,12 +341,12 @@ struct JSONLogger : Logger
     }
 };
 
-std::unique_ptr<Logger> makeJSONLogger(Descriptor fd, bool includeNixPrefix)
+std::shared_ptr<Logger> makeJSONLogger(Descriptor fd, bool includeNixPrefix)
 {
     return std::make_unique<JSONLogger>(fd, includeNixPrefix);
 }
 
-std::unique_ptr<Logger> makeJSONLogger(const std::filesystem::path & path, bool includeNixPrefix)
+std::shared_ptr<Logger> makeJSONLogger(const std::filesystem::path & path, bool includeNixPrefix)
 {
     struct JSONFileLogger : JSONLogger
     {
@@ -378,7 +378,7 @@ void applyJSONLogger()
 {
     if (auto & opt = loggerSettings.jsonLogPath.get()) {
         try {
-            std::vector<std::unique_ptr<Logger>> loggers;
+            std::vector<std::shared_ptr<Logger>> loggers;
             loggers.push_back(makeJSONLogger(*opt, false));
             try {
                 logger = makeTeeLogger(std::move(logger), std::move(loggers));
@@ -435,7 +435,7 @@ bool handleJSONLogMessage(
                     std::piecewise_construct,
                     std::forward_as_tuple(json["id"]),
                     std::forward_as_tuple(
-                        *logger, (Verbosity) json["level"], type, json["text"], getFields(json["fields"]), act.id));
+                        logger, (Verbosity) json["level"], type, json["text"], getFields(json["fields"]), act.id));
         }
 
         else if (action == "stop")
@@ -481,7 +481,7 @@ bool handleJSONLogMessage(
 Activity::~Activity()
 {
     try {
-        logger.stopActivity(id);
+        logger->stopActivity(id);
     } catch (...) {
         ignoreExceptionInDestructor();
     }

--- a/src/libutil/tee-logger.cc
+++ b/src/libutil/tee-logger.cc
@@ -6,10 +6,10 @@ namespace {
 
 class TeeLogger final : public Logger
 {
-    std::vector<std::unique_ptr<Logger>> loggers;
+    std::vector<std::shared_ptr<Logger>> loggers;
 
 public:
-    TeeLogger(std::vector<std::unique_ptr<Logger>> && loggers)
+    TeeLogger(std::vector<std::shared_ptr<Logger>> && loggers)
         : loggers(std::move(loggers))
     {
     }
@@ -99,10 +99,10 @@ public:
 
 } // namespace
 
-std::unique_ptr<Logger>
-makeTeeLogger(std::unique_ptr<Logger> mainLogger, std::vector<std::unique_ptr<Logger>> && extraLoggers)
+std::shared_ptr<Logger>
+makeTeeLogger(std::shared_ptr<Logger> mainLogger, std::vector<std::shared_ptr<Logger>> && extraLoggers)
 {
-    std::vector<std::unique_ptr<Logger>> allLoggers;
+    std::vector<std::shared_ptr<Logger>> allLoggers;
     allLoggers.push_back(std::move(mainLogger));
     for (auto & l : extraLoggers)
         allLoggers.push_back(std::move(l));

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -274,7 +274,7 @@ void deletePath(const std::filesystem::path & path)
 
 void deletePath(const std::filesystem::path & path, uint64_t & bytesFreed)
 {
-    // Activity act(*logger, lvlDebug, "recursively deleting path '%1%'", path);
+    // Activity act(logger, lvlDebug, "recursively deleting path '%1%'", path);
 #ifdef __FreeBSD__
     std::set<std::filesystem::path> mountedPaths;
     struct statfs * mntbuf;

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -231,18 +231,22 @@ static int childEntry(void * arg)
 }
 #endif
 
+std::vector<std::shared_ptr<Logger>> heldLoggers;
+
 pid_t startProcess(fun<void()> processMain, const ProcessOptions & options)
 {
     auto newLogger = makeSimpleLogger();
     ChildWrapperFunction wrapper = [&] {
         if (!options.allowVfork) {
-            /* Set a simple logger, while releasing (not destroying)
-               the parent logger. We don't want to run the parent
-               logger's destructor since that will crash (e.g. when
-               ~ProgressBar() tries to join a thread that doesn't
-               exist. */
-            logger.release();
-            logger = std::move(newLogger);
+            /**
+             * Set a simple logger.
+             *
+             * We don't want to run the parent logger's destructor
+             * since that will crash (e.g. when ~ProgressBar() tries
+             * to join a thread that doesn't exist, so we keep the
+             * previous logger alive. */
+            heldLoggers.push_back(logger);
+            logger = newLogger;
         }
         try {
 #ifdef __linux__

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -248,7 +248,7 @@ static int main_build_remote(int argc, char ** argv)
                 try {
                     storeUri = bestMachine->storeUri.render();
 
-                    Activity act(*logger, lvlTalkative, actUnknown, fmt("connecting to '%s'", storeUri));
+                    Activity act(logger, lvlTalkative, actUnknown, fmt("connecting to '%s'", storeUri));
 
                     sshStore = bestMachine->openStore();
                     sshStore->connect();
@@ -290,7 +290,7 @@ static int main_build_remote(int argc, char ** argv)
         }
 
         {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("waiting for the upload lock to '%s'", storeUri));
+            Activity act(logger, lvlTalkative, actUnknown, fmt("waiting for the upload lock to '%s'", storeUri));
 
             auto old = signal(SIGALRM, handleAlarm);
             alarm(15 * 60);
@@ -303,7 +303,7 @@ static int main_build_remote(int argc, char ** argv)
         auto substitute = settings.getWorkerSettings().buildersUseSubstitutes ? Substitute : NoSubstitute;
 
         {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying dependencies to '%s'", storeUri));
+            Activity act(logger, lvlTalkative, actUnknown, fmt("copying dependencies to '%s'", storeUri));
             copyPaths(*store, *sshStore, store->parseStorePathSet(inputs), NoRepair, NoCheckSigs, substitute);
         }
 
@@ -391,7 +391,7 @@ static int main_build_remote(int argc, char ** argv)
         }
 
         if (!missingPaths.empty()) {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying outputs from '%s'", storeUri));
+            Activity act(logger, lvlTalkative, actUnknown, fmt("copying outputs from '%s'", storeUri));
             if (auto localStore = store.dynamic_pointer_cast<LocalStore>())
                 for (auto & path : missingPaths)
                     localStore->locksHeld.insert(store->printStorePath(path)); /* FIXME: ugly */

--- a/src/nix/flake-prefetch-inputs.cc
+++ b/src/nix/flake-prefetch-inputs.cc
@@ -44,7 +44,7 @@ struct CmdFlakePrefetchInputs : FlakeCommand
 
             if (auto lockedNode = dynamic_cast<const LockedNode *>(&node)) {
                 try {
-                    Activity act(*logger, lvlInfo, actUnknown, fmt("fetching '%s'", lockedNode->lockedRef));
+                    Activity act(logger, lvlInfo, actUnknown, fmt("fetching '%s'", lockedNode->lockedRef));
                     auto accessor = lockedNode->lockedRef.input.getAccessor(fetchSettings, *store).first;
                     fetchToStore(
                         fetchSettings, *store, accessor, FetchMode::Copy, lockedNode->lockedRef.input.getName());

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -401,7 +401,7 @@ struct CmdFlakeCheck : FlakeCommand
         auto checkDerivation =
             [&](const std::string & attrPath, Value & v, const PosIdx pos) -> std::optional<StorePath> {
             try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking derivation %s", attrPath));
+                Activity act(logger, lvlInfo, actUnknown, fmt("checking derivation %s", attrPath));
                 auto packageInfo = getDerivation(*state, v, false);
                 if (!packageInfo)
                     throw Error("flake attribute '%s' is not a derivation", attrPath);
@@ -425,7 +425,7 @@ struct CmdFlakeCheck : FlakeCommand
 
         auto checkApp = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
             try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking app '%s'", attrPath));
+                Activity act(logger, lvlInfo, actUnknown, fmt("checking app '%s'", attrPath));
                 state->forceAttrs(v, pos, "");
                 if (auto attr = v.attrs()->get(state->symbols.create("type")))
                     state->forceStringNoCtx(*attr->value, attr->pos, "");
@@ -466,7 +466,7 @@ struct CmdFlakeCheck : FlakeCommand
 
         auto checkOverlay = [&](std::string_view attrPath, Value & v, const PosIdx pos) {
             try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking overlay '%s'", attrPath));
+                Activity act(logger, lvlInfo, actUnknown, fmt("checking overlay '%s'", attrPath));
                 state->forceValue(v, pos);
                 if (!v.isLambda()) {
                     throw Error("overlay is not a function, but %s instead", showType(v));
@@ -483,7 +483,7 @@ struct CmdFlakeCheck : FlakeCommand
 
         auto checkModule = [&](std::string_view attrPath, Value & v, const PosIdx pos) {
             try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking NixOS module '%s'", attrPath));
+                Activity act(logger, lvlInfo, actUnknown, fmt("checking NixOS module '%s'", attrPath));
                 state->forceValue(v, pos);
             } catch (Error & e) {
                 e.addTrace(resolve(pos), HintFmt("while checking the NixOS module '%s'", attrPath));
@@ -495,7 +495,7 @@ struct CmdFlakeCheck : FlakeCommand
 
         checkHydraJobs = [&](std::string_view attrPath, Value & v, const PosIdx pos) {
             try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking Hydra job '%s'", attrPath));
+                Activity act(logger, lvlInfo, actUnknown, fmt("checking Hydra job '%s'", attrPath));
                 state->forceAttrs(v, pos, "");
 
                 if (state->isDerivation(v))
@@ -505,7 +505,7 @@ struct CmdFlakeCheck : FlakeCommand
                     state->forceAttrs(*attr.value, attr.pos, "");
                     auto attrPath2 = concatStrings(attrPath, ".", state->symbols[attr.name]);
                     if (state->isDerivation(*attr.value)) {
-                        Activity act(*logger, lvlInfo, actUnknown, fmt("checking Hydra job '%s'", attrPath2));
+                        Activity act(logger, lvlInfo, actUnknown, fmt("checking Hydra job '%s'", attrPath2));
                         checkDerivation(attrPath2, *attr.value, attr.pos);
                     } else
                         checkHydraJobs(attrPath2, *attr.value, attr.pos);
@@ -519,7 +519,7 @@ struct CmdFlakeCheck : FlakeCommand
 
         auto checkNixOSConfiguration = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
             try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking NixOS configuration '%s'", attrPath));
+                Activity act(logger, lvlInfo, actUnknown, fmt("checking NixOS configuration '%s'", attrPath));
                 Bindings & bindings = Bindings::emptyBindings;
                 auto vToplevel = findAlongAttrPath(*state, "config.system.build.toplevel", bindings, v).first;
                 state->forceValue(*vToplevel, pos);
@@ -533,7 +533,7 @@ struct CmdFlakeCheck : FlakeCommand
 
         auto checkTemplate = [&](std::string_view attrPath, Value & v, const PosIdx pos) {
             try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking template '%s'", attrPath));
+                Activity act(logger, lvlInfo, actUnknown, fmt("checking template '%s'", attrPath));
 
                 state->forceAttrs(v, pos, "");
 
@@ -566,7 +566,7 @@ struct CmdFlakeCheck : FlakeCommand
 
         auto checkBundler = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
             try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking bundler '%s'", attrPath));
+                Activity act(logger, lvlInfo, actUnknown, fmt("checking bundler '%s'", attrPath));
                 state->forceValue(v, pos);
                 if (!v.isLambda())
                     throw Error("bundler must be a function");
@@ -578,13 +578,13 @@ struct CmdFlakeCheck : FlakeCommand
         };
 
         {
-            Activity act(*logger, lvlInfo, actUnknown, "evaluating flake");
+            Activity act(logger, lvlInfo, actUnknown, "evaluating flake");
 
             auto vFlake = state->allocValue();
             flake::callFlake(*state, flake, *vFlake);
 
             enumerateOutputs(*state, *vFlake, [&](std::string_view name, Value & vOutput, const PosIdx pos) {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking flake output '%s'", name));
+                Activity act(logger, lvlInfo, actUnknown, fmt("checking flake output '%s'", name));
 
                 try {
                     evalSettings.enableImportFromDerivation.setDefault(name != "hydraJobs");
@@ -811,7 +811,7 @@ struct CmdFlakeCheck : FlakeCommand
                     });
             }
 
-            Activity act(*logger, lvlInfo, actUnknown, fmt("running %d flake checks", toBuild.size()));
+            Activity act(logger, lvlInfo, actUnknown, fmt("running %d flake checks", toBuild.size()));
             auto results = store->buildPathsWithResults(toBuild);
 
             // Report build failures with attribute paths
@@ -1248,7 +1248,7 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
 
             auto attrPathS = attrPath.resolve(*state);
 
-            Activity act(*logger, lvlInfo, actUnknown, fmt("evaluating '%s'", attrPath.to_string(*state)));
+            Activity act(logger, lvlInfo, actUnknown, fmt("evaluating '%s'", attrPath.to_string(*state)));
 
             try {
                 auto recurse = [&]() {

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -1089,7 +1089,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
             if (i.hasFailed())
                 continue;
 
-            // Activity act(*logger, lvlDebug, "outputting query result '%1%'", i.attrPath);
+            // Activity act(logger, lvlDebug, "outputting query result '%1%'", i.attrPath);
 
             if (globals.prebuiltOnly && !validPaths.count(i.queryOutPath())
                 && !substitutablePaths.count(i.queryOutPath()))

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -123,7 +123,7 @@ std::tuple<StorePath, Hash> prefetchFile(
 
         /* Optionally unpack the file. */
         if (unpack) {
-            Activity act(*logger, lvlChatty, actUnknown, fmt("unpacking '%s'", url.to_string()));
+            Activity act(logger, lvlChatty, actUnknown, fmt("unpacking '%s'", url.to_string()));
             auto unpacked = tmpDir.path() / "unpacked";
             createDirs(unpacked);
             unpackTarfile(tmpFile, unpacked);
@@ -141,7 +141,7 @@ std::tuple<StorePath, Hash> prefetchFile(
             }
         }
 
-        Activity act(*logger, lvlChatty, actUnknown, fmt("adding '%s' to the store", url.to_string()));
+        Activity act(logger, lvlChatty, actUnknown, fmt("adding '%s' to the store", url.to_string()));
 
         auto info = store->addToStoreSlow(name, makeFSSourceAccessor(tmpFile), method, hashAlgo, {}, expectedHash);
         storePath = info.path;

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -739,7 +739,7 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixProfileElementMatchers,
 
             upgradedCount++;
 
-            Activity act(*logger, lvlChatty, actUnknown, fmt("checking '%s' for updates", element.source->attrPath));
+            Activity act(logger, lvlChatty, actUnknown, fmt("checking '%s' for updates", element.source->attrPath));
 
             auto installable = make_ref<InstallableFlake>(
                 this,

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -95,7 +95,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
             auto attrPathS = state->symbols.resolve({attrPath});
             auto attrPathStr = attrPath.to_string(*state);
 
-            Activity act(*logger, lvlInfo, actUnknown, fmt("evaluating '%s'", attrPathStr));
+            Activity act(logger, lvlInfo, actUnknown, fmt("evaluating '%s'", attrPathStr));
             try {
                 auto recurse = [&]() {
                     for (const auto & attr : cursor.getAttrs()) {

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -53,7 +53,7 @@ struct CmdCopySigs : StorePathsCommand
         // logger->setExpected(doneLabel, storePaths.size());
 
         auto doPath = [&](const StorePath & storePath) {
-            // Activity act(*logger, lvlInfo, "getting signatures for '%s'", storePath);
+            // Activity act(logger, lvlInfo, "getting signatures for '%s'", storePath);
 
             checkInterrupt();
 

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -112,13 +112,13 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         }
 
         {
-            Activity act(*logger, lvlInfo, actUnknown, fmt("downloading '%s'...", store->printStorePath(storePath)));
+            Activity act(logger, lvlInfo, actUnknown, fmt("downloading '%s'...", store->printStorePath(storePath)));
             store->ensurePath(storePath);
         }
 
         {
             Activity act(
-                *logger, lvlInfo, actUnknown, fmt("verifying that '%s' works...", store->printStorePath(storePath)));
+                logger, lvlInfo, actUnknown, fmt("verifying that '%s' works...", store->printStorePath(storePath)));
             auto program = store->printStorePath(storePath) + "/bin/nix-env";
             auto s = runProgram(program, false, {OS_STR("--version")});
             if (s.find("Nix") == std::string::npos)
@@ -129,7 +129,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 
         {
             Activity act(
-                *logger,
+                logger,
                 lvlInfo,
                 actUnknown,
                 fmt("installing '%s' into profile %s...", store->printStorePath(storePath), PathFmt(profileDir)));
@@ -192,7 +192,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
     /* Return the store path of the latest stable Nix. */
     StorePath getLatestNix(ref<Store> store)
     {
-        Activity act(*logger, lvlInfo, actUnknown, "querying latest Nix version");
+        Activity act(logger, lvlInfo, actUnknown, "querying latest Nix version");
 
         // FIXME: use nixos.org?
         auto req = FileTransferRequest(parseURL(upgradeSettings.storePathUrl.get()));

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -69,7 +69,7 @@ struct CmdVerify : StorePathsCommand
 
         auto publicKeys = getDefaultPublicKeys();
 
-        Activity act(*logger, actVerifyPaths);
+        Activity act(logger, actVerifyPaths);
 
         std::atomic<size_t> done{0};
         std::atomic<size_t> untrusted{0};
@@ -93,7 +93,7 @@ struct CmdVerify : StorePathsCommand
                 // Note: info->path can be different from storePath
                 // for binary cache stores when using --all (since we
                 // can't enumerate names efficiently).
-                Activity act2(*logger, lvlInfo, actUnknown, fmt("checking '%s'", store->printStorePath(info->path)));
+                Activity act2(logger, lvlInfo, actUnknown, fmt("checking '%s'", store->printStorePath(info->path)));
 
                 if (!noContents) {
 


### PR DESCRIPTION
Activities now use the logger's shared_ptr rather than a reference. This avoids a race between activity and logger destruction.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

The `fetchTree-file` test was occasionally segfaulting when an activity's destructor tried to access a logger reference that had already been deleted.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Leaking alternative: #15884

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
