### PR TITLE
Spring clean of tests, remove redundant clearStore and other removals

### DIFF
--- a/tests/functional/absolute-path-literals.sh
+++ b/tests/functional/absolute-path-literals.sh
@@ -5,8 +5,6 @@ source common.sh
 # Tests for absolute path literals that require NIX_CONFIG or grepQuietInverse.
 # Basic warn/fatal/default behavior tests are in lang/eval-*-abs-path-*.nix
 
-clearStoreIfPossible
-
 # Test: Setting via NIX_CONFIG
 NIX_CONFIG='lint-absolute-path-literals = warn' nix eval --expr '/tmp/bar' 2>"$TEST_ROOT"/stderr
 grepQuiet "absolute path literals are not portable" "$TEST_ROOT/stderr"

--- a/tests/functional/bash-profile.sh
+++ b/tests/functional/bash-profile.sh
@@ -5,7 +5,5 @@ source common.sh
 sed -e "s|@localstatedir@|$TEST_ROOT/profile-var|g" -e "s|@coreutils@|$coreutils|g" < ../../scripts/nix-profile.sh.in > "$TEST_ROOT"/nix-profile.sh
 
 user=$(whoami)
-rm -rf "$TEST_HOME" "$TEST_ROOT/profile-var"
-mkdir -p "$TEST_HOME"
 USER=$user $SHELL -e -c ". $TEST_ROOT/nix-profile.sh; set"
 USER=$user $SHELL -e -c ". $TEST_ROOT/nix-profile.sh" # test idempotency

--- a/tests/functional/binary-cache-build-remote.sh
+++ b/tests/functional/binary-cache-build-remote.sh
@@ -4,9 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStoreIfPossible
-clearCacheCache
-
 # Fails without remote builders
 (! nix-build --store "file://$cacheDir" dependencies.nix)
 

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -7,13 +7,12 @@ TODO_NixOS
 needLocalStore "'--no-require-sigs' can’t be used with the daemon"
 
 # We can produce drvs directly into the binary cache
-clearStore
-clearCacheCache
 nix-instantiate --store "file://$cacheDir" dependencies.nix
 
-# Create the binary cache.
 clearStore
-clearCache
+clearBinaryCache
+
+# Create the binary cache.
 outPath=$(nix-build dependencies.nix --no-out-link)
 depPath=$(nix-build dependencies.nix -A input0_drv --no-out-link)
 
@@ -183,7 +182,7 @@ grepQuiet "building.*input-2" "$TEST_ROOT/log"
 
 
 # Create a signed binary cache.
-clearCache
+clearBinaryCache
 clearCacheCache
 
 nix key generate-secret --key-name test.nixos.org-1 > "$TEST_ROOT/sk1"
@@ -259,7 +258,7 @@ rm -rfv "$cacheDir/nar"
 
 
 # Test NAR listing generation.
-clearCache
+clearBinaryCache
 
 
 # preserve quotes variables in the single-quoted string
@@ -300,7 +299,7 @@ EOF
 
 
 # Test debug info index generation.
-clearCache
+clearBinaryCache
 
 # preserve quotes variables in the single-quoted string
 # shellcheck disable=SC2016

--- a/tests/functional/brotli.sh
+++ b/tests/functional/brotli.sh
@@ -4,9 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-clearCache
-
 cacheURI="file://$cacheDir?compression=br"
 
 outPath=$(nix-build dependencies.nix --no-out-link)

--- a/tests/functional/build-cores.sh
+++ b/tests/functional/build-cores.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 echo "Testing build-cores configuration behavior..."
 
 # Test 1: When build-cores is set to a non-zero value, NIX_BUILD_CORES should have that value

