### PR TITLE
[Backport 2.35-maintenance] cli: error when remounting store without a private mount namespace

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -37,9 +37,7 @@
 #endif
 
 #ifdef __linux__
-#  include <sched.h>
-#  include <sys/statvfs.h>
-#  include <sys/mount.h>
+#  include "nix/util/linux-namespaces.hh"
 #endif
 
 #ifdef __CYGWIN__
@@ -649,37 +647,7 @@ void LocalStore::makeStoreWritable()
 #ifdef __linux__
     if (!isRootUser())
         return;
-    /* Check if /nix/store is on a read-only mount. */
-    struct statvfs stat;
-    if (statvfs(config->realStoreDir.get().c_str(), &stat) != 0)
-        throw SysError("getting info about the Nix store mount point");
-
-    if (stat.f_flag & ST_RDONLY) {
-        /* In a user namespace, mount flags like `nodev` and `nosuid` are
-           locked and dropping them causes `EPERM`, so here we translate each
-           `statvfs` flag to the corresponding `mount` flag individually. */
-        unsigned long flags = MS_REMOUNT | MS_BIND;
-        if (stat.f_flag & ST_NODEV)
-            flags |= MS_NODEV;
-        if (stat.f_flag & ST_NOSUID)
-            flags |= MS_NOSUID;
-        if (stat.f_flag & ST_NOEXEC)
-            flags |= MS_NOEXEC;
-        if (stat.f_flag & ST_NOATIME)
-            flags |= MS_NOATIME;
-        if (stat.f_flag & ST_NODIRATIME)
-            flags |= MS_NODIRATIME;
-        if (stat.f_flag & ST_RELATIME)
-            flags |= MS_RELATIME;
-        if (stat.f_flag & ST_SYNCHRONOUS)
-            flags |= MS_SYNCHRONOUS;
-#  ifdef ST_NOSYMFOLLOW
-        if (stat.f_flag & ST_NOSYMFOLLOW)
-            flags |= MS_NOSYMFOLLOW;
-#  endif
-        if (mount(0, config->realStoreDir.get().c_str(), "none", flags, 0) == -1)
-            throw SysError("remounting %s writable", PathFmt(config->realStoreDir.get()));
-    }
+    remountReadOnlyWritable(config->realStoreDir.get());
 #endif
 }
 

--- a/src/libutil/linux/include/nix/util/linux-namespaces.hh
+++ b/src/libutil/linux/include/nix/util/linux-namespaces.hh
@@ -1,21 +1,27 @@
 #pragma once
 ///@file
 
