### PR TITLE
doc(lint-absolute-path-literals): edit

### DIFF
--- a/doc/manual/source/language/syntax.md
+++ b/doc/manual/source/language/syntax.md
@@ -44,6 +44,8 @@ See [String literals](string-literals.md).
   > In the case where a function translates a path literal into an absolute path string for a configuration file, it is recommended to write a string literal instead.
   > This avoids some confusion about whether files at that location will be used during evaluation.
   > It also avoids unintentional situations where some function might try to copy everything at the location into the store.
+  >
+  > See [`lint-absolute-path-literals`](@docroot@/command-ref/conf-file.md#conf-lint-absolute-path-literals) for details and enforcement.
 
   If the first component of a path is a `~`, it is interpreted such that the rest of the path were relative to the user's home directory.
   For example, `~/foo` would be equivalent to `/home/edolstra/foo` for a user whose home directory is `/home/edolstra`.

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -400,23 +400,39 @@ struct EvalSettings : Config
         Diagnose::Ignore,
         "lint-absolute-path-literals",
         R"(
-          Controls handling of absolute path literals (paths starting with `/`) and home path literals (paths starting with `~/`).
+          Controls the handling of absolute path literals (paths starting with `/`) and home path literals (paths starting with `~/`).
+          These may be considered antipatterns, as explained below.
+
+          Possible values:
 
           - `ignore`: Ignore without warning (default)
           - `warn`: Emit a warning about non-portability
           - `fatal`: Treat as a parse error
 
-          It is true that some files are more difficult to reference with relative paths,
-          because they would require lots of `../../..` upward traversing to reach them.
-          But firstly, it is probably not a good idea to reference these files ---
-          such paths often make Nix expressions less portable and reproducible,
-          as they depend on the file system layout of the machine evaluating the expression.
+          There are two use cases for these literals.
+          - Specifying a location without reading its contents during evaluation, e.g. using `toString`
+          - Providing more sources for expressions and builds, e.g. using string interpolation
 
-          Secondly, with [pure evaluation mode](#conf-pure-eval), most such files are prohibited to access anyway,
-          whether by absolute or relative paths.
-          In that case, enabling this lint in fatal mode is less disruptive,
-          because the paths pure eval allows are usually not the ones that would be ergonomically expressed with absolute paths anyway.
-        )",
+          These two kinds of literals have significant disadvantages for both use cases.
+
+          The simpler use case is specifying a location without reading its contents.
+          This comes with the risk of accidentally copying unintended files into the store, making a snapshot of those files readable by all system users.
+          This happens easily, because string interpolation (`"${some-path-value}"`) and some other operations blur the line between these two use cases: they implicitly convert the path value to a store path by copying its contents to the store.
+          Arguably, this makes path literals unfit for the simple string-like use case.
+
+          Additionally, a home path literal can make the home directory *location* of the evaluating user an implicit input to the evaluation, specifically when `toString` is called, e.g. `toString ~/.config`.
+          Evaluating on different accounts or machines will result in different derivations - an evaluation impurity.
+
+          Sometimes the intent is to read the file system contents at the path, as part of evaluation or instantiation.
+          In that case, using absolute or home path literals is undesirable for different reasons.
+          It requires that anyone who uses your expressions sets up more sources in those exact locations.
+          This is not a requirement that should normally be imposed on users, because it causes extra work, may not be possible to achieve for all users, or may conflict with their preferred file system layout.
+          Furthermore, it is non-hermetic, so it's difficult to version-control such expressions correctly.
+          A similar problem can be caused by upward relative path literals like `../../..`, which is not checked by this option, but by [pure evaluation mode](#conf-pure-eval).
+
+          [Pure evaluation mode](#conf-pure-eval) by itself also disallows home path literals, with a different error message.
+          It does not disallow absolute path literals, as it only restricts access to the *contents* of most file system locations.
+          )",
     };
 
     Setting<Diagnose> lintUrlLiterals{

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -412,7 +412,11 @@ struct EvalSettings : Config
 
           There are two use cases for these literals.
           - Specifying a location without reading its contents during evaluation, e.g. using [`toString`](@docroot@/language/builtins.md#builtins-toString)
+            Example:
+            
           - Providing more sources for expressions and builds, e.g. using [string interpolation](@docroot@/language/string-interpolation.md)
+            Example:
+            
 
           These two kinds of literals have significant disadvantages for both use cases.
 

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -401,6 +401,7 @@ struct EvalSettings : Config
         "lint-absolute-path-literals",
         R"(
           Controls the handling of absolute path literals (paths starting with `/`) and home path literals (paths starting with `~/`).
+          See [path literals](@docroot@/language/syntax.md#path-literal).
           These may be considered antipatterns, as explained below.
 
           Possible values:
@@ -410,14 +411,14 @@ struct EvalSettings : Config
           - `fatal`: Treat as a parse error
 
           There are two use cases for these literals.
-          - Specifying a location without reading its contents during evaluation, e.g. using `toString`
-          - Providing more sources for expressions and builds, e.g. using string interpolation
+          - Specifying a location without reading its contents during evaluation, e.g. using [`toString`](@docroot@/language/builtins.md#builtins-toString)
+          - Providing more sources for expressions and builds, e.g. using [string interpolation](@docroot@/language/string-interpolation.md)
 
           These two kinds of literals have significant disadvantages for both use cases.
 
           The simpler use case is specifying a location without reading its contents.
           This comes with the risk of accidentally copying unintended files into the store, making a snapshot of those files readable by all system users.
-          This happens easily, because string interpolation (`"${some-path-value}"`) and some other operations blur the line between these two use cases: they implicitly convert the path value to a store path by copying its contents to the store.
+          This happens easily, because [string interpolation](@docroot@/language/string-interpolation.md#interpolated-expression) (`"${some-path-value}"`) and some other operations blur the line between these two use cases: they implicitly convert the path value to a store path by copying its contents to the store.
           Arguably, this makes path literals unfit for the simple string-like use case.
 
           Additionally, a home path literal can make the home directory *location* of the evaluating user an implicit input to the evaluation, specifically when `toString` is called, e.g. `toString ~/.config`.

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -433,6 +433,11 @@ struct EvalSettings : Config
 
           Additionally, a home path literal can make the home directory *location* of the evaluating user an implicit input to the evaluation, specifically when `toString` is called, e.g. `toString ~/.config`.
           Evaluating on different accounts or machines will result in different derivations - an evaluation impurity.
+          Example:
+          ```nix
+          builtins.baseNameOf (builtins.dirOf ~/.)
+          ```
+          => "alice" or "bob"
 
           Sometimes the intent is to read the file system contents at the path, as part of evaluation or instantiation.
           In that case, using absolute or home path literals is undesirable for different reasons.

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -418,6 +418,16 @@ struct EvalSettings : Config
 
           The simpler use case is specifying a location without reading its contents.
           This comes with the risk of accidentally copying unintended files into the store, making a snapshot of those files readable by all system users.
+          Example:
+          ```nix
+          let
+            path = /var/lib/oxidized; # forgot toString
+          in ''
+            [some config file]
+            location_foo = ${path}/foo
+            location_bar = ${path}/bar
+          ''
+          ```
           This happens easily, because [string interpolation](@docroot@/language/string-interpolation.md#interpolated-expression) (`"${some-path-value}"`) and some other operations blur the line between these two use cases: they implicitly convert the path value to a store path by copying its contents to the store.
           Arguably, this makes path literals unfit for the simple string-like use case.
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The previous explanation was vague and meandering.

The new text is structured around the two use cases and their disadvantages, so that it's easier to understand the context in which the arguments are made.
The subjective arguments are largely replaced by concrete ones, such as the accidental store copying risk and the difficulty of version-controlling non-hermetic expressions.


## Context

@Ericson2314 and I did some explaining in NixOS Discourse
[Remove All Absolute Path Literals From Nixpkgs](https://discourse.nixos.org/t/remove-all-absolute-path-literals-from-nixpkgs/77245). I don't think we would have had to explain as much with this text in place.

I wanted to make some recommendations, but "use the right type from the get go" feels like gaslighting, because Nixpkgs `lib.fileset` has an unresolved false positive that's blocked on e.g. an `isHostRoot` primop, and transitively on virtual path value stuff.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
