### PR TITLE
chore(deps): Bump libgit2 to v1.9.4

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -57,17 +57,17 @@ scope: {
   };
 
   libgit2 =
-    if lib.versionAtLeast pkgs.libgit2.version "1.9.3" then
+    if lib.versionAtLeast pkgs.libgit2.version "1.9.4" then
       pkgs.libgit2
     else
       # Grab newer libgit2.
       pkgs.libgit2.overrideAttrs rec {
-        version = "1.9.3";
+        version = "1.9.4";
         src = pkgs.fetchFromGitHub {
           owner = "libgit2";
           repo = "libgit2";
           tag = "v${version}";
-          hash = "sha256-nJrRdPs86oGNL4W2CJb16oSUgfzYr9A2i5sw9BAehME=";
+          hash = "sha256-ZKUiz3pdFE2SKxh53X2oyr7hs32Njj5YVA0OXDXz7h0=";
         };
       };
 


### PR DESCRIPTION
Closes #14987

## Motivation

Bumps to a version of libgit2 that fixes relative worktree usage with things like `nix develop` - https://github.com/libgit2/libgit2/pull/7254
