### PR TITLE
Remove `UnkeyedValidPathInfo::id`

### DIFF
--- a/src/libstore/include/nix/store/path-info.hh
+++ b/src/libstore/include/nix/store/path-info.hh
@@ -91,14 +91,6 @@ struct UnkeyedValidPathInfo
     uint64_t narSize = 0;
 
     /**
-     * internal use only: SQL primary key for on-disk store objects with
-     * `LocalStore`.
-     *
-     * @todo Remove, layer violation
-     */
-    uint64_t id = 0;
-
-    /**
      * Whether the path is ultimately trusted, that is, it's a
      * derivation output that was built locally.
      */

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -814,8 +814,6 @@ std::shared_ptr<const ValidPathInfo> LocalStore::queryPathInfoInternal(State & s
 
     auto info = std::make_shared<ValidPathInfo>(path, UnkeyedValidPathInfo(*this, narHash));
 
-    info->id = id;
-
     info->registrationTime = useQueryPathInfo.getInt(2);
 
     auto s = (const char *) sqlite3_column_text(state.stmts->QueryPathInfo, 3);
@@ -836,7 +834,7 @@ std::shared_ptr<const ValidPathInfo> LocalStore::queryPathInfoInternal(State & s
         info->ca = ContentAddress::parseOpt(s);
 
     /* Get the references. */
-    auto useQueryReferences(state.stmts->QueryReferences.use().apply(info->id));
+    auto useQueryReferences(state.stmts->QueryReferences.use().apply(id));
 
     while (useQueryReferences.next())
         info->references.insert(parseStorePath(useQueryReferences.getStr(0)));


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This doesn't seem to be used anywhere now. It got added initially in 762cee72ccd860e72c7b639a1dd542ac0f298bb2, where it was used in `registerValidPaths`. But nowadays we do `queryValidPathId` for that use-case unconditionally. That can be improved to avoid some unnecessary SQLite queries in case we know the primary id, but it can be done in a much more local way that's not exposed in the interface.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
