### PR TITLE
Add `nix ps` command

### DIFF
--- a/src/libstore/active-builds.cc
+++ b/src/libstore/active-builds.cc
@@ -1,0 +1,155 @@
+#include "nix/store/active-builds.hh"
+#include "nix/util/json-utils.hh"
+
+#include <nlohmann/json.hpp>
+
+#ifndef _WIN32
+#  include <pwd.h>
+#endif
+
+namespace nix {
+
+TrackActiveBuildsStore::~TrackActiveBuildsStore() = default;
+QueryActiveBuildsStore::~QueryActiveBuildsStore() = default;
+
+UserInfo UserInfo::fromUid(uid_t uid)
+{
+    UserInfo info;
+    info.uid = uid;
+
+#ifndef _WIN32
+    // Look up the user name for the UID (thread-safe)
+    struct passwd pwd;
+    struct passwd * result;
+    std::vector<char> buf(16384);
+    if (getpwuid_r(uid, &pwd, buf.data(), buf.size(), &result) == 0 && result)
+        info.name = result->pw_name;
+#endif
+
+    return info;
+}
+
+} // namespace nix
+
+namespace nlohmann {
+
+using namespace nix;
+
+UserInfo adl_serializer<UserInfo>::from_json(const json & j)
+{
+    return UserInfo{
+        .uid = j.at("uid").get<uid_t>(),
+        .name = j.contains("name") && !j.at("name").is_null()
+                    ? std::optional<std::string>(j.at("name").get<std::string>())
+                    : std::nullopt,
+    };
+}
+
+void adl_serializer<UserInfo>::to_json(json & j, const UserInfo & info)
+{
+    j = nlohmann::json{
+        {"uid", info.uid},
+        {"name", info.name},
+    };
+}
+
+// Durations are serialized as floats representing seconds.
+static std::optional<std::chrono::microseconds> parseDuration(const json & j, const char * key)
+{
+    if (j.contains(key) && !j.at(key).is_null())
+        return std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::duration<float, std::chrono::seconds::period>(j.at(key).get<double>()));
+    else
+        return std::nullopt;
+}
+
+static nlohmann::json printDuration(const std::optional<std::chrono::microseconds> & duration)
+{
+    return duration
+               ? nlohmann::json(
+                     std::chrono::duration_cast<std::chrono::duration<float, std::chrono::seconds::period>>(*duration)
+                         .count())
+               : nullptr;
+}
+
+ActiveBuildInfo::ProcessInfo adl_serializer<ActiveBuildInfo::ProcessInfo>::from_json(const json & j)
+{
+    return ActiveBuildInfo::ProcessInfo{
+        .pid = j.at("pid").get<pid_t>(),
+        .parentPid = j.at("parentPid").get<pid_t>(),
+        .user = j.at("user").get<UserInfo>(),
+        .argv = j.at("argv").get<std::vector<std::string>>(),
+        .utime = parseDuration(j, "utime"),
+        .stime = parseDuration(j, "stime"),
+        .cutime = parseDuration(j, "cutime"),
+        .cstime = parseDuration(j, "cstime"),
+    };
+}
+
+void adl_serializer<ActiveBuildInfo::ProcessInfo>::to_json(json & j, const ActiveBuildInfo::ProcessInfo & process)
+{
+    j = nlohmann::json{
+        {"pid", process.pid},
+        {"parentPid", process.parentPid},
+        {"user", process.user},
+        {"argv", process.argv},
+        {"utime", printDuration(process.utime)},
+        {"stime", printDuration(process.stime)},
+        {"cutime", printDuration(process.cutime)},
+        {"cstime", printDuration(process.cstime)},
+    };
+}
+
+ActiveBuild adl_serializer<ActiveBuild>::from_json(const json & j)
+{
+    auto type = j.at("type").get<std::string>();
+    if (type != "build")
+        throw Error("invalid active build JSON: expected type 'build' but got '%s'", type);
+    std::optional<std::filesystem::path> cgroup;
+    if (!j.at("cgroup").is_null())
+        cgroup = j.at("cgroup").get<std::filesystem::path>();
+    return ActiveBuild{
+        .nixPid = j.at("nixPid").get<pid_t>(),
+        .clientPid = j.at("clientPid").get<std::optional<pid_t>>(),
+        .clientUid = j.at("clientUid").get<std::optional<uid_t>>(),
+        .mainPid = j.at("mainPid").get<pid_t>(),
+        .mainUser = j.at("mainUser").get<UserInfo>(),
+        .cgroup = std::move(cgroup),
+        .startTime = (time_t) j.at("startTime").get<double>(),
+        .derivation = StorePath{getString(j.at("derivation"))},
+    };
+}
+
+void adl_serializer<ActiveBuild>::to_json(json & j, const ActiveBuild & build)
+{
+    j = nlohmann::json{
+        {"type", "build"},
+        {"nixPid", build.nixPid},
+        {"clientPid", build.clientPid},
+        {"clientUid", build.clientUid},
+        {"mainPid", build.mainPid},
+        {"mainUser", build.mainUser},
+        {"cgroup", build.cgroup ? nlohmann::json(*build.cgroup) : nlohmann::json(nullptr)},
+        {"startTime", (double) build.startTime},
+        {"derivation", build.derivation.to_string()},
+    };
+}
+
+ActiveBuildInfo adl_serializer<ActiveBuildInfo>::from_json(const json & j)
+{
+    ActiveBuildInfo info(adl_serializer<ActiveBuild>::from_json(j));
+    info.processes = j.at("processes").get<std::vector<ActiveBuildInfo::ProcessInfo>>();
+    info.utime = parseDuration(j, "utime");
+    info.stime = parseDuration(j, "stime");
+    return info;
+}
+
+void adl_serializer<ActiveBuildInfo>::to_json(json & j, const ActiveBuildInfo & build)
+{
+    adl_serializer<ActiveBuild>::to_json(j, build);
+    j["processes"] = build.processes;
+    j["utime"] = printDuration(build.utime);
+    j["stime"] = printDuration(build.stime);
+}
+
+} // namespace nlohmann

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -17,6 +17,8 @@
 #include "nix/util/args.hh"
 #include "nix/util/logging.hh"
 #include "nix/store/globals.hh"
