### PR TITLE
primops: feat `listToAttrsWithValue`

### DIFF
--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -271,29 +271,29 @@ TEST_F(PrimOpTest, listToAttrs)
     ASSERT_THAT(*key->value, IsIntEq(123));
 }
 
-TEST_F(PrimOpTest, listToAttrsNullEmptyList)
+TEST_F(PrimOpTest, listToAttrsWithValueEmptyList)
 {
-    auto v = eval("builtins.listToAttrsNull []");
+    auto v = eval("builtins.listToAttrsWithValue null []");
     ASSERT_THAT(v, IsAttrsOfSize(0));
     ASSERT_EQ(v.type(), nAttrs);
     ASSERT_EQ(v.attrs()->size(), 0u);
 }
 
-TEST_F(PrimOpTest, listToAttrsNullNotString)
+TEST_F(PrimOpTest, listToAttrsWithValueNotString)
 {
-    ASSERT_THROW(eval("builtins.listToAttrsNull [1]"), Error);
+    ASSERT_THROW(eval("builtins.listToAttrsWithValue null [1]"), Error);
 }
 
-TEST_F(PrimOpTest, listToAttrsNull)
+TEST_F(PrimOpTest, listToAttrsWithValue)
 {
-    auto v = eval("builtins.listToAttrsNull [ \"foo\" \"bar\" \"foo\" ]");
+    auto v = eval("builtins.listToAttrsWithValue 123 [ \"foo\" \"bar\" \"foo\" ]");
     ASSERT_THAT(v, IsAttrsOfSize(2));
     auto foo = v.attrs()->get(createSymbol("foo"));
     ASSERT_NE(foo, nullptr);
-    ASSERT_EQ(foo->value->type(), nNull);
+    ASSERT_THAT(*foo->value, IsIntEq(123));
     auto bar = v.attrs()->get(createSymbol("bar"));
     ASSERT_NE(bar, nullptr);
-    ASSERT_EQ(bar->value->type(), nNull);
+    ASSERT_THAT(*bar->value, IsIntEq(123));
 }
 
 TEST_F(PrimOpTest, intersectAttrs)

--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -271,22 +271,22 @@ TEST_F(PrimOpTest, listToAttrs)
     ASSERT_THAT(*key->value, IsIntEq(123));
 }
 
-TEST_F(PrimOpTest, listToSetEmptyList)
+TEST_F(PrimOpTest, listToAttrsNullEmptyList)
 {
-    auto v = eval("builtins.listToSet []");
+    auto v = eval("builtins.listToAttrsNull []");
     ASSERT_THAT(v, IsAttrsOfSize(0));
     ASSERT_EQ(v.type(), nAttrs);
     ASSERT_EQ(v.attrs()->size(), 0u);
 }
 
-TEST_F(PrimOpTest, listToSetNotString)
+TEST_F(PrimOpTest, listToAttrsNullNotString)
 {
-    ASSERT_THROW(eval("builtins.listToSet [1]"), Error);
+    ASSERT_THROW(eval("builtins.listToAttrsNull [1]"), Error);
 }
 
-TEST_F(PrimOpTest, listToSet)
+TEST_F(PrimOpTest, listToAttrsNull)
 {
-    auto v = eval("builtins.listToSet [ \"foo\" \"bar\" \"foo\" ]");
+    auto v = eval("builtins.listToAttrsNull [ \"foo\" \"bar\" \"foo\" ]");
     ASSERT_THAT(v, IsAttrsOfSize(2));
     auto foo = v.attrs()->get(createSymbol("foo"));
     ASSERT_NE(foo, nullptr);

--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -271,6 +271,31 @@ TEST_F(PrimOpTest, listToAttrs)
     ASSERT_THAT(*key->value, IsIntEq(123));
 }
 
