### PR TITLE
SQLiteStmt::Use: Rename operator() -> apply()

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -126,13 +126,23 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::FullAttrs) (0, false).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::FullAttrs)
+                .apply(0, false)
+                .exec();
 
             AttrId rowId = state->db.getLastInsertedRowId();
             assert(rowId);
 
             for (auto & attr : attrs)
-                state->insertAttribute.use()(rowId)(symbols[attr])(AttrType::Placeholder) (0, false).exec();
+                state->insertAttribute.use()
+                    .apply(rowId)
+                    .apply(symbols[attr])
+                    .apply(AttrType::Placeholder)
+                    .apply(0, false)
+                    .exec();
 
             return rowId;
         });
@@ -152,10 +162,20 @@ struct AttrDb
                     ctx.append(elem->view());
                     first = false;
                 }
-                state->insertAttributeWithContext.use()(key.first)(symbols[key.second])(AttrType::String) (s) (ctx)
+                state->insertAttributeWithContext.use()
+                    .apply(key.first)
+                    .apply(symbols[key.second])
+                    .apply(AttrType::String)
+                    .apply(s)
+                    .apply(ctx)
                     .exec();
             } else {
-                state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::String) (s).exec();
+                state->insertAttribute.use()
+                    .apply(key.first)
+                    .apply(symbols[key.second])
+                    .apply(AttrType::String)
+                    .apply(s)
+                    .exec();
             }
 
             return state->db.getLastInsertedRowId();
@@ -167,7 +187,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Bool) (b ? 1 : 0).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Bool)
+                .apply(b ? 1 : 0)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -178,7 +203,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Int) (n).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Int)
+                .apply(n)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -189,9 +219,11 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute
-                .use()(key.first)(symbols[key.second])(
-                    AttrType::ListOfStrings) (dropEmptyInitThenConcatStringsSep("\t", l))
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::ListOfStrings)
+                .apply(dropEmptyInitThenConcatStringsSep("\t", l))
                 .exec();
 
             return state->db.getLastInsertedRowId();
@@ -203,7 +235,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Placeholder) (0, false).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Placeholder)
+                .apply(0, false)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -214,7 +251,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Missing) (0, false).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Missing)
+                .apply(0, false)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -225,7 +267,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Misc) (0, false).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Misc)
+                .apply(0, false)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -236,7 +283,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Failed) (0, false).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Failed)
+                .apply(0, false)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -246,7 +298,7 @@ struct AttrDb
     {
         auto state(_state->lock());
 
-        auto queryAttribute(state->queryAttribute.use()(key.first)(symbols[key.second]));
+        auto queryAttribute(state->queryAttribute.use().apply(key.first).apply(symbols[key.second]));
         if (!queryAttribute.next())
             return {};
 
@@ -259,7 +311,7 @@ struct AttrDb
         case AttrType::FullAttrs: {
             // FIXME: expensive, should separate this out.
             std::vector<Symbol> attrs;
-            auto queryAttributes(state->queryAttributes.use()(rowId));
+            auto queryAttributes(state->queryAttributes.use().apply(rowId));
             while (queryAttributes.next())
                 attrs.emplace_back(symbols.create(queryAttributes.getStr(0)));
             return {{rowId, attrs}};

--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -62,7 +62,11 @@ struct CacheImpl : Cache
     void upsert(const Key & key, const Attrs & value) override
     {
         _state.lock()
-            ->upsert.use()(key.first)(attrsToJSON(key.second).dump())(attrsToJSON(value).dump())(time(nullptr))
+            ->upsert.use()
+            .apply(key.first)
+            .apply(attrsToJSON(key.second).dump())
+            .apply(attrsToJSON(value).dump())
+            .apply(time(nullptr))
             .exec();
     }
 
@@ -89,7 +93,7 @@ struct CacheImpl : Cache
 
         auto keyJSON = attrsToJSON(key.second).dump();
 
-        auto stmt(state->lookup.use()(key.first)(keyJSON));
+        auto stmt(state->lookup.use().apply(key.first).apply(keyJSON));
         if (!stmt.next()) {
             debug("did not find cache entry for '%s:%s'", key.first, keyJSON);
             return {};

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -121,9 +121,9 @@ struct SQLiteStmt
         /**
          * Bind the next parameter.
          */
-        Use & operator()(std::string_view value, bool notNull = true);
-        Use & operator()(const unsigned char * data, size_t len, bool notNull = true);
-        Use & operator()(int64_t value, bool notNull = true);
+        Use & apply(std::string_view value, bool notNull = true);
+        Use & apply(const unsigned char * data, size_t len, bool notNull = true);
+        Use & apply(int64_t value, bool notNull = true);
         Use & bind(); // null
 
         int step();

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -678,9 +678,10 @@ void LocalStore::registerDrvOutput(const Realisation & info)
             if (info.isCompatibleWith(*oldR)) {
                 auto combinedSignatures = oldR->signatures;
                 combinedSignatures.insert(info.signatures.begin(), info.signatures.end());
-                state->stmts->UpdateRealisedOutput
-                    .use()(concatStringsSep(" ", Signature::toStrings(combinedSignatures)))(
-                        info.id.drvPath.to_string())(info.id.outputName)
+                state->stmts->UpdateRealisedOutput.use()
+                    .apply(concatStringsSep(" ", Signature::toStrings(combinedSignatures)))
+                    .apply(info.id.drvPath.to_string())
+                    .apply(info.id.outputName)
                     .exec();
             } else {
                 throw Error(
@@ -693,9 +694,11 @@ void LocalStore::registerDrvOutput(const Realisation & info)
                     printStorePath(info.outPath));
             }
         } else {
-            state->stmts->RegisterRealisedOutput
-                .use()(info.id.drvPath.to_string())(info.id.outputName)(printStorePath(info.outPath))(
-                    concatStringsSep(" ", Signature::toStrings(info.signatures)))
+            state->stmts->RegisterRealisedOutput.use()
+                .apply(info.id.drvPath.to_string())
+                .apply(info.id.outputName)
+                .apply(printStorePath(info.outPath))
+                .apply(concatStringsSep(" ", Signature::toStrings(info.signatures)))
                 .exec();
         }
     });
