### PR TITLE
flake: add generic modules.<kind>.<name> and configurations.<kind>.<name>

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -481,15 +481,16 @@ struct CmdFlakeCheck : FlakeCommand
             }
         };
 
-        auto checkModule = [&](std::string_view attrPath, Value & v, const PosIdx pos) {
-            try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking NixOS module '%s'", attrPath));
-                state->forceValue(v, pos);
-            } catch (Error & e) {
-                e.addTrace(resolve(pos), HintFmt("while checking the NixOS module '%s'", attrPath));
-                reportError(e);
-            }
-        };
+        auto checkModule =
+            [&](std::string_view attrPath, Value & v, const PosIdx pos, std::string_view label = "NixOS module") {
+                try {
+                    Activity act(*logger, lvlInfo, actUnknown, fmt("checking %s '%s'", label, attrPath));
+                    state->forceValue(v, pos);
+                } catch (Error & e) {
+                    e.addTrace(resolve(pos), HintFmt("while checking the %s '%s'", label, attrPath));
+                    reportError(e);
+                }
+            };
 
         std::function<void(std::string_view attrPath, Value & v, const PosIdx pos)> checkHydraJobs;
 
@@ -527,6 +528,23 @@ struct CmdFlakeCheck : FlakeCommand
                     throw Error("attribute 'config.system.build.toplevel' is not a derivation");
             } catch (Error & e) {
                 e.addTrace(resolve(pos), HintFmt("while checking the NixOS configuration '%s'", attrPath));
+                reportError(e);
+            }
+        };
+
+        // FIXME: The attribute path 'config.build.toplevel' is a proposed convention.
+        // We should decide on standardizing this path and update downstream projects
+        // (nixpkgs, home-manager, nix-darwin, etc.) to expose it before this stabilizes.
+        auto checkConfiguration = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
+            try {
+                Activity act(*logger, lvlInfo, actUnknown, fmt("checking configuration '%s'", attrPath));
+                Bindings & bindings = Bindings::emptyBindings;
+                auto vToplevel = findAlongAttrPath(*state, "config.build.toplevel", bindings, v).first;
+                state->forceValue(*vToplevel, pos);
+                if (!state->isDerivation(*vToplevel))
+                    throw Error("attribute 'config.build.toplevel' is not a derivation");
+            } catch (Error & e) {
+                e.addTrace(resolve(pos), HintFmt("while checking the configuration '%s'", attrPath));
                 reportError(e);
             }
         };
@@ -721,11 +739,42 @@ struct CmdFlakeCheck : FlakeCommand
                             checkModule(fmt("%s.%s", name, state->symbols[attr.name]), *attr.value, attr.pos);
                     }
 
+                    else if (name == "modules") {
+                        state->forceAttrs(vOutput, pos, "");
+                        for (auto & kindAttr : *vOutput.attrs()) {
+                            state->forceAttrs(*kindAttr.value, kindAttr.pos, "");
+                            for (auto & moduleAttr : *kindAttr.value->attrs())
+                                checkModule(
+                                    fmt("%s.%s.%s",
+                                        name,
+                                        state->symbols[kindAttr.name],
+                                        state->symbols[moduleAttr.name]),
+                                    *moduleAttr.value,
+                                    moduleAttr.pos,
+                                    "module");
+                        }
+                    }
+
                     else if (name == "nixosConfigurations") {
                         state->forceAttrs(vOutput, pos, "");
                         for (auto & attr : *vOutput.attrs())
                             checkNixOSConfiguration(
                                 fmt("%s.%s", name, state->symbols[attr.name]), *attr.value, attr.pos);
+                    }
+
+                    else if (name == "configurations") {
+                        state->forceAttrs(vOutput, pos, "");
+                        for (auto & kindAttr : *vOutput.attrs()) {
+                            state->forceAttrs(*kindAttr.value, kindAttr.pos, "");
+                            for (auto & configAttr : *kindAttr.value->attrs())
+                                checkConfiguration(
+                                    fmt("%s.%s.%s",
+                                        name,
+                                        state->symbols[kindAttr.name],
+                                        state->symbols[configAttr.name]),
+                                    *configAttr.value,
+                                    configAttr.pos);
+                        }
                     }
 
                     else if (name == "hydraJobs")
