### PR TITLE
PublicKey/SecretKey: Refactor to support different key types

### DIFF
--- a/src/libstore-tests/realisation.cc
+++ b/src/libstore-tests/realisation.cc
@@ -35,8 +35,8 @@ DrvOutput testDrvOutput{
     .outputName = "foo",
 };
 
-const SecretKey testSecretKey{
-    "test-key:tU7tTvLcScf8pmz/eTV0BEtLmRsPpZfKaRcd0nCN+pysBZPHSeg61/u2oc7mIOewfuAY1V1BiX32homTaDJ2Jw=="};
+const auto testSecretKey =
+    "test-key:tU7tTvLcScf8pmz/eTV0BEtLmRsPpZfKaRcd0nCN+pysBZPHSeg61/u2oc7mIOewfuAY1V1BiX32homTaDJ2Jw==";
 
 Realisation simple{
     unkeyedSimple,
@@ -164,7 +164,7 @@ TEST_P(RealisationSigningTest, sign)
 {
     const auto & [name, realisation] = GetParam();
 
-    LocalSigner signer(SecretKey{testSecretKey});
+    LocalSigner signer(SecretKey::parse(testSecretKey));
 
     auto sig = realisation.sign(realisation.id, signer);
 
@@ -175,9 +175,9 @@ TEST_P(RealisationSigningTest, verify)
 {
     const auto & [name, realisation] = GetParam();
 
-    auto publicKey = testSecretKey.toPublicKey();
+    auto publicKey = SecretKey::parse(testSecretKey)->toPublicKey();
     PublicKeys publicKeys;
-    publicKeys.insert_or_assign(publicKey.name, publicKey);
+    publicKeys.insert_or_assign(publicKey->name, std::move(publicKey));
 
     readTest(std::string{name} + "-sig.json", [&](const auto & encoded) {
         Signature sig = json::parse(encoded);
@@ -189,13 +189,13 @@ TEST_P(RealisationSigningTest, verify_rejects_wrong_key)
 {
     const auto & [name, realisation] = GetParam();
 
-    auto wrongKey = SecretKey::generate("wrong-key");
-    auto wrongPublicKey = wrongKey.toPublicKey();
+    auto wrongKey = SecretKey::generate("wrong-key", KeyType::Ed25519);
+    auto wrongPublicKey = wrongKey->toPublicKey();
     PublicKeys publicKeys;
-    publicKeys.insert_or_assign(wrongPublicKey.name, wrongPublicKey);
+    publicKeys.insert_or_assign(wrongPublicKey->name, std::move(wrongPublicKey));
 
     auto r = static_cast<const UnkeyedRealisation &>(realisation);
-    LocalSigner signer(SecretKey{testSecretKey});
+    LocalSigner signer(SecretKey::parse(testSecretKey));
     r.sign(realisation.id, signer);
 
     ASSERT_EQ(r.checkSignatures(realisation.id, publicKeys), 0);
@@ -205,12 +205,12 @@ TEST_P(RealisationSigningTest, verify_rejects_tampered_outpath)
 {
     const auto & [name, realisation] = GetParam();
 
-    auto publicKey = testSecretKey.toPublicKey();
+    auto publicKey = SecretKey::parse(testSecretKey)->toPublicKey();
     PublicKeys publicKeys;
-    publicKeys.insert_or_assign(publicKey.name, publicKey);
+    publicKeys.insert_or_assign(publicKey->name, std::move(publicKey));
 
     auto r = static_cast<const UnkeyedRealisation &>(realisation);
-    LocalSigner signer(SecretKey{testSecretKey});
+    LocalSigner signer(SecretKey::parse(testSecretKey));
     r.sign(realisation.id, signer);
 
     // Tamper with the output path after signing.

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -30,13 +30,13 @@ BinaryCacheStore::BinaryCacheStore(Config & config)
     : config{config}
 {
     if (auto & skf = config.secretKeyFile.get())
-        signers.push_back(std::make_unique<LocalSigner>(SecretKey{readFile(*skf)}));
+        signers.push_back(std::make_unique<LocalSigner>(SecretKey::parse(readFile(*skf))));
 
     if (config.secretKeyFiles != "") {
         std::stringstream ss(config.secretKeyFiles);
         std::string keyPath;
         while (std::getline(ss, keyPath, ',')) {
-            signers.push_back(std::make_unique<LocalSigner>(SecretKey{readFile(keyPath)}));
+            signers.push_back(std::make_unique<LocalSigner>(SecretKey::parse(readFile(keyPath))));
         }
     }
 

--- a/src/libstore/keys.cc
+++ b/src/libstore/keys.cc
@@ -11,14 +11,16 @@ PublicKeys getDefaultPublicKeys()
     // FIXME: filter duplicates
 
     for (const auto & s : settings.trustedPublicKeys.get()) {
-        PublicKey key(s);
-        publicKeys.emplace(key.name, key);
+        auto key = PublicKey::parse(s);
+        auto name = key->name;
+        publicKeys.emplace(name, std::move(key));
     }
 
+    // FIXME: keep secret keys in memory (see Store::signRealisation()).
     for (const auto & secretKeyFile : settings.secretKeyFiles.get()) {
         try {
-            SecretKey secretKey(readFile(secretKeyFile));
-            publicKeys.emplace(secretKey.name, secretKey.toPublicKey());
+            auto secretKey = SecretKey::parse(readFile(secretKeyFile));
+            publicKeys.emplace(secretKey->name, secretKey->toPublicKey());
         } catch (SystemError & e) {
             /* Ignore unreadable key files. That's normal in a
                multi-user installation. */

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1229,8 +1229,7 @@ void Store::signPathInfo(ValidPathInfo & info)
     auto secretKeyFiles = settings.secretKeyFiles;
 
     for (auto & secretKeyFile : secretKeyFiles.get()) {
-        SecretKey secretKey(readFile(secretKeyFile));
-        LocalSigner signer(std::move(secretKey));
+        LocalSigner signer(SecretKey::parse(readFile(secretKeyFile)));
         info.sign(*this, signer);
     }
 }
@@ -1242,8 +1241,7 @@ void Store::signRealisation(Realisation & realisation)
     auto secretKeyFiles = settings.secretKeyFiles;
 
     for (auto & secretKeyFile : secretKeyFiles.get()) {
-        SecretKey secretKey(readFile(secretKeyFile));
-        LocalSigner signer(std::move(secretKey));
+        LocalSigner signer(SecretKey::parse(readFile(secretKeyFile)));
         realisation.sign(realisation.id, signer);
     }
 }

--- a/src/libutil-tests/local-keys.cc
+++ b/src/libutil-tests/local-keys.cc
@@ -7,23 +7,25 @@ namespace nix {
 
 TEST(local_keys, signAndVerify)
 {
-    auto sk = SecretKey::generate("test-key-1");
-    auto pk = sk.toPublicKey();
+    for (auto type : {KeyType::Ed25519}) {
+        auto sk = SecretKey::generate("test-key-1", type);
+        auto pk = sk->toPublicKey();
 
-    auto sig = sk.signDetached("hello world");
-    auto sig2 = sk.signDetached("hello world");
-    ASSERT_EQ(sig, sig2); // checks idempotence of signing
+        auto sig = sk->signDetached("hello world");
+        auto sig2 = sk->signDetached("hello world");
+        ASSERT_EQ(sig, sig2); // checks idempotence of signing
 
-    ASSERT_EQ(sig.keyName, "test-key-1");
-    ASSERT_TRUE(pk.verifyDetached("hello world", sig));
+        ASSERT_EQ(sig.keyName, "test-key-1");
+        ASSERT_TRUE(pk->verifyDetached("hello world", sig));
 
-    auto sk2 = SecretKey(sk.to_string());
-    ASSERT_EQ(sk2.name, sk.name);
-    ASSERT_EQ(sk2.key, sk.key);
+        auto sk2 = SecretKey::parse(sk->to_string());
+        ASSERT_EQ(sk2->name, sk->name);
+        ASSERT_EQ(sk2->key, sk->key);
 
-    auto pk2 = PublicKey(pk.to_string());
-    ASSERT_EQ(pk2.name, pk.name);
-    ASSERT_EQ(pk2.key, pk.key);
+        auto pk2 = PublicKey::parse(pk->to_string());
+        ASSERT_EQ(pk2->name, pk->name);
+        ASSERT_EQ(pk2->key, pk->key);
+    }
 }
 
 TEST(local_keys, rfc8032TestVector)
@@ -50,15 +52,15 @@ TEST(local_keys, rfc8032TestVector)
     auto skBytes = seed + pubKeyBytes;
     auto skString = "test:" + base64::encode(std::as_bytes(std::span<const char>{skBytes.data(), skBytes.size()}));
 
-    auto sk = SecretKey(skString);
-    auto sig = sk.signDetached(message);
+    auto sk = SecretKey::parse(skString);
+    auto sig = sk->signDetached(message);
 
     ASSERT_EQ(sig.keyName, "test");
     ASSERT_EQ(sig.sig, expectedSig);
 
-    auto pk = sk.toPublicKey();
-    ASSERT_EQ(pk.key, pubKeyBytes);
-    ASSERT_TRUE(pk.verifyDetached(message, sig));
+    auto pk = sk->toPublicKey();
+    ASSERT_EQ(pk->key, pubKeyBytes);
+    ASSERT_TRUE(pk->verifyDetached(message, sig));
 }
 
 } // namespace nix

--- a/src/libutil/include/nix/util/signature/local-keys.hh
+++ b/src/libutil/include/nix/util/signature/local-keys.hh
@@ -41,23 +41,23 @@ struct Signature
     auto operator<=>(const Signature &) const = default;
 };
 
+enum KeyType {
+    Ed25519,
+};
+
+KeyType parseKeyType(std::string_view s);
+
+const StringSet & getKeyTypes();
+
+// FIXME: remove this class.
 struct Key
 {
-    std::string name;
-    std::string key;
+    const std::string name;
+    const std::string key;
 
     std::string to_string() const;
 
 protected:
-
-    /**
-     * Construct Key from a string in the format
-     * ‘<name>:<key-in-base64>’.
-     *
-     * @param sensitiveValue Avoid displaying the raw Base64 in error
-     * messages to avoid leaking private keys.
-     */
-    Key(std::string_view s, bool sensitiveValue);
 
     Key(std::string_view name, std::string && key)
         : name(name)
@@ -70,27 +70,29 @@ struct PublicKey;
 
 struct SecretKey : Key
 {
-    SecretKey(std::string_view s);
+    using Key::Key;
+
+    virtual ~SecretKey() {};
+
+    static std::unique_ptr<SecretKey> parse(std::string_view s);
 
     /**
      * Return a detached signature of the given string.
      */
-    Signature signDetached(std::string_view s) const;
+    virtual Signature signDetached(std::string_view s) const;
 
-    PublicKey toPublicKey() const;
+    virtual std::unique_ptr<PublicKey> toPublicKey() const;
 
-    static SecretKey generate(std::string_view name);
-
-private:
-    SecretKey(std::string_view name, std::string && key)
-        : Key(name, std::move(key))
-    {
-    }
+    static std::unique_ptr<SecretKey> generate(std::string_view name, KeyType type);
 };
 
 struct PublicKey : Key
 {
-    PublicKey(std::string_view data);
+    using Key::Key;
+
+    virtual ~PublicKey() {};
+
+    static std::unique_ptr<PublicKey> parse(std::string_view s);
 
     /**
      * @return true iff `sig` and this key's names match, and `sig` is a
@@ -104,20 +106,13 @@ struct PublicKey : Key
      *
      * @param sig the raw signature bytes (not Base64 encoded).
      */
-    bool verifyDetachedAnon(std::string_view data, const Signature & sig) const;
-
-private:
-    PublicKey(std::string_view name, std::string && key)
-        : Key(name, std::move(key))
-    {
-    }
-    friend struct SecretKey;
+    virtual bool verifyDetachedAnon(std::string_view data, const Signature & sig) const;
 };
 
 /**
  * Map from key names to public keys
  */
-typedef std::map<std::string, PublicKey> PublicKeys;
+typedef std::map<std::string, std::unique_ptr<PublicKey>> PublicKeys;
 
 /**
  * @return true iff ‘sig’ is a correct signature over ‘data’ using one

--- a/src/libutil/include/nix/util/signature/signer.hh
+++ b/src/libutil/include/nix/util/signature/signer.hh
@@ -46,7 +46,7 @@ using Signers = std::map<std::string, Signer *>;
  */
 struct LocalSigner : Signer
 {
-    LocalSigner(SecretKey && privateKey);
+    LocalSigner(std::unique_ptr<SecretKey> && privateKey);
 
     Signature signDetached(std::string_view s) const override;
 
@@ -54,8 +54,8 @@ struct LocalSigner : Signer
 
 private:
 
-    SecretKey privateKey;
-    PublicKey publicKey;
+    const std::unique_ptr<SecretKey> privateKey;
+    const std::unique_ptr<PublicKey> publicKey;
 };
 
 } // namespace nix

--- a/src/libutil/signature/local-keys.cc
+++ b/src/libutil/signature/local-keys.cc
@@ -6,10 +6,17 @@
 #include "nix/util/signature/local-keys.hh"
 #include "nix/util/json-utils.hh"
 #include "nix/util/util.hh"
+#include "nix/util/deleter.hh"
 
 namespace nix {
 
 namespace {
+
+std::string_view keyNamePart(std::string_view s)
+{
+    auto colon = s.find(':');
+    return colon == std::string_view::npos ? std::string_view{} : s.substr(0, colon);
+}
 
 /**
  * Parse a colon-separated string where the second part is Base64-encoded.
@@ -81,19 +88,28 @@ Strings Signature::toStrings(const std::set<Signature> & sigs)
     return res;
 }
 
-Key::Key(std::string_view s, bool sensitiveValue)
+static std::unordered_map<std::string_view, KeyType> keyTypeMap{
+    {"ed25519", KeyType::Ed25519},
+};
+
+const StringSet & getKeyTypes()
 {
-    try {
-        auto [parsedName, parsedKey] = parseColonBase64(s, "key");
-        name = std::move(parsedName);
-        key = std::move(parsedKey);
-    } catch (Error & e) {
-        std::string extra;
-        if (!sensitiveValue)
-            extra = fmt(" with raw value '%s'", s);
-        e.addTrace({}, "while decoding key named '%s'%s", name, extra);
-        throw;
-    }
+    static StringSet validKeyTypes = [] {
+        StringSet s;
+        for (const auto & [k, _] : keyTypeMap) {
+            s.insert(std::string(k));
+        }
+        return s;
+    }();
+    return validKeyTypes;
+}
+
+KeyType parseKeyType(std::string_view s)
+{
+    auto i = keyTypeMap.find(s);
+    if (i != keyTypeMap.end())
+        return i->second;
+    throw UsageError("unknown key type '%s'; valid key types are %s", s, concatStringsSep(", ", getKeyTypes()));
 }
 
 std::string Key::to_string() const
@@ -101,46 +117,116 @@ std::string Key::to_string() const
     return serializeColonBase64(name, key);
 }
 
-SecretKey::SecretKey(std::string_view s)
-    : Key{s, true}
+Signature SecretKey::signDetached(std::string_view s) const
 {
-    if (key.size() != crypto_sign_SECRETKEYBYTES)
-        throw Error("secret key is not valid");
+    throw Error("signing is not implemented for this key type");
 }
 
-Signature SecretKey::signDetached(std::string_view data) const
+std::unique_ptr<PublicKey> SecretKey::toPublicKey() const
 {
-    unsigned char sig[crypto_sign_BYTES];
-    unsigned long long sigLen;
-    crypto_sign_detached(sig, &sigLen, (unsigned char *) data.data(), data.size(), (unsigned char *) key.data());
-    return Signature{
-        .keyName = name,
-        .sig = std::string((char *) sig, sigLen),
-    };
+    throw Error("conversion to public key is not implemented for this key type");
 }
 
-PublicKey SecretKey::toPublicKey() const
+struct Ed25519PublicKey : PublicKey
 {
-    unsigned char pk[crypto_sign_PUBLICKEYBYTES];
-    crypto_sign_ed25519_sk_to_pk(pk, (unsigned char *) key.data());
-    return PublicKey(name, std::string((char *) pk, crypto_sign_PUBLICKEYBYTES));
+    Ed25519PublicKey(std::string_view name, std::string && _key)
+        : PublicKey(name, std::move(_key))
+    {
+        assert(key.size() == crypto_sign_PUBLICKEYBYTES);
+    }
+
+    bool verifyDetachedAnon(std::string_view data, const Signature & sig) const override
+    {
+        if (sig.sig.size() != crypto_sign_BYTES)
+            return false;
+
+        return crypto_sign_verify_detached(
+                   (unsigned char *) sig.sig.data(),
+                   (unsigned char *) data.data(),
+                   data.size(),
+                   (unsigned char *) key.data())
+               == 0;
+    }
+};
+
+struct Ed25519SecretKey : SecretKey
+{
+    Ed25519SecretKey(std::string_view name, std::string && _key)
+        : SecretKey(name, std::move(_key))
+    {
+        assert(key.size() == crypto_sign_SECRETKEYBYTES);
+    }
+
+    static std::unique_ptr<Ed25519SecretKey> generate(std::string_view name)
+    {
+        unsigned char pk[crypto_sign_PUBLICKEYBYTES];
+        unsigned char sk[crypto_sign_SECRETKEYBYTES];
+        if (crypto_sign_keypair(pk, sk) != 0)
+            throw Error("key generation failed");
+
+        return std::make_unique<Ed25519SecretKey>(name, std::string((char *) sk, crypto_sign_SECRETKEYBYTES));
+    }
+
+    Signature signDetached(std::string_view data) const override
+    {
+        unsigned char sig[crypto_sign_BYTES];
+        unsigned long long sigLen;
+        crypto_sign_detached(sig, &sigLen, (unsigned char *) data.data(), data.size(), (unsigned char *) key.data());
+        return Signature{
+            .keyName = name,
+            .sig = std::string((char *) sig, sigLen),
+        };
+    }
+
+    std::unique_ptr<PublicKey> toPublicKey() const override
+    {
+        unsigned char pk[crypto_sign_PUBLICKEYBYTES];
+        crypto_sign_ed25519_sk_to_pk(pk, (unsigned char *) key.data());
+        return std::make_unique<Ed25519PublicKey>(name, std::string((char *) pk, crypto_sign_PUBLICKEYBYTES));
+    }
+};
+
+std::unique_ptr<SecretKey> SecretKey::parse(std::string_view s)
+{
+    try {
+        auto [name, key] = parseColonBase64(s, "key");
+
+        if (key.size() == crypto_sign_SECRETKEYBYTES)
+            return std::make_unique<Ed25519SecretKey>(name, std::move(key));
+        else
+            throw Error("secret key is not valid");
+
+    } catch (Error & e) {
+        e.addTrace({}, "while decoding key '%s'", keyNamePart(s));
+        throw;
+    }
 }
 
-SecretKey SecretKey::generate(std::string_view name)
+std::unique_ptr<SecretKey> SecretKey::generate(std::string_view name, KeyType type)
 {
-    unsigned char pk[crypto_sign_PUBLICKEYBYTES];
-    unsigned char sk[crypto_sign_SECRETKEYBYTES];
-    if (crypto_sign_keypair(pk, sk) != 0)
-        throw Error("key generation failed");
+    switch (type) {
 
-    return SecretKey(name, std::string((char *) sk, crypto_sign_SECRETKEYBYTES));
+    case KeyType::Ed25519:
+        return Ed25519SecretKey::generate(name);
+
+    default:
+        unreachable();
+    }
 }
 
-PublicKey::PublicKey(std::string_view s)
-    : Key{s, false}
+std::unique_ptr<PublicKey> PublicKey::parse(std::string_view s)
 {
-    if (key.size() != crypto_sign_PUBLICKEYBYTES)
-        throw Error("public key is not valid");
+    try {
+        auto [name, key] = parseColonBase64(s, "key");
+
+        if (key.size() == crypto_sign_PUBLICKEYBYTES)
+            return std::make_unique<Ed25519PublicKey>(name, std::move(key));
+        else
+            throw Error("public key is not valid");
+    } catch (Error & e) {
+        e.addTrace({}, "while decoding key '%s'", keyNamePart(s));
+        throw;
+    }
 }
 
 bool PublicKey::verifyDetached(std::string_view data, const Signature & sig) const
@@ -153,15 +239,8 @@ bool PublicKey::verifyDetached(std::string_view data, const Signature & sig) con
 
 bool PublicKey::verifyDetachedAnon(std::string_view data, const Signature & sig) const
 {
-    if (sig.sig.size() != crypto_sign_BYTES)
-        throw Error("signature is not valid");
-
-    return crypto_sign_verify_detached(
-               (unsigned char *) sig.sig.data(),
-               (unsigned char *) data.data(),
-               data.size(),
-               (unsigned char *) key.data())
-           == 0;
+    // Unsupported key type, can't verify.
+    return false;
 }
 
 bool verifyDetached(std::string_view data, const Signature & sig, const PublicKeys & publicKeys)
@@ -170,7 +249,7 @@ bool verifyDetached(std::string_view data, const Signature & sig, const PublicKe
     if (key == publicKeys.end())
         return false;
 
-    return key->second.verifyDetachedAnon(data, sig);
+    return key->second->verifyDetachedAnon(data, sig);
 }
 
 } // namespace nix

--- a/src/libutil/signature/signer.cc
+++ b/src/libutil/signature/signer.cc
@@ -4,20 +4,20 @@
 
 namespace nix {
 
-LocalSigner::LocalSigner(SecretKey && privateKey)
-    : privateKey(privateKey)
-    , publicKey(privateKey.toPublicKey())
+LocalSigner::LocalSigner(std::unique_ptr<SecretKey> && _privateKey)
+    : privateKey(std::move(_privateKey))
+    , publicKey(privateKey->toPublicKey())
 {
 }
 
 Signature LocalSigner::signDetached(std::string_view s) const
 {
-    return privateKey.signDetached(s);
+    return privateKey->signDetached(s);
 }
 
 const PublicKey & LocalSigner::getPublicKey()
 {
-    return publicKey;
+    return *publicKey;
 }
 
 } // namespace nix

--- a/src/nix/key-generate-secret.md
+++ b/src/nix/key-generate-secret.md
@@ -24,7 +24,7 @@ R""(
 
 # Description
 
-This command generates a new Ed25519 secret key for signing store
+This command generates a new secret key for signing store
 paths and prints it on standard output. Use `nix key
 convert-secret-to-public` to get the corresponding public key for
 verifying signed store paths.
@@ -36,10 +36,14 @@ the host name of your cache (e.g.  `cache.example.org`) with a suffix
 denoting the number of the key (to be incremented every time you need
 to revoke a key).
 
+Nix supports keys in the following formats (specified using the `--key-type` option):
+
+* `ed25519` (libsodium). This is the default key type. It produces compact keys and signatures, but may not be resistant to attacks using quantum computers.
+
 # Format
 
 Both secret and public keys are represented as the key name followed
-by a base-64 encoding of the Ed25519 key data, e.g.
+by a base-64 encoding of the key data, e.g.
 
 ```
 cache.example.org-0:E7lAO+MsPwTFfPXsdPtW8GKui/5ho4KQHVcAGnX+Tti1V4dUxoVoqLyWJ4YESuZJwQ67GVIksDt47og+tPVUZw==

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -1104,10 +1104,10 @@ static void opGenerateBinaryCacheKey(Strings opFlags, Strings opArgs)
     std::string secretKeyFile = *i++;
     std::string publicKeyFile = *i++;
 
-    auto secretKey = SecretKey::generate(keyName);
+    auto secretKey = SecretKey::generate(keyName, KeyType::Ed25519);
 
-    writeFile(publicKeyFile, secretKey.toPublicKey().to_string(), 0666, FsSync::Yes);
-    writeFile(secretKeyFile, secretKey.to_string(), 0600, FsSync::Yes);
+    writeFile(publicKeyFile, secretKey->toPublicKey()->to_string(), 0666, FsSync::Yes);
+    writeFile(secretKeyFile, secretKey->to_string(), 0600, FsSync::Yes);
 }
 
 static void opVersion(Strings opFlags, Strings opArgs)

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -121,8 +121,7 @@ struct CmdSign : StorePathsCommand
 
     void run(ref<Store> store, StorePaths && storePaths) override
     {
-        SecretKey secretKey(readFile(secretKeyFile));
-        LocalSigner signer(std::move(secretKey));
+        LocalSigner signer(SecretKey::parse(readFile(secretKeyFile)));
 
         size_t added{0};
 
@@ -149,6 +148,7 @@ static auto rCmdSign = registerCommand2<CmdSign>({"store", "sign"});
 struct CmdKeyGenerateSecret : Command
 {
     std::string keyName;
+    std::string keyType = "ed25519";
 
     CmdKeyGenerateSecret()
     {
@@ -158,6 +158,13 @@ struct CmdKeyGenerateSecret : Command
             .labels = {"name"},
             .handler = {&keyName},
             .required = true,
+        });
+
+        addFlag({
+            .longName = "key-type",
+            .description = fmt("Type of key: one of %s.", concatStringsSep(", ", getKeyTypes())),
+            .labels = {"type"},
+            .handler = {&keyType},
         });
     }
 
@@ -176,7 +183,7 @@ struct CmdKeyGenerateSecret : Command
     void run() override
     {
         logger->stop();
-        writeFull(getStandardOutput(), SecretKey::generate(keyName).to_string());
+        writeFull(getStandardOutput(), SecretKey::generate(keyName, parseKeyType(keyType))->to_string());
     }
 };
 
@@ -196,9 +203,8 @@ struct CmdKeyConvertSecretToPublic : Command
 
     void run() override
     {
-        SecretKey secretKey(drainFD(STDIN_FILENO));
         logger->stop();
-        writeFull(getStandardOutput(), secretKey.toPublicKey().to_string());
+        writeFull(getStandardOutput(), SecretKey::parse(drainFD(STDIN_FILENO))->toPublicKey()->to_string());
     }
 };
 

--- a/tests/functional/signing.sh
+++ b/tests/functional/signing.sh
@@ -2,12 +2,18 @@
 
 source common.sh
 
+runTests() {
+
 clearStoreIfPossible
 clearCache
 
-nix-store --generate-binary-cache-key cache1.example.org "$TEST_ROOT"/sk1 "$TEST_ROOT"/pk1
+keyType="$1"
+
+nix key generate-secret --key-name cache1.example.org --key-type "$keyType" > "$TEST_ROOT"/sk1
+nix key convert-secret-to-public < "$TEST_ROOT"/sk1 > "$TEST_ROOT"/pk1
 pk1=$(cat "$TEST_ROOT"/pk1)
-nix-store --generate-binary-cache-key cache2.example.org "$TEST_ROOT"/sk2 "$TEST_ROOT"/pk2
+nix key generate-secret --key-name cache2.example.org --key-type "$keyType" > "$TEST_ROOT"/sk2
+nix key convert-secret-to-public < "$TEST_ROOT"/sk2 > "$TEST_ROOT"/pk2
 pk2=$(cat "$TEST_ROOT"/pk2)
 
 # Build a path.
@@ -120,3 +126,7 @@ for file in "$TEST_ROOT/storemultisig/"*.narinfo; do
         exit 1
     fi
 done
+
+}
+
+runTests ed25519


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This introduces an enum `KeyType` (currently only supporting ed25519) and makes `PublicKey` and `SecretKey` virtual so they can be subclassed to support different cryptographic algorithms (like various CNSA algorithms via openssl).
    
Extracted from https://github.com/DeterminateSystems/nix-src/pull/449.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
