### PR TITLE
Use CompressionAlgo enum for narinfo compression field and TarArchive…

### DIFF
--- a/src/libstore-tests/nar-info.cc
+++ b/src/libstore-tests/nar-info.cc
@@ -75,7 +75,7 @@ static NarInfo makeNarInfo(const Store & store, bool includeImpureInfo)
         };
 
         info.url = "nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz";
-        info.compression = "xz";
+        info.compression = CompressionAlgo::xz;
         info.fileHash = Hash::parseSRI("sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc=");
         info.fileSize = 4029176;
     }

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -172,7 +172,7 @@ ref<NarInfo> BinaryCacheStore::uploadData(Source & narSource, RepairFlag repair,
 
     auto info = mkInfo(narHashSink.finish());
     auto narInfo = make_ref<NarInfo>(info);
-    narInfo->compression = config.compression.to_string(); // FIXME: Make NarInfo use CompressionAlgo
+    narInfo->compression = config.compression;
     auto [fileHash, fileSize] = fileHashSink.finish();
     narInfo->fileHash = fileHash;
     narInfo->fileSize = fileSize;
@@ -565,7 +565,13 @@ void BinaryCacheStore::narFromPath(const StorePath & storePath, Sink & sink)
             stats.narReadBytes += narSize;
         }};
 
-    auto decompressor = makeDecompressionSink(info->compression, uncompressedSink);
+    /* makeDecompressionSink used to treat empty strings as "none". It seems
+       impossible that it would actually end up here with an empty string though
+       (since an empty `Compression: ' is treated as bzip2 when parsed from a
+       .narinfo file and the narinfo disk cache wouldn't handle empty strings).
+       TODO: Revisit this and convert to an assert probably or even made
+       compression a non-optional field. */
+    auto decompressor = makeDecompressionSink(info->compression.value_or(CompressionAlgo::none), uncompressedSink);
 
     try {
         getFile(info->url, *decompressor);

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -54,7 +54,8 @@ static void builtinFetchurl(const BuiltinBuilderContext & ctx)
             }
 #endif
 
-            auto decompressor = makeDecompressionSink(unpack && hasSuffix(mainUrl, ".xz") ? "xz" : "none", sink);
+            auto decompressor = makeDecompressionSink(
+                unpack && hasSuffix(mainUrl, ".xz") ? CompressionAlgo::xz : CompressionAlgo::none, sink);
             fileTransfer->download(std::move(request), *decompressor);
             decompressor->finish();
         });

