### PR TITLE
tests/functional/fixed-slow-vs-bad: Fix fifo permissions

### DIFF
--- a/tests/functional/fixed-slow-vs-bad.nix
+++ b/tests/functional/fixed-slow-vs-bad.nix
@@ -9,7 +9,11 @@ with import ./config.nix;
 
     buildCommand = ''
       echo "slow: Started" >&2
-      echo slow-ready > /sync-fifo/fifo || echo "slow: No sync fifo, continuing" >&2
+      if [[ -p /sync-fifo/fifo ]]; then
+        echo slow-ready > /sync-fifo/fifo
+      else
+        echo "slow: No sync fifo, continuing" >&2
+      fi
       echo "slow: Entering infinite loop" >&2
       while true ; do echo -n .; done
     '';

--- a/tests/functional/fixed-slow-vs-bad.sh
+++ b/tests/functional/fixed-slow-vs-bad.sh
@@ -42,6 +42,7 @@ if canUseSandbox; then
   fifoDir="$TEST_ROOT/sync-fifo"
   mkdir -p "$fifoDir"
   mkfifo "$fifoDir/fifo"
+  chmod a+rw "$fifoDir/fifo"
   sandboxArgs+=(--option extra-sandbox-paths "/sync-fifo=$TEST_ROOT/sync-fifo")
 fi
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Fix the test on NixOS.

Sorry about that. Didn't notice this only affects *some* of the functional-on-NixOS tests.

Tested nix-functional-tests and NixOS functional_root, functional_trusted, functional_symlinked, functional_unprivileged, functional_user.

## Context

<!-- Provide context. Reference open issues if available. -->

Fix NixOS test `functional_root` https://hydra.nixos.org/build/331428739/nixlog/33, and others.

See https://github.com/NixOS/nix/pull/16002#issuecomment-4665335263.


<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