@@ -704,8 +707,9 @@ void LocalStore::registerDrvOutput(const Realisation & info)
 void LocalStore::cacheDrvOutputMapping(
     State & state, const uint64_t deriver, const std::string & outputName, const StorePath & output)
 {
-    retrySQLite<void>(
-        [&]() { state.stmts->AddDerivationOutput.use()(deriver)(outputName) (printStorePath(output)).exec(); });
+    retrySQLite<void>([&]() {
+        state.stmts->AddDerivationOutput.use().apply(deriver).apply(outputName).apply(printStorePath(output)).exec();
+    });
 }
 
 uint64_t LocalStore::addValidPath(State & state, const ValidPathInfo & info)
@@ -715,13 +719,15 @@ uint64_t LocalStore::addValidPath(State & state, const ValidPathInfo & info)
             "cannot add path '%s' to the Nix store because it claims to be content-addressed but isn't",
             printStorePath(info.path));
 
-    state.stmts->RegisterValidPath
-        .use()(printStorePath(info.path))(info.narHash.to_string(HashFormat::Base16, true))(
-            info.registrationTime == 0 ? time(nullptr) : info.registrationTime)(
-            info.deriver ? printStorePath(*info.deriver) : "",
-            (bool) info.deriver)(info.narSize, info.narSize != 0)(info.ultimate ? 1 : 0, info.ultimate)(
-            concatStringsSep(" ", Signature::toStrings(info.sigs)),
-            !info.sigs.empty())(renderContentAddress(info.ca), (bool) info.ca)
+    state.stmts->RegisterValidPath.use()
+        .apply(printStorePath(info.path))
+        .apply(info.narHash.to_string(HashFormat::Base16, true))
+        .apply(info.registrationTime == 0 ? time(nullptr) : info.registrationTime)
+        .apply(info.deriver ? printStorePath(*info.deriver) : "", (bool) info.deriver)
+        .apply(info.narSize, info.narSize != 0)
+        .apply(info.ultimate ? 1 : 0, info.ultimate)
+        .apply(concatStringsSep(" ", Signature::toStrings(info.sigs)), !info.sigs.empty())
+        .apply(renderContentAddress(info.ca), (bool) info.ca)
         .exec();
     uint64_t id = state.db.getLastInsertedRowId();
 