--- a/src/libstore/include/nix/store/nar-info.hh
+++ b/src/libstore/include/nix/store/nar-info.hh
@@ -13,7 +13,7 @@ struct StoreDirConfig;
 struct UnkeyedNarInfo : virtual UnkeyedValidPathInfo
 {
     std::string url;
-    std::string compression; // FIXME: Use CompressionAlgo
+    std::optional<CompressionAlgo> compression;
     std::optional<Hash> fileHash;
     uint64_t fileSize = 0;
 

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -173,7 +173,7 @@ std::optional<std::string> LocalFSStore::getBuildLogExact(const StorePath & path
 
         else if (pathExists(logBz2Path)) {
             try {
-                return decompress("bzip2", readFile(logBz2Path));
+                return decompress(CompressionAlgo::bzip2, readFile(logBz2Path));
             } catch (Error &) {
             }
         }

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -282,7 +282,7 @@ public:
                 auto narInfo = make_ref<NarInfo>(
                     cache.storeDir, StorePath(hashPart + "-" + namePart), Hash::parseAnyPrefixed(queryNAR.getStr(6)));
                 narInfo->url = queryNAR.getStr(2);
-                narInfo->compression = queryNAR.getStr(3);
+                narInfo->compression = parseCompressionAlgo(queryNAR.getStr(3));
                 if (!queryNAR.isNull(4))
                     narInfo->fileHash = Hash::parseAnyPrefixed(queryNAR.getStr(4));
                 narInfo->fileSize = queryNAR.getInt(5);
@@ -359,7 +359,11 @@ public:
                     .apply(hashPart)
                     .apply(std::string(info->path.name()))
                     .apply(narInfo ? narInfo->url : "", narInfo != 0)
-                    .apply(narInfo ? narInfo->compression : "", narInfo != 0)
+                    .apply(
+                        /* TODO: Revisit the whole conditional on nullopt compression. This shouldn't happen. .narinfo
+                           parsing treats empty strings as bzip2 while other code treats it as "none"... */
+                        narInfo && narInfo->compression ? showCompressionAlgo(*narInfo->compression) : "",
+                        narInfo != 0)
                     .apply(
                         narInfo && narInfo->fileHash ? narInfo->fileHash->to_string(HashFormat::Nix32, true) : "",
                         narInfo && narInfo->fileHash)

--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -53,7 +53,12 @@ NarInfo::NarInfo(const StoreDirConfig & store, const std::string & s, const std:
         } else if (name == "URL")
             url = value;
         else if (name == "Compression")
-            compression = value;
+            try {
+                /* XXX: Empty strings used to fall back to the bzip2 normalisation below. Is this intentional? */
+                compression = value.empty() ? CompressionAlgo::bzip2 : parseCompressionAlgo(value);
+            } catch (UnknownCompressionMethod & e) {
+                throw corrupt("invalid Compression");
+            }
         else if (name == "FileHash")
             fileHash = parseHashField(value);
         else if (name == "FileSize") {
@@ -91,8 +96,8 @@ NarInfo::NarInfo(const StoreDirConfig & store, const std::string & s, const std:
         line += 1;
     }
 
-    if (compression == "")
-        compression = "bzip2";
+    if (!compression)
+        compression = CompressionAlgo::bzip2;
 
     if (!havePath || !haveNarHash || url.empty() || narSize == 0) {
         line = 0; // don't include line information in the error
@@ -110,8 +115,8 @@ std::string NarInfo::to_string(const StoreDirConfig & store) const
     std::string res;
     res += "StorePath: " + store.printStorePath(path) + "\n";
     res += "URL: " + url + "\n";
-    assert(compression != "");
-    res += "Compression: " + compression + "\n";
+    assert(compression);
+    res += "Compression: " + showCompressionAlgo(*compression) + "\n";
     if (fileHash) {
         assert(fileHash->algo == HashAlgorithm::SHA256);
         res += "FileHash: " + fileHash->to_string(HashFormat::Nix32, true) + "\n";
@@ -146,8 +151,10 @@ UnkeyedNarInfo::toJSON(const StoreDirConfig * store, bool includeImpureInfo, Pat
     if (includeImpureInfo) {
         if (!url.empty())
             jsonObject["url"] = url;
-        if (!compression.empty())
-            jsonObject["compression"] = compression;
+        /* XXX: Why is this conditional??? Empty `Compression: ' fields in .narinfo have always
+           been treated as bzip2. */
+        if (compression)
+            jsonObject["compression"] = showCompressionAlgo(*compression);
         if (fileHash) {
             if (format == PathInfoJsonFormat::V1)
                 jsonObject["downloadHash"] = fileHash->to_string(HashFormat::SRI, true);
@@ -174,8 +181,9 @@ UnkeyedNarInfo UnkeyedNarInfo::fromJSON(const StoreDirConfig * store, const nloh
     if (auto * url = get(obj, "url"))
         res.url = getString(*url);
 
+    /* XXX: Why is this conditional??? */
     if (auto * compression = get(obj, "compression"))
-        res.compression = getString(*compression);
+        res.compression = parseCompressionAlgo(getString(*compression));
 
     if (auto * downloadHash = get(obj, "downloadHash")) {
         if (format == PathInfoJsonFormat::V1)

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -239,6 +239,7 @@ bool SQLiteStmt::Use::next()
 std::string SQLiteStmt::Use::getStr(int col)
 {
     auto s = (const char *) sqlite3_column_text(stmt, col);
+    // FIXME: Don't crash on nulls?
     assert(s);
     return s;
 }

--- a/src/libutil-tests/compression.cc
+++ b/src/libutil-tests/compression.cc
@@ -15,44 +15,45 @@ TEST(compress, noneMethodDoesNothingToTheInput)
     ASSERT_EQ(o, "this-is-a-test");
 }
 
-/* FIXME: Deduplicate this with a parameterised test suite? */
+struct CompressionDecompressionTest : ::testing::WithParamInterface<CompressionAlgo>, public ::testing::Test
+{
+    static constexpr std::string_view dummyInput = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
+};
+
+TEST_P(CompressionDecompressionTest, roundtrip)
+{
+    auto o = decompress(GetParam(), compress(GetParam(), dummyInput));
+    ASSERT_EQ(o, dummyInput);
+}
+
+TEST_P(CompressionDecompressionTest, roundtripsWithSourceAndSink)
+{
+    StringSink strSink;
+    auto decompressionSink = makeDecompressionSink(CompressionAlgo::bzip2, strSink);
+    auto sink = makeCompressionSink(CompressionAlgo::bzip2, *decompressionSink);
+
+    (*sink)(dummyInput);
+    sink->finish();
+    decompressionSink->finish();
+
+    ASSERT_EQ(strSink.s.c_str(), dummyInput);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CompressionDecompression,
+    CompressionDecompressionTest,
+    ::testing::Values(
+        CompressionAlgo::none,
+        CompressionAlgo::xz,
+        CompressionAlgo::bzip2,
+        CompressionAlgo::brotli,
+        CompressionAlgo::zstd),
+    [](const ::testing::TestParamInfo<CompressionAlgo> & info) { return showCompressionAlgo(info.param); });
 
 TEST(decompress, decompressNoneCompressed)
 {
     auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
     auto o = decompress(CompressionAlgo::none, str);
-
-    ASSERT_EQ(o, str);
-}
-
-TEST(decompress, decompressXzCompressed)
-{
-    auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(CompressionAlgo::xz, compress(CompressionAlgo::xz, str));
-
-    ASSERT_EQ(o, str);
-}
-
-TEST(decompress, decompressBzip2Compressed)
-{
-    auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(CompressionAlgo::bzip2, compress(CompressionAlgo::bzip2, str));
-
-    ASSERT_EQ(o, str);
-}
-
-TEST(decompress, decompressBrCompressed)
-{
-    auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(CompressionAlgo::brotli, compress(CompressionAlgo::brotli, str));
-
-    ASSERT_EQ(o, str);
-}
-
-TEST(decompress, decompressZstdCompressed)
-{
-    auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(CompressionAlgo::zstd, compress(CompressionAlgo::zstd, str));
 
     ASSERT_EQ(o, str);
 }
@@ -122,20 +123,6 @@ TEST(makeCompressionSink, noneSinkDoesNothingToInput)
     auto sink = makeCompressionSink(CompressionAlgo::none, strSink);
     (*sink)(inputString);
     sink->finish();
-
-    ASSERT_STREQ(strSink.s.c_str(), inputString);
-}
-
-TEST(makeCompressionSink, compressAndDecompress)
-{
-    StringSink strSink;
-    auto inputString = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto decompressionSink = makeDecompressionSink(CompressionAlgo::bzip2, strSink);
-    auto sink = makeCompressionSink(CompressionAlgo::bzip2, *decompressionSink);
-
-    (*sink)(inputString);
-    sink->finish();
-    decompressionSink->finish();
 
     ASSERT_STREQ(strSink.s.c_str(), inputString);
 }

--- a/src/libutil-tests/compression.cc
+++ b/src/libutil-tests/compression.cc
@@ -26,6 +26,15 @@ TEST_P(CompressionDecompressionTest, roundtrip)
     ASSERT_EQ(o, dummyInput);
 }
 
+TEST_P(CompressionDecompressionTest, empty)
+{
+    auto compressed = compress(GetParam(), "");
+    if (GetParam() != CompressionAlgo::none)
+        ASSERT_FALSE(compressed.empty());
+    auto o = decompress(GetParam(), compressed);
+    ASSERT_EQ(o, "");
+}
+
 TEST_P(CompressionDecompressionTest, roundtripsWithSourceAndSink)
 {
     StringSink strSink;
@@ -77,16 +86,6 @@ TEST(decompress, decompressZstdMultiFrameLargeInput)
     auto o = decompress(CompressionAlgo::zstd, compressed);
 
     ASSERT_EQ(o, str);
-}
-
-TEST(compress, zstdEmptyInput)
-{
-    auto compressed = compress(CompressionAlgo::zstd, "");
-    // Empty input should still emit a valid (empty-content) zstd
-    // frame so it round-trips through the decompressor.
-    ASSERT_FALSE(compressed.empty());
-    auto o = decompress(CompressionAlgo::zstd, compressed);
-    ASSERT_EQ(o, "");
 }
 
 TEST(compress, zstdExactFrameBoundary)

--- a/src/libutil-tests/compression.cc
+++ b/src/libutil-tests/compression.cc
@@ -15,67 +15,52 @@ TEST(compress, noneMethodDoesNothingToTheInput)
     ASSERT_EQ(o, "this-is-a-test");
 }
 
+/* FIXME: Deduplicate this with a parameterised test suite? */
+
 TEST(decompress, decompressNoneCompressed)
 {
-    auto method = "none";
     auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(method, str);
-
-    ASSERT_EQ(o, str);
-}
-
-TEST(decompress, decompressEmptyCompressed)
-{
-    // Empty-method decompression used e.g. by S3 store
-    // (Content-Encoding == "").
-    auto method = "";
-    auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(method, str);
+    auto o = decompress(CompressionAlgo::none, str);
 
     ASSERT_EQ(o, str);
 }
 
 TEST(decompress, decompressXzCompressed)
 {
-    auto method = "xz";
     auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(method, compress(CompressionAlgo::xz, str));
+    auto o = decompress(CompressionAlgo::xz, compress(CompressionAlgo::xz, str));
 
     ASSERT_EQ(o, str);
 }
 
 TEST(decompress, decompressBzip2Compressed)
 {
-    auto method = "bzip2";
     auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(method, compress(CompressionAlgo::bzip2, str));
+    auto o = decompress(CompressionAlgo::bzip2, compress(CompressionAlgo::bzip2, str));
 
     ASSERT_EQ(o, str);
 }
 
 TEST(decompress, decompressBrCompressed)
 {
-    auto method = "br";
     auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(method, compress(CompressionAlgo::brotli, str));
+    auto o = decompress(CompressionAlgo::brotli, compress(CompressionAlgo::brotli, str));
 
     ASSERT_EQ(o, str);
 }
 
 TEST(decompress, decompressZstdCompressed)
 {
-    auto method = "zstd";
     auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(method, compress(CompressionAlgo::zstd, str));
+    auto o = decompress(CompressionAlgo::zstd, compress(CompressionAlgo::zstd, str));
 
     ASSERT_EQ(o, str);
 }
 
 TEST(decompress, decompressZstdCompressedParallel)
 {
-    auto method = "zstd";
     auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto o = decompress(method, compress(CompressionAlgo::zstd, str, true));
+    auto o = decompress(CompressionAlgo::zstd, compress(CompressionAlgo::zstd, str, true));
 
     ASSERT_EQ(o, str);
 }
@@ -88,7 +73,7 @@ TEST(decompress, decompressZstdMultiFrameLargeInput)
     for (size_t i = 0; i < str.size(); i += 997)
         str[i] = 'y'; // add some variation
     auto compressed = compress(CompressionAlgo::zstd, str);
-    auto o = decompress("zstd", compressed);
+    auto o = decompress(CompressionAlgo::zstd, compressed);
 
     ASSERT_EQ(o, str);
 }
@@ -99,7 +84,7 @@ TEST(compress, zstdEmptyInput)
     // Empty input should still emit a valid (empty-content) zstd
     // frame so it round-trips through the decompressor.
     ASSERT_FALSE(compressed.empty());
-    auto o = decompress("zstd", compressed);
+    auto o = decompress(CompressionAlgo::zstd, compressed);
     ASSERT_EQ(o, "");
 }
 
@@ -109,7 +94,7 @@ TEST(compress, zstdExactFrameBoundary)
     // emit a trailing zero-content frame.
     std::string str(16 * 1024 * 1024, 'z');
     auto compressed = compress(CompressionAlgo::zstd, str);
-    auto o = decompress("zstd", compressed);
+    auto o = decompress(CompressionAlgo::zstd, compressed);
     ASSERT_EQ(o, str);
 
     // Verify there is exactly one frame by checking that
@@ -121,10 +106,9 @@ TEST(compress, zstdExactFrameBoundary)
 
 TEST(decompress, decompressInvalidInputThrowsCompressionError)
 {
-    auto method = "bzip2";
     auto str = "this is a string that does not qualify as valid bzip2 data";
 
-    ASSERT_THROW(decompress(method, str), CompressionError);
+    ASSERT_THROW(decompress(CompressionAlgo::bzip2, str), CompressionError);
 }
 
 /* ----------------------------------------------------------------------------
@@ -146,7 +130,7 @@ TEST(makeCompressionSink, compressAndDecompress)
 {
     StringSink strSink;
     auto inputString = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
-    auto decompressionSink = makeDecompressionSink("bzip2", strSink);
+    auto decompressionSink = makeDecompressionSink(CompressionAlgo::bzip2, strSink);
     auto sink = makeCompressionSink(CompressionAlgo::bzip2, *decompressionSink);
 
     (*sink)(inputString);

--- a/src/libutil-tests/compression.cc
+++ b/src/libutil-tests/compression.cc
@@ -35,6 +35,15 @@ TEST_P(CompressionDecompressionTest, empty)
     ASSERT_EQ(o, "");
 }
 
+TEST_P(CompressionDecompressionTest, invalidDecompression)
+{
+    if (GetParam() == CompressionAlgo::none)
+        GTEST_SKIP();
+
+    ASSERT_THROW(
+        decompress(GetParam(), "this is a string that does not qualify as valid compressed data"), CompressionError);
+}
+
 TEST_P(CompressionDecompressionTest, roundtripsWithSourceAndSink)
 {
     StringSink strSink;
@@ -102,13 +111,6 @@ TEST(compress, zstdExactFrameBoundary)
     size_t frameSize = ZSTD_findFrameCompressedSize(compressed.data(), compressed.size());
     ASSERT_FALSE(ZSTD_isError(frameSize));
     ASSERT_EQ(frameSize, compressed.size());
-}
-
-TEST(decompress, decompressInvalidInputThrowsCompressionError)
-{
-    auto str = "this is a string that does not qualify as valid bzip2 data";
-
-    ASSERT_THROW(decompress(CompressionAlgo::bzip2, str), CompressionError);
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/libutil/compression.cc
+++ b/src/libutil/compression.cc
@@ -45,13 +45,13 @@ struct ChunkedCompressionSink : CompressionSink
 
 struct ArchiveDecompressionSource : Source
 {
-    std::unique_ptr<TarArchive> archive = 0;
+    std::unique_ptr<TarArchive> archive;
     Source & src;
-    std::optional<std::string> compressionMethod;
+    CompressionAlgo compressionMethod;
 
-    ArchiveDecompressionSource(Source & src, std::optional<std::string> compressionMethod = std::nullopt)
+    ArchiveDecompressionSource(Source & src, CompressionAlgo compressionMethod)
         : src(src)
-        , compressionMethod(std::move(compressionMethod))
+        , compressionMethod(compressionMethod)
     {
     }
 
@@ -61,8 +61,8 @@ struct ArchiveDecompressionSource : Source
     {
         struct archive_entry * ae;
         if (!archive) {
-            archive = std::make_unique<TarArchive>(src, /*raw*/ true, compressionMethod);
-            this->archive->check(archive_read_next_header(this->archive->archive, &ae), "failed to read header (%s)");
+            archive = std::make_unique<TarArchive>(src, /*raw=*/true, compressionMethod);
+            archive->check(archive_read_next_header(this->archive->archive, &ae), "failed to read header (%s)");
             if (archive_filter_count(this->archive->archive) < 2) {
                 throw CompressionError("input compression not recognized");
             }
@@ -254,7 +254,7 @@ struct BrotliDecompressionSink : ChunkedCompressionSink
 
 } // namespace
 
-std::string decompress(const std::string & method, std::string_view in)
+std::string decompress(CompressionAlgo method, std::string_view in)
 {
     StringSink ssink;
     auto sink = makeDecompressionSink(method, ssink);
@@ -263,11 +263,11 @@ std::string decompress(const std::string & method, std::string_view in)
     return std::move(ssink.s);
 }
 
-std::unique_ptr<FinishSink> makeDecompressionSink(const std::string & method, Sink & nextSink)
+std::unique_ptr<FinishSink> makeDecompressionSink(CompressionAlgo method, Sink & nextSink)
 {
-    if (method == "none" || method == "" || method == "identity")
+    if (method == CompressionAlgo::none)
         return std::make_unique<NoneSink>(nextSink);
-    else if (method == "br")
+    else if (method == CompressionAlgo::brotli)
         return std::make_unique<BrotliDecompressionSink>(nextSink);
     else
         return sourceToSink([method, &nextSink](Source & source) {

--- a/src/libutil/include/nix/util/compression.hh
+++ b/src/libutil/include/nix/util/compression.hh
@@ -20,9 +20,9 @@ public:
     using FinishSink::finish;
 };
 
-std::string decompress(const std::string & method, std::string_view in);
+std::string decompress(CompressionAlgo method, std::string_view in);
 
-std::unique_ptr<FinishSink> makeDecompressionSink(const std::string & method, Sink & nextSink);
+std::unique_ptr<FinishSink> makeDecompressionSink(CompressionAlgo method, Sink & nextSink);
 
 std::string compress(CompressionAlgo method, std::string_view in, const bool parallel = false, int level = -1);
 

--- a/src/libutil/include/nix/util/tarfile.hh
+++ b/src/libutil/include/nix/util/tarfile.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include "nix/util/compression-algo.hh"
 #include "nix/util/serialise.hh"
 #include "nix/util/fs-sink.hh"
 #include <archive.h>
@@ -13,7 +14,7 @@ struct TarArchive
     Source * source;
     std::vector<unsigned char> buffer;
 
-    void check(int err, const std::string & reason = "failed to extract archive (%s)");
+    void check(int err, const std::string & reason = "failed to extract archive (%s)", bool warningsAreFatal = true);
 
     explicit TarArchive(const std::filesystem::path & path);
 
@@ -21,8 +22,8 @@ struct TarArchive
     /// @param source - Input byte stream.
     /// @param raw - Whether to enable raw file support. For more info look in docs:
     /// https://manpages.debian.org/stretch/libarchive-dev/archive_read_format.3.en.html
-    /// @param compression_method - Primary compression method to use. std::nullopt means 'all'.
-    TarArchive(Source & source, bool raw = false, std::optional<std::string> compression_method = std::nullopt);
+    /// @param compressionMethod - Primary compression method to use. std::nullopt means 'all'.
+    TarArchive(Source & source, bool raw = false, std::optional<CompressionAlgo> compressionMethod = std::nullopt);
 
     /// Disable copy constructor. Explicitly default move assignment/constructor.
     TarArchive(const TarArchive &) = delete;
@@ -34,8 +35,6 @@ struct TarArchive
 
     ~TarArchive();
 };
-
-int getArchiveFilterCodeByName(const std::string & method);
 
 void unpackTarfile(const std::filesystem::path & tarFile, const std::filesystem::path & destDir);
 

--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -36,36 +36,17 @@ int callback_close(struct archive *, void * self)
     return ARCHIVE_OK;
 }
 
-void checkLibArchive(archive * archive, int err, const std::string & reason)
-{
-    if (err == ARCHIVE_EOF)
-        throw EndOfFile("reached end of archive");
-    else if (err != ARCHIVE_OK)
-        throw Error(reason, archive_error_string(archive));
-}
-
 constexpr auto defaultBufferSize = std::size_t{65536};
 } // namespace
 
-void TarArchive::check(int err, const std::string & reason)
+void TarArchive::check(int err, const std::string & reason, bool warningsAreFatal)
 {
-    checkLibArchive(archive, err, reason);
-}
-
-/// @brief Get filter_code from its name.
-///
-/// libarchive does not provide a convenience function like archive_write_add_filter_by_name but for reading.
-/// Instead it's necessary to use this kludge to convert method -> code and
-/// then use archive_read_support_filter_by_code. Arguably this is better than
-/// hand-rolling the equivalent function that is better implemented in libarchive.
-int getArchiveFilterCodeByName(const std::string & method)
-{
-    auto * ar = archive_write_new();
-    auto cleanup = Finally{[&ar]() { checkLibArchive(ar, archive_write_close(ar), "failed to close archive: %s"); }};
-    auto err = archive_write_add_filter_by_name(ar, method.c_str());
-    checkLibArchive(ar, err, "failed to get libarchive filter by name: %s");
-    auto code = archive_filter_code(ar, 0);
-    return code;
+    if (err == ARCHIVE_EOF)
+        throw EndOfFile("reached end of archive");
+    else if (err == ARCHIVE_WARN && !warningsAreFatal)
+        warn(reason, archive_error_string(archive));
+    else if (err != ARCHIVE_OK)
+        throw Error(reason, archive_error_string(archive));
 }
 
 static void enableSupportedFormats(struct archive * archive)
@@ -79,15 +60,56 @@ static void enableSupportedFormats(struct archive * archive)
     archive_read_support_format_empty(archive);
 }
 
