### PR TITLE
Drop old hacks for unachhored vtables and exception handling

### DIFF
--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -139,8 +139,6 @@ let
             !(stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isCygwin)
             # build failure
             && !stdenv.hostPlatform.isStatic
-            # LTO breaks exception handling on x86-64-darwin.
-            && stdenv.system != "x86_64-darwin"
           )
           ''
             case "$mesonBuildType" in

--- a/src/libexpr-tests/derived-path.cc
+++ b/src/libexpr-tests/derived-path.cc
@@ -18,8 +18,6 @@ class DerivedPathExpressionTest : public LibExprTest
 // See https://github.com/emil-e/rapidcheck/blob/master/doc/gtest.md#rc_gtest_fixture_propfixture-name-args
 TEST_F(DerivedPathExpressionTest, force_init) {}
 
-#ifndef COVERAGE
-
 RC_GTEST_FIXTURE_PROP(DerivedPathExpressionTest, prop_opaque_path_round_trip, (const SingleDerivedPath::Opaque & o))
 {
     auto * v = state.allocValue();
@@ -60,7 +58,5 @@ RC_GTEST_FIXTURE_PROP(
     auto [d, _] = state.coerceToSingleDerivedPathUnchecked(noPos, *v, "", mockXpSettings);
     RC_ASSERT(SingleDerivedPath{b} == d);
 }
-
-#endif
 
 } /* namespace nix */

--- a/src/libexpr-tests/value/context.cc
+++ b/src/libexpr-tests/value/context.cc
@@ -120,15 +120,11 @@ TEST(NixStringContextElemTest, built_built_xp)
         NixStringContextElem::parse("!foo!bar!g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-x.drv"), MissingExperimentalFeature);
 }
 
-#ifndef COVERAGE
-
 RC_GTEST_PROP(NixStringContextElemTest, prop_round_rip, (const NixStringContextElem & o))
 {
     ExperimentalFeatureSettings xpSettings;
     xpSettings.set("experimental-features", "dynamic-derivations");
     RC_ASSERT(o == NixStringContextElem::parse(o.to_string(), xpSettings));
 }
-
-#endif
 
 } // namespace nix

--- a/src/libstore-tests/derived-path.cc
+++ b/src/libstore-tests/derived-path.cc
@@ -92,8 +92,6 @@ TEST_F(DerivedPathTest, built_built_xp)
         MissingExperimentalFeature);
 }
 
-#ifndef COVERAGE
-
 /* TODO: Disabled due to the following error:
 
        path '00000000000000000000000000000000-0^0' is not a valid store path:
@@ -112,8 +110,6 @@ RC_GTEST_FIXTURE_PROP(DerivedPathTest, prop_round_rip, (const DerivedPath & o))
     xpSettings.set("experimental-features", "dynamic-derivations");
     RC_ASSERT(o == DerivedPath::parse(*store, o.to_string(*store), xpSettings));
 }
-
-#endif
 
 /* ----------------------------------------------------------------------------
  * JSON

--- a/src/libstore-tests/outputs-spec.cc
+++ b/src/libstore-tests/outputs-spec.cc
@@ -268,13 +268,9 @@ INSTANTIATE_TEST_SUITE_P(
 
 #undef TEST_JSON
 
-#ifndef COVERAGE
-
 RC_GTEST_PROP(OutputsSpec, prop_round_rip, (const OutputsSpec & o))
 {
     RC_ASSERT(o == OutputsSpec::parse(o.to_string()));
 }
-
-#endif
 
 } // namespace nix

--- a/src/libstore-tests/path.cc
+++ b/src/libstore-tests/path.cc
@@ -86,8 +86,6 @@ TEST_DO_PARSE(triple_dot, "...")
 
 #undef TEST_DO_PARSE
 
-#ifndef COVERAGE
-
 RC_GTEST_FIXTURE_PROP(StorePathTest, prop_regex_accept, (const StorePath & p))
 {
     RC_ASSERT(std::regex_match(std::string{p.name()}, nameRegex));
@@ -140,8 +138,6 @@ RC_GTEST_FIXTURE_PROP(StorePathTest, prop_check_regex_eq_parse, ())
     }
     RC_ASSERT(parsed == std::regex_match(std::string{name}, nameRegex));
 }
-
-#endif
 
 /* ----------------------------------------------------------------------------
  * JSON

--- a/src/libutil-tests/args.cc
+++ b/src/libutil-tests/args.cc
@@ -105,8 +105,6 @@ TEST(parseShebangContent, increasingQuotes)
     ASSERT_EQ(*i++, "```");
 }
 
-#ifndef COVERAGE
-
 // quick and dirty
 static inline std::string escape(std::string_view s_)
 {
@@ -163,7 +161,5 @@ RC_GTEST_PROP(parseShebangContent, prop_round_trip_two, (const std::string & one
     RC_ASSERT(*i++ == one);
     RC_ASSERT(*i++ == two);
 }
-
-#endif
 
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

These issues have been caused by unanchored vtables all along, which has now been fixed at the root of the problem (requiring Werror=weak-vtables) and anchoring everything.

Tested on x86_64-darwin build.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
