### PR TITLE
Fix assert when old daemon sends ecIncompleteClosure

### DIFF
--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -209,6 +209,10 @@ Goal::Done Goal::amDone(ExitCode result)
     trace("done");
     assert(top_co);
     assert(exitCode == ecBusy);
+    // Support for ecIncompleteClosure was removed in https://github.com/NixOS/nix/pull/13176
+    // Handle the case where a user has an old daemon and new client
+    if (result == ecIncompleteClosure)
+        result = ecNoSubstituters;
     assert(result == ecSuccess || result == ecFailed || result == ecNoSubstituters);
     exitCode = result;
 

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -132,7 +132,8 @@ private:
     ChildEvents childEvents;
 
 public:
-    typedef enum { ecBusy, ecSuccess, ecFailed, ecNoSubstituters } ExitCode;
+    // Do not remove values from this enum, need to support older daemons
+    typedef enum { ecBusy, ecSuccess, ecFailed, ecNoSubstituters, ecIncompleteClosure } ExitCode;
 
     /**
      * Backlink to the worker.


### PR DESCRIPTION
Trasform it to ecNoSubstituters instead.

Resolves #15916

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Several community members have hit this assert.

## Context

#15916
#13176

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
