### PR TITLE
libstore: http3 support

### DIFF
--- a/doc/manual/rl-next/http3.md
+++ b/doc/manual/rl-next/http3.md
@@ -1,0 +1,25 @@
+---
+synopsis: HTTP/3 (QUIC) support
+---
+
+Nix can now fetch from binary caches and other HTTP(S) sources over HTTP/3
+(QUIC), controlled by a new
+[`http3`](@docroot@/command-ref/conf-file.md#conf-http3) setting (disabled by
+default). When enabled, Nix requests HTTP/3 and transparently falls back to
+HTTP/2 or HTTP/1.1 for servers that do not advertise QUIC. The setting only
+takes effect when linked against a libcurl built with HTTP/3 support, otherwise
+it is ignored and Nix keeps using HTTP/2 without warning or error.
+
+Enable it with:
+
+```
+nix.conf: http3 = true
+CLI:      --http3
+```
+
+Or disable with:
+
+```
+nix.conf: http3 = false
+CLI:      --no-http3
+```

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -134,11 +134,20 @@ struct curlMultiError final : CloneableError<curlMultiError, Error>
     }
 };
 
+/* Check if the linked libcurl was built with HTTP3 support. */
+bool curlSupportsHttp3()
+{
+    const auto * info = ::curl_version_info(CURLVERSION_NOW);
+    return info && (info->features & CURL_VERSION_HTTP3);
+}
+
 } // namespace
 
 struct curlFileTransfer : public FileTransfer
 {
     const FileTransferSettings & settings;
+
+    const bool http3Supported = curlSupportsHttp3();
 
     curlMulti curlm;
 
@@ -599,7 +608,10 @@ struct curlFileTransfer : public FileTransfer
                                                                 : ""))
                     .c_str());
             curl_easy_setopt(req, CURLOPT_PIPEWAIT, 1);
-            if (fileTransfer.settings.enableHttp2)
+            /* Enable HTTP3 only on user config and linked libcurl have support, o.w. fall back. */
+            if (fileTransfer.settings.enableHttp3 && fileTransfer.http3Supported)
+                curl_easy_setopt(req, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3);
+            else if (fileTransfer.settings.enableHttp2)
                 curl_easy_setopt(req, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
             else
                 curl_easy_setopt(req, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -34,6 +34,18 @@ public:
 
     Setting<bool> enableHttp2{this, true, "http2", "Whether to enable HTTP/2 support."};
 
+    Setting<bool> enableHttp3{
+        this,
+        false,
+        "http3",
+        R"(
+          Whether to try enabling HTTP/3 (QUIC).
+          When enabled, Nix requests HTTP/3 and transparently falls back
+          to HTTP/2 or HTTP/1.1 for servers that do not support it.
+          This option has no effect unless the `nix` binary is linked
+          against a libcurl built with HTTP/3 (QUIC) support.
+        )"};
+
     Setting<std::string> userAgentSuffix{
         this, "", "user-agent-suffix", "String appended to the user agent in HTTP requests."};
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

I was configuring my own cache over the weekend and enabled http3 support on fastly but couldn't get nix to use http3

did some digging and found out Lix already have http3 support while Nix does not

from Lix release note I also noticed the office cache had http3 enabled: https://github.com/NixOS/infra/commit/157fa70e46afbd6338a32407be461fce05c57bf8

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

https://gerrit.lix.systems/c/lix/+/4561/4

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
