### PR TITLE
feat: support both ref and rev in git archive inputs (github/gitlab/sourcehut)

### DIFF
--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -129,12 +129,6 @@ struct GitArchiveInputScheme : InputScheme
 
         auto ref = maybeGetStrAttr(attrs, "ref");
         auto rev = maybeGetStrAttr(attrs, "rev");
-        if (ref && rev)
-            throw BadURL(
-                "input %s contains both a commit hash ('%s') and a branch/tag name ('%s')",
-                attrsToJSON(attrs),
-                *rev,
-                *ref);
 
         if (rev)
             Hash::parseAny(*rev, HashAlgorithm::SHA1);
@@ -157,15 +151,16 @@ struct GitArchiveInputScheme : InputScheme
         auto ref = input.getRef();
         auto rev = input.getRev();
         std::vector<std::string> path{owner, repo};
-        assert(!(ref && rev));
         if (ref)
             path.push_back(*ref);
-        if (rev)
+        else if (rev)
             path.push_back(rev->to_string(HashFormat::Base16, false));
         auto url = ParsedURL{
             .scheme = std::string{schemeName()},
             .path = path,
         };
+        if (ref && rev)
+            url.query.insert_or_assign("rev", rev->to_string(HashFormat::Base16, false));
         if (auto narHash = input.getNarHash())
             url.query.insert_or_assign("narHash", narHash->to_string(HashFormat::SRI, true));
         auto host = maybeGetStrAttr(input.attrs, "host");
@@ -177,20 +172,10 @@ struct GitArchiveInputScheme : InputScheme
     Input applyOverrides(const Input & _input, std::optional<std::string> ref, std::optional<Hash> rev) const override
     {
         auto input(_input);
-        if (rev && ref)
-            throw BadURL(
-                "cannot apply both a commit hash (%s) and a branch/tag name ('%s') to input '%s'",
-                rev->gitRev(),
-                *ref,
-                input.to_string());
-        if (rev) {
+        if (rev)
             input.attrs.insert_or_assign("rev", rev->gitRev());
-            input.attrs.erase("ref");
-        }
-        if (ref) {
+        if (ref)
             input.attrs.insert_or_assign("ref", *ref);
-            input.attrs.erase("rev");
-        }
         return input;
     }
 

--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -96,6 +96,19 @@ TEST(parseFlakeRef, GitArchiveInput)
         ASSERT_EQ(fragment, "\"name.with.dot\"");
         ASSERT_EQ(flakeref.to_string(), "github:foo/bar");
     }
+
+    // Both ref and rev can be specified together (https://github.com/NixOS/nix/issues/8226)
+    {
+        auto s = "github:foo/bar/branch?rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        auto flakeref = parseFlakeRef(fetchSettings, s);
+        ASSERT_EQ(flakeref.to_string(), "github:foo/bar/branch?rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    }
+
+    {
+        auto s = "github:foo/bar?ref=branch&rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        auto flakeref = parseFlakeRef(fetchSettings, s);
+        ASSERT_EQ(flakeref.to_string(), "github:foo/bar/branch?rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    }
 }
 
 struct InputFromURLTestCase
@@ -255,6 +268,18 @@ INSTANTIATE_TEST_SUITE_P(
                 },
             .description = "github_ref_slashes_in_path_everywhere",
             .expectedUrl = "github:ownerB/repoA/branchC",
+        },
+        InputFromURLTestCase{
+            .url = "github:foo/bar/v1.0?rev=2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+            .attrs =
+                {
+                    {"type", Attr("github")},
+                    {"owner", Attr("foo")},
+                    {"repo", Attr("bar")},
+                    {"ref", Attr("v1.0")},
+                    {"rev", Attr("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed")},
+                },
+            .description = "github_ref_and_rev",
         },
         InputFromURLTestCase{
             // FIXME: Subgroups in gitlab URLs are busted. This double-encoding


### PR DESCRIPTION
## Summary

Closes #8226

Allow specifying both `ref` (branch/tag name) and `rev` (commit hash) together in GitHub, GitLab, and SourceHut flake input URLs.

Previously this would error:
```
error: URL 'github:ipetkov/crane?ref=v0.12.1&rev=445a3d...' contains both a commit hash and a branch/tag name
```

## Motivation

The `ref` provides human-readable context about which version/branch is pinned, while `rev` ensures exact reproducibility. These are complementary, not conflicting:

- Humans reading `flake.nix` can see which release version is pinned
- `nix flake clone` works properly with both branch and revision info
- `builtins.fetchTree` can have locked inputs that specify both (required for non-`--impure` usage)

The indirect input scheme (e.g. `nixpkgs/branch/rev`) already supports both together. This change extends the same behavior to `GitArchiveInputScheme`.

## Changes

**`src/libfetchers/github.cc`:**
- `inputFromAttrs`: Remove the error thrown when both `ref` and `rev` are present
- `toURL`: Handle serialization when both are present — `ref` goes in the URL path, `rev` goes in query params (e.g. `github:owner/repo/branch?rev=abc123`)
- `applyOverrides`: Allow both `ref` and `rev` to be set simultaneously instead of treating them as mutually exclusive

**`src/libflake-tests/flakeref.cc`:**
- Added unit tests for parsing and round-tripping github URLs with both `ref` and `rev`
- Added parameterized `InputFromURL` test case verifying attrs and round-trip correctness

## Examples

These now work:
```nix
# In flake.nix inputs
crane.url = "github:ipetkov/crane/v0.12.1?rev=445a3d222947632b5593112bb817850e8a9cf737";

# Via builtins.fetchTree
builtins.fetchTree {
  type = "github";
  owner = "ipetkov";
  repo = "crane";
  ref = "v0.12.1";
  rev = "445a3d222947632b5593112bb817850e8a9cf737";
};

# nix flake clone
nix flake clone "github:numtide/system-manager/main?rev=e8957ab8b4cf..." --dest local
```
