### PR TITLE
HashModuloSink: Hash the positions of self-references again

### DIFF
--- a/doc/manual/rl-next/hash-self-reference-positions.md
+++ b/doc/manual/rl-next/hash-self-reference-positions.md
@@ -1,0 +1,12 @@
+---
+synopsis: "Fix hash collision between store paths with self-references and their zeroed-out equivalents"
+issues: [15837]
+prs: [15931]
+---
+
+When computing the hash of a NAR with self-references, Nix zeroes out the self-references but also hashes their positions.
+The latter was accidentally lost in Nix 2.17.0, which meant a NAR with self-references could hash to the same store path as an otherwise-identical NAR in which some of the self-references had been zeroed out.
+
+This release restores hashing the positions of self-references.
+As a consequence, content-addressed store paths derived from self-referential NARs will differ from those produced by Nix 2.17 through 2.34.
+This affects users of the experimental `ca-derivations` features, as well as users of `nix store make-content-addressed`.

--- a/src/libstore-tests/references.cc
+++ b/src/libstore-tests/references.cc
@@ -4,6 +4,9 @@
 
 #include <gtest/gtest.h>
 
+#include <random>
+#include <set>
+
 namespace nix {
 
 struct RewriteParams
@@ -42,6 +45,100 @@ INSTANTIATE_TEST_CASE_P(
         RewriteParams{"foooo", "baroo", {{"foo", "bar"}, {"bar", "baz"}}},
         RewriteParams{"foooo", "bazoo", {{"fou", "bar"}, {"foo", "baz"}}},
         RewriteParams{"foooo", "foooo", {}}));
