### PR TITLE
cli: Rename `nix realisation` to `nix build-trace`

### DIFF
--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -258,6 +258,8 @@ endforeach
 
 nix3_manpages = [
   'nix3-build',
+  'nix3-build-trace-info',
+  'nix3-build-trace',
   'nix3-bundle',
   'nix3-config',
   'nix3-config-check',
@@ -314,8 +316,6 @@ nix3_manpages = [
   'nix3-profile-rollback',
   'nix3-profile-upgrade',
   'nix3-profile-wipe-history',
-  'nix3-realisation-info',
-  'nix3-realisation',
   'nix3-registry-add',
   'nix3-registry-list',
   'nix3-registry',

--- a/src/nix/build-trace.cc
+++ b/src/nix/build-trace.cc
@@ -8,13 +8,13 @@ namespace nix {
 struct CmdRealisation : NixMultiCommand
 {
     CmdRealisation()
-        : NixMultiCommand("realisation", RegisterCommand::getCommandsFor({"realisation"}))
+        : NixMultiCommand("build-trace", RegisterCommand::getCommandsFor({"build-trace"}))
     {
     }
 
     std::string description() override
     {
-        return "manipulate a Nix realisation";
+        return "manipulate a Nix build trace";
     }
 
     Category category() override
@@ -23,19 +23,19 @@ struct CmdRealisation : NixMultiCommand
     }
 };
 
-static auto rCmdRealisation = registerCommand<CmdRealisation>("realisation");
+static auto rCmdRealisation = registerCommand<CmdRealisation>("build-trace");
 
 struct CmdRealisationInfo : BuiltPathsCommand, MixJSON
 {
     std::string description() override
     {
-        return "query information about one or several realisations";
+        return "query information about one or several build traces";
     }
 
     std::string doc() override
     {
         return
-#include "realisation/info.md"
+#include "build-trace/info.md"
             ;
     }
 
@@ -77,6 +77,6 @@ struct CmdRealisationInfo : BuiltPathsCommand, MixJSON
     }
 };
 
-static auto rCmdRealisationInfo = registerCommand2<CmdRealisationInfo>({"realisation", "info"});
+static auto rCmdBuildTraceInfo = registerCommand2<CmdRealisationInfo>({"build-trace", "info"});
 
 } // namespace nix

--- a/src/nix/build-trace/info.md
+++ b/src/nix/build-trace/info.md
@@ -1,14 +1,14 @@
 R"MdBoundary(
 # Description
 
-Display some information about the given realisation
+Display some information about the given build trace
 
 # Examples
 
-Show some information about the realisation of the `hello` package:
+Show some information about the build trace of the `hello` package:
 
 ```console
-$ nix realisation info nixpkgs#hello --json
+$ nix build-trace info nixpkgs#hello --json
 [{"id":"sha256:3d382378a00588e064ee30be96dd0fa7e7df7cf3fbcace85a0e7b7dada1eef25!out","outPath":"fd3m7xawvrqcg98kgz5hc2vk3x9q0lh7-hello"}]
 ```
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -161,6 +161,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs, virtual RootArgs
             {"make-content-addressable", {AliasStatus::Deprecated, {"store", "make-content-addressed"}}},
             {"optimise-store", {AliasStatus::Deprecated, {"store", "optimise"}}},
             {"ping-store", {AliasStatus::Deprecated, {"store", "info"}}},
+            {"realisation", {AliasStatus::Deprecated, {"build-trace"}}},
             {"sign-paths", {AliasStatus::Deprecated, {"store", "sign"}}},
             {"shell", {AliasStatus::AcceptedShorthand, {"env", "shell"}}},
             {"show-derivation", {AliasStatus::Deprecated, {"derivation", "show"}}},

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -77,6 +77,7 @@ subdir('nix-meson-build-support/generate-header')
 nix_sources = [ config_priv_h ] + files(
   'add-to-store.cc',
   'app.cc',
+  'build-trace.cc',
   'build.cc',
   'bundle.cc',
   'cat.cc',
@@ -108,7 +109,6 @@ nix_sources = [ config_priv_h ] + files(
   'path-info.cc',
   'prefetch.cc',
   'profile.cc',
-  'realisation.cc',
   'registry.cc',
   'repl.cc',
   'run.cc',

--- a/tests/functional/ca/substitute.sh
+++ b/tests/functional/ca/substitute.sh
@@ -26,9 +26,10 @@ clearStore
 # this. Force the use of small-step resolutions only to allow not
 # mentioning it explicitly again. (#11896, #11928).
 buildDrvs --substitute --substituters "$REMOTE_STORE" --no-require-sigs -j0 transitivelyDependentCA dependentCA
-# Check that the thing we’ve just substituted has its realisation stored
-nix realisation info --file ./content-addressed.nix transitivelyDependentCA
+# Check that the thing we’ve just substituted has its build trace stored
+nix build-trace info --file ./content-addressed.nix transitivelyDependentCA
 # Check that its dependencies have it too
+# Use the old command to make sure that the alias works
 nix realisation info --file ./content-addressed.nix dependentCA
 # nix realisation info --file ./content-addressed.nix rootCA --outputs out
 

--- a/tests/functional/completions.sh
+++ b/tests/functional/completions.sh
@@ -36,7 +36,7 @@ throw "error"
 EOF
 
 # Test the completion of a subcommand
-[[ "$(NIX_GET_COMPLETIONS=1 nix buil)" == $'normal\nbuild\t' ]]
+[[ "$(NIX_GET_COMPLETIONS=1 nix buil)" == $'normal\nbuild\t\nbuild-trace\t' ]]
 [[ "$(NIX_GET_COMPLETIONS=2 nix flake metad)" == $'normal\nmetadata\t' ]]
 
 # Filename completion


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
The term "realisation" is heavily overused within nix and can be confusing to new users.
Replace the "realisation" command with "build-trace", the new more specific phrase for CAFloating derivations.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

The CADerivations feature is currently experimental and this commit leaves an alias, so it is not expected to cause issues for many users.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