+#include "nix/store/active-builds.hh"
+#include <nlohmann/json.hpp>
 #include <variant>
 
 #ifndef _WIN32 // TODO need graceful async exit support on Windows?
@@ -1011,6 +1013,15 @@ static void performOp(
         }
         logger->stopWork();
         conn.to << 1;
+        break;
+    }
+
+    case WorkerProto::Op::QueryActiveBuilds: {
+        logger->startWork();
+        auto & activeBuildsStore = require<QueryActiveBuildsStore>(*store);
+        auto activeBuilds = activeBuildsStore.queryActiveBuilds();
+        logger->stopWork();
+        conn.to << nlohmann::json(activeBuilds).dump();
         break;
     }
 

--- a/src/libstore/include/nix/store/active-builds.hh
+++ b/src/libstore/include/nix/store/active-builds.hh
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "nix/util/util.hh"
+#include "nix/util/json-impls.hh"
+#include "nix/store/path.hh"
+
+#include <chrono>
+#include <sys/types.h>
+
+namespace nix {
+
+/**
+ * A uid and optional corresponding user name.
+ */
+struct UserInfo
+{
+    uid_t uid = -1;
+    std::optional<std::string> name;
+
+    /**
+     * Create a UserInfo from a UID, looking up the username if possible.
+     */
+    static UserInfo fromUid(uid_t uid);
+};
+
+struct ActiveBuild
+{
+    pid_t nixPid;
+
+    std::optional<pid_t> clientPid;
+    std::optional<uid_t> clientUid;
+
+    pid_t mainPid;
+    UserInfo mainUser;
+    std::optional<std::filesystem::path> cgroup;
+
+    time_t startTime;
+
+    StorePath derivation;
+};
+
+struct ActiveBuildInfo : ActiveBuild
+{
+    struct ProcessInfo
+    {
+        pid_t pid = 0;
+        pid_t parentPid = 0;
+        UserInfo user;
+        std::vector<std::string> argv;
+        std::optional<std::chrono::microseconds> utime, stime, cutime, cstime;
+    };
+
+    // User/system CPU time for the entire cgroup, if available.
+    std::optional<std::chrono::microseconds> utime, stime;
+
+    std::vector<ProcessInfo> processes;
+};
+
+struct TrackActiveBuildsStore
+{
+    struct BuildHandle
+    {
+        TrackActiveBuildsStore & tracker;
+        uint64_t id;
+
+        BuildHandle(TrackActiveBuildsStore & tracker, uint64_t id)
+            : tracker(tracker)
+            , id(id)
+        {
+        }
+
+        BuildHandle(BuildHandle && other) noexcept
+            : tracker(other.tracker)
+            , id(other.id)
+        {
+            other.id = 0;
+        }
+
+        ~BuildHandle()
+        {
+            if (id) {
+                try {
+                    tracker.buildFinished(*this);
+                } catch (...) {
+                    ignoreExceptionInDestructor();
+                }
+            }
+        }
+    };
+
+    virtual ~TrackActiveBuildsStore();
+
+    virtual BuildHandle buildStarted(const ActiveBuild & build) = 0;
+
+    virtual void buildFinished(const BuildHandle & handle) = 0;
+};
+
+struct QueryActiveBuildsStore
+{
+    inline static std::string operationName = "Querying active builds";
+
+    virtual ~QueryActiveBuildsStore();
+
+    virtual std::vector<ActiveBuildInfo> queryActiveBuilds() = 0;
+};
+
+} // namespace nix
+
+JSON_IMPL(UserInfo)
+JSON_IMPL(ActiveBuild)
+JSON_IMPL(ActiveBuildInfo)
+JSON_IMPL(ActiveBuildInfo::ProcessInfo)

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -6,6 +6,7 @@
 #include "nix/store/pathlocks.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/indirect-root-store.hh"
+#include "nix/store/active-builds.hh"
 #include "nix/util/sync.hh"
 
 #include <chrono>
@@ -179,7 +180,10 @@ public:
 
 MakeError(PathInUse, Error);
 
