### PR TITLE
BinaryCacheStore, NarInfo: Use better types for file urls / operations

### DIFF
--- a/src/libstore-tests/data/nar-info/json-2/impure.json
+++ b/src/libstore-tests/data/nar-info/json-2/impure.json
@@ -20,6 +20,6 @@
   ],
   "storeDir": "/nix/store",
   "ultimate": true,
-  "url": "nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz",
+  "url": "nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz?sha256=1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3",
   "version": 2
 }

--- a/src/libstore-tests/data/nar-info/json-2/impure_absolute_url.json
+++ b/src/libstore-tests/data/nar-info/json-2/impure_absolute_url.json
@@ -1,14 +1,17 @@
 {
-  "ca": "fixed:r:sha256:1lr187v6dck1rjh2j6svpikcfz53wyl3qrlcbb405zlh13x0khhh",
+  "ca": {
+    "hash": "sha256-EMIJ+giQ/gLIWoxmPKjno3zHZrxbGymgzGGyZvZBIdM=",
+    "method": "nar"
+  },
   "compression": "xz",
-  "deriver": "/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
+  "deriver": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
   "downloadHash": "sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc=",
   "downloadSize": 4029176,
   "narHash": "sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc=",
   "narSize": 34878,
   "references": [
-    "/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar",
-    "/nix/store/n5wkd9frr45pa74if5gpz9j7mifg27fh-foo"
+    "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar",
+    "n5wkd9frr45pa74if5gpz9j7mifg27fh-foo"
   ],
   "registrationTime": 23423,
   "signatures": [
@@ -17,6 +20,6 @@
   ],
   "storeDir": "/nix/store",
   "ultimate": true,
-  "url": "nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz?sha256=1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3",
-  "version": 1
+  "url": "https://cache.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz?auth=secret",
+  "version": 2
 }

--- a/src/libstore-tests/data/nar-info/text/absolute_url.narinfo
+++ b/src/libstore-tests/data/nar-info/text/absolute_url.narinfo
@@ -1,0 +1,12 @@
+StorePath: /nix/store/n5wkd9frr45pa74if5gpz9j7mifg27fh-foo
+URL: https://cache.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz?auth=secret
+Compression: xz
+FileHash: sha256:09ymwqf5i9q7d4dm7x4pjjcqqj0qrcp5lnznbh42gfsci5hcbqqm
+FileSize: 4029176
+NarHash: sha256:09ymwqf5i9q7d4dm7x4pjjcqqj0qrcp5lnznbh42gfsci5hcbqqm
+NarSize: 34878
+References: g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar n5wkd9frr45pa74if5gpz9j7mifg27fh-foo
+Deriver: g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv
+Sig: asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+Sig: qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+CA: fixed:r:sha256:1lr187v6dck1rjh2j6svpikcfz53wyl3qrlcbb405zlh13x0khhh

--- a/src/libstore-tests/data/nar-info/text/relative_url.narinfo
+++ b/src/libstore-tests/data/nar-info/text/relative_url.narinfo
@@ -1,0 +1,12 @@
+StorePath: /nix/store/n5wkd9frr45pa74if5gpz9j7mifg27fh-foo
+URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz?sha256=1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3
+Compression: xz
+FileHash: sha256:09ymwqf5i9q7d4dm7x4pjjcqqj0qrcp5lnznbh42gfsci5hcbqqm
+FileSize: 4029176
+NarHash: sha256:09ymwqf5i9q7d4dm7x4pjjcqqj0qrcp5lnznbh42gfsci5hcbqqm
+NarSize: 34878
+References: g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar n5wkd9frr45pa74if5gpz9j7mifg27fh-foo
+Deriver: g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv
+Sig: asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+Sig: qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+CA: fixed:r:sha256:1lr187v6dck1rjh2j6svpikcfz53wyl3qrlcbb405zlh13x0khhh

--- a/src/libstore-tests/nar-info.cc
+++ b/src/libstore-tests/nar-info.cc
@@ -41,7 +41,7 @@ class NarInfoTestV3 : public CharacterizationTest, public LibStoreTest
     }
 };
 
