### PR TITLE
libfetchers: Simplify git sink, test much more things and align overwrite semantics closer to libarchive

### DIFF
--- a/src/libfetchers-tests/git-utils.cc
+++ b/src/libfetchers-tests/git-utils.cc
@@ -190,6 +190,129 @@ TEST_F(GitUtilsTest, sink_no_parent_dir_hardlink)
         ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("parent of 'foo/bar' is not a directory")));
 }
 
+TEST_F(GitUtilsTest, sink_replacing_empty_directory)
+{
+    auto repo = openRepo();
+    auto sink = repo->getFileSystemObjectSink();
+
+    sink->createDirectory(CanonPath::root);
+    sink->createDirectory(CanonPath("foo"));
+    sink->createDirectory(CanonPath("foo/bar"));
+    /* Under tarball unpacking semantics, creating the same directories
+       (implicitly or explicitly) is fine. */
+    sink->createDirectory(CanonPath("foo/bar"));
+    sink->createDirectory(CanonPath("foo"));
+
+    sink->createRegularFile(CanonPath("foo/bar"), [](CreateRegularFileSink & fileSink) {
+        writeString(fileSink, "test", /*executable=*/false);
+    });
+
+    auto accessor = repo->getAccessor(sink->flush(), {}, getRepoName());
+
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath("foo"), std::set<std::string>{"bar"}));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("foo/bar"), "test"));
+}
+
+TEST_F(GitUtilsTest, sink_replacing_non_empty_directory)
+{
+    ASSERT_THAT(
+        [&]() {
+            auto repo = openRepo();
+            auto sink = repo->getFileSystemObjectSink();
+
+            sink->createDirectory(CanonPath::root);
+            sink->createDirectory(CanonPath("foo"));
+            sink->createDirectory(CanonPath("foo/bar"));
+
+            /* This fails. libarchive (and other tarball unpackers) doesn't recursive unlink existing non-empty
+               directories.
+               https://github.com/libarchive/libarchive/blob/761652401fe35fca9744607a0cf0009afbf04f42/libarchive/archive_write_disk_posix.c#L3411-L3417
+             */
+
+            sink->createRegularFile(CanonPath("foo"), [](CreateRegularFileSink & fileSink) {
+                writeString(fileSink, "test", /*executable=*/false);
+            });
+
+            sink->flush();
+        },
+        ::testing::ThrowsMessage<Error>(
+            testing::HasSubstrIgnoreANSIMatcher("cannot create 'foo', conflicting non-empty directory")));
+}
+
+TEST_F(GitUtilsTest, sink_hardlink_to_directory)
+{
+    ASSERT_THAT(
+        [&]() {
+            auto repo = openRepo();
+            auto sink = repo->getFileSystemObjectSink();
+
+            sink->createDirectory(CanonPath::root);
+            sink->createDirectory(CanonPath("foo"));
+            sink->createHardlink(CanonPath("bar"), CanonPath("foo"));
+
+            sink->flush();
+        },
+        ::testing::ThrowsMessage<Error>(
+            testing::HasSubstrIgnoreANSIMatcher("cannot create a hard link to a directory")));
+}
+
+TEST_F(GitUtilsTest, sink_hardlink_to_directory_root)
+{
+    auto repo = openRepo();
+    auto sink = repo->getFileSystemObjectSink();
+
+    sink->createDirectory(CanonPath::root);
+    sink->createDirectory(CanonPath("foo"));
+    sink->createHardlink(CanonPath("bar"), CanonPath::root);
+
+    auto accessor = repo->getAccessor(sink->flush(), {}, getRepoName());
+
+    /* FIXME: Why does it behave this way? This seems like a bug. */
+    ASSERT_THAT(
+        accessor,
+        testing::HasDirectory(
+            CanonPath::root,
+            std::set<std::string>{
+                "foo",
+            }));
+}
+
+TEST_F(GitUtilsTest, sink_hardlink_to_self)
+{
+    /* Here we are more strict than libarchive, which only warns on cyclic hardlinks.
+       https://github.com/libarchive/libarchive/blob/761652401fe35fca9744607a0cf0009afbf04f42/libarchive/archive_write_disk_posix.c#L632-L641
+     */
+    ASSERT_THAT(
+        [&]() {
+            auto repo = openRepo();
+            auto sink = repo->getFileSystemObjectSink();
+
+            sink->createDirectory(CanonPath::root);
+            sink->createHardlink(CanonPath("foo"), CanonPath("foo"));
+
+            sink->flush();
+        },
+        ::testing::ThrowsMessage<Error>(testing::HasSubstrIgnoreANSIMatcher("/foo")));
+}
+
+TEST_F(GitUtilsTest, sink_non_directory_root)
+{
+    /* FIXME: Allow non-directory roots. GitFileSystemObjectSink is too tarball-brained. */
+    ASSERT_THAT(
+        [&]() {
+            auto repo = openRepo();
+            auto sink = repo->getFileSystemObjectSink();
+
+            sink->createRegularFile(CanonPath::root, [](CreateRegularFileSink & fileSink) {
+                writeString(fileSink, "test", /*executable=*/false);
+            });
+
+            sink->flush();
+        },
+        ::testing::ThrowsMessage<Error>(
+            testing::HasSubstrIgnoreANSIMatcher("cannot create a file at the root of the git repository")));
+}
+
 TEST_F(GitUtilsTest, peel_reference)
 {
     // Create a commit in the repo

--- a/src/libfetchers-tests/git-utils.cc
+++ b/src/libfetchers-tests/git-utils.cc
@@ -86,13 +86,24 @@ TEST_F(GitUtilsTest, sink_basic)
 
     auto result = repo->dereferenceSingletonDirectory(sink->flush());
     auto accessor = repo->getAccessor(result, {}, getRepoName());
-    auto entries = accessor->readDirectory(CanonPath::root);
-    ASSERT_EQ(entries.size(), 5u);
-    ASSERT_EQ(accessor->readFile(CanonPath("hello")), "hello world");
-    ASSERT_EQ(accessor->readFile(CanonPath("bye")), "thanks for all the fish");
-    ASSERT_EQ(accessor->readLink(CanonPath("bye-link")), "bye");
-    ASSERT_EQ(accessor->readDirectory(CanonPath("empty")).size(), 0u);
-    ASSERT_EQ(accessor->readFile(CanonPath("links/foo")), "hello world");
+
+    ASSERT_THAT(
+        accessor,
+        testing::HasDirectory(
+            CanonPath::root,
+            std::set<std::string>{
+                "hello",
+                "bye",
+                "bye-link",
+                "empty",
+                "links",
+            }));
+
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("hello"), "hello world"));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("bye"), "thanks for all the fish"));
+    ASSERT_THAT(accessor, testing::HasSymlink(CanonPath("bye-link"), "bye"));
+    ASSERT_THAT(accessor, testing::HasDirectory(CanonPath("empty"), std::set<std::string>{}));
+    ASSERT_THAT(accessor, testing::HasContents(CanonPath("links/foo"), "hello world"));
 };
 
 TEST_F(GitUtilsTest, sink_hardlink)

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -33,6 +33,9 @@ deps_private += rapidcheck
 gtest = dependency('gtest', main : true)
 deps_private += gtest
 
