### PR TITLE
libstore: only acquire big write lock when needed, hold read lock

### DIFF
--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -473,7 +473,12 @@ private:
 
     void openDB(State & state, bool create);
 
-    void upgradeDBSchema(State & state);
+    /**
+     * Perform or check if a database schema upgrade is needed.
+     * @param dryRun only check if an upgrade is needed.
+     * @return true if an upgrade is needed or was performed, false otherwise.
+     */
+    bool upgradeDBSchema(State & state, bool dryRun);
 
     void makeStoreWritable();
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -277,11 +277,6 @@ LocalStore::LocalStore(ref<const Config> config)
         }
     };
 
-    Finally releaseLock([&] {
-        if (globalLock)
-            lockFile(globalLock.get(), ltNone, false);
-    });
-
     if (curSchema > nixSchemaVersion)
         throw Error("current Nix store schema is version %1%, but I only support %2%", curSchema, nixSchemaVersion);
 
@@ -337,17 +332,21 @@ LocalStore::LocalStore(ref<const Config> config)
 
         writeFile(schemaPath, fmt("%1%", nixSchemaVersion), 0666, FsSync::Yes);
 
+        // Downgrade to a read lock and hold to prevent other processes from
+        // upgrading the schema while we're using the store
         lockFile(globalLock.get(), ltRead, true);
     }
 
-    else {
-        if (!config->readOnly)
-            acquireWriteLock();
+    else
         openDB(*state, false);
-    }
 
-    if (!config->readOnly)
-        upgradeDBSchema(*state);
+    if (!config->readOnly && upgradeDBSchema(*state, true)) {
+        acquireWriteLock();
+        upgradeDBSchema(*state, false);
+        // Downgrade to a read lock and hold to prevent other processes from
+        // upgrading the schema while we're using the store
+        lockFile(globalLock.get(), ltRead, true);
+    }
 
     /* Prepare SQL statements. */
     state->stmts->RegisterValidPath.create(
@@ -582,9 +581,24 @@ void LocalStore::openDB(State & state, bool create)
     }
 }
 
-void LocalStore::upgradeDBSchema(State & state)
+bool LocalStore::upgradeDBSchema(State & state, bool dryRun)
 {
-    state.db.exec("create table if not exists SchemaMigrations (migration text primary key not null);");
+    bool ret = false;
+
+    {
+        SQLiteStmt queryHasSchemaMigrations;
+        queryHasSchemaMigrations.create(
+            state.db, "SELECT 1 FROM sqlite_master WHERE type='table' AND name='SchemaMigrations';");
+        auto useQueryHasSchemaMigrations(queryHasSchemaMigrations.use());
+        if (!useQueryHasSchemaMigrations.next()) {
+            if (dryRun)
+                return true;
+            else {
+                state.db.exec("create table SchemaMigrations (migration text primary key not null);");
+                ret = true;
+            }
+        }
+    }
 
     StringSet schemaMigrations;
 
@@ -596,8 +610,16 @@ void LocalStore::upgradeDBSchema(State & state)
             schemaMigrations.insert(useQuerySchemaMigrations.getStr(0));
     }
 
-    auto doUpgrade = [&](const std::string & migrationName, const std::string & stmt) {
-        if (schemaMigrations.contains(migrationName))
+    auto needsMigration = [&](const std::string & migrationName) -> bool {
+        return !schemaMigrations.contains(migrationName);
+    };
+
+    auto maybeUpgrade = [&](const std::string & migrationName, const std::string & stmt) {
+        if (!needsMigration(migrationName))
+            return;
+
+        ret = true;
+        if (dryRun)
             return;
 
         debug("executing Nix database schema migration '%s'...", migrationName);
@@ -610,12 +632,14 @@ void LocalStore::upgradeDBSchema(State & state)
     };
 
     if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations))
-        doUpgrade(
+        maybeUpgrade(
             "20251017-ca-derivations",
 #include "ca-specific-schema.sql.gen.hh"
         );
 
-    doUpgrade("20260309-drop-redundant-indexreferrer", "drop index if exists IndexReferrer");
+    maybeUpgrade("20260309-drop-redundant-indexreferrer", "drop index if exists IndexReferrer");
+
+    return ret;
 }
 
 /* To improve purity, users may want to make the Nix store a read-only


### PR DESCRIPTION
Check if a schema migration is actually needed before acquiring exclusive on the big nix store lock, and always hold a shared lock throughout the duration of the LocalStore. Checking if it's needed prevents the build hook from trying to acquire exclusive while the parent is holding shared.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

We need to hold the shared lock throughout the lifetime of the LocalStore to prevent other schema upgrades from happening while we're using the store.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Prior attempt to fix this logic: #15941

There are no schema migration tests that I know of, so this logic should be thoroughly examined before merging, although keeping in mind that the current state of affairs is already broken and can result in a hang.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