-#include <optional>
-
-#include "nix/util/types.hh"
+#include <filesystem>
 
 namespace nix {
 
 /**
- * Save the current mount namespace. Ignored if called more than
- * once.
+ * Save the parent mount namespace and enter a private one via
+ * `unshare(CLONE_NEWNS)`.
  */
-void saveMountNamespace();
+void tryEnterPrivateMountNamespace();
 
 /**
- * Restore the mount namespace saved by saveMountNamespace(). Ignored
- * if saveMountNamespace() was never called.
+ * Remount `path` writable if its mount is read-only, leaving
+ * already-writable mounts untouched. This throws if we aren't in a
+ * private mount namespace, since remounting would leak into the
+ * host mount table.
+ */
+void remountReadOnlyWritable(const std::filesystem::path & path);
+
+/**
+ * Restore the parent mount namespace saved when we entered a private
+ * one. Ignored if `tryEnterPrivateMountNamespace()` never succeeded.
  */
 void restoreMountNamespace();
 

--- a/src/libutil/linux/linux-namespaces.cc
+++ b/src/libutil/linux/linux-namespaces.cc
@@ -7,6 +7,7 @@
 #include <sys/resource.h>
 
 #include <sys/mount.h>
+#include <sys/statvfs.h>
 
 namespace nix {
 
@@ -90,8 +91,11 @@ bool mountAndPidNamespacesSupported()
 
 static AutoCloseFD fdSavedMountNamespace;
 static AutoCloseFD fdSavedRoot;
+static bool havePrivateMountNs = false;
 
-void saveMountNamespace()
+/* Save the current mount namespace so restoreMountNamespace() can return
+   to it later. Ignored if called more than once. */
+static void saveMountNamespace()
 {
     static std::once_flag done;
     std::call_once(done, []() {
@@ -103,12 +107,69 @@ void saveMountNamespace()
     });
 }
 
+void tryEnterPrivateMountNamespace()
+{
+    try {
+        saveMountNamespace();
+        if (unshare(CLONE_NEWNS) == -1)
+            throw SysError("setting up a private mount namespace");
+        havePrivateMountNs = true;
+    } catch (Error & e) {
+        debug("failed to set up a private mount namespace: %s", e.message());
+    }
+}
+
+void remountReadOnlyWritable(const std::filesystem::path & path)
+{
+    struct statvfs stat;
+    if (statvfs(path.c_str(), &stat) != 0)
+        throw SysError("getting mount info for %s", PathFmt(path));
+
+    if (!(stat.f_flag & ST_RDONLY))
+        return;
+
+    if (!havePrivateMountNs)
+        throw Error(
+            "cannot remount %s writable: not in a private mount namespace, "
+            "so the remount would affect the host mount table. "
+            "This usually happens inside containers or user namespaces where unshare(CLONE_NEWNS) is not permitted",
+            PathFmt(path));
+
+    /* In a user namespace, mount flags like `nodev` and `nosuid` are
+       locked and dropping them causes `EPERM`, so here we translate each
+       `statvfs` flag to the corresponding `mount` flag individually. */
+    unsigned long flags = MS_REMOUNT | MS_BIND;
+    if (stat.f_flag & ST_NODEV)
+        flags |= MS_NODEV;
+    if (stat.f_flag & ST_NOSUID)
+        flags |= MS_NOSUID;
+    if (stat.f_flag & ST_NOEXEC)
+        flags |= MS_NOEXEC;
+    if (stat.f_flag & ST_NOATIME)
+        flags |= MS_NOATIME;
+    if (stat.f_flag & ST_NODIRATIME)
+        flags |= MS_NODIRATIME;
+    if (stat.f_flag & ST_RELATIME)
+        flags |= MS_RELATIME;
+    if (stat.f_flag & ST_SYNCHRONOUS)
+        flags |= MS_SYNCHRONOUS;
+#ifdef ST_NOSYMFOLLOW
+    if (stat.f_flag & ST_NOSYMFOLLOW)
+        flags |= MS_NOSYMFOLLOW;
+#endif
+    if (mount(0, path.c_str(), "none", flags, 0) == -1)
+        throw SysError("remounting %s writable", PathFmt(path));
+}
+
 void restoreMountNamespace()
 {
+    if (!havePrivateMountNs)
+        return;
+
     try {
         auto savedCwd = std::filesystem::current_path();
 
-        if (fdSavedMountNamespace && setns(fdSavedMountNamespace.get(), CLONE_NEWNS) == -1)
+        if (setns(fdSavedMountNamespace.get(), CLONE_NEWNS) == -1)
             throw SysError("restoring parent mount namespace");
 
         if (fdSavedRoot) {
@@ -120,6 +181,8 @@ void restoreMountNamespace()
 
         if (chdir(savedCwd.c_str()) == -1)
             throw SysError("restoring cwd");
+
+        havePrivateMountNs = false;
     } catch (Error & e) {
         debug(e.msg());
     }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -398,15 +398,8 @@ void mainWrapped(int argc, char ** argv)
     flakeSettings.configureEvalSettings(evalSettings);
 
 #ifdef __linux__
-    if (isRootUser()) {
-        try {
-            saveMountNamespace();
-            if (unshare(CLONE_NEWNS) == -1)
-                throw SysError("setting up a private mount namespace");
-        } catch (Error & e) {
-            warn("failed to set up a private mount namespace: %s", e.msg());
-        }
-    }
+    if (isRootUser())
+        tryEnterPrivateMountNamespace();
 #endif
 
     Finally f([] { logger->stop(); });


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Manual backport of https://github.com/NixOS/nix/pull/15547 to 2.35 (not yet released). I think it makes sense to have this to avoid false positive warnings and incorrectly leaking remounts.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
