### PR TITLE
Substitute outputs with an incomplete closure after building deps

### DIFF
--- a/doc/manual/rl-next/reinstate-incomplete-closure-substitution.md
+++ b/doc/manual/rl-next/reinstate-incomplete-closure-substitution.md
@@ -1,0 +1,16 @@
+---
+synopsis: Substitute outputs with an incomplete closure after building their dependencies
+issues: [77]
+prs: []
+---
+
+When a substituter advertises a derivation output but is missing some of the store objects
+that output depends on (an "incomplete closure", e.g. because a binary cache garbage-collected
+a deep dependency), Nix now builds the missing dependencies from source and then substitutes
+the output, instead of rebuilding the output and everything downstream of the hole.
+
+This reinstates the practical effect of the feature removed in commit
+`99cb85cd37cf2c086bb9c01ec4b99077e5b866e5` (see the "Revert incomplete closure mixed download
+and build feature" note), but with a simpler implementation: the output substitution is retried
+once, inline, after the derivation's inputs have been realised. It does not reintroduce the
+`ecIncompleteClosure` exit code, the retry state machine, or any re-entrancy in the scheduler.

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -2,6 +2,7 @@
 #include "nix/store/build/drv-output-substitution-goal.hh"
 #include "nix/store/build/derivation-building-goal.hh"
 #include "nix/store/build/derivation-resolution-goal.hh"
+#include "nix/store/build/substitution-goal.hh"
 #include "nix/store/build/worker.hh"
 #include "nix/util/util.hh"
 #include "nix/store/common-protocol.hh"
@@ -49,6 +50,12 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
 {
     trace("have derivation");
 
+    /* Set if substituting an output found the output's substitute but with an
+       incomplete closure. In that case, once we've realised this derivation's
+       inputs (filling the hole), we retry substituting the output rather than
+       rebuilding it. */
+    bool outputIncompleteClosure = false;
+
     auto drvOptions = [&]() -> DerivationOptions<SingleDerivedPath> {
         try {
             return derivationOptionsFromStructuredAttrs(
@@ -81,6 +88,10 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
 
         Goals waitees;
 
+        /* The substitution goal for our (known) output path, kept so we can
+           inspect whether it failed due to an incomplete closure. */
+        std::shared_ptr<PathSubstitutionGoal> outputSubGoal;
+
         /* We are first going to try to create the invalid output paths
            through substitutes.  If that doesn't work, we'll build
            them. */
@@ -106,10 +117,11 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
                 }
             } else {
                 auto * cap = getDerivationCA(*drv);
-                waitees.insert(upcast_goal(worker.makePathSubstitutionGoal(
+                outputSubGoal = worker.makePathSubstitutionGoal(
                     checkResult->first.outPath,
                     buildMode == bmRepair ? Repair : NoRepair,
-                    cap ? std::optional{*cap} : std::nullopt)));
+                    cap ? std::optional{*cap} : std::nullopt);
+                waitees.insert(upcast_goal(outputSubGoal));
             }
         }
 
@@ -118,6 +130,12 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
         co_await await(std::move(waitees));
 
         trace("all outputs substituted (maybe)");
+
+        /* Remember whether the output's substitute had an incomplete closure,
+           then drop the goal so we don't pin it across the build below. */
+        if (outputSubGoal)
+            outputIncompleteClosure = outputSubGoal->incompleteClosure;
+        outputSubGoal.reset();
 
         assert(!drv->type().isImpure());
 
@@ -223,6 +241,34 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
 
     /* We don't need it any more and don't want to hold on to it while suspended. */
     resolutionGoal.reset();
+
+    /* The output's substitute existed but its closure was incomplete (a
+       runtime dependency was missing from the substituters). Now that we've
+       realised this derivation's inputs, that hole is filled, so try once more
+       to substitute the output rather than rebuilding it. If that still fails,
+       we fall through to building as usual. */
+    if (buildMode == bmNormal && outputIncompleteClosure) {
+        auto checkResult = checkPathValidity();
+        if (checkResult && checkResult->second == PathStatus::Valid) {
+            /* Became valid while we were awaiting inputs (e.g. a sibling
+               goal produced this path). Nothing left to do. */
+            co_return doneSuccess(BuildResult::Success::AlreadyValid, checkResult->first);
+        }
+        if (checkResult) {
+            auto * cap = getDerivationCA(*drv);
+            Goals waitees{upcast_goal(worker.makePathSubstitutionGoal(
+                checkResult->first.outPath, NoRepair, cap ? std::optional{*cap} : std::nullopt))};
+            co_await await(std::move(waitees));
+
+            trace("retried output substitution after building inputs");
+
+            nrFailed = nrNoSubstituters = 0;
+
+            checkResult = checkPathValidity();
+            if (checkResult && checkResult->second == PathStatus::Valid)
+                co_return doneSuccess(BuildResult::Success::Substituted, checkResult->first);
+        }
+    }
 
     /* Give up on substitution for the output we want, actually build this derivation */
 

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -170,6 +170,11 @@ Goal::Co PathSubstitutionGoal::tryToRun(
     trace("all references realised");
 
     if (nrFailed > 0) {
+        /* We found this path's substitute, but couldn't realise its
+           references: the substituter served an incomplete closure. Record
+           this so a downstream derivation goal can retry substituting after
+           building the missing dependencies. */
+        incompleteClosure = true;
         co_return doneFailure(
             nrNoSubstituters > 0 ? ecNoSubstituters : ecFailed,
             BuildResult::Failure{{

--- a/src/libstore/include/nix/store/build/substitution-goal.hh
+++ b/src/libstore/include/nix/store/build/substitution-goal.hh
@@ -35,6 +35,14 @@ struct PathSubstitutionGoal : public Goal
      */
     std::optional<ContentAddress> ca;
 
+    /**
+     * Set when this path's substitute was found, but one of its references
+     * could not be realised (i.e. the substituter served an incomplete
+     * closure). Lets a downstream derivation goal retry substituting this
+     * path after building its inputs to fill the hole.
+     */
+    bool incompleteClosure = false;
+
 public:
     PathSubstitutionGoal(
         const StorePath & storePath,

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -176,10 +176,12 @@ grepQuiet "don't know how to build" "$TEST_ROOT/log"
 grepQuiet "building.*input-1" "$TEST_ROOT/log"
 grepQuiet "building.*input-2" "$TEST_ROOT/log"
 
-# Removed for now since 299141ecbd08bae17013226dbeae71e842b4fdd7 / issue #77 is reverted
-
-#grepQuiet "copying path.*input-0" "$TEST_ROOT/log"
-#grepQuiet "copying path.*top" "$TEST_ROOT/log"
+# The missing dependency (input-2) is built from source, which fills the hole
+# in the cached closure of 'top'. Nix then substitutes 'top' (and input-0)
+# rather than rebuilding them.
+grepQuiet "copying path '.*-dependencies-input-0'" "$TEST_ROOT/log"
+grepQuiet "copying path '.*-dependencies-top'" "$TEST_ROOT/log"
+grepQuietInverse "building '.*-dependencies-top.drv'" "$TEST_ROOT/log"
 
 
 # Create a signed binary cache.

--- a/tests/functional/ca/incomplete-closure.sh
+++ b/tests/functional/ca/incomplete-closure.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Regression test for incomplete closures of content-addressed derivations:
+# when a binary cache is missing a transitive dependency's path (e.g. it was
+# garbage-collected), Nix should build the missing dependency and substitute
+# the still-cached parents, rather than rebuilding the whole closure.
+
+source common.sh
+
+needLocalStore "'--no-require-sigs' can’t be used with the daemon"
+
+export REMOTE_STORE_DIR="$TEST_ROOT/binary_cache"
+export REMOTE_STORE="file://$REMOTE_STORE_DIR"
+rm -rf "$REMOTE_STORE_DIR"
+
+# Build the full CA closure (transitivelyDependentCA -> dependentCA -> rootCA)
+# and populate the binary cache (paths + realisations).
+clearStore
+clearCacheCache
+nix copy --to "$REMOTE_STORE" --file ./content-addressed.nix transitivelyDependentCA
+
+# Simulate a cache GC of the deepest dependency (rootCA): drop its narinfo and
+# NAR, keeping its realisation and the parents' paths. This leaves the cache
+# serving an incomplete closure of the parents.
+narinfo=$(grep -l "StorePath:.*-rootCA$" "$REMOTE_STORE_DIR"/*.narinfo)
+[[ -f "$narinfo" ]] || fail "setup: could not locate rootCA narinfo in $REMOTE_STORE_DIR"
+url=$(awk '/^URL:/{print $2}' "$narinfo")
+[[ -n "$url" && -f "$REMOTE_STORE_DIR/$url" ]] || fail "setup: rootCA narinfo had no URL or NAR missing ($url)"
+rm "$narinfo" "$REMOTE_STORE_DIR/$url"
+
+# Realise from the (incomplete) cache, allowing builds.
+clearStore
+clearCacheCache
+nix build --file ./content-addressed.nix -L --no-link \
+    --substitute --substituters "$REMOTE_STORE" --no-require-sigs \
+    transitivelyDependentCA 2>&1 | tee "$TEST_ROOT/log"
+
+# The garbage-collected dependency is rebuilt from source ...
+grepQuiet "building '.*-rootCA.drv'" "$TEST_ROOT/log"
+# ... which fills the hole, so the still-cached top of the closure is
+# substituted rather than rebuilt.
+grepQuiet "copying path '.*-transitively-dependent'" "$TEST_ROOT/log"
+grepQuietInverse "building '.*-transitively-dependent.drv'" "$TEST_ROOT/log"

--- a/tests/functional/ca/meson.build
+++ b/tests/functional/ca/meson.build
@@ -19,6 +19,7 @@ suites += {
     'eval-store.sh',
     'gc.sh',
     'import-from-derivation.sh',
+    'incomplete-closure.sh',
     'issue-13247.sh',
     'multiple-outputs.sh',
     'new-build-cmd.sh',


### PR DESCRIPTION
When a substituter advertises a derivation output but is missing some of the store objects it depends on (an "incomplete closure", e.g. because a binary cache garbage-collected a deep dependency), build the missing dependencies from source and then substitute the output, instead of rebuilding the output and everything downstream of the hole. The latter needlessly rebuilds (and, for non-reproducible builds, orphans) store paths that are still available from the cache.

This reinstates the practical effect of the feature removed in 99cb85cd37cf2c086bb9c01ec4b99077e5b866e5 ("Revert: If a substitute closure is incomplete, build dependencies, then retry the substituter"), but with a much simpler implementation: PathSubstitutionGoal records when a substitute had an incomplete closure, and DerivationGoal retries the output substitution once, inline, after the derivation's inputs have been realised. It does not reintroduce the ecIncompleteClosure exit code, the nrIncompleteClosure counter, the RetrySubstitution state machine, or any re-entrancy in the scheduler.

The fix targets input-addressed (known-output-path) derivations, which is the case the revert regressed. Content-addressed derivations already substitute cached parents and rebuild only the missing dependency via their realisation/resolution machinery; a regression test under the `ca` suite guards that behavior.
