### PR TITLE
Strip ANSI escapes from stdout when it's not a TTY

### DIFF
--- a/src/libutil-tests/terminal.cc
+++ b/src/libutil-tests/terminal.cc
@@ -69,4 +69,46 @@ TEST(filterANSIEscapes, osc8_bell_as_sep)
     ASSERT_EQ(filterANSIEscapes("\e]8;;http://example.com\a\\This is a link\e]8;;\a"), "\\This is a link");
 }
 
+/* ----------------------------------------------------------------------------
+ * stripANSIEscapes
+ * --------------------------------------------------------------------------*/
+
+TEST(stripANSIEscapes, emptyString)
+{
+    ASSERT_EQ(stripANSIEscapes(""), "");
+}
+
+TEST(stripANSIEscapes, doesntChangePrintableChars)
+{
+    auto s = "09 2q304ruyhr slk2-19024 kjsadh sar f";
+    ASSERT_EQ(stripANSIEscapes(s), s);
+}
+
+TEST(stripANSIEscapes, stripsColorCodes)
+{
+    ASSERT_EQ(stripANSIEscapes("\e[31;1m4.3 MiB\e[0m"), "4.3 MiB");
+    ASSERT_EQ(stripANSIEscapes("\e[30m A \e[31m B \e[32m C \e[0m"), " A  B  C ");
+}
+
+TEST(stripANSIEscapes, preservesTabsAndCarriageReturns)
+{
+    // Unlike filterANSIEscapes, tabs are NOT expanded and \r is NOT dropped;
+    // this matters for tab-delimited output such as shell completions.
+    ASSERT_EQ(stripANSIEscapes("foo\tbar\tbaz"), "foo\tbar\tbaz");
+    ASSERT_EQ(stripANSIEscapes("\e[1m--rebuild\e[0m\trebuild the given path"), "--rebuild\trebuild the given path");
+    ASSERT_EQ(stripANSIEscapes("a\r\nb"), "a\r\nb");
+}
+
+TEST(stripANSIEscapes, preservesUTF8)
+{
+    ASSERT_EQ(stripANSIEscapes("fóóbär"), "fóóbär");
+    ASSERT_EQ(stripANSIEscapes("\e[32mhello: 2.10 → 2.12.1\e[0m"), "hello: 2.10 → 2.12.1");
+}
+
+TEST(stripANSIEscapes, osc8Hyperlink)
+{
+    ASSERT_EQ(stripANSIEscapes("\e]8;;http://example.com\e\\This is a link\e]8;;\e\\"), "This is a link");
+    ASSERT_EQ(stripANSIEscapes("\e]8;;http://example.com\aThis is a link\e]8;;\a"), "This is a link");
+}
+
 } // namespace nix

--- a/src/libutil/include/nix/util/terminal.hh
+++ b/src/libutil/include/nix/util/terminal.hh
@@ -30,6 +30,15 @@ std::string filterANSIEscapes(
     std::string_view s, bool filterAll = false, unsigned int width = std::numeric_limits<unsigned int>::max());
 
 /**
+ * Remove all ANSI escape sequences (CSI, OSC, etc.) from a string,
+ * leaving every other byte -- including tabs, carriage returns and
+ * UTF-8 -- untouched. Unlike filterANSIEscapes(), this does not expand
+ * tabs, drop control characters or truncate, so it is safe to apply to
+ * machine-readable output such as stdout.
+ */
+std::string stripANSIEscapes(std::string_view s);
+
+/**
  * Recalculate the window size, updating a global variable.
  *
  * Used in the `SIGWINCH` signal handler on Unix, for example.

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -48,7 +48,18 @@ void Logger::warn(const std::string & msg)
 void Logger::writeToStdout(std::string_view s)
 {
     Descriptor standard_out = getStandardOutput();
-    writeFull(standard_out, s);
+    // Call sites emit ANSI escapes unconditionally, and -- unlike the stderr
+    // log path -- nothing filters them here. Strip them when stdout is not an
+    // interactive terminal (or the user set NO_COLOR), following the CLI
+    // guideline that design elements are removed when no TTY is detected on
+    // stdout. Only the escapes are removed, so tab-delimited output (e.g. shell
+    // completions) and other bytes are preserved.
+    static const bool ansi = isTTY(getStandardOutput()) && getEnv("TERM").value_or("dumb") != "dumb"
+                             && !(getEnv("NO_COLOR").has_value() || getEnv("NOCOLOR").has_value());
+    if (ansi)
+        writeFull(standard_out, s);
+    else
+        writeFull(standard_out, stripANSIEscapes(s));
     writeFull(standard_out, "\n");
 }
 

--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -158,6 +158,50 @@ std::string filterANSIEscapes(std::string_view s, bool filterAll, unsigned int w
     return t;
 }
 
+std::string stripANSIEscapes(std::string_view s)
+{
+    std::string t;
+    t.reserve(s.size());
+    auto i = s.begin();
+
+    while (i != s.end()) {
+        if (*i == '\e') {
+            i++;
+            if (i != s.end() && *i == '[') {
+                // CSI: parameter bytes, then intermediate bytes, then a final byte.
+                i++;
+                while (i != s.end() && *i >= 0x30 && *i <= 0x3f)
+                    i++;
+                while (i != s.end() && *i >= 0x20 && *i <= 0x2f)
+                    i++;
+                if (i != s.end() && *i >= 0x40 && *i <= 0x7e)
+                    i++;
+            } else if (i != s.end() && *i == ']') {
+                // OSC: terminated by ST (ESC '\') or BEL ('\a').
+                i++;
+                while (i != s.end() && *i != '\e' && *i != '\a')
+                    i++;
+                if (i != s.end()) {
+                    char v = *i;
+                    i++;
+                    if (i != s.end() && v == '\e' && *i == '\\')
+                        i++;
+                }
+            } else {
+                // Other escape: eat one byte in the 0x40-0x5f range, if present.
+                if (i != s.end() && *i >= 0x40 && *i <= 0x5f)
+                    i++;
+            }
+        } else {
+            // Copy every non-escape byte verbatim, including tabs, carriage
+            // returns and UTF-8 sequences.
+            t += *i++;
+        }
+    }
+
+    return t;
+}
+
 //////////////////////////////////////////////////////////////////////
 
 // Note: this object intentionally leaks to avoid a destructor ordering issue (specifically, ~ProgressBar() calling


### PR DESCRIPTION
This is just a draft PR for now because I haven't reviewed the code yet.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Resolves #4626, resolves #9486.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