-TarArchive::TarArchive(Source & source, bool raw, std::optional<std::string> compression_method)
+static int compressionAlgoToFilterCode(CompressionAlgo algo)
+{
+    switch (algo) {
+    case CompressionAlgo::none:
+        return ARCHIVE_FILTER_NONE;
+    case CompressionAlgo::bzip2:
+        return ARCHIVE_FILTER_BZIP2;
+    case CompressionAlgo::compress:
+        return ARCHIVE_FILTER_COMPRESS;
+    case CompressionAlgo::grzip:
+        return ARCHIVE_FILTER_GRZIP;
+    case CompressionAlgo::gzip:
+        return ARCHIVE_FILTER_GZIP;
+    case CompressionAlgo::lrzip:
+        return ARCHIVE_FILTER_LRZIP;
+    case CompressionAlgo::lz4:
+        return ARCHIVE_FILTER_LZ4;
+    case CompressionAlgo::lzip:
+        return ARCHIVE_FILTER_LZIP;
+    case CompressionAlgo::lzma:
+        return ARCHIVE_FILTER_LZMA;
+    case CompressionAlgo::lzop:
+        return ARCHIVE_FILTER_LZOP;
+    case CompressionAlgo::xz:
+        return ARCHIVE_FILTER_XZ;
+    case CompressionAlgo::zstd:
+        return ARCHIVE_FILTER_ZSTD;
+    /* Brotli is handled separately and it shouldn't end up in this code. */
+    case CompressionAlgo::brotli:
+    default:
+        unreachable();
+    }
+}
+
+TarArchive::TarArchive(Source & source, bool raw, std::optional<CompressionAlgo> compressionMethod)
     : archive{archive_read_new()}
     , source{&source}
     , buffer(defaultBufferSize)
 {
-    if (!compression_method) {
+    if (!compressionMethod) {
+        /* Can't fail and always returns ARCHIVE_OK. Doesn't warn if some filters
+           would require calling an external program. */
         archive_read_support_filter_all(archive);
     } else {
-        archive_read_support_filter_by_code(archive, getArchiveFilterCodeByName(*compression_method));
+        int compressionCode = compressionAlgoToFilterCode(*compressionMethod);
+        /* Will warn if enabling some algorithm requires calling an external program. */
+        check(
+            archive_read_support_filter_by_code(archive, compressionCode),
+            "enabling libarchive decompression filter (%s)",
+            /*warningsAreFatal=*/false);
     }
 
     if (!raw)
@@ -229,7 +251,7 @@ time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & 
                 while (true) {
                     auto n = archive_read_data(archive.archive, buf.data(), buf.size());
                     if (n < 0)
-                        checkLibArchive(archive.archive, n, "cannot read file from tarball: %s");
+                        archive.check(n, "cannot read file from tarball: %s");
                     if (n == 0)
                         break;
                     crf(std::string_view{


### PR DESCRIPTION
…/decompression sink


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Gets rid of the strignly typed code for good. There are a lot of questions about
what an empty string means, so I left of a lot of FIXMEs around the code which we
should revisit later. The intention of this commit is to be a no-op change, just with
better internal types and earlier validation.

Decompressions sinks/sources are no longer used for `Content-Encoding` handling in
filetransfer code now, so some code specific to that (like "identity") can be safely
removed.

Also extend `TarArchive::check` to emit warnings on compression algorithms that
would require shelling out to an external program. We are also quite inconsistent there,
since we accepted this for *decompression*, while *compression* would barf, since we
treat anything other than `ARCHIVE_OK` as an error - including warnings from libarchive. This
is kept for now, but I wonder if we should get rid of the inconsistency and either disallow
non-built-in compression or completely allow it.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
