### PR TITLE
Fix #15916

### DIFF
--- a/src/libstore/build/derivation-trampoline-goal.cc
+++ b/src/libstore/build/derivation-trampoline-goal.cc
@@ -2,6 +2,9 @@
 #include "nix/store/build/worker.hh"
 #include "nix/store/derivations.hh"
 
+#include <ranges>
+#include <algorithm>
+
 namespace nix {
 
 DerivationTrampolineGoal::DerivationTrampolineGoal(
@@ -144,11 +147,14 @@ Goal::Co DerivationTrampolineGoal::haveDerivation(StorePath drvPath, Derivation 
         },
         wantedOutputs.raw);
 
+    /* Must have at least one wanted output. This is assumed below. */
+    assert(!resolvedWantedOutputs.empty());
+
     Goals concreteDrvGoals;
 
     /* Build this step! */
 
-    auto sharedDrv = make_ref<Derivation>(std::move(drv));
+    auto sharedDrv = make_ref<const Derivation>(std::move(drv));
 
     for (auto & output : resolvedWantedOutputs) {
         auto g = upcast_goal(worker.makeDerivationGoal(drvPath, sharedDrv, output, buildMode, false));
@@ -157,20 +163,71 @@ Goal::Co DerivationTrampolineGoal::haveDerivation(StorePath drvPath, Derivation 
         concreteDrvGoals.insert(std::move(g));
     }
 
-    // Copy on purpose
-    co_await await(Goals(concreteDrvGoals));
+    co_await await(concreteDrvGoals);
 
     trace("outer build done");
 
-    auto & g = *concreteDrvGoals.begin();
-    buildResult = g->buildResult;
-    if (auto * successP = buildResult.tryGetSuccess())
-        for (auto & g2 : concreteDrvGoals)
-            if (auto * successP2 = g2->buildResult.tryGetSuccess())
-                for (auto && [x, y] : successP2->builtOutputs)
-                    successP->builtOutputs.insert_or_assign(x, y);
+    if (nrFailed != 0) {
+        auto gi = std::ranges::find_if(concreteDrvGoals, [](const GoalPtr & goal) -> bool {
+            auto exitCode = goal->exitCode;
+            /* Note that without --keep-going waitees might be cancelled before
+               we are woken up. */
+            return exitCode != ecBusy && exitCode != ecSuccess;
+        });
 
-    co_return amDone(g->exitCode);
+        const Goal * g = gi->get();
+        assert(gi != concreteDrvGoals.end() && "expected a failing goal");
+        auto exitCode = g->exitCode;
+        const auto * failure = g->buildResult.tryGetFailure();
+        assert(failure && "failing goal does not report a failed build result");
+
+        /* Report the exit status of *some* failing goal. This might not be strictly
+           correct, since multiple subgoals can fail independently, but this should be
+           a good enough heuristic without --keep-going. */
+        co_return doneFailure(exitCode, *failure);
+    }
+
+    SingleDrvOutputs outputs;
+
+    auto successes = std::views::transform(concreteDrvGoals, [](const GoalPtr & a) -> const BuildResult::Success & {
+        auto * success = a->buildResult.tryGetSuccess();
+        assert(success && "goal succeeded, but some waitees do not report a successful status");
+        return *success;
+    });
+
+    for (const auto & success : successes)
+        std::ranges::copy(success.builtOutputs, std::inserter(outputs, outputs.end()));
+
+    auto statuses = successes | std::views::transform(&BuildResult::Success::status);
+
+    /* Aggregate the status code. If some outputs we already valid, but we had
+       to build/substitute the other ones, report it as the smallest common
+       denominator. */
+    auto compareSuccesses = [](auto a, auto b) {
+        /* This is technically an identity mapping of the underlying values, but
+           it would be worse to rely on the enum ordering here. */
+        auto toPriority = [](auto st) {
+            using enum BuildResult::Success::Status;
+            switch (st) {
+            case Built:
+                return 0;
+            case Substituted:
+                return 1;
+            case AlreadyValid:
+                return 2;
+            case ResolvesToAlreadyValid:
+                return 3;
+            default:
+                unreachable();
+            }
+        };
+        return toPriority(a) < toPriority(b);
+    };
+
+    co_return doneSuccess({
+        .status = std::ranges::min(statuses, compareSuccesses),
+        .builtOutputs = std::move(outputs),
+    });
 }
 
 } // namespace nix

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -129,6 +129,7 @@ suites = [
       'logging.sh',
       'make-content-addressed.sh',
       'misc.sh',
+      'multiple-outputs-substitute-failure.sh',
       'multiple-outputs.sh',
       'nar-access.sh',
       'nars.sh',

--- a/tests/functional/multiple-outputs-substitute-failure.sh
+++ b/tests/functional/multiple-outputs-substitute-failure.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# See https://github.com/NixOS/nix/issues/15916
+
+source common.sh
+
+TODO_NixOS # Requires substituting from a local binary cache, enable when we sign paths in NixOS tests
+needLocalStore "'--no-require-sigs' can’t be used with the daemon"
+
+BINARY_CACHE=file://$cacheDir
+
+readarray -t outPaths < <(nix build -f multiple-outputs.nix 'independent^*' --no-link --print-out-paths)
+[[ ${#outPaths[@]} -eq 2 ]]
+nix copy --to "$BINARY_CACHE" "${outPaths[@]}"
+for p in "${outPaths[@]}"; do
+    [[ $p == *-second ]] && secondOut=$p
+done
+
+# Corrupt the second output, so that the substitution partially succeeds.
+secondNarInfoFile="$cacheDir/$(basename "$secondOut" | cut -c1-32).narinfo"
+sed -i 's|^NarHash:.*|NarHash: sha256:0000000000000000000000000000000000000000000000000000|' "$secondNarInfoFile"
+
+clearStore
+clearCacheCache
+
+# Note that using "^*" matters here. We want all wanted outputs for the same goal.
+expect 1 nix build -j 0 -f multiple-outputs.nix "independent^*" --no-link \
+    --substituters "$BINARY_CACHE" --no-require-sigs --substitute 2>&1 | grepQuiet "hash mismatch"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fix #15916. The bug got surfaced when recently hydra broke a tiny bit of the cache.

The core of the issue is that the trampoline goal reported an arbitrary
`exitCode`, which without --keep-going ends up cancelling goals and we
end up dying with an assert in `Goal::amDone()`.

See: https://github.com/NixOS/nix/pull/16042#issuecomment-4760250433

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
