### PR TITLE
libstore: parameterize the inputs of `Derivation`

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1515,8 +1515,9 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
             "passed to builtins.derivationStrict");
 
     /* Build the derivation expression by processing the attributes. */
-    Derivation drv;
-    drv.name = drvName;
+    Derivation drv{
+        .name = std::string{drvName},
+    };
 
     NixStringContext context;
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1749,18 +1749,18 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
                     StorePathSet refs;
                     state.store->computeFSClosure(d.drvPath, refs);
                     for (auto & j : refs) {
-                        drv.inputSrcs.insert(j);
+                        drv.inputs.srcs.insert(j);
                         if (j.isDerivation()) {
-                            drv.inputDrvs.map[j].value = state.store->readDerivation(j).outputNames();
+                            drv.inputs.drvs.map[j].value = state.store->readDerivation(j).outputNames();
                         }
                     }
                 },
                 [&](const NixStringContextElem::Built & b) {
-                    drv.inputDrvs.ensureSlot(*b.drvPath).value.insert(b.output);
+                    drv.inputs.drvs.ensureSlot(*b.drvPath).value.insert(b.output);
                 },
                 [&](const NixStringContextElem::Opaque & o) {
                     state.ensureLazyPathCopied(o.path);
-                    drv.inputSrcs.insert(o.path);
+                    drv.inputs.srcs.insert(o.path);
                 },
             },
             c.raw);

--- a/src/libstore-tests/derivation-advanced-attrs.cc
+++ b/src/libstore-tests/derivation-advanced-attrs.cc
@@ -37,7 +37,7 @@ public:
         this->readTest(fileName, [&](auto encoded) {
             auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
             auto options = derivationOptionsFromStructuredAttrs(
-                *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
+                *this->store, got.inputs.drvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
             EXPECT_EQ(options.getRequiredSystemFeatures(got), expectedFeatures);
         });
     }