@@ -1202,7 +1251,8 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
 
             try {
                 if ((attrPathS[0] == "apps" || attrPathS[0] == "checks" || attrPathS[0] == "devShells"
-                     || attrPathS[0] == "legacyPackages" || attrPathS[0] == "packages")
+                     || attrPathS[0] == "legacyPackages" || attrPathS[0] == "packages" || attrPathS[0] == "modules"
+                     || attrPathS[0] == "configurations")
                     && (attrPathS.size() == 1 || attrPathS.size() == 2)) {
                     for (const auto & subAttr : visitor2->getAttrs()) {
                         if (hasContent(*visitor2, attrPath2, subAttr)) {
@@ -1312,7 +1362,8 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                             || attrPathS[0] == "templates" || attrPathS[0] == "overlays"))
                     || ((attrPath.size() == 1 || attrPath.size() == 2)
                         && (attrPathS[0] == "checks" || attrPathS[0] == "packages" || attrPathS[0] == "devShells"
-                            || attrPathS[0] == "apps"))) {
+                            || attrPathS[0] == "apps" || attrPathS[0] == "modules"
+                            || attrPathS[0] == "configurations"))) {
                     recurse();
                 }
 
@@ -1450,6 +1501,10 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                                                : (attrPath.size() == 1 && attrPathS[0] == "nixosModule")
                                                        || (attrPath.size() == 2 && attrPathS[0] == "nixosModules")
                                                    ? std::make_pair("nixos-module", "NixOS module")
