### PR TITLE
libexpr-c: fix nix_get_external 

### DIFF
--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -335,7 +335,7 @@ ExternalValue * nix_get_external(nix_c_context * context, nix_value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_out(value);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nExternal);
         return (ExternalValue *) v.external();
     }

--- a/src/libexpr-tests/nix_api_external.cc
+++ b/src/libexpr-tests/nix_api_external.cc
@@ -104,4 +104,34 @@ TEST_F(nix_api_expr_test, nix_external_printValueAsJSON_can_use_state)
     nix_gc_decref(ctx, toJsonFn);
 }
 
+TEST_F(nix_api_expr_test, nix_get_external_roundtrip)
+{
+    int content = 42;
+    NixCExternalValueDesc desc{};
+    ExternalValue * ext = nix_create_external_value(ctx, &desc, &content);
+    assert_ctx_ok();
+    ASSERT_NE(nullptr, ext);
+
+    nix_init_external(ctx, value, ext);
+    assert_ctx_ok();
+
+    nix_value_force(ctx, state, value);
+    assert_ctx_ok();
+
+    ExternalValue * retrieved = nix_get_external(ctx, value);
+    assert_ctx_ok();
+    ASSERT_NE(nullptr, retrieved);
+
+    void * content_ptr = nix_get_external_value_content(ctx, retrieved);
+    assert_ctx_ok();
+    ASSERT_EQ(&content, content_ptr);
+
+    nix_gc_decref(ctx, ext);
+}
+
+TEST_F(nix_api_expr_test, nix_get_external_value_content_null)
+{
+    ASSERT_EQ(nullptr, nix_get_external_value_content(ctx, nullptr));
+}
+
 } // namespace nixC

--- a/src/libexpr-tests/nix_api_value.cc
+++ b/src/libexpr-tests/nix_api_value.cc
@@ -119,6 +119,14 @@ TEST_F(nix_api_expr_test, nix_value_set_get_path)
     ASSERT_EQ(NIX_TYPE_PATH, nix_get_type(ctx, value));
 }
 
+TEST_F(nix_api_expr_test, nix_get_external_invalid)
+{
+    ASSERT_EQ(nullptr, nix_get_external(ctx, nullptr));
+    assert_ctx_err();
+    ASSERT_EQ(nullptr, nix_get_external(ctx, value));
+    assert_ctx_err();
+}
+
 TEST_F(nix_api_expr_test, nix_build_and_init_list_invalid)
 {
     ASSERT_EQ(nullptr, nix_get_list_byidx(ctx, nullptr, state, 0));


### PR DESCRIPTION
# AI Disclamier
This change is made in China ™️ 

# Change explanation
nix_get_external reads from an already-initialized nix_value (set via nix_init_external). Every other getter in the file (nix_get_bool, nix_get_int, nix_get_float, nix_get_string, nix_get_path_string) uses check_value_in, which asserts the value IS initialized.  nix_get_external was the sole getter using check_value_out, which asserts the value is UNinitialized and throws "nix_value already initialized" for any valid external value — making the function always fail.

Also made the value parameter const to match all other getters.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

# Motivation

I'm working on updating the cffi Python bindings from tweag so we can have the Nix we deserve in Python 😄 

https://github.com/NixOS/nix/milestone/52 

# Context

I found this when creating unit tests at https://github.com/lillecarl/python-nix to cover the entire API surface and the external value tests just wouldn't pass.

@yorickvP 