### PR TITLE
BinaryCacheStore: Improve upload parallelism

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -311,11 +311,8 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
 void BinaryCacheStore::addToStore(
     const ValidPathInfo & info, Source & narSource, RepairFlag repair, CheckSigsFlag checkSigs)
 {
-    if (!repair && isValidPath(info.path)) {
-        // FIXME: copyNAR -> null sink
-        narSource.drain();
+    if (!repair && isValidPath(info.path))
         return;
-    }
 
     addToStoreCommon(narSource, repair, checkSigs, {[&](HashResult nar) {
                          /* FIXME reinstate these, once we can correctly do hash modulo sink as
@@ -431,10 +428,7 @@ void BinaryCacheStore::addMultipleToStore(
                            lock held by LegacySSHStore::narFromPath(). */
                         auto source = std::move(source_);
 
-                        if (!repair && isValidPath(info.path)) {
-                            // FIXME: copyNAR -> null sink
-                            source->drain();
-                        } else {
+                        if (repair || !isValidPath(info.path)) {
                             MaintainCount<decltype(nrRunning)> mc(nrRunning);
                             showProgress();
                             auto narInfo = uploadData(*source, repair, [&](HashResult nar) {

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -12,11 +12,13 @@
 #include "nix/util/callback.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/archive.hh"
+#include "nix/util/util.hh"
 
 #include <chrono>
 #include <future>
 #include <regex>
 #include <sstream>
+#include <variant>
 
 #include <nlohmann/json.hpp>
 
@@ -140,8 +142,7 @@ void BinaryCacheStore::writeNarInfo(ref<NarInfo> narInfo)
             std::shared_ptr<NarInfo>(narInfo));
 }
 
-ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
-    Source & narSource, RepairFlag repair, CheckSigsFlag checkSigs, fun<ValidPathInfo(HashResult)> mkInfo)
+ref<NarInfo> BinaryCacheStore::uploadData(Source & narSource, RepairFlag repair, fun<ValidPathInfo(HashResult)> mkInfo)
 {
     auto fdTemp = createAnonymousTempFile();
 
@@ -192,19 +193,6 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
         info.narSize,
         ((1.0 - (double) fileSize / info.narSize) * 100.0),
         duration);
-
-    /* Verify that all references are valid. This may do some .narinfo
-       reads, but typically they'll already be cached. */
-    for (auto & ref : info.references)
-        try {
-            if (ref != info.path)
-                queryPathInfo(ref);
-        } catch (InvalidPath &) {
-            throw Error(
-                "cannot add '%s' to the binary cache because the reference '%s' is not valid",
-                printStorePath(info.path),
-                printStorePath(ref));
-        }
 
     /* Optionally write a JSON file containing a listing of the
        contents of the NAR. */
@@ -286,13 +274,37 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
     stats.narWriteCompressedBytes += fileSize;
     stats.narWriteCompressionTimeMs += duration;
 
+    return narInfo;
+}
+
+void BinaryCacheStore::uploadNarInfo(ref<NarInfo> narInfo)
+{
+    /* Verify that all references are valid. This may do some .narinfo
+       reads, but typically they'll already be cached. */
+    for (auto & ref : narInfo->references)
+        try {
+            if (ref != narInfo->path)
+                queryPathInfo(ref);
+        } catch (InvalidPath &) {
+            throw Error(
+                "cannot add '%s' to the binary cache because the reference '%s' is not valid",
+                printStorePath(narInfo->path),
+                printStorePath(ref));
+        }
+
     narInfo->sign(*this, signers);
 
     /* Atomically write the NAR info file.*/
     writeNarInfo(narInfo);
 
     stats.narInfoWrite++;
+}
 
+ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
+    Source & narSource, RepairFlag repair, CheckSigsFlag checkSigs, fun<ValidPathInfo(HashResult)> mkInfo)
+{
+    auto narInfo = uploadData(narSource, repair, std::move(mkInfo));
+    uploadNarInfo(narInfo);
     return narInfo;
 }
 
@@ -312,6 +324,139 @@ void BinaryCacheStore::addToStore(
                          // assert(info.narSize == nar.second);
                          return info;
                      }});
+}
+
+void BinaryCacheStore::addMultipleToStore(
+    PathsSource && pathsToCopy, Activity & act, RepairFlag repair, CheckSigsFlag checkSigs)
+{
+    /* Index the paths to copy by store path so the graph nodes below
+       can look up each path's info (NAR size, references) and source. */
+    std::map<StorePath, std::pair<ValidPathInfo, std::unique_ptr<Source>> *> infosMap;
+    uint64_t bytesExpected = 0;
+    for (auto & item : pathsToCopy) {
+        bytesExpected += item.first.narSize;
+        infosMap.insert_or_assign(item.first.path, &item);
+    }
+    act.setExpected(actCopyPath, bytesExpected);
+
+    std::atomic<size_t> nrDone{0};
+    std::atomic<uint64_t> nrRunning{0};
+    auto showProgress = [&, nrTotal = pathsToCopy.size()]() { act.progress(nrDone, nrTotal, nrRunning); };
+
+    /* The NarInfos produced by uploading the NARs, to be consumed when
+       writing the .narinfo files. Populated by the `UploadNar` nodes
+       and read by the corresponding `UploadNarInfo` nodes. */
+    Sync<std::map<StorePath, ref<NarInfo>>> narInfos_;
+
+    /* The work graph has two kinds of nodes: uploading the NAR for a
+       path (which has no dependencies, since NARs are independent of
+       each other), and uploading the .narinfo for a path (which depends
+       on the corresponding NAR upload and on the .narinfo uploads of all
+       the path's references). Processing the latter in topological order
+       maintains the closure invariant: whenever a .narinfo exists, the
+       .narinfo files of all its references exist as well. */
+    struct UploadNar
+    {
+        StorePath path;
+        uint64_t narSize;
+
+        /* Order NAR uploads by descending size so that the largest
+           (and typically slowest) NARs are started first. */
+        bool operator<(const UploadNar & other) const
+        {
+            return narSize != other.narSize ? narSize > other.narSize : path < other.path;
+        }
+    };
+
+    struct UploadNarInfo
+    {
+        StorePath path;
+
+        bool operator<(const UploadNarInfo & other) const
+        {
+            return path < other.path;
+        }
+    };
+
+    /* `std::variant`'s `operator<` orders by alternative index first, so
+       all `UploadNar` nodes sort (and thus get enqueued) before any
+       `UploadNarInfo` node.
+       TODO: uploading the debug info and NAR listings could be turned into separate graph nodes as well.
+       */
+    using Node = std::variant<UploadNar, UploadNarInfo>;
+
+    std::set<Node> nodes;
+    for (auto & [path, item] : infosMap) {
+        nodes.insert(UploadNar{path, item->first.narSize});
+        nodes.insert(UploadNarInfo{path});
+    }
+
+    processGraph<Node>(
+        nodes,
+
+        [&](const Node & node) -> std::set<Node> {
+            return std::visit(
+                overloaded{
+                    [&](const UploadNar &) -> std::set<Node> {
+                        /* NAR uploads have no dependencies. */
+                        return {};
+                    },
+                    [&](const UploadNarInfo & n) -> std::set<Node> {
+                        std::set<Node> edges;
+                        auto & info = infosMap.at(n.path)->first;
+                        /* Wait for our own NAR to be uploaded ... */
+                        edges.insert(UploadNar{n.path, info.narSize});
+                        /* ... and for the .narinfo files of all
+                           references that are part of this copy (other
+                           references are already valid in the store). */
+                        for (auto & ref : info.references) {
+                            if (ref != n.path && infosMap.count(ref))
+                                edges.insert(UploadNarInfo{ref});
+                        }
+                        return edges;
+                    },
+                },
+                node);
+        },
+
+        [&](const Node & node) {
+            checkInterrupt();
+            std::visit(
+                overloaded{
+                    [&](const UploadNar & n) {
+                        auto & [info, source_] = *infosMap.at(n.path);
+
+                        /* Make sure the Source object is destroyed when
+                           we're done, e.g. to release the connection
+                           lock held by LegacySSHStore::narFromPath(). */
+                        auto source = std::move(source_);
+
+                        if (!repair && isValidPath(info.path)) {
+                            // FIXME: copyNAR -> null sink
+                            source->drain();
+                        } else {
+                            MaintainCount<decltype(nrRunning)> mc(nrRunning);
+                            showProgress();
+                            auto narInfo = uploadData(*source, repair, [&](HashResult nar) {
+                                auto info2 = info;
+                                info2.ultimate = false;
+                                return info2;
+                            });
+                            narInfos_.lock()->insert_or_assign(info.path, narInfo);
+                        }
+
+                        nrDone++;
+                        showProgress();
+                    },
+                    [&](const UploadNarInfo & n) {
+                        auto & info = infosMap.at(n.path)->first;
+                        if (!repair && isValidPath(info.path))
+                            return;
+                        uploadNarInfo(narInfos_.lock()->at(n.path));
+                    },
+                },
+                node);
+        });
 }
 
 StorePath BinaryCacheStore::addToStoreFromDump(

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -446,7 +446,8 @@ void BinaryCacheStore::addMultipleToStore(
                         auto & info = infosMap.at(n.path)->first;
                         if (!repair && isValidPath(info.path))
                             return;
-                        uploadNarInfo(narInfos_.lock()->at(n.path));
+                        auto narInfo = narInfos_.lock()->at(n.path);
+                        uploadNarInfo(narInfo);
                     },
                 },
                 node);

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -183,6 +183,23 @@ private:
 
     void writeNarInfo(ref<NarInfo> narInfo);
 
