### PR TITLE
develop: allow overriding SHELL variable

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -630,10 +630,6 @@ struct CmdDevelop : Common, MixEnvironment
                     fmt("[ -n \"$PS1\" ] && PS1+=%s;\n", escapeShellArgAlways(developSettings.bashPromptSuffix.get()));
         }
 
-        setEnviron();
-        // prevent garbage collection until shell exits
-        setEnv("NIX_GCROOT", store->printStorePath(gcroot).c_str());
-
         std::filesystem::path shell = "bash";
         bool foundInteractive = false;
 
@@ -677,7 +673,13 @@ struct CmdDevelop : Common, MixEnvironment
 
         // Override SHELL with the one chosen for this environment.
         // This is to make sure the system shell doesn't leak into the build environment.
-        setEnvOs(OS_STR("SHELL"), shell.c_str());
+        if (!setVars.contains("SHELL") && !keepVars.contains("SHELL"))
+            setVars["SHELL"] = shell;
+
+        setEnviron();
+        // prevent garbage collection until shell exits
+        setEnv("NIX_GCROOT", store->printStorePath(gcroot).c_str());
+
         /* See: https://github.com/NixOS/nix/issues/5873
            Format via .string() and not PathFmt intentionally. */
         script += fmt("SHELL=\"%s\"\n", shell.string());

--- a/tests/functional/flakes/develop.sh
+++ b/tests/functional/flakes/develop.sh
@@ -117,6 +117,16 @@ EOF
   [[ "$got" == "$expect" ]]
 )
 
+# Test whether `--set-env-var` can set SHELL.
+(
+  expect='/bin/bash'
+  got="$(nix develop --ignore-env --set-env-var SHELL '/bin/bash' --no-write-lock-file .#hello <<EOF
+echo "\$SHELL"
+EOF
+)"
+  [[ "$got" == "$expect" ]]
+)
+
 # Check that we throw an error when `--keep-env-var` is used without `--ignore-env`.
 expectStderr 1 nix develop --keep-env-var FOO .#hello |
   grepQuiet "error: --keep-env-var does not make sense without --ignore-env"


### PR DESCRIPTION
Resolves #15903

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

We should respect the user's wishes if they want to override `SHELL`.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#15903

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
