### PR TITLE
libstore: Make FileTransfer throw Interrupted on interrupted transfers

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -294,12 +294,7 @@ struct curlFileTransfer : public FileTransfer
             }
             try {
                 if (!done && enqueued)
-                    fail(FileTransferError(
-                        Interrupted,
-                        {},
-                        "%s of '%s' was interrupted",
-                        Uncolored(request.noun()),
-                        request.displayUri()));
+                    failInterruptedOrCancelled();
             } catch (...) {
                 ignoreExceptionInDestructor();
             }
@@ -326,6 +321,18 @@ struct curlFileTransfer : public FileTransfer
         void fail(T && e) noexcept
         {
             failEx(std::make_exception_ptr(std::forward<T>(e)));
+        }
+
+        void failInterruptedOrCancelled()
+        {
+            HintFmt fmt("%s of '%s' was interrupted", Uncolored(request.noun()), request.displayUri());
+
+            /* Technically, we don't really have per-transfer cancellation currently,
+               but it's nice to distinguish between the two in the future. */
+            if (getInterrupted())
+                fail(nix::Interrupted(std::move(fmt)));
+            else
+                fail(nix::Cancelled(std::move(fmt)));
         }
 
         LambdaSink finalSink;
@@ -872,13 +879,14 @@ struct curlFileTransfer : public FileTransfer
                 std::optional<std::string> response;
                 if (errorSink)
                     response = std::move(errorSink->s);
-                auto exc = code == CURLE_ABORTED_BY_CALLBACK && getInterrupted() ? FileTransferError(
-                                                                                       Interrupted,
-                                                                                       std::move(response),
-                                                                                       "%s of '%s' was interrupted",
-                                                                                       Uncolored(request.noun()),
-                                                                                       request.displayUri())
-                           : httpStatus != 0
+
+                /* TODO: Also support per-transfer cancellations. */
+                if (code == CURLE_ABORTED_BY_CALLBACK && getInterrupted()) {
+                    failInterruptedOrCancelled();
+                    return;
+                }
+
+                auto exc = httpStatus != 0
                                ? FileTransferError(
                                      err,
                                      std::move(response),

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -470,7 +470,7 @@ public:
     void
     download(FileTransferRequest && request, Sink & sink, std::function<void(FileTransferResult)> resultCallback = {});
 
-    enum Error { NotFound, Unauthorized, Forbidden, Misc, Transient, Interrupted };
+    enum Error { NotFound, Unauthorized, Forbidden, Misc, Transient };
 };
 
 /**

--- a/src/libutil/include/nix/util/async.hh
+++ b/src/libutil/include/nix/util/async.hh
@@ -95,10 +95,14 @@ asio::awaitable<void> forEachAsync(Range && range, const F & f)
     auto pending = std::ranges::size(range);
     if (pending == 0)
         co_return;
+    else if (pending == 1)
+        co_return co_await f(*range.begin());
 
     auto executor = co_await asio::this_coro::executor;
     std::exception_ptr err;
 
+    /* TODO: Handle cancellation on first error. Not very useful for now since we
+       do all-or-nothing cancellation typically. */
     co_await asio::async_initiate<decltype(asio::use_awaitable), void(std::exception_ptr)>(
         [&](auto handler) {
             auto h = std::make_shared<decltype(handler)>(std::move(handler));

--- a/src/libutil/include/nix/util/signals.hh
+++ b/src/libutil/include/nix/util/signals.hh
@@ -43,6 +43,7 @@ inline void checkInterrupt();
  * @note Never will happen on Windows
  */
 MakeError(Interrupted, BaseError);
+MakeError(Cancelled, BaseError);
 
 struct InterruptCallback
 {

--- a/src/libutil/unix/signals.cc
+++ b/src/libutil/unix/signals.cc
@@ -11,6 +11,8 @@ namespace nix {
 
 void Interrupted::anchor() {}
 
+void Cancelled::anchor() {}
+
 std::atomic<bool> unix::_isInterrupted = false;
 
 thread_local std::function<bool()> unix::interruptCheck;

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -249,6 +249,10 @@ void ignoreExceptionExceptInterrupt(Verbosity lvl)
         throw;
     } catch (const Interrupted & e) {
         throw;
+    } catch (const Cancelled & e) {
+        /* Morally the same as Interrupted, just not triggered by a user but some other
+           cancellation. */
+        throw;
     } catch (Error & e) {
         printMsg(lvl, ANSI_RED "error (ignored):" ANSI_NORMAL " %s", e.info().msg);
     } catch (std::exception & e) {

--- a/src/libutil/windows/signals.cc
+++ b/src/libutil/windows/signals.cc
@@ -4,4 +4,6 @@ namespace nix {
 
 void Interrupted::anchor() {}
 
+void Cancelled::anchor() {}
+
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

We are now issuing many more requests in `queryMissing` concurrently,
without doing `checkInterrupt()` when enqueuing downloads (arguably we
shouldn't).

The exception ignoring behavior of querySubstitutablePathInfosAsync, where
it swallows and prints exceptions derived from Error & doesn't help - we end
up with a wall of text like (and 100 lines more of this):

```
error: download of 'https://cache.nixos.org/b2s9lqzdi2pg80j0lawgw8ndian3k9mn.narinfo' was interrupted
error: download of 'https://cache.nixos.org/5h2h4brfrgr89gvh1l93mh63mm0h5r6s.narinfo' was interrupted
error: download of 'https://cache.nixos.org/azz5rixma8na4h9s75406w94yjsk2b4k.narinfo' was interrupted
error: download of 'https://cache.nixos.org/xdlfnymy64jxfhnj19sjvdvmbbmyn468.narinfo' was interrupted
error: download of 'https://cache.nixos.org/q8sra2q3n8gvalzbfq48jvv18xjsg2gb.narinfo' was interrupted
error: download of 'https://cache.nixos.org/pzmm2bczb5gb1nvgv5xp6ims9iqcc4af.narinfo' was interrupted
error: download of 'https://cache.nixos.org/s3slcivizcjkppyvf5drlbx0b8dxafg9.narinfo' was interrupted
```

Rethrowing `Interrupted` instead of `FileTransferError` on proper interrupts seems
correct to me. And since it doesn't inherit from Error (but rather `BaseError`)
it escapes out of `catch (Error &)` blocks and properly unwinds the stack eagerly.

Also add a new `Cancelled` exception type to reflect cases (not very useful for now)
to indicate that a filetransfer was cancelled without a global interrupt.

In the future we should add per-transfer cancellation mechanisms for this purpose.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