+gmock = dependency('gmock')
+deps_private += gmock
+
 libgit2 = dependency('libgit2')
 deps_private += libgit2
 

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1204,6 +1204,11 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
     {
     }
 
+    GitFileSystemObjectSinkImpl(GitFileSystemObjectSinkImpl &&) = delete;
+    GitFileSystemObjectSinkImpl(const GitFileSystemObjectSinkImpl &) = delete;
+    GitFileSystemObjectSinkImpl & operator=(GitFileSystemObjectSinkImpl &&) = delete;
+    GitFileSystemObjectSinkImpl & operator=(const GitFileSystemObjectSinkImpl &) = delete;
+
     ~GitFileSystemObjectSinkImpl()
     {
         // Make sure the worker threads are destroyed before any state

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -45,6 +45,7 @@
 #include <iostream>
 #include <regex>
 #include <ranges>
+#include <future>
 
 namespace std {
 
@@ -1246,27 +1247,30 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
         }
     };
 
-    size_t nextId = 0; // for Child.id
+    /* FIXME: Most of this logic is independent from git. Come up with a tree sink interface
+       and an adapter for a ExtendedFileSystemObjectSink that implements the tarball unpacking
+       semantics (i.e. overwriting of entries). Also deduplicate with MemorySourceAccessor. */
 
     struct Child
     {
         git_filemode_t mode;
-        std::variant<Directory, git_oid> file;
+        std::variant<Directory, git_oid, std::shared_future<git_oid>> file;
 
-        /// Sequential numbering of the file in the tarball. This is
-        /// used to make sure we only import the latest version of a
-        /// path.
-        size_t id{0};
+        const git_oid & getOid() const &
+        {
+            return std::visit(
+                overloaded{
+                    [](const Directory & dir) -> const git_oid & { return dir.oid.value(); },
+                    [](const git_oid & oid) -> const git_oid & { return oid; },
+                    [](const std::shared_future<git_oid> & oid) -> const git_oid & { return oid.get(); },
+                },
+                file);
+        }
     };
 