-static NarInfo makeNarInfo(const Store & store, bool includeImpureInfo)
+static NarInfo makeNarInfo(const Store & store, bool includeImpureInfo, bool useAbsoluteUrl = false)
 {
     auto info = NarInfo::makeFromCA(
         store,
@@ -74,7 +74,13 @@ static NarInfo makeNarInfo(const Store & store, bool includeImpureInfo)
             Signature{.keyName = "qwer", .sig = std::string(64, '\0')},
         };
 
-        info.url = "nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz";
+        if (useAbsoluteUrl) {
+            info.url = parseURL(
+                "https://cache.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz?auth=secret");
+        } else {
+            info.url = ParsedRelativeUrl::parse(
+                "nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz?sha256=1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3");
+        }
         info.compression = "xz";
         info.fileHash = Hash::parseSRI("sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc=");
         info.fileSize = 4029176;
@@ -180,5 +186,75 @@ JSON_TEST_V3(impure, true)
 #undef JSON_TEST_V3
 #undef JSON_READ_TEST_V3
 #undef JSON_WRITE_TEST_V3
+
+// Tests for absolute URLs in the url field
+#define JSON_READ_TEST_V2_ABSURL(STEM)                             \
+    TEST_F(NarInfoTestV2, NarInfo_##STEM##_from_json)              \
+    {                                                              \
+        readTest(#STEM, [&](const auto & encoded_) {               \
+            auto encoded = json::parse(encoded_);                  \
+            auto expected = makeNarInfo(*store, true, true);       \
+            auto got = UnkeyedNarInfo::fromJSON(nullptr, encoded); \
+            ASSERT_EQ(got, expected);                              \
+        });                                                        \
+    }
+
+#define JSON_WRITE_TEST_V2_ABSURL(STEM)                                                                              \
+    TEST_F(NarInfoTestV2, NarInfo_##STEM##_to_json)                                                                  \
+    {                                                                                                                \
+        writeTest(                                                                                                   \
+            #STEM,                                                                                                   \
+            [&]() -> json { return makeNarInfo(*store, true, true).toJSON(nullptr, true, PathInfoJsonFormat::V2); }, \
+            [](const auto & file) { return json::parse(readFile(file)); },                                           \
+            [](const auto & file, const auto & got) { return writeFile(file, got.dump(2) + "\n"); });                \
+    }
+
+#define JSON_TEST_V2_ABSURL(STEM)  \
+    JSON_READ_TEST_V2_ABSURL(STEM) \
+    JSON_WRITE_TEST_V2_ABSURL(STEM)
+
+JSON_TEST_V2_ABSURL(impure_absolute_url)
+
+// Text format (.narinfo) tests
+
+class NarInfoTextTest : public CharacterizationTest, public LibStoreTest
+{
+    std::filesystem::path unitTestData = getUnitTestData() / "nar-info" / "text";
+
+    std::filesystem::path goldenMaster(PathView testStem) const override
+    {
+        return unitTestData / (testStem + ".narinfo");
+    }
+};
+
+#define TEXT_READ_TEST(STEM, USE_ABSURL)                           \
+    TEST_F(NarInfoTextTest, NarInfo_##STEM##_from_text)            \
+    {                                                              \
+        readTest(#STEM, [&](const auto & encoded) {                \
+            auto expected = makeNarInfo(*store, true, USE_ABSURL); \
+            /* Text format doesn't have these fields */            \
+            expected.registrationTime = 0;                         \
+            expected.ultimate = false;                             \
+            NarInfo got{*store, encoded, "test"};                  \
+            ASSERT_EQ(got, expected);                              \
+        });                                                        \
+    }
+
+#define TEXT_WRITE_TEST(STEM, USE_ABSURL)                                                             \
+    TEST_F(NarInfoTextTest, NarInfo_##STEM##_to_text)                                                 \
+    {                                                                                                 \
+        writeTest(                                                                                    \
+            #STEM,                                                                                    \
+            [&]() -> std::string { return makeNarInfo(*store, true, USE_ABSURL).to_string(*store); }, \
+            [](const auto & file) { return readFile(file); },                                         \
+            [](const auto & file, const auto & got) { return writeFile(file, got); });                \
+    }
+
+#define TEXT_TEST(STEM, USE_ABSURL)  \
+    TEXT_READ_TEST(STEM, USE_ABSURL) \
+    TEXT_WRITE_TEST(STEM, USE_ABSURL)
+
+TEXT_TEST(relative_url, false)
+TEXT_TEST(absolute_url, true)
 
 } // namespace nix

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -79,52 +79,39 @@ void BinaryCacheStore::init()
 
 std::optional<std::string> BinaryCacheStore::getNixCacheInfo()
 {
-    return getFile(cacheInfoFile);
+    return getFile(ParsedRelativeUrl::parse(cacheInfoFile.rel()));
 }
 
 void BinaryCacheStore::upsertFile(
-    const std::string & path, std::string && data, const std::string & mimeType, uint64_t sizeHint)
+    const CanonPath & path, std::string && data, const std::string & mimeType, uint64_t sizeHint)
 {
     StringSource source{data};
     upsertFile(path, source, mimeType, sizeHint);
 }
 
-void BinaryCacheStore::getFile(const std::string & path, Callback<std::optional<std::string>> callback) noexcept
+void BinaryCacheStore::getFile(const ParsedRelativeUrl & url, Callback<std::optional<std::string>> callback) noexcept
 {
     try {
-        callback(getFile(path));
+        callback(getFile(url));
     } catch (...) {
         callback.rethrow();
     }
 }
 
-void BinaryCacheStore::getFile(const std::string & path, Sink & sink)
-{
-    std::promise<std::optional<std::string>> promise;
-    getFile(path, {[&](std::future<std::optional<std::string>> result) {
-                try {
-                    promise.set_value(result.get());
-                } catch (...) {
-                    promise.set_exception(std::current_exception());
-                }
-            }});
-    sink(*promise.get_future().get());
-}
-
-std::optional<std::string> BinaryCacheStore::getFile(const std::string & path)
+std::optional<std::string> BinaryCacheStore::getFile(const ParsedRelativeUrl & url)
 {
     StringSink sink;
     try {
-        getFile(path, sink);
+        getFile(ParsedMaybeRelativeURL{url}, sink);
     } catch (NoSuchBinaryCacheFile &) {
         return std::nullopt;
     }
     return std::move(sink.s);
 }
 
-std::string BinaryCacheStore::narInfoFileFor(const StorePath & storePath)
+CanonPath BinaryCacheStore::narInfoFileFor(const StorePath & storePath)
 {
-    return std::string(storePath.hashPart()) + ".narinfo";
+    return CanonPath::fromFilename(std::string{storePath.hashPart()} + ".narinfo");
 }
 
 void BinaryCacheStore::writeNarInfo(ref<NarInfo> narInfo)
@@ -176,14 +163,16 @@ ref<NarInfo> BinaryCacheStore::uploadData(Source & narSource, RepairFlag repair,
     auto [fileHash, fileSize] = fileHashSink.finish();
     narInfo->fileHash = fileHash;
     narInfo->fileSize = fileSize;
-    narInfo->url = "nar/" + narInfo->fileHash->to_string(HashFormat::Nix32, false) + ".nar"
-                   + (config.compression == CompressionAlgo::xz       ? ".xz"
-                      : config.compression == CompressionAlgo::bzip2  ? ".bz2"
-                      : config.compression == CompressionAlgo::zstd   ? ".zst"
-                      : config.compression == CompressionAlgo::lzip   ? ".lzip"
-                      : config.compression == CompressionAlgo::lz4    ? ".lz4"
-                      : config.compression == CompressionAlgo::brotli ? ".br"
-                                                                      : "");
+    auto narUrl = CanonPath::fromFilename("nar")
+                  / (narInfo->fileHash->to_string(HashFormat::Nix32, false) + ".nar"
+                     + (config.compression == CompressionAlgo::xz       ? ".xz"
+                        : config.compression == CompressionAlgo::bzip2  ? ".bz2"
+                        : config.compression == CompressionAlgo::zstd   ? ".zst"
+                        : config.compression == CompressionAlgo::lzip   ? ".lzip"
+                        : config.compression == CompressionAlgo::lz4    ? ".lz4"
+                        : config.compression == CompressionAlgo::brotli ? ".br"
+                                                                        : ""));
+    narInfo->url = ParsedRelativeUrl::parse(narUrl.rel());
 
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now2 - now1).count();
     printMsg(
@@ -202,7 +191,7 @@ ref<NarInfo> BinaryCacheStore::uploadData(Source & narSource, RepairFlag repair,
             {"root", narAccessor->getListing()},
         };
 
-        upsertFile(std::string(info.path.hashPart()) + ".ls", j.dump(), "application/json");
+        upsertFile(CanonPath::fromFilename(std::string{info.path.hashPart()} + ".ls"), j.dump(), "application/json");
     }
 
     /* Optionally maintain an index of DWARF debug info files
@@ -216,7 +205,7 @@ ref<NarInfo> BinaryCacheStore::uploadData(Source & narSource, RepairFlag repair,
 
             ThreadPool threadPool(25);
 
-            auto doFile = [&](std::string member, std::string key, std::string target) {
+            auto doFile = [&](std::string member, CanonPath key, std::string target) {
                 checkInterrupt();
 
                 nlohmann::json json;
@@ -250,8 +239,8 @@ ref<NarInfo> BinaryCacheStore::uploadData(Source & narSource, RepairFlag repair,
 
                     auto buildId = s1 + s2;
 
-                    std::string key = "debuginfo/" + buildId;
-                    std::string target = "../" + narInfo->url;
+                    auto key = CanonPath::fromFilename("debuginfo") / buildId;
+                    std::string target = "../" + std::string{narUrl.rel()};
 
                     threadPool.enqueue(std::bind(doFile, std::string(debugPath.rel()), key, target));
                 }
@@ -262,11 +251,11 @@ ref<NarInfo> BinaryCacheStore::uploadData(Source & narSource, RepairFlag repair,
     }
 
     /* Atomically write the NAR file. */
-    if (repair || !fileExists(narInfo->url)) {
+    if (repair || !fileExists(narUrl)) {
         FdSource source{fdTemp.get()};
         source.restart(); /* Seek back to the start of the file. */
         stats.narWrite++;
-        upsertFile(narInfo->url, source, "application/x-nix-nar", narInfo->fileSize);
+        upsertFile(narUrl, source, "application/x-nix-nar", narInfo->fileSize);
     } else
         stats.narWriteAverted++;
 
@@ -596,7 +585,7 @@ void BinaryCacheStore::queryPathInfoUncached(
 
         auto narInfoFile = narInfoFileFor(storePath);
 
-        getFile(narInfoFile, {[=, this](std::future<std::optional<std::string>> fut) {
+        getFile(ParsedRelativeUrl::parse(narInfoFile.rel()), {[=, this](std::future<std::optional<std::string>> fut) {
                     try {
                         auto data = fut.get();
 
@@ -605,8 +594,8 @@ void BinaryCacheStore::queryPathInfoUncached(
 
                         stats.narInfoRead++;
 
-                        (*callbackPtr)(
-                            (std::shared_ptr<ValidPathInfo>) std::make_shared<NarInfo>(*this, *data, narInfoFile));
+                        (*callbackPtr)((std::shared_ptr<ValidPathInfo>) std::make_shared<NarInfo>(
+                            *this, *data, std::string{narInfoFile.rel()}));
 
                         (void) act; // force Activity into this lambda to ensure it stays alive
                     } catch (...) {
@@ -658,9 +647,9 @@ StorePath BinaryCacheStore::addToStore(
         ->path;
 }
 
-std::string BinaryCacheStore::makeRealisationPath(const DrvOutput & id)
+CanonPath BinaryCacheStore::makeRealisationPath(const DrvOutput & id)
 {
-    return realisationsPrefix + "/" + id.drvPath.to_string() + "/" + id.outputName + ".doi";
+    return realisationsPrefix / id.drvPath.to_string() / (id.outputName + ".doi");
 }
 
 void BinaryCacheStore::queryRealisationUncached(
@@ -693,7 +682,7 @@ void BinaryCacheStore::queryRealisationUncached(
         }
     }};
 
-    getFile(outputInfoFilePath, std::move(newCallback));
+    getFile(ParsedRelativeUrl::parse(outputInfoFilePath.rel()), std::move(newCallback));
 }
 
 void BinaryCacheStore::registerDrvOutput(const Realisation & info)
@@ -737,11 +726,11 @@ void BinaryCacheStore::addSignatures(const StorePath & storePath, const std::set
 
 std::optional<std::string> BinaryCacheStore::getBuildLogExact(const StorePath & path)
 {
-    auto logPath = "log/" + std::string(baseNameOf(printStorePath(path)));
+    auto logPath = CanonPath::fromFilename("log") / path.to_string();
 
     debug("fetching build log from binary cache '%s/%s'", config.getHumanReadableURI(), logPath);
 
-    return getFile(logPath);
+    return getFile(ParsedRelativeUrl::parse(logPath.rel()));
 }
 
 void BinaryCacheStore::addBuildLog(const StorePath & drvPath, std::string_view log)
@@ -749,7 +738,7 @@ void BinaryCacheStore::addBuildLog(const StorePath & drvPath, std::string_view l
     assert(drvPath.isDerivation());
 
     upsertFile(
-        "log/" + std::string(drvPath.to_string()),
+        CanonPath::fromFilename("log") / drvPath.to_string(),
         (std::string) log, // FIXME: don't copy
         "text/plain; charset=utf-8");
 }

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -129,13 +129,13 @@ StorePaths HttpBinaryCacheStore::topoSortPaths(const StorePathSet & paths)
         result);
 }
 
-std::optional<CompressionAlgo> HttpBinaryCacheStore::getCompressionMethod(const std::string & path)
+std::optional<CompressionAlgo> HttpBinaryCacheStore::getCompressionMethod(const CanonPath & path)
 {
-    if (hasSuffix(path, ".narinfo") && config->narinfoCompression.get())
+    if (hasSuffix(path.rel(), ".narinfo") && config->narinfoCompression.get())
         return config->narinfoCompression;
-    else if (hasSuffix(path, ".ls") && config->lsCompression.get())
+    else if (hasSuffix(path.rel(), ".ls") && config->lsCompression.get())
         return config->lsCompression;
-    else if (hasPrefix(path, "log/") && config->logCompression.get())
+    else if (path.isWithin(CanonPath::fromFilename("log")) && config->logCompression.get())
         return config->logCompression;
     else
         return std::nullopt;
@@ -165,12 +165,12 @@ void HttpBinaryCacheStore::checkEnabled()
     throw SubstituterDisabled("substituter '%s' is disabled", config->getHumanReadableURI());
 }
 
-bool HttpBinaryCacheStore::fileExists(const std::string & path)
+bool HttpBinaryCacheStore::fileExists(const CanonPath & path)
 {
     checkEnabled();
 
     try {
-        FileTransferRequest request(makeRequest(path));
+        FileTransferRequest request(makeRequest(path.rel()));
         request.method = HttpMethod::Head;
         fileTransfer->download(request);
         return true;
@@ -206,7 +206,7 @@ void HttpBinaryCacheStore::upload(
 }
 
 void HttpBinaryCacheStore::upsertFile(
-    const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint)
+    const CanonPath & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint)
 {
     try {
         if (auto compressionMethod = getCompressionMethod(path)) {
@@ -214,9 +214,9 @@ void HttpBinaryCacheStore::upsertFile(
             /* TODO: Validate that this is a valid content encoding. We probably shouldn't set non-standard values here.
              */
             Headers headers = {{"Content-Encoding", showCompressionAlgo(*compressionMethod)}};
-            upload(path, compressed, compressed.s.size(), mimeType, std::move(headers));
+            upload(path.rel(), compressed, compressed.s.size(), mimeType, std::move(headers));
         } else {
-            upload(path, source, sizeHint, mimeType, std::nullopt);
+            upload(path.rel(), source, sizeHint, mimeType, std::nullopt);
         }
     } catch (FileTransferError & e) {
         UploadToHTTP err(e.message());
@@ -277,29 +277,40 @@ FileTransferRequest HttpBinaryCacheStore::makeRequest(std::string_view path)
     return request;
 }
 
-void HttpBinaryCacheStore::getFile(const std::string & path, Sink & sink)
+void HttpBinaryCacheStore::getFileImpl(
+    FileTransferRequest && request, Sink & sink, std::function<NoSuchBinaryCacheFile()> makeError)
 {
     checkEnabled();
-    auto request(makeRequest(path));
     try {
         fileTransfer->download(std::move(request), sink);
     } catch (FileTransferError & e) {
         if (e.error == FileTransfer::NotFound || e.error == FileTransfer::Forbidden)
-            throw NoSuchBinaryCacheFile(
-                "file '%s' does not exist in binary cache '%s'", path, config->getHumanReadableURI());
+            throw makeError();
         maybeDisable();
         throw;
     }
 }
 
-void HttpBinaryCacheStore::getFile(const std::string & path, Callback<std::optional<std::string>> callback) noexcept
+void HttpBinaryCacheStore::getFile(const ParsedMaybeRelativeURL & url, Sink & sink)
+{
+    auto urlStr = renderURL(url);
+    getFileImpl(makeRequest(urlStr), sink, [&]() {
+        return std::holds_alternative<ParsedRelativeUrl>(url)
+                   ? NoSuchBinaryCacheFile(
+                         "file '%s' does not exist in binary cache '%s'", urlStr, config->getHumanReadableURI())
+                   : NoSuchBinaryCacheFile("file '%s' does not exist", urlStr);
+    });
+}
+
+void HttpBinaryCacheStore::getFile(
+    const ParsedRelativeUrl & url, Callback<std::optional<std::string>> callback) noexcept
 {
     auto callbackPtr = std::make_shared<decltype(callback)>(std::move(callback));
 
     try {
         checkEnabled();
 
-        auto request(makeRequest(path));
+        auto request(makeRequest(url.to_string()));
 
         fileTransfer->enqueueFileTransfer(request, {[callbackPtr, this](std::future<FileTransferResult> result) {
                                               try {
@@ -324,7 +335,7 @@ void HttpBinaryCacheStore::getFile(const std::string & path, Callback<std::optio
 std::optional<std::string> HttpBinaryCacheStore::getNixCacheInfo()
 {
     try {
-        auto result = fileTransfer->download(makeRequest(cacheInfoFile));
+        auto result = fileTransfer->download(makeRequest(cacheInfoFile.rel()));
         return result.data;
     } catch (FileTransferError & e) {
         if (e.error == FileTransfer::NotFound)

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -1,9 +1,12 @@
 #pragma once
 ///@file
 
+#include "nix/util/canon-path.hh"
 #include "nix/util/compression-settings.hh"
+#include "nix/util/url.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/log-store.hh"
+#include "nix/store/nar-info.hh"
 
 #include "nix/util/pool.hh"
 
@@ -11,7 +14,6 @@
 
 namespace nix {
 
-struct NarInfo;
 class RemoteFSAccessor;
 
 struct BinaryCacheStoreConfig : virtual StoreConfig
@@ -115,9 +117,9 @@ protected:
      * the build trace entries themselves than the entire directory, for
      * a smoother migration path.
      */
-    constexpr const static std::string realisationsPrefix = "build-trace-v2";
+    inline static const CanonPath realisationsPrefix = CanonPath::fromFilename("build-trace-v2");
 
-    constexpr const static std::string cacheInfoFile = "nix-cache-info";
+    inline static const CanonPath cacheInfoFile = CanonPath::fromFilename("nix-cache-info");
 
     BinaryCacheStore(Config &);
 
@@ -126,24 +128,24 @@ protected:
      *
      * It's `${realisationsPrefix}/${drvPath}/${outputName}`.
      */
-    std::string makeRealisationPath(const DrvOutput & id);
+    CanonPath makeRealisationPath(const DrvOutput & id);
 
 public:
 
-    virtual bool fileExists(const std::string & path) = 0;
+    virtual bool fileExists(const CanonPath & path) = 0;
 
-    virtual void upsertFile(
-        const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) = 0;
+    virtual void
+    upsertFile(const CanonPath & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) = 0;
 
     void upsertFile(
-        const std::string & path,
+        const CanonPath & path,
         // FIXME: use std::string_view
         std::string && data,
         const std::string & mimeType,
         uint64_t sizeHint);
 
     void upsertFile(
-        const std::string & path,
+        const CanonPath & path,
         // FIXME: use std::string_view
         std::string && data,
         const std::string & mimeType)
@@ -153,9 +155,13 @@ public:
     }
 
     /**
-     * Dump the contents of the specified file to a sink.
+     * Fetch the contents of a URL to a sink.
+     *
+     * For relative URLs, fetches from the binary cache.
+     * For absolute URLs, default implementation throws; subclasses with
+     * network support (like HTTP) may override to support absolute URLs.
      */
-    virtual void getFile(const std::string & path, Sink & sink);
+    virtual void getFile(const ParsedMaybeRelativeURL & url, Sink & sink) = 0;
 
     /**
      * Get the contents of /nix-cache-info. Return std::nullopt if it
@@ -167,9 +173,9 @@ public:
      * Fetch the specified file and call the specified callback with
      * the result. A subclass may implement this asynchronously.
      */
-    virtual void getFile(const std::string & path, Callback<std::optional<std::string>> callback) noexcept;
+    virtual void getFile(const ParsedRelativeUrl & url, Callback<std::optional<std::string>> callback) noexcept;
 
-    std::optional<std::string> getFile(const std::string & path);
+    std::optional<std::string> getFile(const ParsedRelativeUrl & url);
 
 public:
 
@@ -179,7 +185,7 @@ private:
 
     std::string narMagic;
 
-    std::string narInfoFileFor(const StorePath & storePath);
+    CanonPath narInfoFileFor(const StorePath & storePath);
 
     void writeNarInfo(ref<NarInfo> narInfo);
 

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -7,6 +7,7 @@
 #include "nix/util/sync.hh"
 
 #include <chrono>
+#include <functional>
 
 namespace nix {
 
@@ -120,16 +121,16 @@ public:
 
 protected:
 
-    std::optional<CompressionAlgo> getCompressionMethod(const std::string & path);
+    std::optional<CompressionAlgo> getCompressionMethod(const CanonPath & path);
 
     void maybeDisable();
 
     void checkEnabled();
 
-    bool fileExists(const std::string & path) override;
+    bool fileExists(const CanonPath & path) override;
 
     void upsertFile(
-        const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override;
+        const CanonPath & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override;
 
     FileTransferRequest makeRequest(std::string_view path);
 
@@ -153,9 +154,11 @@ protected:
         std::string_view mimeType,
         std::optional<Headers> headers);
 
-    void getFile(const std::string & path, Sink & sink) override;
+    void getFile(const ParsedMaybeRelativeURL & url, Sink & sink) override;
 
-    void getFile(const std::string & path, Callback<std::optional<std::string>> callback) noexcept override;
+    void getFileImpl(FileTransferRequest && request, Sink & sink, std::function<NoSuchBinaryCacheFile()> makeError);
+
+    void getFile(const ParsedRelativeUrl & url, Callback<std::optional<std::string>> callback) noexcept override;
 
     std::optional<std::string> getNixCacheInfo() override;
 

--- a/src/libstore/include/nix/store/nar-info.hh
+++ b/src/libstore/include/nix/store/nar-info.hh
@@ -4,7 +4,11 @@
 #include "nix/util/compression-algo.hh"
 #include "nix/util/types.hh"
 #include "nix/util/hash.hh"
+#include "nix/util/url.hh"
+#include "nix/util/canon-path.hh"
 #include "nix/store/path-info.hh"
+
+#include <variant>
 
 namespace nix {
 
@@ -12,13 +16,14 @@ struct StoreDirConfig;
 
 struct UnkeyedNarInfo : virtual UnkeyedValidPathInfo
 {
-    std::string url;
+    ParsedMaybeRelativeURL url;
     std::string compression; // FIXME: Use CompressionAlgo
     std::optional<Hash> fileHash;
     uint64_t fileSize = 0;
 
     UnkeyedNarInfo(UnkeyedValidPathInfo info)
         : UnkeyedValidPathInfo(std::move(info))
+        , url{ParsedRelativeUrl{}}
     {
     }
 

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -2,27 +2,11 @@
 #include "nix/util/environment-variables.hh"
 #include "nix/util/signals.hh"
 #include "nix/store/store-registration.hh"
+#include "nix/util/url.hh"
 
 #include <atomic>
 
 namespace nix {
-
-static std::filesystem::path checkBinaryCachePath(const std::filesystem::path & root, const std::string & path)
-{
-    auto p = std::filesystem::path(requireCString(path));
-    if (p.empty())
-        throw Error("local binary cache path must not be empty");
-
-    if (p.is_absolute())
-        throw Error("local binary cache path '%s' must not be absolute", path);
-
-    for (const auto & segment : p) {
-        if (segment.native() == OS_STR("..") || segment.native() == OS_STR("."))
-            throw Error("local binary cache path '%s' must not contain '..' or '.' segments", path);
-    }
-
-    return root / p.relative_path();
-}
 
 LocalBinaryCacheStoreConfig::LocalBinaryCacheStoreConfig(
     const std::filesystem::path & binaryCacheDir, const StoreReference::Params & params)
@@ -71,12 +55,12 @@ public:
 
 protected:
 
-    bool fileExists(const std::string & path) override;
+    bool fileExists(const CanonPath & path) override;
 
     void upsertFile(
-        const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override
+        const CanonPath & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override
     {
-        auto path2 = checkBinaryCachePath(config->binaryCacheDir, path);
+        auto path2 = config->binaryCacheDir / path.rel();
         static std::atomic<int> counter{0};
         createDirs(path2.parent_path());
         auto tmp = path2;
@@ -87,16 +71,32 @@ protected:
         del.cancel();
     }
 
-    void getFile(const std::string & path, Sink & sink) override
+    void getFile(const ParsedMaybeRelativeURL & url, Sink & sink) override
     {
-        try {
-            /* TODO: Don't follow symlinks? */
-            readFile(checkBinaryCachePath(config->binaryCacheDir, path), sink);
-        } catch (SystemError & e) {
-            if (e.is(std::errc::no_such_file_or_directory))
-                throw NoSuchBinaryCacheFile("file '%s' does not exist in binary cache", path);
-            throw;
-        }
+        std::visit(
+            overloaded{
+                [&](const ParsedRelativeUrl & url) {
+                    if (url.query)
+                        throw Error(
+                            "local binary cache does not support query parameters in URL '%s', not even empty params map trailing ?",
+                            url.to_string());
+                    if (!url.fragment.empty())
+                        throw Error("local binary cache does not support fragment in URL '%s'", url.to_string());
+                    auto path = urlPathToPath(url.path);
+                    if (path.is_absolute())
+                        throw Error("local binary cache does not support absolute path in URL '%s'", url.to_string());
+                    try {
+                        /* TODO: Don't follow symlinks? */
+                        readFile(config->binaryCacheDir / path, sink);
+                    } catch (SystemError & e) {
+                        if (e.is(std::errc::no_such_file_or_directory))
+                            throw NoSuchBinaryCacheFile("file %s does not exist in binary cache", PathFmt(path));
+                        throw;
+                    }
+                },
+                [&](const ParsedURL &) { unsupported("getFile from absolute URL"); },
+            },
+            url);
     }
 
     StorePathSet queryAllValidPaths() override
@@ -123,16 +123,16 @@ protected:
 void LocalBinaryCacheStore::init()
 {
     createDirs(config->binaryCacheDir / "nar");
-    createDirs(config->binaryCacheDir / realisationsPrefix);
+    createDirs(config->binaryCacheDir / realisationsPrefix.rel());
     if (config->writeDebugInfo)
         createDirs(config->binaryCacheDir / "debuginfo");
     createDirs(config->binaryCacheDir / "log");
     BinaryCacheStore::init();
 }
 
-bool LocalBinaryCacheStore::fileExists(const std::string & path)
+bool LocalBinaryCacheStore::fileExists(const CanonPath & path)
 {
-    return pathExists(checkBinaryCachePath(config->binaryCacheDir, path));
+    return pathExists(config->binaryCacheDir / path.rel());
 }
 
 StringSet LocalBinaryCacheStoreConfig::uriSchemes()

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -281,7 +281,7 @@ public:
                 auto namePart = queryNAR.getStr(1);
                 auto narInfo = make_ref<NarInfo>(
                     cache.storeDir, StorePath(hashPart + "-" + namePart), Hash::parseAnyPrefixed(queryNAR.getStr(6)));
-                narInfo->url = queryNAR.getStr(2);
+                narInfo->url = parsePossiblyRelativeURL(queryNAR.getStr(2));
                 narInfo->compression = queryNAR.getStr(3);
                 if (!queryNAR.isNull(4))
                     narInfo->fileHash = Hash::parseAnyPrefixed(queryNAR.getStr(4));
@@ -358,7 +358,7 @@ public:
                     .apply(cache.info.id)
                     .apply(hashPart)
                     .apply(std::string(info->path.name()))
-                    .apply(narInfo ? narInfo->url : "", narInfo != 0)
+                    .apply(narInfo ? renderURL(narInfo->url) : "", narInfo != 0)
                     .apply(narInfo ? narInfo->compression : "", narInfo != 0)
                     .apply(
                         narInfo && narInfo->fileHash ? narInfo->fileHash->to_string(HashFormat::Nix32, true) : "",

--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -30,6 +30,7 @@ NarInfo::NarInfo(const StoreDirConfig & store, const std::string & s, const std:
     };
 
     bool havePath = false;
+    bool haveUrl = false;
     bool haveNarHash = false;
 
     size_t pos = 0;
@@ -50,9 +51,10 @@ NarInfo::NarInfo(const StoreDirConfig & store, const std::string & s, const std:
         if (name == "StorePath") {
             path = store.parseStorePath(value);
             havePath = true;
-        } else if (name == "URL")
-            url = value;
-        else if (name == "Compression")
+        } else if (name == "URL") {
+            url = parsePossiblyRelativeURL(value);
+            haveUrl = true;
+        } else if (name == "Compression")
             compression = value;
         else if (name == "FileHash")
             fileHash = parseHashField(value);
@@ -94,12 +96,12 @@ NarInfo::NarInfo(const StoreDirConfig & store, const std::string & s, const std:
     if (compression == "")
         compression = "bzip2";
 
-    if (!havePath || !haveNarHash || url.empty() || narSize == 0) {
+    if (!havePath || !haveUrl || !haveNarHash || narSize == 0) {
         line = 0; // don't include line information in the error
         throw corrupt(
             !havePath      ? "StorePath missing"
+            : !haveUrl     ? "URL missing"
             : !haveNarHash ? "NarHash missing"
-            : url.empty()  ? "URL missing"
             : narSize == 0 ? "NarSize missing or zero"
                            : "?");
     }
@@ -109,7 +111,7 @@ std::string NarInfo::to_string(const StoreDirConfig & store) const
 {
     std::string res;
     res += "StorePath: " + store.printStorePath(path) + "\n";
-    res += "URL: " + url + "\n";
+    res += "URL: " + renderURL(url) + "\n";
     assert(compression != "");
     res += "Compression: " + compression + "\n";
     if (fileHash) {
@@ -144,8 +146,8 @@ UnkeyedNarInfo::toJSON(const StoreDirConfig * store, bool includeImpureInfo, Pat
     auto jsonObject = UnkeyedValidPathInfo::toJSON(store, includeImpureInfo, format);
 
     if (includeImpureInfo) {
-        if (!url.empty())
-            jsonObject["url"] = url;
+        if (!std::holds_alternative<ParsedRelativeUrl>(url) || !std::get<ParsedRelativeUrl>(url).path.empty())
+            jsonObject["url"] = renderURL(url);
         if (!compression.empty())
             jsonObject["compression"] = compression;
         if (fileHash) {
@@ -172,7 +174,7 @@ UnkeyedNarInfo UnkeyedNarInfo::fromJSON(const StoreDirConfig * store, const nloh
         format = *version;
 
     if (auto * url = get(obj, "url"))
-        res.url = getString(*url);
+        res.url = parsePossiblyRelativeURL(getString(*url));
 
     if (auto * compression = get(obj, "compression"))
         res.compression = getString(*compression);

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -35,7 +35,7 @@ public:
     }
 
     void upsertFile(
-        const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override;
+        const CanonPath & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override;
 
 private:
     ref<S3BinaryCacheStoreConfig> s3Config;
@@ -134,7 +134,7 @@ private:
 };
 
 void S3BinaryCacheStore::upsertFile(
-    const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint)
+    const CanonPath & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint)
 {
     auto doUpload = [&](RestartableSource & src, uint64_t size, std::optional<Headers> headers) {
         Headers uploadHeaders = headers.value_or(Headers());
@@ -156,9 +156,9 @@ void S3BinaryCacheStore::upsertFile(
         }
 
         if (s3Config->multipartUpload && size > s3Config->multipartThreshold) {
-            uploadMultipart(path, src, size, mimeType, std::move(uploadHeaders));
+            uploadMultipart(path.rel(), src, size, mimeType, std::move(uploadHeaders));
         } else {
-            upload(path, src, size, mimeType, std::move(uploadHeaders));
+            upload(path.rel(), src, size, mimeType, std::move(uploadHeaders));
         }
     };
 

--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -541,6 +541,21 @@ struct ParseURLRelativeParam
 class ParseURLRelativeTestSuite : public ::testing::TestWithParam<ParseURLRelativeParam>
 {};
 
+TEST_P(ParseURLRelativeTestSuite, baseRoundTrips)
+{
+    auto & p = GetParam();
+    auto base = parseURL(p.base);
+    EXPECT_EQ(base.to_string(), p.base);
+}
+
+TEST_P(ParseURLRelativeTestSuite, relativeRoundTrips)
+{
+    auto & p = GetParam();
+    auto parsed = parsePossiblyRelativeURL(p.relative);
+    auto str = std::visit([](auto & url) { return url.to_string(); }, parsed);
+    EXPECT_EQ(str, p.relative);
+}
+
 TEST_P(ParseURLRelativeTestSuite, resolve)
 {
     auto & p = GetParam();

--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -893,7 +893,7 @@ TEST_P(ParseURLRelativeTestSuite, relativeRoundTrips)
 {
     auto & p = GetParam();
     auto parsed = parsePossiblyRelativeURL(p.relative);
-    auto str = std::visit([](auto & url) { return url.to_string(); }, parsed);
+    auto str = renderURL(parsed);
     EXPECT_EQ(str, p.relative);
 }
 
@@ -1540,5 +1540,104 @@ INSTANTIATE_TEST_SUITE_P(
     [](const auto & info) { return info.param.description; });
 
 #endif // _WIN32
+
+/* ----------------------------------------------------------------------------
+ * pathToUrlPath / urlPathToPath for relative URLs
+ * --------------------------------------------------------------------------*/
+
+struct RelativeUrlPathTestCase
+{
+    std::string_view urlString;
+    ParsedRelativeUrl urlParsed;
+    std::filesystem::path path;
+    std::string description;
+};
+
+class RelativeUrlPathTest : public ::testing::TestWithParam<RelativeUrlPathTestCase>
+{};
+
+TEST_P(RelativeUrlPathTest, pathToUrlPath)
+{
+    const auto & testCase = GetParam();
+    auto urlPath = pathToUrlPath(testCase.path);
+    EXPECT_EQ(urlPath, testCase.urlParsed.path);
+}
+
+TEST_P(RelativeUrlPathTest, urlPathToPath)
+{
+    const auto & testCase = GetParam();
+    auto path = urlPathToPath(testCase.urlParsed.path);
+    EXPECT_EQ(path, testCase.path);
+}
+
+TEST_P(RelativeUrlPathTest, urlToString)
+{
+    const auto & testCase = GetParam();
+    EXPECT_EQ(testCase.urlParsed.to_string(), testCase.urlString);
+}
+
+TEST_P(RelativeUrlPathTest, stringToUrl)
+{
+    const auto & testCase = GetParam();
+    auto parsed = ParsedRelativeUrl::parse(testCase.urlString);
+    EXPECT_EQ(parsed, testCase.urlParsed);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RelativeUrlPathTestSuite,
+    RelativeUrlPathTest,
+    ::testing::Values(
+        RelativeUrlPathTestCase{
+            .urlString = "nar/abc123.nar.xz",
+            .urlParsed =
+                ParsedRelativeUrl{
+                    .path = {"nar", "abc123.nar.xz"},
+                },
+#ifdef _WIN32
+            .path = L"nar\\abc123.nar.xz",
+#else
+            .path = "nar/abc123.nar.xz",
+#endif
+            .description = "simple_relative",
+        },
+        RelativeUrlPathTestCase{
+            .urlString = "foo",
+            .urlParsed =
+                ParsedRelativeUrl{
+                    .path = {"foo"},
+                },
+            .path = "foo",
+            .description = "single_segment",
+        },
+        RelativeUrlPathTestCase{
+            .urlString = "a/b/c",
+            .urlParsed =
+                ParsedRelativeUrl{
+                    .path = {"a", "b", "c"},
+                },
+#ifdef _WIN32
+            .path = L"a\\b\\c",
+#else
+            .path = "a/b/c",
+#endif
+            .description = "multiple_segments",
+        },
+        RelativeUrlPathTestCase{
+            .urlString = "/foo/bar",
+            .urlParsed =
+                ParsedRelativeUrl{
+                    .path = {"", "foo", "bar"},
+                },
+#ifdef _WIN32
+            /* Note this is not an absolute path on Windows, but the
+               leading slash still matters (current drive vs current
+               directory). */
+            .path = L"\\foo\\bar",
+#else
+            .path = "/foo/bar",
+#endif
+            .description = "absolute_path_relative_url",
+        }),
+    [](const auto & info) { return info.param.description; });
 
 } // namespace nix

--- a/src/libutil/include/nix/util/url.hh
+++ b/src/libutil/include/nix/util/url.hh
@@ -253,6 +253,58 @@ struct ParsedURL
 
 std::ostream & operator<<(std::ostream & os, const ParsedURL & url);
 
+/**
+ * A relative URL (no scheme or authority) with path, query parameters, and fragment.
+ *
+ * This represents a URL reference relative to some base, such as:
+ * - A path within a binary cache: "nar/xxx.nar.xz?sig=abc"
+ * - An absolute path reference: "/foo/bar?x=1#section"
+ * - A relative path reference: "foo/bar?x=1#section"
+ *
+ * The path is represented the same way as `ParsedURL::path`:
+ * a vector of percent-decoded path segments split on '/'.
+ *
+ * @see ParsedURL::path for documentation on the path representation.
+ */
+struct ParsedRelativeUrl
+{
+    /**
+     * Path segments, same representation as `ParsedURL::path`.
+     *
+     * An absolute path starts with an empty segment (leading slash),
+     * a relative path does not.
+     */
+    std::vector<std::string> path;
+    /**
+     * Query parameters. `std::nullopt` means no query component (preserves base query
+     * during resolution), empty map means empty query (e.g., `?` with no params).
+     */
+    std::optional<StringMap> query;
+    /**
+     * Fragment identifier. `std::nullopt` means no fragment component,
+     * empty string means empty fragment (e.g., `#` with nothing after).
+     */
+    std::optional<std::string> fragment;
+
+    static ParsedRelativeUrl parse(std::string_view raw, bool lenient = false);
+
+    /**
+     * Render to a string, encoding the path, query parameters, and fragment.
+     */
+    std::string to_string() const;
+
+    /**
+     * Render the path to a string.
+     *
+     * @param encode Whether to percent encode path segments.
+     */
+    std::string renderPath(bool encode = false) const;
+
+    auto operator<=>(const ParsedRelativeUrl &) const = default;
+};
+
+std::ostream & operator<<(std::ostream & os, const ParsedRelativeUrl & url);
+
 MakeError(BadURL, Error);
 
 std::string percentDecode(std::string_view in);
@@ -298,10 +350,38 @@ std::string encodeQuery(const StringMap & query);
 ParsedURL parseURL(std::string_view url, bool lenient = false);
 
 /**
- * Like `parseURL`, but also accepts relative URLs, which are resolved
- * against the given base URL.
+ * Exactly what is says.
+ *
+ * It is important that we don't use one type for both of these, because there
+ * are many cases where we must know whether we have one or the other.
+ */
+using ParsedMaybeRelativeURL = std::variant<ParsedRelativeUrl, ParsedURL>;
+
+/**
+ * Parse a URL that may be either absolute or relative.
+ *
+ * @return `ParsedURL` if the URL has a scheme, `ParsedRelativeUrl` otherwise.
+ *
+ * @throws BadURL
+ */
+ParsedMaybeRelativeURL parsePossiblyRelativeURL(std::string_view url);
+
+/**
+ * Resolve a relative URL against a base URL.
  *
  * This is specified in [IETF RFC 3986, section 5](https://datatracker.ietf.org/doc/html/rfc3986#section-5)
+ *
+ * @param url The relative URL to resolve
+ * @param base The base URL to resolve against
+ * @return The resolved absolute URL
+ *
+ * @throws BadURL
+ */
+ParsedURL resolveParsedRelativeUrl(const ParsedRelativeUrl & url, const ParsedURL & base);
+
+/**
+ * A small wrapper around @ref parsePossiblyRelativeURL and @ref
+ * resolveParsedRelativeUrl.
  *
  * @throws BadURL
  *
@@ -371,6 +451,9 @@ std::filesystem::path urlPathToPath(std::span<const std::string> urlPath);
  * not strictly RFC3986 compliant. We must preserve that information verbatim.
  *
  * Though we perform parsing and validation for internal needs.
+ *
+ * There is intentionally no `operator==` on `VerbatimURL` because
+ * equality on string-based ad-hoc URLs is not well-defined.
  */
 struct VerbatimURL
 {

--- a/src/libutil/include/nix/util/url.hh
+++ b/src/libutil/include/nix/util/url.hh
@@ -357,6 +357,11 @@ ParsedURL parseURL(std::string_view url, bool lenient = false);
  */
 using ParsedMaybeRelativeURL = std::variant<ParsedRelativeUrl, ParsedURL>;
 
+inline std::string renderURL(const ParsedMaybeRelativeURL & url)
+{
+    return std::visit([](const auto & u) { return u.to_string(); }, url);
+}
+
 /**
  * Parse a URL that may be either absolute or relative.
  *

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -111,6 +111,7 @@ static std::string percentEncodeCharSet(std::string_view s, auto charSet)
 }
 
 static ParsedURL fromBoostUrlView(boost::urls::url_view url, bool lenient);
+static ParsedRelativeUrl fromBoostUrlViewRelative(boost::urls::url_view urlView, bool lenient);
 
 ParsedURL parseURL(std::string_view url, bool lenient)
 try {
@@ -158,6 +159,38 @@ try {
     throw BadURL("'%s' is not a valid URL: %s", url, e.code().message());
 }
 
+ParsedRelativeUrl ParsedRelativeUrl::parse(std::string_view raw, bool lenient)
+{
+    auto parsed = boost::urls::parse_relative_ref(raw);
+    if (!parsed)
+        throw BadURL("invalid relative URL '%s': %s", raw, parsed.error().message());
+
+    return fromBoostUrlViewRelative(*parsed, lenient);
+}
+
+/**
+ * Decode a percent-encoded URL path into path segments.
+ */
+static std::vector<std::string> decodeUrlPath(std::string_view encodedPath)
+{
+    return std::views::transform(splitString<std::vector<std::string_view>>(encodedPath, "/"), percentDecode)
+           | std::ranges::to<std::vector<std::string>>();
+}
+
+/**
+ * Extract path, query, and fragment from a boost url_view into a ParsedRelativeUrl.
+ */
+static ParsedRelativeUrl fromBoostUrlViewRelative(boost::urls::url_view urlView, bool lenient)
+{
+    return ParsedRelativeUrl{
+        .path = decodeUrlPath(urlView.encoded_path()),
+        /* Get the raw query. Store URI supports smuggling doubly nested queries, where
+           the inner &/? are pct-encoded. */
+        .query = urlView.has_query() ? std::optional{decodeQuery(urlView.encoded_query(), lenient)} : std::nullopt,
+        .fragment = urlView.has_fragment() ? std::optional{std::string{urlView.fragment()}} : std::nullopt,
+    };
+}
+
 static ParsedURL fromBoostUrlView(boost::urls::url_view urlView, bool lenient)
 {
     if (!urlView.has_scheme())
@@ -181,78 +214,136 @@ static ParsedURL fromBoostUrlView(boost::urls::url_view urlView, bool lenient)
     if (authority && authority->host.size() && transportIsFile)
         throw BadURL("file:// URL '%s' has unexpected authority '%s'", urlView.buffer(), *authority);
 
-    auto fragment = urlView.fragment(); /* Does pct-decoding */
+    ParsedRelativeUrl relative = fromBoostUrlViewRelative(urlView, lenient);
 
-    boost::core::string_view encodedPath = urlView.encoded_path();
-    if (transportIsFile && encodedPath.empty())
-        encodedPath = "/";
-
-    auto path = std::views::transform(splitString<std::vector<std::string_view>>(encodedPath, "/"), percentDecode)
-                | std::ranges::to<std::vector<std::string>>();
-
-    /* Get the raw query. Store URI supports smuggling doubly nested queries, where
-       the inner &/? are pct-encoded. */
-    auto query = std::string_view(urlView.encoded_query());
+    // Handle empty path for file:// URLs
+    if (transportIsFile && relative.path.empty())
+        relative.path = {""};
 
     return ParsedURL{
         .scheme = scheme,
         .authority = authority,
-        .path = std::move(path),
-        .query = decodeQuery(query, lenient),
-        .fragment = fragment,
+        .path = std::move(relative.path),
+        .query = std::move(relative.query).value_or(StringMap{}),
+        .fragment = std::move(relative.fragment).value_or(""),
+    };
+}
+
+std::variant<ParsedRelativeUrl, ParsedURL> parsePossiblyRelativeURL(std::string_view url)
+{
+    auto parsed = boost::urls::parse_uri_reference(url);
+    if (!parsed)
+        throw BadURL("'%s' is not a valid URL: %s", url, parsed.error().message());
+
+    if (parsed->has_scheme())
+        return fromBoostUrlView(*parsed, /*lenient=*/false);
+    else
+        return fromBoostUrlViewRelative(*parsed, /*lenient=*/false);
+}
+
+/**
+ * Check if a URL path is empty (no path or just a single empty segment).
+ */
+static bool isEmptyPath(const std::vector<std::string> & path)
+{
+    return path.empty() || (path.size() == 1 && path[0].empty());
+}
+
+/**
+ * Remove dot segments from a path per RFC 3986 Section 5.2.4.
+ */
+static std::vector<std::string> canonicalizeDotSegments(std::vector<std::string> path)
+{
+    std::vector<std::string> output;
+    for (auto & segment : path) {
+        if (segment == ".") {
+            // Skip "." segments, but preserve trailing slash
+            if (&segment == &path.back())
+                output.push_back("");
+        } else if (segment == "..") {
+            // Go up one level: remove last non-empty segment
+            if (output.size() > 1)
+                output.pop_back();
+            // Preserve trailing slash
+            if (&segment == &path.back() && !output.empty())
+                output.push_back("");
+        } else {
+            output.push_back(std::move(segment));
+        }
+    }
+    return output;
+}
+
+/**
+ * Merge a relative path with a base path per RFC 3986 Section 5.2.3.
+ */
+static std::vector<std::string>
+mergePaths(const std::vector<std::string> & base, const std::vector<std::string> & ref, bool baseHasAuthority)
+{
+    // If base has authority and empty path, result is "/" + ref
+    if (baseHasAuthority && isEmptyPath(base)) {
+        std::vector<std::string> result = {""};
+        result.insert(result.end(), ref.begin(), ref.end());
+        return result;
+    }
+
+    // Remove everything after last "/" in base (i.e., remove last segment) and append ref
+    std::vector<std::string> result = base;
+    if (!result.empty())
+        result.pop_back();
+    result.insert(result.end(), ref.begin(), ref.end());
+    return result;
+}
+
+ParsedURL resolveParsedRelativeUrl(const ParsedRelativeUrl & ref, const ParsedURL & base)
+{
+    // RFC 3986 Section 5.2.2 - Transform References
+    // Since we only handle relative references here (no scheme), we follow the R.scheme undefined branch
+
+    std::vector<std::string> targetPath;
+    StringMap targetQuery;
+
+    // Path representations:
+    // - "" parses to [""] (one empty segment)
+    // - "/" parses to ["", ""] (two empty segments)
+    // - "/foo" parses to ["", "foo"]
+    // - "foo" parses to ["foo"]
+    bool hasEmptyPath = isEmptyPath(ref.path);
+    bool hasAbsolutePath = ref.path.size() >= 2 && ref.path[0].empty();
+
+    if (hasEmptyPath) {
+        // Empty path: use base path
+        targetPath = base.path;
+        // If ref has query, use it; otherwise use base query
+        targetQuery = ref.query.value_or(base.query);
+    } else if (hasAbsolutePath) {
+        // Absolute path (starts with "/"): use ref path directly
+        targetPath = canonicalizeDotSegments(ref.path);
+        targetQuery = ref.query.value_or(StringMap{});
+    } else {
+        // Relative path: merge with base
+        targetPath = canonicalizeDotSegments(mergePaths(base.path, ref.path, base.authority.has_value()));
+        targetQuery = ref.query.value_or(StringMap{});
+    }
+
+    return ParsedURL{
+        .scheme = base.scheme,
+        .authority = base.authority,
+        .path = targetPath,
+        .query = targetQuery,
+        .fragment = ref.fragment.value_or(""),
     };
 }
 
 ParsedURL parseURLRelative(std::string_view urlS, const ParsedURL & base)
-try {
-
-    boost::urls::url resolved;
-
-    try {
-        resolved.set_scheme(base.scheme);
-        if (base.authority) {
-            auto & authority = *base.authority;
-            resolved.set_host_address(authority.host);
-            if (authority.user)
-                resolved.set_user(*authority.user);
-            if (authority.password)
-                resolved.set_password(*authority.password);
-            if (authority.port)
-                resolved.set_port_number(*authority.port);
-        }
-        resolved.set_encoded_path(encodeUrlPath(base.path));
-        resolved.set_encoded_query(encodeQuery(base.query));
-        resolved.set_fragment(base.fragment);
-    } catch (boost::system::system_error & e) {
-        throw BadURL("'%s' is not a valid URL: %s", base.to_string(), e.code().message());
-    }
-
-    boost::urls::url_view url;
-    try {
-        url = urlS;
-        resolved.resolve(url).value();
-    } catch (boost::system::system_error & e) {
-        throw BadURL("'%s' is not a valid URL: %s", urlS, e.code().message());
-    }
-
-    auto ret = fromBoostUrlView(resolved, /*lenient=*/false);
-
-    /* Hack: Boost `url_view` supports Zone IDs, but `url` does not.
-       Just manually take the authority from the original URL to work
-       around it. See https://github.com/boostorg/url/issues/919 for
-       details. */
-    if (!url.has_authority()) {
-        ret.authority = base.authority;
-    }
-
-    /* Hack, work around fragment of base URL improperly being preserved
-       https://github.com/boostorg/url/issues/920 */
-    ret.fragment = url.has_fragment() ? std::string{url.fragment()} : "";
-
-    return ret;
-} catch (BadURL & e) {
-    e.addTrace({}, "while resolving possibly-relative url '%s' against base URL '%s'", urlS, base);
-    throw;
+{
+    auto parsed = parsePossiblyRelativeURL(urlS);
+    return std::visit(
+        overloaded{
+            [&](ParsedRelativeUrl & relative) { return resolveParsedRelativeUrl(relative, base); },
+            [&](ParsedURL & absolute) { return std::move(absolute); },
+        },
+        parsed);
 }
 
 std::string percentDecode(std::string_view in)
@@ -333,23 +424,52 @@ std::string ParsedURL::renderPath(bool encode) const
     return renderUrlPathNoPctEncoding(path);
 }
 
-std::string ParsedURL::renderAuthorityAndPath() const
+std::string ParsedRelativeUrl::renderPath(bool encode) const
 {
-    std::string res;
-    /* The following assertions correspond to 3.3. Path [rfc3986]. URL parser
-       will never violate these properties, but hand-constructed ParsedURLs might. */
+    if (encode)
+        return encodeUrlPath(path);
+    return renderUrlPathNoPctEncoding(path);
+}
+
+/**
+ * Render the authority component, validating path constraints per RFC 3986 Section 3.3.
+ *
+ * URL parser will never violate these properties, but hand-constructed ParsedURLs might.
+ */
+static std::string
+renderAuthority(const std::optional<ParsedURL::Authority> & authority, const std::vector<std::string> & path)
+{
     if (authority.has_value()) {
         /* If a URI contains an authority component, then the path component
            must either be empty or begin with a slash ("/") character. */
         assert(path.empty() || path.front().empty());
-        res += authority->to_string();
+        return authority->to_string();
     } else if (std::ranges::equal(std::views::take(path, 3), std::views::repeat("", 3))) {
         /* If a URI does not contain an authority component, then the path cannot begin
            with two slash characters ("//") */
         unreachable();
     }
-    res += encodeUrlPath(path);
+    return "";
+}
+
+static std::string
+renderPathQueryFragment(const std::vector<std::string> & path, const StringMap * query, const std::string * fragment)
+{
+    std::string res = encodeUrlPath(path);
+    if (query) {
+        res += '?';
+        res += encodeQuery(*query);
+    }
+    if (fragment) {
+        res += '#';
+        res += percentEncode(*fragment);
+    }
     return res;
+}
+
+std::string ParsedURL::renderAuthorityAndPath() const
+{
+    return renderAuthority(authority, path) + encodeUrlPath(path);
 }
 
 std::string ParsedURL::to_string() const
@@ -359,19 +479,23 @@ std::string ParsedURL::to_string() const
     res += ":";
     if (authority.has_value())
         res += "//";
-    res += renderAuthorityAndPath();
-    if (!query.empty()) {
-        res += "?";
-        res += encodeQuery(query);
-    }
-    if (!fragment.empty()) {
-        res += "#";
-        res += percentEncode(fragment);
-    }
+    res += renderAuthority(authority, path);
+    res += renderPathQueryFragment(path, query.empty() ? nullptr : &query, fragment.empty() ? nullptr : &fragment);
     return res;
 }
 
+std::string ParsedRelativeUrl::to_string() const
+{
+    return renderPathQueryFragment(path, get(query), get(fragment));
+}
+
 std::ostream & operator<<(std::ostream & os, const ParsedURL & url)
+{
+    os << url.to_string();
+    return os;
+}
+
+std::ostream & operator<<(std::ostream & os, const ParsedRelativeUrl & url)
 {
     os << url.to_string();
     return os;

--- a/tests/functional/binary-cache-peculiar-url.sh
+++ b/tests/functional/binary-cache-peculiar-url.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+TODO_NixOS
+
+needLocalStore "'--no-require-sigs' can't be used with the daemon"
+
+# Test that narinfo files with absolute URLs for NARs work correctly.
+# This tests that the URL field in narinfo can be an absolute URL, not just
+# a relative path like "nar/xxx.nar.xz".
+
+clearStore
+clearCache
+clearCacheCache
+
+outPath=$(nix-build dependencies.nix --no-out-link)
+nix copy --to "file://$cacheDir" "$outPath"
+
+# Move NARs to a separate directory outside the cache
+narDir="$TEST_ROOT/external-nars"
+rm -rf "$narDir"
+mkdir -p "$narDir"
+mv "$cacheDir"/nar "$narDir"/
+
+# Rewrite narinfo files to use absolute file:// URLs pointing to the external location
+# Include a query parameter to test that URL parsing handles it correctly
+for narinfo in "$cacheDir"/*.narinfo; do
+    sed -i "s|^URL: \(.*\)|URL: file://$narDir/\1?foo=bar|" "$narinfo"
+done
+
+# Verify narinfo files now have absolute URLs pointing outside the cache
+grep -q "^URL: file://$narDir/" "$cacheDir"/*.narinfo
+
+# Clear the store and fetch using the cache with absolute NAR URLs
+clearStore
+clearCacheCache
+
+# This should succeed - the store should fetch NARs via absolute file:// URLs
+_NIX_FORCE_HTTP=1 nix-store --substituters "file://$cacheDir" --no-require-sigs -r "$outPath"
+
+# Verify the path was successfully fetched
+[ -e "$outPath" ]
+
+# Test that local binary cache (without _NIX_FORCE_HTTP) rejects absolute URLs
+clearStore
+clearCacheCache
+
+# This should fail - local binary cache doesn't support absolute URLs
+if nix-store --substituters "file://$cacheDir" --no-require-sigs -r "$outPath" 2>&1; then
+    echo "Expected failure: local binary cache should reject absolute URLs in narinfo" >&2
+    exit 1
+fi
+
+# Test that local binary cache rejects query parameters in relative URLs
+clearStore
+clearCache
+clearCacheCache
+
+nix copy --to "file://$cacheDir" "$outPath"
+
+# Add query parameters to the relative URL
+for narinfo in "$cacheDir"/*.narinfo; do
+    sed -i 's|^URL: \(.*\)|URL: \1?sha256=test|' "$narinfo"
+done
+
+# This should fail - local binary cache doesn't support query parameters
+if nix-store --substituters "file://$cacheDir" --no-require-sigs -r "$outPath" 2>&1; then
+    echo "Expected failure: local binary cache should reject query parameters" >&2
+    exit 1
+fi
+
+# But HTTP cache should handle relative URLs with query parameters fine
+clearStore
+clearCacheCache
+
+_NIX_FORCE_HTTP=1 nix-store --substituters "file://$cacheDir" --no-require-sigs -r "$outPath"
+[ -e "$outPath" ]

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -66,6 +66,7 @@ suites = [
       'user-envs-migration.sh',
       'cli-characterisation.sh',
       'binary-cache.sh',
+      'binary-cache-peculiar-url.sh',
       'multiple-outputs.sh',
       'nix-build.sh',
       'gc-concurrent.sh',


### PR DESCRIPTION
Firstly, `UnkeyedNarinfo::url` is cleaned up to be a new `NarURL` type
(alias), rather than a plain string. See the documentation for what this
is. This provides type safety and ensures paths are properly
normalized.

The `std::variant<CanonPath, ParsedURL>` used covers the two cases, but
the are only two cases downloading (the absolute URL one is indeed
rather a grandfathered in hack, as documented). In the upload case, we
definitely will *not* support to pushing data to arbitrary locations, so
we only need to support `CanonPath`, and not also `ParsedURL`.

All this means we can likewise cleanup a number of `BinaryCacheStore`
methods. (Remember, `BinaryCacheStore` and `.narinfo` go together.)
`fileExists`, `upsertFile` just take  `CanonPath` instead of
`std::string`. `fileExists`, while a "reading" and not "writing"
function, is only used in upload code paths, and so can also rely on
more invariants as to the path.

`getFile is slightly more complicated. We have two virtual methods for
each case, and then one non-virtual wrapper doing the `std::visit`.

In particular `CanonPath` has safer `operator/` than
`std::filesystem::path`. And when we need to do `filePath /
canonPath.rel()`, with that unsafe operator, the `.rel()` is an
excellent local indication that what we think will happen
(concatenation, not absolute path overriding) actually will be what
happens, making code review/auditing easier.

- `narInfoFileFor` and `makeRealisationPath` now return `CanonPath`

- `cacheInfoFile` and `realisationsPrefix` are now `CanonPath` constants

- Subclasses (`LocalBinaryCacheStore`, `HttpBinaryCacheStore`,
  `S3BinaryCacheStore`) updated to use `path.rel()` as needed

- Use `CanonPath::isWithin` for log directory check instead of string
  prefix

Also, `LocalBinaryCacheStoreConfig::binaryCacheDir` changed to
`std::filesystem::path`, as this is semantically a native path.

Finally, add a unit tests for parsing/render round trips, and a
functional test, for absolute URLs in narinfo files.