### PR TITLE
Print attributes in repl commands (:env or :st) in lexicographic order

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -667,27 +667,34 @@ std::optional<EvalState::Doc> EvalState::getDoc(Value & v)
     return {};
 }
 
+static StaticEnv::Vars lexicographicOrder(const SymbolTable & st, StaticEnv::Vars vars)
+{
+    std::ranges::sort(vars, [&st](const auto & lhs, const auto & rhs) {
+        return std::string_view(st[lhs.first]) < std::string_view(st[rhs.first]);
+    });
+    return vars;
+}
+
 // just for the current level of StaticEnv, not the whole chain.
-void printStaticEnvBindings(const SymbolTable & st, const StaticEnv & se)
+static void printStaticEnvBindings(const SymbolTable & st, const StaticEnv & se)
 {
     std::cout << ANSI_MAGENTA;
-    for (auto & i : se.vars)
-        std::cout << st[i.first] << " ";
+    for (auto & [name, displacement] : lexicographicOrder(st, se.vars))
+        std::cout << st[name] << " ";
     std::cout << ANSI_NORMAL;
     std::cout << std::endl;
 }
 
 // just for the current level of Env, not the whole chain.
-void printWithBindings(const SymbolTable & st, const Env & env)
+static void printWithBindings(const SymbolTable & st, const Env & env)
 {
     if (!env.values[0]->isThunk()) {
         std::cout << "with: ";
         std::cout << ANSI_MAGENTA;
-        auto j = env.values[0]->attrs()->begin();
-        while (j != env.values[0]->attrs()->end()) {
-            std::cout << st[j->name] << " ";
-            ++j;
-        }
+        auto * bindings = env.values[0]->attrs();
+        /* TODO: Don't print the whole attribute set, since it can be quite large. */
+        for (const Attr * attr : bindings->lexicographicOrder(st))
+            std::cout << st[attr->name] << " ";
         std::cout << ANSI_NORMAL;
         std::cout << std::endl;
     }
@@ -708,7 +715,7 @@ void printEnvBindings(const SymbolTable & st, const StaticEnv & se, const Env & 
         std::cout << ANSI_MAGENTA;
         // for the top level, don't print the double underscore ones;
         // they are in builtins.
-        for (auto & i : se.vars)
+        for (auto & i : lexicographicOrder(st, se.vars))
             if (!hasPrefix(st[i.first], "__"))
                 std::cout << st[i.first] << " ";
         std::cout << ANSI_NORMAL;

--- a/tests/functional/repl/debugger-fail-throw-env-1.expected
+++ b/tests/functional/repl/debugger-fail-throw-env-1.expected
@@ -8,7 +8,7 @@ Env level 0
 static: _ 
 
 Env level 1
-builtins true false null scopedImport import isNull break abort throw derivationStrict placeholder baseNameOf dirOf removeAttrs map toString fetchMercurial fetchTree fetchTarball fetchGit fromTOML derivation 
+abort baseNameOf break builtins derivation derivationStrict dirOf false fetchGit fetchMercurial fetchTarball fetchTree fromTOML import isNull map null placeholder removeAttrs scopedImport throw toString true 
 
 nix-repl> :quit
 error:

--- a/tests/functional/repl/debugger-fail-throw-env-2.expected
+++ b/tests/functional/repl/debugger-fail-throw-env-2.expected
@@ -15,7 +15,7 @@ Env level 2
 static: x 
 
 Env level 3
-builtins true false null scopedImport import isNull break abort throw derivationStrict placeholder baseNameOf dirOf removeAttrs map toString fetchMercurial fetchTree fetchTarball fetchGit fromTOML derivation 
+abort baseNameOf break builtins derivation derivationStrict dirOf false fetchGit fetchMercurial fetchTarball fetchTree fromTOML import isNull map null placeholder removeAttrs scopedImport throw toString true 
 
 nix-repl> :bt
 

--- a/tests/functional/repl/debugger-okay-ignore-try.expected
+++ b/tests/functional/repl/debugger-okay-ignore-try.expected
@@ -29,7 +29,7 @@ Env level 0
 static: someFailingExpr tried 
 
 Env level 1
-builtins true false null scopedImport import isNull break abort throw derivationStrict placeholder baseNameOf dirOf removeAttrs map toString fetchMercurial fetchTree fetchTarball fetchGit fromTOML derivation 
+abort baseNameOf break builtins derivation derivationStrict dirOf false fetchGit fetchMercurial fetchTarball fetchTree fromTOML import isNull map null placeholder removeAttrs scopedImport throw toString true 
 
 nix-repl> :p bricked
 error: undefined variable 'bricked'
@@ -54,7 +54,7 @@ Env level 1
 static: someFailingExpr tried 
 
 Env level 2
-builtins true false null scopedImport import isNull break abort throw derivationStrict placeholder baseNameOf dirOf removeAttrs map toString fetchMercurial fetchTree fetchTarball fetchGit fromTOML derivation 
+abort baseNameOf break builtins derivation derivationStrict dirOf false fetchGit fetchMercurial fetchTarball fetchTree fromTOML import isNull map null placeholder removeAttrs scopedImport throw toString true 
 
 nix-repl> :p bricked
 error: infinite recursion encountered
@@ -85,7 +85,7 @@ Env level 1
 static: someFailingExpr tried 
 
 Env level 2
-builtins true false null scopedImport import isNull break abort throw derivationStrict placeholder baseNameOf dirOf removeAttrs map toString fetchMercurial fetchTree fetchTarball fetchGit fromTOML derivation 
+abort baseNameOf break builtins derivation derivationStrict dirOf false fetchGit fetchMercurial fetchTarball fetchTree fromTOML import isNull map null placeholder removeAttrs scopedImport throw toString true 
 
 nix-repl> :p bricked
 error: infinite recursion encountered
@@ -110,7 +110,7 @@ Env level 1
 static: someFailingExpr tried 
 
 Env level 2
-builtins true false null scopedImport import isNull break abort throw derivationStrict placeholder baseNameOf dirOf removeAttrs map toString fetchMercurial fetchTree fetchTarball fetchGit fromTOML derivation 
+abort baseNameOf break builtins derivation derivationStrict dirOf false fetchGit fetchMercurial fetchTarball fetchTree fromTOML import isNull map null placeholder removeAttrs scopedImport throw toString true 
 
 nix-repl> :p bricked
 error: infinite recursion encountered


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Depending on how nix is built, the order of variables in the environments can differ [1], due to static initialisation order. Technically, in non-unity builds the order is fully undefined due to the static initialisation order fiasco.

I recently added tests for this functionality and they started failing in nixpkgs, because it doesn't use unity builds.

[1]: https://github.com/NixOS/nixpkgs/pull/532575

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
