### PR TITLE
libfetchers: namespace input fingerprint by scheme

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -125,6 +125,9 @@ std::optional<std::string> Input::getFingerprint(Store & store) const
 
     auto fingerprint = scheme->getFingerprint(store, *this);
 
+    if (fingerprint)
+        fingerprint = std::string(scheme->schemeName()) + ":" + *fingerprint;
+
     cachedFingerprint = fingerprint;
 
     return fingerprint;


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

i've been getting hash mismatch errors almost daily when there's update on flake input from dependabot and that dependency have a local checkout

## Context

see https://github.com/stepbrobd/nix-cache-hash-mismatch-mre

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