-    struct State
-    {
-        Directory root;
-    };
+    Directory root;
 
-    Sync<State> _state;
-
-    void addNode(State & state, const CanonPath & path, Child && child)
+    void addNode(const CanonPath & path, Child && child)
     {
         if (path.isRoot())
             throw Error("cannot create a file at the root of the git repository");
@@ -1274,7 +1278,7 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
         auto parent = path.parent();
         assert(parent);
 
-        Directory * cur = &state.root;
+        Directory * cur = &root;
 
         for (auto & i : *parent) {
             auto child = std::get_if<Directory>(
@@ -1285,31 +1289,29 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
         }
 
         std::string name(*path.baseName());
+        auto prev = cur->children.find(name);
 
-        if (auto prev = cur->children.find(name); prev == cur->children.end() || prev->second.id < child.id)
-            cur->children.insert_or_assign(name, std::move(child));
-    }
-
-    /* Set the object ID of a reserved leaf, skipping if it was superseded (id changed) meanwhile. */
-    void setNodeOid(State & state, const CanonPath & path, const git_oid & oid, size_t id)
-    {
-        auto parent = path.parent();
-        assert(parent);
-
-        Directory * cur = &state.root;
-        for (auto & name : *parent) {
-            auto i = cur->children.find(name);
-            if (i == cur->children.end())
-                return;
-            auto dir = std::get_if<Directory>(&i->second.file);
-            if (!dir)
-                return;
-            cur = dir;
+        if (prev == cur->children.end()) {
+            cur->children.insert_or_assign(std::move(name), std::move(child));
+            return;
         }
 
-        auto i = cur->children.find(*path.baseName());
-        if (i != cur->children.end() && i->second.id == id)
-            i->second.file = oid;
+        /* Overwriting part of the tree. We'd like to behave somewhat
+           similarly to libarchive without ARCHIVE_EXTRACT_NO_OVERWRITE. */
+        const auto & prevChild = prev->second;
+
+        /* libarchive tries to unlink an entry, which only succeeds on empty
+           trees - so behave the same way. Everything else is fair game. */
+        if (const auto * maybePrevDir = std::get_if<Directory>(&prevChild.file)) {
+            /* "Replacing" directory with a directory is always a-ok. */
+            if (std::holds_alternative<Directory>(child.file))
+                return;
+
+            if (!maybePrevDir->children.empty())
+                throw Error("cannot create '%1%', conflicting non-empty directory", path.rel());
+        }
+
+        cur->children.insert_or_assign(std::move(name), std::move(child));
     }
 
     void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)> func) override
@@ -1380,12 +1382,6 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
 
         func(*crf);
 
