### PR TITLE
libexpr: Handle lazy paths in builtins.storePath better

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1961,25 +1961,21 @@ static void prim_storePath(EvalState & state, const PosIdx pos, Value ** args, V
             .debugThrow();
 
     NixStringContext context;
-    auto path =
-        state.coerceToPath(pos, *args[0], context, "while evaluating the first argument passed to 'builtins.storePath'")
-            .path;
-    /* Here we are leaving the realm of the rootFS accessor and must actually fetch to the store.
-       TODO: This could probably get optimised to avoid the fetching altogether to short-circuit when the path
-       is already mounted on storeFS. */
-    state.ensureLazyPathsCopied(context);
+    SourcePath sourcePath = state.coerceToPath(
+        pos, *args[0], context, "while evaluating the first argument passed to 'builtins.storePath'");
+
     /* Resolve symlinks in ‘path’, unless ‘path’ itself is a symlink
        directly in the store.  The latter condition is necessary so
        e.g. nix-push does the right thing. */
-    if (!state.store->isStorePath(path.abs()))
-        path = CanonPath(canonPath(path.abs(), true).string());
-    if (!state.store->isInStore(path.abs()))
-        state.error<EvalError>("path '%1%' is not in the Nix store", path).atPos(pos).debugThrow();
-    auto path2 = state.store->toStorePath(path.abs()).first;
-    if (!settings.readOnlyMode)
-        state.store->ensurePath(path2);
-    context.insert(NixStringContextElem::Opaque{.path = path2});
-    v.mkString(path.abs(), context, state.mem);
+    if (!state.store->isStorePath(sourcePath.path.abs()))
+        sourcePath = sourcePath.resolveSymlinks(SymlinkResolution::Full);
+    if (!state.store->isInStore(sourcePath.path.abs()))
+        state.error<EvalError>("path '%1%' is not in the Nix store", sourcePath).atPos(pos).debugThrow();
+    auto storePath = state.store->toStorePath(sourcePath.path.abs()).first;
+    if (!state.storeFS->getMount(CanonPath(state.store->printStorePath(storePath))) && !settings.readOnlyMode)
+        state.store->ensurePath(storePath);
+    context.insert(NixStringContextElem::Opaque{.path = storePath});
+    v.mkString(sourcePath.path.abs(), context, state.mem);
 }
 
 static RegisterPrimOp primop_storePath({


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

When building `nix.dev` manual I ran into an issue with the current handling of lazy paths:

```
    … while calling the 'import' builtin
     at /nix/store/8kpx53qi52yhjai1vdw8zpa95iqa61bv-source/default.nix:167:19:
      166|
      167|           flake = import (outPath + "/flake.nix");
         |                   ^
      168|

   … while realising the context of a path

   … while calling the 'storePath' builtin
     at /nix/store/8kpx53qi52yhjai1vdw8zpa95iqa61bv-source/default.nix:115:15:
      114|               # If it's already a store path, don't copy it again.
      115|               builtins.storePath src
         |               ^
      116|             else

    error: path '/nix/store/5fn5lshxlh5zb8w1a747apqlqlbi3j0x-source' is required, but there is no substituter that can build it
```

This also has the benefit of not relying on `nix::canonPath()`, which is one of the bits of I/O not funneled through the `rootFS` accessor.

The responsible code is in `flake-compat` [1]. With a path we lack the correct context but it points to a "lazy" path in the store. Funneling I/O into the accessor seems like the correct solution here.

[1]: https://github.com/NixOS/flake-compat/blob/5edf11c44bc78a0d334f6334cdaf7d60d732daab/default.nix#L147-L156

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Found in https://github.com/NixOS/nix.dev/pull/1244.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
