### PR TITLE
fix(libstore): don't crash the daemon when a GC roots client thread is interrupted

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -498,6 +498,19 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                         } catch (Error & e) {
                             debug("reading GC root from client: %s", e.msg());
                             break;
+                        } catch (...) {
+                            /* This is the top-level body of a std::thread, so
+                               any exception that escapes it calls
+                               std::terminate() and aborts the whole daemon
+                               (true whether the thread is later joined or
+                               detached). readLine() throws Interrupted, which
+                               derives from BaseError, not Error, when the
+                               interrupt flag is set -- e.g. when another client
+                               disconnects mid-operation while this GC runs --
+                               so the catch above does not catch it. Swallow it
+                               and drop this connection instead of crashing. */
+                            ignoreExceptionInDestructor();
+                            break;
                         }
                     }
                 });


### PR DESCRIPTION
## Motivation

Fixes #15962.

`LocalStore::collectGarbage` runs a GC roots server that handles each connected client in a **detached `std::thread`**. That thread's read loop is guarded by only `catch (Error & e)`:

```cpp
} catch (Error & e) {
    debug("reading GC root from client: %s", e.msg());
    break;
}
```

But `FdSource::readLine()` → `read()` → `checkInterrupt()` throws `Interrupted`, which is `MakeError(Interrupted, BaseError)` — it derives from `BaseError`, **not** `Error` — so `catch (Error&)` does not catch it. The exception escapes the detached thread, calls `std::terminate()`, and aborts the entire `nix-daemon` (SIGABRT).

The interrupt flag is process-global, so this fires whenever any client disconnects mid-operation while a `collectGarbage()` is running (scheduled or reactive `min-free` auto-GC). On a busy multi-client daemon — e.g. CI, where builds are routinely cancelled or time out — this crashes the daemon frequently (we observed 30–90 aborts/day on one host), taking down every concurrent build. Coredump backtrace and details in #15962.

## Context

Broaden the catch in that detached thread to `catch (...)` and swallow via `ignoreExceptionInDestructor()`, **mirroring the auto-GC worker thread a few hundred lines down in the same file** (which already does exactly this). A detached thread must never let an exception escape.

## Priorities

Add 👍 to [pull requests you find important](https://github.com/NixOS/nix/labels/idea%20approved).

---
_Authored by an AI agent (Claude) with operator review. The change mirrors an existing pattern in the same file; CI builds it._