-        auto id = nextId++;
-        auto mode = crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB;
-
-        /* Reserve the node now, in order; workers fill the oid later. */
-        addNode(*_state.lock(), crf->path, Child{mode, git_oid{}, id});
-
         if (crf->stream) {
             /* Finish the slow path by creating the blob object synchronously.
                Call .release(), since git_blob_create_from_stream_commit
@@ -1393,43 +1389,52 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
             git_oid oid;
             if (git_blob_create_from_stream_commit(&oid, crf->stream.release()))
                 throw GitError("creating a blob object for '%s'", path);
-            setNodeOid(*_state.lock(), crf->path, oid, id);
+            addNode(crf->path, Child{crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB, oid});
             return;
         }
 
-        /* Fast path: create the blob object in a separate thread. */
-        workers.enqueue([this, crf{std::move(crf)}, id]() {
-            auto repo(repoPool.get());
+        std::promise<git_oid> promise;
+        addNode(
+            crf->path,
+            Child{
+                crf->executable ? GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB,
+                promise.get_future(),
+            });
 
-            git_oid oid;
-            if (git_blob_create_from_buffer(&oid, *repo, crf->contents.data(), crf->contents.size()))
-                throw GitError("creating a blob object for '%s' from in-memory buffer", crf->path);
+        /* Fast path: create the blob object in a separate thread.
+           FIXME: Ugly, make ThreadPool use std::move_only_function. */
+        workers.enqueue(
+            [this, crf{std::move(crf)}, promise = make_ref<decltype(promise)>(std::move(promise))]() mutable {
+                auto repo(repoPool.get());
 
-            setNodeOid(*_state.lock(), crf->path, oid, id);
-        });
+                git_oid oid;
+                if (git_blob_create_from_buffer(&oid, *repo, crf->contents.data(), crf->contents.size()))
+                    throw GitError("creating a blob object for '%s' from in-memory buffer", crf->path);
+
+                /* We don't generally bother with exceptions because those will
+                   be propagated by the thread pool during .process(). */
+                promise->set_value(oid);
+            });
     }
 
     void createDirectory(const CanonPath & path) override
     {
         if (path.isRoot())
             return;
-        auto state(_state.lock());
-        addNode(*state, path, {GIT_FILEMODE_TREE, Directory()});
+        addNode(path, {GIT_FILEMODE_TREE, Directory()});
     }
 
     void createSymlink(const CanonPath & path, const std::string & target) override
     {
-        auto id = nextId++;
-        addNode(*_state.lock(), path, Child{GIT_FILEMODE_LINK, git_oid{}, id});
-        workers.enqueue([this, path, target, id]() {
-            auto repo(repoPool.get());
+        /* Symlinks are written to the this repo instance, the mempack backend
+           for which includes the trees. This way we flush both symlinks and
+           trees to the same packfile. Doing this synchronously isn't expensive
+           because symlinks are tiny, so hashing them is cheap. */
+        git_oid oid;
+        if (git_blob_create_from_buffer(&oid, *repo, requireCString(target), target.size()))
+            throw GitError("creating a blob object for tarball symlink member '%s'", path);
 
-            git_oid oid;
-            if (git_blob_create_from_buffer(&oid, *repo, target.c_str(), target.size()))
-                throw GitError("creating a blob object for tarball symlink member '%s'", path);
-
-            setNodeOid(*_state.lock(), path, oid, id);
-        });
+        addNode(path, Child{GIT_FILEMODE_LINK, oid});
     }
 
     std::map<CanonPath, CanonPath> hardLinks;
@@ -1445,16 +1450,14 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
 
         /* Create hard links. */
         {
-            auto state(_state.lock());
             for (auto & [path, target] : hardLinks) {
                 if (target.isRoot())
                     continue;
                 try {
-                    auto child = state->root.lookup(target);
-                    auto oid = std::get_if<git_oid>(&child.file);
-                    if (!oid)
+                    const auto & child = root.lookup(target);
+                    if (std::holds_alternative<Directory>(child.file))
                         throw Error("cannot create a hard link to a directory");
-                    addNode(*state, path, {child.mode, *oid});
+                    addNode(path, {child.mode, child.getOid()});
                 } catch (Error & e) {
                     e.addTrace(nullptr, "while creating a hard link from '%s' to '%s'", path, target);
                     throw;
@@ -1468,30 +1471,30 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
             ThreadPool workers{repos.size()};
             for (auto & repo : repos)
                 workers.enqueue([repo]() { repo->flush(); });
+            workers.enqueue([repo = repo]() { repo->flush(); });
             workers.process();
         }
 
         // Write the Git trees to disk. Would be nice to have this multithreaded too, but that's hard because a tree
         // can't refer to an object that hasn't been written yet. Also it doesn't make a big difference for performance.
-        auto repo(repoPool.get());
 
-        [&](this const auto & visit, Directory & node) -> void {
+        [&, &repo = *repo](this const auto & visit, Directory & node) -> void {
             checkInterrupt();
 
             // Write the child directories.
             for (auto & child : node.children)
                 if (auto dir = std::get_if<Directory>(&child.second.file))
+                    /* TODO: Limit recursion depth? */
                     visit(*dir);
 
             // Write this directory.
             git_treebuilder * b;
-            if (git_treebuilder_new(&b, *repo, nullptr))
+            if (git_treebuilder_new(&b, repo, nullptr))
                 throw GitError("creating a tree builder");
             TreeBuilder builder(b);
 
-            for (auto & [name, child] : node.children) {
-                auto oid_p = std::get_if<git_oid>(&child.file);
-                auto oid = oid_p ? *oid_p : std::get<Directory>(child.file).oid.value();
+            for (const auto & [name, child] : node.children) {
+                const auto & oid = child.getOid();
                 if (git_treebuilder_insert(nullptr, builder.get(), name.c_str(), &oid, child.mode))
                     throw GitError("adding a file to a tree builder");
             }
@@ -1500,11 +1503,11 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
             if (git_treebuilder_write(&oid, builder.get()))
                 throw GitError("creating a tree object");
             node.oid = oid;
-        }(_state.lock()->root);
+        }(root);
 
         repo->flush();
 
-        return toHash(_state.lock()->root.oid.value());
+        return toHash(root.oid.value());
     }
 };
 

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -99,6 +99,32 @@ struct GitError final : public CloneableError<GitError, Error>
     }
 };
 
