### PR TITLE
libfetchers/git: Add -N flag to suggested git command for untracked files

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -786,7 +786,7 @@ struct GitInputScheme : InputScheme
                     "\n"
                     "To make it visible to Nix, run:\n"
                     "\n"
-                    "git -C %2% add \"%1%\"",
+                    "git -C %2% add -N \"%1%\"",
                     path.rel(),
                     PathFmt(repoPath));
             else


### PR DESCRIPTION
## Motivation

`-N` aka `--intent-to-add`, makes a file visible in git without staging the changes from the file. This improves user experience by interfering less with the workflow of staging changes, while having functionally no impact on Nix side.

The full error message after the changes:

```
error: Path 'flake.nix' in the repository "/path/to/my/project" is not tracked by Git.

       To make it visible to Nix, run:

       git -C "/path/to/my/project" add -N "flake.nix"
```


## Context

It seems that suggesting `git add -N <file>` is what we should have done from the beginning, but nobody caught this in the previous PR (#12870).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
