### PR TITLE
Set MADV_DONTDUMP for bump allocator

### DIFF
--- a/src/libutil/bump-memory-resource.cc
+++ b/src/libutil/bump-memory-resource.cc
@@ -1,4 +1,6 @@
 #include "nix/util/bump-memory-resource.hh"
+#include "nix/util/environment-variables.hh"
+#include "nix/util/error.hh"
 #include "nix/util/file-system.hh"
 #include "nix/util/alignment.hh"
 #include "nix/util/logging.hh"
@@ -57,7 +59,7 @@ static bool canOvercommit(std::size_t reserveSize)
 
 #endif // _WIN32
 
-BumpMemoryResource::BumpMemoryResource(std::size_t reserveSize, std::pmr::memory_resource * upstream)
+BumpMemoryResource::BumpMemoryResource(std::size_t reserveSize, std::pmr::memory_resource * upstream, bool dontDump)
     : upstreamResource(upstream)
 {
 #ifndef _WIN32
@@ -83,6 +85,12 @@ BumpMemoryResource::BumpMemoryResource(std::size_t reserveSize, std::pmr::memory
 
     base = p;
     capacity = reserveSize;
+
+#  ifdef MADV_DONTDUMP
+    static const bool dumpEverything = getEnv("_NIX_CORE_DUMP_EVERYTHING").value_or("0") == "1";
+    if (!dumpEverything && dontDump && ::madvise(p, reserveSize, MADV_DONTDUMP))
+        throw SysError("calling madvise");
+#  endif
 #endif
 }
 

--- a/src/libutil/include/nix/util/bump-memory-resource.hh
+++ b/src/libutil/include/nix/util/bump-memory-resource.hh
@@ -39,7 +39,8 @@ public:
 
     explicit BumpMemoryResource(
         std::size_t reserveSize = defaultReserveSize,
-        std::pmr::memory_resource * upstream = std::pmr::new_delete_resource());
+        std::pmr::memory_resource * upstream = std::pmr::new_delete_resource(),
+        bool dontDump = true);
 
     BumpMemoryResource(BumpMemoryResource &&) = delete;
     BumpMemoryResource(const BumpMemoryResource &) = delete;


### PR DESCRIPTION
This should drastically reduce the time needed to generate a coredump.

Resolves #16057

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Without this, coredumps can take a long time to generate for Nix crashes.

## Context

#16057

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
