### PR TITLE
flake lock: fix relative inputs in nested flakes

### DIFF
--- a/doc/manual/rl-next/flake-lock-nested-relative-inputs.md
+++ b/doc/manual/rl-next/flake-lock-nested-relative-inputs.md
@@ -1,0 +1,9 @@
+---
+synopsis: "Fix locking of relative `path:` inputs in deeply nested flakes"
+issues: [14762]
+---
+
+Locking a flake that transitively depends on a flake with a relative `path:`
+input (three or more levels deep) no longer fails with
+`path '.../flake.nix' does not exist`. The relative input is now resolved
+against the correct flake's source tree.

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -638,6 +638,18 @@ LockedFlake lockFlake(
                                those. */
                             for (auto & i : oldLock->inputs) {
                                 if (auto lockedNode = std::get_if<0>(&i.second)) {
+                                    /* A relative path input (e.g. 'path:./foo')
+                                       can only be resolved against the source
+                                       tree of *this* flake. In the lazy path we
+                                       don't have that tree, so the input would
+                                       be resolved against the parent flake's
+                                       tree instead -- wrong when this flake is
+                                       itself a nested input. Refetch so we get
+                                       the correct source path. See #14762. */
+                                    if ((*lockedNode)->lockedRef.input.isRelative()) {
+                                        mustRefetch = true;
+                                        break;
+                                    }
                                     fakeInputs.emplace(
                                         i.first,
                                         FlakeInput{

--- a/tests/functional/flakes/relative-paths.sh
+++ b/tests/functional/flakes/relative-paths.sh
@@ -172,3 +172,45 @@ EOF
   nix eval --json .#nestedFlake1.nestedFlake2 --no-eval-cache
   nix eval --json .#nestedFlake1.nestedFlake2 --no-eval-cache
 )
+
+# https://github.com/NixOS/nix/issues/14762
+# A relative 'path:' input nested under a flake that is itself kept from an
+# existing lock (the lazy "keep" path) must be resolved against that flake's
+# source tree, not its parent's. This only goes wrong at three levels:
+# top -> middle -> library, where 'library' has a relative 'subflake' input.
+n14762="$TEST_ROOT/issue-14762"
+rm -rf "$n14762"
+mkdir -p "$n14762/library/subflake" "$n14762/middle" "$n14762/top"
+
+cat > "$n14762/library/subflake/flake.nix" <<EOF
+{ outputs = _: { }; }
+EOF
+cat > "$n14762/library/flake.nix" <<EOF
+{
+  inputs.subflake.url = "path:./subflake";
+  outputs = _: { };
+}
+EOF
+cat > "$n14762/middle/flake.nix" <<EOF
+{
+  inputs.library.url = "path:$n14762/library";
+  outputs = _: { };
+}
+EOF
+cat > "$n14762/top/flake.nix" <<EOF
+{
+  inputs.middle.url = "path:$n14762/middle";
+  outputs = _: { };
+}
+EOF
+
+# These are plain 'path:' inputs with no fingerprint, so fetching them is
+# uncacheable (as on master); disable the test-only barf, like other tests do.
+
+# Establish the middle flake's lock first, so that when the top flake locks,
+# 'library' is taken from middle's lock via the lazy "keep" path.
+_NIX_TEST_BARF_ON_UNCACHEABLE='' nix flake lock "$n14762/middle"
+
+# Previously failed: "path '.../subflake/flake.nix' does not exist".
+_NIX_TEST_BARF_ON_UNCACHEABLE='' nix flake update --flake "$n14762/top"
+[[ -e "$n14762/top/flake.lock" ]]


### PR DESCRIPTION
## Motivation

`nix flake update` / `nix flake lock` (and any command that locks the flake) fails for a flake that transitively depends on a flake which itself has a relative `path:` input, once the nesting is at least three levels deep. Locking aborts with an error like:

```
error: path '/nix/store/…-source/subflake/flake.nix' does not exist
```

The relative input is resolved against the wrong flake's source tree.

## Context

Closes: #14762

### Reproducer

Using the reporter's minimal repo (in #14762):

```console
$ git clone https://github.com/yunfachi/broken-nix-subflakes.git
$ cd broken-nix-subflakes && ./set-local-path.sh
$ cd user-of-library-that-depends-on-library && nix flake update
error: … path '/nix/store/…-source/subflake/flake.nix' does not exist
```

The graph is `user → library-that-depends-on-library → library → subflake`, where `subflake` is `library`'s relative `path:./subflake` input.

### Root cause

When `computeLocks()` (`src/libflake/flake.cc`) keeps an existing flake input without refetching it, it recurses into that flake's inputs using the **parent** flake's source path. That value is only consulted to resolve relative `path:` inputs, so it is harmless unless the kept flake actually has one. When it does (`library`'s `path:./subflake`), the relative input is resolved against the parent flake's tree (`library-that-depends-on-library`) instead of the kept flake's (`library`), and locking fails.

This only surfaces at ≥ 3 levels, because at shallower depth the flake holding the relative input is the one being fetched, so the source path is already correct.

### The fix

Force a refetch of a kept flake when it has a relative input, so its real source path is available to resolve that input. Flakes without relative inputs stay on the lazy path unchanged:

```cpp
if ((*lockedNode)->lockedRef.input.isRelative()) {
    mustRefetch = true;
    break;
}
```

This mirrors the existing pattern a few lines down, where a disappeared override likewise sets `mustRefetch = true; break;`. It is narrower than the `if (true)` workaround suggested in the issue, which would defeat the laziness optimization for *every* kept flake.

### Performance

- **No relative inputs → no change**: the new branch is never entered, so the lazy fast path is untouched (the common case).
- **Affected flakes** pay one extra source fetch of the relevant flake, per incremental lock, proportional to that flake's source size. `nix flake update` (which recreates the lock from scratch) is unaffected.

Measured with a `nix-flake-benchmarks` microbenchmark on the lock path: no measurable change without relative inputs; ~0.7 ms re-eval overhead for a tiny nested relative flake, scaling with source size for larger ones (≈ tens of ms for a multi-thousand-file tree). A fuller fix that also restores the lazy copy is described under "Future work" below.

~~A new benchmark for flakes is added in pull request #15983, which should be merged before this pull request, since there is no performance benchmark for this change.~~

### Future work (out of scope)

A second, correctness-neutral quirk remains: `parentInputAttrPath` is stored relative to each lock file's own root but compared against the outer lock's coordinate system, so the relative input is re-locked from scratch rather than copied from the existing lock. Rebasing that path when merging nested lock files would remove the residual refetch cost. Left out to keep this change minimal.

The diagnosis and the pointer to the `mustRefetch` branch come from @yunfachi in #14762.

---

Checklist:
- [x] Tests: functional — `tests/functional/flakes/relative-paths.sh`
- [x] Release note — `doc/manual/rl-next/`
- [x] Code and comments are self-explanatory
- [x] Commit message explains **why** the change was made