### PR TITLE
Add optimize as an alias of optimise

### DIFF
--- a/doc/manual/rl-next/optimise-alias.md
+++ b/doc/manual/rl-next/optimise-alias.md
@@ -1,0 +1,7 @@
+---
+synopsis: Add an alias for optimise.
+issues: [1902, 11326]
+prs: [11577, 15997]
+---
+
+Add "optimize" as a linguistic variation of "optimise". Now both the `nix-store` and `nix store` commands work with the same spelling.

--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -417,6 +417,8 @@ public:
         AcceptedShorthand,
         /** Aliases that will go away */
         Deprecated,
+        /** Aliases for linguistic variation */
+        LinguisticVariation,
     };
 
     /** An alias, except for the original syntax, which is in the map key. */

--- a/src/nix/store.cc
+++ b/src/nix/store.cc
@@ -9,6 +9,7 @@ struct CmdStore : NixMultiCommand
     {
         aliases = {
             {"ping", {AliasStatus::Deprecated, {"info"}}},
+            {"optimize", {AliasStatus::LinguisticVariation, {"optimise"}}},
         };
     }
 

--- a/tests/functional/optimise-store.sh
+++ b/tests/functional/optimise-store.sh
@@ -44,6 +44,30 @@ if [ "$inode1" != "$inode3" ]; then
     exit 1
 fi
 
+# shellcheck disable=SC2016
+outPath4=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo4"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link)
+
+NIX_REMOTE="" nix store optimise
+
+inode1="$(stat --format=%i "$outPath1"/foo)"
+inode4="$(stat --format=%i "$outPath4"/foo)"
+if [ "$inode1" != "$inode4" ]; then
+    echo "inodes do not match"
+    exit 1
+fi
+
+# shellcheck disable=SC2016
+outPath5=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo5"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link)
+
+NIX_REMOTE="" nix store optimize # alias of optimise
+
+inode1="$(stat --format=%i "$outPath1"/foo)"
+inode5="$(stat --format=%i "$outPath5"/foo)"
+if [ "$inode1" != "$inode5" ]; then
+    echo "inodes do not match"
+    exit 1
+fi
+
 nix-store --gc
 
 if [ -n "$(ls "$NIX_STORE_DIR"/.links)" ]; then

--- a/tests/functional/optimise-store.sh
+++ b/tests/functional/optimise-store.sh
@@ -15,14 +15,12 @@ TODO_NixOS # ignoring the client-specified setting 'auto-optimise-store', becaus
 inode1="$(stat --format=%i "$outPath1"/foo)"
 inode2="$(stat --format=%i "$outPath2"/foo)"
 if [ "$inode1" != "$inode2" ]; then
-    echo "inodes do not match"
-    exit 1
+    fail "inodes do not match"
 fi
 
 nlink="$(stat --format=%h "$outPath1"/foo)"
 if [ "$nlink" != 3 ]; then
-    echo "link count incorrect"
-    exit 1
+    fail "link count incorrect"
 fi
 
 # shellcheck disable=SC2016
@@ -30,8 +28,7 @@ outPath3=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo3"; bu
 
 inode3="$(stat --format=%i "$outPath3"/foo)"
 if [ "$inode1" = "$inode3" ]; then
-    echo "inodes match unexpectedly"
-    exit 1
+    fail "inodes match unexpectedly"
 fi
 
 # XXX: This should work through the daemon too
@@ -40,8 +37,7 @@ NIX_REMOTE="" nix-store --optimise
 inode1="$(stat --format=%i "$outPath1"/foo)"
 inode3="$(stat --format=%i "$outPath3"/foo)"
 if [ "$inode1" != "$inode3" ]; then
-    echo "inodes do not match"
-    exit 1
+    fail "inodes do not match"
 fi
 
 # shellcheck disable=SC2016
@@ -52,19 +48,16 @@ NIX_REMOTE="" nix store optimise
 inode1="$(stat --format=%i "$outPath1"/foo)"
 inode4="$(stat --format=%i "$outPath4"/foo)"
 if [ "$inode1" != "$inode4" ]; then
-    echo "inodes do not match"
-    exit 1
+    fail "inodes do not match"
 fi
 
 # alias of optimise
 if ! NIX_REMOTE="" nix store optimize; then
-    echo "nix store optimize alias is not present"
-    exit 1
+    fail "nix store optimize alias is not present"
 fi
 
 nix-store --gc
 
 if [ -n "$(ls "$NIX_STORE_DIR"/.links)" ]; then
-    echo ".links directory not empty after GC"
-    exit 1
+    fail ".links directory not empty after GC"
 fi

--- a/tests/functional/optimise-store.sh
+++ b/tests/functional/optimise-store.sh
@@ -56,15 +56,9 @@ if [ "$inode1" != "$inode4" ]; then
     exit 1
 fi
 
-# shellcheck disable=SC2016
-outPath5=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo5"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link)
-
-NIX_REMOTE="" nix store optimize # alias of optimise
-
-inode1="$(stat --format=%i "$outPath1"/foo)"
-inode5="$(stat --format=%i "$outPath5"/foo)"
-if [ "$inode1" != "$inode5" ]; then
-    echo "inodes do not match"
+# alias of optimise
+if ! NIX_REMOTE="" nix store optimize; then
+    echo "nix store optimize alias is not present"
     exit 1
 fi
 


### PR DESCRIPTION
This PR allows the use of both `nix store optimise` and `nix store optimize` via a new linguistic alias type.

Continuation of #11577 with the trivial merge conflict resolved and formatting/shellcheck fixed. Previously received 2 positive reviews and then didn't get any attention.

Closes #11577. Closes #1902.
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
