### PR TITLE
Fix sqlite race in LocalStore

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -266,6 +266,22 @@ LocalStore::LocalStore(ref<const Config> config)
                            : "database schema needs migrating, but this cannot be done in read-only mode");
     }
 
+    auto acquireWriteLock = [&]() {
+        if (!lockFile(globalLock.get(), ltWrite, false)) {
+            printInfo("waiting for exclusive access to the Nix store...");
+            // We have acquired a shared lock; release it to prevent deadlocks.
+            // This can happen if someone else is trying to promote their read
+            // lock into a write lock.
+            lockFile(globalLock.get(), ltNone, false);
+            lockFile(globalLock.get(), ltWrite, true);
+        }
+    };
+
+    Finally releaseLock([&] {
+        if (globalLock)
+            lockFile(globalLock.get(), ltNone, false);
+    });
+
     if (curSchema > nixSchemaVersion)
         throw Error("current Nix store schema is version %1%, but I only support %2%", curSchema, nixSchemaVersion);
 
@@ -288,12 +304,7 @@ LocalStore::LocalStore(ref<const Config> config)
                 "which is no longer supported. To convert to the new format,\n"
                 "please upgrade Nix to version 1.11 first.");
 
-        if (!lockFile(globalLock.get(), ltWrite, false)) {
-            printInfo("waiting for exclusive access to the Nix store...");
-            lockFile(
-                globalLock.get(), ltNone, false); // We have acquired a shared lock; release it to prevent deadlocks
-            lockFile(globalLock.get(), ltWrite, true);
-        }
+        acquireWriteLock();
 
         /* Get the schema version again, because another process may
            have performed the upgrade already. */
@@ -329,10 +340,14 @@ LocalStore::LocalStore(ref<const Config> config)
         lockFile(globalLock.get(), ltRead, true);
     }
 
-    else
+    else {
+        if (!config->readOnly)
+            acquireWriteLock();
         openDB(*state, false);
+    }
 
-    upgradeDBSchema(*state);
+    if (!config->readOnly)
+        upgradeDBSchema(*state);
 
     /* Prepare SQL statements. */
     state->stmts->RegisterValidPath.create(


### PR DESCRIPTION
A write lock is needed for upgradeDBSchema. Otherwise, another process can write to the database causing error `SQLITE_BUSY_SNAPSHOT` (517) to be returned.

This also wraps upgradeDBSchema in a !readOnly guard, since it performs database writes.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Without this, the concurrent-builds test sometimes hangs.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

This has been plaguing the CI for awhile.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
