### PR TITLE
Remove non-atomically initialised variable vImportedDrvToDerivation

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -297,6 +297,10 @@ EvalState::EvalState(
           CanonPath("derivation-internal.nix"),
 #include "primops/derivation.nix.gen.hh"
           )}
+    , importedDrvToDerivation{internalFS->addFile(
+          CanonPath("imported-drv-to-derivation.nix"),
+#include "imported-drv-to-derivation.nix.gen.hh"
+          )}
     , store(store)
     , buildStore(buildStore ? buildStore : store)
     , inputCache(fetchers::InputCache::create())

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -396,6 +396,7 @@ public:
     const ref<MemorySourceAccessor> internalFS;
 
     const SourcePath derivationInternal;
+    const SourcePath importedDrvToDerivation;
 
     /**
      * Store used to materialise .drv files.
@@ -406,8 +407,6 @@ public:
      * Store used to build stuff.
      */
     const ref<Store> buildStore;
-
-    RootValue vImportedDrvToDerivation = nullptr;
 
     const ref<fetchers::InputCache> inputCache;
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -247,18 +247,10 @@ void derivationToValue(
     auto w = state.allocValue();
     w->mkAttrs(attrs);
 
-    if (!state.vImportedDrvToDerivation) {
-        state.vImportedDrvToDerivation = allocRootValue(state.allocValue());
-        state.eval(
-            state.parseExprFromString(
-#include "imported-drv-to-derivation.nix.gen.hh"
-                , state.rootPath(CanonPath::root)),
-            **state.vImportedDrvToDerivation);
-    }
+    auto vImportedDrvToDerivation = state.allocValue();
+    state.evalFile(state.importedDrvToDerivation, *vImportedDrvToDerivation); // has caching
 
-    state.forceFunction(
-        **state.vImportedDrvToDerivation, pos, "while evaluating imported-drv-to-derivation.nix.gen.hh");
-    v.mkApp(*state.vImportedDrvToDerivation, w);
+    v.mkApp(vImportedDrvToDerivation, w);
     state.forceAttrs(v, pos, "while calling imported-drv-to-derivation.nix.gen.hh");
 }
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fixes https://github.com/DeterminateSystems/nix-src/issues/447. (Only an issue with parallel eval which we don't have yet, but may as well fix it now.)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
