### PR TITLE
libstore: treat `\r\n` as a single line terminator in build logs

### DIFF
--- a/src/libstore/build/build-log.cc
+++ b/src/libstore/build/build-log.cc
@@ -10,9 +10,16 @@ BuildLog::BuildLog(size_t maxTailLines, std::unique_ptr<Activity> act)
 
 void BuildLog::operator()(std::string_view data)
 {
-    for (auto c : data)
+    for (auto c : data) {
+        /* Only let a '\r' reset the column if it isn't followed by '\n', so
+           "\r\n" acts as a line terminator; defer a char to handle split chunks. */
+        if (pendingCR) {
+            pendingCR = false;
+            if (c != '\n')
+                currentLogLinePos = 0;
+        }
         if (c == '\r')
-            currentLogLinePos = 0;
+            pendingCR = true;
         else if (c == '\n')
             flushLine();
         else {
@@ -20,6 +27,7 @@ void BuildLog::operator()(std::string_view data)
                 currentLogLine.resize(currentLogLinePos + 1);
             currentLogLine[currentLogLinePos++] = c;
         }
+    }
 }
 
 void BuildLog::flush()

--- a/src/libstore/include/nix/store/build/build-log.hh
+++ b/src/libstore/include/nix/store/build/build-log.hh
@@ -31,6 +31,8 @@ private:
     std::string currentLogLine;
     size_t currentLogLinePos = 0; // to handle carriage return
 
+    bool pendingCR = false; // defer '\r' so "\r\n" is treated as a line terminator
+
     void flushLine();
 
 public:


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Builders that emit `\r\n` line endings (e.g. tools under Wine, or native Windows builders) have their build logs silently blanked: `\r` resets the line's column and the following `\n` then flushes an empty line. Nix should treat `\r\n` the same as `\n`.

## Context

See: https://git.m-labs.hk/M-Labs/nac3/issues/804

`BuildLog::operator()` now resets the column on a `\r` only when it isn't followed by `\n` (a `pendingCR` flag carries the state across read chunks). Bare `\r` (e.g. for progress bars) is unchanged.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
