### PR TITLE
Fix FreeBSD build with Werror=weak-vtables, non-unity mingw build

### DIFF
--- a/src/libstore/freebsd/build/freebsd-derivation-builder.cc
+++ b/src/libstore/freebsd/build/freebsd-derivation-builder.cc
@@ -23,6 +23,8 @@
 
 namespace nix {
 
+FreeBSDDerivationBuilder::~FreeBSDDerivationBuilder() {}
+
 namespace {
 
 struct PasswordEntry

--- a/src/libstore/freebsd/build/freebsd-derivation-builder.hh
+++ b/src/libstore/freebsd/build/freebsd-derivation-builder.hh
@@ -7,6 +7,13 @@ namespace nix {
 struct FreeBSDDerivationBuilder : virtual DerivationBuilderImpl
 {
     using DerivationBuilderImpl::DerivationBuilderImpl;
+
+    FreeBSDDerivationBuilder(FreeBSDDerivationBuilder &&) = delete;
+    FreeBSDDerivationBuilder(const FreeBSDDerivationBuilder &) = delete;
+    FreeBSDDerivationBuilder & operator=(FreeBSDDerivationBuilder &&) = delete;
+    FreeBSDDerivationBuilder & operator=(const FreeBSDDerivationBuilder &) = delete;
+    /* To appease Wweak-vtables. */
+    ~FreeBSDDerivationBuilder() override;
 };
 
 } // namespace nix

--- a/src/libutil/include/nix/util/os-string.hh
+++ b/src/libutil/include/nix/util/os-string.hh
@@ -7,6 +7,8 @@
 #include <string>
 #include <string_view>
 
+#include "nix/util/strings.hh"
+
 namespace nix {
 
 /**


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fixes https://hydra.nixos.org/build/330644993/nixlog/1 and my SNAFU with non-unity build of mingw.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