-class LocalStore : public virtual IndirectRootStore, public virtual GcStore
+class LocalStore : public virtual IndirectRootStore,
+                   public virtual GcStore,
+                   public virtual TrackActiveBuildsStore,
+                   public virtual QueryActiveBuildsStore
 {
     void anchor() override;
 
@@ -521,6 +525,24 @@ private:
     friend struct DerivationGoal;
     /* Only used for createTempDirInStore. */
     friend class DerivationBuilderImpl;
+
+private:
+
+    std::filesystem::path activeBuildsDir;
+
+    struct ActiveBuildFile
+    {
+        AutoCloseFD fd;
+        AutoDelete del;
+    };
+
+    Sync<std::unordered_map<uint64_t, ActiveBuildFile>> activeBuilds;
+
+    std::vector<ActiveBuildInfo> queryActiveBuilds() override;
+
+    BuildHandle buildStarted(const ActiveBuild & build) override;
+
+    void buildFinished(const BuildHandle & handle) override;
 };
 
 } // namespace nix

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -10,6 +10,7 @@ config_pub_h = configure_file(
 )
 
 headers = [ config_pub_h ] + files(
+  'active-builds.hh',
   'aws-creds.hh',
   'binary-cache-store.hh',
   'build-result.hh',

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -10,6 +10,7 @@
 #include "nix/util/file-descriptor.hh"
 #include "nix/store/gc-store.hh"
 #include "nix/store/log-store.hh"
+#include "nix/store/active-builds.hh"
 
 namespace nix {
 
@@ -46,7 +47,10 @@ public:
  * \todo RemoteStore is a misnomer - should be something like
  * DaemonStore.
  */
-struct RemoteStore : public virtual Store, public virtual GcStore, public virtual LogStore
+struct RemoteStore : public virtual Store,
+                     public virtual GcStore,
+                     public virtual LogStore,
+                     public virtual QueryActiveBuildsStore
 {
 private:
     void anchor() override;
@@ -154,6 +158,8 @@ public:
     MissingPaths queryMissing(const std::vector<DerivedPath> & targets) override;
 
     void addBuildLog(const StorePath & drvPath, std::string_view log) override;
+
+    std::vector<ActiveBuildInfo> queryActiveBuilds() override;
 
     std::optional<std::string> getVersion() override;
 

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -135,6 +135,8 @@ struct WorkerProto
      */
     static constexpr std::string_view featureDisableSetOptions = "disable-set-options";
 
+    static constexpr std::string_view featureQueryActiveBuilds = "queryActiveBuilds";
+
     /**
      * A unidirectional read connection, to be used by the read half of the
      * canonical serializers below.
@@ -256,6 +258,7 @@ enum struct WorkerProto::Op : uint64_t {
     AddBuildLog = 45,
     BuildPathsWithResults = 46,
     AddPermRoot = 47,
+    QueryActiveBuilds = 48,
 };
 
 struct WorkerProto::ClientHandshakeInfo

--- a/src/libstore/local-store-active-builds.cc
+++ b/src/libstore/local-store-active-builds.cc
@@ -209,7 +209,7 @@ std::vector<ActiveBuildInfo> LocalStore::queryActiveBuilds()
             // Open the file. If we can lock it, the build is not active.
             auto fd = openLockFile(path, false);
             if (!fd || lockFile(fd.get(), ltRead, false)) {
-                AutoDelete(path, false);
+                tryUnlink(path);
                 continue;
             }
 

--- a/src/libstore/local-store-active-builds.cc
+++ b/src/libstore/local-store-active-builds.cc
@@ -1,0 +1,282 @@
+#include "nix/store/local-store.hh"
+#include "nix/util/json-utils.hh"
+#ifdef __linux__
+#  include "nix/util/cgroup.hh"
+#  include <regex>
+#  include <unistd.h>
+#  include <pwd.h>
+#endif
+
+#ifdef __APPLE__
+#  include <libproc.h>
+#  include <sys/sysctl.h>
+#  include <mach/mach_time.h>
+#endif
+
+#include <nlohmann/json.hpp>
+#include <queue>
+
+namespace nix {
+
+#ifdef __linux__
+static ActiveBuildInfo::ProcessInfo getProcessInfo(pid_t pid)
+{
+    ActiveBuildInfo::ProcessInfo info;
+    info.pid = pid;
+    info.argv =
+        tokenizeString<std::vector<std::string>>(readFile(fmt("/proc/%d/cmdline", pid)), std::string("\000", 1));
+
+    auto statPath = fmt("/proc/%d/stat", pid);
+
+    AutoCloseFD statFd = open(statPath.c_str(), O_RDONLY | O_CLOEXEC);
+    if (!statFd)
+        throw SysError("opening '%s'", statPath);
+
+    // Get the UID from the ownership of the stat file.
+    struct stat st;
+    if (fstat(statFd.get(), &st) == -1)
+        throw SysError("getting ownership of '%s'", statPath);
+    info.user = UserInfo::fromUid(st.st_uid);
+
+    // Read /proc/[pid]/stat for parent PID and CPU times.
+    // Format: pid (comm) state ppid ...
+    // Note that the comm field can contain spaces, so use a regex to parse it.
+    auto statContent = trim(readFile(statFd.get()));
+    static std::regex statRegex(R"((\d+) \(([^)]*)\) (.*))");
+    std::smatch match;
+    if (!std::regex_match(statContent, match, statRegex))
+        throw Error("failed to parse /proc/%d/stat", pid);
+
+    // Parse the remaining fields after (comm).
+    auto remainingFields = tokenizeString<std::vector<std::string>>(match[3].str());
+
+    if (remainingFields.size() > 1)
+        info.parentPid = string2Int<pid_t>(remainingFields[1]).value_or(0);
+
+    static long clkTck = sysconf(_SC_CLK_TCK);
+    if (remainingFields.size() > 14 && clkTck > 0) {
+        if (auto utime = string2Int<uint64_t>(remainingFields[11]))
+            info.utime = std::chrono::microseconds((*utime * 1'000'000) / clkTck);
+        if (auto stime = string2Int<uint64_t>(remainingFields[12]))
+            info.stime = std::chrono::microseconds((*stime * 1'000'000) / clkTck);
+        if (auto cutime = string2Int<uint64_t>(remainingFields[13]))
+            info.cutime = std::chrono::microseconds((*cutime * 1'000'000) / clkTck);
+        if (auto cstime = string2Int<uint64_t>(remainingFields[14]))
+            info.cstime = std::chrono::microseconds((*cstime * 1'000'000) / clkTck);
+    }
+
+    return info;
+}
+
+/**
+ * Recursively get all descendant PIDs of a given PID using /proc/[pid]/task/[pid]/children.
+ */
+static std::set<pid_t> getDescendantPids(pid_t pid)
+{
+    std::set<pid_t> descendants;
+
+    [&](this auto self, pid_t pid) -> void {
+        try {
+            descendants.insert(pid);
+            for (const auto & childPidStr :
+                 tokenizeString<std::vector<std::string>>(readFile(fmt("/proc/%d/task/%d/children", pid, pid))))
+                if (auto childPid = string2Int<pid_t>(childPidStr))
+                    self(*childPid);
+        } catch (...) {
+            // Process may have exited.
+            ignoreExceptionExceptInterrupt();
+        }
+    }(pid);
+
+    return descendants;
+}
+#endif
+
+#ifdef __APPLE__
+static ActiveBuildInfo::ProcessInfo getProcessInfo(pid_t pid)
+{
+    ActiveBuildInfo::ProcessInfo info;
+    info.pid = pid;
+
+    // Get basic process info including ppid and uid.
+    struct proc_bsdinfo procInfo;
+    if (proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &procInfo, sizeof(procInfo)) != sizeof(procInfo))
+        throw SysError("getting process info for pid %d", pid);
+
+    info.parentPid = procInfo.pbi_ppid;
+    info.user = UserInfo::fromUid(procInfo.pbi_uid);
+
+    // Get CPU times.
+    struct proc_taskinfo taskInfo;
+    if (proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &taskInfo, sizeof(taskInfo)) == sizeof(taskInfo)) {
+
+        mach_timebase_info_data_t timebase;
+        mach_timebase_info(&timebase);
+        auto nanosecondsPerTick = (double) timebase.numer / (double) timebase.denom;
+
+        // Convert nanoseconds to microseconds.
+        info.utime =
+            std::chrono::microseconds((uint64_t) ((double) taskInfo.pti_total_user * nanosecondsPerTick / 1000));
+        info.stime =
+            std::chrono::microseconds((uint64_t) ((double) taskInfo.pti_total_system * nanosecondsPerTick / 1000));
+    }
+
+    // Get argv using sysctl.
+    int mib[3] = {CTL_KERN, KERN_PROCARGS2, pid};
+    size_t size = 0;
+
+    // First call to get size.
+    if (sysctl(mib, 3, nullptr, &size, nullptr, 0) == 0 && size > 0) {
+        std::vector<char> buffer(size);
+        if (sysctl(mib, 3, buffer.data(), &size, nullptr, 0) == 0) {
+            // Format: argc (int), followed by executable path, followed by null-terminated args
+            if (size >= sizeof(int)) {
+                int argc;
+                memcpy(&argc, buffer.data(), sizeof(argc));
+
+                // Skip past argc and executable path (null-terminated).
+                size_t pos = sizeof(int);
+                while (pos < size && buffer[pos] != '\0')
+                    pos++;
+                pos++; // Skip the null terminator
+
+                // Parse the arguments.
+                while (pos < size && info.argv.size() < (size_t) argc) {
+                    size_t argStart = pos;
+                    while (pos < size && buffer[pos] != '\0')
+                        pos++;
+
+                    if (pos > argStart)
+                        info.argv.emplace_back(buffer.data() + argStart, pos - argStart);
+
+                    pos++; // Skip the null terminator
+                }
+            }
+        }
+    }
+
+    return info;
+}
+
+/**
+ * Recursively get all descendant PIDs using sysctl with KERN_PROC.
+ */
+static std::set<pid_t> getDescendantPids(pid_t startPid)
+{
+    // Get all processes.
+    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0};
+    size_t size = 0;
+
+    if (sysctl(mib, 4, nullptr, &size, nullptr, 0) == -1)
+        return {startPid};
+
+    std::vector<struct kinfo_proc> procs(size / sizeof(struct kinfo_proc));
+    if (sysctl(mib, 4, procs.data(), &size, nullptr, 0) == -1)
+        return {startPid};
+
+    // Get the children of all processes.
+    std::map<pid_t, std::set<pid_t>> children;
+    size_t count = size / sizeof(struct kinfo_proc);
+    for (size_t i = 0; i < count; i++) {
+        pid_t childPid = procs[i].kp_proc.p_pid;
+        pid_t parentPid = procs[i].kp_eproc.e_ppid;
+        children[parentPid].insert(childPid);
+    }
+
+    // Get all children of `pid`.
+    std::set<pid_t> descendants;
+    std::queue<pid_t> todo;
+    todo.push(startPid);
+    while (auto pid = pop(todo)) {
+        if (!descendants.insert(*pid).second)
+            continue;
+        for (auto & child : children[*pid])
+            todo.push(child);
+    }
+
+    return descendants;
+}
+#endif
+
+std::vector<ActiveBuildInfo> LocalStore::queryActiveBuilds()
+{
+    std::vector<ActiveBuildInfo> result;
+
+    for (auto & entry : DirectoryIterator{activeBuildsDir}) {
+        auto path = entry.path();
+
+        try {
+            // Open the file. If we can lock it, the build is not active.
+            auto fd = openLockFile(path, false);
+            if (!fd || lockFile(fd.get(), ltRead, false)) {
+                AutoDelete(path, false);
+                continue;
+            }
+
+            ActiveBuildInfo info(nlohmann::json::parse(readFile(fd.get())).get<ActiveBuild>());
+
+#if defined(__linux__) || defined(__APPLE__)
+            /* Read process information. */
+            try {
+#  ifdef __linux__
+                if (info.cgroup) {
+                    for (auto pid : linux::getPidsInCgroup(*info.cgroup))
+                        info.processes.push_back(getProcessInfo(pid));
+
+                    /* Read CPU statistics from the cgroup. */
+                    auto stats = linux::getCgroupStats(*info.cgroup);
+                    info.utime = stats.cpuUser;
+                    info.stime = stats.cpuSystem;
+                } else
+#  endif
+                {
+                    for (auto pid : getDescendantPids(info.mainPid))
+                        info.processes.push_back(getProcessInfo(pid));
+                }
+            } catch (...) {
+                ignoreExceptionExceptInterrupt();
+            }
+#endif
+
+            result.push_back(std::move(info));
+        } catch (...) {
+            ignoreExceptionExceptInterrupt();
+        }
+    }
+
+    return result;
+}
+
+LocalStore::BuildHandle LocalStore::buildStarted(const ActiveBuild & build)
+{
+    // Write info about the active build to the active-builds directory where it can be read by `queryBuilds()`.
+    static std::atomic<uint64_t> nextId{1};
+
+    auto id = nextId++;
+
+    auto infoFileName = fmt("%d-%d", getpid(), id);
+    auto infoFilePath = activeBuildsDir / infoFileName;
+
+    auto infoFd = openLockFile(infoFilePath, true);
+
+    // Lock the file to denote that the build is active.
+    lockFile(infoFd.get(), ltWrite, true);
+
+    writeFile(infoFilePath, nlohmann::json(build).dump(), 0600, FsSync::Yes);
+
+    activeBuilds.lock()->emplace(
+        id,
+        ActiveBuildFile{
+            .fd = std::move(infoFd),
+            .del = AutoDelete(infoFilePath, false),
+        });
+
+    return BuildHandle(*this, id);
+}
+
+void LocalStore::buildFinished(const BuildHandle & handle)
+{
+    activeBuilds.lock()->erase(handle.id);
+}
+
+} // namespace nix

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -132,6 +132,7 @@ LocalStore::LocalStore(ref<const Config> config)
     , schemaPath(dbDir / "schema")
     , tempRootsDir(config->stateDir.get() / "temproots")
     , fnTempRoots(tempRootsDir / std::to_string(getpid()))
