### PR TITLE
libcmd: add missing `<string>` include to `markdown.hh`

### DIFF
--- a/src/libcmd/include/nix/cmd/markdown.hh
+++ b/src/libcmd/include/nix/cmd/markdown.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include <string>
 #include <string_view>
 
 namespace nix {


### PR DESCRIPTION
Upcoming `gcc-17` cleaned up transitive header inclusion a bit and exposed missing `nix` header dependency as a build failure:

```
../src/libcmd/include/nix/cmd/markdown.hh:15:6: error: 'string' in namespace 'std' does not name a type
   15 | std::string renderMarkdownToTerminal(std::string_view markdown);
      |      ^~~~~~
../src/libcmd/include/nix/cmd/markdown.hh:5:1: note: 'std::string' is defined in header '<string>'; this is probably fixable by adding '#include <string>'
    4 | #include <string_view>
  +++ |+#include <string>
    5 |
```

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
