### PR TITLE
remote-store: do not forward use-xdg-base-directories

### DIFF
--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -145,6 +145,7 @@ void RemoteStore::setOptions(Connection & conn)
     overrides.erase(settings.getWorkerSettings().useSubstitutes.name);
     overrides.erase(loggerSettings.showTrace.name);
     overrides.erase(experimentalFeatureSettings.experimentalFeatures.name);
+    overrides.erase(settings.useXDGBaseDirectories.name);
     overrides.erase("plugin-files");
     conn.to << overrides.size();
     for (auto & i : overrides)

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -150,6 +150,7 @@ void RemoteStore::setOptions(Connection & conn)
     overrides.erase(settings.getWorkerSettings().useSubstitutes.name);
     overrides.erase(loggerSettings.showTrace.name);
     overrides.erase(experimentalFeatureSettings.experimentalFeatures.name);
+    overrides.erase(settings.useXDGBaseDirectories.name);
     overrides.erase("plugin-files");
     conn.to << overrides.size();
     for (auto & i : overrides)

--- a/tests/functional/remote-store.sh
+++ b/tests/functional/remote-store.sh
@@ -22,6 +22,13 @@ else
     nix store info --json | jq -e 'has("trusted") | not'
 fi
 
+# `nix-env --install` through the daemon should not warn about
+# `use-xdg-base-directories`, and should still install successfully.
+expectStderr 0 nix-env --option use-xdg-base-directories true \
+    -p "$TEST_ROOT/daemon-profile" -f ./user-envs.nix -i foo-1.0 \
+    | grepQuietInverse "ignoring the client-specified setting 'use-xdg-base-directories'"
+nix-env -p "$TEST_ROOT/daemon-profile" -q '*' | grepQuiet foo-1.0
+
 # Test import-from-derivation through the daemon.
 [[ $(nix eval --impure --raw --file ./ifd.nix) = hi ]]
 


### PR DESCRIPTION
## Motivation

Fix #15988.
When passing --option use-xdg-base-directories to certain nix-env subcommands like --install, a warning is erroneously printed.

According to the `nix-daemon` documentation, the purpose of the daemon is to run builds and other operations on behalf of unprivileged users. Therefore, it is weird to forward `use-xdg-base-directories` option.

The image below shows that the warning is reproduced, while the expected XDG profile symlinks are still created:
<img width="2402" height="512" alt="nix-bug-repro" src="https://github.com/user-attachments/assets/26f92c64-e237-4675-aead-7421c94dc4f6" />

The fix removes `settings.useXDGBaseDirectories.name` from the forwarded override set.

The image below shows that after the fix warning no longer appears, while expected XDG profile symlinks are still created:
<img width="2403" height="481" alt="nix-fix-repro" src="https://github.com/user-attachments/assets/69120810-5641-425f-b0b6-70e6c917521a" />




## Context