+TEST_F(PrimOpTest, listToSetEmptyList)
+{
+    auto v = eval("builtins.listToSet []");
+    ASSERT_THAT(v, IsAttrsOfSize(0));
+    ASSERT_EQ(v.type(), nAttrs);
+    ASSERT_EQ(v.attrs()->size(), 0u);
+}
+
+TEST_F(PrimOpTest, listToSetNotString)
+{
+    ASSERT_THROW(eval("builtins.listToSet [1]"), Error);
+}
+
+TEST_F(PrimOpTest, listToSet)
+{
+    auto v = eval("builtins.listToSet [ \"foo\" \"bar\" \"foo\" ]");
+    ASSERT_THAT(v, IsAttrsOfSize(2));
+    auto foo = v.attrs()->get(createSymbol("foo"));
+    ASSERT_NE(foo, nullptr);
+    ASSERT_EQ(foo->value->type(), nNull);
+    auto bar = v.attrs()->get(createSymbol("bar"));
+    ASSERT_NE(bar, nullptr);
+    ASSERT_EQ(bar->value->type(), nNull);
+}
+
 TEST_F(PrimOpTest, intersectAttrs)
 {
     auto v = eval("builtins.intersectAttrs { a = 1; b = 2; } { b = 3; c = 4; }");

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3392,6 +3392,75 @@ static RegisterPrimOp primop_listToAttrs({
     .impl = prim_listToAttrs,
 });
 
+static void prim_listToSet(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+{
+    state.forceList(*args[0], pos, "while evaluating the argument passed to builtins.listToSet");
+
+    auto listView = args[0]->listView();
+    size_t listSize = listView.size();
+
+    if (listSize == 0) {
+        v.mkAttrs(&Bindings::emptyBindings);
+        return;
+    }
+
+    auto & bindings = *state.mem.allocBindings(listSize);
+
+    size_t idx = 0;
+    for (auto v2 : listView) {
+        auto name = state.forceStringNoCtx(
+            *v2,
+            pos,
+            "while evaluating an element of the list passed to builtins.listToSet");
+        auto sym = state.symbols.create(name);
+        bindings[idx++] = Attr(sym, nullptr);
+    }
+
+    std::sort(&bindings[0], &bindings[listSize]);
+
+    Symbol prev;
+    for (size_t n = 0; n < listSize; n++) {
+        auto attr = bindings[n];
+        if (prev == attr.name) {
+            continue;
+        }
+        prev = attr.name;
+        bindings.push_back({prev, &Value::vNull, pos});
+    }
+    // help GC and clear end of allocated array
+    for (size_t n = bindings.size(); n < listSize; n++) {
+        bindings[n] = Attr{};
+    }
+    v.mkAttrs(&bindings);
+}
+
+static RegisterPrimOp primop_listToSet({
+    .name = "__listToSet",
+    .args = {"list"},
+    .doc = R"(
+      Construct an attribute set from a list of strings. Every attribute in the
+      result set has its value set to `null`.
+
+      In case of duplicate occurrences of the same name, only one attribute
+      is created.
+
+      Example:
+
+      ```nix
+      builtins.listToSet [ "foo" "bar" "foo" ]
+      ```
+
+      evaluates to
+
+      ```nix
+      { foo = null; bar = null; }
+      ```
+
+      Has `O(n log n)` time complexity, where `n` is size of the list.
+    )",
+    .impl = prim_listToSet,
+});
+
 static void prim_intersectAttrs(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
     state.forceAttrs(*args[0], pos, "while evaluating the first argument passed to builtins.intersectAttrs");

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3414,9 +3414,9 @@ static RegisterPrimOp primop_listToAttrs({
     .impl = prim_listToAttrs,
 });
 
-static void prim_listToSet(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+static void prim_listToAttrsNull(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
-    state.forceList(*args[0], pos, "while evaluating the argument passed to builtins.listToSet");
+    state.forceList(*args[0], pos, "while evaluating the argument passed to builtins.listToAttrsNull");
 
     auto listView = args[0]->listView();
     size_t listSize = listView.size();
@@ -3431,7 +3431,7 @@ static void prim_listToSet(EvalState & state, const PosIdx pos, Value ** args, V
     size_t idx = 0;
     for (auto v2 : listView) {
         auto sym =
-            forceStringSymbol(state, pos, *v2, "while evaluating an element of the list passed to builtins.listToSet");
+            forceStringSymbol(state, pos, *v2, "while evaluating an element of the list passed to builtins.listToAttrsNull");
         bindings[idx++] = Attr(sym, nullptr);
     }
 
@@ -3440,8 +3440,8 @@ static void prim_listToSet(EvalState & state, const PosIdx pos, Value ** args, V
     finalizeBindings(state, bindings, listSize, v, [&](const Attr & attr) { return std::pair{&Value::vNull, pos}; });
 }
 
-static RegisterPrimOp primop_listToSet({
-    .name = "__listToSet",
+static RegisterPrimOp primop_listToAttrsNull({
+    .name = "__listToAttrsNull",
     .args = {"list"},
     .doc = R"(
       Construct an attribute set from a list of strings. Every attribute in the
@@ -3453,7 +3453,7 @@ static RegisterPrimOp primop_listToSet({
       Example:
 
       ```nix
-      builtins.listToSet [ "foo" "bar" "foo" ]
+      builtins.listToAttrsNull [ "foo" "bar" "foo" ]
       ```
 
       evaluates to
@@ -3464,7 +3464,7 @@ static RegisterPrimOp primop_listToSet({
 
       Has `O(n log n)` time complexity, where `n` is size of the list.
     )",
-    .impl = prim_listToSet,
+    .impl = prim_listToAttrsNull,
 });
 
 static void prim_intersectAttrs(EvalState & state, const PosIdx pos, Value ** args, Value & v)

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3414,11 +3414,11 @@ static RegisterPrimOp primop_listToAttrs({
     .impl = prim_listToAttrs,
 });
 
-static void prim_listToAttrsNull(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+static void prim_listToAttrsWithValue(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
-    state.forceList(*args[0], pos, "while evaluating the argument passed to builtins.listToAttrsNull");
+    state.forceList(*args[1], pos, "while evaluating the second argument passed to builtins.listToAttrsWithValue");
 
-    auto listView = args[0]->listView();
+    auto listView = args[1]->listView();
     size_t listSize = listView.size();
 
     if (listSize == 0) {
@@ -3431,21 +3431,21 @@ static void prim_listToAttrsNull(EvalState & state, const PosIdx pos, Value ** a
     size_t idx = 0;
     for (auto v2 : listView) {
         auto sym =
-            forceStringSymbol(state, pos, *v2, "while evaluating an element of the list passed to builtins.listToAttrsNull");
+            forceStringSymbol(state, pos, *v2, "while evaluating an element of the list passed to builtins.listToAttrsWithValue");
         bindings[idx++] = Attr(sym, nullptr);
     }
 
     std::sort(&bindings[0], &bindings[listSize]);
 
-    finalizeBindings(state, bindings, listSize, v, [&](const Attr & attr) { return std::pair{&Value::vNull, pos}; });
+    finalizeBindings(state, bindings, listSize, v, [&](const Attr & attr) { return std::pair{args[0], pos}; });
 }
 
-static RegisterPrimOp primop_listToAttrsNull({
-    .name = "__listToAttrsNull",
-    .args = {"list"},
+static RegisterPrimOp primop_listToAttrsWithValue({
+    .name = "__listToAttrsWithValue",
+    .args = {"value", "list"},
     .doc = R"(
-      Construct an attribute set from a list of strings. Every attribute in the
-      result set has its value set to `null`.
+      Construct an attribute set from a list of strings where every attribute in the
+      result set has its value set to the given `value`.
 
       In case of duplicate occurrences of the same name, only one attribute
       is created.
@@ -3453,18 +3453,18 @@ static RegisterPrimOp primop_listToAttrsNull({
       Example:
 
       ```nix
-      builtins.listToAttrsNull [ "foo" "bar" "foo" ]
+      builtins.listToAttrsWithValue true [ "foo" "bar" "foo" ]
       ```
 
       evaluates to
 
       ```nix
-      { foo = null; bar = null; }
+      { foo = true; bar = true; }
       ```
 
       Has `O(n log n)` time complexity, where `n` is size of the list.
     )",
-    .impl = prim_listToAttrsNull,
+    .impl = prim_listToAttrsWithValue,
 });
 
 static void prim_intersectAttrs(EvalState & state, const PosIdx pos, Value ** args, Value & v)

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3308,6 +3308,34 @@ static RegisterPrimOp primop_removeAttrs({
    "nameN"; value = valueN;}] is transformed to {name1 = value1;
    ... nameN = valueN;}.  In case of duplicate occurrences of the same
    name, the first takes precedence. */
+static Symbol forceStringSymbol(EvalState & state, const PosIdx pos, Value & v, std::string_view errorMsg)
+{
+    auto name = state.forceStringNoCtx(v, pos, errorMsg);
+    return state.symbols.create(name);
+}
+
+template<typename GetAttrValue>
+static void
+finalizeBindings(EvalState & state, Bindings & bindings, size_t listSize, Value & v, GetAttrValue && getAttrValue)
+{
+    Symbol prev;
+    for (size_t n = 0; n < listSize; n++) {
+        auto attr = bindings[n];
+        if (prev == attr.name) {
+            continue;
+        }
+        prev = attr.name;
+        auto [val, pos] = getAttrValue(attr);
+        bindings.push_back({prev, val, pos});
+    }
+
+    // help GC and clear end of allocated array
+    for (size_t n = bindings.size(); n < listSize; n++) {
+        bindings[n] = Attr{};
+    }
+    v.mkAttrs(&bindings);
+}
+
 static void prim_listToAttrs(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
     state.forceList(*args[0], pos, "while evaluating the argument passed to builtins.listToAttrs");
@@ -3315,6 +3343,12 @@ static void prim_listToAttrs(EvalState & state, const PosIdx pos, Value ** args,
     // Step 1. Sort the name-value attrsets in place using the memory we allocate for the result
     auto listView = args[0]->listView();
     size_t listSize = listView.size();
+
+    if (listSize == 0) {
+        v.mkAttrs(&Bindings::emptyBindings);
+        return;
+    }
+
     auto & bindings = *state.mem.allocBindings(listSize);
     using ElemPtr = decltype(&bindings[0].value);
 
@@ -3323,11 +3357,11 @@ static void prim_listToAttrs(EvalState & state, const PosIdx pos, Value ** args,
 
         auto j = state.getAttr(state.s.name, v2->attrs(), "in a {name=...; value=...;} pair");
 
-        auto name = state.forceStringNoCtx(
-            *j->value,
+        auto sym = forceStringSymbol(
+            state,
             j->pos,
+            *j->value,
             "while evaluating the `name` attribute of an element of the list passed to builtins.listToAttrs");
-        auto sym = state.symbols.create(name);
 
         // (ab)use Attr to store a Value * * instead of a Value *, so that we can stabilize the sort using the Value * *
         bindings[n] = Attr(sym, std::bit_cast<Value *>(&v2));
@@ -3339,24 +3373,12 @@ static void prim_listToAttrs(EvalState & state, const PosIdx pos, Value ** args,
     });
 
     // Step 2. Unpack the bindings in place and skip name-value pairs with duplicate names
-    Symbol prev;
-    for (size_t n = 0; n < listSize; n++) {
-        auto attr = bindings[n];
-        if (prev == attr.name) {
-            continue;
-        }
+    finalizeBindings(state, bindings, listSize, v, [&](const Attr & attr) {
         // Note that .value is actually a Value * *; see earlier comments
         Value * v2 = *std::bit_cast<ElemPtr>(attr.value);
-
         auto j = state.getAttr(state.s.value, v2->attrs(), "in a {name=...; value=...;} pair");
-        prev = attr.name;
-        bindings.push_back({prev, j->value, j->pos});
-    }
-    // help GC and clear end of allocated array
-    for (size_t n = bindings.size(); n < listSize; n++) {
-        bindings[n] = Attr{};
-    }
-    v.mkAttrs(&bindings);
+        return std::pair{j->value, j->pos};
+    });
 }
 
 static RegisterPrimOp primop_listToAttrs({
@@ -3408,30 +3430,14 @@ static void prim_listToSet(EvalState & state, const PosIdx pos, Value ** args, V
 
     size_t idx = 0;
     for (auto v2 : listView) {
-        auto name = state.forceStringNoCtx(
-            *v2,
-            pos,
-            "while evaluating an element of the list passed to builtins.listToSet");
-        auto sym = state.symbols.create(name);
+        auto sym =
+            forceStringSymbol(state, pos, *v2, "while evaluating an element of the list passed to builtins.listToSet");
         bindings[idx++] = Attr(sym, nullptr);
     }
 
     std::sort(&bindings[0], &bindings[listSize]);
 
-    Symbol prev;
-    for (size_t n = 0; n < listSize; n++) {
-        auto attr = bindings[n];
-        if (prev == attr.name) {
-            continue;
-        }
-        prev = attr.name;
-        bindings.push_back({prev, &Value::vNull, pos});
-    }
-    // help GC and clear end of allocated array
-    for (size_t n = bindings.size(); n < listSize; n++) {
-        bindings[n] = Attr{};
-    }
-    v.mkAttrs(&bindings);
+    finalizeBindings(state, bindings, listSize, v, [&](const Attr & attr) { return std::pair{&Value::vNull, pos}; });
 }
 
 static RegisterPrimOp primop_listToSet({


### PR DESCRIPTION
## Motivation

Sets can allow for O(1) optimisations that lists cannot, since sets guarantee unique keys

As such, constructing attribute sets where only the keys are useful (and values not needed) is and should be a common pattern in Nix to represent sets, notably for fast membership checks

This PR introduces a new primop `builtins.listToAttrsWithValue` to optimize for this case

## Context

This PR contains:
1. The implementation of `builtins.listToAttrsWithValue`
2. Refactoring for code sharing in `primops.cc`
3. Corresponding unit tests in `src/libexpr-tests/primops.cc`

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
