### PR TITLE
doc: put system string table next to mechanism description

### DIFF
--- a/doc/manual/source/development/building.md
+++ b/doc/manual/source/development/building.md
@@ -199,23 +199,7 @@ Nix uses a string with the following format to identify the *system type* or *pl
 <cpu>-<os>[-<abi>]
 ```
 
-It is set when Nix is compiled for the given system, and based on the output of Meson's [`host_machine` information](https://mesonbuild.com/Reference-manual_builtin_host_machine.html)>
-
-```
-<cpu>-<vendor>-<os>[<version>][-<abi>]
-```
-
-When cross-compiling Nix with Meson for local development, you need to specify a [cross-file](https://mesonbuild.com/Cross-compilation.html) using the `--cross-file` option. Cross-files define the target architecture and toolchain. When cross-compiling Nix with Nix, Nixpkgs takes care of this for you.
-
-In the nix flake we also have some cross-compilation targets available:
-
-```
-nix build .#nix-everything-riscv64-unknown-linux-gnu
-nix build .#nix-everything-armv7l-unknown-linux-gnueabihf
-nix build .#nix-everything-armv7l-unknown-linux-gnueabihf
-nix build .#nix-everything-x86_64-unknown-freebsd
-nix build .#nix-everything-x86_64-w64-mingw32
-```
+It is set when Nix is compiled for the given system, and based on the output of Meson's [`host_machine` information](https://mesonbuild.com/Reference-manual_builtin_host_machine.html).
 
 For historic reasons and backward-compatibility, some CPU and OS identifiers are translated as follows:
 
@@ -231,6 +215,19 @@ For historic reasons and backward-compatibility, some CPU and OS identifiers are
 | `mips64`                    | `little`                | `mips64el`          |
 | `mips`                      | `big`                   | `mips`              |
 | `mips64`                    | `big`                   | `mips64`            |
+
+
+When cross-compiling Nix with Meson for local development, you need to specify a [cross-file](https://mesonbuild.com/Cross-compilation.html) using the `--cross-file` option. Cross-files define the target architecture and toolchain. When cross-compiling Nix with Nix, Nixpkgs takes care of this for you.
+
+In the nix flake we also have some cross-compilation targets available:
+
+```
+nix build .#nix-everything-riscv64-unknown-linux-gnu
+nix build .#nix-everything-armv7l-unknown-linux-gnueabihf
+nix build .#nix-everything-armv7l-unknown-linux-gnueabihf
+nix build .#nix-everything-x86_64-unknown-freebsd
+nix build .#nix-everything-x86_64-w64-mingw32
+```
 
 ## Compilation environments
 


### PR DESCRIPTION
## Motivation

The interjection about cross compilation weakened the connection to the
mention that Meson is the source of these system strings. Putting the
table right after that mention makes the link more evident.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).