### PR TITLE
flake archive: copy relative path inputs from the locked node graph

### DIFF
--- a/doc/manual/rl-next/flake-archive-relative-paths.md
+++ b/doc/manual/rl-next/flake-archive-relative-paths.md
@@ -1,0 +1,13 @@
+---
+synopsis: "`nix flake archive` now archives relative `path:` inputs"
+issues: [12438]
+---
+
+`nix flake archive` previously skipped flake inputs that use a relative path
+(e.g. `inputs.x.url = "path:./x"`), so they were neither copied to the store
+nor reported in the `--json` output. Such inputs are not independently
+fetchable, so the command now copies them from the already-resolved source
+trees of the locked flake's node graph — the same data `callFlake` consumes —
+instead of re-resolving the relative flakeref. Relative inputs (including
+transitively nested ones) now get a store path and are copied to the
+destination store.

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1100,25 +1100,65 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun, MixNoCheckSigs
 
         sources.insert(storePath);
 
+        /* The source tree (flake directory) of the root flake. Relative
+           'path:' inputs are resolved against the source path of their parent
+           flake; lockFlake() records the root's source path in 'nodePaths'. */
+        auto rootSourcePath = flake.nodePaths.at(flake.lockFile.root);
+
         // FIXME: use graph output, handle cycles.
