### PR TITLE
packaging: build aws-c-io with s2n TLS on macOS

### DIFF
--- a/packaging/aws-c-io-s2n-darwin.patch
+++ b/packaging/aws-c-io-s2n-darwin.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 403bbf6..f095c4d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -100,6 +100,9 @@ elseif (APPLE)
+             "source/posix/*.c"
+             "source/darwin/*.c"
+             )
++    # nix#15857: use s2n TLS, not fork-unsafe Apple SecureTransport
++    list(REMOVE_ITEM AWS_IO_OS_SRC "${CMAKE_CURRENT_SOURCE_DIR}/source/darwin/secure_transport_tls_channel_handler.c")
++    set(USE_S2N ON)
+ 
+     find_library(SECURITY_LIB Security)
+     find_library(NETWORK_LIB Network)
+diff --git a/cmake/aws-c-io-config.cmake b/cmake/aws-c-io-config.cmake
+index 156e032..d6b222d 100644
+--- a/cmake/aws-c-io-config.cmake
++++ b/cmake/aws-c-io-config.cmake
+@@ -1,6 +1,6 @@
+ include(CMakeFindDependencyMacro)
+ 
+-if (UNIX AND NOT APPLE AND NOT BYO_CRYPTO)
++if (UNIX AND NOT BYO_CRYPTO)
+     find_dependency(s2n)
+ endif()
+ 

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -56,6 +56,34 @@ scope: {
     useTBB = !(stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isStatic);
   };
 
+  # Force the s2n TLS backend in aws-c-io on macOS; Apple SecureTransport is not
+  # fork-safe and crashes daemon workers (NixOS/nix#15857). Override it across
+  # the whole aws-c-* stack so one aws-c-io is shared.
+  aws-crt-cpp =
+    if !stdenv.hostPlatform.isDarwin then
+      pkgs.aws-crt-cpp
+    else
+      let
+        aws-c-io = pkgs.aws-c-io.overrideAttrs (old: {
+          patches = (old.patches or [ ]) ++ [ ./aws-c-io-s2n-darwin.patch ];
+        });
+        aws-c-http = pkgs.aws-c-http.override { inherit aws-c-io; };
+        aws-c-auth = pkgs.aws-c-auth.override { inherit aws-c-io aws-c-http; };
+        aws-c-event-stream = pkgs.aws-c-event-stream.override { inherit aws-c-io; };
+        aws-c-mqtt = pkgs.aws-c-mqtt.override { inherit aws-c-io aws-c-http; };
+        aws-c-s3 = pkgs.aws-c-s3.override { inherit aws-c-io aws-c-http aws-c-auth; };
+      in
+      pkgs.aws-crt-cpp.override {
+        inherit
+          aws-c-io
+          aws-c-http
+          aws-c-auth
+          aws-c-event-stream
+          aws-c-mqtt
+          aws-c-s3
+          ;
+      };
+
   libgit2 =
     if lib.versionAtLeast pkgs.libgit2.version "1.9.3" then
       pkgs.libgit2


### PR DESCRIPTION
aws-c-io uses Apple SecureTransport for TLS on macOS. Its handshake calls SSLCreateContext/SecTrust, which route through XPC and abort in a process forked without exec(). The daemon forks a worker per connection without exec, so an S3 substituter that opens a TLS connection during credential resolution (SSO, STS) crashes the worker.

Build aws-c-io with s2n instead, which does not touch Apple frameworks. Overriding aws-c-io alone would leave two copies in the closure, so the dependent aws-c-* libraries are rebuilt against it too.

Fixes NixOS/nix#15857.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