+struct GitIndexerSink final : public BufferedSink
+{
+    git_indexer * indexer;
+    git_indexer_progress stats{};
+
+    GitIndexerSink(git_indexer * indexer)
+        : BufferedSink(1 * 1024 * 1024)
+        , indexer(indexer)
+    {
+        assert(indexer);
+    }
+
+    GitIndexerSink(GitIndexerSink &&) = delete;
+    GitIndexerSink(const GitIndexerSink &) = delete;
+    GitIndexerSink & operator=(GitIndexerSink &&) = delete;
+    GitIndexerSink & operator=(const GitIndexerSink &) = delete;
+    ~GitIndexerSink() = default;
+
+    void writeUnbuffered(std::string_view data) override
+    {
+        checkInterrupt();
+        if (git_indexer_append(indexer, data.data(), data.size(), &stats))
+            throw GitError("appending to git packfile index");
+    }
+};
+
 } // namespace
 
 typedef std::unique_ptr<git_repository, Deleter<git_repository_free>> Repository;
@@ -337,52 +363,79 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
     void flush() override
     {
+        std::size_t objectCount;
+        if (git_mempack_object_count(&objectCount, mempackBackend))
+            throw GitError("querying the number of objects in a git memory packer backend");
+
+        if (!objectCount)
+            /* Nothing to do. */
+            return;
+
         checkInterrupt();
 
-        git_buf buf = GIT_BUF_INIT;
-        Finally _disposeBuf{[&] { git_buf_dispose(&buf); }};
         PackBuilder packBuilder;
         PackBuilderContext packBuilderContext;
-        git_packbuilder_new(Setter(packBuilder), *this);
-        git_packbuilder_set_callbacks(packBuilder.get(), PACKBUILDER_PROGRESS_CHECK_INTERRUPT, &packBuilderContext);
+        if (git_packbuilder_new(Setter(packBuilder), *this))
+            throw GitError("creating git pack builder");
+
+        if (git_packbuilder_set_callbacks(packBuilder.get(), PACKBUILDER_PROGRESS_CHECK_INTERRUPT, &packBuilderContext))
+            throw GitError("setting git pack builder callbacks");
+
         git_packbuilder_set_threads(packBuilder.get(), 0 /* autodetect */);
 
         packBuilderContext.handleException(
             "preparing packfile", git_mempack_write_thin_pack(mempackBackend, packBuilder.get()));
         checkInterrupt();
-        packBuilderContext.handleException("writing packfile", git_packbuilder_write_buf(&buf, packBuilder.get()));
-        checkInterrupt();
 
-        std::string repo_path = std::string(git_repository_path(repo.get()));
-        while (!repo_path.empty() && repo_path.back() == '/')
-            repo_path.pop_back();
-        std::string pack_dir_path = repo_path + "/objects/pack";
+        auto packFilesPath = std::filesystem::path(git_repository_path(repo.get())) / "objects/pack";
 
-        // TODO (performance): could the indexing be done in a separate thread?
-        //                     we'd need a more streaming variation of
-        //                     git_packbuilder_write_buf, or incur the cost of
-        //                     copying parts of the buffer to a separate thread.
-        //                     (synchronously on the git_packbuilder_write_buf thread)
         Indexer indexer;
-        git_indexer_progress stats;
-        if (git_indexer_new(Setter(indexer), pack_dir_path.c_str(), 0, nullptr, nullptr))
+        if (git_indexer_new(Setter(indexer), packFilesPath.c_str(), 0, nullptr, nullptr))
             throw GitError("creating git packfile indexer");
 
-        // TODO: provide index callback for checkInterrupt() termination
-        //       though this is about an order of magnitude faster than the packbuilder
-        //       expect up to 1 sec latency due to uninterruptible git_indexer_append.
-        constexpr size_t chunkSize = 128 * 1024;
-        for (size_t offset = 0; offset < buf.size; offset += chunkSize) {
-            if (git_indexer_append(indexer.get(), buf.ptr + offset, std::min(chunkSize, buf.size - offset), &stats))
-                throw GitError("appending to git packfile index");
-            checkInterrupt();
-        }
+        struct State
+        {
+            Indexer & indexer;
+            PackBuilderContext & packBuilderContext;
+            GitIndexerSink sink{indexer.get()};
+        };
+
+        State state{
+            .indexer = indexer,
+            .packBuilderContext = packBuilderContext,
+        };
+
+        packBuilderContext.handleException(
+            "writing packfile",
+            git_packbuilder_foreach(
+                packBuilder.get(),
+                [](void * buf, size_t size, void * payload) -> int {
+                    auto & state = *static_cast<State *>(payload);
+                    try {
+                        state.sink(std::string_view(static_cast<const char *>(buf), size));
+                    } catch (...) {
+                        state.packBuilderContext.exception = std::current_exception();
+                        return GIT_EUSER;
+                    }
+                    return GIT_OK;
+                },
+                &state));
+
+        state.sink.flush();
+
+        auto & stats = state.sink.stats;
 
         if (git_indexer_commit(indexer.get(), &stats))
             throw GitError("committing git packfile index");
 
         if (git_mempack_reset(mempackBackend))
             throw GitError("resetting git mempack backend");
+
+        debug(
+            "committed index and pack file to pack-%s.{idx,pack}, objects = %d, deltas = %d",
+            git_indexer_name(indexer.get()),
+            stats.total_objects,
+            stats.total_deltas);
 
         checkInterrupt();
     }

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -447,7 +447,6 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
      */
     Pool<GitRepoImpl> getPool()
     {
-        // TODO: as an optimization, it would be nice to include `this` in the pool.
         return Pool<GitRepoImpl>(std::numeric_limits<size_t>::max(), [this]() -> ref<GitRepoImpl> {
             auto repo = make_ref<GitRepoImpl>(path, options);
 
@@ -1194,6 +1193,13 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
 
     ThreadPool workers{concurrency};
 
+    /**
+     * If repo has a non-null packBackend, this has a copy of the refresh function
+     * from the backend virtual table. This is needed to restore it after we've flushed
+     * the sink. We modify it to avoid unnecessary I/O on non-existent oids.
+     */
+    decltype(::git_odb_backend::refresh) packfileOdbRefresh = nullptr;
+
     /** Total file contents in flight. */
     std::atomic<size_t> totalBufSize{0};
 
@@ -1203,6 +1209,8 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
         : repo(repo)
         , repoPool(repo->getPool())
     {
+        if (auto * backend = repo->packBackend)
+            packfileOdbRefresh = std::exchange(backend->refresh, nullptr);
     }
 
     GitFileSystemObjectSinkImpl(GitFileSystemObjectSinkImpl &&) = delete;
@@ -1215,6 +1223,8 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
         // Make sure the worker threads are destroyed before any state
         // they're referring to.
         workers.shutdown();
+        if (auto * backend = repo->packBackend; backend && packfileOdbRefresh)
+            backend->refresh = packfileOdbRefresh;
     }
 
     struct Child;
@@ -1475,6 +1485,10 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
             workers.process();
         }
 
+        if (auto * backend = repo->packBackend)
+            /* We are done writing blobs. Need to refresh to get the objects written by other threads. */
+            packfileOdbRefresh(backend);
+
         // Write the Git trees to disk. Would be nice to have this multithreaded too, but that's hard because a tree
         // can't refer to an object that hasn't been written yet. Also it doesn't make a big difference for performance.
 
@@ -1506,6 +1520,9 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
         }(root);
 
         repo->flush();
