### PR TITLE
Establish Automation/AI policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,10 +44,12 @@ assignees: ''
 
 - [ ] checked [latest Nix manual] \([source])
 - [ ] checked [open bug issues and pull requests] for possible duplicates
+- [ ] reviewed the [contributing guide]
 
 [latest Nix manual]: https://nix.dev/manual/nix/development/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open bug issues and pull requests]: https://github.com/NixOS/nix/labels/bug
+[contributing guide]: https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -29,10 +29,12 @@ assignees: ''
 
 - [ ] checked [latest Nix manual] \([source])
 - [ ] checked [open feature issues and pull requests] for possible duplicates
+- [ ] reviewed the [contributing guide]
 
 [latest Nix manual]: https://nix.dev/manual/nix/development/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open feature issues and pull requests]: https://github.com/NixOS/nix/labels/feature
+[contributing guide]: https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/installer.md
+++ b/.github/ISSUE_TEMPLATE/installer.md
@@ -37,10 +37,12 @@ assignees: ''
 
 - [ ] checked [latest Nix manual] \([source])
 - [ ] checked [open installer issues and pull requests] for possible duplicates
+- [ ] reviewed the [contributing guide]
 
 [latest Nix manual]: https://nix.dev/manual/nix/development/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open installer issues and pull requests]: https://github.com/NixOS/nix/labels/installer
+[contributing guide]: https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/missing_documentation.md
+++ b/.github/ISSUE_TEMPLATE/missing_documentation.md
@@ -21,10 +21,12 @@ assignees: ''
 
 - [ ] checked [latest Nix manual] \([source])
 - [ ] checked [open documentation issues and pull requests] for possible duplicates
+- [ ] reviewed the [contributing guide]
 
 [latest Nix manual]: https://nix.dev/manual/nix/development/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open documentation issues and pull requests]: https://github.com/NixOS/nix/labels/documentation
+[contributing guide]: https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@ so you understand the process and the expectations.
 - what information to include in commit messages
 - proper attribution
 - volunteering contributions effectively
+- AI/automation policy
 - how to get help and our review process.
 
 PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ Check out the [security policy](https://github.com/NixOS/nix/security/policy).
 
    * Make sure to have [a clean history of commits on your branch by using rebase](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request).
    * [Mark the pull request as draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) if you're not done with the changes.
+   * Review the **Automation/AI Policy** below.
 
 6. Do not expect your pull request to be reviewed immediately.
    Nix maintainers follow a [structured process for reviews and design decisions](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol), which may or may not prioritise your work.
@@ -86,6 +87,66 @@ Check out the [security policy](https://github.com/NixOS/nix/security/policy).
    - [ ] New feature or incompatible change: [add a release note](https://nix.dev/manual/nix/development/development/contributing.html#add-a-release-note)
 
 7. If you need additional feedback or help to getting pull request into shape, ask other contributors using [@mentions](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#mentioning-people-and-teams).
+
+## Automation/AI policy
+
+Every contribution to Nix and related development venues, including code, documentation, and communication on GitHub and Matrix, must have a responsible person in the loop who is accountable for that contribution and reviews it before submission, and must transparently disclose any non‐trivial use of automation to produce it, including but not limited to LLM‐based AI tools.
+
+Human communication must remain human. Pull request / issue descriptions and comments, documentation, commit messages, and code comments must be human-authored.
+
+The following sections give more detail.
+
+### Scope
+
+Any use of automated tools to generate non‐trivial amounts of output as part of a contribution, in whole or in part, verbatim or edited, is covered by this policy, except as listed in the Exemptions section.
+Both LLM‐based AI tools and hand‐written automation are covered.
+Contributions include code and documentation in commits, commit messages, pull request summaries and reviews, issue and vulnerability reports, GitHub comments, Matrix messages, and Discourse posts.
+The covered venues are the GitHub repositories for Nix and related projects under the jurisdiction of the Nix team, Matrix rooms that are focused on development of those projects, and Discourse topics about Nix development.
+
+PRs that seek to address issues that appear easier to fix, such as those marked with [good first issue](https://github.com/NixOS/nix/labels/good%20first%20issue), are held to the same standard as other issues.
+Just because the problem seems "easy" and more likely to be successfully fixed by an unsupervised agent does not mean bending the rules is permissible.
+Even the most trivial changes still must have a responsible person in the loop.
+
+### Accountability
+
+Everyone who submits a contribution to Nix is responsible for it, regardless of the use of automated tooling.
+Before submission, they must establish a reasonable level of understanding of the contribution and expectation of its correctness.
+A contributor submitting a contribution intended for inclusion in Nix is also responsible for ensuring that it is [appropriately licensed](https://github.com/NixOS/nix/blob/master/COPYING) and credited, and not encumbered by any incompatible copyright.
+
+When output from automated tooling is used in contributions, a contributor must establish confidence in that output.
+
+This policy applies equally to any further discussion of a contribution.
+Comments and reviews must separately satisfy the same requirements of understanding, review, and disclosure.
+Contributors are expected to be able to answer questions about their contribution and respond to feedback appropriately, **without simply forwarding messages back and forth to automated tools**.
+
+It is not permitted to submit automated contributions without any manual review or intervention, outside of standard community automation.
+Automation without any manual review must not be used as the sole arbiter of whether to merge a change.
+
+### Transparency
+
+All covered use of automated tooling for a contribution must be disclosed as part of that contribution.
+
+In the case of LLM‐based AI tooling used for commits, this **must** be in the form of an `Assisted-by:` Git commit trailer, including at least the tool name and the primary model name and version used for the contribution. When using unreleased models, it is acceptable to say "unspecified".
+A `Co-authored-by:` trailer does not satisfy this policy.
+
+Any adequate form of disclosure is permitted for other kinds of tooling and contribution.
+
+### Exemptions
+
+The following situations are fully or partially exempt:
+
+* Use of standard deterministic editor/IDE/formatter/text transformation tooling to produce changes that the author manually reviews and understands is exempt, including inline "auto‐completion" (even if LLM‐based) of short, rote snippets of text that do not contribute anything beyond boilerplate the author would have written anyway, and spelling and grammar checkers.
+
+* Use of standard community automation is exempt (e.g. dependabot).
+
+* Use of AI tools for research, testing, debugging, or review is out of scope, if no substantial amount of their output is included in the resulting contribution.
+  However, if these tools had a significant technical influence on your contribution, you are still responsible for it per the Accountability section, and are expected to disclose this where relevant.
+
+* Use of machine translation for commit and pull request descriptions and comments is exempt from the requirement to understand the translated output.
+  However, the requirements of appropriate confidence in the original text, responsibility, and disclosure still apply, and you should additionally include the original untranslated contribution.
+
+* Use of automation in a contribution clearly marked as not being ready for merge (e.g. a draft pull request) is exempt from the requirement for full self‐review, as long as some amount of review has been done and it is expected that the requirements will be met by the time it is marked as ready.
+  This does not waive any other requirement.
 
 ## Making changes to the Nix manual
 


### PR DESCRIPTION
This is adapted from the [nixpkgs policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy), but with additional restrictions around authorship of human communication.

Resolves #15340

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Nixpkgs has already adopted a policy, so we should also have one. Slop communication especially can really take a toll on the team so we should at the very least have a policy addressing that.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#15340
Nixpkgs PR: https://github.com/NixOS/nixpkgs/pull/514587

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
