### PR TITLE
libfetchers: fix race in the Git filesystem object sink

### DIFF
--- a/src/libfetchers-tests/git-utils.cc
+++ b/src/libfetchers-tests/git-utils.cc
@@ -139,6 +139,46 @@ TEST_F(GitUtilsTest, sink_no_parent_dir)
         ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("parent of 'foo/bar' is not a directory")));
 }
 
+TEST_F(GitUtilsTest, sink_no_parent_dir_symlink)
+{
+    ASSERT_THAT(
+        [&]() {
+            auto repo = openRepo();
+            auto sink = repo->getFileSystemObjectSink();
+
+            sink->createDirectory(CanonPath::root);
+
+            sink->createRegularFile(CanonPath("foo"), [](CreateRegularFileSink & fileSink) {
+                writeString(fileSink, "test", /*executable=*/false);
+            });
+
+            sink->createSymlink(CanonPath("foo/bar"), "target");
+
+            sink->flush();
+        },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("parent of 'foo/bar' is not a directory")));
+}
+
+TEST_F(GitUtilsTest, sink_no_parent_dir_hardlink)
+{
+    ASSERT_THAT(
+        [&]() {
+            auto repo = openRepo();
+            auto sink = repo->getFileSystemObjectSink();
+
+            sink->createDirectory(CanonPath::root);
+
+            sink->createRegularFile(CanonPath("foo"), [](CreateRegularFileSink & fileSink) {
+                writeString(fileSink, "test", /*executable=*/false);
+            });
+
+            sink->createHardlink(CanonPath("foo/bar"), CanonPath("foo"));
+
+            sink->flush();
+        },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("parent of 'foo/bar' is not a directory")));
+}
+
 TEST_F(GitUtilsTest, peel_reference)
 {
     // Create a commit in the repo

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1163,7 +1163,7 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
     /// A directory to be written as a Git tree.
     struct Directory
     {
-        std::map<std::string, Child> children;
+        std::map<std::string, Child, std::less<>> children;
         std::optional<git_oid> oid;
 
         Child & lookup(const CanonPath & path)
@@ -1172,7 +1172,7 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
             auto parent = path.parent();
             auto cur = this;
             for (auto & name : *parent) {
-                auto i = cur->children.find(std::string(name));
+                auto i = cur->children.find(name);
                 if (i == cur->children.end())
                     throw Error("path '%s' does not exist", path);
                 auto dir = std::get_if<Directory>(&i->second.file);
@@ -1181,7 +1181,7 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
                 cur = dir;
             }
 
-            auto i = cur->children.find(std::string(*path.baseName()));
+            auto i = cur->children.find(*path.baseName());
             if (i == cur->children.end())
                 throw Error("path '%s' does not exist", path);
             return i->second;
@@ -1240,7 +1240,7 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
 
         Directory * cur = &state.root;
         for (auto & name : *parent) {
-            auto i = cur->children.find(std::string(name));
+            auto i = cur->children.find(name);
             if (i == cur->children.end())
                 return;
             auto dir = std::get_if<Directory>(&i->second.file);
@@ -1249,7 +1249,7 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
             cur = dir;
         }
 
-        auto i = cur->children.find(std::string(*path.baseName()));
+        auto i = cur->children.find(*path.baseName());
         if (i != cur->children.end() && i->second.id == id)
             i->second.file = oid;
     }

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1232,6 +1232,28 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
             cur->children.insert_or_assign(name, std::move(child));
     }
 
+    /* Set the object ID of a reserved leaf, skipping if it was superseded (id changed) meanwhile. */
+    void setNodeOid(State & state, const CanonPath & path, const git_oid & oid, size_t id)
+    {
+        auto parent = path.parent();
+        assert(parent);
+
+        Directory * cur = &state.root;
+        for (auto & name : *parent) {
+            auto i = cur->children.find(std::string(name));
+            if (i == cur->children.end())
+                return;
+            auto dir = std::get_if<Directory>(&i->second.file);
+            if (!dir)
+                return;
+            cur = dir;
+        }
+
+        auto i = cur->children.find(std::string(*path.baseName()));
+        if (i != cur->children.end() && i->second.id == id)
+            i->second.file = oid;
+    }
+
     void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func) override
     {
         checkInterrupt();
@@ -1301,6 +1323,10 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
         func(*crf);
 
         auto id = nextId++;
+        auto mode = crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB;
+
+        /* Reserve the node now, in order; workers fill the oid later. */
+        addNode(*_state.lock(), crf->path, Child{mode, git_oid{}, id});
 
         if (crf->stream) {
             /* Finish the slow path by creating the blob object synchronously.
@@ -1309,10 +1335,7 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
             git_oid oid;
             if (git_blob_create_from_stream_commit(&oid, crf->stream.release()))
                 throw GitError("creating a blob object for '%s'", path);
-            addNode(
-                *_state.lock(),
-                crf->path,
-                Child{crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB, oid, id});
+            setNodeOid(*_state.lock(), crf->path, oid, id);
             return;
         }
 
@@ -1324,10 +1347,7 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
             if (git_blob_create_from_buffer(&oid, *repo, crf->contents.data(), crf->contents.size()))
                 throw GitError("creating a blob object for '%s' from in-memory buffer", crf->path);
 
-            addNode(
-                *_state.lock(),
-                crf->path,
-                Child{crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB, oid, id});
+            setNodeOid(*_state.lock(), crf->path, oid, id);
         });
     }
 
@@ -1341,15 +1361,16 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
 
     void createSymlink(const CanonPath & path, const std::string & target) override
     {
-        workers.enqueue([this, path, target]() {
+        auto id = nextId++;
+        addNode(*_state.lock(), path, Child{GIT_FILEMODE_LINK, git_oid{}, id});
+        workers.enqueue([this, path, target, id]() {
             auto repo(repoPool.get());
 
             git_oid oid;
             if (git_blob_create_from_buffer(&oid, *repo, target.c_str(), target.size()))
                 throw GitError("creating a blob object for tarball symlink member '%s'", path);
 
-            auto state(_state.lock());
-            addNode(*state, path, Child{GIT_FILEMODE_LINK, oid});
+            setNodeOid(*_state.lock(), path, oid, id);
         });
     }
 


### PR DESCRIPTION
The sink built its tree structure from worker threads, after the blob bytes were written. Workers finish in any order, so for "foo" then "foo/bar" the "foo/bar" worker could run first and create "foo" as a directory instead of rejecting it as a file. Hence the flaky GitUtilsTest.sink_no_parent_dir.

Reserve each node synchronously, in order; workers only fill in the object ID afterwards.
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
