### PR TITLE
sinkToSource: Use an intermediate buffer to reduce context switching

### DIFF
--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -452,12 +452,28 @@ std::unique_ptr<Source> sinkToSource(fun<void(Sink &)> writer, fun<void()> eof)
             if (!hasCoro) {
                 coro =
                     coro_t::pull_type(boost::coroutines2::protected_fixedsize_stack(), [&](coro_t::push_type & yield) {
-                        LambdaSink sink([&](std::string_view data) {
-                            if (!data.empty()) {
+                        /* Feed the consumer in chunks, instead of on each write
+                           to avoid excessive context switching. parseDump does
+                           lots of small writes to the sink, which we should
+                           accumulate. */
+                        struct CoroBufferedSink : BufferedSink
+                        {
+                            coro_t::push_type & yield;
+
+                            void writeUnbuffered(std::string_view data) override
+                            {
                                 yield(data);
                             }
-                        });
+
+                            CoroBufferedSink(coro_t::push_type & yield)
+                                : yield(yield)
+                            {
+                            }
+                        };
+
+                        CoroBufferedSink sink(yield);
                         writer(sink);
+                        sink.flush();
                     });
             }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Noticed when profiling https://github.com/NixOS/nix/pull/15957.

`jump_fcontext` and `sinkToSource` was too hot (with just `jump_fcontext` taking ~1% time of copying around a system closure), even though it's dominated by compression/hashing.

Each write to the sink in `parseDump` was causing a context switch, even if we are writing a handful of bytes.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
