### PR TITLE
libstore: skip optimisation when GC removes a link concurrently

### DIFF
--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -210,9 +210,15 @@ void LocalStore::optimisePath_(
 
     /* Yes!  We've seen a file with the same contents.  Replace the
        current file with a hard link to that file. */
-    auto stLink = lstat(linkPath);
+    auto stLink = maybeLstat(linkPath);
 
-    if (st.st_ino == stLink.st_ino) {
+    /* A concurrent garbage collection may have removed the link in the
+       links directory between the existence check above and now. Skip
+       optimising this path; a later pass will dedup it. */
+    if (!stLink)
+        return;
+
+    if (st.st_ino == stLink->st_ino) {
         debug("%1% is already linked to %2%", PathFmt(path), PathFmt(linkPath));
         return;
     }
@@ -243,6 +249,12 @@ void LocalStore::optimisePath_(
                Just shrug and ignore. */
             if (st.st_size)
                 printInfo("%1% has maximum number of links", PathFmt(linkPath));
+            return;
+        }
+        if (e.code() == std::errc::no_such_file_or_directory) {
+            /* A concurrent garbage collection removed the link in the
+               links directory. Skip optimising this path; a later pass
+               will dedup it. */
             return;
         }
         throw SystemError(e.code(), "creating hard link from %1% to %2%", PathFmt(linkPath), PathFmt(tempLink));


### PR DESCRIPTION
## Motivation

`nix store optimise` and `auto-optimise-store` can abort a build with:

```
filesystem error: cannot create hard link: No such file or directory [/nix/store/.links/1hyl5nszryd45bmwfln09f76hyan53zv40cvrymimcsp9qn6slhx] [/nix/store/.tmp-link-1196778-845337060]
```

https://github.com/cachix/devenv/actions/runs/26294238442/job/77408282471#step:6:2534

when a garbage collection runs at the same time.

### The race

In `optimisePath_`, when a file with matching contents is already indexed, the flow is:

1. confirm `/nix/store/.links/<hash>` exists,
2. `lstat` it,
3. compare inodes,
4. `create_hard_link(linkPath, tempLink)` and then `rename(tempLink, path)`.

The links-directory entry can have a link count of 1 (the original store path that created it was already collected, but `removeUnusedLinks` has not run yet). A concurrent GC's `removeUnusedLinks` then deletes that entry in the window between the existence check and `create_hard_link`. The source is gone, so `create_hard_link` fails with `ENOENT`, and the exception propagates and fails the whole operation.

This is the `No such file or directory` variant of #7273. The variant reported there is `File exists`, which was addressed by switching to `makeTempPath` in #14676; the `ENOENT` window described above is still unhandled.

## Fix

Store optimisation is best effort, so a link disappearing underneath us is benign: skip optimising this path and let a later pass dedup it. This mirrors how the existing `too_many_links` and `file_exists` cases already shrug and return.

Two windows are guarded:

- `lstat(linkPath)` becomes `maybeLstat(linkPath)`, returning early if the entry vanished before the inode comparison.
- the `create_hard_link` catch now returns on `std::errc::no_such_file_or_directory`.

## Context

This is a race condition. There is no hook to deterministically remove `linkPath` mid call, so a non flaky regression test is not feasible, consistent with #7273 which also has none.