### PR TITLE
Add build options for setting absolute paths to Nix libexec helpers

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1,4 +1,6 @@
 #include "nix/fetchers/git-utils.hh"
+
+#include "fetchers-config-private.hh"
 #include "nix/fetchers/git-lfs-fetch.hh"
 #include "nix/fetchers/cache.hh"
 #include "nix/fetchers/fetch-settings.hh"
@@ -663,7 +665,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         gitArgs.push_back(string_to_os_string(url));
         gitArgs.push_back(string_to_os_string(refspec));
 
-        auto status = runProgram({.program = "git", .args = gitArgs, .isInteractive = true}).first;
+        auto status = runProgram({.program = GIT_PROGRAM, .args = gitArgs, .isInteractive = true}).first;
 
         if (status > 0)
             throw Error("Failed to fetch git repository '%s'", url);
@@ -704,7 +706,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
         // Run verification command
         auto [status, output] = runProgram({
-            .program = "git",
+            .program = GIT_PROGRAM,
             .args{
                 OS_STR("-c"),
                 OS_STR("gpg.ssh.allowedSignersFile=") + allowedSignersFile.native(),
@@ -1589,6 +1591,12 @@ bool isLegalRefName(const std::string & refName)
     }
 
     return false;
+}
+
+const std::string & gitProgram()
+{
+    static const std::string program = GIT_PROGRAM;
+    return program;
 }
 
 } // namespace nix

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -1,4 +1,6 @@
 #include "nix/util/environment-variables.hh"
+
+#include "fetchers-config-private.hh"
 #include "nix/util/error.hh"
 #include "nix/fetchers/fetchers.hh"
 #include "nix/util/users.hh"
