### PR TITLE
ExprAttrs::eval: Don't update emptyBindings

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -150,7 +150,7 @@ MixEvalArgs::MixEvalArgs()
     });
 }
 
-Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
+const Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
 {
     auto res = state.buildBindings(autoArgs.size());
     for (auto & [name, arg] : autoArgs) {

--- a/src/libcmd/include/nix/cmd/common-eval-args.hh
+++ b/src/libcmd/include/nix/cmd/common-eval-args.hh
@@ -52,7 +52,7 @@ struct MixEvalArgs : virtual Args, virtual MixRepair
 
     MixEvalArgs();
 
-    Bindings * getAutoArgs(EvalState & state);
+    const Bindings * getAutoArgs(EvalState & state);
 
     LookupPath lookupPath;
 

--- a/src/libcmd/include/nix/cmd/repl.hh
+++ b/src/libcmd/include/nix/cmd/repl.hh
@@ -9,7 +9,7 @@ namespace nix {
 struct AbstractNixRepl
 {
     ref<EvalState> state;
-    Bindings * autoArgs;
+    const Bindings * autoArgs;
 
     AbstractNixRepl(ref<EvalState> state)
         : state(state)

--- a/src/libcmd/installable-attr-path.cc
+++ b/src/libcmd/installable-attr-path.cc
@@ -43,7 +43,7 @@ DerivedPathsWithInfo InstallableAttrPath::toDerivedPaths()
         return {*derivedPathWithInfo};
     }
 
-    Bindings & autoArgs = *cmd.getAutoArgs(*state);
+    const Bindings & autoArgs = *cmd.getAutoArgs(*state);
 
     PackageInfos packageInfos;
     getDerivations(*state, *v, "", autoArgs, packageInfos, false);

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -55,7 +55,7 @@ std::vector<SymbolStr> AttrPath::resolve(EvalState & state) const
 }
 
 std::pair<Value *, PosIdx>
-findAlongAttrPath(EvalState & state, const std::string & attrPath, Bindings & autoArgs, Value & vIn)
+findAlongAttrPath(EvalState & state, const std::string & attrPath, const Bindings & autoArgs, Value & vIn)
 {
     Strings tokens = parseAttrPath(attrPath);
 

--- a/src/libexpr/attr-set.cc
+++ b/src/libexpr/attr-set.cc
@@ -5,7 +5,7 @@
 
 namespace nix {
 
-Bindings Bindings::emptyBindings;
+const constinit Bindings Bindings::emptyBindings;
 
 /* Allocate a new array of attributes for an attribute set with a specific
    capacity. The space is implicitly reserved after the Bindings
@@ -13,7 +13,8 @@ Bindings Bindings::emptyBindings;
 Bindings * EvalMemory::allocBindings(size_t capacity)
 {
     if (capacity == 0)
-        return &Bindings::emptyBindings;
+        /* Swear that we are not going to modify this. */
+        return const_cast<Bindings *>(&Bindings::emptyBindings);
     if (capacity > std::numeric_limits<Bindings::size_type>::max())
         throw Error("attribute set of size %d is too big", capacity);
     stats.nrAttrsets++;

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1359,7 +1359,11 @@ void ExprAttrs::eval(EvalState & state, Env & env, Value & v)
         sort = true;
     }
 
-    bindings.bindings->pos = pos;
+    /* FIXME: Currently we can't track the positions of empty bindings. A way
+       to fix this is to store the position in the Value storage with more
+       clever bitpacking (we have spare 32 bits in the Bindings * variant). */
+    if (bindings.bindings != &Bindings::emptyBindings)
+        bindings.bindings->pos = pos;
 
     v.mkAttrs(sort ? bindings.finish() : bindings.alreadySorted());
 }

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -393,7 +393,7 @@ static void getDerivations(
     EvalState & state,
     Value & vIn,
     const std::string & pathPrefix,
-    Bindings & autoArgs,
+    const Bindings & autoArgs,
     PackageInfos & drvs,
     Done & done,
     bool ignoreAssertionFailures)
@@ -464,7 +464,7 @@ void getDerivations(
     EvalState & state,
     Value & v,
     const std::string & pathPrefix,
-    Bindings & autoArgs,
+    const Bindings & autoArgs,
     PackageInfos & drvs,
     bool ignoreAssertionFailures)
 {

--- a/src/libexpr/include/nix/expr/attr-path.hh
+++ b/src/libexpr/include/nix/expr/attr-path.hh
@@ -12,7 +12,7 @@ MakeError(AttrPathNotFound, Error);
 MakeError(NoPositionInfo, Error);
 
 std::pair<Value *, PosIdx>
-findAlongAttrPath(EvalState & state, const std::string & attrPath, Bindings & autoArgs, Value & vIn);
+findAlongAttrPath(EvalState & state, const std::string & attrPath, const Bindings & autoArgs, Value & vIn);
 
 /**
  * Heuristic to find the filename and lineno or a nix value.

--- a/src/libexpr/include/nix/expr/attr-set.hh
+++ b/src/libexpr/include/nix/expr/attr-set.hh
@@ -29,11 +29,15 @@ struct Attr
     Symbol name;
     PosIdx pos;
     Value * value = nullptr;
+
     Attr(Symbol name, Value * value, PosIdx pos = noPos)
         : name(name)
         , pos(pos)
-        , value(value) {};
-    Attr() {};
+        , value(value)
+    {
+    }
+
+    constexpr Attr() {}
 
     auto operator<=>(const Attr & a) const
     {
@@ -70,7 +74,7 @@ public:
      * An instance of bindings objects with 0 attributes.
      * This object must never be modified.
      */
-    static Bindings emptyBindings;
+    static const constinit Bindings emptyBindings;
 
 private:
     /**
@@ -101,7 +105,7 @@ private:
      */
     Attr attrs[0];
 
-    Bindings() = default;
+    constexpr Bindings() = default;
     Bindings(const Bindings &) = delete;
     Bindings(Bindings &&) = delete;
     Bindings & operator=(const Bindings &) = delete;
@@ -550,14 +554,14 @@ public:
 
     Value & alloc(std::string_view name, PosIdx pos = noPos);
 
-    Bindings * finish()
+    const Bindings * finish()
     {
         bindings->sort();
         finishSizeIfNecessary();
         return bindings;
     }
 
-    Bindings * alreadySorted()
+    const Bindings * alreadySorted()
     {
         finishSizeIfNecessary();
         return bindings;

--- a/src/libexpr/include/nix/expr/get-drvs.hh
+++ b/src/libexpr/include/nix/expr/get-drvs.hh
@@ -112,7 +112,7 @@ void getDerivations(
     EvalState & state,
     Value & v,
     const std::string & pathPrefix,
-    Bindings & autoArgs,
+    const Bindings & autoArgs,
     PackageInfos & drvs,
     bool ignoreAssertionFailures);
 

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -505,7 +505,7 @@ struct PayloadTypeToInternalType
     MACRO(ValueBase::StringWithContext, string, tString)            \
     MACRO(ValueBase::Path, path, tPath)                             \
     MACRO(ValueBase::Null, null_, tNull)                            \
-    MACRO(Bindings *, attrs, tAttrs)                                \
+    MACRO(const Bindings *, attrs, tAttrs)                          \
     MACRO(ValueBase::List, bigList, tListN)                         \
     MACRO(ValueBase::SmallList, smallList, tListSmall)              \
     MACRO(ValueBase::ClosureThunk, thunk, tThunk)                   \
@@ -900,7 +900,7 @@ protected:
         primOp = std::bit_cast<PrimOp *>(payload[1]);
     }
 
-    void getStorage(Bindings *& attrs) const noexcept
+    void getStorage(const Bindings *& attrs) const noexcept
     {
         Payload payload = loadPayload();
         attrs = std::bit_cast<Bindings *>(payload[1]);
@@ -963,7 +963,7 @@ protected:
         setSingleDWordPayload<tPrimOp>(std::bit_cast<PackedPointer>(primOp));
     }
 
-    void setStorage(Bindings * bindings) noexcept
+    void setStorage(const Bindings * bindings) noexcept
     {
         setSingleDWordPayload<tAttrs>(std::bit_cast<PackedPointer>(bindings));
     }
@@ -1361,7 +1361,7 @@ public:
         setStorage(Null{});
     }
 
-    inline void mkAttrs(Bindings * a) noexcept
+    inline void mkAttrs(const Bindings * a) noexcept
     {
         setStorage(a);
     }
@@ -1487,7 +1487,7 @@ public:
 
     const Bindings * attrs() const noexcept
     {
-        return getStorage<Bindings *>();
+        return getStorage<const Bindings *>();
     }
 
     const PrimOp * primOp() const noexcept

--- a/src/libutil/include/nix/util/pos-idx.hh
+++ b/src/libutil/include/nix/util/pos-idx.hh
@@ -15,13 +15,13 @@ class PosIdx
 private:
     uint32_t id;
 
-    explicit PosIdx(uint32_t id)
+    constexpr explicit PosIdx(uint32_t id)
         : id(id)
     {
     }
 
 public:
-    PosIdx()
+    constexpr PosIdx()
         : id(0)
     {
     }

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -530,7 +530,7 @@ struct CmdFlakeCheck : FlakeCommand, MixPrintOutPaths, MixOutLinkBase
         auto checkNixOSConfiguration = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
             try {
                 Activity act(*logger, lvlInfo, actUnknown, fmt("checking NixOS configuration '%s'", attrPath));
-                Bindings & bindings = Bindings::emptyBindings;
+                const Bindings & bindings = Bindings::emptyBindings;
                 auto vToplevel = findAlongAttrPath(*state, "config.system.build.toplevel", bindings, v).first;
                 state->forceValue(*vToplevel, pos);
                 if (!state->isDerivation(*vToplevel))

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -76,7 +76,7 @@ struct InstallSourceInfo
     std::shared_ptr<SourcePath> nixExprPath; /* for srcNixExprDrvs, srcNixExprs */
     std::filesystem::path profile;           /* for srcProfile */
     std::string systemFilter;                /* for srcNixExprDrvs */
-    Bindings * autoArgs;
+    const Bindings * autoArgs;
 };
 
 struct Globals
@@ -207,7 +207,7 @@ static void loadDerivations(
     EvalState & state,
     const SourcePath & nixExprPath,
     std::string systemFilter,
-    Bindings & autoArgs,
+    const Bindings & autoArgs,
     const std::string & pathPrefix,
     PackageInfos & elems)
 {

--- a/src/nix/nix-env/user-env.cc
+++ b/src/nix/nix-env/user-env.cc
@@ -23,7 +23,7 @@ PackageInfos queryInstalled(EvalState & state, const std::filesystem::path & use
     if (pathExists(manifestFile)) {
         Value v;
         state.evalFile(state.rootPath(CanonPath(manifestFile.string())).resolveSymlinks(), v);
-        Bindings & bindings = Bindings::emptyBindings;
+        const Bindings & bindings = Bindings::emptyBindings;
         getDerivations(state, v, "", bindings, elems, false);
     }
     return elems;

--- a/src/nix/nix-instantiate/nix-instantiate.cc
+++ b/src/nix/nix-instantiate/nix-instantiate.cc
@@ -27,7 +27,7 @@ void processExpr(
     const Strings & attrPaths,
     bool parseOnly,
     bool strict,
-    Bindings & autoArgs,
+    const Bindings & autoArgs,
     bool evalOnly,
     OutputKind output,
     bool location,
@@ -172,7 +172,7 @@ static int main_nix_instantiate(int argc, char ** argv)
         auto state = std::make_shared<EvalState>(myArgs.lookupPath, evalStore, fetchSettings, evalSettings, store);
         state->repair = myArgs.repair;
 
-        Bindings & autoArgs = *myArgs.getAutoArgs(*state);
+        const Bindings & autoArgs = *myArgs.getAutoArgs(*state);
 
         if (attrPaths.empty())
             attrPaths = {""};

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -205,7 +205,7 @@ static int main_nix_prefetch_url(int argc, char ** argv)
         auto store = openStore();
         auto state = std::make_shared<EvalState>(myArgs.lookupPath, store, fetchSettings, evalSettings);
 
-        Bindings & autoArgs = *myArgs.getAutoArgs(*state);
+        const Bindings & autoArgs = *myArgs.getAutoArgs(*state);
 
         /* If -A is given, get the URL from the specified Nix
            expression. */

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -201,7 +201,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         auto state = std::make_shared<EvalState>(LookupPath{}, store, fetchSettings, evalSettings);
         auto v = state->allocValue();
         state->eval(state->parseExprFromString(res.data, state->rootPath(CanonPath("/no-such-path"))), *v);
-        Bindings & bindings = Bindings::emptyBindings;
+        const Bindings & bindings = Bindings::emptyBindings;
         auto v2 = findAlongAttrPath(*state, settings.thisSystem, bindings, *v).first;
 
         return store->parseStorePath(


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is a (probably harmless) data race, but more importantly, it causes a lot of false sharing on the cache line holding `emptyBindings`, which is bad for parallel eval.

Taken from https://github.com/DeterminateSystems/nix-src/pull/534.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