+                                               : attrPath.size() == 3 && attrPathS[0] == "configurations"
+                                                   ? std::make_pair("configuration", "configuration")
+                                               : attrPath.size() == 3 && attrPathS[0] == "modules"
+                                                   ? std::make_pair("module", "module")
                                                    : std::make_pair("unknown", "unknown");
                     if (json) {
                         j.emplace("type", type);

--- a/tests/functional/flakes/check.sh
+++ b/tests/functional/flakes/check.sh
@@ -66,6 +66,87 @@ EOF
 
 (! nix flake check "$flakeDir")
 
+# Test generic modules.<kind>.<name> output — grouped by kind, modules can be attrsets, lambdas, or paths
+cat > "$flakeDir"/mymodule.nix <<EOF
+{ config, pkgs, ... }: { }
+EOF
+
+cat > "$flakeDir"/flake.nix <<EOF
+{
+  outputs = { self }: {
+    modules.nixos.attrset-module = {
+      a.b.c = 123;
+      foo = true;
+    };
+    modules.home-manager.lambda-module = { config, ... }: {
+      home.stateVersion = "23.11";
+    };
+    modules.nixos.path-module = ./mymodule.nix;
+  };
+}
+EOF
+
+nix flake check "$flakeDir"
+
+# modules.<kind>.<name> should fail when a module fails to evaluate
+cat > "$flakeDir"/flake.nix <<EOF
+{
+  outputs = { self }: {
+    modules.nixos.bad = assert false; { };
+  };
+}
+EOF
+
+(! nix flake check "$flakeDir")
+
+# Test generic configurations.<kind>.<name> output — requires config.build.toplevel derivation
+cat > "$flakeDir"/flake.nix <<EOF
+{
+  outputs = { self }: {
+    configurations.nixos.myMachine = {
+      config.build.toplevel = derivation {
+        name = "toplevel";
+        system = "$system";
+        builder = "/bin/sh";
+      };
+    };
+    configurations.home-manager.myHome = {
+      config.build.toplevel = derivation {
+        name = "toplevel";
+        system = "$system";
+        builder = "/bin/sh";
+      };
+    };
+  };
+}
+EOF
+
+nix flake check "$flakeDir"
+
+# configurations.<kind>.<name> should fail when config.build.toplevel is missing
+cat > "$flakeDir"/flake.nix <<EOF
+{
+  outputs = { self }: {
+    configurations.nixos.bad = { system = "x86_64-linux"; };
+  };
+}
+EOF
+
+(! nix flake check "$flakeDir")
+
+# configurations.<kind>.<name> should fail when config.build.toplevel is not a derivation
+cat > "$flakeDir"/flake.nix <<EOF
+{
+  outputs = { self }: {
+    configurations.nixos.bad = {
+      config.build.toplevel = "not-a-derivation";
+    };
+  };
+}
+EOF
+
+(! nix flake check "$flakeDir")
+
 cat > "$flakeDir"/flake.nix <<EOF
 {
   outputs = { self }: {

--- a/tests/functional/flakes/show.sh
+++ b/tests/functional/flakes/show.sh
@@ -59,6 +59,8 @@ cat >flake.nix <<EOF
     formatter = { };
     nixosConfigurations = { };
     nixosModules = { };
+    modules.nixos = { };
+    configurations.nixos = { }; # empty kind, no entries to check
   };
 }
 EOF
@@ -67,6 +69,28 @@ nix eval --impure --expr '
 let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
 in
 assert show_output == { };
+true
+'
+
+# Test that modules.<kind>.<name> and configurations.<kind>.<name> are shown with correct types
+cat >flake.nix <<EOF
+{
+  outputs = inputs: {
+    modules.nixos.moduleA = { a = 1; };
+    modules."home-manager".moduleB = { b = 2; };
+    configurations.nixos.myMachine = { system = "x86_64-linux"; };
+    configurations.darwin.myMac = { system = "aarch64-darwin"; };
+  };
+}
+EOF
+nix flake show --json --all-systems > show-output.json
+nix eval --impure --expr '
+let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
+in
+assert show_output.modules.nixos.moduleA.type == "module";
+assert show_output.modules."home-manager".moduleB.type == "module";
+assert show_output.configurations.nixos.myMachine.type == "configuration";
+assert show_output.configurations.darwin.myMac.type == "configuration";
 true
 '
 


### PR DESCRIPTION
## flake: add generic `modules.<kind>.<name>` and `configurations.<kind>.<name>` outputs

## Motivation

The Nix ecosystem has grown well beyond NixOS. Tools like home-manager and nix-darwin are widely used, but there is no standard flake output schema for their modules or configurations. Each project and user invents their own convention — `homeModules`, `darwinModules`, `homeConfigurations`, `darwinConfigurations`, etc. — none of which Nix recognizes. These show up as "unknown flake output" warnings, and `nix flake show` cannot introspect or display them as structured trees.

This adds two generic outputs that give the broader ecosystem a standard home, eliminating the fragmentation and the unknown-output warnings.

## Context

Two new recognized flake outputs:

- **`modules.<kind>.<name>`** — a two-level attrset of modules grouped by kind (e.g. `nixos`, `home-manager`, `darwin`). Each leaf is validated the same way as `nixosModules` entries — `forceValue` accepts attrsets, lambdas, and paths.

- **`configurations.<kind>.<name>`** — a two-level attrset of configurations grouped by kind. Each entry is required to expose `config.build.toplevel` as a derivation, establishing a kind-agnostic equivalent of the `config.system.build.toplevel` convention used by NixOS and nix-darwin. This gives tools like home-manager and nix-darwin a standard interface to implement so `nix flake check` can meaningfully validate any configuration type.

Both outputs are fully recognized by `nix flake check` and `nix flake show`, display as proper trees, and do not produce "unknown flake output" warnings. The existing `nixosModules` and `nixosConfigurations` outputs are unchanged.

Example output of `nix flake show`:

```
├───configurations
│   ├───darwin
│   │   └───myMac: configuration
│   ├───home-manager
│   │   └───myHome: configuration
│   └───nixos
│       └───myMachine: configuration
└───modules
    ├───home-manager
    │   └───myModule: module
    └───nixos
        ├───moduleA: module
        └───moduleB: module
```
