### PR TITLE
Fix exceptions not being caught in nix::Pid::~Pid

### DIFF
--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -50,11 +50,13 @@ Pid::Pid(pid_t pid)
 }
 
 Pid::~Pid()
-try {
-    if (pid != -1)
-        kill(/*allowInterrupts=*/false);
-} catch (...) {
-    ignoreExceptionInDestructor();
+{
+    try {
+        if (pid != -1)
+            kill(/*allowInterrupts=*/false);
+    } catch (...) {
+        ignoreExceptionInDestructor();
+    }
 }
 
 void Pid::operator=(pid_t pid)


### PR DESCRIPTION
## Motivation

Using function-try-blocks with destructors causes the exception to be rethrown instead of properly caught (like `ignoreExceptionInDestructor` presumably intends)

This manifested as a higher-level issue very occasionally in our CI as functional test failures by the daemon crashing on initializaion (`nix::Pid` dtor logic racing `bind` helper teardown and throwing `SysError` if it could not `waitpid` the already dead helper) on aarch64-darwin, but this is a more general, cross-platform problem with `nix::Pid` and just happened to occur for us only there

We originally noticed in our fork tecnix when rebasing on Determinate Nix 3.19.0, but when debugging it reproduced the issue on Determinate Nix 3.19.0 without our patches and then reproduced on upstream vanilla Nix 2.34.6 as well

## Context

See https://en.cppreference.com/cpp/language/try#:~:text=The%20currently%20handled%20exception%20is%20rethrown%20if%20control%20reaches%20the%20end%20of%20a%20handler%20of%20the%20function%20try%20block%20of%20a%20constructor%20or%20destructor for C++ reference on why this catch block rethrows the exception at the end of the `catch` statement (which can also be confirmed via disassembly of the relevant destructor function with and without the braces that change the syntax from a function-try-block to a normal function block)

Bug introduced in https://github.com/NixOS/nix/commit/9e496f9af2ff43a54d88ac7abebdde50901e74d2

We've been running the fix in https://github.com/Shopify/tecnix/commit/f59d310168acf48a57d5b031bceeccf570229189 for a while now

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
