### PR TITLE
lfs: don't store entire file in memory

### DIFF
--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -1,6 +1,8 @@
 #include "nix/fetchers/git-lfs-fetch.hh"
 #include "nix/fetchers/git-utils.hh"
 #include "nix/store/filetransfer.hh"
+#include "nix/util/file-descriptor.hh"
+#include "nix/util/file-system.hh"
 #include "nix/util/os-string.hh"
 #include "nix/util/processes.hh"
 #include "nix/util/url.hh"
@@ -23,9 +25,7 @@ namespace nix::lfs {
 static void downloadToSink(
     const std::string & url,
     const std::optional<std::string> & authHeader,
-    // FIXME: passing a StringSink is superfluous, we may as well
-    // return a string. Or use an abstract Sink for streaming.
-    StringSink & sink,
+    Sink & sink,
     std::string sha256Expected,
     size_t sizeExpected)
 {
@@ -34,13 +34,19 @@ static void downloadToSink(
     if (authHeader.has_value())
         headers.push_back({"Authorization", *authHeader});
     request.headers = headers;
-    getFileTransfer()->download(std::move(request), sink);
 
-    auto sizeActual = sink.s.length();
-    if (sizeExpected != sizeActual)
-        throw Error("size mismatch while fetching %s: expected %d but got %d", url, sizeExpected, sizeActual);
+    HashSink hashSink(HashAlgorithm::SHA256);
+    TeeSink teeSink(hashSink, sink);
 
-    auto sha256Actual = hashString(HashAlgorithm::SHA256, sink.s).to_string(HashFormat::Base16, false);
+    getFileTransfer()->download(std::move(request), teeSink);
+
+    auto hashResult = hashSink.finish();
+
+    if (sizeExpected != hashResult.numBytesDigested)
+        throw Error(
+            "size mismatch while fetching %s: expected %d but got %d", url, sizeExpected, hashResult.numBytesDigested);
+
+    auto sha256Actual = hashResult.hash.to_string(HashFormat::Base16, false);
     if (sha256Actual != sha256Expected)
         throw Error(
             "hash mismatch while fetching %s: expected sha256:%s but got sha256:%s", url, sha256Expected, sha256Actual);
@@ -255,7 +261,7 @@ std::vector<nlohmann::json> Fetch::fetchUrls(const std::vector<Pointer> & pointe
 void Fetch::fetch(
     const std::string & content,
     const CanonPath & pointerFilePath,
-    StringSink & sink,
+    Sink & sink,
     std::function<void(uint64_t)> sizeCallback) const
 {
     debug("trying to fetch '%s' using git-lfs", pointerFilePath);
@@ -279,9 +285,13 @@ void Fetch::fetch(
     std::string key = hashString(HashAlgorithm::SHA256, pointerFilePath.rel()).to_string(HashFormat::Base16, false)
                       + "/" + pointer->oid;
     auto cachePath = cacheDir / key;
-    if (pathExists(cachePath)) {
+    AutoCloseFD cacheFile(openFileReadonly(cachePath, FinalSymlink::DontFollow));
+    if (cacheFile) {
         debug("using cache entry %s -> %s", key, PathFmt(cachePath));
-        sink(readFile(cachePath));
+        FdSource cacheSource(cacheFile.get());
+        auto size = getFileSize(cacheFile.get());
+        sizeCallback(size);
+        cacheSource.drainInto(sink, size);
         return;
     }
     debug("did not find cache entry for %s", key);
@@ -319,13 +329,23 @@ void Fetch::fetch(
                 pointer->size);
         }
 
-        sizeCallback(size);
-        downloadToSink(ourl, authHeader, sink, sha256, size);
-
         debug("creating cache entry %s -> %s", key, PathFmt(cachePath));
+
         if (!pathExists(cachePath.parent_path()))
             createDirs(cachePath.parent_path());
-        writeFile(cachePath, sink.s);
+        auto [tempFile, tempPath] = createTempFile(cachePath.parent_path(), {});
+        AutoDelete tempDeleter(tempPath);
+        FdSink tempSink(tempFile.get());
+        downloadToSink(ourl, authHeader, tempSink, sha256, size);
+        tempSink.flush();
+
+        std::filesystem::rename(tempPath, cachePath);
+        tempDeleter.cancel();
+
+        FdSource cacheSource(tempFile.get());
+        cacheSource.restart();
+        sizeCallback(size);
+        cacheSource.drainInto(sink, size);
 
         debug("%s fetched with git-lfs", pointerFilePath);
     } catch (const nlohmann::json::out_of_range & e) {

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -812,20 +812,16 @@ struct GitSourceAccessor : SourceAccessor
 
         if (state->lfsFetch) {
             if (state->lfsFetch->shouldFetch(path)) {
-                StringSink s;
                 try {
                     // FIXME: do we need to hold the state lock while
                     // doing this?
                     auto contents =
                         std::string((const char *) git_blob_rawcontent(blob.get()), git_blob_rawsize(blob.get()));
-                    state->lfsFetch->fetch(contents, path, s, [&s](uint64_t size) { s.s.reserve(size); });
+                    state->lfsFetch->fetch(contents, path, sink, sizeCallback);
                 } catch (Error & e) {
                     e.addTrace({}, "while smudging git-lfs file '%s'", path);
                     throw;
                 }
-                sizeCallback(s.s.size());
-                StringSource source{s.s};
-                source.drainInto(sink);
                 return;
             }
         }

--- a/src/libfetchers/include/nix/fetchers/git-lfs-fetch.hh
+++ b/src/libfetchers/include/nix/fetchers/git-lfs-fetch.hh
@@ -38,7 +38,7 @@ struct Fetch
     void fetch(
         const std::string & content,
         const CanonPath & pointerFilePath,
-        StringSink & sink,
+        Sink & sink,
         std::function<void(uint64_t)> sizeCallback) const;
     std::vector<nlohmann::json> fetchUrls(const std::vector<Pointer> & pointers) const;
 };

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -515,10 +515,11 @@ AutoCloseFD createAnonymousTempFile()
     return fd;
 }
 
-std::pair<AutoCloseFD, std::filesystem::path> createTempFile(const std::filesystem::path & prefix)
+std::pair<AutoCloseFD, std::filesystem::path>
+createTempFile(const std::filesystem::path & root, const std::filesystem::path & prefix)
 {
     assert(!prefix.is_absolute());
-    auto tmpl = (defaultTempDir() / (prefix.string() + ".XXXXXX")).string();
+    auto tmpl = (root / (prefix.string() + ".XXXXXX")).string();
     // FIXME: use O_TMPFILE.
     // `mkstemp` modifies the string to contain the actual filename.
     AutoCloseFD fd = toDescriptor(mkstemp(tmpl.data()));
@@ -529,6 +530,11 @@ std::pair<AutoCloseFD, std::filesystem::path> createTempFile(const std::filesyst
     unix::closeOnExec(fd.get());
 #endif
     return {std::move(fd), std::filesystem::path(std::move(tmpl))};
+}
+
+std::pair<AutoCloseFD, std::filesystem::path> createTempFile(const std::filesystem::path & prefix)
+{
+    return createTempFile(defaultTempDir(), prefix);
 }
 
 std::filesystem::path makeTempPath(const std::filesystem::path & root, const std::string & suffix)

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -435,6 +435,12 @@ createTempDir(const std::filesystem::path & tmpRoot = "", const std::string & pr
 AutoCloseFD createAnonymousTempFile();
 
 /**
+ * Create a temporary file at a root, returning a file handle and its path.
+ */
+std::pair<AutoCloseFD, std::filesystem::path>
+createTempFile(const std::filesystem::path & root, const std::filesystem::path & prefix);
+
+/**
  * Create a temporary file, returning a file handle and its path.
  */
 std::pair<AutoCloseFD, std::filesystem::path> createTempFile(const std::filesystem::path & prefix = "nix");


### PR DESCRIPTION
This is an optimization to the LFS fetcher that makes it download directly to the provided sink rather than using an intermediary StringSink, avoiding storing the entire file in memory.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Storing the entire file in memory is a waste of memory, we should instead just dump it directly to the provided sink.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Ran the `.#hydraJobs.tests.fetch-git` nixos tests to verify.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
