### PR TITLE
libexpr: Make hash mismatches while copying lazy paths to the store a…

### DIFF
--- a/src/libexpr/paths.cc
+++ b/src/libexpr/paths.cc
@@ -40,15 +40,15 @@ void EvalState::ensureLazyPathCopied(const StorePath & path)
         FetchMode::Copy,
         path.name());
 
-    /* Catch hash mismatches more loudly. This is more likely caused by unsound
-       caching of different accessor types that fetch the same repo with
-       the same git revision, but with different kinds of accessors (think
-       tarball-based fetchers vs local/remote git accessors). */
+    /* This can happen if the source gets modified by another process while we are evaluaing
+       from it. Alternatively, the caching might be unsound and fetcher cache is poisoned somehow.
+       See https://github.com/NixOS/nix/issues/14317. */
     if (storePath != path) {
-        panic(fmt(
-            "hashed store path computed by the evaluator ('%1%') does not match what was computed when copying to the store ('%2%'), this is a bug",
+        throw Error(
+            (unsigned int) 102,
+            "store path ('%1%') was hashed to avoid a full copy at first, but upon reading it again, the contents have changed ('%2%'), so we can not proceed. Make sure files do not change during evaluation",
             store->printStorePath(path),
-            store->printStorePath(storePath)));
+            store->printStorePath(storePath));
     }
 }
 


### PR DESCRIPTION
… proper error

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This can happen when the local source tree (dirty git repo) gets modified when the nix process is evaluating stuff from it. Make this a proper error and not an assert. I've hit this issue myself once now.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
