### PR TITLE
installer: Bail out early if running on macOS < 14.0

### DIFF
--- a/scripts/install-nix-from-tarball.sh
+++ b/scripts/install-nix-from-tarball.sh
@@ -28,14 +28,15 @@ fi
 
 OS="$(uname -s)"
 
-# macOS support for 10.12.6 or higher
+# Since nixpkgs 25.11 the minimum deployment target is macOS 14.0
 if [ "$OS" = "Darwin" ]; then
+    # shellcheck disable=SC2034
     IFS='.' read -r macos_major macos_minor macos_patch << EOF
 $(sw_vers -productVersion)
 EOF
-    if [ "$macos_major" -lt 10 ] || { [ "$macos_major" -eq 10 ] && [ "$macos_minor" -lt 12 ]; } || { [ "$macos_minor" -eq 12 ] && [ "$macos_patch" -lt 6 ]; }; then
+    if [ "$macos_major" -lt 14 ]; then
         # patch may not be present; command substitution for simplicity
-        echo "$0: macOS $(sw_vers -productVersion) is not supported, upgrade to 10.12.6 or higher"
+        echo "$0: macOS $(sw_vers -productVersion) is not supported, upgrade to 14.0 or higher"
         exit 1
     fi
 fi


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Nixpkgs 25.11 bumped the min deployment target to 14.0 and before that we had also used symbols without version gates (2.32-2.33, but those aren't supported anymore and shouldn't have this problem since 25.05 shipped a vendored libc++ iirc).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

https://github.com/NixOS/nix/issues/16060
https://github.com/NixOS/nix/issues/15764
https://github.com/NixOS/nix/issues/16029

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
