### PR TITLE
Return correct `nix-build` error codes with daemon

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -135,6 +135,8 @@ struct TunnelLogger : public Logger
         else {
             if (clientVersion >= WorkerProto::Version{.number = {1, 26}}) {
                 to << STDERR_ERROR << *ex;
+                if (clientVersion.features.contains(WorkerProto::featureErrorStatus))
+                    to << ex->info().status;
             } else {
                 to << STDERR_ERROR << ex->what() << ex->info().status;
             }

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -136,6 +136,11 @@ struct WorkerProto
     static constexpr std::string_view featureDisableSetOptions = "disable-set-options";
 
     /**
+     * Feature for preserving `ErrorInfo::status` in daemon errors.
+     */
+    static constexpr std::string_view featureErrorStatus = "error-status";
+
+    /**
      * A unidirectional read connection, to be used by the read half of the
      * canonical serializers below.
      */

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -63,7 +63,10 @@ WorkerProto::BasicClientConnection::processStderrReturn(Sink * sink, Source * so
 
         else if (msg == STDERR_ERROR) {
             if (protoVersion >= WorkerProto::Version{.number = {1, 26}}) {
-                ex = std::make_exception_ptr(readError(from));
+                auto error = readError(from);
+                if (protoVersion.features.contains(WorkerProto::featureErrorStatus))
+                    error.withExitStatus(readInt(from));
+                ex = std::make_exception_ptr(std::move(error));
             } else {
                 auto error = readString(from);
                 unsigned int status = readInt(from);

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -29,6 +29,7 @@ const WorkerProto::Version WorkerProto::latest = {
                 WorkerProto::featureRealisationWithPath,
             },
             std::string{WorkerProto::featureDeleteDeadSpecificReferrers},
+            std::string{WorkerProto::featureErrorStatus},
         },
 };
 

--- a/tests/functional/check.sh
+++ b/tests/functional/check.sh
@@ -2,8 +2,7 @@
 
 source common.sh
 
-# XXX: This shouldn’t be, but #4813 cause this test to fail
-buggyNeedLocalStore "see #4813"
+requireDaemonNewerThan "2.35pre"
 
 checkBuildTempDirRemoved ()
 {

--- a/tests/functional/dyn-drv/failing-outer.sh
+++ b/tests/functional/dyn-drv/failing-outer.sh
@@ -2,13 +2,10 @@
 
 source common.sh
 
-# Store layer needs bugfix
-requireDaemonNewerThan "2.30pre20250515"
+# Store layer needs bugfixes.
+requireDaemonNewerThan "2.35pre"
 
-expected=100
-if [[ -v NIX_DAEMON_PACKAGE ]]; then expected=1; fi # work around the daemon not returning a 100 status correctly
-
-expectStderr "$expected" nix-build ./text-hashed-output.nix -A failingWrapper --no-out-link \
+expectStderr 100 nix-build ./text-hashed-output.nix -A failingWrapper --no-out-link \
     | grepQuiet "build of resolved derivation '.*use-dynamic-drv-in-non-dynamic-drv-wrong.drv' failed"
 
 # Test that error messages are not empty when a producer derivation fails.

--- a/tests/functional/fetchurl.sh
+++ b/tests/functional/fetchurl.sh
@@ -84,7 +84,5 @@ test -x "$outPath/fetchurl.sh"
 test -L "$outPath/symlink"
 
 # Make sure that *not* passing a outputHash fails.
-requireDaemonNewerThan "2.20"
-expected=100
-if [[ -v NIX_DAEMON_PACKAGE ]]; then expected=1; fi # work around the daemon not returning a 100 status correctly
-expectStderr $expected nix-build --expr '{ url }: builtins.derivation { name = "nix-cache-info"; system = "x86_64-linux"; builder = "builtin:fetchurl"; inherit url; outputHashMode = "flat"; }' --argstr url "file://$narxz" 2>&1 | grep 'must be a fixed-output or impure derivation'
+requireDaemonNewerThan "2.35pre"
+expectStderr 100 nix-build --expr '{ url }: builtins.derivation { name = "nix-cache-info"; system = "x86_64-linux"; builder = "builtin:fetchurl"; inherit url; outputHashMode = "flat"; }' --argstr url "file://$narxz" 2>&1 | grep 'must be a fixed-output or impure derivation'

--- a/tests/functional/timeout.sh
+++ b/tests/functional/timeout.sh
@@ -4,14 +4,16 @@
 
 source common.sh
 
-# XXX: This shouldn’t be, but #4813 cause this test to fail
-needLocalStore "see #4813"
+requireDaemonNewerThan "2.35pre"
 
-# FIXME: https://github.com/NixOS/nix/issues/4813
-expectStderr 101 nix-build -Q timeout.nix -A infiniteLoop --timeout 2 | grepQuiet "timed out" \
-    || skipTest "Do not block CI until fixed"
+expectStderr 101 nix-build -Q timeout.nix -A infiniteLoop --timeout 2 | grepQuiet "timed out"
 
-expectStderr 1 nix-build -Q timeout.nix -A infiniteLoop --max-build-log-size 100 | grepQuiet "killed after writing more than 100 bytes of log output"
+# When this test runs in the NixOS VM, builds go through the daemon as an
+# untrusted user. The daemon ignores client-provided max-build-log-size in that
+# mode, so the builder below would run until the Meson test timeout.
+if ! isTestOnNixOS; then
+    expectStderr 1 nix-build -Q timeout.nix -A infiniteLoop --max-build-log-size 100 | grepQuiet "killed after writing more than 100 bytes of log output"
+fi
 
 expectStderr 101 nix-build timeout.nix -A silent --max-silent-time 2 | grepQuiet "timed out after 2 seconds"
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

This PR causes the exit codes returned by `nix-build` to differentiate between evaluation errors and build errors [as described in the documentation](https://nix.dev/manual/nix/2.34/command-ref/nix-build#special-exit-codes-for-build-failure), even when using the daemon. This is particularly useful for, e.g., `git bisect run` in Nixpkgs.

## Context

<!-- Provide context. Reference open issues if available. -->

This fixes #4813.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

I added a new `error-status` feature to the worker protocol which can be checked for and used to get the error status from the daemon.

Un-skipping the first test in `tests/functional/timeout.sh` unblocked the second test, which seems to fail unrelated to this PR; so I've gated that test behind a condition to make CI pass.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
