### PR TITLE
Fix git lfs for github fetcher

### DIFF
--- a/src/libfetchers-tests/git-lfs-fetch.cc
+++ b/src/libfetchers-tests/git-lfs-fetch.cc
@@ -1,0 +1,28 @@
+#include "nix/fetchers/git-lfs-fetch.hh"
+#include "nix/util/url.hh"
+
+#include <gtest/gtest.h>
+
+namespace nix::lfs {
+
+struct GitLFSParameterizedTestFixture : public ::testing::TestWithParam<std::pair<std::string, std::string>>
+{};
+
+TEST_P(GitLFSParameterizedTestFixture, get_lfs_api)
+{
+    auto & [input, expected] = GetParam();
+    ASSERT_EQ(getLfsApi(parseURL(input)).endpoint, expected);
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    GitLFSTests,
+    GitLFSParameterizedTestFixture,
+    ::testing::Values(
+        std::pair{"https://git-server.com/foo/bar", "https://git-server.com/foo/bar.git/info/lfs"},
+        std::pair{"https://git-server.com/foo/bar.git", "https://git-server.com/foo/bar.git/info/lfs"},
+        std::pair{"https://git-server.com", "https://git-server.com/.git/info/lfs"},
+        std::pair{"https://git-server.com/", "https://git-server.com/.git/info/lfs"},
+        std::pair{"https://git-server.com//", "https://git-server.com//.git/info/lfs"},
+        std::pair{"https://git-server.com/foo/bar/", "https://git-server.com/foo/bar.git/info/lfs"}));
+
+} // namespace nix::lfs

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -41,6 +41,7 @@ subdir('nix-meson-build-support/common')
 sources = files(
   'access-tokens.cc',
   'attrs.cc',
+  'git-lfs-fetch.cc',
   'git-utils.cc',
   'git.cc',
   'input.cc',

--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -46,17 +46,7 @@ static void downloadToSink(
             "hash mismatch while fetching %s: expected sha256:%s but got sha256:%s", url, sha256Expected, sha256Actual);
 }
 
-namespace {
-
-struct LfsApiInfo
-{
-    std::string endpoint;
-    std::optional<std::string> authHeader;
-};
-
-} // namespace
-
-static LfsApiInfo getLfsApi(const ParsedURL & url)
+LfsApiInfo getLfsApi(ParsedURL url)
 {
     assert(url.authority.has_value());
     if (url.scheme == "ssh") {
@@ -96,7 +86,41 @@ static LfsApiInfo getLfsApi(const ParsedURL & url)
         return {queryResp.at("href").get<std::string>(), authIt->get<std::string>()};
     }
 
-    return {url.to_string() + "/info/lfs", std::nullopt};
+    /**
+     * Try to mimic what git-lfs will do to plain remotes
+     * https://github.com/git-lfs/git-lfs/blob/main/docs/api/server-discovery.md
+     *
+     * Try to be smarter with remotes ending in a /, like
+     * `https://github.com/NixOS/nix/`. This should be
+     * `https://github.com/NixOS/nix.git/info/lfs`, not
+     * `https://github.com/NixOS/nix/.git/info/lfs`
+     */
+    bool hasDotGit = false;
+    for (auto it = url.path.rbegin(); it != url.path.rend(); ++it) {
+        if (it->empty())
+            continue;
+        if (!it->ends_with(".git"))
+            *it += ".git";
+        hasDotGit = true;
+        break;
+    }
+    if (!hasDotGit) {
+        if (url.path.size() > 1) // e.g. {"", ""} (single trailing slash)
+            url.path.back() = ".git";
+        else if (url.path.size() == 1) // {""}
+            url.path.push_back(".git");
+        else { // {}
+            url.path.push_back("");
+            url.path.push_back(".git");
+        }
+    }
+    if (url.path.back().empty())
+        url.path.back() = "info";
+    else
+        url.path.push_back("info");
+    url.path.push_back("lfs");
+
+    return {url.to_string(), std::nullopt};
 }
 
 typedef std::unique_ptr<git_config, Deleter<git_config_free>> GitConfig;

--- a/src/libfetchers/include/nix/fetchers/git-lfs-fetch.hh
+++ b/src/libfetchers/include/nix/fetchers/git-lfs-fetch.hh
@@ -43,4 +43,12 @@ struct Fetch
     std::vector<nlohmann::json> fetchUrls(const std::vector<Pointer> & pointers) const;
 };
 
+struct LfsApiInfo
+{
+    std::string endpoint;
+    std::optional<std::string> authHeader;
+};
+
+LfsApiInfo getLfsApi(ParsedURL url);
+
 } // namespace nix::lfs


### PR DESCRIPTION
According to
https://github.com/git-lfs/git-lfs/blob/main/docs/api/server-discovery.md LFS endpoints must end in `.git`.

Resolves #15285

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Attempting to use LFS with a github fetcher can fail with HTTP 422 without this.

## Context

Confirmed the fix works in #15285

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
