### PR TITLE
cli: error instead of crashing when realisations cannot be queried

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -300,11 +300,10 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
 
     // `get-env.sh` will write its JSON output to an arbitrary output
     // path, so return the first non-empty output path.
-    for (auto & [_0, optPath] : deepQueryPartialDerivationOutputMap(*evalStore, shellDrvPath)) {
-        assert(optPath);
-        auto accessor = evalStore->requireStoreObjectAccessor(*optPath);
+    for (auto & [_0, path] : deepQueryDerivationOutputMap(*evalStore, shellDrvPath)) {
+        auto accessor = evalStore->requireStoreObjectAccessor(path);
         if (auto st = accessor->maybeLstat(CanonPath::root); st && st->fileSize.value_or(0))
-            return *optPath;
+            return path;
     }
 
     throw Error("get-env.sh failed to produce an environment");

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -534,13 +534,18 @@ static void main_nix_build(int argc, char ** argv)
             return;
 
         if (shellDrv) {
+            // Only "out" needs to be realized here, so query partially rather than requiring every output.
             auto shellDrvOutputs = deepQueryPartialDerivationOutputMap(*store, shellDrv.value(), &*evalStore);
-            shell = store->printStorePath(shellDrvOutputs.at("out").value()) + "/bin/bash";
+            auto & outPath = shellDrvOutputs.at("out");
+            if (!outPath)
+                throw MissingRealisation(*store, shellDrv.value(), "out");
+            shell = store->printStorePath(*outPath) + "/bin/bash";
         }
 
         if (drv.shouldResolve()) {
             auto resolvedDrv = drv.tryResolve(*store);
-            assert(resolvedDrv && "Successfully resolved the derivation");
+            if (!resolvedDrv)
+                throw Error("failed to resolve derivation '%s'", store->printStorePath(packageInfo.requireDrvPath()));
             drv = *resolvedDrv;
         }
 
@@ -590,13 +595,21 @@ static void main_nix_build(int argc, char ** argv)
 
             fun<void(const StorePath &, const DerivedPathMap<StringSet>::ChildNode &)> accumInputClosure =
                 [&](const StorePath & inputDrv, const DerivedPathMap<StringSet>::ChildNode & inputNode) {
+                    // Only the depended-on outputs need realizing, so query partially rather than requiring every
+                    // output.
                     auto outputs = deepQueryPartialDerivationOutputMap(*store, inputDrv, &*evalStore);
                     for (auto & i : inputNode.value) {
-                        auto o = outputs.at(i);
+                        auto & o = outputs.at(i);
+                        if (!o)
+                            throw MissingRealisation(*store, inputDrv, i);
                         store->computeFSClosure(*o, inputs);
                     }
-                    for (const auto & [outputName, childNode] : inputNode.childMap)
-                        accumInputClosure(*outputs.at(outputName), childNode);
+                    for (const auto & [outputName, childNode] : inputNode.childMap) {
+                        auto & o = outputs.at(outputName);
+                        if (!o)
+                            throw MissingRealisation(*store, inputDrv, outputName);
+                        accumInputClosure(*o, childNode);
+                    }
                 };
 
             for (const auto & [inputDrv, inputNode] : drv.inputDrvs.map)
@@ -726,7 +739,8 @@ static void main_nix_build(int argc, char ** argv)
                 drvPrefix += fmt("-%d", counter + 1);
 
             auto outPath = deepQueryPartialDerivationOutput(*store, drvPath, outputName, &*evalStore);
-            assert(outPath);
+            if (!outPath)
+                throw MissingRealisation(*store, drvPath, outputName);
             auto outputPath = *outPath;
 
             if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>()) {

--- a/tests/functional/ca-old-daemon.sh
+++ b/tests/functional/ca-old-daemon.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# A daemon too old to report content-addressed realisations should not crash `nix-build`
+
+source common.sh
+
+TODO_NixOS
+
+enableFeatures "ca-derivations"
+export NIX_TESTS_CA_BY_DEFAULT=1
+restartDaemon
+
+if isDaemonNewer "2.35.0pre20260303"; then
+    nix-build dependencies.nix --no-out-link
+else
+    expectStderr 1 nix-build dependencies.nix --no-out-link |
+        grepQuiet "cannot operate on output"
+fi

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -70,6 +70,7 @@ suites = [
       'build-remote-trustless-should-pass-3.sh',
       'build-remote-with-mounted-ssh-ng.sh',
       'build.sh',
+      'ca-old-daemon.sh',
       'characterisation-test-infra.sh',
       'check-refs.sh',
       'check-reqs.sh',


### PR DESCRIPTION
## Motivation

Against a daemon without the `realisation-with-path-not-hash` feature,
nix-build/nix-shell/nix develop dereferenced empty optionals from `queryRealisation`
and aborted.

## Context

This is another follow-up to https://github.com/NixOS/nix/pull/15927#issuecomment-4636188956. In general, an older daemon shouldn't crash a newer client. In this commit, each site that dereferenced a `queryRealisation` result now checks it and throws `MissingRealisation` instead.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