+    /**
+     * Upload the NAR for a path and everything else *except* the
+     * `.narinfo` file (i.e. the compressed NAR, an optional NAR
+     * listing, and optional debuginfo links), and construct the
+     * corresponding `NarInfo`. The returned `NarInfo` is neither signed
+     * nor published yet; call `uploadNarInfo()` to do that.
+     */
+    ref<NarInfo> uploadData(Source & narSource, RepairFlag repair, fun<ValidPathInfo(HashResult)> mkInfo);
+
+    /**
+     * Sign and publish the `.narinfo` file for a path whose NAR has
+     * already been uploaded by `uploadData()`. This is what establishes
+     * the closure invariant, so all of the path's references must
+     * already be valid in the store.
+     */
+    void uploadNarInfo(ref<NarInfo> narInfo);
+
     ref<const ValidPathInfo> addToStoreCommon(
         Source & narSource, RepairFlag repair, CheckSigsFlag checkSigs, fun<ValidPathInfo(HashResult)> mkInfo);
 
@@ -202,6 +219,9 @@ public:
 
     void
     addToStore(const ValidPathInfo & info, Source & narSource, RepairFlag repair, CheckSigsFlag checkSigs) override;
+
+    void
+    addMultipleToStore(PathsSource && pathsToCopy, Activity & act, RepairFlag repair, CheckSigsFlag checkSigs) override;
 
     StorePath addToStoreFromDump(
         Source & dump,


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Previously NARs were uploaded along with the narinfos in a topological ordering, i.e. we didn't upload a NAR until all the NARs/narinfos of its references were uploaded. However, for preserving the closure invariant, it's only needed to maintain an ordering between the narinfo uploads, since the existence of a narinfo determines whether a store path is considered "valid" in the binary cache.

So now we drop the ordering requirement between NARs; we only require a NAR to be uploaded before its narinfo.

Also, NARs are now uploaded in order of descending NAR size. This typically reduces the makespan since if there is a giant NAR that takes forever to upload/compress, it's best to start as soon as possible.

As an example, this speeds up a copy between two binary caches:

```
# nix copy --from file:///tmp/binary-cache --to file:///tmp/binary-cache-2?compression=xz --no-check-sigs /nix/store/8xyk1qxxjfb8cm62g61yc59phwha92w7-kdenlive-25.08.3
```

from 117.7s to 47.2s.

However, whether you get a speedup highly depends on the shape of the graph; e.g. NixOS system configurations are often dominated by a few giant store paths (e.g. `linux-firmware` - 750 MiB) which may take longer than all the other paths together in parallel.

Also removed the calls to `drain()` that should be unncessary now (see 602a1f86bc392e915bb927d3e22ae9e8c7109968).

Taken from https://github.com/DeterminateSystems/nix-src/pull/477.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
