### PR TITLE
fetchTarball: Use the tarball fetcher

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -569,35 +569,39 @@ static void fetch(
         }
     }
 
-    // Download the file/tarball if substitution failed or no hash was provided
-    auto storePath = unpack ? fetchToStore(
-                                  state.fetchSettings,
-                                  *state.store,
-                                  fetchers::downloadTarball(*state.store, state.fetchSettings, *url),
-                                  FetchMode::Copy,
-                                  name)
-                            : fetchers::downloadFile(*state.store, state.fetchSettings, *url, name).storePath;
-
-    if (expectedHash) {
-        auto hash = unpack ? state.store->queryPathInfo(storePath)->narHash
-                           : hashPath(
-                                 {state.store->requireStoreObjectAccessor(storePath)},
-                                 FileSerialisationMethod::Flat,
-                                 HashAlgorithm::SHA256)
-                                 .hash;
-        if (hash != *expectedHash) {
-            state
-                .error<EvalError>(
-                    "hash mismatch in file downloaded from '%s':\n  specified: %s\n  got:       %s",
-                    *url,
-                    expectedHash->to_string(HashFormat::Nix32, true),
-                    hash.to_string(HashFormat::Nix32, true))
-                .withExitStatus(102)
-                .debugThrow();
+    if (unpack) {
+        auto attrs = fetchers::Attrs{
+            {"type", "tarball"},
+            {"url", *url},
+            {"name", name},
+        };
+        if (expectedHash)
+            attrs.emplace("narHash", expectedHash->to_string(HashFormat::SRI, true));
+        auto input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
+        auto cachedInput =
+            state.inputCache->getAccessor(state.fetchSettings, *state.store, input, fetchers::UseRegistries::No);
+        auto storePath = state.mountInput(cachedInput.lockedInput, input, cachedInput.accessor);
+        state.mkStorePathString(storePath, v);
+    } else {
+        auto storePath = fetchers::downloadFile(*state.store, state.fetchSettings, *url, name).storePath;
+        if (expectedHash) {
+            auto hash = hashPath(
+                            {state.store->requireStoreObjectAccessor(storePath)},
+                            FileSerialisationMethod::Flat,
+                            HashAlgorithm::SHA256)
+                            .hash;
+            if (hash != *expectedHash)
+                state
+                    .error<EvalError>(
+                        "hash mismatch in file downloaded from '%s':\n  specified: %s\n  got:       %s",
+                        *url,
+                        expectedHash->to_string(HashFormat::Nix32, true),
+                        hash.to_string(HashFormat::Nix32, true))
+                    .withExitStatus(102)
+                    .debugThrow();
         }
+        state.allowAndSetStorePathString(storePath, v);
     }
-
-    state.allowAndSetStorePathString(storePath, v);
 }
 
 static void prim_fetchurl(EvalState & state, const PosIdx pos, Value ** args, Value & v)

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -545,38 +545,17 @@ static void fetch(
             .atPos(pos)
             .debugThrow();
 
-    // early exit if pinned and already in the store
-    if (expectedHash && expectedHash->algo == HashAlgorithm::SHA256) {
-        auto expectedPath = state.store->makeFixedOutputPath(
-            name,
-            FixedOutputInfo{
-                .method = unpack ? FileIngestionMethod::NixArchive : FileIngestionMethod::Flat,
-                .hash = *expectedHash,
-                .references = {}});
-
-        // Try to get the path from the local store or substituters
-        try {
-            state.store->ensurePath(expectedPath);
-            debug("using substituted/cached path '%s' for '%s'", state.store->printStorePath(expectedPath), *url);
-            state.allowAndSetStorePathString(expectedPath, v);
-            return;
-        } catch (Error & e) {
-            debug(
-                "substitution of '%s' failed, will try to download: %s",
-                state.store->printStorePath(expectedPath),
-                e.what());
-            // Fall through to download
-        }
-    }
-
     if (unpack) {
         auto attrs = fetchers::Attrs{
             {"type", "tarball"},
             {"url", *url},
             {"name", name},
         };
-        if (expectedHash)
+        if (expectedHash) {
             attrs.emplace("narHash", expectedHash->to_string(HashFormat::SRI, true));
+            // Mark as final to allow the tree to be substituted.
+            attrs.emplace("__final", Explicit<bool>{true});
+        }
         auto input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
         auto cachedInput =
             state.inputCache->getAccessor(state.fetchSettings, *state.store, input, fetchers::UseRegistries::No);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This removes the need for NAR hash checking and substitution code, since libfetchers already does that.

Cherry-picked from https://github.com/DeterminateSystems/nix-src/pull/468 (where it makes `fetchTarball` lazy if lazy-trees is enabled, but that's done in `mountInput()`).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
