### PR TITLE
libexpr: specialize builtins.elem scans over attribute set needles

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3929,13 +3929,60 @@ static RegisterPrimOp primop_filter({
 /* Return true if a list contains a given element. */
 static void prim_elem(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
+    constexpr std::string_view errorCtx = "while searching for the presence of the given element in the list";
     bool res = false;
     state.forceList(*args[1], pos, "while evaluating the second argument passed to builtins.elem");
-    for (auto elem : args[1]->listView())
-        if (state.eqValues(*args[0], *elem, pos, "while searching for the presence of the given element in the list")) {
-            res = true;
-            break;
+    auto list = args[1]->listView();
+    auto & needle = *args[0];
+    state.forceValue(needle, pos);
+    if (needle.type() == nAttrs) {
+        /* For attribute set needles, hoist the needle-side work that
+           eqValues would otherwise redo for every element: the
+           derivation check (a `type` attribute lookup) and the size.
+           Elements that aren't attribute sets or whose size differs
+           (when no derivation outPath comparison applies) can then be
+           rejected without the generic comparison machinery. */
+        auto needleAttrs = needle.attrs();
+        bool needleIsDrv = state.isDerivation(needle);
+        const Attr * needleOutPath = needleIsDrv ? needleAttrs->get(state.s.outPath) : nullptr;
+        for (auto elem : list) {
+            state.forceValue(*elem, pos);
+            if (elem->type() != nAttrs)
+                continue;
+            if (elem->attrs() == needleAttrs) {
+                res = true;
+                break;
+            }
+            if (needleOutPath) {
+                /* Mirrors eqValues: when both sides are derivations
+                   with an outPath, equality is outPath equality. */
+                if (state.isDerivation(*elem)) {
+                    if (auto j = elem->attrs()->get(state.s.outPath)) {
+                        if (state.eqValues(*needleOutPath->value, *j->value, pos, errorCtx)) {
+                            res = true;
+                            break;
+                        }
+                        continue;
+                    }
+                }
+            } else if (!needleIsDrv && needleAttrs->size() != elem->attrs()->size()) {
+                /* eqValues would short-circuit isDerivation on the
+                   needle and then reject on size without inspecting
+                   the element further. */
+                continue;
+            }
+            if (state.eqValues(needle, *elem, pos, errorCtx)) {
+                res = true;
+                break;
+            }
         }
+    } else {
+        for (auto elem : list)
+            if (state.eqValues(needle, *elem, pos, errorCtx)) {
+                res = true;
+                break;
+            }
+    }
     v.mkBool(res);
 }
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I ran Claude Fable 5 (earlier this week before it got pulled) with the prompt 'make this nix eval 2x as fast' and let it run overnight to see what it came up with. This was one of the highest-impact changes, with a -5% improvement in runtime for a medium-complex NixOS configuration.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

I've human-reviewed the change and it makes sense to me, but I'm not knowledgeable enough about the nix codebase to say if there's a better way to structure this.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
