### PR TITLE
Fix `LocalStoreAccessor::maybeLstat`

### DIFF
--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -69,6 +69,8 @@ class WholeStoreViewAccessor : public SourceAccessor
         });
 
         if (!res)
+            /* The accessor is truly empty, i.e. without any file at root so
+               any subsequent operation with it will fail. */
             res = &emptyAccessor;
 
         return callback(*res, path);
@@ -107,6 +109,7 @@ public:
 
     DirEntries readDirectory(const CanonPath & path) override
     {
+        /* FIXME: Special-case the root directory to read the whole store, not just an empty root. */
         return callWithAccessorForPath(
             path, [](SourceAccessor & accessor, const CanonPath & path) { return accessor.readDirectory(path); });
     }

--- a/src/libstore/include/nix/store/remote-fs-accessor.hh
+++ b/src/libstore/include/nix/store/remote-fs-accessor.hh
@@ -33,6 +33,8 @@ public:
 
     /**
      * @return nullptr if the store does not contain any object at that path.
+     *
+     * @todo This actually doesn't return nullptr, but throws on invalid paths.
      */
     std::shared_ptr<SourceAccessor> accessObject(const StorePath & path);
 

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -49,11 +49,31 @@ public:
     {
     }
 
-    void requireStoreObject(const CanonPath & path)
+    void requireStoreObject(const StorePath & storePath)
     {
-        auto [storePath, rest] = store->toStorePath(store->storeDir + path.abs());
         if (requireValidPath && !store->isValidPath(storePath))
             throw InvalidPath("path '%1%' is not a valid store path", store->printStorePath(storePath));
+    }
+
+    static StorePath getStoreObjectPath(const CanonPath & path)
+    {
+        /* See special handling of isRoot() in maybeLstat. */
+        if (path.isRoot())
+            throw BadStorePath("path '%1%' is not a valid store path", path);
+        return StorePath(*path.begin());
+    }
+
+    static std::optional<StorePath> maybeGetStoreObjectPath(const CanonPath & path)
+    try {
+        return getStoreObjectPath(path);
+    } catch (BadStorePath &) {
+        /* FIXME: Stop using exceptions for control flow. */
+        return std::nullopt;
+    }
+
+    void requireStoreObject(const CanonPath & path)
+    {
+        requireStoreObject(getStoreObjectPath(path));
     }
 
     std::optional<Stat> maybeLstat(const CanonPath & path) override
@@ -63,7 +83,13 @@ public:
         if (path.isRoot())
             return Stat{.type = tDirectory};
 
-        requireStoreObject(path);
+        /* Querying existence should not fail for things like
+           `/nix/store/foo.nix`. The store cannot contain such files (unless
+           some weird impurities sneak in, but that's UB from nix's PoV). */
+        auto maybeStorePath = maybeGetStoreObjectPath(path);
+        if (!maybeStorePath)
+            return std::nullopt;
+        requireStoreObject(*maybeStorePath);
         return accessor->maybeLstat(path);
     }
 
@@ -122,11 +148,6 @@ public:
     std::optional<time_t> getLastModified() override
     {
         return accessor->getLastModified();
-    }
-
-    bool pathExists(const CanonPath & path) override
-    {
-        return accessor->pathExists(path);
     }
 };
 

--- a/src/libstore/remote-fs-accessor.cc
+++ b/src/libstore/remote-fs-accessor.cc
@@ -39,6 +39,8 @@ std::optional<SourceAccessor::Stat> RemoteFSAccessor::maybeLstat(const CanonPath
 {
     if (path.isRoot())
         return Stat{.type = tDirectory};
+    /* FIXME: Correctly handle invalid names (return nullopt) and don't fail on
+       non-existent paths. */
     auto res = fetch(path);
     return res.first->maybeLstat(res.second);
 }

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -83,6 +83,13 @@ public:
      */
     virtual void readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback = [](uint64_t size) {});
 
+    /**
+     * @brief Check whether a file exists at @p path.
+     *
+     * @todo Consider making this non-virtual, since the evaluator uses
+     * maybeLstat as an indication that a file exists always (for positive
+     * caching purposes).
+     */
     virtual bool pathExists(const CanonPath & path);
 
     enum Type {

--- a/tests/functional/flakes/follow-paths.sh
+++ b/tests/functional/flakes/follow-paths.sh
@@ -131,7 +131,7 @@ EOF
 git -C "$flakeFollowsA" add flake.nix
 
 expect 1 nix flake lock "$flakeFollowsA" 2>&1 | grep '/flakeB.*is forbidden in pure evaluation mode'
-expect 1 nix flake lock --impure "$flakeFollowsA" 2>&1 | grep "'flakeB' is too short to be a valid store path"
+expect 1 nix flake lock --impure "$flakeFollowsA" 2>&1 | grep '/flakeB.*does not exist'
 
 # Test relative non-flake inputs.
 cat > "$flakeFollowsA"/flake.nix <<EOF

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -13,7 +13,7 @@ function diffAndAccept() {
 }
 
 export TEST_VAR=foo # for eval-okay-getenv.nix
-export NIX_REMOTE=dummy://
+export NIX_REMOTE=dummy:// # FIXME: Run with multiple store types and without readonly mode
 export NIX_STORE_DIR=/nix/store
 
 nix-instantiate --eval -E 'builtins.trace "Hello" 123' 2>&1 | grepQuiet Hello

--- a/tests/functional/lang/eval-okay-pathexists.nix
+++ b/tests/functional/lang/eval-okay-pathexists.nix
@@ -32,3 +32,6 @@ builtins.pathExists (./lib.nix)
 && builtins.pathExists ./symlink-resolution/foo/overlays/overlay.nix
 && builtins.pathExists ./symlink-resolution/broken
 && builtins.pathExists (builtins.toString ./symlink-resolution/foo/overlays + "/.")
+&& builtins.pathExists "${builtins.storeDir}"
+&& !builtins.pathExists "${builtins.storeDir}/foo"
+&& !builtins.pathExists "${builtins.storeDir}/foo/bar"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Paths that are not valid store path names (i.e. `foo` or `bar`) can't ever exist in the store, and the correct semantics for it is to return `std::nullopt` instead of throwing.

Also noticed a lot of bugs in `RemoteFSAccessor`, but that's for a later patch. There are also lots of missing overrides of pathExists in SourceAccessor implementations, so I wonder whether that should just be made non-virtual. The evaluator doesn't benefit from potentially optimised pathExists, because `MountedSourceAccesso`r and various other combinators don't propagate them. Plus we should typically still query the `lstat` to do positive caching (`CachingSourceAccessor`).

See https://github.com/NixOS/nix/issues/16017.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
