### PR TITLE
Get rid of duplicated 'Build failed due to failed dependency' error m…

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -149,10 +149,14 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
     }
 
     auto resolutionGoal = worker.makeDerivationResolutionGoal(drvPath, drv, buildMode);
+    /* We'll handle the error below. */
+    resolutionGoal->preserveFailure = true;
     co_await await({resolutionGoal});
 
     if (nrFailed != 0) {
-        co_return doneFailure({BuildResult::Failure::DependencyFailed, "Build failed due to failed dependency"});
+        auto * failure = resolutionGoal->buildResult.tryGetFailure();
+        assert(failure);
+        co_return doneFailure(*failure);
     }
 
     if (resolutionGoal->resolvedDrv) {

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -189,13 +189,9 @@ test "$status" = 1
 # Precise number of errors depends on daemon version / goal refactorings
 (( "$(<<<"$out" grep -cE '^error:')" >= 2 ))
 
-if isDaemonNewer "2.31"; then
+if isDaemonNewer "2.29pre"; then
     <<<"$out" grepQuiet -E "error: Cannot build '.*-x4\\.drv'"
     <<<"$out" grepQuiet -E "Reason: 1 dependency failed."
-elif isDaemonNewer "2.29pre"; then
-    <<<"$out" grepQuiet -E "error: Cannot build '.*-x4\\.drv'"
-    <<<"$out" grepQuiet -E "Reason: 1 dependency failed."
-    <<<"$out" grepQuiet -E "Build failed due to failed dependency"
 else
     <<<"$out" grepQuiet -E "error: 1 dependencies of derivation '.*-x4\\.drv' failed to build"
 fi


### PR DESCRIPTION
…essages

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fix the UX regression.
This was spamming a gazillion duplicated error messages to stderr:

```
error: Build failed due to failed dependency
error: Build failed due to failed dependency
error: Build failed due to failed dependency
error: Build failed due to failed dependency
error: Build failed due to failed dependency
error: Build failed due to failed dependency
```

Notably, it was just duplicating the more detailed errors above.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