@@ -53,7 +53,7 @@ public:
         this->readTest(fileName, [&](auto encoded) {
             auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
             auto options = derivationOptionsFromStructuredAttrs(
-                *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
+                *this->store, got.inputs.drvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
 
             EXPECT_EQ(options, expected);
             EXPECT_EQ(options.getRequiredSystemFeatures(got), expectedSystemFeatures);
@@ -185,7 +185,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_defaults)
         auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
 
         auto options = derivationOptionsFromStructuredAttrs(
-            *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
+            *this->store, got.inputs.drvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
 
         EXPECT_TRUE(!got.structuredAttrs);
 
@@ -229,7 +229,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes)
         auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
 
         auto options = derivationOptionsFromStructuredAttrs(
-            *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
+            *this->store, got.inputs.drvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
 
         EXPECT_TRUE(!got.structuredAttrs);
 
@@ -325,7 +325,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs_d
         auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
 
         auto options = derivationOptionsFromStructuredAttrs(
-            *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
+            *this->store, got.inputs.drvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
 
         EXPECT_TRUE(got.structuredAttrs);
 
@@ -374,7 +374,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs)
         auto got = parseDerivation(*this->store, std::move(encoded), "foo", this->mockXpSettings);
 
         auto options = derivationOptionsFromStructuredAttrs(
-            *this->store, got.inputDrvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
+            *this->store, got.inputs.drvs, got.env, get(got.structuredAttrs), true, this->mockXpSettings);
 
         EXPECT_TRUE(got.structuredAttrs);
 

--- a/src/libstore-tests/derivation/external-formats.cc
+++ b/src/libstore-tests/derivation/external-formats.cc
@@ -188,10 +188,10 @@ MAKE_TEST_P(DerivationJsonAtermTest);
 INSTANTIATE_TEST_SUITE_P(DerivationJSONATerm, DerivationJsonAtermTest, ::testing::Values([]() {
                              Derivation drv;
                              drv.name = "simple-derivation";
-                             drv.inputSrcs = {
+                             drv.inputs.srcs = {
                                  StorePath("c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-dep1"),
                              };
-                             drv.inputDrvs = {
+                             drv.inputs.drvs = {
                                  .map =
                                      {
                                          {
@@ -232,10 +232,10 @@ Derivation makeDynDepDerivation()
 {
     Derivation drv;
     drv.name = "dyn-dep-derivation";
-    drv.inputSrcs = {
+    drv.inputs.srcs = {
         StorePath{"c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-dep1"},
     };
-    drv.inputDrvs = {
+    drv.inputs.drvs = {
         .map =
             {
                 {

--- a/src/libstore-tests/derivation/external-formats.cc
+++ b/src/libstore-tests/derivation/external-formats.cc
@@ -74,11 +74,10 @@ INSTANTIATE_TEST_SUITE_P(
         std::pair{
             "caFixedNAR",
             DerivationOutput{DerivationOutput::CAFixed{
-                .ca =
-                    {
-                        .method = ContentAddressMethod::Raw::NixArchive,
-                        .hash = Hash::parseAnyPrefixed("sha256-iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="),
-                    },
+                .ca{
+                    .method = ContentAddressMethod::Raw::NixArchive,
+                    .hash = Hash::parseAnyPrefixed("sha256-iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="),
+                },
             }},
         },
         std::pair{
@@ -185,41 +184,36 @@ struct DerivationJsonAtermTest : DerivationTest,
 
 MAKE_TEST_P(DerivationJsonAtermTest);
 
-INSTANTIATE_TEST_SUITE_P(DerivationJSONATerm, DerivationJsonAtermTest, ::testing::Values([]() {
-                             Derivation drv;
-                             drv.name = "simple-derivation";
-                             drv.inputs.srcs = {
-                                 StorePath("c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-dep1"),
-                             };
-                             drv.inputs.drvs = {
-                                 .map =
-                                     {
-                                         {
-                                             StorePath("c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-dep2.drv"),
-                                             {
-                                                 .value =
-                                                     {
-                                                         "cat",
-                                                         "dog",
-                                                     },
-                                             },
-                                         },
-                                     },
-                             };
-                             drv.platform = "wasm-sel4";
-                             drv.builder = "foo";
-                             drv.args = {
-                                 "bar",
-                                 "baz",
-                             };
-                             drv.env = StringPairs{
-                                 {
-                                     "BIG_BAD",
-                                     "WOLF",
-                                 },
-                             };
-                             return drv;
-                         }()));
+INSTANTIATE_TEST_SUITE_P(
+    DerivationJSONATerm,
+    DerivationJsonAtermTest,
+    ::testing::Values(
+        Derivation{
+            .outputs = {},
+            .inputs{
+                .srcs{
+                    StorePath{"c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-dep1"},
+                },
+                .drvs{.map{
+                    {
+                        StorePath{"c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-dep2.drv"},
+                        {
+                            .value{
+                                "cat",
+                                "dog",
+                            },
+                        },
+                    },
+                }},
+            },
+            .platform = "wasm-sel4",
+            .builder = "foo",
+            .args = {"bar", "baz"},
+            .env{
+                {"BIG_BAD", "WOLF"},
+            },
+            .name = "simple-derivation",
+        }));
 
 struct DynDerivationJsonAtermTest : DynDerivationTest,
                                     JsonCharacterizationTest<Derivation>,
@@ -230,60 +224,36 @@ MAKE_TEST_P(DynDerivationJsonAtermTest);
 
 Derivation makeDynDepDerivation()
 {
-    Derivation drv;
-    drv.name = "dyn-dep-derivation";
-    drv.inputs.srcs = {
-        StorePath{"c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-dep1"},
-    };
-    drv.inputs.drvs = {
-        .map =
-            {
+    return Derivation{
+        .outputs = {},
+        .inputs{
+            .srcs{
+                StorePath{"c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-dep1"},
+            },
+            .drvs{.map{
                 {
                     StorePath{"c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-dep2.drv"},
                     DerivedPathMap<StringSet>::ChildNode{
-                        .value =
-                            {
-                                "cat",
-                                "dog",
-                            },
-                        .childMap =
-                            {
-                                {
-                                    "cat",
-                                    DerivedPathMap<StringSet>::ChildNode{
-                                        .value =
-                                            {
-                                                "kitten",
-                                            },
-                                    },
-                                },
-                                {
-                                    "goose",
-                                    DerivedPathMap<StringSet>::ChildNode{
-                                        .value =
-                                            {
-                                                "gosling",
-                                            },
-                                    },
-                                },
-                            },
+                        .value{
+                            "cat",
+                            "dog",
+                        },
+                        .childMap{
+                            {"cat", DerivedPathMap<StringSet>::ChildNode{.value = {"kitten"}}},
+                            {"goose", DerivedPathMap<StringSet>::ChildNode{.value = {"gosling"}}},
+                        },
                     },
                 },
-            },
-    };
-    drv.platform = "wasm-sel4";
-    drv.builder = "foo";
-    drv.args = {
-        "bar",
-        "baz",
-    };
-    drv.env = StringPairs{
-        {
-            "BIG_BAD",
-            "WOLF",
+            }},
         },
+        .platform = "wasm-sel4",
+        .builder = "foo",
+        .args = {"bar", "baz"},
+        .env{
+            {"BIG_BAD", "WOLF"},
+        },
+        .name = "dyn-dep-derivation",
     };
-    return drv;
 }
 
 INSTANTIATE_TEST_SUITE_P(DynDerivationJSONATerm, DynDerivationJsonAtermTest, ::testing::Values(makeDynDepDerivation()));

--- a/src/libstore-tests/derivation/invariants.cc
+++ b/src/libstore-tests/derivation/invariants.cc
@@ -216,7 +216,7 @@ TEST_F(FillInOutputPathsTest, preservesDeferredWithInputDrvs)
         {"out", ""},
     };
     // Add the real input derivation dependency
-    drv.inputDrvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
+    drv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
 
     // Serialize before state
     checkpointJson("depends-on-drv-pre", drv);
@@ -252,7 +252,7 @@ TEST_F(FillInOutputPathsTest, throwsOnPatWhenShouldBeDeffered)
         {"out", ""},
     };
     // Add the real input derivation dependency
-    drv.inputDrvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
+    drv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
 
     // Serialize before state
     checkpointJson("bad-depends-on-drv-pre", drv);

--- a/src/libstore-tests/derivation/invariants.cc
+++ b/src/libstore-tests/derivation/invariants.cc
@@ -29,21 +29,21 @@ protected:
      */
     StorePath makeCAFloatingDependency(std::string_view name)
     {
-        Derivation depDrv;
-        depDrv.name = name;
-        depDrv.platform = "x86_64-linux";
-        depDrv.builder = "/bin/sh";
-        depDrv.outputs = {
-            {
-                "out",
-                // will ensure that downstream is deferred
-                DerivationOutput{DerivationOutput::CAFloating{
-                    .method = ContentAddressMethod::Raw::NixArchive,
-                    .hashAlgo = HashAlgorithm::SHA256,
-                }},
+        Derivation depDrv{
+            .outputs{
+                {
+                    "out",
+                    DerivationOutput{DerivationOutput::CAFloating{
+                        .method = ContentAddressMethod::Raw::NixArchive,
+                        .hashAlgo = HashAlgorithm::SHA256,
+                    }},
+                },
             },
+            .platform = "x86_64-linux",
+            .builder = "/bin/sh",
+            .env = {{"out", ""}},
+            .name = std::string{name},
         };
-        depDrv.env = {{"out", ""}};
 
         // Fill in the dependency derivation's output paths
         depDrv.fillInOutputPaths(*store);
@@ -64,14 +64,13 @@ TEST_F(FillInOutputPathsTest, fillsDeferredOutputs_emptyStringEnvVar)
     using nlohmann::json;
 
     // Before: Derivation with deferred output
-    Derivation drv;
-    drv.name = "filled-in-deferred-empty-env-var";
-    drv.platform = "x86_64-linux";
-    drv.builder = "/bin/sh";
-    drv.outputs = {
-        {"out", DerivationOutput{DerivationOutput::Deferred{}}},
+    Derivation drv{
+        .outputs = {{"out", DerivationOutput{DerivationOutput::Deferred{}}}},
+        .platform = "x86_64-linux",
+        .builder = "/bin/sh",
+        .env = {{"__doc", "Fill in deferred output with empty env var"}, {"out", ""}},
+        .name = "filled-in-deferred-empty-env-var",
     };
-    drv.env = {{"__doc", "Fill in deferred output with empty env var"}, {"out", ""}};
 
     // Serialize before state
     checkpointJson("filled-in-deferred-empty-env-var-pre", drv);
@@ -95,15 +94,12 @@ TEST_F(FillInOutputPathsTest, fillsDeferredOutputs_empty_string_var)
     using nlohmann::json;
 
     // Before: Derivation with deferred output
-    Derivation drv;
-    drv.name = "filled-in-deferred-no-env-var";
-    drv.platform = "x86_64-linux";
-    drv.builder = "/bin/sh";
-    drv.outputs = {
-        {"out", DerivationOutput{DerivationOutput::Deferred{}}},
-    };
-    drv.env = {
-        {"__doc", "Fill in deferred with missing env var"},
+    Derivation drv{
+        .outputs = {{"out", DerivationOutput{DerivationOutput::Deferred{}}}},
+        .platform = "x86_64-linux",
+        .builder = "/bin/sh",
+        .env = {{"__doc", "Fill in deferred with missing env var"}},
+        .name = "filled-in-deferred-no-env-var",
     };
 
     // Serialize before state
@@ -127,16 +123,12 @@ TEST_F(FillInOutputPathsTest, preservesInputAddressedOutputs)
 {
     auto expectedPath = StorePath{"w4bk7hpyxzgy2gx8fsa8f952435pll3i-filled-in-already"};
 
-    Derivation drv;
-    drv.name = "filled-in-already";
-    drv.platform = "x86_64-linux";
-    drv.builder = "/bin/sh";
-    drv.outputs = {
-        {"out", DerivationOutput{DerivationOutput::InputAddressed{.path = expectedPath}}},
-    };
-    drv.env = {
-        {"__doc", "Correct path stays unchanged"},
-        {"out", store->printStorePath(expectedPath)},
+    Derivation drv{
+        .outputs = {{"out", DerivationOutput{DerivationOutput::InputAddressed{.path = expectedPath}}}},
+        .platform = "x86_64-linux",
+        .builder = "/bin/sh",
+        .env = {{"__doc", "Correct path stays unchanged"}, {"out", store->printStorePath(expectedPath)}},
+        .name = "filled-in-already",
     };
 
     // Serialize before state
@@ -154,16 +146,12 @@ TEST_F(FillInOutputPathsTest, throwsOnIncorrectInputAddressedPath)
 {
     auto wrongPath = StorePath{"c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-wrong-name"};
 
-    Derivation drv;
-    drv.name = "bad-path";
-    drv.platform = "x86_64-linux";
-    drv.builder = "/bin/sh";
-    drv.outputs = {
-        {"out", DerivationOutput{DerivationOutput::InputAddressed{.path = wrongPath}}},
-    };
-    drv.env = {
-        {"__doc", "Wrong InputAddressed path throws error"},
-        {"out", store->printStorePath(wrongPath)},
+    Derivation drv{
+        .outputs = {{"out", DerivationOutput{DerivationOutput::InputAddressed{.path = wrongPath}}}},
+        .platform = "x86_64-linux",
+        .builder = "/bin/sh",
+        .env = {{"__doc", "Wrong InputAddressed path throws error"}, {"out", store->printStorePath(wrongPath)}},
+        .name = "bad-path",
     };
 
     // Serialize before state
@@ -177,16 +165,12 @@ TEST_F(FillInOutputPathsTest, throwsOnIncorrectEnvVar)
 {
     auto wrongPath = StorePath{"c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-wrong-name"};
 
-    Derivation drv;
-    drv.name = "bad-env-var";
-    drv.platform = "x86_64-linux";
-    drv.builder = "/bin/sh";
-    drv.outputs = {
-        {"out", DerivationOutput{DerivationOutput::Deferred{}}},
-    };
-    drv.env = {
-        {"__doc", "Wrong env var value throws error"},
-        {"out", store->printStorePath(wrongPath)},
+    Derivation drv{
+        .outputs = {{"out", DerivationOutput{DerivationOutput::Deferred{}}}},
+        .platform = "x86_64-linux",
+        .builder = "/bin/sh",
+        .env = {{"__doc", "Wrong env var value throws error"}, {"out", store->printStorePath(wrongPath)}},
+        .name = "bad-env-var",
     };
 
     // Serialize before state
@@ -204,19 +188,14 @@ TEST_F(FillInOutputPathsTest, preservesDeferredWithInputDrvs)
     auto depDrvPath = makeCAFloatingDependency("dependency");
 
     // Create a derivation that depends on the dependency
-    Derivation drv;
-    drv.name = "depends-on-drv";
-    drv.platform = "x86_64-linux";
-    drv.builder = "/bin/sh";
-    drv.outputs = {
-        {"out", DerivationOutput{DerivationOutput::Deferred{}}},
+    Derivation drv{
+        .outputs = {{"out", DerivationOutput{DerivationOutput::Deferred{}}}},
+        .inputs = {.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}}},
+        .platform = "x86_64-linux",
+        .builder = "/bin/sh",
+        .env = {{"__doc", "Deferred stays deferred with CA dependencies"}, {"out", ""}},
+        .name = "depends-on-drv",
     };
-    drv.env = {
-        {"__doc", "Deferred stays deferred with CA dependencies"},
-        {"out", ""},
-    };
-    // Add the real input derivation dependency
-    drv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
 
     // Serialize before state
     checkpointJson("depends-on-drv-pre", drv);
@@ -240,19 +219,14 @@ TEST_F(FillInOutputPathsTest, throwsOnPatWhenShouldBeDeffered)
     auto wrongPath = StorePath{"c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-wrong-name"};
 
     // Create a derivation that depends on the dependency
-    Derivation drv;
-    drv.name = "depends-on-drv";
-    drv.platform = "x86_64-linux";
-    drv.builder = "/bin/sh";
-    drv.outputs = {
-        {"out", DerivationOutput{DerivationOutput::InputAddressed{.path = wrongPath}}},
+    Derivation drv{
+        .outputs = {{"out", DerivationOutput{DerivationOutput::InputAddressed{.path = wrongPath}}}},
+        .inputs = {.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}}},
+        .platform = "x86_64-linux",
+        .builder = "/bin/sh",
+        .env = {{"__doc", "InputAddressed throws when should be deferred"}, {"out", ""}},
+        .name = "depends-on-drv",
     };
-    drv.env = {
-        {"__doc", "InputAddressed throws when should be deferred"},
-        {"out", ""},
-    };
-    // Add the real input derivation dependency
-    drv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
 
     // Serialize before state
     checkpointJson("bad-depends-on-drv-pre", drv);

--- a/src/libstore-tests/derivations.cc
+++ b/src/libstore-tests/derivations.cc
@@ -174,7 +174,7 @@ TEST_F(TryResolveTest, withInputs)
             drv.platform = "x86_64-linux";
             drv.builder = "/bin/bash";
             drv.outputs = multiOutputs;
-            drv.inputDrvs = {
+            drv.inputs.drvs = {
                 .map = {
                     {dep1DrvPath, {.value = {"out", "dev"}}},
                     {dep2DrvPath, {.value = {"out"}}},
@@ -219,7 +219,7 @@ TEST_F(TryResolveTest, withInputs)
             expected.platform = "x86_64-linux";
             expected.builder = "/bin/bash";
             expected.outputs = multiOutputs;
-            expected.inputSrcs = {dep1OutPath, dep1DevPath, dep2OutPath};
+            expected.inputs = {dep1OutPath, dep1DevPath, dep2OutPath};
             expected.env = {
                 {"DEP1_OUT", "prefix-" + store->printStorePath(dep1OutPath) + "-suffix"},
                 {"DEP1_DEV", store->printStorePath(dep1DevPath)},
@@ -243,7 +243,7 @@ TEST_F(TryResolveTest, resolutionFailure)
     drv.platform = "x86_64-linux";
     drv.builder = "/bin/bash";
     drv.outputs = {{"out", caFloatingOutput()}};
-    drv.inputDrvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
+    drv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
 
     BuildTrace buildTrace;
 
@@ -273,7 +273,7 @@ void TryResolveTest::exportRefGraphSubpathTest(
 
     nix::checkpointJson(*this, std::string{stem} + "-before", drv);
 
-    auto options = derivationOptionsFromStructuredAttrs(*store, drv.inputDrvs, drv.env, parsed, true);
+    auto options = derivationOptionsFromStructuredAttrs(*store, drv.inputs.drvs, drv.env, parsed, true);
 
     nix::checkpointJson(*this, std::string{stem} + "-before-options", options);
 
@@ -333,7 +333,7 @@ TEST_F(TryResolveTest, exportReferencesGraphPlaceholderSubpath)
     drv.platform = "x86_64-linux";
     drv.builder = "/bin/bash";
     drv.outputs = {{"out", caFloatingOutput()}};
-    drv.inputDrvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
+    drv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
     drv.env = {
         {"exportReferencesGraph", "refs " + placeholder + "/foo"},
     };
@@ -351,7 +351,7 @@ TEST_F(TryResolveTest, exportReferencesGraphPlaceholderSubpath_structuredAttrs)
     drv.platform = "x86_64-linux";
     drv.builder = "/bin/bash";
     drv.outputs = {{"out", caFloatingOutput()}};
-    drv.inputDrvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
+    drv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
     drv.structuredAttrs = StructuredAttrs{{
         {"exportReferencesGraph", nlohmann::json::object({{"refs", nlohmann::json::array({placeholder + "/foo"})}})},
     }};

--- a/src/libstore-tests/derivations.cc
+++ b/src/libstore-tests/derivations.cc
@@ -128,13 +128,13 @@ TEST_F(TryResolveTest, noInputs)
     resolveExpect(
         "no-inputs",
         [&] {
-            Derivation drv;
-            drv.name = "no-inputs";
-            drv.platform = "x86_64-linux";
-            drv.builder = "/bin/bash";
-            drv.outputs = {{"out", caFloatingOutput()}};
-            drv.env = {{"FOO", "bar"}};
-            return drv;
+            return Derivation{
+                .outputs = {{"out", caFloatingOutput()}},
+                .platform = "x86_64-linux",
+                .builder = "/bin/bash",
+                .env = {{"FOO", "bar"}},
+                .name = "no-inputs",
+            };
         }(),
         {},
         [&] {
@@ -168,28 +168,28 @@ TEST_F(TryResolveTest, withInputs)
 
     resolveExpect(
         "with-inputs",
-        [&] {
-            Derivation drv;
-            drv.name = "with-inputs";
-            drv.platform = "x86_64-linux";
-            drv.builder = "/bin/bash";
-            drv.outputs = multiOutputs;
-            drv.inputs.drvs = {
-                .map = {
+        Derivation{
+            .outputs = multiOutputs,
+            .inputs{
+                .drvs{.map{
                     {dep1DrvPath, {.value = {"out", "dev"}}},
                     {dep2DrvPath, {.value = {"out"}}},
-                }};
-            drv.env = {
-                {"DEP1_OUT", "prefix-" + placeholder1Out + "-suffix"},
-                {"DEP1_DEV", placeholder1Dev},
-                {"DEP2", placeholder2Out},
-            };
-            drv.structuredAttrs = StructuredAttrs{{
+                }},
+            },
+            .platform = "x86_64-linux",
+            .builder = "/bin/bash",
+            .env =
+                {
+                    {"DEP1_OUT", "prefix-" + placeholder1Out + "-suffix"},
+                    {"DEP1_DEV", placeholder1Dev},
+                    {"DEP2", placeholder2Out},
+                },
+            .structuredAttrs = StructuredAttrs{{
                 {"dep1out", placeholder1Out},
                 {"nested", nlohmann::json::object({{"dep2", "before " + placeholder2Out + " after"}})},
-            }};
-            return drv;
-        }(),
+            }},
+            .name = "with-inputs",
+        },
         {.dict{
             {
                 SingleDerivedPath::Built{
@@ -238,12 +238,13 @@ TEST_F(TryResolveTest, resolutionFailure)
 {
     StorePath depDrvPath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-dep.drv"};
 
-    Derivation drv;
-    drv.name = "resolution-failure";
-    drv.platform = "x86_64-linux";
-    drv.builder = "/bin/bash";
-    drv.outputs = {{"out", caFloatingOutput()}};
-    drv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
+    Derivation drv{
+        .outputs = {{"out", caFloatingOutput()}},
+        .inputs = {.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}}},
+        .platform = "x86_64-linux",
+        .builder = "/bin/bash",
+        .name = "resolution-failure",
+    };
 
     BuildTrace buildTrace;
 
@@ -328,14 +329,13 @@ TEST_F(TryResolveTest, exportReferencesGraphPlaceholderSubpath)
     StorePath depDrvPath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-dep.drv"};
     auto placeholder = DownstreamPlaceholder::unknownCaOutput(depDrvPath, "out").render();
 
-    Derivation drv;
-    drv.name = "export-ref-subpath";
-    drv.platform = "x86_64-linux";
-    drv.builder = "/bin/bash";
-    drv.outputs = {{"out", caFloatingOutput()}};
-    drv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
-    drv.env = {
-        {"exportReferencesGraph", "refs " + placeholder + "/foo"},
+    Derivation drv{
+        .outputs = {{"out", caFloatingOutput()}},
+        .inputs = {.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}}},
+        .platform = "x86_64-linux",
+        .builder = "/bin/bash",
+        .env = {{"exportReferencesGraph", "refs " + placeholder + "/foo"}},
+        .name = "export-ref-subpath",
     };
 
     exportRefGraphSubpathTest("export-ref-subpath", drv, nullptr);
@@ -346,15 +346,20 @@ TEST_F(TryResolveTest, exportReferencesGraphPlaceholderSubpath_structuredAttrs)
     StorePath depDrvPath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-dep.drv"};
     auto placeholder = DownstreamPlaceholder::unknownCaOutput(depDrvPath, "out").render();
 
-    Derivation drv;
-    drv.name = "export-ref-subpath-sa";
-    drv.platform = "x86_64-linux";
-    drv.builder = "/bin/bash";
-    drv.outputs = {{"out", caFloatingOutput()}};
-    drv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
-    drv.structuredAttrs = StructuredAttrs{{
-        {"exportReferencesGraph", nlohmann::json::object({{"refs", nlohmann::json::array({placeholder + "/foo"})}})},
-    }};
+    Derivation drv{
+        .outputs = {{"out", caFloatingOutput()}},
+        .inputs = {.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}}},
+        .platform = "x86_64-linux",
+        .builder = "/bin/bash",
+        .structuredAttrs = StructuredAttrs{{
+            {
+                "exportReferencesGraph",
+                nlohmann::json::object({{"refs", nlohmann::json::array({placeholder + "/foo"})}}),
+            },
+        }},
+        .name = "export-ref-subpath-sa",
+    };
+    // env depends on structuredAttrs, so set it after construction
     drv.env = {
         {std::string{StructuredAttrs::envVarName}, nlohmann::json(drv.structuredAttrs->structuredAttrs).dump()},
     };

--- a/src/libstore-tests/dummy-store.cc
+++ b/src/libstore-tests/dummy-store.cc
@@ -158,9 +158,7 @@ INSTANTIATE_TEST_SUITE_P(DummyStoreJSON, DummyStoreJsonTest, [] {
             "one-derivation",
             [&] {
                 auto store = writeCfg->openDummyStore();
-                Derivation drv;
-                drv.name = "foo";
-                store->writeDerivation(drv);
+                store->writeDerivation(Derivation{.name = "foo"});
                 return store;
             }(),
         },

--- a/src/libstore-tests/outputs-query.cc
+++ b/src/libstore-tests/outputs-query.cc
@@ -72,8 +72,8 @@ TEST_F(OutputsQueryTest, fibonacciChainQueryCount)
     // d_i depends on d_{i-1} and d_{i-2}
     for (size_t i = 2; i <= N; ++i) {
         Derivation drv = makeLeafDrv("d" + std::to_string(i));
-        drv.inputDrvs.map[drvPaths[i - 1]].value.insert("out");
-        drv.inputDrvs.map[drvPaths[i - 2]].value.insert("out");
+        drv.inputs.drvs.map[drvPaths[i - 1]].value.insert("out");
+        drv.inputs.drvs.map[drvPaths[i - 2]].value.insert("out");
         drvPaths.push_back(store->writeDerivation(drv));
     }
 

--- a/src/libstore-tests/outputs-query.cc
+++ b/src/libstore-tests/outputs-query.cc
@@ -43,12 +43,12 @@ protected:
      */
     Derivation makeLeafDrv(std::string name)
     {
-        Derivation drv;
-        drv.name = std::move(name);
-        drv.platform = "x86_64-linux";
-        drv.builder = "/bin/sh";
-        drv.outputs = {{"out", caFloatingOutput()}};
-        return drv;
+        return Derivation{
+            .outputs = {{"out", caFloatingOutput()}},
+            .platform = "x86_64-linux",
+            .builder = "/bin/sh",
+            .name = std::move(name),
+        };
     }
 };
 

--- a/src/libstore-tests/register-valid-paths-bench.cc
+++ b/src/libstore-tests/register-valid-paths-bench.cc
@@ -34,12 +34,13 @@ static void BM_RegisterValidPathsDerivations(benchmark::State & state)
             std::string drvName = fmt("register-valid-paths-bench-%d", i);
             auto drvPath = StorePath::random(drvName + ".drv");
 
-            Derivation drv;
-            drv.name = drvName;
-            drv.outputs.emplace("out", DerivationOutput{DerivationOutput::Deferred{}});
-            drv.platform = "x86_64-linux";
-            drv.builder = "foo";
-            drv.env["out"] = "";
+            Derivation drv{
+                .outputs = {{"out", DerivationOutput{DerivationOutput::Deferred{}}}},
+                .platform = "x86_64-linux",
+                .builder = "foo",
+                .env = {{"out", ""}},
+                .name = drvName,
+            };
             drv.fillInOutputPaths(*localStore);
 
             auto drvContents = drv.unparse(*localStore, /*maskOutputs=*/false);

--- a/src/libstore-tests/worker-substitution.cc
+++ b/src/libstore-tests/worker-substitution.cc
@@ -179,16 +179,17 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutput)
     EnableExperimentalFeature enableCA{"ca-derivations"};
 
     // Create a CA floating output derivation
-    Derivation drv;
-    drv.name = "test-ca-drv";
-    drv.outputs = {
-        {
-            "out",
-            DerivationOutput{DerivationOutput::CAFloating{
-                .method = ContentAddressMethod::Raw::NixArchive,
-                .hashAlgo = HashAlgorithm::SHA256,
-            }},
+    Derivation drv{
+        .outputs{
+            {
+                "out",
+                DerivationOutput{DerivationOutput::CAFloating{
+                    .method = ContentAddressMethod::Raw::NixArchive,
+                    .hashAlgo = HashAlgorithm::SHA256,
+                }},
+            },
         },
+        .name = "test-ca-drv",
     };
 
     // Write the derivation to the destination store
@@ -317,19 +318,20 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
         });
 
     // Create the root CA floating derivation that depends on depDrv
-    Derivation rootDrv;
-    rootDrv.name = "root-drv";
-    rootDrv.outputs = {
-        {
-            "out",
-            DerivationOutput{DerivationOutput::CAFloating{
-                .method = ContentAddressMethod::Raw::NixArchive,
-                .hashAlgo = HashAlgorithm::SHA256,
-            }},
+    Derivation rootDrv{
+        .outputs{
+            {
+                "out",
+                DerivationOutput{DerivationOutput::CAFloating{
+                    .method = ContentAddressMethod::Raw::NixArchive,
+                    .hashAlgo = HashAlgorithm::SHA256,
+                }},
+            },
         },
+        // Add the dependency derivation as an input
+        .inputs = {.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}}},
+        .name = "root-drv",
     };
-    // Add the dependency derivation as an input
-    rootDrv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
 
     // Write the root derivation to the destination store
     auto rootDrvPath = dummyStore->writeDerivation(rootDrv);

--- a/src/libstore-tests/worker-substitution.cc
+++ b/src/libstore-tests/worker-substitution.cc
@@ -329,7 +329,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
         },
     };
     // Add the dependency derivation as an input
-    rootDrv.inputDrvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
+    rootDrv.inputs.drvs = {.map = {{depDrvPath, {.value = {"out"}}}}};
 
     // Write the root derivation to the destination store
     auto rootDrvPath = dummyStore->writeDerivation(rootDrv);
@@ -345,7 +345,7 @@ TEST_F(WorkerSubstitutionTest, floatingDerivationOutputWithDepDrv)
     ASSERT_TRUE(resolvedRootDrv);
 
     // Write the resolved derivation to the substituter
-    auto resolvedRootDrvPath = substituter->writeDerivation(Derivation{*resolvedRootDrv});
+    auto resolvedRootDrvPath = substituter->writeDerivation(resolvedRootDrv->unresolve());
 
     // Snapshot the destination store before
     checkpointJson("issue-11928/store-before", dummyStore);

--- a/src/libstore-tests/write-derivation.cc
+++ b/src/libstore-tests/write-derivation.cc
@@ -31,15 +31,13 @@ protected:
 
 TEST_F(WriteDerivationTest, addToStoreFromDumpCalledOnce)
 {
-    auto drv = []() {
-        Derivation drv;
-        drv.name = "simple-derivation";
-        drv.platform = "system";
-        drv.builder = "foo";
-        drv.args = {"bar", "baz"};
-        drv.env = StringPairs{{"BIG_BAD", "WOLF"}};
-        return drv;
-    }();
+    Derivation drv{
+        .platform = "system",
+        .builder = "foo",
+        .args = {"bar", "baz"},
+        .env = {{"BIG_BAD", "WOLF"}},
+        .name = "simple-derivation",
+    };
 
     auto path1 = store->writeDerivation(drv, NoRepair);
     config->readOnly = true;

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -32,8 +32,8 @@
 namespace nix {
 
 DerivationBuildingGoal::DerivationBuildingGoal(
-    const StorePath & drvPath, ref<const Derivation> drv, Worker & worker, BuildMode buildMode, bool storeDerivation)
-    : Goal(worker, gaveUpOnSubstitution(storeDerivation))
+    const StorePath & drvPath, ref<const BasicDerivation> drv, Worker & worker, BuildMode buildMode)
+    : Goal(worker, gaveUpOnSubstitution())
     , drvPath(drvPath)
     , drv{std::move(drv)}
     , buildMode(buildMode)
@@ -53,7 +53,8 @@ std::string DerivationBuildingGoal::key()
     return "dd$" + std::string(drvPath.name()) + "$" + worker.store.printStorePath(drvPath);
 }
 
-std::string showKnownOutputs(const StoreDirConfig & store, const Derivation & drv)
+template<typename InputsType>
+std::string showKnownOutputs(const StoreDirConfig & store, const DerivationT<InputsType> & drv)
 {
     std::string msg;
     StorePathSet expectedOutputPaths;
@@ -67,6 +68,9 @@ std::string showKnownOutputs(const StoreDirConfig & store, const Derivation & dr
     }
     return msg;
 }
+
+template std::string showKnownOutputs(const StoreDirConfig & store, const DerivationT<FullInputs> & drv);
+template std::string showKnownOutputs(const StoreDirConfig & store, const DerivationT<StorePathSet> & drv);
 
 namespace {
 
@@ -146,7 +150,7 @@ static std::unique_ptr<PostBuildHookState> runPostBuildHook(
 
 /* At least one of the output paths could not be
    produced using a substitute.  So we have to build instead. */
-Goal::Co DerivationBuildingGoal::gaveUpOnSubstitution(bool storeDerivation)
+Goal::Co DerivationBuildingGoal::gaveUpOnSubstitution()
 {
     Goals waitees;
 
@@ -157,13 +161,13 @@ Goal::Co DerivationBuildingGoal::gaveUpOnSubstitution(bool storeDerivation)
        are (resolved) derivation outputs in a resolved derivation. */
     if (&worker.evalStore != &worker.store) {
         RealisedPath::Set inputSrcs;
-        for (auto & i : drv->inputSrcs)
+        for (auto & i : drv->inputs)
             if (worker.evalStore.isValidPath(i))
                 inputSrcs.insert(i);
         copyClosure(worker.evalStore, worker.store, inputSrcs);
     }
 
-    for (auto & i : drv->inputSrcs) {
+    for (auto & i : drv->inputs) {
         if (worker.store.isValidPath(i))
             continue;
         if (!worker.settings.useSubstitutes)
@@ -194,47 +198,8 @@ Goal::Co DerivationBuildingGoal::gaveUpOnSubstitution(bool storeDerivation)
 
     /* Determine the full set of input paths. */
 
-    if (storeDerivation) {
-        assert(drv->inputDrvs.map.empty());
-        /* Store the resolved derivation, as part of the record of
-           what we're actually building */
-        worker.store.writeDerivation(*drv);
-    }
-
     StorePathSet inputPaths;
-
-    {
-        /* If we get this far, we know no dynamic drvs inputs */
-
-        for (auto & [depDrvPath, depNode] : drv->inputDrvs.map) {
-            for (auto & outputName : depNode.value) {
-                /* Don't need to worry about `inputGoals`, because
-                   impure derivations are always resolved above. Can
-                   just use DB. This case only happens in the (older)
-                   input addressed and fixed output derivation cases. */
-                auto outMap = [&] {
-                    for (auto * drvStore : {&worker.evalStore, &worker.store})
-                        if (drvStore->isValidPath(depDrvPath))
-                            return deepQueryDerivationOutputMap(worker.store, depDrvPath, drvStore);
-                    assert(false);
-                }();
-
-                auto outMapPath = outMap.find(outputName);
-                if (outMapPath == outMap.end()) {
-                    throw Error(
-                        "derivation '%s' requires non-existent output '%s' from input derivation '%s'",
-                        worker.store.printStorePath(drvPath),
-                        outputName,
-                        worker.store.printStorePath(depDrvPath));
-                }
-
-                worker.store.computeFSClosure(outMapPath->second, inputPaths);
-            }
-        }
-    }
-
-    /* Second, the input sources. */
-    worker.store.computeFSClosure(drv->inputSrcs, inputPaths);
+    worker.store.computeFSClosure(drv->inputs, inputPaths);
 
     debug("added input paths %s", concatMapStringsSep(", ", inputPaths, [&](auto & p) {
               return "'" + worker.store.printStorePath(p) + "'";
@@ -339,35 +304,12 @@ static BuildError reject(const LocalBuildRejection & rejection, std::string_view
 Goal::Co DerivationBuildingGoal::tryToBuild(StorePathSet inputPaths)
 {
     auto drvOptions = [&] {
-        DerivationOptions<SingleDerivedPath> temp;
         try {
-            temp =
-                derivationOptionsFromStructuredAttrs(worker.store, drv->inputDrvs, drv->env, get(drv->structuredAttrs));
+            return derivationOptionsFromStructuredAttrs(worker.store, drv->env, get(drv->structuredAttrs));
         } catch (Error & e) {
             e.addTrace({}, "while parsing derivation '%s'", worker.store.printStorePath(drvPath));
             throw;
         }
-
-        auto res = tryResolve(
-            temp,
-            [&](ref<const SingleDerivedPath> drvPath, const std::string & outputName) -> std::optional<StorePath> {
-                try {
-                    return resolveDerivedPath(
-                        worker.store, SingleDerivedPath::Built{drvPath, outputName}, &worker.evalStore);
-                } catch (Error &) {
-                    return std::nullopt;
-                }
-            });
-
-        /* The derivation must have all of its inputs gotten this point,
-           so the resolution will surely succeed.
-
-           (Actually, we shouldn't even enter this goal until we have a
-           resolved derivation, or derivation with only input addressed
-           transitive inputs, so this should be a no-opt anyways.)
-         */
-        assert(res);
-        return *res;
     }();
 
     std::map<std::string, InitialOutput> initialOutputs;

--- a/src/libstore/build/derivation-env-desugar.cc
+++ b/src/libstore/build/derivation-env-desugar.cc
@@ -19,7 +19,7 @@ std::string & DesugaredEnv::atFileEnvPair(std::string_view name, std::string fil
 
 DesugaredEnv DesugaredEnv::create(
     Store & store,
-    const Derivation & drv,
+    const BasicDerivation & drv,
     const DerivationOptions<StorePath> & drvOptions,
     const StorePathSet & inputPaths)
 {

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -52,7 +52,7 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
     auto drvOptions = [&]() -> DerivationOptions<SingleDerivedPath> {
         try {
             return derivationOptionsFromStructuredAttrs(
-                worker.store, drv->inputDrvs, drv->env, get(drv->structuredAttrs));
+                worker.store, drv->inputs.drvs, drv->env, get(drv->structuredAttrs));
         } catch (Error & e) {
             e.addTrace({}, "while parsing derivation '%s'", worker.store.printStorePath(drvPath));
             throw;
@@ -164,7 +164,7 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
 
         auto resolvedDrvGoal = worker.makeDerivationGoal(
             pathResolved,
-            make_ref<const Derivation>(drvResolved),
+            make_ref<const Derivation>(drvResolved.unresolve()),
             wantedOutput,
             buildMode,
             /*storeDerivation=*/true);
@@ -230,7 +230,54 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
 
     /* Give up on substitution for the output we want, actually build this derivation */
 
-    auto g = worker.makeDerivationBuildingGoal(drvPath, drv, buildMode, storeDerivation);
+    /* Project down to the `BasicDerivation` the builder consumes,
+       adding the outputs of the input derivations to the input
+       sources. */
+    auto resolvedDrv = make_ref<const BasicDerivation>(drv->mapInputs([&](const FullInputs & inputs) {
+        auto srcs = inputs.srcs;
+        for (auto & [depDrvPath, depNode] : inputs.drvs.map) {
+            for (auto & outputName : depNode.value) {
+                /* Don't need to worry about `inputGoals`, because
+                   impure derivations are always resolved above. Can
+                   just use DB. This case only happens in the (older)
+                   input addressed and fixed output derivation cases. */
+                auto outMap = [&] {
+                    for (auto * drvStore : {&worker.evalStore, &worker.store})
+                        if (drvStore->isValidPath(depDrvPath))
+                            return deepQueryDerivationOutputMap(worker.store, depDrvPath, drvStore);
+                    assert(false);
+                }();
+                auto outMapPath = outMap.find(outputName);
+                if (outMapPath == outMap.end()) {
+                    throw Error(
+                        "derivation '%s' requires non-existent output '%s' from input derivation '%s'",
+                        worker.store.printStorePath(drvPath),
+                        outputName,
+                        worker.store.printStorePath(depDrvPath));
+                }
+                srcs.insert(outMapPath->second);
+            }
+        }
+        return srcs;
+    }));
+
+    if (storeDerivation) {
+        assert(drv->inputs.drvs.map.empty());
+        /* `writeDerivation` checks the derivation's references are valid,
+           so the eval store's sources must be copied over first. */
+        if (&worker.evalStore != &worker.store) {
+            RealisedPath::Set inputSrcs;
+            for (auto & i : resolvedDrv->inputs)
+                if (worker.evalStore.isValidPath(i))
+                    inputSrcs.insert(i);
+            copyClosure(worker.evalStore, worker.store, inputSrcs);
+        }
+        /* Store the resolved derivation, as part of the record of
+           what we're actually building */
+        worker.store.writeDerivation(resolvedDrv->unresolve());
+    }
+
+    auto g = worker.makeDerivationBuildingGoal(drvPath, resolvedDrv, buildMode);
 
     /* We will finish with it ourselves, as if we were the derivational goal. */
     g->preserveFailure = true;

--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -51,7 +51,7 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
             self(make_ref<SingleDerivedPath>(SingleDerivedPath::Built{inputDrv, outputName}), childNode);
     };
 
-    for (const auto & [inputDrvPath, inputNode] : drv->inputDrvs.map) {
+    for (const auto & [inputDrvPath, inputNode] : drv->inputs.drvs.map) {
         /* Ensure that pure, non-fixed-output derivations don't
            depend on impure derivations. */
         if (experimentalFeatureSettings.isEnabled(Xp::ImpureDerivations) && !drv->type().isImpure()
@@ -133,7 +133,7 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
             }
             assert(attempt);
 
-            auto pathResolved = computeStorePath(worker.store, Derivation{*attempt});
+            auto pathResolved = computeStorePath(worker.store, attempt->unresolve());
 
             auto msg =
                 fmt("resolved derivation: '%s' -> '%s'",

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -107,7 +107,7 @@ std::vector<KeyedBuildResult> Worker::buildPathsWithResults(const std::vector<De
 
 BuildResult Worker::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
 {
-    auto goal = makeDerivationTrampolineGoal(drvPath, OutputsSpec::All{}, drv, buildMode);
+    auto goal = makeDerivationTrampolineGoal(drvPath, OutputsSpec::All{}, drv.unresolve(), buildMode);
 
     try {
         run(Goals{goal});

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -109,11 +109,10 @@ Worker::makeDerivationResolutionGoal(const StorePath & drvPath, ref<const Deriva
     return initGoalIfNeeded(derivationResolutionGoals[drvPath], drvPath, drv, *this, buildMode);
 }
 
-std::shared_ptr<DerivationBuildingGoal> Worker::makeDerivationBuildingGoal(
-    const StorePath & drvPath, ref<const Derivation> drv, BuildMode buildMode, bool storeDerivation)
+std::shared_ptr<DerivationBuildingGoal>
+Worker::makeDerivationBuildingGoal(const StorePath & drvPath, ref<const BasicDerivation> drv, BuildMode buildMode)
 {
-    return initGoalIfNeeded(
-        derivationBuildingGoals[drvPath], drvPath, std::move(drv), *this, buildMode, storeDerivation);
+    return initGoalIfNeeded(derivationBuildingGoals[drvPath], drvPath, std::move(drv), *this, buildMode);
 }
 
 std::shared_ptr<PathSubstitutionGoal>

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -650,9 +650,7 @@ static void performOp(
                paths. */
             assert(drvType.isCA());
 
-            Derivation drv2;
-            static_cast<BasicDerivation &>(drv2) = drv;
-            drvPath = store->writeDerivation(Derivation{drv2});
+            drvPath = store->writeDerivation(drv.unresolve());
         }
 
         auto res = builder.buildDerivation(drvPath, drv, buildMode);

--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -358,7 +358,8 @@ DerivationOptions<SingleDerivedPath> derivationOptionsFromStructuredAttrs(
 }
 
 template<typename Input>
-StringSet DerivationOptions<Input>::getRequiredSystemFeatures(const BasicDerivation & drv) const
+template<typename Inputs>
+StringSet DerivationOptions<Input>::getRequiredSystemFeatures(const DerivationT<Inputs> & drv) const
 {
     // FIXME: cache this?
     StringSet res;
@@ -376,10 +377,19 @@ bool DerivationOptions<Input>::substitutesAllowed(const WorkerSettings & workerS
 }
 
 template<typename Input>
-bool DerivationOptions<Input>::useUidRange(const BasicDerivation & drv) const
+template<typename Inputs>
+bool DerivationOptions<Input>::useUidRange(const DerivationT<Inputs> & drv) const
 {
     return getRequiredSystemFeatures(drv).count("uid-range");
 }
+
+// Explicit instantiations for member function templates
+template StringSet DerivationOptions<StorePath>::getRequiredSystemFeatures(const BasicDerivation &) const;
+template StringSet DerivationOptions<StorePath>::getRequiredSystemFeatures(const Derivation &) const;
+template StringSet DerivationOptions<SingleDerivedPath>::getRequiredSystemFeatures(const Derivation &) const;
+
+template bool DerivationOptions<StorePath>::useUidRange(const BasicDerivation &) const;
+template bool DerivationOptions<SingleDerivedPath>::useUidRange(const Derivation &) const;
 
 std::optional<DerivationOptions<StorePath>> tryResolve(
     const DerivationOptions<SingleDerivedPath> & drvOptions,

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -451,8 +451,9 @@ Derivation parseDerivation(
 {
     using namespace std::literals::string_view_literals;
 
-    Derivation drv;
-    drv.name = name;
+    Derivation drv{
+        .name = std::string{name},
+    };
 
     StringViewStream str{s};
     expect(str, 'D');

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -15,10 +15,6 @@
 
 namespace nix {
 
-BasicDerivation::~BasicDerivation() {}
-
-Derivation::~Derivation() {}
-
 std::optional<StorePath>
 DerivationOutput::path(const StoreDirConfig & store, std::string_view drvName, OutputNameView outputName) const
 {
@@ -101,15 +97,26 @@ bool DerivationType::isImpure() const
         raw);
 }
 
-bool BasicDerivation::isBuiltin() const
+bool isBuiltin(const BasicDerivation & drv)
+{
+    return drv.builder.substr(0, 8) == "builtin:";
+}
+
+template<typename InputsType>
+bool DerivationT<InputsType>::isBuiltin() const
 {
     return builder.substr(0, 8) == "builtin:";
 }
 
+// Forward declaration of specialization
+template<>
+std::string DerivationT<FullInputs>::unparse(
+    const StoreDirConfig & store, bool maskOutputs, DerivedPathMap<StringSet>::ChildNode::Map * actualInputs) const;
+
 static auto infoForDerivation(const StoreDirConfig & store, const Derivation & drv)
 {
-    auto references = drv.inputSrcs;
-    for (auto & i : drv.inputDrvs.map)
+    auto references = drv.inputs.srcs;
+    for (auto & i : drv.inputs.drvs.map)
         references.insert(i.first);
     /* Note that the outputs of a derivation are *not* references
        (that can be missing (of course) and should not necessarily be
@@ -489,13 +496,13 @@ Derivation parseDerivation(
         expect(str, '(');
         auto drvPath = parsePath(str);
         expect(str, ',');
-        drv.inputDrvs.map.insert_or_assign(
+        drv.inputs.drvs.map.insert_or_assign(
             store.parseStorePath(*drvPath), parseDerivedPathMapNode(store, str, version));
         expect(str, ')');
     }
 
     expect(str, ',');
-    drv.inputSrcs = store.parseStorePathSet(parseStrings(str, true));
+    drv.inputs.srcs = store.parseStorePathSet(parseStrings(str, true));
     expect(str, ',');
     drv.platform = parseString(str).toOwned();
     expect(str, ',');
@@ -640,13 +647,14 @@ static void unparseDerivedPathMapNode(
 static bool hasDynamicDrvDep(const Derivation & drv)
 {
     return std::find_if(
-               drv.inputDrvs.map.begin(),
-               drv.inputDrvs.map.end(),
+               drv.inputs.drvs.map.begin(),
+               drv.inputs.drvs.map.end(),
                [](auto & kv) { return !kv.second.childMap.empty(); })
-           != drv.inputDrvs.map.end();
+           != drv.inputs.drvs.map.end();
 }
 
-std::string Derivation::unparse(
+template<>
+std::string DerivationT<FullInputs>::unparse(
     const StoreDirConfig & store, bool maskOutputs, DerivedPathMap<StringSet>::ChildNode::Map * actualInputs) const
 {
     using namespace std::literals::string_view_literals;
@@ -736,7 +744,7 @@ std::string Derivation::unparse(
             s += ')';
         }
     } else {
-        for (auto & [drvPath, childMap] : inputDrvs.map) {
+        for (auto & [drvPath, childMap] : inputs.drvs.map) {
             if (first)
                 first = false;
             else
@@ -749,7 +757,7 @@ std::string Derivation::unparse(
     }
 
     s += "],"sv;
-    auto paths = store.printStorePathSet(inputSrcs); // FIXME: slow
+    auto paths = store.printStorePathSet(inputs.srcs); // FIXME: slow
     printUnquotedStrings(s, paths.begin(), paths.end());
 
     s += ',';
@@ -808,7 +816,8 @@ std::string outputPathName(std::string_view drvName, OutputNameView outputName)
     return res;
 }
 
-DerivationType BasicDerivation::type() const
+template<typename InputsType>
+DerivationType DerivationT<InputsType>::type() const
 {
     using namespace std::literals::string_view_literals;
 
@@ -945,7 +954,7 @@ DrvHashModulo hashDerivationModulo(Store & store, const Derivation & drv, bool m
     /* For other derivations, replace the inputs paths with recursive
        calls to this function. */
     DerivedPathMap<StringSet>::ChildNode::Map inputs2;
-    for (auto & [drvPath, node] : drv.inputDrvs.map) {
+    for (auto & [drvPath, node] : drv.inputs.drvs.map) {
         /* Need to build and resolve dynamic derivations first */
         if (!node.childMap.empty()) {
             return DrvHashModulo::DeferredDrv{};
@@ -993,7 +1002,8 @@ static DerivationOutput readDerivationOutput(Source & in, const StoreDirConfig &
     return parseDerivationOutput(store, pathS, hashAlgo, hash, experimentalFeatureSettings);
 }
 
-StringSet BasicDerivation::outputNames() const
+template<typename InputsType>
+StringSet DerivationT<InputsType>::outputNames() const
 {
     StringSet names;
     for (auto & i : outputs)
@@ -1001,7 +1011,8 @@ StringSet BasicDerivation::outputNames() const
     return names;
 }
 
-DerivationOutputsAndOptPaths BasicDerivation::outputsAndOptPaths(const StoreDirConfig & store) const
+template<typename InputsType>
+DerivationOutputsAndOptPaths DerivationT<InputsType>::outputsAndOptPaths(const StoreDirConfig & store) const
 {
     DerivationOutputsAndOptPaths outsAndOptPaths;
     for (auto & [outputName, output] : outputs)
@@ -1010,7 +1021,8 @@ DerivationOutputsAndOptPaths BasicDerivation::outputsAndOptPaths(const StoreDirC
     return outsAndOptPaths;
 }
 
-std::string_view BasicDerivation::nameFromPath(const StorePath & drvPath)
+template<typename InputsType>
+std::string_view DerivationT<InputsType>::nameFromPath(const StorePath & drvPath)
 {
     drvPath.requireDerivation();
     auto nameWithSuffix = drvPath.name();
@@ -1030,7 +1042,7 @@ Source & readDerivation(Source & in, const StoreDirConfig & store, BasicDerivati
         drv.outputs.emplace(std::move(name), std::move(output));
     }
 
-    drv.inputSrcs = CommonProto::Serialise<StorePathSet>::read(store, CommonProto::ReadConn{.from = in});
+    drv.inputs = CommonProto::Serialise<StorePathSet>::read(store, CommonProto::ReadConn{.from = in});
     in >> drv.platform >> drv.builder;
     drv.args = readStrings<Strings>(in);
 
@@ -1074,7 +1086,7 @@ void writeDerivation(Sink & out, const StoreDirConfig & store, const BasicDeriva
             },
             i.second.raw);
     }
-    CommonProto::write(store, CommonProto::WriteConn{.to = out}, drv.inputSrcs);
+    CommonProto::write(store, CommonProto::WriteConn{.to = out}, drv.inputs);
     out << drv.platform << drv.builder << drv.args;
 
     auto writeEnv = [&](const StringPairs atermEnv) {
@@ -1101,7 +1113,8 @@ std::string hashPlaceholder(const OutputNameView outputName)
                  .to_string(HashFormat::Nix32, false);
 }
 
-void BasicDerivation::applyRewrites(const StringMap & rewrites)
+template<typename InputsType>
+void DerivationT<InputsType>::applyRewrites(const StringMap & rewrites)
 {
     if (rewrites.empty())
         return;
@@ -1131,10 +1144,17 @@ void BasicDerivation::applyRewrites(const StringMap & rewrites)
     }
 }
 
+template<>
+Derivation DerivationT<StorePathSet>::unresolve() const
+{
+    return mapInputs([](const StorePathSet & inputs) -> FullInputs { return {.srcs = inputs, .drvs = {}}; });
+}
+
+template<>
 bool Derivation::shouldResolve() const
 {
     /* No input drvs means nothing to resolve. */
-    if (inputDrvs.map.empty())
+    if (inputs.drvs.map.empty())
         return false;
 
     auto drvType = type();
@@ -1159,22 +1179,13 @@ bool Derivation::shouldResolve() const
 
     /* Also need to resolve if any inputs are outputs of dynamic derivations. */
     bool hasDynamicInputs = std::ranges::any_of(
-        inputDrvs.map.begin(), inputDrvs.map.end(), [](auto & pair) { return !pair.second.childMap.empty(); });
+        inputs.drvs.map.begin(), inputs.drvs.map.end(), [](auto & pair) { return !pair.second.childMap.empty(); });
 
     return typeNeedsResolve || hasDynamicInputs;
 }
 
-std::optional<BasicDerivation> Derivation::tryResolve(Store & store, Store * evalStore) const
-{
-    return tryResolve(
-        store, [&](ref<const SingleDerivedPath> drvPath, const std::string & outputName) -> std::optional<StorePath> {
-            try {
-                return resolveDerivedPath(store, SingleDerivedPath::Built{drvPath, outputName}, evalStore);
-            } catch (Error &) {
-                return std::nullopt;
-            }
-        });
-}
+template<bool fillIn>
+static void processDerivationOutputPaths(Store & store, auto && drv, std::string_view drvName);
 
 static bool tryResolveInput(
     const StoreDirConfig & store,
@@ -1221,20 +1232,49 @@ static bool tryResolveInput(
     return true;
 }
 
-std::optional<BasicDerivation> Derivation::tryResolve(
+// Forward declaration of specialization
+template<>
+std::optional<BasicDerivation> DerivationT<FullInputs>::tryResolve(
+    Store & store,
+    fun<std::optional<StorePath>(ref<const SingleDerivedPath> drvPath, const std::string & outputName)>
+        queryResolutionChain) const;
+
+template<>
+std::optional<BasicDerivation> DerivationT<FullInputs>::tryResolve(Store & store, Store * evalStore) const
+{
+    return tryResolve(
+        store, [&](ref<const SingleDerivedPath> drvPath, const std::string & outputName) -> std::optional<StorePath> {
+            try {
+                return resolveDerivedPath(store, SingleDerivedPath::Built{drvPath, outputName}, evalStore);
+            } catch (Error &) {
+                return std::nullopt;
+            }
+        });
+}
+
+template<>
+std::optional<BasicDerivation> DerivationT<FullInputs>::tryResolve(
     Store & store,
     fun<std::optional<StorePath>(ref<const SingleDerivedPath> drvPath, const std::string & outputName)>
         queryResolutionChain) const
 {
-    BasicDerivation resolved{*this};
+    BasicDerivation resolved{
+        .outputs = outputs,
+        .inputs = inputs.srcs,
+        .platform = platform,
+        .builder = builder,
+        .args = args,
+        .env = env,
+        .structuredAttrs = structuredAttrs,
+        .name = name,
+    };
 
-    // Input paths that we'll want to rewrite in the derivation
     StringMap inputRewrites;
 
-    for (auto & [inputDrv, inputNode] : inputDrvs.map)
+    for (auto & [inputDrv, inputNode] : inputs.drvs.map)
         if (!tryResolveInput(
                 store,
-                resolved.inputSrcs,
+                resolved.inputs,
                 inputRewrites,
                 nullptr,
                 make_ref<const SingleDerivedPath>(SingleDerivedPath::Opaque{inputDrv}),
@@ -1244,11 +1284,9 @@ std::optional<BasicDerivation> Derivation::tryResolve(
 
     resolved.applyRewrites(inputRewrites);
 
-    Derivation resolved2{std::move(resolved)};
+    processDerivationOutputPaths<true>(store, resolved, resolved.name);
 
-    resolved2.fillInOutputPaths(store);
-
-    return resolved2;
+    return resolved;
 }
 
 /**
@@ -1280,7 +1318,11 @@ static void processDerivationOutputPaths(Store & store, auto && drv, std::string
     auto hashModulo = [&]() -> const auto & {
         if (!hashModulo_) {
             // somewhat expensive so we do lazily
-            hashModulo_ = hashDerivationModulo(store, drv, true);
+            if constexpr (std::is_same_v<std::decay_t<decltype(drv)>, Derivation>) {
+                hashModulo_ = hashDerivationModulo(store, drv, true);
+            } else {
+                hashModulo_ = hashDerivationModulo(store, drv.unresolve(), true);
+            }
         }
         return *hashModulo_;
     };
@@ -1397,7 +1439,8 @@ static void processDerivationOutputPaths(Store & store, auto && drv, std::string
     drv.type();
 }
 
-void Derivation::checkInvariants(Store & store, const StorePath & drvPath) const
+template<typename InputsType>
+void DerivationT<InputsType>::checkInvariants(Store & store, const StorePath & drvPath) const
 {
     assert(drvPath.isDerivation());
     std::string drvName(drvPath.name());
@@ -1415,16 +1458,25 @@ void Derivation::checkInvariants(Store & store, const StorePath & drvPath) const
     }
 }
 
+template<>
+void BasicDerivation::checkInvariants(Store & store) const
+{
+    processDerivationOutputPaths<false>(store, *this, name);
+}
+
+template<>
 void Derivation::checkInvariants(Store & store) const
 {
     processDerivationOutputPaths<false>(store, *this, name);
 }
 
+template<>
 void Derivation::fillInOutputPaths(Store & store)
 {
     processDerivationOutputPaths<true>(store, *this, name);
 }
 
+template<>
 Derivation Derivation::parseJsonAndValidate(Store & store, const nlohmann::json & json)
 {
     auto drv = static_cast<Derivation>(json);
@@ -1442,6 +1494,10 @@ Derivation Derivation::parseJsonAndValidate(Store & store, const nlohmann::json 
 }
 
 const Hash impureOutputHash = hashString(HashAlgorithm::SHA256, "impure");
+
+// Explicit template instantiations
+template struct DerivationT<StorePathSet>;
+template struct DerivationT<FullInputs>;
 
 } // namespace nix
 
@@ -1544,14 +1600,40 @@ nix::DerivationOutput adl_serializer<nix::DerivationOutput>::from_json(
     }
 }
 
-static void inputSrcsToJson(json & res, const nix::StorePathSet & inputSrcs)
+static void inputsToJson(json & res, const nix::StorePathSet & inputs)
 {
     res = nlohmann::json::array();
-    for (auto & input : inputSrcs)
+    for (auto & input : inputs)
         res.emplace_back(input);
 }
 
-static void basicDerivationToJson(json & res, const nix::BasicDerivation & d)
+static void inputsToJson(json & res, const nix::FullInputs & inputs)
+{
+    using namespace nix;
+    res = nlohmann::json::object();
+
+    inputsToJson(res["srcs"], inputs.srcs);
+
+    auto doInput = [&](this const auto & doInput, const auto & inputNode) -> nlohmann::json {
+        auto value = nlohmann::json::object();
+        value["outputs"] = inputNode.value;
+        {
+            auto next = nlohmann::json::object();
+            for (auto & [outputId, childNode] : inputNode.childMap)
+                next[outputId] = doInput(childNode);
+            value["dynamicOutputs"] = std::move(next);
+        }
+        return value;
+    };
+
+    auto & inputDrvsObj = res["drvs"];
+    inputDrvsObj = nlohmann::json::object();
+    for (auto & [inputDrv, inputNode] : inputs.drvs.map)
+        inputDrvsObj[inputDrv.to_string()] = doInput(inputNode);
+}
+
+template<typename Inputs>
+void adl_serializer<nix::DerivationT<Inputs>>::to_json(json & res, const nix::DerivationT<Inputs> & d)
 {
     using namespace nix;
     res = nlohmann::json::object();
@@ -1566,6 +1648,8 @@ static void basicDerivationToJson(json & res, const nix::BasicDerivation & d)
             outputsObj[outputName] = output;
     }
 
+    inputsToJson(res["inputs"], d.inputs);
+
     res["system"] = d.platform;
     res["builder"] = d.builder;
     res["args"] = d.args;
@@ -1575,157 +1659,119 @@ static void basicDerivationToJson(json & res, const nix::BasicDerivation & d)
         res["structuredAttrs"] = d.structuredAttrs->structuredAttrs;
 }
 
-void adl_serializer<nix::BasicDerivation>::to_json(json & res, const nix::BasicDerivation & d)
-{
-    basicDerivationToJson(res, d);
+template<typename Inputs>
+static Inputs inputsFromJson(const json & inputsJson, const nix::ExperimentalFeatureSettings & xpSettings);
 
-    inputSrcsToJson(res["inputs"], d.inputSrcs);
-}
-
-void adl_serializer<nix::Derivation>::to_json(json & res, const nix::Derivation & d)
+template<>
+nix::StorePathSet inputsFromJson<nix::StorePathSet>(const json & inputsJson, const nix::ExperimentalFeatureSettings &)
 {
     using namespace nix;
-
-    basicDerivationToJson(res, d);
-
-    {
-        auto & inputsObj = res["inputs"];
-        inputsObj = nlohmann::json::object();
-
-        inputSrcsToJson(inputsObj["srcs"], d.inputSrcs);
-
-        auto doInput = [&](this const auto & doInput, const auto & inputNode) -> nlohmann::json {
-            auto value = nlohmann::json::object();
-            value["outputs"] = inputNode.value;
-            {
-                auto next = nlohmann::json::object();
-                for (auto & [outputId, childNode] : inputNode.childMap)
-                    next[outputId] = doInput(childNode);
-                value["dynamicOutputs"] = std::move(next);
-            }
-            return value;
-        };
-
-        auto & inputDrvsObj = inputsObj["drvs"];
-        inputDrvsObj = nlohmann::json::object();
-        for (auto & [inputDrv, inputNode] : d.inputDrvs.map)
-            inputDrvsObj[inputDrv.to_string()] = doInput(inputNode);
-    }
-}
-
-static void inputSrcsFromJson(const json & inputSrcsJson, nix::StorePathSet & inputSrcs)
-{
-    auto arr = nix::getArray(inputSrcsJson);
-    for (auto & input : arr)
+    StorePathSet inputSrcs;
+    for (auto & input : getArray(inputsJson))
         inputSrcs.insert(input);
+    return inputSrcs;
 }
 
-static void basicDerivationFromJson(
-    const json::object_t & json, nix::BasicDerivation & res, const nix::ExperimentalFeatureSettings & xpSettings)
+template<>
+nix::FullInputs
+inputsFromJson<nix::FullInputs>(const json & inputsJson, const nix::ExperimentalFeatureSettings & xpSettings)
 {
     using namespace nix;
 
-    res.name = getString(valueAt(json, "name"));
+    auto inputsObj = getObject(inputsJson);
+    FullInputs inputs;
 
+    try {
+        for (auto & input : getArray(valueAt(inputsObj, "srcs")))
+            inputs.srcs.insert(input);
+    } catch (Error & e) {
+        e.addTrace({}, "while reading key 'srcs'");
+        throw;
+    }
+
+    try {
+        auto doInput = [&](this const auto & doInput, const auto & _json) -> DerivedPathMap<StringSet>::ChildNode {
+            auto & json = getObject(_json);
+            DerivedPathMap<StringSet>::ChildNode node;
+            node.value = getStringSet(valueAt(json, "outputs"));
+            for (auto & [outputId, childNode] : getObject(valueAt(json, "dynamicOutputs"))) {
+                xpSettings.require(
+                    Xp::DynamicDerivations, [&] { return fmt("dynamic output '%s' in JSON", outputId); });
+                node.childMap[outputId] = doInput(childNode);
+            }
+            return node;
+        };
+        for (auto & [inputDrvPath, inputOutputs] : getObject(valueAt(inputsObj, "drvs")))
+            inputs.drvs.map[StorePath{inputDrvPath}] = doInput(inputOutputs);
+    } catch (Error & e) {
+        e.addTrace({}, "while reading key 'drvs'");
+        throw;
+    }
+
+    return inputs;
+}
+
+template<typename Inputs>
+nix::DerivationT<Inputs> adl_serializer<nix::DerivationT<Inputs>>::from_json(
+    const json & _json, const nix::ExperimentalFeatureSettings & xpSettings)
+{
+    using namespace nix;
+
+    auto & json = getObject(_json);
     {
         auto version = getUnsigned(valueAt(json, "version"));
-        if (valueAt(json, "version") != expectedJsonVersionDerivation)
+        if (version != expectedJsonVersionDerivation)
             throw Error(
                 "Unsupported derivation JSON format version %d, only format version %d is currently supported.",
                 version,
                 expectedJsonVersionDerivation);
     }
 
-    try {
-        auto outputs = getObject(valueAt(json, "outputs"));
-        for (auto & [outputName, output] : outputs) {
-            res.outputs.insert_or_assign(outputName, adl_serializer<DerivationOutput>::from_json(output, xpSettings));
-        }
-    } catch (Error & e) {
-        e.addTrace({}, "while reading key 'outputs'");
-        throw;
-    }
-
-    res.platform = getString(valueAt(json, "system"));
-    res.builder = getString(valueAt(json, "builder"));
-    res.args = getStringList(valueAt(json, "args"));
-
-    auto envJson = valueAt(json, "env");
-    try {
-        res.env = getStringMap(envJson);
-    } catch (Error & e) {
-        e.addTrace({}, "while reading key 'env'");
-        throw;
-    }
-
-    if (auto structuredAttrs = get(json, "structuredAttrs"))
-        res.structuredAttrs = StructuredAttrs{*structuredAttrs};
-}
-
-nix::BasicDerivation
-adl_serializer<nix::BasicDerivation>::from_json(const json & _json, const nix::ExperimentalFeatureSettings & xpSettings)
-{
-    using namespace nix;
-
-    BasicDerivation res;
-    auto & json = getObject(_json);
-    basicDerivationFromJson(json, res, xpSettings);
-
-    try {
-        inputSrcsFromJson(valueAt(json, "inputs"), res.inputSrcs);
-    } catch (Error & e) {
-        e.addTrace({}, "while reading key 'inputs'");
-        throw;
-    }
-
-    return res;
-}
-
-nix::Derivation
-adl_serializer<nix::Derivation>::from_json(const json & _json, const nix::ExperimentalFeatureSettings & xpSettings)
-{
-    using namespace nix;
-
-    Derivation res;
-    auto & json = getObject(_json);
-    basicDerivationFromJson(json, res, xpSettings);
-
-    try {
-        auto inputsObj = getObject(valueAt(json, "inputs"));
-
-        try {
-            inputSrcsFromJson(valueAt(inputsObj, "srcs"), res.inputSrcs);
-        } catch (Error & e) {
-            e.addTrace({}, "while reading key 'srcs'");
-            throw;
-        }
-
-        try {
-            auto doInput = [&](this const auto & doInput, const auto & _json) -> DerivedPathMap<StringSet>::ChildNode {
-                auto & json = getObject(_json);
-                DerivedPathMap<StringSet>::ChildNode node;
-                node.value = getStringSet(valueAt(json, "outputs"));
-                auto drvs = getObject(valueAt(json, "dynamicOutputs"));
-                for (auto & [outputId, childNode] : drvs) {
-                    xpSettings.require(
-                        Xp::DynamicDerivations, [&] { return fmt("dynamic output '%s' in JSON", outputId); });
-                    node.childMap[outputId] = doInput(childNode);
+    return DerivationT<Inputs>{
+        .outputs =
+            [&] {
+                DerivationOutputs outputs;
+                try {
+                    for (auto & [outputName, output] : getObject(valueAt(json, "outputs")))
+                        outputs.insert_or_assign(
+                            outputName, adl_serializer<DerivationOutput>::from_json(output, xpSettings));
+                } catch (Error & e) {
+                    e.addTrace({}, "while reading key 'outputs'");
+                    throw;
                 }
-                return node;
-            };
-            auto drvs = getObject(valueAt(inputsObj, "drvs"));
-            for (auto & [inputDrvPath, inputOutputs] : drvs)
-                res.inputDrvs.map[StorePath{inputDrvPath}] = doInput(inputOutputs);
-        } catch (Error & e) {
-            e.addTrace({}, "while reading key 'drvs'");
-            throw;
-        }
-    } catch (Error & e) {
-        e.addTrace({}, "while reading key 'inputs'");
-        throw;
-    }
-
-    return res;
+                return outputs;
+            }(),
+        .inputs =
+            [&] {
+                try {
+                    return inputsFromJson<Inputs>(valueAt(json, "inputs"), xpSettings);
+                } catch (Error & e) {
+                    e.addTrace({}, "while reading key 'inputs'");
+                    throw;
+                }
+            }(),
+        .platform = getString(valueAt(json, "system")),
+        .builder = getString(valueAt(json, "builder")),
+        .args = getStringList(valueAt(json, "args")),
+        .env =
+            [&] {
+                try {
+                    return getStringMap(valueAt(json, "env"));
+                } catch (Error & e) {
+                    e.addTrace({}, "while reading key 'env'");
+                    throw;
+                }
+            }(),
+        .structuredAttrs = [&]() -> std::optional<StructuredAttrs> {
+            if (auto structuredAttrs = get(json, "structuredAttrs"))
+                return StructuredAttrs{*structuredAttrs};
+            return std::nullopt;
+        }(),
+        .name = getString(valueAt(json, "name")),
+    };
 }
+
+template struct adl_serializer<nix::BasicDerivation>;
+template struct adl_serializer<nix::Derivation>;
 
 } // namespace nlohmann

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -279,7 +279,7 @@ bool Settings::isWSL1()
 #endif
 }
 
-const ExternalBuilder * LocalSettings::findExternalDerivationBuilderIfSupported(const Derivation & drv)
+const ExternalBuilder * LocalSettings::findExternalDerivationBuilderIfSupported(const BasicDerivation & drv)
 {
     if (auto it = std::ranges::find_if(
             externalBuilders.get(), [&](const auto & handler) { return handler.systems.contains(drv.platform); });

--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
@@ -34,20 +34,11 @@ struct DerivationBuildingGoal : public Goal
     friend class Worker;
 
     /**
-     * @param storeDerivation Whether to store the derivation in
-     * `worker.store`. This is useful for newly-resolved derivations. In this
-     * case, the derivation was not created a priori, e.g. purely (or close
-     * enough) from evaluation of the Nix language, but also depends on the
-     * exact content produced by upstream builds. It is strongly advised to
-     * have a permanent record of such a resolved derivation in order to
-     * faithfully reconstruct the build history.
+     * @param drv The derivation to build, with the outputs of its input
+     * derivations already added to its input sources.
      */
     DerivationBuildingGoal(
-        const StorePath & drvPath,
-        ref<const Derivation> drv,
-        Worker & worker,
-        BuildMode buildMode,
-        bool storeDerivation);
+        const StorePath & drvPath, ref<const BasicDerivation> drv, Worker & worker, BuildMode buildMode);
     ~DerivationBuildingGoal();
 
 private:
@@ -56,9 +47,9 @@ private:
     const StorePath drvPath;
 
     /**
-     * The derivation stored at drvPath.
+     * The derivation to build.
      */
-    const ref<const Derivation> drv;
+    const ref<const BasicDerivation> drv;
 
     /**
      * The remainder is state held during the build.
@@ -79,7 +70,7 @@ private:
     /**
      * The states.
      */
-    Co gaveUpOnSubstitution(bool storeDerivation);
+    Co gaveUpOnSubstitution();
     Co tryToBuild(StorePathSet inputPaths);
     Co buildWithHook(
         StorePathSet inputPaths,

--- a/src/libstore/include/nix/store/build/derivation-building-misc.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-misc.hh
@@ -9,7 +9,11 @@
 namespace nix {
 
 class Store;
-struct Derivation;
+
+template<typename Inputs>
+struct DerivationT;
+struct FullInputs;
+using Derivation = DerivationT<FullInputs>;
 
 /**
  * Unless we are repairing, we don't both to test validity and just assume it,
@@ -51,6 +55,7 @@ struct InitialOutput
 /**
  * Format the known outputs of a derivation for use in error messages.
  */
-std::string showKnownOutputs(const StoreDirConfig & store, const Derivation & drv);
+template<typename InputsType>
+std::string showKnownOutputs(const StoreDirConfig & store, const DerivationT<InputsType> & drv);
 
 } // namespace nix

--- a/src/libstore/include/nix/store/build/derivation-env-desugar.hh
+++ b/src/libstore/include/nix/store/build/derivation-env-desugar.hh
@@ -7,7 +7,13 @@
 namespace nix {
 
 class Store;
-struct Derivation;
+
+template<typename Inputs>
+struct DerivationT;
+struct FullInputs;
+using Derivation = DerivationT<FullInputs>;
+using BasicDerivation = DerivationT<StorePathSet>;
+
 template<typename Input>
 struct DerivationOptions;
 
@@ -79,7 +85,7 @@ struct DesugaredEnv
      */
     static DesugaredEnv create(
         Store & store,
-        const Derivation & drv,
+        const BasicDerivation & drv,
         const DerivationOptions<StorePath> & drvOptions,
         const StorePathSet & inputPaths);
 };

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -306,8 +306,8 @@ public:
     /**
      * @ref DerivationBuildingGoal "derivation building goal"
      */
-    std::shared_ptr<DerivationBuildingGoal> makeDerivationBuildingGoal(
-        const StorePath & drvPath, ref<const Derivation> drv, BuildMode buildMode, bool storeDerivation);
+    std::shared_ptr<DerivationBuildingGoal>
+    makeDerivationBuildingGoal(const StorePath & drvPath, ref<const BasicDerivation> drv, BuildMode buildMode);
 
     /**
      * @ref PathSubstitutionGoal "substitution goal"

--- a/src/libstore/include/nix/store/derivation-options.hh
+++ b/src/libstore/include/nix/store/derivation-options.hh
@@ -13,8 +13,15 @@
 
 namespace nix {
 
+class Store;
+
 struct StoreDirConfig;
-struct BasicDerivation;
+
+template<typename Inputs>
+struct DerivationT;
+struct FullInputs;
+using BasicDerivation = DerivationT<StorePathSet>;
+
 struct StructuredAttrs;
 
 template<typename V>
@@ -180,14 +187,16 @@ struct DerivationOptions
      * the future we'll flip things around so a `BasicDerivation` has
      * `DerivationOptions` instead.
      */
-    StringSet getRequiredSystemFeatures(const BasicDerivation & drv) const;
+    template<typename Inputs>
+    StringSet getRequiredSystemFeatures(const DerivationT<Inputs> & drv) const;
 
     bool substitutesAllowed(const WorkerSettings & workerSettings) const;
 
     /**
      * @param drv See note on `getRequiredSystemFeatures`
      */
-    bool useUidRange(const BasicDerivation & drv) const;
+    template<typename Inputs>
+    bool useUidRange(const DerivationT<Inputs> & drv) const;
 };
 
 extern template struct DerivationOptions<StorePath>;

--- a/src/libstore/include/nix/store/derivations.hh
+++ b/src/libstore/include/nix/store/derivations.hh
@@ -152,6 +152,23 @@ typedef std::map<std::string, std::pair<DerivationOutput, std::optional<StorePat
  */
 typedef std::map<StorePath, StringSet> DerivationInputs;
 
+/**
+ * Inputs for full Derivation - both source and derivation inputs
+ */
+struct FullInputs
+{
+    /**
+     * inputs that are sources
+     */
+    StorePathSet srcs;
+    /**
+     * inputs that are sub-derivations
+     */
+    DerivedPathMap<std::set<OutputName, std::less<>>> drvs;
+
+    bool operator==(const FullInputs &) const = default;
+};
+
 struct DerivationType
 {
     /**
@@ -263,16 +280,20 @@ struct DerivationType
     bool hasKnownOutputPaths() const;
 };
 
-struct BasicDerivation
+template<typename Inputs>
+struct DerivationT;
+
+using BasicDerivation = DerivationT<StorePathSet>;
+using Derivation = DerivationT<FullInputs>;
+
+template<typename Inputs>
+struct DerivationT
 {
     /**
      * keyed on symbolic IDs
      */
     DerivationOutputs outputs;
-    /**
-     * inputs that are sources
-     */
-    StorePathSet inputSrcs;
+    Inputs inputs;
     std::string platform;
     /**
      * Probably should be an absolute path in the path format that `platform` uses
@@ -287,12 +308,7 @@ struct BasicDerivation
 
     std::string name;
 
-    BasicDerivation() = default;
-    BasicDerivation(BasicDerivation &&) = default;
-    BasicDerivation(const BasicDerivation &) = default;
-    BasicDerivation & operator=(BasicDerivation &&) = default;
-    BasicDerivation & operator=(const BasicDerivation &) = default;
-    virtual ~BasicDerivation();
+    bool operator==(const DerivationT &) const = default;
 
     bool isBuiltin() const;
 
@@ -321,27 +337,14 @@ struct BasicDerivation
      */
     void applyRewrites(const StringMap & rewrites);
 
-    bool operator==(const BasicDerivation &) const = default;
-    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
-    // auto operator <=> (const BasicDerivation &) const = default;
-};
-
-class Store;
-
-struct Derivation : BasicDerivation
-{
     /**
-     * inputs that are sub-derivations
-     */
-    DerivedPathMap<std::set<OutputName, std::less<>>> inputDrvs;
-
-    /**
-     * Print a derivation.
+     * Print a derivation (only meaningful for full Derivation).
      */
     std::string unparse(
         const StoreDirConfig & store,
         bool maskOutputs,
-        DerivedPathMap<StringSet>::ChildNode::Map * actualInputs = nullptr) const;
+        DerivedPathMap<StringSet>::ChildNode::Map * actualInputs = nullptr) const
+        requires std::is_same_v<Inputs, FullInputs>;
 
     /**
      * Determine whether this derivation should be resolved before building.
@@ -354,7 +357,8 @@ struct Derivation : BasicDerivation
      * - Impure derivations always need resolution
      * - Any input derivations have outputs from dynamic derivations
      */
-    bool shouldResolve() const;
+    bool shouldResolve() const
+        requires std::is_same_v<Inputs, FullInputs>;
 
     /**
      * Return the underlying basic derivation but with these changes:
@@ -365,7 +369,8 @@ struct Derivation : BasicDerivation
      * 2. Input placeholders are replaced with realized input store
      *    paths.
      */
-    std::optional<BasicDerivation> tryResolve(Store & store, Store * evalStore = nullptr) const;
+    std::optional<BasicDerivation> tryResolve(Store & store, Store * evalStore = nullptr) const
+        requires std::is_same_v<Inputs, FullInputs>;
 
     /**
      * Like the above, but instead of querying the Nix database for
@@ -375,7 +380,34 @@ struct Derivation : BasicDerivation
     std::optional<BasicDerivation> tryResolve(
         Store & store,
         fun<std::optional<StorePath>(ref<const SingleDerivedPath> drvPath, const std::string & outputName)>
-            queryResolutionChain) const;
+            queryResolutionChain) const
+        requires std::is_same_v<Inputs, FullInputs>;
+
+    /**
+     * Convert a BasicDerivation to a full Derivation.
+     * The resulting Derivation has empty inputDrvs since BasicDerivation
+     * is already resolved.
+     */
+    Derivation unresolve() const
+        requires std::is_same_v<Inputs, StorePathSet>;
+
+    /**
+     * Return a derivation identical to this one, but with the inputs transformed by `f`.
+     */
+    template<typename F>
+    DerivationT<std::invoke_result_t<F, const Inputs &>> mapInputs(F f) const
+    {
+        return {
+            .outputs = outputs,
+            .inputs = f(inputs),
+            .platform = platform,
+            .builder = builder,
+            .args = args,
+            .env = env,
+            .structuredAttrs = structuredAttrs,
+            .name = name,
+        };
+    }
 
     /**
      * Check that the derivation is valid and does not present any
@@ -424,24 +456,8 @@ struct Derivation : BasicDerivation
      * @param store The store to use for path computation
      * @param drvName The derivation name (without .drv extension)
      */
-    void fillInOutputPaths(Store & store);
-
-    Derivation() = default;
-    Derivation(Derivation &&) = default;
-    Derivation(const Derivation &) = default;
-    Derivation & operator=(Derivation &&) = default;
-    Derivation & operator=(const Derivation &) = default;
-    ~Derivation() override;
-
-    Derivation(const BasicDerivation & bd)
-        : BasicDerivation(bd)
-    {
-    }
-
-    Derivation(BasicDerivation && bd)
-        : BasicDerivation(std::move(bd))
-    {
-    }
+    void fillInOutputPaths(Store & store)
+        requires std::is_same_v<Inputs, FullInputs>;
 
     /**
      * Parse a derivation from JSON, and also perform various
@@ -464,14 +480,34 @@ struct Derivation : BasicDerivation
      * @return A validated derivation with output paths filled in
      * @throws Error if parsing fails, output paths can't be computed, or validation fails
      */
-    static Derivation parseJsonAndValidate(Store & store, const nlohmann::json & json);
-
-    bool operator==(const Derivation &) const = default;
-    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
-    // auto operator <=> (const Derivation &) const = default;
+    static Derivation parseJsonAndValidate(Store & store, const nlohmann::json & json)
+        requires std::is_same_v<Inputs, FullInputs>;
 };
 
 class Store;
+
+template<>
+std::string DerivationT<FullInputs>::unparse(
+    const StoreDirConfig & store, bool maskOutputs, DerivedPathMap<StringSet>::ChildNode::Map * actualInputs) const;
+template<>
+bool DerivationT<FullInputs>::shouldResolve() const;
+template<>
+std::optional<BasicDerivation> DerivationT<FullInputs>::tryResolve(Store & store, Store * evalStore) const;
+template<>
+std::optional<BasicDerivation> DerivationT<FullInputs>::tryResolve(
+    Store & store,
+    fun<std::optional<StorePath>(ref<const SingleDerivedPath> drvPath, const std::string & outputName)>
+        queryResolutionChain) const;
+template<>
+void DerivationT<FullInputs>::fillInOutputPaths(Store & store);
+template<>
+Derivation DerivationT<FullInputs>::parseJsonAndValidate(Store & store, const nlohmann::json & json);
+template<>
+Derivation DerivationT<StorePathSet>::unresolve() const;
+template<>
+void DerivationT<StorePathSet>::checkInvariants(Store & store) const;
+template<>
+void DerivationT<FullInputs>::checkInvariants(Store & store) const;
 
 /**
  * Compute the store path that would be used for a derivation without writing it.
@@ -625,5 +661,8 @@ constexpr unsigned expectedJsonVersionDerivation = 4;
 } // namespace nix
 
 JSON_IMPL_WITH_XP_FEATURES(nix::DerivationOutput)
-JSON_IMPL_WITH_XP_FEATURES(nix::BasicDerivation)
-JSON_IMPL_WITH_XP_FEATURES(nix::Derivation)
+
+namespace nlohmann {
+template<typename Inputs>
+JSON_IMPL_WITH_XP_FEATURES_INNER(nix::DerivationT<Inputs>);
+} // namespace nlohmann

--- a/src/libstore/include/nix/store/downstream-placeholder.hh
+++ b/src/libstore/include/nix/store/downstream-placeholder.hh
@@ -37,7 +37,7 @@ using DrvRef = std::variant<OutputName, Input>;
  * We use them with `Derivation`: the `render()` method is called to
  * render an opaque string which can be used in the derivation, and the
  * resolving logic can substitute those strings for store paths when
- * resolving `Derivation.inputDrvs` to `BasicDerivation.inputSrcs`.
+ * resolving `Derivation.inputs.drvs` to `BasicDerivation.inputs.srcs`.
  */
 class DownstreamPlaceholder
 {

--- a/src/libstore/include/nix/store/local-settings.hh
+++ b/src/libstore/include/nix/store/local-settings.hh
@@ -736,7 +736,7 @@ public:
      * Finds the first external derivation builder that supports this
      * derivation, or else returns a null pointer.
      */
-    const ExternalBuilder * findExternalDerivationBuilderIfSupported(const Derivation & drv);
+    const ExternalBuilder * findExternalDerivationBuilderIfSupported(const BasicDerivation & drv);
 };
 
 template<>

--- a/src/libstore/include/nix/store/outputs-query.hh
+++ b/src/libstore/include/nix/store/outputs-query.hh
@@ -19,7 +19,7 @@ using QueryRealisationFun = std::function<std::shared_ptr<const UnkeyedRealisati
 void queryPartialDerivationOutputMapCA(
     Store & store,
     const StorePath & drvPath,
-    const BasicDerivation & drv,
+    const Derivation & drv,
     std::map<std::string, std::optional<StorePath>> & outputs,
     QueryRealisationFun queryRealisation = {});
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -36,8 +36,11 @@ struct Realisation;
 struct RealisedPath;
 struct DrvOutput;
 
-struct BasicDerivation;
-struct Derivation;
+template<typename Inputs>
+struct DerivationT;
+struct FullInputs;
+using BasicDerivation = DerivationT<StorePathSet>;
+using Derivation = DerivationT<FullInputs>;
 
 struct SourceAccessor;
 struct NarInfoDiskCache;
@@ -1107,7 +1110,7 @@ OutputPathMap resolveDerivedPath(Store &, const DerivedPath::Built &, Store * ev
 std::optional<ValidPathInfo>
 decodeValidPathInfo(const Store & store, std::istream & str, std::optional<HashResult> hashGiven = std::nullopt);
 
-const ContentAddress * getDerivationCA(const BasicDerivation & drv);
+const ContentAddress * getDerivationCA(const Derivation & drv);
 
 template<>
 struct json_avoids_null<TrustedFlag> : std::true_type

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -75,7 +75,7 @@ void Store::computeFSClosure(
     computeFSClosure(paths, paths_, flipDirection, includeOutputs, includeDerivers);
 }
 
-const ContentAddress * getDerivationCA(const BasicDerivation & drv)
+const ContentAddress * getDerivationCA(const Derivation & drv)
 {
     auto out = drv.outputs.find("out");
     if (out == drv.outputs.end())
@@ -184,7 +184,7 @@ MissingPaths Store::queryMissing(const std::vector<DerivedPath> & targets)
 
     auto mustBuildDrv = [&](const StorePath & drvPath, const Derivation & drv, std::set<DerivedPath> & edges) {
         res.willBuild.insert(drvPath);
-        for (const auto & [inputDrv, inputNode] : drv.inputDrvs.map)
+        for (const auto & [inputDrv, inputNode] : drv.inputs.drvs.map)
             collectDerivedPaths(edges, makeConstantStorePathRef(inputDrv), inputNode);
     };
 
@@ -231,7 +231,7 @@ MissingPaths Store::queryMissing(const std::vector<DerivedPath> & targets)
                         // FIXME: this is a lot of work just to get the value
                         // of `allowSubstitutes`.
                         drvOptions = derivationOptionsFromStructuredAttrs(
-                            *this, drv->inputDrvs, drv->env, get(drv->structuredAttrs));
+                            *this, drv->inputs.drvs, drv->env, get(drv->structuredAttrs));
                     } catch (Error & e) {
                         e.addTrace({}, "while parsing derivation '%s'", printStorePath(drvPath));
                         throw;

--- a/src/libstore/outputs-query.cc
+++ b/src/libstore/outputs-query.cc
@@ -105,7 +105,7 @@ static std::pair<Derivation, StorePath> resolveDerivation(
                     store, *concreteDrvPath, depOutputName, evalStore_, queryRealisation, cache, resCache);
             });
         if (resolvedDrv)
-            drv = Derivation{*resolvedDrv};
+            drv = resolvedDrv->unresolve();
     }
 
     auto resolvedDrvPath = computeStorePath(store, drv);
@@ -117,7 +117,7 @@ static std::pair<Derivation, StorePath> resolveDerivation(
 void queryPartialDerivationOutputMapCA(
     Store & store,
     const StorePath & drvPath,
-    const BasicDerivation & drv,
+    const Derivation & drv,
     std::map<std::string, std::optional<StorePath>> & outputs,
     QueryRealisationFun queryRealisation,
     RealisationCache & resCache)
@@ -185,7 +185,7 @@ static std::optional<StorePath> deepQueryPartialDerivationOutputImpl(
 void queryPartialDerivationOutputMapCA(
     Store & store,
     const StorePath & drvPath,
-    const BasicDerivation & drv,
+    const Derivation & drv,
     std::map<std::string, std::optional<StorePath>> & outputs,
     QueryRealisationFun queryRealisation)
 {

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1230,7 +1230,7 @@ std::optional<StorePath> Store::getBuildDerivationPath(const StorePath & path)
         // resolved derivation, so we need to get it first
         auto resolvedDrv = drv.tryResolve(*this);
         if (resolvedDrv)
-            return nix::computeStorePath(*this, Derivation{*resolvedDrv});
+            return nix::computeStorePath(*this, resolvedDrv->unresolve());
     }
 
     return path;

--- a/src/libutil/include/nix/util/json-impls.hh
+++ b/src/libutil/include/nix/util/json-impls.hh
@@ -31,14 +31,17 @@
     JSON_IMPL_INNER(TYPE); \
     }
 
-#define JSON_IMPL_WITH_XP_FEATURES(TYPE)                                                             \
-    namespace nlohmann {                                                                             \
-    template<>                                                                                       \
+#define JSON_IMPL_WITH_XP_FEATURES_INNER(TYPE)                                                       \
     struct adl_serializer<TYPE>                                                                      \
     {                                                                                                \
         static TYPE from_json(                                                                       \
             const json & json,                                                                       \
             const nix::ExperimentalFeatureSettings & xpSettings = nix::experimentalFeatureSettings); \
         static void to_json(json & json, const TYPE & t);                                            \
-    };                                                                                               \
+    }
+
+#define JSON_IMPL_WITH_XP_FEATURES(TYPE)    \
+    namespace nlohmann {                    \
+    template<>                              \
+    JSON_IMPL_WITH_XP_FEATURES_INNER(TYPE); \
     }

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -328,18 +328,26 @@ static int main_build_remote(int argc, char ** argv)
         // This condition mirrors that: that code enforces the "rules" outlined there;
         // we do the best we can given those "rules".
         if (trustedOrLegacy || drv.type().isCA()) {
-            // Hijack the inputs paths of the derivation to include all
-            // the paths that come from the `inputDrvs` set. We don’t do
-            // that for the derivations whose `inputDrvs` is empty
-            // because:
-            //
-            // 1. It’s not needed
-            //
-            // 2. Changing the `inputSrcs` set changes the associated
-            //    output ids, which break CA derivations
-            if (!drv.inputDrvs.map.empty())
-                drv.inputSrcs = store->parseStorePathSet(inputs);
-            optResult = sshStore->getBuilder()->buildDerivation(*drvPath, static_cast<const BasicDerivation &>(drv));
+            BasicDerivation resolvedDrv{
+                .outputs = drv.outputs,
+                // Hijack the inputs paths of the derivation to include
+                // all the paths that come from the `inputDrvs` set. We
+                // don’t do that for the derivations whose `inputDrvs`
+                // is empty because:
+                //
+                // 1. It’s not needed
+                //
+                // 2. Changing the `inputSrcs` set changes the
+                //    associated output ids, which break CA derivations
+                .inputs = drv.inputs.drvs.map.empty() ? drv.inputs.srcs : store->parseStorePathSet(inputs),
+                .platform = drv.platform,
+                .builder = drv.builder,
+                .args = drv.args,
+                .env = drv.env,
+                .structuredAttrs = drv.structuredAttrs,
+                .name = drv.name,
+            };
+            optResult = sshStore->getBuilder()->buildDerivation(*drvPath, resolvedDrv);
             auto & result = *optResult;
             if (auto * failureP = result.tryGetFailure()) {
                 if (settings.keepFailed) {

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -268,7 +268,7 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
        'buildDerivation', but that's privileged. */
     drv.name += "-env";
     drv.env.emplace("name", drv.name);
-    drv.inputSrcs.insert(std::move(getEnvShPath));
+    drv.inputs.srcs.insert(std::move(getEnvShPath));
     for (auto & [outputName, output] : drv.outputs) {
         std::visit(
             overloaded{

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -511,7 +511,7 @@ static void main_nix_build(int argc, char ** argv)
         };
 
         // Build or fetch all dependencies of the derivation.
-        for (const auto & [inputDrv0, inputNode] : drv.inputDrvs.map) {
+        for (const auto & [inputDrv0, inputNode] : drv.inputs.drvs.map) {
             // To get around lambda capturing restrictions in the
             // standard.
             const auto & inputDrv = inputDrv0;
@@ -522,7 +522,7 @@ static void main_nix_build(int argc, char ** argv)
                 pathsToCopy.insert(inputDrv);
             }
         }
-        for (const auto & src : drv.inputSrcs) {
+        for (const auto & src : drv.inputs.srcs) {
             pathsToBuild.emplace_back(DerivedPath::Opaque{src});
             pathsToCopy.insert(src);
         }
@@ -545,7 +545,7 @@ static void main_nix_build(int argc, char ** argv)
             auto resolvedDrv = drv.tryResolve(*store);
             if (!resolvedDrv)
                 throw Error("failed to resolve derivation '%s'", store->printStorePath(packageInfo.requireDrvPath()));
-            drv = *resolvedDrv;
+            drv = resolvedDrv->unresolve();
         }
 
         // Set the environment.
@@ -611,7 +611,7 @@ static void main_nix_build(int argc, char ** argv)
                     }
                 };
 
-            for (const auto & [inputDrv, inputNode] : drv.inputDrvs.map)
+            for (const auto & [inputDrv, inputNode] : drv.inputs.drvs.map)
                 accumInputClosure(inputDrv, inputNode);
 
             auto json = drv.structuredAttrs->prepareStructuredAttrs(*store, drvOptions, inputs, drv.outputs);


### PR DESCRIPTION
Working with templates adds some overhead, but parameterizing the inputs
is an important prerequisite for storing the options inside the derivation.
Subsequent commits can clean this up significantly.