### PR TITLE
Fix repl multiline binding continuation

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -171,7 +171,7 @@ static std::ostream & showDebugTrace(std::ostream & out, const PosTable & positi
  * but those must be reported as errors, not trigger continuation. The
  * exception subtype is what distinguishes the two cases.
  */
-MakeError(IncompleteReplExpr, ParseError);
+MakeError(IncompleteReplExpr, Error);
 
 static bool isIncompleteInput(const ParseError & e)
 {

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -663,6 +663,8 @@ ProcessLineResult NixRepl::processLine(std::string line)
         ExprAttrs * bindings = nullptr;
         try {
             bindings = parseReplBindings(line);
+        } catch (IncompleteReplExpr &) {
+            throw;
         } catch (ParseError &) {
         }
 
@@ -897,7 +899,13 @@ ExprAttrs * NixRepl::parseReplBindings(std::string s)
     // Use original source (s) for error messages, not s + ";"
     try {
         return state->parseReplBindings(s + ";", s, basePath, staticEnv);
-    } catch (ParseError &) {
+    } catch (ParseError & e) {
+        // All binding parse attempts failed. If the last error indicates
+        // incomplete input (e.g. unclosed multi-line string), signal the
+        // mainLoop to read continuation lines instead of falling through
+        // to expression parsing which would produce a misleading error.
+        if (e.msg().find("unexpected end of file") != std::string::npos)
+            throw IncompleteReplExpr(e.msg());
         // Semicolon retry failed; rethrow the original bindings error
         std::rethrow_exception(bindingsError);
     }

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -161,7 +161,22 @@ static std::ostream & showDebugTrace(std::ostream & out, const PosTable & positi
     return out;
 }
 
+/**
+ * Thrown when the REPL's own input is incomplete (e.g. unclosed multi-line
+ * string or open parenthesis). The mainLoop catches this to prompt for
+ * continuation lines instead of showing an error.
+ *
+ * Only parseString and parseReplBindings may throw this. Evaluation can also
+ * produce "unexpected end of file" ParseErrors (e.g. `import ./broken.nix`),
+ * but those must be reported as errors, not trigger continuation. The
+ * exception subtype is what distinguishes the two cases.
+ */
 MakeError(IncompleteReplExpr, ParseError);
+
+static bool isIncompleteInput(const ParseError & e)
+{
+    return e.msg().find("unexpected end of file") != std::string::npos;
+}
 
 static bool isFirstRepl = true;
 
@@ -660,13 +675,7 @@ ProcessLineResult NixRepl::processLine(std::string line)
 
     else {
         // Try parsing as bindings first (handles `x = 1`, `inherit ...`, etc.)
-        ExprAttrs * bindings = nullptr;
-        try {
-            bindings = parseReplBindings(line);
-        } catch (IncompleteReplExpr &) {
-            throw;
-        } catch (ParseError &) {
-        }
+        ExprAttrs * bindings = parseReplBindings(line);
 
         if (bindings) {
             Env * inheritEnv = bindings->inheritFromExprs ? bindings->buildInheritFromEnv(*state, *env) : nullptr;
@@ -874,12 +883,9 @@ Expr * NixRepl::parseString(std::string s)
     try {
         return state->parseExprFromString(std::move(s), state->rootPath("."), staticEnv);
     } catch (ParseError & e) {
-        if (e.msg().find("unexpected end of file") != std::string::npos)
-            // For parse errors on incomplete input, we continue waiting for the next line of
-            // input without clearing the input so far.
+        if (isIncompleteInput(e))
             throw IncompleteReplExpr(e.msg());
-        else
-            throw;
+        throw;
     }
 }
 
@@ -888,11 +894,9 @@ ExprAttrs * NixRepl::parseReplBindings(std::string s)
     auto basePath = state->rootPath(".");
 
     // Try parsing as bindings
-    std::exception_ptr bindingsError;
     try {
         return state->parseReplBindings(s, basePath, staticEnv);
     } catch (ParseError &) {
-        bindingsError = std::current_exception();
     }
 
     // Try with semicolon appended (for `inherit foo` shorthand)
@@ -900,14 +904,10 @@ ExprAttrs * NixRepl::parseReplBindings(std::string s)
     try {
         return state->parseReplBindings(s + ";", s, basePath, staticEnv);
     } catch (ParseError & e) {
-        // All binding parse attempts failed. If the last error indicates
-        // incomplete input (e.g. unclosed multi-line string), signal the
-        // mainLoop to read continuation lines instead of falling through
-        // to expression parsing which would produce a misleading error.
-        if (e.msg().find("unexpected end of file") != std::string::npos)
+        if (isIncompleteInput(e))
             throw IncompleteReplExpr(e.msg());
-        // Semicolon retry failed; rethrow the original bindings error
-        std::rethrow_exception(bindingsError);
+        // Semicolon retry also failed; not valid binding syntax.
+        return nullptr;
     }
 }
 

--- a/tests/functional/repl/multiline-string-binding.expected
+++ b/tests/functional/repl/multiline-string-binding.expected
@@ -1,0 +1,9 @@
+Nix <nix version>
+Type :? for help.
+
+nix-repl> x = ''
+        >   hello
+        > ''
+
+nix-repl> x
+"hello\n"

--- a/tests/functional/repl/multiline-string-binding.in
+++ b/tests/functional/repl/multiline-string-binding.in
@@ -1,0 +1,5 @@
+# COM: Multi-line string in binding should trigger continuation (issue #15801)
+x = ''
+  hello
+''
+x

--- a/tests/functional/repl/multiline-string-function-binding.expected
+++ b/tests/functional/repl/multiline-string-function-binding.expected
@@ -1,0 +1,11 @@
+Nix <nix version>
+Type :? for help.
+
+nix-repl> f = x: x
+
+nix-repl> y = f ''
+        >   world
+        > ''
+
+nix-repl> y
+"world\n"

--- a/tests/functional/repl/multiline-string-function-binding.in
+++ b/tests/functional/repl/multiline-string-function-binding.in
@@ -1,0 +1,6 @@
+# COM: Multi-line string in function call binding (issue #15801)
+f = x: x
+y = f ''
+  world
+''
+y


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

- Fixes #15801
- Clarify the code (commit 2 and 3)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Bug introduced in #15082

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