+
+        if (auto * backend = repo->packBackend)
+            backend->refresh = std::exchange(packfileOdbRefresh, nullptr);
 
         return toHash(root.oid.value());
     }

--- a/src/libutil-test-support/include/nix/util/tests/gmock-matchers.hh
+++ b/src/libutil-test-support/include/nix/util/tests/gmock-matchers.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include "nix/util/error.hh"
+#include "nix/util/source-accessor.hh"
 #include "nix/util/terminal.hh"
 #include <gmock/gmock.h>
 
@@ -64,6 +65,66 @@ HasSubstrIgnoreANSIMatcher(const std::string & substring)
 inline auto ThrowsSysError(int expected)
 {
     return ::testing::Throws<SysError>(::testing::Field(&SysError::errNo, expected));
+}
+
+MATCHER_P2(HasContents, path, expected, "")
+{
+    auto stat = arg->maybeLstat(path);
+    if (!stat) {
+        *result_listener << arg->showPath(path) << " does not exist";
+        return false;
+    }
+    if (stat->type != SourceAccessor::tRegular) {
+        *result_listener << arg->showPath(path) << " is not a regular file";
+        return false;
+    }
+    auto actual = arg->readFile(path);
+    if (actual != expected) {
+        *result_listener << arg->showPath(path) << " has contents " << ::testing::PrintToString(actual);
+        return false;
+    }
+    return true;
+}
+
+MATCHER_P2(HasSymlink, path, target, "")
+{
+    auto stat = arg->maybeLstat(path);
+    if (!stat) {
+        *result_listener << arg->showPath(path) << " does not exist";
+        return false;
+    }
+    if (stat->type != SourceAccessor::tSymlink) {
+        *result_listener << arg->showPath(path) << " is not a symlink";
+        return false;
+    }
+    auto actual = arg->readLink(path);
+    if (actual != target) {
+        *result_listener << arg->showPath(path) << " points to " << ::testing::PrintToString(actual);
+        return false;
+    }
+    return true;
+}
+
+MATCHER_P2(HasDirectory, path, dirents, "")
+{
+    auto stat = arg->maybeLstat(path);
+    if (!stat) {
+        *result_listener << arg->showPath(path) << " does not exist";
+        return false;
+    }
+    if (stat->type != SourceAccessor::tDirectory) {
+        *result_listener << arg->showPath(path) << " is not a directory";
+        return false;
+    }
+    auto actual = arg->readDirectory(path);
+    std::set<std::string> actualKeys, expectedKeys(dirents.begin(), dirents.end());
+    for (auto & [k, _] : actual)
+        actualKeys.insert(k);
+    if (actualKeys != expectedKeys) {
+        *result_listener << arg->showPath(path) << " has entries " << ::testing::PrintToString(actualKeys);
+        return false;
+    }
+    return true;
 }
 
 } // namespace nix::testing

