### PR TITLE
[Backport 2.34-maintenance] nix-store --register-validity: fix ENOENT under chroot stores

### DIFF
--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -575,6 +575,7 @@ static void opDumpDB(Strings opFlags, Strings opArgs)
 
 static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
 {
+    auto localStore = ensureLocalStore();
     ValidPathInfos infos;
 
     while (1) {
@@ -592,7 +593,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
             /* !!! races */
             if (canonicalise)
                 canonicalisePathMetaData(
-                    store->printStorePath(info->path),
+                    localStore->toRealPath(info->path),
                     {NIX_WHEN_SUPPORT_ACLS(settings.getLocalSettings().ignoredAcls)});
             if (!hashGiven) {
                 HashResult hash = hashPath(
@@ -606,7 +607,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
         }
     }
 
-    ensureLocalStore()->registerValidPaths(infos);
+    localStore->registerValidPaths(infos);
 }
 
 static void opLoadDB(Strings opFlags, Strings opArgs)

--- a/tests/functional/chroot-store.sh
+++ b/tests/functional/chroot-store.sh
@@ -60,6 +60,15 @@ PATH7=$(nix path-info --store "local://$TEST_ROOT/x%2Bchroot" "$CORRECT_PATH")
 # Path gets decoded.
 [[ ! -d "$TEST_ROOT/x%2Bchroot" ]]
 
+# Regression test: `nix-store --register-validity` against a chroot store must
+# canonicalise the real (chroot-prefixed) path, not the logical store path
+# (which does not exist on the host filesystem).
+regPath=$NIX_STORE_DIR/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-reg
+touch "$TEST_ROOT/x/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-reg"
+[[ ! -e "$regPath" ]]
+(echo "$regPath" && echo && echo 0) | nix-store --store "local?root=$TEST_ROOT/x" --register-validity
+nix-store --store "$TEST_ROOT/x" --check-validity "$regPath"
+
 # Ensure store info trusted works with local store
 nix --store "$TEST_ROOT/x" store info --json | jq -e '.trusted'
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Manual backport of https://github.com/NixOS/nix/pull/16053.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
