### PR TITLE
Rename nix build-trace -> nix store build-trace

### DIFF
--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -261,8 +261,6 @@ endforeach
 nix3_manpages = [
   'nix',
   'nix3-build',
-  'nix3-build-trace',
-  'nix3-build-trace-info',
   'nix3-bundle',
   'nix3-config',
   'nix3-config-check',
@@ -337,6 +335,8 @@ nix3_manpages = [
   'nix3-store-add',
   'nix3-store-add-file',
   'nix3-store-add-path',
+  'nix3-store-build-trace-info',
+  'nix3-store-build-trace',
   'nix3-store-cat',
   'nix3-store-copy-log',
   'nix3-store-copy-sigs',

--- a/src/nix/build-trace.cc
+++ b/src/nix/build-trace.cc
@@ -8,7 +8,7 @@ namespace nix {
 struct CmdRealisation : NixMultiCommand
 {
     CmdRealisation()
-        : NixMultiCommand("build-trace", RegisterCommand::getCommandsFor({"build-trace"}))
+        : NixMultiCommand("build-trace", RegisterCommand::getCommandsFor({"store", "build-trace"}))
     {
     }
 
@@ -23,7 +23,7 @@ struct CmdRealisation : NixMultiCommand
     }
 };
 
-static auto rCmdRealisation = registerCommand<CmdRealisation>("build-trace");
+static auto rCmdRealisation = registerCommand2<CmdRealisation>({"store", "build-trace"});
 
 struct CmdRealisationInfo : BuiltPathsCommand, MixJSON
 {
@@ -77,6 +77,6 @@ struct CmdRealisationInfo : BuiltPathsCommand, MixJSON
     }
 };
 
-static auto rCmdBuildTraceInfo = registerCommand2<CmdRealisationInfo>({"build-trace", "info"});
+static auto rCmdBuildTraceInfo = registerCommand2<CmdRealisationInfo>({"store", "build-trace", "info"});
 
 } // namespace nix

--- a/src/nix/build-trace/info.md
+++ b/src/nix/build-trace/info.md
@@ -8,7 +8,7 @@ Display some information about the given build trace
 Show some information about the build trace of the `hello` package:
 
 ```console
-$ nix build-trace info nixpkgs#hello --json
+$ nix store build-trace info nixpkgs#hello --json
 [{"id":"sha256:3d382378a00588e064ee30be96dd0fa7e7df7cf3fbcace85a0e7b7dada1eef25!out","outPath":"fd3m7xawvrqcg98kgz5hc2vk3x9q0lh7-hello"}]
 ```
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -161,7 +161,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs, virtual RootArgs
             {"make-content-addressable", {AliasStatus::Deprecated, {"store", "make-content-addressed"}}},
             {"optimise-store", {AliasStatus::Deprecated, {"store", "optimise"}}},
             {"ping-store", {AliasStatus::Deprecated, {"store", "info"}}},
-            {"realisation", {AliasStatus::Deprecated, {"build-trace"}}},
+            {"realisation", {AliasStatus::Deprecated, {"store", "build-trace"}}},
             {"sign-paths", {AliasStatus::Deprecated, {"store", "sign"}}},
             {"shell", {AliasStatus::AcceptedShorthand, {"env", "shell"}}},
             {"show-derivation", {AliasStatus::Deprecated, {"derivation", "show"}}},

--- a/tests/functional/ca/substitute.sh
+++ b/tests/functional/ca/substitute.sh
@@ -27,7 +27,7 @@ clearStore
 # mentioning it explicitly again. (#11896, #11928).
 buildDrvs --substitute --substituters "$REMOTE_STORE" --no-require-sigs -j0 transitivelyDependentCA dependentCA
 # Check that the thing we’ve just substituted has its build trace stored
-nix build-trace info --file ./content-addressed.nix transitivelyDependentCA
+nix store build-trace info --file ./content-addressed.nix transitivelyDependentCA
 # Check that its dependencies have it too
 # Use the old command to make sure that the alias works
 nix realisation info --file ./content-addressed.nix dependentCA

--- a/tests/functional/completions.sh
+++ b/tests/functional/completions.sh
@@ -36,7 +36,7 @@ throw "error"
 EOF
 
 # Test the completion of a subcommand
-[[ "$(NIX_GET_COMPLETIONS=1 nix buil)" == $'normal\nbuild\t\nbuild-trace\t' ]]
+[[ "$(NIX_GET_COMPLETIONS=1 nix buil)" == $'normal\nbuild\t' ]]
 [[ "$(NIX_GET_COMPLETIONS=2 nix flake metad)" == $'normal\nmetadata\t' ]]
 
 # Filename completion


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

We generally want to minimize the number of top-level commands, especially for infrequently used non-porcelain operations.

https://github.com/NixOS/nix/pull/15948#issuecomment-4612685080

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
