### PR TITLE
libfetchers/git-utils: Fix #15680

### DIFF
--- a/src/libfetchers-tests/git-utils.cc
+++ b/src/libfetchers-tests/git-utils.cc
@@ -1,5 +1,7 @@
 #include "nix/fetchers/git-utils.hh"
 #include "nix/util/file-system.hh"
+#include "nix/util/tests/gmock-matchers.hh"
+
 #include <gmock/gmock.h>
 #include <git2/global.h>
 #include <git2/repository.h>
@@ -19,7 +21,7 @@ namespace nix::fetchers {
 class GitUtilsTest : public ::testing::Test
 {
     // We use a single repository for all tests.
-    std::unique_ptr<AutoDelete> delTmpDir;
+    AutoDelete delTmpDir;
 
 protected:
     std::filesystem::path tmpDir;
@@ -27,27 +29,19 @@ protected:
 public:
     void SetUp() override
     {
-        tmpDir = createTempDir();
-        delTmpDir = std::make_unique<AutoDelete>(tmpDir, true);
-
-        // Create the repo with libgit2
-        git_libgit2_init();
-        git_repository * repo = nullptr;
-        auto r = git_repository_init(&repo, tmpDir.string().c_str(), 0);
-        ASSERT_EQ(r, 0);
-        git_repository_free(repo);
+        tmpDir = createTempDir() / "test-git-repo";
+        GitRepo::openRepo(tmpDir, {.create = true});
+        delTmpDir = AutoDelete(tmpDir, true);
     }
 
     void TearDown() override
     {
-        // Destroy the AutoDelete, triggering removal
-        // not AutoDelete::reset(), which would cancel the deletion.
-        delTmpDir.reset();
+        delTmpDir.deletePath();
     }
 
     ref<GitRepo> openRepo()
     {
-        return GitRepo::openRepo(tmpDir, {.create = true});
+        return GitRepo::openRepo(tmpDir, {.create = false});
     }
 
     std::string getRepoName() const
@@ -117,11 +111,33 @@ TEST_F(GitUtilsTest, sink_hardlink)
         sink->flush();
         FAIL() << "Expected an exception";
     } catch (const nix::Error & e) {
-        ASSERT_THAT(e.msg(), testing::HasSubstr("does not exist"));
-        ASSERT_THAT(e.msg(), testing::HasSubstr("/hello"));
-        ASSERT_THAT(e.msg(), testing::HasSubstr("foo-1.1/link"));
+        ASSERT_THAT(e.msg(), ::testing::HasSubstr("does not exist"));
+        ASSERT_THAT(e.msg(), ::testing::HasSubstr("/hello"));
+        ASSERT_THAT(e.msg(), ::testing::HasSubstr("foo-1.1/link"));
     }
 };
+
+TEST_F(GitUtilsTest, sink_no_parent_dir)
+{
+    ASSERT_THAT(
+        [&]() {
+            auto repo = openRepo();
+            auto sink = repo->getFileSystemObjectSink();
+
+            sink->createDirectory(CanonPath::root);
+
+            sink->createRegularFile(CanonPath("foo"), [](CreateRegularFileSink & fileSink) {
+                writeString(fileSink, "test", /*executable=*/false);
+            });
+
+            sink->createRegularFile(CanonPath("foo/bar"), [](CreateRegularFileSink & fileSink) {
+                writeString(fileSink, "boom", /*executable=*/false);
+            });
+
+            sink->flush();
+        },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("parent of 'foo/bar' is not a directory")));
+}
 
 TEST_F(GitUtilsTest, peel_reference)
 {

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -786,7 +786,7 @@ ref<GitRepo> GitRepo::openRepo(const std::filesystem::path & path, GitRepo::Opti
  * Raw git tree input accessor.
  */
 
-struct GitSourceAccessor : SourceAccessor
+struct GitSourceAccessor final : SourceAccessor
 {
 private:
     void anchor() override {};
@@ -1063,7 +1063,7 @@ public:
     }
 };
 
-struct GitExportIgnoreSourceAccessor : CachingFilteringSourceAccessor
+struct GitExportIgnoreSourceAccessor final : CachingFilteringSourceAccessor
 {
 private:
     void anchor() override {};
@@ -1130,7 +1130,7 @@ void GitFileSystemObjectSink::anchor() {}
 
 namespace {
 
-struct GitFileSystemObjectSinkImpl : GitFileSystemObjectSink
+struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
 {
     ref<GitRepoImpl> repo;
 
@@ -1210,15 +1210,19 @@ struct GitFileSystemObjectSinkImpl : GitFileSystemObjectSink
 
     void addNode(State & state, const CanonPath & path, Child && child)
     {
-        assert(!path.isRoot());
+        if (path.isRoot())
+            throw Error("cannot create a file at the root of the git repository");
+
         auto parent = path.parent();
+        assert(parent);
 
         Directory * cur = &state.root;
 
         for (auto & i : *parent) {
             auto child = std::get_if<Directory>(
                 &cur->children.emplace(std::string(i), Child{GIT_FILEMODE_TREE, {Directory()}}).first->second.file);
-            assert(child);
+            if (!child)
+                throw Error("parent of '%1%' is not a directory", path.rel());
             cur = child;
         }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Replace the assertion with a proper error. Also add a test and slightly deduplicate git-utils tests repo creation logic.

Also sprinkle some `final` on top while we are at it.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes https://github.com/NixOS/nix/issues/15680.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
