### PR TITLE
[Backport 2.34-maintenance] Increase the sourceToSink/sinkToSource coroutine stack sizes

### DIFF
--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -34,8 +34,7 @@ static GlobalConfig::Register rArchiveSettings(&archiveSettings);
 
 /* Maximum directory nesting depth for dumpPath()/parseDump(). Bounds
    stack usage so deep trees cannot overflow the (possibly coroutine)
-   stack these run on. Chosen to fit comfortably in the default 128 KiB
-   boost coroutine stack. */
+   stack these run on. */
 static constexpr size_t narMaxDepth = 64;
 
 PathFilter defaultPathFilter = [](const std::string &) { return true; };

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -305,6 +305,13 @@ CompressedSource::CompressedSource(RestartableSource & source, CompressionAlgo c
 {
 }
 
+/* 512KiB is a conservative estimate for deeply nested NARs, which are limited
+   to 64 levels. We also tend to allocate rather large buffers on the stack, so
+   we should leave plenty of headroom. Note that no evaluation is supposed to
+   happen on sourceToSink/sinkToSource coroutine stacks (for Boehm GC reasons),
+   which requires much more stack space. */
+static constexpr size_t defaultCoroutineStackSize = 512 * 1024;
+
 std::unique_ptr<FinishSink> sourceToSink(fun<void(Source &)> reader)
 {
     struct SourceToSink : FinishSink
@@ -328,8 +335,9 @@ std::unique_ptr<FinishSink> sourceToSink(fun<void(Source &)> reader)
             cur = in;
 
             if (!coro) {
-                coro =
-                    coro_t::push_type(boost::coroutines2::protected_fixedsize_stack(), [&](coro_t::pull_type & yield) {
+                coro = coro_t::push_type(
+                    boost::coroutines2::protected_fixedsize_stack(defaultCoroutineStackSize),
+                    [&](coro_t::pull_type & yield) {
                         LambdaSource source([&](char * out, size_t out_len) {
                             if (cur.empty()) {
                                 yield();
@@ -386,8 +394,9 @@ std::unique_ptr<Source> sinkToSource(fun<void(Sink &)> writer, fun<void()> eof)
         {
             bool hasCoro = coro.has_value();
             if (!hasCoro) {
-                coro =
-                    coro_t::pull_type(boost::coroutines2::protected_fixedsize_stack(), [&](coro_t::push_type & yield) {
+                coro = coro_t::pull_type(
+                    boost::coroutines2::protected_fixedsize_stack(defaultCoroutineStackSize),
+                    [&](coro_t::push_type & yield) {
                         LambdaSink sink([&](std::string_view data) {
                             if (!data.empty()) {
                                 yield(data);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

We had too little headroom previously, since the default stack size if 128KiB and half of that is typically consumed by a 64KiB buffer for copying between Source/Sink.

512KiB should be more than enough for the limit that we have (64 levels in NARs , which usually also bounds the recursion depth with some constant factor).

(cherry picked from commit c37e17c280934a6ca667984151516b0bb6212de4)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