@@ -51,7 +53,7 @@ std::optional<std::string> readHead(const std::filesystem::path & path)
 {
     auto [status, output] = runProgram(
         RunOptions{
-            .program = "git",
+            .program = GIT_PROGRAM,
             // FIXME: use 'HEAD' to avoid returning all refs
             .args = {OS_STR("ls-remote"), OS_STR("--symref"), path.native()},
             .isInteractive = true,
@@ -81,7 +83,7 @@ bool storeCachedHead(const std::string & actualUrl, bool shallow, const std::str
     std::filesystem::path cacheDir = getCachePath(actualUrl, shallow);
     try {
         runProgram(
-            "git",
+            GIT_PROGRAM,
             true,
             {
                 OS_STR("-C"),
@@ -463,7 +465,7 @@ struct GitInputScheme : InputScheme
 
         args.push_back(destDir.native());
 
-        runProgram("git", true, args, true);
+        runProgram(GIT_PROGRAM, true, args, true);
     }
 
     std::optional<std::filesystem::path> getSourcePath(const Input & input) const override
@@ -487,7 +489,7 @@ struct GitInputScheme : InputScheme
 
         auto result = runProgram(
             RunOptions{
-                .program = "git",
+                .program = GIT_PROGRAM,
                 .args{
                     OS_STR("-C"),
                     repoPath->native(),
@@ -509,7 +511,7 @@ struct GitInputScheme : InputScheme
         if (exitCode != 0) {
             // The path is not `.gitignore`d, we can add the file.
             runProgram(
-                "git",
+                GIT_PROGRAM,
                 true,
                 {
                     OS_STR("-C"),
@@ -530,7 +532,7 @@ struct GitInputScheme : InputScheme
                 // Pause the logger to allow for user input (such as a gpg passphrase) in `git commit`
                 auto suspension = logger->suspend();
                 runProgram(
-                    "git",
+                    GIT_PROGRAM,
                     true,
                     {
                         OS_STR("-C"),

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -5,6 +5,14 @@
 
 namespace nix {
 
+/**
+ * The git program used for all git invocations (build-time configurable
+ * via the `git-program` option; either a name resolved via PATH or an
+ * absolute path).
+ */
+const std::string & gitProgram();
+
+
 namespace fetchers {
 struct PublicKey;
 struct Settings;

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -1,4 +1,6 @@
 #include "nix/fetchers/fetchers.hh"
+
+#include "fetchers-config-private.hh"
 #include "nix/util/file-system.hh"
 #include "nix/util/fmt.hh"
 #include "nix/util/os-string.hh"
@@ -46,6 +48,11 @@ struct MercurialInputScheme : InputScheme
     {
         if (url.scheme != "hg+http" && url.scheme != "hg+https" && url.scheme != "hg+ssh" && url.scheme != "hg+file")
             return {};
+
+#if !ENABLE_MERCURIAL
+        throw Error(
+            "cannot fetch '%s': Mercurial support is not included in this build of Nix", url.to_string());
+#endif
 
         auto url2(url);
         url2.scheme = std::string(url2.scheme, 3);
@@ -110,6 +117,11 @@ struct MercurialInputScheme : InputScheme
 
     std::optional<Input> inputFromAttrs(const Settings & settings, const Attrs & attrs) const override
     {
+#if !ENABLE_MERCURIAL
+        throw Error(
+            "cannot fetch Mercurial input '%s': Mercurial support is not included in this build of Nix",
+            getStrAttr(attrs, "url"));
+#endif
         parseURL(getStrAttr(attrs, "url"));
 
         if (auto ref = maybeGetStrAttr(attrs, "ref")) {

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -25,6 +25,13 @@ deps_public_maybe_subproject = [
 ]
 subdir('nix-meson-build-support/subprojects')
 
+configdata_priv = configuration_data()
+configdata_priv.set_quoted('GIT_PROGRAM', get_option('git-program'))
+config_priv_h = configure_file(
+  configuration : configdata_priv,
+  output : 'fetchers-config-private.hh',
+)
+
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 
@@ -33,7 +40,7 @@ deps_private += libgit2
 
 subdir('nix-meson-build-support/common')
 
-sources = files(
+sources = [ config_priv_h ] + files(
   'attrs.cc',
   'cache.cc',
   'fetch-settings.cc',

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -27,6 +27,7 @@ subdir('nix-meson-build-support/subprojects')
 
 configdata_priv = configuration_data()
 configdata_priv.set_quoted('GIT_PROGRAM', get_option('git-program'))
+configdata_priv.set('ENABLE_MERCURIAL', get_option('mercurial-fetcher') ? 1 : 0)
 config_priv_h = configure_file(
   configuration : configdata_priv,
   output : 'fetchers-config-private.hh',

--- a/src/libfetchers/meson.options
+++ b/src/libfetchers/meson.options
@@ -6,3 +6,10 @@ option(
   value : 'git',
   description : 'the git program used for fetching, ls-remote and signature verification (a name resolved via PATH, or an absolute path)',
 )
+
+option(
+  'mercurial-fetcher',
+  type : 'boolean',
+  value : true,
+  description : 'support fetching from Mercurial repositories by shelling out to hg; when disabled, hg inputs fail with an explicit error',
+)

--- a/src/libfetchers/meson.options
+++ b/src/libfetchers/meson.options
@@ -1,0 +1,8 @@
+# vim: filetype=meson
+
+option(
+  'git-program',
+  type : 'string',
+  value : 'git',
+  description : 'the git program used for fetching, ls-remote and signature verification (a name resolved via PATH, or an absolute path)',
+)

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -265,13 +265,13 @@ if host_machine.system() != 'windows'
   configdata_priv.set_quoted('NIX_CONF_DIR', sysconfdir / 'nix')
 endif
 
-lsof = find_program('lsof', required : false)
-configdata_priv.set_quoted(
-  'LSOF',
-  lsof.found() ? lsof.full_path()
-  # Just look up on the PATH
-: 'lsof',
-)
+lsof_program = get_option('lsof-program')
+if lsof_program == ''
+  lsof = find_program('lsof', required : false)
+  # Just look up on the PATH if not found at build time
+  lsof_program = lsof.found() ? lsof.full_path() : 'lsof'
+endif
+configdata_priv.set_quoted('LSOF', lsof_program)
 
 configdata_priv.set_quoted('SSH_PROGRAM', get_option('ssh-program'))
 

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -273,6 +273,8 @@ configdata_priv.set_quoted(
 : 'lsof',
 )
 
+configdata_priv.set_quoted('SSH_PROGRAM', get_option('ssh-program'))
+
 config_priv_h = configure_file(
   configuration : configdata_priv,
   output : 'store-config-private.hh',

--- a/src/libstore/meson.options
+++ b/src/libstore/meson.options
@@ -46,3 +46,10 @@ option(
   value : 'ssh',
   description : 'the ssh program used for remote stores, remote builders and store copies (a name resolved via PATH, or an absolute path)',
 )
+
+option(
+  'lsof-program',
+  type : 'string',
+  value : '',
+  description : 'the lsof program used by the garbage collector to find runtime roots (empty means: detect at build time, falling back to PATH lookup at run time)',
+)

--- a/src/libstore/meson.options
+++ b/src/libstore/meson.options
@@ -39,3 +39,10 @@ option(
   type : 'feature',
   description : 'build support for AWS authentication with S3',
 )
+
+option(
+  'ssh-program',
+  type : 'string',
+  value : 'ssh',
+  description : 'the ssh program used for remote stores, remote builders and store copies (a name resolved via PATH, or an absolute path)',
+)

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -1,4 +1,6 @@
 #include "nix/store/ssh.hh"
+
+#include "store-config-private.hh"
 #include "nix/util/current-process.hh"
 #include "nix/util/environment-variables.hh"
 #include "nix/util/os-string.hh"
@@ -123,7 +125,7 @@ bool SSHMaster::isMasterRunning()
     OsStrings args = {OS_STR("-O"), OS_STR("check"), string_to_os_string(hostnameAndUser)};
     addCommonSSHOpts(args);
 
-    auto res = runProgram(RunOptions{.program = "ssh", .args = std::move(args), .mergeStderrToStdout = true});
+    auto res = runProgram(RunOptions{.program = SSH_PROGRAM, .args = std::move(args), .mergeStderrToStdout = true});
     return res.first == 0;
 }
 
@@ -185,7 +187,7 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(OsStrings && comm
             OsStrings args;
 
             if (!fakeSSH) {
-                args = {"ssh", hostnameAndUser.c_str(), "-x"};
+                args = {SSH_PROGRAM, hostnameAndUser.c_str(), "-x"};
                 addCommonSSHOpts(args);
                 if (!socketPath.empty())
                     args.insert(args.end(), {"-S", socketPath.string()});

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -1,4 +1,6 @@
 #include "nix/cmd/command.hh"
+
+#include "cli-config-private.hh"
 #include "nix/util/config-global.hh"
 #include "nix/expr/eval.hh"
 #include "nix/cmd/installable-flake.hh"
@@ -639,7 +641,7 @@ struct CmdDevelop : Common, MixEnvironment
         // prevent garbage collection until shell exits
         setEnv("NIX_GCROOT", store->printStorePath(gcroot).c_str());
 
-        std::filesystem::path shell = "bash";
+        std::filesystem::path shell = FALLBACK_BASH;
         bool foundInteractive = false;
 
         try {

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1,4 +1,5 @@
 #include "nix/cmd/command.hh"
+#include "nix/fetchers/git-utils.hh"
 #include "nix/cmd/common-eval-args.hh"
 #include "nix/main/common-args.hh"
 #include "nix/main/shared.hh"
@@ -991,7 +992,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
             };
             for (auto & s : changedFiles)
                 args.emplace_back(s.native());
-            runProgram("git", true, args);
+            runProgram(gitProgram(), true, args);
         }
 
         if (auto welcomeText = cursor->maybeGetAttr("welcomeText")) {

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -66,6 +66,8 @@ mandir = get_option('mandir')
 mandir = fs.is_absolute(mandir) ? mandir : prefix / mandir
 configdata.set_quoted('NIX_MAN_DIR', mandir)
 
+configdata.set_quoted('FALLBACK_BASH', get_option('bash-program'))
+
 config_priv_h = configure_file(
   configuration : configdata,
   output : 'cli-config-private.hh',

--- a/src/nix/meson.options
+++ b/src/nix/meson.options
@@ -21,3 +21,10 @@ option(
   value : false,
   description : 'Embed the public C API into nix so plugins can resolve those symbols from the executable',
 )
+
+option(
+  'bash-program',
+  type : 'string',
+  value : 'bash',
+  description : 'the bash used as the fallback interactive shell for nix develop / nix-shell when bashInteractive from nixpkgs is unavailable (a name resolved via PATH, or an absolute path)',
+)

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -1,3 +1,4 @@
+#include "cli-config-private.hh"
 #include <cstring>
 #include <iostream>
 #include <filesystem>
@@ -494,7 +495,7 @@ static void main_nix_build(int argc, char ** argv)
             } catch (Error & e) {
                 logError(e.info());
                 notice("uses bash from your environment");
-                shell = "bash";
+                shell = FALLBACK_BASH;
             }
         }
 


### PR DESCRIPTION
## Motivation

Nix uses several binaries to do its work. `git`. `bash`. `hg`. `lsof`. `ssh`. I'd like to bundle a known-good version of these tools, and bake that path into the binary, and I didn't have a tool other than patching Nix for doing so.

## Context

I'm looking to build stand-alone Nix which doesn't depend on the Nix store, but *also* doesn't just use whatever tools are in the path. That takes some discernment.

## AI disclosure

I used Claude to help find the right incantations for Meson.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
