### PR TITLE
libstore: detect Rosetta via runtime file instead of spawning arch

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -4,6 +4,7 @@
 #include "nix/util/config-global.hh"
 #include "nix/util/current-process.hh"
 #include "nix/util/executable-path.hh"
+#include "nix/util/file-system.hh"
 #include "nix/util/args.hh"
 #include "nix/util/abstract-setting-to-json.hh"
 #include "nix/util/compute-levels.hh"
@@ -254,11 +255,11 @@ StringSet Settings::getDefaultExtraPlatforms()
     // machines. Note that we can’t force processes from executing
     // x86_64 in aarch64 environments or vice versa since they can
     // always exec with their own binary preferences.
+    //
+    // The runtime file exists iff Rosetta 2 is installed; checking it avoids
+    // spawning a subprocess during static initialization of `settings`.
     if (std::string{NIX_LOCAL_SYSTEM} == "aarch64-darwin"
-        && runProgram(
-               RunOptions{.program = "arch", .args = {"-arch", "x86_64", "/usr/bin/true"}, .mergeStderrToStdout = true})
-                   .first
-               == 0)
+        && pathExists("/Library/Apple/usr/libexec/oah/libRosettaRuntime"))
         extraPlatforms.insert("x86_64-darwin");
 #endif
 


### PR DESCRIPTION
## Motivation

Running something as trivial as `nix-env --version` on Apple silicon is slower than it should be. The process never touches `extra-platforms`, yet it still pays to compute that setting's default, because the default is built during static initialization of the global `settings` object.

Computing that default ran `arch -arch x86_64 /usr/bin/true` and checked the exit code to find out whether Rosetta 2 can run x86_64 binaries. Spawning that subprocess costs roughly 13ms of dyld startup on my machine, and every libstore linked process on Apple silicon pays it, including `nix-env --version` and other commands that do no real work.

## The fix

Rosetta 2 ships a runtime file at `/Library/Apple/usr/libexec/oah/libRosettaRuntime`. It is present exactly when Rosetta 2 is installed, which is exactly when the `arch` probe used to succeed, so a `pathExists` check on that path gives the same answer. A stat costs about 0.01ms against 12.5ms for the subprocess, so finding Rosetta this way is roughly a thousand times faster and removes the process spawn from startup entirely.

This is a pure speedup with no behavior change: the same systems gain `x86_64-darwin` in `extra-platforms` as before.
