### PR TITLE
doc/why-depends: fix example store hash prefix

### DIFF
--- a/src/nix/why-depends.md
+++ b/src/nix/why-depends.md
@@ -55,7 +55,7 @@ Nix automatically determines potential runtime dependencies between
 store paths by scanning for the *hash parts* of store paths. For
 instance, if there exists a store path
 `/nix/store/q9mknq836i0kblq8g1hm9f3cv9qda0r9-glibc-2.31`, and a file
-inside another store path contains the string `9df65igw…`, then the
+inside another store path contains the string `q9mknq83…`, then the
 latter store path *refers* to the former, and thus might need it at
 runtime. Nix always maintains the existence of the transitive closure
 of a store path under the references relationship; it is therefore not


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

In 8ba7ebca3 (Replace hashes that appear in cache.nixos.org with hashes which are unlikely to do so (for the diff from 3.14.0 to 3.15.0), 2025-12-23) / #14923, real store paths in documentation were removed and replaced with fake ones to avoid docs getting accidental runtime dependencies.  However, this missed one string in the `nix why-depends` documentation, which quoted the prefix of the string and now seems incongruous.  Fix the prefix so it's consistent with the full path earlier in the documentation.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
