### PR TITLE
fix(libnixstore): prevent rw remount

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -40,6 +40,7 @@
 #  include <sched.h>
 #  include <sys/statvfs.h>
 #  include <sys/mount.h>
+#  include "nix/util/linux-namespaces.hh"
 #endif
 
 #ifdef __CYGWIN__
@@ -618,16 +619,10 @@ void LocalStore::makeStoreWritable()
     if (stat.f_flag & ST_RDONLY) {
         /* Confine the upcoming remount to this process and its descendants.
            Without this, libnixstore consumers that don't unshare their
-           own mount namespace (e.g. cachix, PackageKit) silently strip
-           ro/nosuid/nodev from the host's view of the store. */
-        if (unshare(CLONE_NEWNS) == -1) {
-            warn(
-                "could not unshare mount namespace to make the Nix store writable (%s); "
-                "the rw remount may leak into the host namespace",
-                strerror(errno));
-        } else if (mount(0, "/", 0, MS_PRIVATE | MS_REC, 0) == -1) {
-            throw SysError("making mount namespace private after unshare");
-        }
+           own mount namespace silently strip ro/nosuid/nodev from the
+           host's view of the store. Idempotent: if nix(1)'s main()
+           already unshared, this is a cheap no-op. */
+        ensurePrivateMountNamespace();
 
         /* In a user namespace, mount flags like `nodev` and `nosuid` are
            locked and dropping them causes `EPERM`, so here we translate each

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -616,6 +616,19 @@ void LocalStore::makeStoreWritable()
         throw SysError("getting info about the Nix store mount point");
 
     if (stat.f_flag & ST_RDONLY) {
+        /* Confine the upcoming remount to this process and its descendants.
+           Without this, libnixstore consumers that don't unshare their
+           own mount namespace (e.g. cachix, PackageKit) silently strip
+           ro/nosuid/nodev from the host's view of the store. */
+        if (unshare(CLONE_NEWNS) == -1) {
+            warn(
+                "could not unshare mount namespace to make the Nix store writable (%s); "
+                "the rw remount may leak into the host namespace",
+                strerror(errno));
+        } else if (mount(0, "/", 0, MS_PRIVATE | MS_REC, 0) == -1) {
+            throw SysError("making mount namespace private after unshare");
+        }
+
         /* In a user namespace, mount flags like `nodev` and `nosuid` are
            locked and dropping them causes `EPERM`, so here we translate each
            `statvfs` flag to the corresponding `mount` flag individually. */

--- a/src/libutil/linux/include/nix/util/linux-namespaces.hh
+++ b/src/libutil/linux/include/nix/util/linux-namespaces.hh
@@ -28,6 +28,19 @@ void restoreMountNamespace();
  */
 void tryUnshareFilesystem();
 
+/**
+ * Idempotent: place this process in a private mount namespace whose
+ * root is recursively MS_PRIVATE, so that subsequent mount-flag changes
+ * cannot propagate back to the host. The first call performs the work;
+ * later calls are cheap no-ops.
+ *
+ * Best-effort: if unshare() fails (e.g. restricted user namespace) the
+ * caller stays in its current namespace and the function returns false.
+ * Throws on the rarer case where unshare succeeds but the MS_PRIVATE
+ * remount of "/" fails.
+ */
+bool ensurePrivateMountNamespace();
+
 bool userNamespacesSupported();
 
 bool mountAndPidNamespacesSupported();

--- a/src/libutil/linux/linux-namespaces.cc
+++ b/src/libutil/linux/linux-namespaces.cc
@@ -88,6 +88,27 @@ bool mountAndPidNamespacesSupported()
 
 //////////////////////////////////////////////////////////////////////
 
+bool ensurePrivateMountNamespace()
+{
+    static std::once_flag done;
+    static bool ok = false;
+    std::call_once(done, []() {
+        if (unshare(CLONE_NEWNS) == -1) {
+            warn(
+                "could not unshare mount namespace (%s); "
+                "subsequent mount changes will land in the current namespace",
+                strerror(errno));
+            return;
+        }
+        if (mount(0, "/", 0, MS_PRIVATE | MS_REC, 0) == -1)
+            throw SysError("making mount namespace private after unshare");
+        ok = true;
+    });
+    return ok;
+}
+
+//////////////////////////////////////////////////////////////////////
+
 static AutoCloseFD fdSavedMountNamespace;
 static AutoCloseFD fdSavedRoot;
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -39,6 +39,7 @@
 
 #ifdef __linux__
 #  include "nix/util/linux-namespaces.hh"
+#  include <sys/mount.h>
 #endif
 
 #include "nix/util/strings.hh"
@@ -402,6 +403,8 @@ void mainWrapped(int argc, char ** argv)
             saveMountNamespace();
             if (unshare(CLONE_NEWNS) == -1)
                 throw SysError("setting up a private mount namespace");
+            if (mount(0, "/", 0, MS_PRIVATE | MS_REC, 0) == -1)
+                throw SysError("making the mount namespace private");
         } catch (Error & e) {
             warn("failed to set up a private mount namespace: %s", e.msg());
         }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -39,7 +39,6 @@
 
 #ifdef __linux__
 #  include "nix/util/linux-namespaces.hh"
-#  include <sys/mount.h>
 #endif
 
 #include "nix/util/strings.hh"
@@ -401,10 +400,7 @@ void mainWrapped(int argc, char ** argv)
     if (isRootUser()) {
         try {
             saveMountNamespace();
-            if (unshare(CLONE_NEWNS) == -1)
-                throw SysError("setting up a private mount namespace");
-            if (mount(0, "/", 0, MS_PRIVATE | MS_REC, 0) == -1)
-                throw SysError("making the mount namespace private");
+            ensurePrivateMountNamespace();
         } catch (Error & e) {
             warn("failed to set up a private mount namespace: %s", e.msg());
         }


### PR DESCRIPTION
When libnixstore is used directly, the remount operation is not done in a private namespace, leading to the host's /nix/store getting remounted as rw. This can happen with something like cachix, nix-eval-jobs, etc.

(Claude written after the initial investigation of the cause.)

Related: https://github.com/NixOS/nix/issues/13242