-        auto traverse = [&store, json = json, &sources, &getStorePath](
-                            this const auto & self, const flake::Node & node) -> nlohmann::json {
+        auto traverse = [this, &store, json = json, &sources, &getStorePath](
+                            this const auto & self,
+                            const flake::Node & node,
+                            const SourcePath & nodeSourcePath) -> nlohmann::json {
             nlohmann::json jsonObj2 = json ? nlohmann::json::object() : nlohmann::json(nullptr);
             for (auto & [inputName, input] : node.inputs) {
                 if (auto inputNode = std::get_if<0>(&input)) {
                     std::optional<StorePath> storePath;
                     const auto & lockedRef = (*inputNode)->lockedRef;
-                    if (!lockedRef.input.isRelative()) {
+                    /* The source tree of this input, used to resolve any
+                       relative inputs that it has in turn. */
+                    SourcePath inputSourcePath = nodeSourcePath;
+                    if (auto relativePath = lockedRef.input.isRelative()) {
+                        /* A relative 'path:' input is not independently
+                           fetchable: it only has meaning relative to its
+                           parent flake's source tree. Resolve it against the
+                           parent's source path (exactly as lockFlake() and
+                           callFlake() do) and copy that subtree to the store,
+                           instead of re-fetching the relative flakeref, which
+                           would trip the relative-path guard. See #12438. */
+                        inputSourcePath = SourcePath{
+                            nodeSourcePath.accessor, CanonPath(relativePath->string(), nodeSourcePath.path)};
+                        storePath = fetchToStore(
+                            fetchSettings,
+                            *store,
+                            inputSourcePath,
+                            dryRun ? FetchMode::DryRun : FetchMode::Copy,
+                            lockedRef.input.getName());
+                    } else {
                         storePath = getStorePath(lockedRef);
-                        sources.insert(*storePath);
+                        /* If this fetched input itself has relative inputs,
+                           resolve its source tree so they can be resolved
+                           against it in turn. Done lazily to avoid fetching
+                           (e.g. in --dry-run) inputs we don't need to. */
+                        auto hasRelativeInputs = [&] {
+                            for (auto & [_, childEdge] : (*inputNode)->inputs)
+                                if (auto childNode = std::get_if<0>(&childEdge))
+                                    if ((*childNode)->lockedRef.input.isRelative())
+                                        return true;
+                            return false;
+                        };
+                        if (hasRelativeInputs())
+                            inputSourcePath = SourcePath{
+                                lockedRef.input.getAccessor(fetchSettings, *store).first,
+                                lockedRef.subdir.empty() ? CanonPath::root : CanonPath(lockedRef.subdir)};
                     }
+                    sources.insert(*storePath);
                     if (json) {
                         auto & jsonObj3 = jsonObj2[inputName];
-                        if (storePath)
-                            jsonObj3["path"] = store->printStorePath(*storePath);
-                        jsonObj3["inputs"] = self(**inputNode);
+                        jsonObj3["path"] = store->printStorePath(*storePath);
+                        jsonObj3["inputs"] = self(**inputNode, inputSourcePath);
                     } else
-                        self(**inputNode);
+                        self(**inputNode, inputSourcePath);
                 }
             }
             return jsonObj2;
@@ -1127,11 +1167,11 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun, MixNoCheckSigs
         if (json) {
             nlohmann::json jsonRoot = {
                 {"path", store->printStorePath(storePath)},
-                {"inputs", traverse(*flake.lockFile.root)},
+                {"inputs", traverse(*flake.lockFile.root, rootSourcePath)},
             };
             printJSON(jsonRoot);
         } else {
-            traverse(*flake.lockFile.root);
+            traverse(*flake.lockFile.root, rootSourcePath);
         }
 
         if (!dryRun && dstUri) {

--- a/tests/functional/flakes/relative-paths.sh
+++ b/tests/functional/flakes/relative-paths.sh
@@ -86,10 +86,53 @@ json=$(nix flake archive --json "$rootFlake" --to "$TEST_ROOT/store2")
 [[ $(echo "$json" | jq .inputs.sub0.inputs) = {} ]]
 [[ -n $(echo "$json" | jq .path) ]]
 
+# The relative 'path:' input must be archived too (issue #12438): it gets a
+# store path and is actually copied to the destination store. No '?narHash='
+# workaround is involved.
+sub0Path=$(echo "$json" | jq -r .inputs.sub0.path)
+[[ -n "$sub0Path" && "$sub0Path" != null ]]
+[ -e "$TEST_ROOT/store2/nix/store/$(basename "$sub0Path")" ]
+echo "$json" | grepQuietInverse narHash
+
 nix flake prefetch --out-link "$TEST_ROOT/result" "$rootFlake"
 outPath=$(readlink "$TEST_ROOT/result")
 
 [ -e "$TEST_ROOT/store2/nix/store/$(basename "$outPath")" ]
+
+# Test `nix flake archive` with three levels of relative path nesting
+# (a -> b -> c, where c is a relative input of b). This is the multi-level
+# variant of the lost-parent-context bug; see issue #14762.
+archiveNest="$TEST_ROOT/archive-nested"
+rm -rf "$archiveNest"
+mkdir -p "$archiveNest/b/c"
+cat > "$archiveNest/flake.nix" <<EOF
+{
+  inputs.b.url = "path:./b";
+  outputs = _: { };
+}
+EOF
+cat > "$archiveNest/b/flake.nix" <<EOF
+{
+  inputs.c.url = "path:./c";
+  outputs = _: { };
+}
+EOF
+cat > "$archiveNest/b/c/flake.nix" <<EOF
+{ outputs = _: { }; }
+EOF
+initGitRepo "$archiveNest"
+git -C "$archiveNest" add .
+git -C "$archiveNest" commit -m "Initial commit"
+
+rm -rf "$TEST_ROOT/store3"
+json=$(nix flake archive --json "$archiveNest" --to "$TEST_ROOT/store3")
+bPath=$(echo "$json" | jq -r .inputs.b.path)
+cPath=$(echo "$json" | jq -r .inputs.b.inputs.c.path)
+[[ -n "$bPath" && "$bPath" != null ]]
+[[ -n "$cPath" && "$cPath" != null ]]
+[ -e "$TEST_ROOT/store3/nix/store/$(basename "$bPath")" ]
+[ -e "$TEST_ROOT/store3/nix/store/$(basename "$cPath")" ]
+echo "$json" | grepQuietInverse narHash
 
 # Test circular relative path flakes. FIXME: doesn't work at the moment.
 if false; then


### PR DESCRIPTION
## Motivation

`nix flake archive` (and `nix flake archive --json`) does not properly archive flake inputs that use a relative path, e.g. `inputs.x.url = "path:./x"`. Such inputs are silently skipped: they are neither copied to the (destination) store nor given a `path` in the `--json` output, so the archive is incomplete.

This is the unresolved part of #12438. The earlier fix for that issue (b4dfeafed, "nix flake archive: Skip relative path inputs") stopped the hard error `cannot fetch input '…' because it uses a relative path`, but did so by skipping relative inputs entirely rather than archiving them.

## Context

Closes: #12438

A relative `path:` input is not independently fetchable: it only has meaning relative to its parent flake's source tree, so re-resolving its flakeref through the fetcher trips the relative-path guard in `libfetchers/path.cc`. By the time a flake is locked, however, Nix already holds everything `archive` needs — every node's resolved source path is recorded in the locked flake's node graph (`nodePaths`), the same data `callFlake` consumes.

Implementation strategy:

- Thread each node's source path (flake directory) through the archive traversal, mirroring how `lockFlake`/`callFlake` resolve relative inputs. The root's source path comes from `nodePaths`.
- For a relative input, resolve it against its parent's source path (`SourcePath{parent.accessor, CanonPath(relativePath, parentDir)}`) and copy that subtree to the store via `fetchToStore`, respecting `--dry-run`. No `?narHash=` fallback is involved.
- Non-relative inputs keep the existing fetch-by-ref behaviour. Their source tree is only resolved (via `getAccessor`) when they actually contain relative inputs, so `--dry-run` and the common case avoid needless fetches.
- The walk stays recursive, so transitively nested relative inputs are archived too.

~~This also covers the multi-level nesting variant tracked in #14762: a three-level relative chain (`a` → `b` → `c`) now archives correctly, and there is a regression test for it.~~

Builds on the work of @edolstra in b4dfeafed.

### Tests

`tests/functional/flakes/relative-paths.sh` is extended to assert that a relative `path:` input gets a store path, is copied to the destination store, contains no `?narHash=`, and that a three-level nested case works.

A release note is added under `doc/manual/rl-next/`.

Checklist:
- [x] Tests: functional (`tests/functional/flakes/relative-paths.sh`)
- [x] Release note (`doc/manual/rl-next/flake-archive-relative-paths.md`)
- [x] Code and comments are self-explanatory
- [x] Commit message explains **why** the change was made
