### PR TITLE
Make zipAttrsWith more parallel-eval friendly

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3593,54 +3593,67 @@ static RegisterPrimOp primop_mapAttrs({
 
 static void prim_zipAttrsWith(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
-    // we will first count how many values are present for each given key.
-    // we then allocate a single attrset and pre-populate it with lists of
-    // appropriate sizes, stash the pointers to the list elements of each,
-    // and populate the lists. after that we replace the list in the every
-    // attribute with the merge function application. this way we need not
-    // use (slightly slower) temporary storage the GC does not know about.
+    // We collect all (name, value) pairs into a vector and group them by
+    // stable-sorting on the name, which yields the same attribute order and
+    // per-attribute value order as inserting into a std::map<Symbol, ...>.
+    // Note that it's fine that the vector is invisible to the GC: the values
+    // it points to are kept alive by the attrsets in *args[1], which is
+    // reachable for the duration of this function. This avoids allocating
+    // GC-visible (uncollectable) storage for temporaries, which is expensive
+    // and a source of GC allocation lock contention during parallel
+    // evaluation.
 
-    struct Item
+    struct NameValue
     {
-        size_t size = 0;
-        size_t pos = 0;
-        std::optional<ListBuilder> list;
+        Symbol name;
+        Value * value;
     };
-
-    std::map<Symbol, Item, std::less<Symbol>, traceable_allocator<std::pair<const Symbol, Item>>> attrsSeen;
 
     state.forceFunction(*args[0], pos, "while evaluating the first argument passed to builtins.zipAttrsWith");
     state.forceList(*args[1], pos, "while evaluating the second argument passed to builtins.zipAttrsWith");
     const auto listItems = args[1]->listView();
 
+    size_t nrAttrs = 0;
     for (auto & vElem : listItems) {
         state.forceAttrs(
             *vElem, noPos, "while evaluating a value of the list passed as second argument to builtins.zipAttrsWith");
+        nrAttrs += vElem->attrs()->size();
+    }
+
+    std::vector<NameValue> attrsSeen;
+    attrsSeen.reserve(nrAttrs);
+
+    for (auto & vElem : listItems)
         for (auto & attr : *vElem->attrs())
-            attrsSeen.try_emplace(attr.name).first->second.size++;
-    }
+            attrsSeen.push_back({attr.name, attr.value});
 
-    for (auto & [sym, elem] : attrsSeen)
-        elem.list.emplace(state.buildList(elem.size));
+    std::stable_sort(
+        attrsSeen.begin(), attrsSeen.end(), [](const NameValue & a, const NameValue & b) { return a.name < b.name; });
 
-    for (auto & vElem : listItems) {
-        for (auto & attr : *vElem->attrs()) {
-            auto & item = attrsSeen.at(attr.name);
-            (*item.list)[item.pos++] = attr.value;
-        }
-    }
+    size_t nrNames = 0;
+    for (size_t i = 0; i < attrsSeen.size(); ++i)
+        if (i == 0 || attrsSeen[i - 1].name != attrsSeen[i].name)
+            nrNames++;
 
-    auto attrs = state.buildBindings(attrsSeen.size());
+    auto attrs = state.buildBindings(nrNames);
 
-    for (auto & [sym, elem] : attrsSeen) {
+    for (size_t i = 0; i < attrsSeen.size();) {
+        auto sym = attrsSeen[i].name;
+        size_t j = i;
+        while (j < attrsSeen.size() && attrsSeen[j].name == sym)
+            j++;
+        auto list = state.buildList(j - i);
+        for (size_t k = i; k < j; ++k)
+            list[k - i] = attrsSeen[k].value;
         auto name = Value::toPtr(state.symbols[sym]);
         auto call1 = state.allocValue();
         call1->mkApp(args[0], name);
         auto call2 = state.allocValue();
         auto arg = state.allocValue();
-        arg->mkList(*elem.list);
+        arg->mkList(list);
         call2->mkApp(call1, arg);
         attrs.insert(sym, call2);
+        i = j;
     }
 
     v.mkAttrs(attrs.alreadySorted());


### PR DESCRIPTION



<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The previous implementation used an `std::map` with `traceable_allocator` to collect the attributes, which is extremely expensive in parallel eval because every uncollectable alloc/free takes the global GC lock. The new implementation collects all the attributes in a vector (without the `ListBuilder` that was the reason why we needed `traceable_allocator`), sorts them by name, and then performs a single sweep through the vector to build one list at a time.

While this is mostly beneficial for parallel eval, it also seems to give a modest speedup for single-threaded eval (e.g. `nix search nixpkgs fizzbuzz --no-eval-cache` went from 28.9s to 28.5s).

Assisted-by: Claude Fable 5 <noreply@anthropic.com>

Taken from https://github.com/DeterminateSystems/nix-src/pull/534.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