--- a/tests/functional/build-delete.sh
+++ b/tests/functional/build-delete.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 # https://github.com/NixOS/nix/issues/6572
 issue_6572_independent_outputs() {
     nix build -f multiple-outputs.nix --json independent --no-link > "$TEST_ROOT"/independent.json

--- a/tests/functional/build-dry.sh
+++ b/tests/functional/build-dry.sh
@@ -8,14 +8,10 @@ TODO_NixOS
 # Check that --dry-run isn't confused with read-only mode
 # https://github.com/NixOS/nix/issues/1795
 
-clearStore
-clearCache
-
 # Ensure this builds successfully first
 nix build --no-link -f dependencies.nix
 
 clearStore
-clearCache
 
 # Try --dry-run using old command first
 nix-build --no-out-link dependencies.nix --dry-run 2>&1 | grep "will be built"
@@ -23,7 +19,6 @@ nix-build --no-out-link dependencies.nix --dry-run 2>&1 | grep "will be built"
 nix build -f dependencies.nix --dry-run 2>&1 | grep "will be built"
 
 clearStore
-clearCache
 
 # Try --dry-run using new command first
 nix build -f dependencies.nix --dry-run 2>&1 | grep "will be built"
@@ -34,7 +29,6 @@ nix-build --no-out-link dependencies.nix --dry-run 2>&1 | grep "will be built"
 # Check --dry-run doesn't create links with --dry-run
 # https://github.com/NixOS/nix/issues/1849
 clearStore
-clearCache
 
 RESULT=$TEST_ROOT/result-link
 rm -f "$RESULT"
@@ -54,7 +48,6 @@ nix build -f dependencies.nix -o "$RESULT"
 ###################################################
 # Check the JSON output
 clearStore
-clearCache
 
 RES=$(nix build -f dependencies.nix --dry-run --json)
 

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 # Make sure that 'nix build' returns all outputs by default.
 nix build -f multiple-outputs.nix --json a b --no-link | jq --exit-status '
   (.[0] |

--- a/tests/functional/ca/build-cache.sh
+++ b/tests/functional/ca/build-cache.sh
@@ -37,7 +37,7 @@ copyAttr () {
 
 testRemoteCacheFor () {
     local derivationPath=$1
-    clearCache
+    clearBinaryCache
     copyAttr "$derivationPath" 1
     clearStore
     # Check nothing gets built.

--- a/tests/functional/ca/concurrent-builds.sh
+++ b/tests/functional/ca/concurrent-builds.sh
@@ -9,8 +9,6 @@ buggyNeedLocalStore "For some reason, this deadlocks with the daemon"
 
 export NIX_TESTS_CA_BY_DEFAULT=1
 
-clearStore
-
 for i in {0..5}; do
     nix build --no-link --file ./racy.nix &
 done

--- a/tests/functional/ca/duplicate-realisation-in-closure.sh
+++ b/tests/functional/ca/duplicate-realisation-in-closure.sh
@@ -4,11 +4,7 @@ source common.sh
 
 requireDaemonNewerThan "2.4pre20210625"
 
-export REMOTE_STORE_DIR="$TEST_ROOT/remote_store"
-export REMOTE_STORE="file://$REMOTE_STORE_DIR"
-
-rm -rf "$REMOTE_STORE_DIR"
-clearStore
+export REMOTE_STORE="file://$cacheDir"
 
 # Build dep1 and push that to the binary cache.
 # This entails building (and pushing) current-time.

--- a/tests/functional/ca/issue-13247.sh
+++ b/tests/functional/ca/issue-13247.sh
@@ -6,8 +6,6 @@ export NIX_TESTS_CA_BY_DEFAULT=1
 
 source common.sh
 
-clearStoreIfPossible
-
 set -x
 
 # Build derivation (both outputs)

--- a/tests/functional/ca/nix-copy.sh
+++ b/tests/functional/ca/nix-copy.sh
@@ -2,8 +2,7 @@
 
 source common.sh
 
-export REMOTE_STORE_DIR="$TEST_ROOT/remote_store"
-export REMOTE_STORE="file://$REMOTE_STORE_DIR"
+export REMOTE_STORE="file://$cacheDir"
 
 ensureCorrectlyCopied () {
     attrPath="$1"
@@ -12,7 +11,7 @@ ensureCorrectlyCopied () {
 
 testOneCopy () {
     clearStore
-    rm -rf "$REMOTE_STORE_DIR"
+    clearBinaryCache
 
     attrPath="$1"
     nix copy --to "$REMOTE_STORE" "$attrPath" --file ./content-addressed.nix

--- a/tests/functional/ca/signatures.sh
+++ b/tests/functional/ca/signatures.sh
@@ -2,14 +2,10 @@
 
 source common.sh
 
-clearStore
-clearCache
-
 nix-store --generate-binary-cache-key cache1.example.org "$TEST_ROOT/sk1" "$TEST_ROOT/pk1"
 pk1=$(cat "$TEST_ROOT/pk1")
 
-export REMOTE_STORE_DIR="$TEST_ROOT/remote_store"
-export REMOTE_STORE="file://$REMOTE_STORE_DIR"
+export REMOTE_STORE="file://$cacheDir"
 
 ensureCorrectlyCopied () {
     attrPath="$1"
@@ -18,7 +14,7 @@ ensureCorrectlyCopied () {
 
 testOneCopy () {
     clearStore
-    rm -rf "$REMOTE_STORE_DIR"
+    clearBinaryCache
 
     attrPath="$1"
     nix copy -vvvv --to "$REMOTE_STORE" "$attrPath" --file ./content-addressed.nix \

--- a/tests/functional/ca/substitute.sh
+++ b/tests/functional/ca/substitute.sh
@@ -7,10 +7,7 @@ source common.sh
 # shellcheck disable=SC1111
 needLocalStore "“--no-require-sigs” can’t be used with the daemon"
 
-rm -rf "$TEST_ROOT/binary_cache"
-
-export REMOTE_STORE_DIR=$TEST_ROOT/binary_cache
-export REMOTE_STORE=file://$REMOTE_STORE_DIR
+export REMOTE_STORE="file://$cacheDir"
 
 buildDrvs () {
     nix build --file ./content-addressed.nix -L --no-link "$@"
@@ -49,5 +46,5 @@ buildDrvs --substitute --substituters "$REMOTE_STORE" --no-require-sigs -j0
 # Try rebuilding, but remove the realisations from the remote cache to force
 # using the cachecache
 clearStore
-rm -r "$REMOTE_STORE_DIR"/build-trace-v2/*
+rm -r "$cacheDir"/build-trace-v2/*
 buildDrvs --substitute --substituters "$REMOTE_STORE" --no-require-sigs -j0

--- a/tests/functional/check-refs.sh
+++ b/tests/functional/check-refs.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 RESULT=$TEST_ROOT/result
 
 dep=$(nix-build -o "$RESULT" check-refs.nix -A dep)

--- a/tests/functional/check-reqs.sh
+++ b/tests/functional/check-reqs.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 RESULT=$TEST_ROOT/result
 
 nix-build -o "$RESULT" check-reqs.nix -A test1

--- a/tests/functional/check.sh
+++ b/tests/functional/check.sh
@@ -17,8 +17,6 @@ checkBuildId=$(date +%s%N)
 
 TODO_NixOS
 
-clearStore
-
 nix-build dependencies.nix --no-out-link
 nix-build dependencies.nix --no-out-link --check
 

--- a/tests/functional/cli-characterisation.sh
+++ b/tests/functional/cli-characterisation.sh
@@ -35,8 +35,6 @@ diffAndAccept() {
     diffAndAcceptInner "$testName" "$got" "$expected"
 }
 
-clearProfiles
-
 # Each test case has a descriptor: cli-characterisation/<name>.cmd
 # containing: <expected-exit-code> <command...>
 #

--- a/tests/functional/common/functions.sh
+++ b/tests/functional/common/functions.sh
@@ -54,7 +54,7 @@ doClearStore() {
     clearProfiles
 }
 
-clearCache() {
+clearBinaryCache() {
     rm -rf "${cacheDir?}"
 }
 

--- a/tests/functional/compression-levels.sh
+++ b/tests/functional/compression-levels.sh
@@ -2,9 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-clearCache
-
 outPath=$(nix-build dependencies.nix --no-out-link)
 
 cacheURI="file://$cacheDir?compression=xz&compression-level=0"
@@ -13,7 +10,7 @@ nix copy --to "$cacheURI" "$outPath"
 
 FILESIZES=$(cat "${cacheDir}"/*.narinfo | awk '/FileSize: /{sum+=$2}END{print sum}')
 
-clearCache
+clearBinaryCache
 
 cacheURI="file://$cacheDir?compression=xz&compression-level=5"
 

--- a/tests/functional/config.sh
+++ b/tests/functional/config.sh
@@ -2,10 +2,6 @@
 
 source common.sh
 
-# Isolate the home for this test.
-# Other tests (e.g. flake registry tests) could be writing to $HOME in parallel.
-export HOME=$TEST_ROOT/userhome
-
 # Test that using XDG_CONFIG_HOME works
 # Assert the config folder didn't exist initially.
 [ ! -e "$HOME/.config" ]

--- a/tests/functional/debugger.sh
+++ b/tests/functional/debugger.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 # regression #9932
 echo ":env" | expect 1 nix eval --debugger --expr '(_: throw "oh snap") 42'
 echo ":env" | expect 1 nix eval --debugger --expr '

--- a/tests/functional/dependencies.sh
+++ b/tests/functional/dependencies.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 drvPath=$(nix-instantiate dependencies.nix)
 
 echo "derivation is $drvPath"

--- a/tests/functional/dump-db.sh
+++ b/tests/functional/dump-db.sh
@@ -6,8 +6,6 @@ TODO_NixOS
 
 needLocalStore "--dump-db requires a local store"
 
-clearStore
-
 nix-build dependencies.nix -o "$TEST_ROOT"/result
 deps="$(nix-store -qR "$TEST_ROOT"/result)"
 

--- a/tests/functional/dyn-drv/recursive-mod-json.sh
+++ b/tests/functional/dyn-drv/recursive-mod-json.sh
@@ -9,10 +9,6 @@ export NIX_TESTS_CA_BY_DEFAULT=1
 enableFeatures 'recursive-nix'
 restartDaemon
 
-clearStore
-
-rm -f "$TEST_ROOT"/result
-
 EXTRA_PATH=$(dirname "$(type -p nix)"):$(dirname "$(type -p jq)")
 export EXTRA_PATH
 

--- a/tests/functional/eval-store.sh
+++ b/tests/functional/eval-store.sh
@@ -11,9 +11,6 @@ needLocalStore "“--eval-store” doesn't achieve much with the daemon"
 
 eval_store=$TEST_ROOT/eval-store
 
-clearStore
-rm -rf "$eval_store"
-
 nix build -f dependencies.nix --eval-store "$eval_store" -o "$TEST_ROOT/result"
 [[ -e $TEST_ROOT/result/foobar ]]
 if [[ -z "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then

--- a/tests/functional/eval.sh
+++ b/tests/functional/eval.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 testStdinHeredoc=$(nix eval -f - <<EOF
 {
   bar = 3 + 1;

--- a/tests/functional/export-graph.sh
+++ b/tests/functional/export-graph.sh
@@ -4,9 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-clearProfiles
-
 checkRef() {
     nix-store -q --references "$TEST_ROOT"/result | grepQuiet "$1"'$' || fail "missing reference $1"
 }

--- a/tests/functional/export.sh
+++ b/tests/functional/export.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 outPath=$(nix-build dependencies.nix --no-out-link)
 
 nix-store --export "$outPath" > "$TEST_ROOT"/exp

--- a/tests/functional/fetchClosure.sh
+++ b/tests/functional/fetchClosure.sh
@@ -6,9 +6,6 @@ enableFeatures "fetch-closure"
 
 TODO_NixOS
 
-clearStore
-clearCacheCache
-
 # Old daemons don't properly zero out the self-references when
 # calculating the CA hashes, so this breaks `nix store
 # make-content-addressed` which expects the client and the daemon to

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -4,15 +4,11 @@ source common.sh
 
 requireGit
 
-clearStoreIfPossible
-
 # Intentionally not in a canonical form
 # See https://github.com/NixOS/nix/issues/6195
 repo=$TEST_ROOT/./git
 
 export _NIX_FORCE_HTTP=1
-
-rm -rf "${repo}"-tmp "$TEST_HOME"/.cache/nix "$TEST_ROOT"/worktree "$TEST_ROOT"/minimal
 
 createGitRepo "$repo"
 

--- a/tests/functional/fetchGitRefs.sh
+++ b/tests/functional/fetchGitRefs.sh
@@ -4,11 +4,7 @@ source common.sh
 
 requireGit
 
-clearStoreIfPossible
-
 repo="$TEST_ROOT/git"
-
-rm -rf "${repo}-tmp" "$TEST_HOME/.cache/nix"
 
 createGitRepo "$repo"
 

--- a/tests/functional/fetchGitSubmodules.sh
+++ b/tests/functional/fetchGitSubmodules.sh
@@ -2,16 +2,10 @@
 
 source common.sh
 
-set -u
-
 requireGit
-
-clearStoreIfPossible
 
 rootRepo=$TEST_ROOT/gitSubmodulesRoot
 subRepo=$TEST_ROOT/gitSubmodulesSub
-
-rm -rf "${rootRepo}" "${subRepo}" "$TEST_HOME"/.cache/nix
 
 # Submodules can't be fetched locally by default, which can cause
 # information leakage vulnerabilities, but for these tests our

--- a/tests/functional/fetchGitVerification.sh
+++ b/tests/functional/fetchGitVerification.sh
@@ -7,8 +7,6 @@ requireGit
 
 enableFeatures "verified-fetches"
 
-clearStoreIfPossible
-
 repo="$TEST_ROOT/git"
 
 # generate signing keys

--- a/tests/functional/fetchMercurial.sh
+++ b/tests/functional/fetchMercurial.sh
@@ -6,13 +6,9 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 # Intentionally not in a canonical form
 # See https://github.com/NixOS/nix/issues/6195
 repo=$TEST_ROOT/./hg
-
-rm -rf "$repo" "${repo}"-tmp "$TEST_HOME"/.cache/nix
 
 hg init "$repo"
 {

--- a/tests/functional/fetchTree-file.sh
+++ b/tests/functional/fetchTree-file.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 cd "$TEST_ROOT"
 
 test_fetch_file () {

--- a/tests/functional/fetchurl.sh
+++ b/tests/functional/fetchurl.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 # Test fetching a flat file.
 hash=$(nix-hash --flat --type sha256 ./fetchurl.sh)
 

--- a/tests/functional/filter-source.sh
+++ b/tests/functional/filter-source.sh
@@ -2,14 +2,8 @@
 
 source common.sh
 
-rm -rf "$TEST_ROOT/filterin"
-mkdir "$TEST_ROOT/filterin"
-mkdir "$TEST_ROOT/filterin/foo"
-touch "$TEST_ROOT/filterin/foo/bar"
-touch "$TEST_ROOT/filterin/xyzzy"
-touch "$TEST_ROOT/filterin/b"
-touch "$TEST_ROOT/filterin/bak"
-touch "$TEST_ROOT"/filterin/bla.c.bak
+mkdir -p "$TEST_ROOT/filterin/foo"
+touch "$TEST_ROOT"/filterin/{foo/bar,xyzzy,b,bak,bla.c.bak}
 ln -s xyzzy "$TEST_ROOT/filterin/link"
 
 checkFilter() {

--- a/tests/functional/fixed-slow-vs-bad.sh
+++ b/tests/functional/fixed-slow-vs-bad.sh
@@ -7,8 +7,6 @@ requireSandboxSupport
 # Requires bug fix for daemon
 requireDaemonNewerThan "2.35.0pre20260518"
 
-clearStoreIfPossible
-
 # See https://github.com/NixOS/nix/issues/15846
 #
 # `slow` is a fixed-output derivation that never finishes (which simulates a

--- a/tests/functional/fixed.sh
+++ b/tests/functional/fixed.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 path=$(nix-store -q "$(nix-instantiate fixed.nix -A good.0)")
 
 echo 'testing bad...'

--- a/tests/functional/flakes/develop.sh
+++ b/tests/functional/flakes/develop.sh
@@ -4,9 +4,6 @@ source ../common.sh
 
 TODO_NixOS
 
-clearStore
-rm -rf "$TEST_HOME/.cache" "$TEST_HOME/.config" "$TEST_HOME/.local"
-
 # Create flake under test.
 cp ../shell-hello.nix "$config_nix" "$TEST_HOME/"
 cat <<EOF >"$TEST_HOME/flake.nix"

--- a/tests/functional/flakes/flake-in-submodule.sh
+++ b/tests/functional/flakes/flake-in-submodule.sh
@@ -17,8 +17,6 @@ requireGit
 
 TODO_NixOS
 
-clearStore
-
 # Submodules can't be fetched locally by default.
 # See fetchGitSubmodules.sh
 export GIT_CONFIG_COUNT=1

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -6,9 +6,6 @@ TODO_NixOS
 
 requireGit
 
-clearStore
-rm -rf "$TEST_HOME"/.cache "$TEST_HOME"/.config
-
 createFlake1
 createFlake2
 

--- a/tests/functional/flakes/relative-paths.sh
+++ b/tests/functional/flakes/relative-paths.sh
@@ -9,7 +9,6 @@ subflake0="$rootFlake/sub0"
 subflake1="$rootFlake/sub1"
 subflake2="$rootFlake/sub2"
 
-rm -rf "$rootFlake"
 mkdir -p "$rootFlake" "$subflake0" "$subflake1" "$subflake2"
 
 cat > "$rootFlake/flake.nix" <<EOF

--- a/tests/functional/flakes/run.sh
+++ b/tests/functional/flakes/run.sh
@@ -4,9 +4,6 @@ source ../common.sh
 
 TODO_NixOS
 
-clearStore
-rm -rf "$TEST_HOME"/.cache "$TEST_HOME"/.config "$TEST_HOME"/.local
-
 cp ../shell-hello.nix "${config_nix}" "$TEST_HOME"
 cd "$TEST_HOME"
 

--- a/tests/functional/flakes/search-root.sh
+++ b/tests/functional/flakes/search-root.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 writeSimpleFlake "$TEST_HOME"
 cd "$TEST_HOME"
 mkdir -p foo/subdir

--- a/tests/functional/formatter.sh
+++ b/tests/functional/formatter.sh
@@ -4,9 +4,6 @@ source common.sh
 
 TODO_NixOS # Provide a `shell` variable. Try not to `export` it, perhaps.
 
-clearStoreIfPossible
-rm -rf "$TEST_HOME"/.cache "$TEST_HOME"/.config "$TEST_HOME"/.local
-
 cp ./simple.nix ./simple.builder.sh ./formatter.simple.sh "${config_nix}" "$TEST_HOME"
 
 cd "$TEST_HOME"

--- a/tests/functional/gc-auto.sh
+++ b/tests/functional/gc-auto.sh
@@ -7,8 +7,6 @@ needLocalStore "“min-free” and “max-free” are daemon options"
 
 TODO_NixOS
 
-clearStore
-
 # shellcheck disable=SC2034
 garbage1=$(nix store add-path --name garbage1 ./nar-access.sh)
 # shellcheck disable=SC2034

--- a/tests/functional/gc-concurrent.sh
+++ b/tests/functional/gc-concurrent.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 lockFifo1=$TEST_ROOT/test1.fifo
 mkfifo "$lockFifo1"
 

--- a/tests/functional/gc-non-blocking.sh
+++ b/tests/functional/gc-non-blocking.sh
@@ -8,8 +8,6 @@ TODO_NixOS
 
 needLocalStore "the GC test needs a synchronisation point"
 
-clearStore
-
 # This FIFO is read just after the global GC lock has been acquired,
 # but before the root server is started.
 fifo1=$TEST_ROOT/test2.fifo

--- a/tests/functional/gc.sh
+++ b/tests/functional/gc.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 drvPath=$(nix-instantiate dependencies.nix)
 outPath=$(nix-store -rvv "$drvPath")
 

--- a/tests/functional/git-hashing/common.sh
+++ b/tests/functional/git-hashing/common.sh
@@ -4,9 +4,6 @@ source ../common.sh
 
 TODO_NixOS # Need to enable git hashing feature and make sure test is ok for store we don't clear
 
-clearStore
-clearCache
-
 # Need backend to support git-hashing too
 requireDaemonNewerThan "2.19"
 

--- a/tests/functional/git/packed-refs-no-cache.sh
+++ b/tests/functional/git/packed-refs-no-cache.sh
@@ -15,8 +15,6 @@ source ../common.sh
 
 requireGit
 
-clearStoreIfPossible
-
 # Intentionally not in a canonical form
 # See https://github.com/NixOS/nix/issues/6195
 repo=$TEST_ROOT/./git

--- a/tests/functional/hash-path.sh
+++ b/tests/functional/hash-path.sh
@@ -73,7 +73,6 @@ try2 () {
     fi
 }
 
-rm -rf "$TEST_ROOT/hash-path"
 mkdir "$TEST_ROOT/hash-path"
 echo "Hello World" > "$TEST_ROOT/hash-path/hello"
 

--- a/tests/functional/import-from-derivation.sh
+++ b/tests/functional/import-from-derivation.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStoreIfPossible
-
 export NIX_PATH=config="${config_nix}"
 
 if nix-instantiate --readonly-mode ./import-from-derivation.nix -A result; then

--- a/tests/functional/impure-derivations.sh
+++ b/tests/functional/impure-derivations.sh
@@ -9,8 +9,6 @@ TODO_NixOS
 enableFeatures "ca-derivations impure-derivations"
 restartDaemon
 
-clearStoreIfPossible
-
 # Basic test of impure derivations: building one a second time should not use the previous result.
 printf 0 > "$TEST_ROOT"/counter
 

--- a/tests/functional/impure-env.sh
+++ b/tests/functional/impure-env.sh
@@ -17,7 +17,6 @@ varTest() {
     clearStore
 }
 
-clearStore
 startDaemon
 
 varTest env_name value --impure-env env_name=value

--- a/tests/functional/lang-gc.sh
+++ b/tests/functional/lang-gc.sh
@@ -7,8 +7,6 @@
 
 source common.sh
 
-set -o pipefail
-
 skipTest "Too memory intensive for CI. Attempt to reduce memory usage was unsuccessful, because it made detection of the bug unreliable."
 
 # Regression test for #11141. The stack pointer corrector assigned the base

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-set -o pipefail
-
 source characterisation/framework.sh
 
 # specialize function a bit

--- a/tests/functional/linux-sandbox.sh
+++ b/tests/functional/linux-sandbox.sh
@@ -6,8 +6,6 @@ needLocalStore "the sandbox only runs on the builder side, so it makes no sense 
 
 TODO_NixOS
 
-clearStore
-
 requireSandboxSupport
 requiresUnprivilegedUserNamespaces
 
@@ -18,9 +16,6 @@ requiresUnprivilegedUserNamespaces
 if [[ ! $SHELL =~ /nix/store ]]; then skipTest "Shell is not from Nix store"; fi
 # An alias to automatically bind-mount the $SHELL on nix-build invocations
 nix-sandbox-build () { nix-build --no-out-link --sandbox-paths /nix/store "$@"; }
-
-chmod -R u+w "$TEST_ROOT"/store0 || true
-rm -rf "$TEST_ROOT"/store0
 
 export NIX_STORE_DIR=/my/store
 export NIX_REMOTE=$TEST_ROOT/store0

--- a/tests/functional/logging.sh
+++ b/tests/functional/logging.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 path=$(nix-build dependencies.nix --no-out-link)
 
 # Test nix-store -l.

--- a/tests/functional/multiple-outputs.sh
+++ b/tests/functional/multiple-outputs.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStoreIfPossible
-
 rm -f "$TEST_ROOT"/result*
 
 # Placeholder strings are opaque, so cannot do this check for floating

--- a/tests/functional/nars.sh
+++ b/tests/functional/nars.sh
@@ -2,12 +2,7 @@
 
 source common.sh
 
-TODO_NixOS
-
-clearStore
-
 # Check that NARs with duplicate directory entries are rejected.
-rm -rf "$TEST_ROOT/out"
 expectStderr 1 nix-store --restore "$TEST_ROOT/out" < duplicate.nar | grepQuiet "NAR directory is not sorted"
 
 # Check that nix-store --restore fails if the output already exists.

--- a/tests/functional/nix-build.sh
+++ b/tests/functional/nix-build.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStoreIfPossible
-
 outPath=$(nix-build dependencies.nix -o "$TEST_ROOT"/result)
 test "$(cat "$TEST_ROOT"/result/foobar)" = FOOBAR
 

--- a/tests/functional/nix-collect-garbage-d.sh
+++ b/tests/functional/nix-collect-garbage-d.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 ## Test `nix-collect-garbage -d`
 
 # TODO make `nix-env` doesn't work with CA derivations, and make

--- a/tests/functional/nix-copy-ssh-common.sh
+++ b/tests/functional/nix-copy-ssh-common.sh
@@ -5,9 +5,6 @@ shift
 
 TODO_NixOS
 
-clearStore
-clearCache
-
 mkdir -p "$TEST_ROOT"/stores
 
 # Create path to copy back and forth

--- a/tests/functional/nix-copy-ssh-ng.sh
+++ b/tests/functional/nix-copy-ssh-ng.sh
@@ -6,9 +6,6 @@ source nix-copy-ssh-common.sh "ssh-ng"
 
 TODO_NixOS
 
-clearStore
-clearRemoteStore
-
 outPath=$(nix-build --no-out-link dependencies.nix)
 
 nix store info --store "$remoteStore"

--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -4,9 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-clearProfiles
-
 enableFeatures "ca-derivations"
 restartDaemon
 

--- a/tests/functional/nix-shell.sh
+++ b/tests/functional/nix-shell.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 if [[ -n ${NIX_TESTS_CA_BY_DEFAULT:-} ]]; then
     shellDotNix="$PWD/ca-shell.nix"
 else
@@ -244,8 +242,6 @@ diff "$TEST_ROOT"/dev-env{,2}.json
 
 # Run tests involving `source <(nix print-dev-env)` in subshells to avoid modifying the current
 # environment.
-
-set -u
 
 # Ensure `source <(nix print-dev-env)` modifies the environment.
 (

--- a/tests/functional/optimise-store.sh
+++ b/tests/functional/optimise-store.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 # shellcheck disable=SC2016
 outPath1=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo1"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link --auto-optimise-store)
 # shellcheck disable=SC2016

--- a/tests/functional/parallel.sh
+++ b/tests/functional/parallel.sh
@@ -7,10 +7,6 @@ echo "testing nix-build -j..."
 
 TODO_NixOS
 
-clearStore
-
-rm -f "$_NIX_TEST_SHARED".cur "$_NIX_TEST_SHARED".max
-
 outPath=$(nix-build -j10000 parallel.nix --no-out-link)
 
 echo "output path is $outPath"

--- a/tests/functional/pass-as-file.sh
+++ b/tests/functional/pass-as-file.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 # shellcheck disable=SC2034
 outPath=$(nix-build --no-out-link -E "
 with import ${config_nix};

--- a/tests/functional/placeholders.sh
+++ b/tests/functional/placeholders.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 # shellcheck disable=SC2016
 nix-build --no-out-link -E '
   with import '"${config_nix}"';

--- a/tests/functional/post-hook.sh
+++ b/tests/functional/post-hook.sh
@@ -4,11 +4,7 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
-rm -f "$TEST_ROOT"/result
-
-export REMOTE_STORE=file:$TEST_ROOT/remote_store
+export REMOTE_STORE="file://$cacheDir"
 echo 'require-sigs = false' >> "$test_nix_conf"
 
 restartDaemon

--- a/tests/functional/pure-eval.sh
+++ b/tests/functional/pure-eval.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 nix eval --expr 'assert 1 + 2 == 3; true'
 
 [[ $(nix eval --impure --expr 'builtins.readFile ./pure-eval.sh') =~ clearStore ]]

--- a/tests/functional/readfile-context.sh
+++ b/tests/functional/readfile-context.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS # NixOS doesn't provide $NIX_STATE_DIR (and shouldn't)
 
-clearStore
-
 outPath=$(nix-build --no-out-link readfile-context.nix)
 
 # Set a GC root.

--- a/tests/functional/recursive.sh
+++ b/tests/functional/recursive.sh
@@ -7,10 +7,6 @@ TODO_NixOS # can't enable a sandbox feature easily
 enableFeatures 'recursive-nix'
 restartDaemon
 
-clearStore
-
-rm -f "$TEST_ROOT"/result
-
 unreachable=$(nix store add-path ./recursive.sh)
 export unreachable
 

--- a/tests/functional/referrers.sh
+++ b/tests/functional/referrers.sh
@@ -6,8 +6,6 @@ needLocalStore "uses some low-level store manipulations that aren’t available 
 
 TODO_NixOS
 
-clearStore
-
 max=500
 
 reference=$NIX_STORE_DIR/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bla

--- a/tests/functional/remote-store.sh
+++ b/tests/functional/remote-store.sh
@@ -4,8 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 # Ensure "fake ssh" remote store works just as legacy fake ssh would.
 nix --store ssh-ng://localhost?remote-store="$TEST_ROOT"/other-store doctor
 

--- a/tests/functional/repair.sh
+++ b/tests/functional/repair.sh
@@ -6,8 +6,6 @@ needLocalStore "--repair needs a local store"
 
 TODO_NixOS
 
-clearStore
-
 path=$(nix-build dependencies.nix -o "$TEST_ROOT"/result)
 path2=$(nix-store -qR "$path" | grep input-2)
 
@@ -51,7 +49,7 @@ fi
 
 # Corrupt a path that has a substitute and check whether nix-store
 # --verify can fix it.
-clearCache
+clearBinaryCache
 
 nix copy --to file://"$cacheDir" "$path"
 

--- a/tests/functional/restricted.sh
+++ b/tests/functional/restricted.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 nix-instantiate --restrict-eval --eval -E '1 + 2'
 (! nix-instantiate --eval --restrict-eval ./restricted.nix)
 TMPFILE=$(mktemp -p "$TEST_ROOT"); echo '1 + 2' >"$TMPFILE"; (! nix-instantiate --eval --restrict-eval "$TMPFILE");

--- a/tests/functional/search.sh
+++ b/tests/functional/search.sh
@@ -2,9 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-clearCache
-
 (( $(nix search -f search.nix '' hello | wc -l) > 0 ))
 
 # Check descriptions are searched

--- a/tests/functional/secure-drv-outputs.sh
+++ b/tests/functional/secure-drv-outputs.sh
@@ -8,8 +8,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-
 startDaemon
 
 # Determine the output path of the "good" derivation.

--- a/tests/functional/selfref-gc.sh
+++ b/tests/functional/selfref-gc.sh
@@ -4,8 +4,6 @@ source common.sh
 
 requireDaemonNewerThan "2.6.0pre20211215"
 
-clearStoreIfPossible
-
 # shellcheck disable=SC2016
 nix-build --no-out-link -E '
   with import '"${config_nix}"';

--- a/tests/functional/shell.sh
+++ b/tests/functional/shell.sh
@@ -4,9 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-clearCache
-
 # nix shell is an alias for nix env shell. We'll use the shorter form in the rest of the test.
 nix env shell -f shell-hello.nix hello -c hello | grep 'Hello World'
 

--- a/tests/functional/signing.sh
+++ b/tests/functional/signing.sh
@@ -2,9 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-clearCache
-
 nix-store --generate-binary-cache-key cache1.example.org "$TEST_ROOT"/sk1 "$TEST_ROOT"/pk1
 pk1=$(cat "$TEST_ROOT"/pk1)
 nix-store --generate-binary-cache-key cache2.example.org "$TEST_ROOT"/sk2 "$TEST_ROOT"/pk2

--- a/tests/functional/store-print-env.sh
+++ b/tests/functional/store-print-env.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 # Regression test for nix-store --print-env argument escaping
 # This tests that arguments in _args are properly escaped as a single string
 # rather than double-escaped which could lead to command injection

--- a/tests/functional/structured-attrs.sh
+++ b/tests/functional/structured-attrs.sh
@@ -5,10 +5,6 @@ source common.sh
 # https://github.com/NixOS/nix/pull/14189
 requireDaemonNewerThan "2.33"
 
-clearStoreIfPossible
-
-rm -f "$TEST_ROOT"/result
-
 nix-build structured-attrs.nix -A all -o "$TEST_ROOT"/result
 
 [[ $(cat "$TEST_ROOT"/result/foo) = bar ]]

--- a/tests/functional/suggestions.sh
+++ b/tests/functional/suggestions.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 cd "$TEST_HOME"
 
 cat <<EOF > flake.nix

--- a/tests/functional/tarball.sh
+++ b/tests/functional/tarball.sh
@@ -2,12 +2,7 @@
 
 source common.sh
 
-clearStoreIfPossible
-
-rm -rf "$TEST_HOME"
-
 tarroot=$TEST_ROOT/tarball
-rm -rf "$tarroot"
 mkdir -p "$tarroot"
 cp dependencies.nix "$tarroot/default.nix"
 cp "${config_nix}" dependencies.builder*.sh "$tarroot/"
@@ -83,7 +78,6 @@ json=$(nix flake prefetch --json "tarball+file://$(pwd)/tree.tar.gz" --out-link 
 [[ $(cat "$TEST_ROOT/result/fnord") = bar ]]
 
 # Test a tarball that has multiple top-level directories.
-rm -rf "$TEST_ROOT/tar_root"
 mkdir -p "$TEST_ROOT/tar_root" "$TEST_ROOT/tar_root/foo" "$TEST_ROOT/tar_root/bar"
 tar cvf "$TEST_ROOT/tar.tar" -C "$TEST_ROOT/tar_root" .
 path="$(nix flake prefetch --json "tarball+file://$TEST_ROOT/tar.tar" | jq -r .storePath)"

--- a/tests/functional/user-envs-migration.sh
+++ b/tests/functional/user-envs-migration.sh
@@ -15,10 +15,6 @@ unset NIX_REMOTE
 
 TODO_NixOS
 
-clearStore
-clearProfiles
-rm -rf ~/.nix-profile
-
 # Fill the environment using the older Nix
 PATH_WITH_NEW_NIX="$PATH"
 export PATH="$NIX_DAEMON_PACKAGE/bin:$PATH"

--- a/tests/functional/why-depends.sh
+++ b/tests/functional/why-depends.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-clearStoreIfPossible
-
 cp ./dependencies.nix ./dependencies.builder0.sh "${config_nix}" "$TEST_HOME"
 
 cd "$TEST_HOME"

--- a/tests/functional/zstd.sh
+++ b/tests/functional/zstd.sh
@@ -4,9 +4,6 @@ source common.sh
 
 TODO_NixOS
 
-clearStore
-clearCache
-
 cacheURI="file://$cacheDir?compression=zstd"
 
 outPath=$(nix-build dependencies.nix --no-out-link)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Now the test runner infrastructure (`common/init.sh`) ensures that the state gets a clean slate and clears the previous $TEST_ROOT if needed.

I've also renamed `clearCache` -> `clearBinaryCache`, since the former would be more useful for deleting `~/.cache/nix` instead - for which there's no helper function yet.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
