### PR TITLE
Stop polluting the source tree in tests, always write to TEST_ROOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,23 +5,6 @@ src/.wraplock
 # Python bytecode (clang-tidy runner scripts)
 __pycache__/
 
-# /tests/functional/
-/tests/functional/common/subst-vars.sh
-/tests/functional/restricted-innocent
-/tests/functional/debugger-test-out
-/tests/functional/test-libstoreconsumer/test-libstoreconsumer
-/tests/functional/nix-shell
-
-# /tests/functional/lang/
-/tests/functional/lang/*.out
-/tests/functional/lang/*.out.xml
-/tests/functional/lang/*.err
-/tests/functional/lang/*.ast
-
-# /tests/functional/cli-characterisation/
-/tests/functional/cli-characterisation/*.out
-/tests/functional/cli-characterisation/*.err
-
 /outputs
 
 *~

--- a/tests/functional/ca/config.nix.in
+++ b/tests/functional/ca/config.nix.in
@@ -1,1 +1,0 @@
-../config.nix.in

--- a/tests/functional/cli-characterisation.sh
+++ b/tests/functional/cli-characterisation.sh
@@ -30,7 +30,7 @@ normalize() {
 
 diffAndAccept() {
     local testName="$1"
-    local got="cli-characterisation/$testName.$2"
+    local got="$TEST_ROOT/$testName.$2"
     local expected="cli-characterisation/$testName.$3"
     diffAndAcceptInner "$testName" "$got" "$expected"
 }
@@ -53,10 +53,10 @@ for cmdFile in cli-characterisation/*.cmd; do
     if
         # shellcheck disable=SC2086 # word splitting of cmd is intended
         expect "$expectedExit" $cmd \
-            1> "cli-characterisation/$testName.out" \
-            2> "cli-characterisation/$testName.err"
+            1> "$TEST_ROOT/$testName.out" \
+            2> "$TEST_ROOT/$testName.err"
     then
-        normalize "cli-characterisation/$testName.out" "cli-characterisation/$testName.err"
+        normalize "$TEST_ROOT/$testName.out" "$TEST_ROOT/$testName.err"
         diffAndAccept "$testName" out out.exp
         diffAndAccept "$testName" err err.exp
     else
@@ -74,10 +74,10 @@ testName=nix-build-multi-output
 echo "testing $testName"
 if
     expect 1 nix-build "$drvPath!out,bin" \
-        1> "cli-characterisation/$testName.out" \
-        2> "cli-characterisation/$testName.err"
+        1> "$TEST_ROOT/$testName.out" \
+        2> "$TEST_ROOT/$testName.err"
 then
-    normalize "cli-characterisation/$testName.out" "cli-characterisation/$testName.err"
+    normalize "$TEST_ROOT/$testName.out" "$TEST_ROOT/$testName.err"
     diffAndAccept "$testName" out out.exp
     diffAndAccept "$testName" err err.exp
 else
@@ -90,10 +90,10 @@ testName=nix-build-bad-output
 echo "testing $testName"
 if
     expect 1 nix-build "$drvPath!nonexistent" \
-        1> "cli-characterisation/$testName.out" \
-        2> "cli-characterisation/$testName.err"
+        1> "$TEST_ROOT/$testName.out" \
+        2> "$TEST_ROOT/$testName.err"
 then
-    normalize "cli-characterisation/$testName.out" "cli-characterisation/$testName.err"
+    normalize "$TEST_ROOT/$testName.out" "$TEST_ROOT/$testName.err"
     diffAndAccept "$testName" out out.exp
     diffAndAccept "$testName" err err.exp
 else

--- a/tests/functional/debugger.sh
+++ b/tests/functional/debugger.sh
@@ -10,6 +10,6 @@ echo ":env" | expect 1 nix eval --debugger --expr '
   let x.a = 1; in
   with x;
   (_: builtins.seq x.a (throw "oh snap")) x.a
-' >debugger-test-out
-grep -P 'with: .*a' debugger-test-out
-grep -P 'static: .*x' debugger-test-out
+' >"$TEST_ROOT/debugger-test-out"
+grep -P 'with: .*a' "$TEST_ROOT/debugger-test-out"
+grep -P 'static: .*x' "$TEST_ROOT/debugger-test-out"

--- a/tests/functional/dyn-drv/config.nix.in
+++ b/tests/functional/dyn-drv/config.nix.in
@@ -1,1 +1,0 @@
-../config.nix.in

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -9,7 +9,7 @@ source characterisation/framework.sh
 # specialize function a bit
 function diffAndAccept() {
     local -r testName="$1"
-    local -r got="lang/$testName.$2"
+    local -r got="$TEST_ROOT/$testName.$2"
     local -r expected="lang/$testName.$3"
     diffAndAcceptInner "$testName" "$got" "$expected"
 }
@@ -60,7 +60,7 @@ postprocess() {
             # just exposes us to the complexity of not having /usr/bin/env in
             # the sandbox. So let's just hardcode bash for now.
             set -x;
-            bash "lang/$1.postprocess" "lang/$1"
+            bash "lang/$1.postprocess" "$TEST_ROOT/$1"
         )
     fi
 }
@@ -68,7 +68,7 @@ postprocess() {
 for i in lang/parse-fail-*.nix; do
     echo "parsing $i (should fail)";
     i=$(basename "$i" .nix)
-    if expectStderr 1 nix-instantiate --parse - < "lang/$i.nix" > "lang/$i.err"
+    if expectStderr 1 nix-instantiate --parse - < "lang/$i.nix" > "$TEST_ROOT/$i.err"
     then
         postprocess "$i"
         diffAndAccept "$i" err err.exp
@@ -83,10 +83,10 @@ for i in lang/parse-okay-*.nix; do
     i=$(basename "$i" .nix)
     if
         expect 0 nix-instantiate --parse - < "lang/$i.nix" \
-            1> "lang/$i.out" \
-            2> "lang/$i.err"
+            1> "$TEST_ROOT/$i.out" \
+            2> "$TEST_ROOT/$i.err"
     then
-        sed "s!$(pwd)!/pwd!g" "lang/$i.out" "lang/$i.err"
+        sed "s!$(pwd)!/pwd!g" "$TEST_ROOT/$i.out" "$TEST_ROOT/$i.err"
         postprocess "$i"
         diffAndAccept "$i" out exp
         diffAndAccept "$i" err err.exp
@@ -110,7 +110,7 @@ for i in lang/eval-fail-*.nix; do
     if
         # shellcheck disable=SC2086 # word splitting of flags is intended
         expectStderr 1 nix-instantiate $flags "lang/$i.nix" \
-            | sed "s!$(pwd)!/pwd!g" > "lang/$i.err"
+            | sed "s!$(pwd)!/pwd!g" > "$TEST_ROOT/$i.err"
     then
         postprocess "$i"
         diffAndAccept "$i" err err.exp
@@ -126,7 +126,7 @@ for i in lang/eval-okay-*.nix; do
 
     if test -e "lang/$i.exp.xml"; then
         if expect 0 nix-instantiate --eval --xml --no-location --strict \
-                "lang/$i.nix" > "lang/$i.out.xml"
+                "lang/$i.nix" > "$TEST_ROOT/$i.out.xml"
         then
             postprocess "$i"
             diffAndAccept "$i" out.xml exp.xml
@@ -145,10 +145,10 @@ for i in lang/eval-okay-*.nix; do
                 NIX_PATH=lang/dir3:lang/dir4 \
                 HOME=/fake-home \
                 nix-instantiate "${flags[@]}" --eval --strict "lang/$i.nix" \
-                1> "lang/$i.out" \
-                2> "lang/$i.err"
+                1> "$TEST_ROOT/$i.out" \
+                2> "$TEST_ROOT/$i.err"
         then
-            sed -i "s!$(pwd)!/pwd!g" "lang/$i.out" "lang/$i.err"
+            sed -i "s!$(pwd)!/pwd!g" "$TEST_ROOT/$i.out" "$TEST_ROOT/$i.err"
             postprocess "$i"
             diffAndAccept "$i" out exp
             diffAndAccept "$i" err err.exp

--- a/tests/functional/logging.sh
+++ b/tests/functional/logging.sh
@@ -19,11 +19,11 @@ nix-build dependencies.nix --no-out-link --compress-build-log
 [ "$(nix-store -l "$path")" = FOO ]
 
 # test whether empty logs work fine with `nix log`.
-builder="$(realpath "$(mktemp)")"
+builder=$TEST_ROOT/builder
 echo -e "#!/bin/sh\nmkdir \$out" > "$builder"
 outp="$(nix-build -E \
     'with import '"${config_nix}"'; mkDerivation { name = "fnord"; builder = '"$builder"'; }' \
-    --out-link "$(mktemp -d)/result")"
+    --out-link "$TEST_ROOT/result")"
 
 test -d "$outp"
 

--- a/tests/functional/nix-shell.sh
+++ b/tests/functional/nix-shell.sh
@@ -35,7 +35,7 @@ output=$(nix-shell --pure --keep SELECTED_IMPURE_VAR "$shellDotNix" -A shellDrv 
 [ "$output" = " - foo - bar - baz" ]
 
 # test NIX_BUILD_TOP
-testTmpDir=$(pwd)/nix-shell
+testTmpDir=$TEST_ROOT/tmp-dir
 mkdir -p "$testTmpDir"
 # shellcheck disable=SC2016
 output=$(TMPDIR="$testTmpDir" nix-shell --pure "$shellDotNix" -A shellDrv --run 'echo $NIX_BUILD_TOP')

--- a/tests/functional/restricted.sh
+++ b/tests/functional/restricted.sh
@@ -6,7 +6,7 @@ clearStoreIfPossible
 
 nix-instantiate --restrict-eval --eval -E '1 + 2'
 (! nix-instantiate --eval --restrict-eval ./restricted.nix)
-TMPFILE=$(mktemp); echo '1 + 2' >"$TMPFILE"; (! nix-instantiate --eval --restrict-eval "$TMPFILE"); rm "$TMPFILE"
+TMPFILE=$(mktemp -p "$TEST_ROOT"); echo '1 + 2' >"$TMPFILE"; (! nix-instantiate --eval --restrict-eval "$TMPFILE");
 
 mkdir -p "$TEST_ROOT/nix"
 cp ./simple.nix "$TEST_ROOT/nix"
@@ -62,8 +62,8 @@ expectStderr 1 nix-instantiate --restrict-eval --eval -E "let __nixPath = [ { pr
 [[ $(nix-instantiate --restrict-eval --eval -E "let __nixPath = [ { prefix = \"foo\"; path = $TEST_ROOT/tunnel.d; } ]; in builtins.readDir <foo/tunnel>" -I "$TEST_ROOT"/tunnel.d) == '{ "tunnel.d" = "directory"; }' ]]
 
 # Check whether we can leak symlink information through directory traversal.
-traverseDir="${_NIX_TEST_SOURCE_DIR}/restricted-traverse-me"
-ln -sfn "${_NIX_TEST_SOURCE_DIR}/restricted-secret" "${_NIX_TEST_SOURCE_DIR}/restricted-innocent"
+traverseDir="$TEST_ROOT/restricted-traverse-me"
+ln -sfn "$TEST_ROOT/restricted-secret" "$TEST_ROOT/restricted-innocent"
 mkdir -p "$traverseDir"
 # shellcheck disable=SC2001
 goUp="..$(echo "$traverseDir" | sed -e 's,[^/]\+,..,g')"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Pretty self-explanatory. There's a lot we can improve about the test suite, but this is a nice start at least.

Also cleans up 2 unnecessary symlinks that John has fixed up in ee8b56e3040af712a105f3874400573687e60564, but I accidentally dropped those changes in a rebase.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