+
+TEST(references, rewritingSinkChunking)
+{
+    std::mt19937 rng(42);
+
+    /* Build a set of rewrites. Keys are random [a-z] strings of random
+       length in [8, 32]; values are same-length [A-Z] strings so a
+       replacement never produces a new match for any key. We also skip
+       any key that would be a substring of (or have as a substring) an
+       existing key, so that inserting one key into the input cannot also
+       produce a match for a different key. */
+    StringMap rewrites;
+    std::vector<std::string> keys;
+    {
+        std::uniform_int_distribution<int> lowerDist('a', 'z');
+        std::uniform_int_distribution<int> upperDist('A', 'Z');
+        std::uniform_int_distribution<size_t> lenDist(8, 32);
+
+        while (rewrites.size() < 8) {
+            std::string from(lenDist(rng), '\0');
+            for (auto & c : from)
+                c = lowerDist(rng);
+            if (rewrites.count(from))
+                continue;
+            bool overlap = false;
+            for (auto & other : keys)
+                if (from.find(other) != std::string::npos || other.find(from) != std::string::npos) {
+                    overlap = true;
+                    break;
+                }
+            if (overlap)
+                continue;
+            std::string to(from.size(), '\0');
+            for (auto & c : to)
+                c = upperDist(rng);
+            rewrites[from] = to;
+            keys.push_back(from);
+        }
+    }
+
+    /* Build a ~1 MB input mixing rewrite keys with [0-9] digits. Always
+       emit at least one digit between two consecutive keys so adjacency
+       cannot create spurious matches at key boundaries. Compute the
+       expected output string and matches vector at the same time. */
+    std::string input;
+    std::string expectedOutput;
+    std::set<uint64_t> expectedMatches;
+    input.reserve(1'000'000);
+    expectedOutput.reserve(1'000'000);
+    {
+        std::uniform_int_distribution<int> digitDist('0', '9');
+        std::uniform_int_distribution<size_t> keyDist(0, keys.size() - 1);
+        std::bernoulli_distribution useKeyDist(0.2);
+        bool justInsertedKey = false;
+
+        while (input.size() < 1'000'000) {
+            if (useKeyDist(rng) && !justInsertedKey) {
+                const auto & from = keys[keyDist(rng)];
+                expectedMatches.insert(input.size());
+                expectedOutput += rewrites.at(from);
+                input += from;
+                justInsertedKey = true;
+            } else {
+                char d = static_cast<char>(digitDist(rng));
+                input.push_back(d);
+                expectedOutput.push_back(d);
+                justInsertedKey = false;
+            }
+        }
+    }
+
+    StringSink singleOut;
+    RewritingSink singleSink(rewrites, singleOut);
+    singleSink(input);
+    singleSink.flush();
+
+    StringSink chunkedOut;
+    RewritingSink chunkedSink(rewrites, chunkedOut);
+    {
+        std::uniform_int_distribution<size_t> chunkDist(1, 128);
+        std::string_view remaining(input);
+        while (!remaining.empty()) {
+            auto n = std::min(chunkDist(rng), remaining.size());
+            chunkedSink(remaining.substr(0, n));
+            remaining = remaining.substr(n);
+        }
+    }
+    chunkedSink.flush();
+
+    ASSERT_EQ(singleOut.s, expectedOutput);
+    ASSERT_EQ(chunkedOut.s, expectedOutput);
+    ASSERT_EQ(singleSink.matches, expectedMatches);
+    ASSERT_EQ(chunkedSink.matches, expectedMatches);
+}
 
 TEST(references, scan)
 {

--- a/src/libstore/include/nix/store/references.hh
+++ b/src/libstore/include/nix/store/references.hh
@@ -41,7 +41,7 @@ public:
     Sink & nextSink;
     uint64_t pos = 0;
 
-    std::vector<uint64_t> matches;
+    std::set<uint64_t> matches;
 
     RewritingSink(const std::string & from, const std::string & to, Sink & nextSink);
     RewritingSink(const StringMap & rewrites, Sink & nextSink);

--- a/src/libstore/references.cc
+++ b/src/libstore/references.cc
@@ -78,7 +78,7 @@ void RewritingSink::operator()(std::string_view data)
     std::string s(prev);
     s.append(data);
 
-    s = rewriteStrings(s, rewrites);
+    s = rewriteStrings(s, rewrites, &matches, pos);
 
     prev = s.size() < maxRewriteSize ? s
            : maxRewriteSize == 0     ? ""
@@ -103,6 +103,7 @@ void RewritingSink::flush()
 
 HashModuloSink::HashModuloSink(HashAlgorithm ha, const std::string & modulus)
     : hashSink(ha)
+    // Zero out self-references (the "modulus").
     , rewritingSink(modulus, std::string(modulus.size(), 0), hashSink)
 {
 }

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -83,7 +83,12 @@ std::string trim(std::string_view s, std::string_view whitespace = " \n\r\t");
  */
 std::string replaceStrings(std::string s, std::string_view from, std::string_view to);
 
-std::string rewriteStrings(std::string s, const StringMap & rewrites);
+/**
+ * Replace all occurrences of the keys in `rewrites` with their corresponding values. Optionally returns the positions
+ * of the matches in `matches`.
+ */
+std::string rewriteStrings(
+    std::string s, const StringMap & rewrites, std::vector<uint64_t> * matches = nullptr, uint64_t offsetShift = 0);
 
 /**
  * Parse a string into an integer.

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <functional>
 #include <map>
+#include <set>
 #include <sstream>
 #include <bit>
 #include <optional>
@@ -88,7 +89,7 @@ std::string replaceStrings(std::string s, std::string_view from, std::string_vie
  * of the matches in `matches`.
  */
 std::string rewriteStrings(
-    std::string s, const StringMap & rewrites, std::vector<uint64_t> * matches = nullptr, uint64_t offsetShift = 0);
+    std::string s, const StringMap & rewrites, std::set<uint64_t> * matches = nullptr, uint64_t offsetShift = 0);
 
 /**
  * Parse a string into an integer.

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -86,7 +86,7 @@ std::string replaceStrings(std::string res, std::string_view from, std::string_v
 }
 
 std::string
-rewriteStrings(std::string s, const StringMap & rewrites, std::vector<uint64_t> * matches, uint64_t offsetShift)
+rewriteStrings(std::string s, const StringMap & rewrites, std::set<uint64_t> * matches, uint64_t offsetShift)
 {
     for (auto & i : rewrites) {
         if (i.first == i.second)
@@ -94,7 +94,7 @@ rewriteStrings(std::string s, const StringMap & rewrites, std::vector<uint64_t> 
         size_t j = 0;
         while ((j = s.find(i.first, j)) != s.npos) {
             if (matches)
-                matches->push_back(j + offsetShift);
+                matches->insert(j + offsetShift);
             s.replace(j, i.first.size(), i.second);
         }
     }

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -85,14 +85,18 @@ std::string replaceStrings(std::string res, std::string_view from, std::string_v
     return res;
 }
 
-std::string rewriteStrings(std::string s, const StringMap & rewrites)
+std::string
+rewriteStrings(std::string s, const StringMap & rewrites, std::vector<uint64_t> * matches, uint64_t offsetShift)
 {
     for (auto & i : rewrites) {
         if (i.first == i.second)
             continue;
         size_t j = 0;
-        while ((j = s.find(i.first, j)) != s.npos)
+        while ((j = s.find(i.first, j)) != s.npos) {
+            if (matches)
+                matches->push_back(j + offsetShift);
             s.replace(j, i.first.size(), i.second);
+        }
     }
     return s;
 }

--- a/tests/functional/fetchClosure.sh
+++ b/tests/functional/fetchClosure.sh
@@ -7,10 +7,10 @@ enableFeatures "fetch-closure"
 TODO_NixOS
 
 # Old daemons don't properly zero out the self-references when
-# calculating the CA hashes, so this breaks `nix store
+# calculating the CA hashes and take their positions into account, so this breaks `nix store
 # make-content-addressed` which expects the client and the daemon to
-# compute the same hash
-requireDaemonNewerThan "2.16.0pre20230524"
+# compute the same hash.
+requireDaemonNewerThan "2.35"
 
 # Initialize binary cache.
 nonCaPath=$(nix build --json --file ./dependencies.nix --no-link | jq -r .[].outputs.out)

--- a/tests/functional/make-content-addressed.nix
+++ b/tests/functional/make-content-addressed.nix
@@ -1,0 +1,25 @@
+{ zeroSelfReference }:
+
+with import ./config.nix;
+
+mkDerivation {
+  name = "foo";
+  buildCommand = ''
+    mkdir $out
+    ${
+      if zeroSelfReference then
+        ''
+          {
+            printf "hello $NIX_STORE/"
+            head -c 32 /dev/zero
+            printf -- '-foo\n'
+          } > $out/self-ref
+        ''
+      else
+        ''
+          echo "hello $out" > $out/self-ref
+        ''
+    }
+      echo "hello $out" > $out/always-self-ref
+  '';
+}

--- a/tests/functional/make-content-addressed.sh
+++ b/tests/functional/make-content-addressed.sh
@@ -2,9 +2,13 @@
 
 source common.sh
 
+requireDaemonNewerThan "2.35"
+
+TODO_NixOS
+
 enableFeatures "ca-derivations"
 
-clearStore
+restartDaemon
 
 # Build a floating output with a self-reference.
 outPath1=$(nix build --print-out-paths --no-link --impure --file ./make-content-addressed.nix --arg zeroSelfReference false)

--- a/tests/functional/make-content-addressed.sh
+++ b/tests/functional/make-content-addressed.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+enableFeatures "ca-derivations"
+
+clearStore
+
+# Build a floating output with a self-reference.
+outPath1=$(nix build --print-out-paths --no-link --impure --file ./make-content-addressed.nix --arg zeroSelfReference false)
+
+# Make it content-addressed.
+outPathCA=$(nix store make-content-addressed --json "$outPath1" | jq -r '.rewrites | map(.) | .[]')
+[[ $outPath1 != "$outPathCA" ]]
+
+# Check that the result is content-addressed.
+nix path-info --json --json-format 2 "$outPathCA" | jq -e 'all(.info[].ca.method; . == "nar")'
+
+# Verify the CA-rewritten path.
+nix store verify "$outPathCA"
+
+# Building the same derivation but as a CA derivation should produce the same store path.
+outPathCA2=$(NIX_TESTS_CA_BY_DEFAULT=1 nix build --print-out-paths --no-link --impure --file ./make-content-addressed.nix --arg zeroSelfReference false)
+[[ $outPathCA == "$outPathCA2" ]]
+
+# Build the same derivation except that one self-reference is zeroed out.
+outPathZero=$(nix build --print-out-paths --no-link --impure --file ./make-content-addressed.nix --arg zeroSelfReference true)
+
+# Make it content-addressed as well.
+outPathZeroCA=$(nix store make-content-addressed --json "$outPathZero" | jq -r '.rewrites | map(.) | .[]')
+
+# The resulting paths should be different, since HashModuloSink hashes the positions of self-references.
+# https://github.com/NixOS/nix/issues/15837
+[[ $outPathCA != "$outPathZeroCA" ]]
+
+outPathZeroCA2=$(NIX_TESTS_CA_BY_DEFAULT=1 nix build --print-out-paths --no-link --impure --file ./make-content-addressed.nix --arg zeroSelfReference true)
+[[ $outPathZeroCA == "$outPathZeroCA2" ]]

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -128,6 +128,7 @@ suites = [
       'legacy-ssh-store.sh',
       'linux-sandbox.sh',
       'logging.sh',
+      'make-content-addressed.sh',
       'misc.sh',
       'multiple-outputs.sh',
       'nar-access.sh',


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This was accidentally lost in https://github.com/NixOS/nix/commit/3ebe1341abe1b0ad59bd4925517af18d9200f818 (Nix 2.17.0), allowing content-addressed output paths with self-references to hash to the same store path as output paths that are identical except that some of the self-references are zeroed out.

Note: this will cause self-referential store paths to differ from those produced by Nix 2.17-2.34. This affects users of CA derivations and `nix store make-content-addressed`.

Fixes #15837, #9397.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
