### PR TITLE
worker-settings: speed factor is non-integer

### DIFF
--- a/src/libstore/include/nix/store/worker-settings.hh
+++ b/src/libstore/include/nix/store/worker-settings.hh
@@ -185,7 +185,7 @@ public:
           4. The maximum number of builds that Nix executes in parallel on the machine.
              Typically this should be equal to the number of CPU cores.
 
-          5. The “speed factor”, indicating the relative speed of the machine as a positive integer.
+          5. The “speed factor”, indicating the relative speed of the machine as a positive integer or decimal number.
              If there are multiple machines of the right type, Nix prefers the fastest, taking load into account.
 
           6. A comma-separated list of supported [system features](#conf-system-features).


### PR DESCRIPTION
The value of the speed factor when specifying a remote builder can be
any positive number.  Correct the comments / documentation to reflect
that fact.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Make the documentation for `nix.conf` match the code.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
