### PR TITLE
Fix nix-copy-closure --include-outputs

### DIFF
--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -1139,7 +1139,8 @@ void copyClosure(
     const std::set<RealisedPath> & paths,
     RepairFlag repair = NoRepair,
     CheckSigsFlag checkSigs = CheckSigs,
-    SubstituteFlag substitute = NoSubstitute);
+    SubstituteFlag substitute = NoSubstitute,
+    bool includeOutputs = false);
 
 void copyClosure(
     Store & srcStore,
@@ -1147,7 +1148,8 @@ void copyClosure(
     const StorePathSet & paths,
     RepairFlag repair = NoRepair,
     CheckSigsFlag checkSigs = CheckSigs,
-    SubstituteFlag substitute = NoSubstitute);
+    SubstituteFlag substitute = NoSubstitute,
+    bool includeOutputs = false);
 
 /**
  * Remove the temporary roots file for this process.  Any temporary

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1085,7 +1085,8 @@ void copyClosure(
     const RealisedPath::Set & paths,
     RepairFlag repair,
     CheckSigsFlag checkSigs,
-    SubstituteFlag substitute)
+    SubstituteFlag substitute,
+    bool includeOutputs)
 {
     if (&srcStore == &dstStore)
         return;
@@ -1096,7 +1097,7 @@ void copyClosure(
     }
 
     StorePathSet closure1;
-    srcStore.computeFSClosure(closure0, closure1);
+    srcStore.computeFSClosure(closure0, closure1, false, includeOutputs);
 
     RealisedPath::Set closure = paths;
     for (auto && path : closure1)
@@ -1111,13 +1112,14 @@ void copyClosure(
     const StorePathSet & storePaths,
     RepairFlag repair,
     CheckSigsFlag checkSigs,
-    SubstituteFlag substitute)
+    SubstituteFlag substitute,
+    bool includeOutputs)
 {
     if (&srcStore == &dstStore)
         return;
 
     StorePathSet closure;
-    srcStore.computeFSClosure(storePaths, closure);
+    srcStore.computeFSClosure(storePaths, closure, false, includeOutputs);
     copyPaths(srcStore, dstStore, closure, repair, checkSigs, substitute);
 }
 

--- a/src/nix/nix-copy-closure/nix-copy-closure.cc
+++ b/src/nix/nix-copy-closure/nix-copy-closure.cc
@@ -62,7 +62,7 @@ static int main_nix_copy_closure(int argc, char ** argv)
         for (auto & path : storePaths)
             storePaths2.insert(from->followLinksToStorePath(path));
 
-        copyClosure(*from, *to, storePaths2, NoRepair, NoCheckSigs, useSubstitutes);
+        copyClosure(*from, *to, storePaths2, NoRepair, NoCheckSigs, useSubstitutes, includeOutputs);
 
         return 0;
     }

--- a/tests/nixos/nix-copy-closure.nix
+++ b/tests/nixos/nix-copy-closure.nix
@@ -14,6 +14,7 @@ let
   pkgB = pkgs.wget;
   pkgC = pkgs.hello;
   pkgD = pkgs.tmux;
+  pkgE = pkgs.tree;
 
 in
 {
@@ -32,6 +33,7 @@ in
         virtualisation.additionalPaths = [
           pkgA
           pkgD.drvPath
+          pkgE.drvPath
         ];
         nix.settings.substituters = lib.mkForce [ ];
       };
@@ -41,9 +43,12 @@ in
       {
         services.openssh.enable = true;
         virtualisation.writableStore = true;
+        # Including pkgC.drvPath (versus just pkgC) so common build deps
+        # are already in the store, limiting what the --include-outputs test
+        # needs to copy.
         virtualisation.additionalPaths = [
           pkgB
-          pkgC
+          pkgC.drvPath
         ];
       };
   };
@@ -86,10 +91,16 @@ in
       # Copy the closure of package C via the SSH substituter.
       client.fail("nix-store -r ${pkgC}")
 
-      # Copy the derivation of package D's derivation from the client to the server.
+      # Copy the derivation of package D from the client to the server.
       server.fail("nix-store --check-validity ${pkgD.drvPath}")
       client.succeed("nix-copy-closure --to server --gzip ${pkgD.drvPath} >&2")
       server.succeed("nix-store --check-validity ${pkgD.drvPath}")
+      server.fail("nix-store --check-validity ${pkgD}")
+
+      # Copy the derivation and outputs of package E from client to server.
+      server.fail("nix-store --check-validity ${pkgE}")
+      client.succeed("nix-copy-closure --to server --gzip --include-outputs ${pkgE.drvPath} >&2")
+      server.succeed("nix-store --check-validity ${pkgE}")
 
       # FIXME
       # client.succeed(


### PR DESCRIPTION
The option has been broken since Nix 2.4. The flag was accepted, but not used. This change plumbs it through to computeFSClosure.

Closes #5105

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

`nix-copy-closure` has an `--include-outputs` option, but currently it is silently ignored.

## Context

It looks like it was broken by https://github.com/NixOS/nix/commit/2e199673a523fa81de31ffdd2a25976ce0814631

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