@@ -768,7 +774,7 @@ void LocalStore::queryPathInfoUncached(
 std::shared_ptr<const ValidPathInfo> LocalStore::queryPathInfoInternal(State & state, const StorePath & path)
 {
     /* Get the path info. */
-    auto useQueryPathInfo(state.stmts->QueryPathInfo.use()(printStorePath(path)));
+    auto useQueryPathInfo(state.stmts->QueryPathInfo.use().apply(printStorePath(path)));
 
     if (!useQueryPathInfo.next())
         return std::shared_ptr<ValidPathInfo>();
@@ -806,7 +812,7 @@ std::shared_ptr<const ValidPathInfo> LocalStore::queryPathInfoInternal(State & s
         info->ca = ContentAddress::parseOpt(s);
 
     /* Get the references. */
-    auto useQueryReferences(state.stmts->QueryReferences.use()(info->id));
+    auto useQueryReferences(state.stmts->QueryReferences.use().apply(info->id));
 
     while (useQueryReferences.next())
         info->references.insert(parseStorePath(useQueryReferences.getStr(0)));
@@ -817,17 +823,19 @@ std::shared_ptr<const ValidPathInfo> LocalStore::queryPathInfoInternal(State & s
 /* Update path info in the database. */
 void LocalStore::updatePathInfo(State & state, const ValidPathInfo & info)
 {
-    state.stmts->UpdatePathInfo
-        .use()(info.narSize, info.narSize != 0)(info.narHash.to_string(HashFormat::Base16, true))(
-            info.ultimate ? 1 : 0,
-            info.ultimate)(concatStringsSep(" ", Signature::toStrings(info.sigs)), !info.sigs.empty())(
-            renderContentAddress(info.ca), (bool) info.ca)(printStorePath(info.path))
+    state.stmts->UpdatePathInfo.use()
+        .apply(info.narSize, info.narSize != 0)
+        .apply(info.narHash.to_string(HashFormat::Base16, true))
+        .apply(info.ultimate ? 1 : 0, info.ultimate)
+        .apply(concatStringsSep(" ", Signature::toStrings(info.sigs)), !info.sigs.empty())
+        .apply(renderContentAddress(info.ca), (bool) info.ca)
+        .apply(printStorePath(info.path))
         .exec();
 }
 
 uint64_t LocalStore::queryValidPathId(State & state, const StorePath & path)
 {
-    auto use(state.stmts->QueryPathInfo.use()(printStorePath(path)));
+    auto use(state.stmts->QueryPathInfo.use().apply(printStorePath(path)));
     if (!use.next())
         throw InvalidPath("path '%s' is not valid", printStorePath(path));
     return use.getInt(0);
@@ -835,7 +843,7 @@ uint64_t LocalStore::queryValidPathId(State & state, const StorePath & path)
 
 bool LocalStore::isValidPath_(State & state, const StorePath & path)
 {
-    return state.stmts->QueryPathInfo.use()(printStorePath(path)).next();
+    return state.stmts->QueryPathInfo.use().apply(printStorePath(path)).next();
 }
 
 bool LocalStore::isValidPathUncached(const StorePath & path)
@@ -866,7 +874,7 @@ StorePathSet LocalStore::queryAllValidPaths()
 
 void LocalStore::queryReferrers(State & state, const StorePath & path, StorePathSet & referrers)
 {
-    auto useQueryReferrers(state.stmts->QueryReferrers.use()(printStorePath(path)));
+    auto useQueryReferrers(state.stmts->QueryReferrers.use().apply(printStorePath(path)));
 
     while (useQueryReferrers.next())
         referrers.insert(parseStorePath(useQueryReferrers.getStr(0)));
@@ -882,7 +890,7 @@ StorePathSet LocalStore::queryValidDerivers(const StorePath & path)
     return retrySQLite<StorePathSet>([&]() {
         auto state(_state->lock());
 
-        auto useQueryValidDerivers(state->stmts->QueryValidDerivers.use()(printStorePath(path)));
+        auto useQueryValidDerivers(state->stmts->QueryValidDerivers.use().apply(printStorePath(path)));
 
         StorePathSet derivers;
         while (useQueryValidDerivers.next())
@@ -900,7 +908,7 @@ LocalStore::queryStaticPartialDerivationOutputMap(const StorePath & path)
         std::map<std::string, std::optional<StorePath>> outputs;
         uint64_t drvId;
         drvId = queryValidPathId(*state, path);
-        auto use(state->stmts->QueryDerivationOutputs.use()(drvId));
+        auto use(state->stmts->QueryDerivationOutputs.use().apply(drvId));
         while (use.next())
             outputs.insert_or_assign(use.getStr(0), parseStorePath(use.getStr(1)));
 
@@ -939,7 +947,7 @@ std::optional<StorePath> LocalStore::queryPathFromHashPart(const std::string & h
     return retrySQLite<std::optional<StorePath>>([&]() -> std::optional<StorePath> {
         auto state(_state->lock());
 
-        auto useQueryPathFromHashPart(state->stmts->QueryPathFromHashPart.use()(prefix));
+        auto useQueryPathFromHashPart(state->stmts->QueryPathFromHashPart.use().apply(prefix));
 
         if (!useQueryPathFromHashPart.next())
             return {};
@@ -985,7 +993,7 @@ void LocalStore::registerValidPaths(const ValidPathInfos & infos)
         for (auto & [_, i] : infos) {
             auto referrer = queryValidPathId(*state, i.path);
             for (auto & j : i.references)
-                state->stmts->AddReference.use()(referrer)(queryValidPathId(*state, j)).exec();
+                state->stmts->AddReference.use().apply(referrer).apply(queryValidPathId(*state, j)).exec();
         }
 
         /* Do a topological sort of the paths.  This will throw an
@@ -1019,7 +1027,7 @@ void LocalStore::invalidatePath(State & state, const StorePath & path)
 {
     debug("invalidating path '%s'", printStorePath(path));
 
-    state.stmts->InvalidatePath.use()(printStorePath(path)).exec();
+    state.stmts->InvalidatePath.use().apply(printStorePath(path)).exec();
 
     /* Note that the foreign key constraints on the Refs table take
        care of deleting the references entries for `path'. */
@@ -1585,7 +1593,8 @@ void LocalStore::addSignatures(const StorePath & storePath, const std::set<Signa
 std::optional<std::pair<int64_t, UnkeyedRealisation>>
 LocalStore::queryRealisationCore_(LocalStore::State & state, const DrvOutput & id)
 {
-    auto useQueryRealisedOutput(state.stmts->QueryRealisedOutput.use()(id.drvPath.to_string())(id.outputName));
+    auto useQueryRealisedOutput(
+        state.stmts->QueryRealisedOutput.use().apply(id.drvPath.to_string()).apply(id.outputName));
     if (!useQueryRealisedOutput.next())
         return std::nullopt;
     auto realisationDbId = useQueryRealisedOutput.getInt(0);

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -163,14 +163,15 @@ public:
                     .use()
                     // Use a minimum TTL to prevent --refresh from
                     // nuking the entire disk cache.
-                    (now - std::max(settings.ttlNegative.get(), 3600U))(
-                        now - std::max(settings.ttlPositive.get(), 30 * 24 * 3600U))
+                    .apply(now - std::max(settings.ttlNegative.get(), 3600U))
+                    .apply(now - std::max(settings.ttlPositive.get(), 30 * 24 * 3600U))
                     .exec();
 
                 debug("deleted %d entries from the NAR info disk cache", sqlite3_changes(state->db));
 
                 SQLiteStmt(state->db, "insert or replace into LastPurge(dummy, value) values ('', ?)")
-                    .use()(now)
+                    .use()
+                    .apply(now)
                     .exec();
             }
         });
@@ -194,7 +195,7 @@ private:
                the the subtraction would promote time_t to unsigned if time_t is
                32 bit. */
             auto timestamp = static_cast<int64_t>(time(nullptr)) - static_cast<int64_t>(settings.ttlMeta.get());
-            auto queryCache(state.queryCache.use()(uri)(timestamp));
+            auto queryCache(state.queryCache.use().apply(uri).apply(timestamp));
             if (!queryCache.next())
                 return std::nullopt;
             auto cache = Cache{
@@ -230,7 +231,12 @@ public:
             };
 
             {
-                auto r(state->insertCache.use()(uri)(time(nullptr))(storeDir) (wantMassQuery) (priority));
+                auto r(state->insertCache.use()
+                           .apply(uri)
+                           .apply(time(nullptr))
+                           .apply(storeDir)
+                           .apply(wantMassQuery)
+                           .apply(priority));
                 if (!r.next()) {
                     unreachable();
                 }
@@ -266,8 +272,11 @@ public:
 
                 auto now = time(nullptr);
 
-                auto queryNAR(
-                    state->queryNAR.use()(cache.id)(hashPart) (now - settings.ttlNegative)(now - settings.ttlPositive));
+                auto queryNAR(state->queryNAR.use()
+                                  .apply(cache.id)
+                                  .apply(hashPart)
+                                  .apply(now - settings.ttlNegative)
+                                  .apply(now - settings.ttlPositive));
 
                 if (!queryNAR.next())
                     return {oUnknown, 0};
@@ -307,8 +316,12 @@ public:
 
                 auto now = time(nullptr);
 
-                auto queryRealisation(state->queryRealisation.use()(cache.id)(id.drvPath.to_string())(id.outputName)(
-                    now - settings.ttlNegative)(now - settings.ttlPositive));
+                auto queryRealisation(state->queryRealisation.use()
+                                          .apply(cache.id)
+                                          .apply(id.drvPath.to_string())
+                                          .apply(id.outputName)
+                                          .apply(now - settings.ttlNegative)
+                                          .apply(now - settings.ttlPositive));
 
                 if (!queryRealisation.next())
                     return {oUnknown, nullptr};
@@ -347,20 +360,27 @@ public:
 
                 // assert(hashPart == storePathToHash(info->path));
 
-                state->insertNAR
-                    .use()(cache.id)(hashPart) (std::string(info->path.name()))(
-                        narInfo ? narInfo->url : "", narInfo != 0)(narInfo ? narInfo->compression : "", narInfo != 0)(
+                state->insertNAR.use()
+                    .apply(cache.id)
+                    .apply(hashPart)
+                    .apply(std::string(info->path.name()))
+                    .apply(narInfo ? narInfo->url : "", narInfo != 0)
+                    .apply(narInfo ? narInfo->compression : "", narInfo != 0)
+                    .apply(
                         narInfo && narInfo->fileHash ? narInfo->fileHash->to_string(HashFormat::Nix32, true) : "",
-                        narInfo && narInfo->fileHash)(
-                        narInfo ? narInfo->fileSize : 0, narInfo != 0 && narInfo->fileSize)(info->narHash.to_string(
-                        HashFormat::Nix32, true))(info->narSize)(concatStringsSep(" ", info->shortRefs()))(
-                        info->deriver ? std::string(info->deriver->to_string()) : "",
-                        (bool) info->deriver)(concatStringsSep(" ", Signature::toStrings(info->sigs)))(
-                        renderContentAddress(info->ca))(time(nullptr))
+                        narInfo && narInfo->fileHash)
+                    .apply(narInfo ? narInfo->fileSize : 0, narInfo != 0 && narInfo->fileSize)
+                    .apply(info->narHash.to_string(HashFormat::Nix32, true))
+                    .apply(info->narSize)
+                    .apply(concatStringsSep(" ", info->shortRefs()))
+                    .apply(info->deriver ? std::string(info->deriver->to_string()) : "", (bool) info->deriver)
+                    .apply(concatStringsSep(" ", Signature::toStrings(info->sigs)))
+                    .apply(renderContentAddress(info->ca))
+                    .apply(time(nullptr))
                     .exec();
 
             } else {
-                state->insertMissingNAR.use()(cache.id)(hashPart) (time(nullptr)).exec();
+                state->insertMissingNAR.use().apply(cache.id).apply(hashPart).apply(time(nullptr)).exec();
             }
         });
     }
@@ -372,10 +392,13 @@ public:
 
             auto & cache(getCache(*state, uri));
 
-            state->insertRealisation
-                .use()(cache.id)(realisation.id.drvPath.to_string())(realisation.id.outputName)(
-                    realisation.outPath.to_string())(static_cast<nlohmann::json>(realisation.signatures).dump())(
-                    time(nullptr))
+            state->insertRealisation.use()
+                .apply(cache.id)
+                .apply(realisation.id.drvPath.to_string())
+                .apply(realisation.id.outputName)
+                .apply(realisation.outPath.to_string())
+                .apply(static_cast<nlohmann::json>(realisation.signatures).dump())
+                .apply(time(nullptr))
                 .exec();
         });
     }
@@ -386,7 +409,11 @@ public:
             auto state(_state.lock());
 
             auto & cache(getCache(*state, uri));
-            state->insertMissingRealisation.use()(cache.id)(id.drvPath.to_string())(id.outputName)(time(nullptr))
+            state->insertMissingRealisation.use()
+                .apply(cache.id)
+                .apply(id.drvPath.to_string())
+                .apply(id.outputName)
+                .apply(time(nullptr))
                 .exec();
         });
     }

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -178,7 +178,7 @@ SQLiteStmt::Use::~Use()
     sqlite3_reset(stmt);
 }
 