+    , activeBuildsDir(config->stateDir.get() / "active-builds")
 {
     auto state(_state->lock());
     state->stmts = std::make_unique<State::Stmts>();
@@ -152,6 +153,7 @@ LocalStore::LocalStore(ref<const Config> config)
     const auto & localSettings = config->getLocalSettings();
     const auto & gcSettings = localSettings.getGCSettings();
     createDirs(gcRootsDir);
+    createDirs(activeBuildsDir);
 
     for (auto & perUserDir : {profilesDir / "per-user", gcRootsDir / "per-user"}) {
         createDirs(perUserDir);

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -278,6 +278,7 @@ config_priv_h = configure_file(
 subdir('nix-meson-build-support/common')
 
 sources = files(
+  'active-builds.cc',
   'binary-cache-store.cc',
   'build-result.cc',
   'build/build-log.cc',
@@ -318,6 +319,7 @@ sources = files(
   'local-fs-store.cc',
   'local-gc.cc',
   'local-overlay-store.cc',
+  'local-store-active-builds.cc',
   'local-store.cc',
   'log-store.cc',
   'machines.cc',

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -790,6 +790,16 @@ void RemoteStore::addBuildLog(const StorePath & drvPath, std::string_view log)
     readInt(conn->from);
 }
 
+std::vector<ActiveBuildInfo> RemoteStore::queryActiveBuilds()
+{
+    auto conn(getConnection());
+    if (!conn->protoVersion.features.count(WorkerProto::featureQueryActiveBuilds))
+        throw Error("remote store does not support querying active builds");
+    conn->to << WorkerProto::Op::QueryActiveBuilds;
+    conn.processStderr();
+    return nlohmann::json::parse(readString(conn->from)).get<std::vector<ActiveBuildInfo>>();
+}
+
 std::optional<std::string> RemoteStore::getVersion()
 {
     auto conn(getConnection());

--- a/src/libstore/unix/build/derivation-builder-impl.hh
+++ b/src/libstore/unix/build/derivation-builder-impl.hh
@@ -4,6 +4,7 @@
 #include "nix/store/build/derivation-builder.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/local-store.hh"
+#include "nix/store/active-builds.hh"
 #include "nix/store/user-lock.hh"
 
 namespace nix {
@@ -31,6 +32,11 @@ protected:
      * The process ID of the builder.
      */
     Pid pid;
+
+    /**
+     * Handles to track active builds for `nix ps`.
+     */
+    std::optional<TrackActiveBuildsStore::BuildHandle> activeBuildHandle;
 
     LocalStore & store;
 
@@ -200,6 +206,11 @@ protected:
     {
         return acquireUserLock(settings.nixStateDir, localSettings, 1, false);
     }
+
+    /**
+     * Construct the `ActiveBuild` object for `ActiveBuildsTracker`.
+     */
+    virtual ActiveBuild getActiveBuild();
 
     /**
      * Return the paths that should be made available in the sandbox.

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -2,6 +2,7 @@
 #include "nix/util/file-system-at.hh"
 #include "nix/util/file-system.hh"
 #include "nix/store/local-store.hh"
+#include "nix/store/active-builds.hh"
 #include "nix/util/processes.hh"
 #include "nix/store/builtins.hh"
 #include "nix/store/path-references.hh"
@@ -178,6 +179,8 @@ bool DerivationBuilderImpl::killChild()
 
         pid.wait();
 
+        activeBuildHandle.reset();
+
         miscMethods->childTerminated();
     }
     return ret;
@@ -211,6 +214,8 @@ SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()
        open and modifies them after they have been chown'ed to
        root. */
     killSandbox(true);
+
+    activeBuildHandle.reset();
 
     /* Terminate the recursive Nix daemon. */
     stopDaemon();
@@ -511,9 +516,26 @@ std::optional<Descriptor> DerivationBuilderImpl::startBuild()
 
     pid.setSeparatePG(true);
 
+    /* Make the build visible to `nix ps`. */
+    if (auto tracker = dynamic_cast<TrackActiveBuildsStore *>(&store))
+        activeBuildHandle.emplace(tracker->buildStarted(getActiveBuild()));
+
     processSandboxSetupMessages();
 
     return builderOut.get();
+}
+
+ActiveBuild DerivationBuilderImpl::getActiveBuild()
+{
+    return {
+        .nixPid = getpid(),
+        .clientPid = std::nullopt,
+        .clientUid = std::nullopt,
+        .mainPid = pid,
+        .mainUser = UserInfo::fromUid(buildUser ? buildUser->getUID() : getuid()),
+        .startTime = buildResult.startTime,
+        .derivation = drvPath,
+    };
 }
 
 PathsInChroot DerivationBuilderImpl::getPathsInSandbox()

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -29,6 +29,7 @@ const WorkerProto::Version WorkerProto::latest = {
                 WorkerProto::featureRealisationWithPath,
             },
             std::string{WorkerProto::featureDeleteDeadSpecificReferrers},
+            std::string{WorkerProto::featureQueryActiveBuilds},
         },
 };
 

--- a/src/libutil/include/nix/util/table.hh
+++ b/src/libutil/include/nix/util/table.hh
@@ -2,10 +2,26 @@
 
 #include "nix/util/types.hh"
 
+#include <limits>
+
 namespace nix {
 
-typedef std::vector<std::vector<std::string>> Table;
+struct TableCell
+{
+    std::string content;
 
-void printTable(std::ostream & out, Table & table);
+    enum Alignment { Left, Right } alignment = Left;
+
+    TableCell(std::string content, Alignment alignment = Left)
+        : content(std::move(content))
+        , alignment(alignment)
+    {
+    }
+};
+
+using TableRow = std::vector<TableCell>;
+using Table = std::vector<TableRow>;
+
+void printTable(std::ostream & out, Table & table, unsigned int width = std::numeric_limits<unsigned int>::max());
 
 } // namespace nix

--- a/src/libutil/include/nix/util/terminal.hh
+++ b/src/libutil/include/nix/util/terminal.hh
@@ -45,6 +45,11 @@ void updateWindowSize();
 std::pair<unsigned short, unsigned short> getWindowSize();
 
 /**
+ * @return The number of columns of the terminal, or std::numeric_limits<unsigned int>::max() if unknown.
+ */
+unsigned int getWindowWidth();
+
+/**
  * Get the slave name of a pseudoterminal in a thread-safe manner.
  *
  * @param fd The file descriptor of the pseudoterminal master

--- a/src/libutil/linux/cgroup.cc
+++ b/src/libutil/linux/cgroup.cc
@@ -174,4 +174,23 @@ CanonPath getRootCgroup()
     return rootCgroup;
 }
 
+std::set<pid_t> getPidsInCgroup(const std::filesystem::path & cgroup)
+{
+    if (!pathExists(cgroup))
+        return {};
+
+    auto procsFile = cgroup / "cgroup.procs";
+
+    std::set<pid_t> result;
+
+    for (auto & pidStr : tokenizeString<std::vector<std::string>>(readFile(procsFile))) {
+        if (auto o = string2Int<pid_t>(pidStr))
+            result.insert(*o);
+        else
+            throw Error("invalid PID '%s'", pidStr);
+    }
+
+    return result;
+}
+
 } // namespace nix::linux

--- a/src/libutil/linux/include/nix/util/cgroup.hh
+++ b/src/libutil/linux/include/nix/util/cgroup.hh
@@ -41,4 +41,9 @@ CanonPath getCurrentCgroup();
  */
 CanonPath getRootCgroup();
 
+/**
+ * Get the PIDs of all processes in the given cgroup.
+ */
+std::set<pid_t> getPidsInCgroup(const std::filesystem::path & cgroup);
+
 } // namespace nix::linux

--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -190,6 +190,14 @@ std::pair<unsigned short, unsigned short> getWindowSize()
     return *windowSize->lock();
 }
 
+unsigned int getWindowWidth()
+{
+    unsigned int width = getWindowSize().second;
+    if (width <= 0)
+        width = std::numeric_limits<unsigned int>::max();
+    return width;
+}
+
 #ifndef _WIN32
 std::string getPtsName(int fd)
 {

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -109,6 +109,7 @@ nix_sources = [ config_priv_h ] + files(
   'path-info.cc',
   'prefetch.cc',
   'profile.cc',
+  'ps.cc',
   'registry.cc',
   'repl.cc',
   'run.cc',

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -1096,7 +1096,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                 continue;
 
             /* For table output. */
-            std::vector<std::string> columns;
+            TableRow columns;
 
             /* For XML output. */
             XMLAttrs attrs;

--- a/src/nix/ps.cc
+++ b/src/nix/ps.cc
@@ -1,0 +1,146 @@
+#include "nix/cmd/command.hh"
+#include "nix/main/common-args.hh"
+#include "nix/main/shared.hh"
+#include "nix/store/store-api.hh"
+#include "nix/store/store-cast.hh"
+#include "nix/store/active-builds.hh"
+#include "nix/util/table.hh"
+#include "nix/util/terminal.hh"
+
+#include <nlohmann/json.hpp>
+
+using namespace nix;
+
+struct CmdPs : MixJSON, StoreCommand
+{
+    std::string description() override
+    {
+        return "list active builds";
+    }
+
+    Category category() override
+    {
+        return catUtility;
+    }
+
+    std::string doc() override
+    {
+        return
+#include "ps.md"
+            ;
+    }
+
+    void run(ref<Store> store) override
+    {
+        auto & tracker = require<QueryActiveBuildsStore>(*store);
+
+        auto builds = tracker.queryActiveBuilds();
+
+        if (json) {
+            printJSON(nlohmann::json(builds));
+            return;
+        }
+
+        if (builds.empty()) {
+            notice("No active builds.");
+            return;
+        }
+
+        /* Helper to format user info: show name if available, else UID */
+        auto formatUser = [](const UserInfo & user) -> std::string {
+            return user.name ? *user.name : std::to_string(user.uid);
+        };
+
+        Table table;
+
+        /* Add column headers. */
+        table.push_back({{"USER"}, {"PID"}, {"CPU", TableCell::Alignment::Right}, {"DERIVATION/COMMAND"}});
+
+        for (const auto & build : builds) {
+            /* Calculate CPU time - use cgroup stats if available, otherwise sum process times. */
+            std::chrono::microseconds cpuTime = build.utime && build.stime ? *build.utime + *build.stime : [&]() {
+                std::chrono::microseconds total{0};
+                for (const auto & process : build.processes)
+                    total += process.utime.value_or(std::chrono::microseconds(0))
+                             + process.stime.value_or(std::chrono::microseconds(0))
+                             + process.cutime.value_or(std::chrono::microseconds(0))
+                             + process.cstime.value_or(std::chrono::microseconds(0));
+                return total;
+            }();
+
+            /* Add build summary row. */
+            table.push_back(
+                {formatUser(build.mainUser),
+                 std::to_string(build.mainPid),
+                 {fmt("%.1fs",
+                      std::chrono::duration_cast<std::chrono::duration<float, std::chrono::seconds::period>>(cpuTime)
+                          .count()),
+                  TableCell::Alignment::Right},
+                 fmt(ANSI_BOLD "%s" ANSI_NORMAL " (wall=%ds)",
+                     store->printStorePath(build.derivation),
+                     time(nullptr) - build.startTime)});
+
+            if (build.processes.empty()) {
+                table.push_back(
+                    {formatUser(build.mainUser),
+                     std::to_string(build.mainPid),
+                     {"", TableCell::Alignment::Right},
+                     fmt("%s" ANSI_ITALIC "(no process info)" ANSI_NORMAL, treeLast)});
+            } else {
+                /* Recover the tree structure of the processes. */
+                std::set<pid_t> pids;
+                for (auto & process : build.processes)
+                    pids.insert(process.pid);
+
+                using Processes = std::set<const ActiveBuildInfo::ProcessInfo *>;
+                std::map<pid_t, Processes> children;
+                Processes rootProcesses;
+                for (auto & process : build.processes) {
+                    if (pids.contains(process.parentPid))
+                        children[process.parentPid].insert(&process);
+                    else
+                        rootProcesses.insert(&process);
+                }
+
+                /* Render the process tree. */
+                [&](this auto const & visit, const Processes & processes, std::string_view prefix) -> void {
+                    for (const auto & [n, process] : enumerate(processes)) {
+                        bool last = n + 1 == processes.size();
+
+                        // Format CPU time if available
+                        std::string cpuInfo;
+                        if (process->utime || process->stime || process->cutime || process->cstime) {
+                            auto totalCpu = process->utime.value_or(std::chrono::microseconds(0))
+                                            + process->stime.value_or(std::chrono::microseconds(0))
+                                            + process->cutime.value_or(std::chrono::microseconds(0))
+                                            + process->cstime.value_or(std::chrono::microseconds(0));
+                            auto totalSecs =
+                                std::chrono::duration_cast<std::chrono::duration<float, std::chrono::seconds::period>>(
+                                    totalCpu)
+                                    .count();
+                            cpuInfo = fmt("%.1fs", totalSecs);
+                        }
+
+                        // Format argv with tree structure
+                        auto argv = concatStringsSep(
+                            " ", tokenizeString<std::vector<std::string>>(concatStringsSep(" ", process->argv)));
+
+                        table.push_back(
+                            {formatUser(process->user),
+                             std::to_string(process->pid),
+                             {cpuInfo, TableCell::Alignment::Right},
+                             fmt("%s%s%s", prefix, last ? treeLast : treeConn, argv)});
+
+                        visit(children[process->pid], last ? prefix + treeNull : prefix + treeLine);
+                    }
+                }(rootProcesses, "");
+            }
+        }
+
+        auto width = isTTY() && isatty(STDOUT_FILENO) ? getWindowWidth() : std::numeric_limits<unsigned int>::max();
+
+        printTable(std::cout, table, width);
+    }
+};
+
+static auto rCmdPs = registerCommand2<CmdPs>({"ps"});

--- a/src/nix/ps.md
+++ b/src/nix/ps.md
@@ -1,0 +1,27 @@
+R"(
+
+# Examples
+
+* Show all active builds:
+
+  ```console
+  # nix ps
+  USER      PID         CPU  DERIVATION/COMMAND
+  nixbld11  3534394  110.2s  /nix/store/lzvdxlbr6xjd9w8py4nd2y2nnqb9gz7p-nix-util-tests-3.13.2.drv (wall=8s)
+  nixbld11  3534394    0.8s  └───bash -e /nix/store/jwqf79v5p51x9mv8vx20fv9mzm2x7kig-source-stdenv.sh /nix/store/shkw4qm9qcw5sc5n1k5jznc83ny02
+  nixbld11  3534751   36.3s      └───ninja -j24
+  nixbld11  3535637    0.0s          ├───/nix/store/0v2jfvx71l1zn14l97pznvbqnhiq3pyd-gcc-14.3.0/bin/g++ -fPIC -fstack-clash-protection -O2 -U_
+  nixbld11  3535639    0.1s          │   └───/nix/store/0v2jfvx71l1zn14l97pznvbqnhiq3pyd-gcc-14.3.0/libexec/gcc/x86_64-unknown-linux-gnu/14.3.
+  nixbld11  3535658    0.0s          └───/nix/store/0v2jfvx71l1zn14l97pznvbqnhiq3pyd-gcc-14.3.0/bin/g++ -fPIC -fstack-clash-protection -O2 -U_
+  nixbld1   3534377    1.8s  /nix/store/nh2dx9cqcy9lw4d4rvd0dbsflwdsbzdy-patchelf-0.18.0.drv (wall=5s)
+  nixbld1   3534377    1.8s  └───bash -e /nix/store/xk05lkk4ij6pc7anhdbr81appiqbcb01-default-builder.sh
+  nixbld1   3535074    0.0s      └───/nix/store/21ymxxap3y8hb9ijcfah8ani9cjpv8m6-bash-5.2p37/bin/bash ./configure --disable-dependency-trackin
+  ```
+
+# Description
+
+This command lists all currently running Nix builds.
+For each build, it shows the derivation path and the main process ID.
+On Linux and macOS, it also shows the child processes of each build.
+
+)"

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -181,6 +181,7 @@ suites = [
       'external-builders.sh',
       'delete-no-keep.sh',
       'fixed-slow-vs-bad.sh',
+      'ps.sh',
     ],
     'workdir' : meson.current_source_dir(),
   },

--- a/tests/functional/ps.sh
+++ b/tests/functional/ps.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+TODO_NixOS
+
+needLocalStore "the active-builds directory is per-store"
+
+clearStore
+
+# Two FIFOs: the builder writes to "started" once it is running, and
+# reads from "finish" to know when to exit.
+started=$TEST_ROOT/nix-ps-started.fifo
+finish=$TEST_ROOT/nix-ps-finish.fifo
+mkfifo "$started"
+mkfifo "$finish"
+
+# Start a build in the background that blocks until we tell it to finish.
+nix-build --max-silent-time 60 -o "$TEST_ROOT/result" -E "
+  with import ${config_nix};
+  mkDerivation {
+    name = \"nix-ps-test\";
+    buildCommand = ''
+      sleep 600 > /dev/null 2>&1 &
+      echo started > $started
+      read line < $finish
+      mkdir \$out
+    '';
+  }" >"$TEST_ROOT/nix-ps-build.out" 2>&1 &
+buildPid=$!
+
+# Wait for the build to signal that it has started.
+read -r _ < "$started"
+
+# The build is now blocked on $finish. Check that `nix ps` sees it and
+# the backgrounded `sleep 600` child process.
+out=$(nix ps)
+echo "$out"
+echo "$out" | grepQuiet 'nix-ps-test.drv'
+echo "$out" | grepQuiet 'sleep 600'
+
+# Check the JSON output as well.
+json=$(nix ps --json)
+echo "$json" | jq -e 'length == 1' >/dev/null
+echo "$json" | jq -e '.[0].derivation | test("nix-ps-test\\.drv$")' >/dev/null
+echo "$json" | jq -e '.[0].mainPid | type == "number"' >/dev/null
+echo "$json" | jq -e '[.[0].processes[].argv | join(" ")] | any(. | test("bash"))' >/dev/null
+echo "$json" | jq -e '[.[0].processes[].argv | join(" ")] | any(. | test("sleep 600"))' >/dev/null
+echo "$json" | jq -e '.[0].processes | length == 2' >/dev/null
+
+# Release the build and wait for it to finish successfully.
+echo "done" > "$finish"
+wait "$buildPid"
+
+# After the build finishes, `nix ps` should be empty again.
+nix ps --json | jq -e 'length == 0' >/dev/null


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

`nix ps` shows active builds, e.g.
```
USER      PID         CPU  DERIVATION/COMMAND
nixbld11  3534394  110.2s  /nix/store/lzvdxlbr6xjd9w8py4nd2y2nnqb9gz7p-nix-util-tests-3.13.2.drv (wall=8s)
nixbld11  3534394    0.8s  └───bash -e /nix/store/vj1c3wf9c11a0qs6p3ymfvrnsdgsdcbq-source-stdenv.sh /nix/store/shkw4qm9qcw5sc5n1k5jznc83ny02
nixbld11  3534751   36.3s      └───ninja -j24
nixbld11  3535637    0.0s          ├───/nix/store/8adzgnxs3s0pbj22qhk9zjxi1fqmz3xv-gcc-14.3.0/bin/g++ -fPIC -fstack-clash-protection -O2 -U_
nixbld11  3535639    0.1s          │   └───/nix/store/8adzgnxs3s0pbj22qhk9zjxi1fqmz3xv-gcc-14.3.0/libexec/gcc/x86_64-unknown-linux-gnu/14.3.
nixbld11  3535658    0.0s          └───/nix/store/8adzgnxs3s0pbj22qhk9zjxi1fqmz3xv-gcc-14.3.0/bin/g++ -fPIC -fstack-clash-protection -O2 -U_
nixbld1   3534377    1.8s  /nix/store/nh2dx9cqcy9lw4d4rvd0dbsflwdsbzdy-patchelf-0.18.0.drv (wall=5s)
nixbld1   3534377    1.8s  └───bash -e /nix/store/v6x3cs394jgqfbi0a42pam708flxaphh-default-builder.sh
nixbld1   3535074    0.0s      └───/nix/store/0irlcqx2n3qm6b1pc9rsd2i8qpvcccaj-bash-5.2p37/bin/bash ./configure --disable-dependency-trackin
```

This improves the observability of a Nix system.

It's implemented by having Nix keep track of the root PIDs of active builds in `/nix/var/nix/active-builds/` and adding a daemon protocol operation for querying active builds and their CPU stats (so this also works over ssh-ng stores).

Taken from Determinate Nix (mostly https://github.com/DeterminateSystems/nix-src/pull/282).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
