### PR TITLE
tests/functional: fix the CA suite daemon version gate

### DIFF
--- a/tests/functional/ca/common.sh
+++ b/tests/functional/ca/common.sh
@@ -2,7 +2,7 @@
 source ../common.sh
 
 # Need backend to support revamped CA
-requireDaemonNewerThan "2.34.0pre20251217"
+requireDaemonNewerThan "2.35.0pre20260303"
 
 enableFeatures "ca-derivations"
 


### PR DESCRIPTION
## Motivation

Stable 2.34.x daemons are newer than 2.34.0pre20251217, but predate
the `realisation-with-path-not-hash` protocol feature, so the suite ran
against them and crashed.

## Context

See https://github.com/NixOS/nix/pull/15927#issuecomment-4636188956

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
