### PR TITLE
Add utility view for identifying the last element in a range

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -66,8 +66,7 @@ void printMissing(ref<Store> store, const MissingPaths & missing, Verbosity lvl)
         else
             printMsg(lvl, "these %d derivations will be built:", missing.willBuild.size());
         auto sorted = store->topoSortPaths(missing.willBuild);
-        reverse(sorted.begin(), sorted.end());
-        for (auto & i : sorted)
+        for (auto & i : sorted | std::views::reverse)
             printMsg(lvl, "  %s", store->printStorePath(i));
     }
 

--- a/src/libstore/export-import.cc
+++ b/src/libstore/export-import.cc
@@ -37,9 +37,8 @@ static void exportPath(Store & store, const StorePath & path, Sink & sink)
 void exportPaths(Store & store, const StorePathSet & paths, Sink & sink)
 {
     auto sorted = store.topoSortPaths(paths);
-    std::reverse(sorted.begin(), sorted.end());
 
-    for (auto & path : sorted) {
+    for (auto & path : sorted | std::views::reverse) {
         sink << 1;
         exportPath(store, path, sink);
     }

--- a/src/libstore/make-content-addressed.cc
+++ b/src/libstore/make-content-addressed.cc
@@ -10,11 +10,9 @@ std::map<StorePath, StorePath> makeContentAddressed(Store & srcStore, Store & ds
 
     auto paths = srcStore.topoSortPaths(closure);
 
-    std::reverse(paths.begin(), paths.end());
-
     std::map<StorePath, StorePath> remappings;
 
-    for (auto & path : paths) {
+    for (auto & path : paths | std::views::reverse) {
         auto pathS = srcStore.printStorePath(path);
         auto oldInfo = srcStore.queryPathInfo(path);
         std::string oldHashPart(path.hashPart());

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1013,7 +1013,6 @@ std::map<StorePath, StorePath> copyPaths(
     // In the general case, `addMultipleToStore` requires a sorted list of
     // store paths to add, so sort them right now
     auto sortedMissing = srcStore.topoSortPaths(missing);
-    std::reverse(sortedMissing.begin(), sortedMissing.end());
 
     std::map<StorePath, StorePath> pathsMap;
     for (auto & path : storePaths)
@@ -1039,7 +1038,7 @@ std::map<StorePath, StorePath> copyPaths(
         return storePathForDst;
     };
 
-    for (auto & missingPath : sortedMissing) {
+    for (auto & missingPath : sortedMissing | std::views::reverse) {
         auto info = srcStore.queryPathInfo(missingPath);
 
         auto storePathForDst = computeStorePathForDst(*info);

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1230,11 +1230,9 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
             [](auto & sorted) { return sorted; }},
         topoSortResult);
 
-    std::reverse(sortedOutputNames.begin(), sortedOutputNames.end());
-
     OutputPathMap finalOutputs;
 
-    for (auto & outputName : sortedOutputNames) {
+    for (auto & outputName : sortedOutputNames | std::views::reverse) {
         auto output = get(drv.outputs, outputName);
         auto scratchPath = get(scratchOutputs, outputName);
         assert(output && scratchPath);

--- a/src/libutil-tests/util.cc
+++ b/src/libutil-tests/util.cc
@@ -377,4 +377,44 @@ TEST(getOr, getFromContainer)
     ASSERT_EQ(getOr(s, "one", "nope"), expected);
 }
 
+/* ----------------------------------------------------------------------------
+ * markLast
+ * --------------------------------------------------------------------------*/
+
+TEST(markLast, empty)
+{
+    std::vector<int> v;
+    std::vector<std::pair<bool, int>> result;
+    for (auto [last, x] : markLast(v))
+        result.emplace_back(last, x);
+    ASSERT_TRUE(result.empty());
+}
+
+TEST(markLast, singleElement)
+{
+    std::vector<int> v{42};
+    std::vector<std::pair<bool, int>> result;
+    for (auto [last, x] : markLast(v))
+        result.emplace_back(last, x);
+    ASSERT_EQ(result, (std::vector<std::pair<bool, int>>{{true, 42}}));
+}
+
+TEST(markLast, multipleElements)
+{
+    std::vector<int> v{10, 20, 30};
+    std::vector<std::pair<bool, int>> result;
+    for (auto [last, x] : markLast(v))
+        result.emplace_back(last, x);
+    ASSERT_EQ(result, (std::vector<std::pair<bool, int>>{{false, 10}, {false, 20}, {true, 30}}));
+}
+
+TEST(markLast, mutateThroughReference)
+{
+    std::vector<int> v{1, 2, 3};
+    for (auto && [last, x] : markLast(v))
+        if (last)
+            x = 99;
+    ASSERT_EQ(v, (std::vector<int>{1, 2, 99}));
+}
+
 } // namespace nix

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -424,6 +424,20 @@ constexpr auto enumerate(R && range)
 }
 
 /**
+ * An iterator adapter that enumerates the elements of a range,
+ * pairing each element with a boolean indicating whether it is the
+ * last element.
+ */
+template<std::ranges::viewable_range R>
+    requires std::ranges::sized_range<R>
+constexpr auto markLast(R && range)
+{
+    auto n = std::ranges::size(range);
+    return std::views::zip(
+        std::views::iota(size_t{1}) | std::views::transform([n](size_t i) { return i == n; }), std::forward<R>(range));
+}
+
+/**
  * C++17 std::visit boilerplate
  */
 template<class... Ts>

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -273,9 +273,7 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
             std::set<ref<flake::Node>> visited{lockedFlake.lockFile.root};
 
             [&](this const auto & recurse, const flake::Node & node, const std::string & prefix) -> void {
-                for (const auto & [i, input] : enumerate(node.inputs)) {
-                    bool last = i + 1 == node.inputs.size();
-
+                for (const auto & [last, input] : markLast(node.inputs)) {
                     if (auto lockedNode = std::get_if<0>(&input.second)) {
                         std::string lastModifiedStr = "";
                         if (auto lastModified = (*lockedNode)->lockedRef.input.getLastModified())
@@ -1260,9 +1258,8 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                             attrs.push_back(attr);
                     }
 
-                    for (const auto & [i, attr] : enumerate(attrs)) {
+                    for (const auto & [last, attr] : markLast(attrs)) {
                         const auto & attrName = state->symbols[attr];
-                        bool last = i + 1 == attrs.size();
                         auto visitor2 = visitor.getAttr(attrName);
                         auto attrPath2(attrPath);
                         attrPath2.push_back(attr);

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -291,11 +291,9 @@ printTree(const StorePath & path, const std::string & firstPad, const std::strin
        input of B, then A is printed first.  This has the effect of
        flattening the tree, preventing deeply nested structures.  */
     auto sorted = store->topoSortPaths(info->references);
-    reverse(sorted.begin(), sorted.end());
 
-    for (const auto & [last, i] : markLast(sorted)) {
+    for (const auto & [last, i] : markLast(sorted | std::views::reverse))
         printTree(i, tailPad + (last ? treeLast : treeConn), tailPad + (last ? treeNull : treeLine), done);
-    }
 }
 
 /* Perform various sorts of queries. */

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -293,8 +293,7 @@ printTree(const StorePath & path, const std::string & firstPad, const std::strin
     auto sorted = store->topoSortPaths(info->references);
     reverse(sorted.begin(), sorted.end());
 
-    for (const auto & [n, i] : enumerate(sorted)) {
-        bool last = n + 1 == sorted.size();
+    for (const auto & [last, i] : markLast(sorted)) {
         printTree(i, tailPad + (last ? treeLast : treeConn), tailPad + (last ? treeNull : treeLine), done);
     }
 }

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -256,10 +256,10 @@ struct CmdWhyDepends : SourceExprCommand, MixOperateOnOptions
                 });
             }
 
-            for (auto & ref : refs) {
+            for (const auto & [isLast, ref] : markLast(refs)) {
                 std::string hash(ref.second->path.hashPart());
 
-                bool last = all ? ref == *refs.rbegin() : true;
+                bool last = all ? isLast : true;
 
                 for (auto & hit : hits[hash]) {
                     bool first = hit == *hits[hash].begin();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

In a couple of places, when going through a range, the last element needs to treated differently. `enumerate()` isn't helpful here, so add another helper view.

Also replaced a few uses of `std::reverse` by `std::views::reverse`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