--- a/src/libutil-tests/source-accessor.cc
+++ b/src/libutil-tests/source-accessor.cc
@@ -1,72 +1,13 @@
 #include "nix/util/fs-sink.hh"
 #include "nix/util/file-system.hh"
 #include "nix/util/processes.hh"
+#include "nix/util/tests/gmock-matchers.hh"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <rapidcheck/gtest.h>
 
 namespace nix {
-
-MATCHER_P2(HasContents, path, expected, "")
-{
-    auto stat = arg->maybeLstat(path);
-    if (!stat) {
-        *result_listener << arg->showPath(path) << " does not exist";
-        return false;
-    }
-    if (stat->type != SourceAccessor::tRegular) {
-        *result_listener << arg->showPath(path) << " is not a regular file";
-        return false;
-    }
-    auto actual = arg->readFile(path);
-    if (actual != expected) {
-        *result_listener << arg->showPath(path) << " has contents " << ::testing::PrintToString(actual);
-        return false;
-    }
-    return true;
-}
-
-MATCHER_P2(HasSymlink, path, target, "")
-{
-    auto stat = arg->maybeLstat(path);
-    if (!stat) {
-        *result_listener << arg->showPath(path) << " does not exist";
-        return false;
-    }
-    if (stat->type != SourceAccessor::tSymlink) {
-        *result_listener << arg->showPath(path) << " is not a symlink";
-        return false;
-    }
-    auto actual = arg->readLink(path);
-    if (actual != target) {
-        *result_listener << arg->showPath(path) << " points to " << ::testing::PrintToString(actual);
-        return false;
-    }
-    return true;
-}
-
-MATCHER_P2(HasDirectory, path, dirents, "")
-{
-    auto stat = arg->maybeLstat(path);
-    if (!stat) {
-        *result_listener << arg->showPath(path) << " does not exist";
-        return false;
-    }
-    if (stat->type != SourceAccessor::tDirectory) {
-        *result_listener << arg->showPath(path) << " is not a directory";
-        return false;
-    }
-    auto actual = arg->readDirectory(path);
-    std::set<std::string> actualKeys, expectedKeys(dirents.begin(), dirents.end());
-    for (auto & [k, _] : actual)
-        actualKeys.insert(k);
-    if (actualKeys != expectedKeys) {
-        *result_listener << arg->showPath(path) << " has entries " << ::testing::PrintToString(actualKeys);
-        return false;
-    }
-    return true;
-}
 
 class FSSourceAccessorTest : public ::testing::Test
 {
@@ -105,17 +46,19 @@ TEST_F(FSSourceAccessorTest, works)
         sink.createSymlink(CanonPath("a/dirlink"), "../subdir");
     }
 
-    EXPECT_THAT(makeFSSourceAccessor(tmpDir / "file1"), HasContents(CanonPath::root, "content1"));
-    EXPECT_THAT(makeFSSourceAccessor(tmpDir / "rootlink"), HasSymlink(CanonPath::root, "target"));
+    EXPECT_THAT(makeFSSourceAccessor(tmpDir / "file1"), testing::HasContents(CanonPath::root, "content1"));
+    EXPECT_THAT(makeFSSourceAccessor(tmpDir / "rootlink"), testing::HasSymlink(CanonPath::root, "target"));
     EXPECT_THAT(
         makeFSSourceAccessor(tmpDir),
-        HasDirectory(CanonPath::root, std::set<std::string>{"file1", "subdir", "rootlink", "a"}));
-    EXPECT_THAT(makeFSSourceAccessor(tmpDir / "subdir"), HasDirectory(CanonPath::root, std::set<std::string>{"file2"}));
+        testing::HasDirectory(CanonPath::root, std::set<std::string>{"file1", "subdir", "rootlink", "a"}));
+    EXPECT_THAT(
+        makeFSSourceAccessor(tmpDir / "subdir"),
+        testing::HasDirectory(CanonPath::root, std::set<std::string>{"file2"}));
 
     {
         auto accessor = makeFSSourceAccessor(tmpDir);
-        EXPECT_THAT(accessor, HasContents(CanonPath("file1"), "content1"));
-        EXPECT_THAT(accessor, HasContents(CanonPath("subdir/file2"), "content2"));
+        EXPECT_THAT(accessor, testing::HasContents(CanonPath("file1"), "content1"));
+        EXPECT_THAT(accessor, testing::HasContents(CanonPath("subdir/file2"), "content2"));
 
         EXPECT_TRUE(accessor->pathExists(CanonPath("file1")));
         EXPECT_FALSE(accessor->pathExists(CanonPath("nonexistent")));
@@ -159,9 +102,9 @@ TEST_F(FSSourceAccessorTest, invalidateCacheDropsStaleDirFds)
 
     EXPECT_FALSE(accessor->pathExists(CanonPath("a/b/f")));
     EXPECT_TRUE(accessor->pathExists(CanonPath("a/b/g")));
-    EXPECT_THAT(accessor, HasContents(CanonPath("a/b/g"), "new"));
-    EXPECT_THAT(accessor, HasDirectory(CanonPath("a/b"), (std::set<std::string>{"g", "l"})));
-    EXPECT_THAT(accessor, HasSymlink(CanonPath("a/b/l"), "g"));
+    EXPECT_THAT(accessor, testing::HasContents(CanonPath("a/b/g"), "new"));
+    EXPECT_THAT(accessor, testing::HasDirectory(CanonPath("a/b"), (std::set<std::string>{"g", "l"})));
+    EXPECT_THAT(accessor, testing::HasSymlink(CanonPath("a/b/l"), "g"));
 }
 
 /* ----------------------------------------------------------------------------
@@ -178,7 +121,7 @@ TEST_F(FSSourceAccessorTest, RestoreSinkRegularFileAtRoot)
         sink.createRegularFile(CanonPath::root, [](CreateRegularFileSink & crf) { crf("root content"); });
     }
 
-    EXPECT_THAT(makeFSSourceAccessor(filePath), HasContents(CanonPath::root, "root content"));
+    EXPECT_THAT(makeFSSourceAccessor(filePath), testing::HasContents(CanonPath::root, "root content"));
 }
 
 TEST_F(FSSourceAccessorTest, RestoreSinkSymlinkAtRoot)
@@ -194,7 +137,7 @@ TEST_F(FSSourceAccessorTest, RestoreSinkSymlinkAtRoot)
         sink.createSymlink(CanonPath::root, "symlink_target");
     }
 
-    EXPECT_THAT(makeFSSourceAccessor(linkPath), HasSymlink(CanonPath::root, "symlink_target"));
+    EXPECT_THAT(makeFSSourceAccessor(linkPath), testing::HasSymlink(CanonPath::root, "symlink_target"));
 }
 
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Solves the issue incrementally addressed in https://github.com/NixOS/nix/pull/16088 in a much easier way. Now there's no state to synchronize and each blob can either be a delayed computation (aka promise with a `shared_future` handle).

Test a lot more stuff (found partially by looking at libarchive special-casing some weird stuff and our code coverage reports for missing coverage). Note that this changes the behavior to behave more like a real tar unpacker:

- Replacing non-empty directories with other files is no longer legal (see the linked piece of code to libarchive unlinking logic).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

The first commit is pulled out from my local tree where I started working on adding tarball cache incremental repacking.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
