### PR TITLE
Test group membership properly on darwin

### DIFF
--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -34,6 +34,9 @@
 #include <grp.h>
 #include <fcntl.h>
 
+#if defined(__APPLE__)
+#  include <membership.h>
+#endif
 #ifdef __linux__
 #  include "nix/util/cgroup.hh"
 #endif
@@ -153,11 +156,24 @@ static void setSigChldAction(bool autoReap)
  *
  * @param group Group the user might be a member of.
  */
-static bool matchUser(std::string_view user, const struct group & gr)
+static bool matchUser(const std::string & user, const struct group & group)
 {
-    for (char ** mem = gr.gr_mem; *mem; mem++)
-        if (user == std::string_view(*mem))
+    for (char ** mem = group.gr_mem; *mem; mem++)
+        if (user == *mem)
             return true;
+
+#if defined(__APPLE__)
+    if (auto pw = getpwnam(user.c_str())) {
+        uuid_t user_uuid, group_uuid;
+        if (!mbr_uid_to_uuid(pw->pw_uid, user_uuid) && !mbr_gid_to_uuid(group.gr_gid, group_uuid)) {
+            int ismember = 0;
+            if (!mbr_check_membership(user_uuid, group_uuid, &ismember)) {
+                return !!ismember;
+            }
+        }
+    }
+#endif
+
     return false;
 }
 


### PR DESCRIPTION
Based upon https://github.com/lix-project/lix/commit/7f98021c93d56eab9e500603e28106da5a135304 with some minor edits.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I set allowed-users @staff and that did not work out of the box.

## Context

Closes https://github.com/NixOS/nix/issues/5885

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