-SQLiteStmt::Use & SQLiteStmt::Use::operator()(std::string_view value, bool notNull)
+SQLiteStmt::Use & SQLiteStmt::Use::apply(std::string_view value, bool notNull)
 {
     if (notNull) {
         if (sqlite3_bind_text(stmt, curArg++, value.data(), value.size(), SQLITE_TRANSIENT) != SQLITE_OK)
@@ -188,7 +188,7 @@ SQLiteStmt::Use & SQLiteStmt::Use::operator()(std::string_view value, bool notNu
     return *this;
 }
 
-SQLiteStmt::Use & SQLiteStmt::Use::operator()(const unsigned char * data, size_t len, bool notNull)
+SQLiteStmt::Use & SQLiteStmt::Use::apply(const unsigned char * data, size_t len, bool notNull)
 {
     if (notNull) {
         if (sqlite3_bind_blob(stmt, curArg++, data, len, SQLITE_TRANSIENT) != SQLITE_OK)
@@ -198,7 +198,7 @@ SQLiteStmt::Use & SQLiteStmt::Use::operator()(const unsigned char * data, size_t
     return *this;
 }
 
-SQLiteStmt::Use & SQLiteStmt::Use::operator()(int64_t value, bool notNull)
+SQLiteStmt::Use & SQLiteStmt::Use::apply(int64_t value, bool notNull)
 {
     if (notNull) {
         if (sqlite3_bind_int64(stmt, curArg++, value) != SQLITE_OK)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Using `operator()` causes very ugly clang formatting, e.g.

```c++
    state.stmts->RegisterValidPath
        .use()(printStorePath(info.path))(info.narHash.to_string(HashFormat::Base16, true))(
            info.registrationTime == 0 ? time(nullptr) : info.registrationTime)(
            info.deriver ? printStorePath(*info.deriver) : "",
            (bool) info.deriver)(info.narSize, info.narSize != 0)(info.ultimate ? 1 : 0, info.ultimate)(
            concatStringsSep(" ", Signature::toStrings(info.sigs)),
            !info.sigs.empty())(renderContentAddress(info.ca), (bool) info.ca)
```
This was especially painful when there was a merge conflict involving this type of code.

Now it looks like this:
```c++
    state.stmts->RegisterValidPath.use()
        .apply(printStorePath(info.path))
        .apply(info.narHash.to_string(HashFormat::Base16, true))
        .apply(info.registrationTime == 0 ? time(nullptr) : info.registrationTime)
        .apply(info.deriver ? printStorePath(*info.deriver) : "", (bool) info.deriver)
        .apply(info.narSize, info.narSize != 0)
        .apply(info.ultimate ? 1 : 0, info.ultimate)
        .apply(concatStringsSep(" ", Signature::toStrings(info.sigs)), !info.sigs.empty())
        .apply(renderContentAddress(info.ca), (bool) info.ca)
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
