### PR TITLE
Fix FreeBSD makeFSSourceAccessor on symlinks

### DIFF
--- a/src/libutil/include/nix/util/file-system-at.hh
+++ b/src/libutil/include/nix/util/file-system-at.hh
@@ -22,6 +22,12 @@
 #ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
+#elif defined(__FreeBSD__)
+// FreeBSD openat(..., AT_NOFOLLOW) on a symlink returns
+// `EMLINK`, not the posix-specified `ELOOP`.
+#  define NIX_ERR_OPEN_SYMLINK EMLINK
+#else
+#  define NIX_ERR_OPEN_SYMLINK ELOOP
 #endif
 
 namespace nix {

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -761,7 +761,7 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackL
     AutoCloseFD fd = openFileReadonly(root, finalSymlink);
 
     if (!fd) {
-        if (finalSymlink == FinalSymlink::Follow || errno != ELOOP)
+        if (finalSymlink == FinalSymlink::Follow || errno != NIX_ERR_OPEN_SYMLINK)
             throw NativeSysError("opening file %1%", PathFmt(root));
 
         /* A helper class that holds the symlink destination in memory. */

--- a/src/libutil/unix/file-system-at.cc
+++ b/src/libutil/unix/file-system-at.cc
@@ -188,7 +188,7 @@ static AutoCloseFD openFileEnsureBeneathNoSymlinksIterative(
                 if (auto st = maybeFstatat(getParentFd(), component); st && S_ISLNK(st->st_mode))
                     throw SymlinkNotAllowed(path2);
                 errno = ENOTDIR; /* Restore the errno. */
-            } else if (errno == ELOOP) {
+            } else if (errno == NIX_ERR_OPEN_SYMLINK) {
                 throw SymlinkNotAllowed(path2);
             }
 
@@ -205,7 +205,7 @@ static AutoCloseFD openFileEnsureBeneathNoSymlinksIterative(
     AutoCloseFD res = ::openat(getParentFd(), lastComponent.c_str(), flags | O_NOFOLLOW, mode);
 
     if (!res) {
-        if (errno == ELOOP)
+        if (errno == NIX_ERR_OPEN_SYMLINK)
             throw SymlinkNotAllowed(path);
         /* `O_DIRECTORY | O_NOFOLLOW` on a trailing symlink returns
            `ENOTDIR` rather than `ELOOP`. Post-check via `fstatat` to
@@ -272,7 +272,7 @@ AutoCloseFD openFileEnsureBeneathNoSymlinks(
 
     if (auto maybeFd = linux::openat2(
             dirFd, path.rel_c_str(), flagsAdj, static_cast<uint64_t>(mode), RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)) {
-        if (!*maybeFd && errno == ELOOP)
+        if (!*maybeFd && errno == NIX_ERR_OPEN_SYMLINK)
             throw SymlinkNotAllowed(path);
         return std::move(*maybeFd);
     }


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
The `makeFSSourceAccessor` has special handling when it detects it is directly opening a symlink. 
It may be triggered when the output of a derivation is a symlink to another path, with no intermediate directory.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context
FreeBSD sets EMLINK instead of ELOOP when opening symlinks with `O_NOFOLLOW` in order to distinguish different error cases.

This change is necessary to build nixpkgs stdenv.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
