### PR TITLE
nix-store --register-validity: fix ENOENT under chroot stores

### DIFF
--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -570,6 +570,7 @@ static void opDumpDB(Strings opFlags, Strings opArgs)
 
 static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
 {
+    auto localStore = ensureLocalStore();
     ValidPathInfos infos;
 
     while (1) {
@@ -587,7 +588,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
             /* !!! races */
             if (canonicalise)
                 canonicalisePathMetaData(
-                    store->printStorePath(info->path),
+                    localStore->toRealPath(info->path),
                     {NIX_WHEN_SUPPORT_ACLS(settings.getLocalSettings().ignoredAcls)});
             if (!hashGiven) {
                 HashResult hash = hashPath(
@@ -601,7 +602,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
         }
     }
 
-    ensureLocalStore()->registerValidPaths(infos);
+    localStore->registerValidPaths(infos);
 }
 
 static void opLoadDB(Strings opFlags, Strings opArgs)

--- a/tests/functional/chroot-store.sh
+++ b/tests/functional/chroot-store.sh
@@ -60,6 +60,15 @@ PATH7=$(nix path-info --store "local://$TEST_ROOT/x%2Bchroot" "$CORRECT_PATH")
 # Path gets decoded.
 [[ ! -d "$TEST_ROOT/x%2Bchroot" ]]
 
+# Regression test: `nix-store --register-validity` against a chroot store must
+# canonicalise the real (chroot-prefixed) path, not the logical store path
+# (which does not exist on the host filesystem).
+regPath=$NIX_STORE_DIR/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-reg
+touch "$TEST_ROOT/x/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-reg"
+[[ ! -e "$regPath" ]]
+(echo "$regPath" && echo && echo 0) | nix-store --store "local?root=$TEST_ROOT/x" --register-validity
+nix-store --store "$TEST_ROOT/x" --check-validity "$regPath"
+
 # Ensure store info trusted works with local store
 nix --store "$TEST_ROOT/x" store info --json | jq -e '.trusted'
 


### PR DESCRIPTION
## Motivation

`nix-store --store local?root=<dir> --register-validity` fails with

```
error: getting status of "/nix/store/...": No such file or directory
```

because `registerValidity()` canonicalises the *logical* `printStorePath()` instead of the chroot-prefixed `toRealPath()`. The path exists only under `<dir>/nix/store/...`, not on the host filesystem.

`ensureLocalStore()` was already required at the end of this function for `registerValidPaths()`, so it is now hoisted to the top and reused for both `toRealPath()` and `registerValidPaths()`; this does not narrow the set of accepted stores.

## Context

Hit this while registering pre-built paths into a chroot store as part of an external build pipeline.

Added a regression test to `tests/functional/chroot-store.sh` that reproduces the ENOENT on the unpatched code.