### PR TITLE
misc/launchd: point the daemon plist at the configured bindir

### DIFF
--- a/misc/launchd/meson.build
+++ b/misc/launchd/meson.build
@@ -5,9 +5,9 @@ configure_file(
   install_dir : get_option('prefix') / 'Library/LaunchDaemons',
   install_mode : 'rw-r--r--',
   configuration : {
-    # TODO: unhardcode paths with something like:
+    # TODO: unhardcode more paths with something like:
     # 'storedir' : store_dir,
     # 'localstatedir' : localstatedir,
-    # 'bindir' : bindir,
-},
+    'bindir' : bindir,
+  },
 )

--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -12,7 +12,7 @@
     <array>
       <string>/bin/sh</string>
       <string>-c</string>
-      <string>/bin/wait4path /nix/var/nix/profiles/default/bin/nix-daemon &amp;&amp; exec /nix/var/nix/profiles/default/bin/nix-daemon</string>
+      <string>/bin/wait4path @bindir@/nix-daemon &amp;&amp; exec @bindir@/nix-daemon</string>
     </array>
     <key>StandardErrorPath</key>
     <string>/var/log/nix-daemon.log</string>


### PR DESCRIPTION
The meson-installed `org.nixos.nix-daemon.plist` hardcodes `/nix/var/nix/profiles/default/bin/nix-daemon` regardless of the configured prefix.

I'd like to place the `nix-daemon` somewhere else, so I have reason to implement the TODO in `misc/launchd/meson.build`.