### PR TITLE
Allocate RootValues more efficiently

### DIFF
--- a/src/libcmd/include/nix/cmd/installable-attr-path.hh
+++ b/src/libcmd/include/nix/cmd/installable-attr-path.hh
@@ -27,7 +27,7 @@ namespace nix {
 class InstallableAttrPath : public InstallableValue
 {
     SourceExprCommand & cmd;
-    UniqueRootValue v;
+    RootValue v;
     std::string attrPath;
     ExtendedOutputsSpec extendedOutputsSpec;
 

--- a/src/libcmd/include/nix/cmd/installable-attr-path.hh
+++ b/src/libcmd/include/nix/cmd/installable-attr-path.hh
@@ -20,13 +20,14 @@
 
 #include <regex>
 #include <queue>
+#include "nix/expr/root-value.hh"
 
 namespace nix {
 
 class InstallableAttrPath : public InstallableValue
 {
     SourceExprCommand & cmd;
-    RootValue v;
+    UniqueRootValue v;
     std::string attrPath;
     ExtendedOutputsSpec extendedOutputsSpec;
 

--- a/src/libcmd/installable-attr-path.cc
+++ b/src/libcmd/installable-attr-path.cc
@@ -21,7 +21,7 @@ InstallableAttrPath::InstallableAttrPath(
     ExtendedOutputsSpec extendedOutputsSpec)
     : InstallableValue(state)
     , cmd(cmd)
-    , v(allocRootValue(v))
+    , v(UniqueRootValue(v))
     , attrPath(attrPath)
     , extendedOutputsSpec(std::move(extendedOutputsSpec))
 {

--- a/src/libcmd/installable-attr-path.cc
+++ b/src/libcmd/installable-attr-path.cc
@@ -21,7 +21,7 @@ InstallableAttrPath::InstallableAttrPath(
     ExtendedOutputsSpec extendedOutputsSpec)
     : InstallableValue(state)
     , cmd(cmd)
-    , v(UniqueRootValue(v))
+    , v(RootValue(v))
     , attrPath(attrPath)
     , extendedOutputsSpec(std::move(extendedOutputsSpec))
 {

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -344,7 +344,7 @@ void NixRepl::loadDebugTraceEnv(DebugTrace & dt)
 
         // add staticenv vars.
         for (auto & [name, value] : *(vm.get()))
-            addVarToScope(state->symbols.create(name), *value);
+            addVarToScope(state->symbols.create(name), **value);
     }
 }
 
@@ -954,7 +954,7 @@ ReplExitStatus AbstractNixRepl::runSimple(ref<EvalState> evalState, const ValMap
 
     // add 'extra' vars.
     for (auto & [name, value] : extraEnv)
-        repl->addVarToScope(repl->state->symbols.create(name), *value);
+        repl->addVarToScope(repl->state->symbols.create(name), **value);
 
     return repl->mainLoop();
 }

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -363,7 +363,7 @@ Value * EvalCache::getRootValue()
 {
     if (!value) {
         debug("getting root value");
-        value = allocRootValue(rootLoader());
+        value = UniqueRootValue(rootLoader());
     }
     return *value;
 }
@@ -380,7 +380,7 @@ AttrCursor::AttrCursor(
     , cachedValue(std::move(cachedValue))
 {
     if (value)
-        _value = allocRootValue(value);
+        _value = UniqueRootValue(value);
 }
 
 AttrKey AttrCursor::getKey()
@@ -403,9 +403,9 @@ Value & AttrCursor::getValue()
             auto attr = vParent.attrs()->get(parent->second);
             if (!attr)
                 throw Error("attribute '%s' is unexpectedly missing", getAttrPathStr());
-            _value = allocRootValue(attr->value);
+            _value = UniqueRootValue(attr->value);
         } else
-            _value = allocRootValue(root->getRootValue());
+            _value = UniqueRootValue(root->getRootValue());
     }
     return **_value;
 }

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -363,7 +363,7 @@ Value * EvalCache::getRootValue()
 {
     if (!value) {
         debug("getting root value");
-        value = UniqueRootValue(rootLoader());
+        value = RootValue(rootLoader());
     }
     return *value;
 }
@@ -380,7 +380,7 @@ AttrCursor::AttrCursor(
     , cachedValue(std::move(cachedValue))
 {
     if (value)
-        _value = UniqueRootValue(value);
+        _value = RootValue(value);
 }
 
 AttrKey AttrCursor::getKey()
@@ -403,9 +403,9 @@ Value & AttrCursor::getValue()
             auto attr = vParent.attrs()->get(parent->second);
             if (!attr)
                 throw Error("attribute '%s' is unexpectedly missing", getAttrPathStr());
-            _value = UniqueRootValue(attr->value);
+            _value = RootValue(attr->value);
         } else
-            _value = UniqueRootValue(root->getRootValue());
+            _value = RootValue(root->getRootValue());
     }
     return **_value;
 }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -104,46 +104,6 @@ const StringData & StringData::make(EvalMemory & mem, std::string_view s)
     return res;
 }
 
-RootValue allocRootValue(Value * v)
-{
-#if NIX_USE_BOEHMGC
-    /* Root slots are carved out of uncollectable slabs, which are
-       permanently part of the GC root set, and recycled through a free
-       list. This avoids doing a GC_MALLOC_UNCOLLECTABLE() / GC_FREE()
-       pair per root value, which requires taking the global GC
-       allocation lock — a significant source of contention during
-       parallel evaluation. Never destroyed since root values held by
-       other statics may be released after us during shutdown. */
-    static auto & pool = *new Sync<std::vector<Value **>>;
-
-    Value ** slot;
-    {
-        auto pool_(pool.lock());
-        if (pool_->empty()) {
-            constexpr size_t slabSize = 4096;
-            auto slab = (Value **) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Value *));
-            if (!slab)
-                throw std::bad_alloc();
-            pool_->reserve(slabSize);
-            for (size_t i = 0; i < slabSize; ++i)
-                pool_->push_back(slab + i);
-        }
-        slot = pool_->back();
-        pool_->pop_back();
-    }
-
-    *slot = v;
-
-    return RootValue(slot, [](Value ** slot) {
-        /* Clear the slot so it doesn't keep the value alive. */
-        *slot = nullptr;
-        pool.lock()->push_back(slot);
-    });
-#else
-    return std::make_shared<Value *>(v);
-#endif
-}
-
 // Pretty print types for assertion errors
 std::ostream & operator<<(std::ostream & os, const ValueType t)
 {
@@ -599,7 +559,7 @@ Value * EvalState::addPrimOp(PrimOp && primOp)
     v->mkPrimOp(new PrimOp(primOp));
 
     if (primOp.internal)
-        internalPrimOps.emplace(primOp.name, v);
+        internalPrimOps.emplace(primOp.name, UniqueRootValue(v));
     else {
         staticBaseEnv->vars.emplace_back(envName, baseEnvDispl);
         baseEnv.values[baseEnvDispl++] = v;
@@ -780,11 +740,11 @@ void mapStaticEnvBindings(const SymbolTable & st, const StaticEnv & se, const En
         if (se.isWith && !env.values[0]->isThunk()) {
             // add 'with' bindings.
             for (auto & j : *env.values[0]->attrs())
-                vm.insert_or_assign(std::string(st[j.name]), j.value);
+                vm.insert_or_assign(std::string(st[j.name]), UniqueRootValue(j.value));
         } else {
             // iterate through staticenv bindings and add them.
             for (auto & i : se.vars)
-                vm.insert_or_assign(std::string(st[i.first]), env.values[i.second]);
+                vm.insert_or_assign(std::string(st[i.first]), UniqueRootValue(env.values[i.second]));
         }
     }
 }
@@ -1190,10 +1150,14 @@ void EvalState::evalFile(const SourcePath & path, Value & v, bool mustBeTrivial)
         importResolutionCache->emplace(path, *resolvedPath);
     }
 
-    if (auto v2 = getConcurrent(*fileEvalCache, *resolvedPath)) {
-        forceValue(**v2, noPos);
-        v = **v2;
-        return;
+    {
+        Value * v2 = nullptr;
+        fileEvalCache->cvisit(*resolvedPath, [&](auto & i) { v2 = *i.second; });
+        if (v2) {
+            forceValue(*v2, noPos);
+            v = *v2;
+            return;
+        }
     }
 
     Value * vExpr;
@@ -1205,13 +1169,13 @@ void EvalState::evalFile(const SourcePath & path, Value & v, bool mustBeTrivial)
 
     fileEvalCache->try_emplace_and_cvisit(
         *resolvedPath,
-        nullptr,
+        UniqueRootValue(nullptr),
         [&](auto & i) {
             vExpr = allocValue();
             vExpr->mkThunk(&baseEnv, expr);
-            i.second = vExpr;
+            *i.second = vExpr;
         },
-        [&](auto & i) { vExpr = i.second; });
+        [&](auto & i) { vExpr = *i.second; });
 
     forceValue(*vExpr, noPos);
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -559,7 +559,7 @@ Value * EvalState::addPrimOp(PrimOp && primOp)
     v->mkPrimOp(new PrimOp(primOp));
 
     if (primOp.internal)
-        internalPrimOps.emplace(primOp.name, UniqueRootValue(v));
+        internalPrimOps.emplace(primOp.name, RootValue(v));
     else {
         staticBaseEnv->vars.emplace_back(envName, baseEnvDispl);
         baseEnv.values[baseEnvDispl++] = v;
@@ -740,11 +740,11 @@ void mapStaticEnvBindings(const SymbolTable & st, const StaticEnv & se, const En
         if (se.isWith && !env.values[0]->isThunk()) {
             // add 'with' bindings.
             for (auto & j : *env.values[0]->attrs())
-                vm.insert_or_assign(std::string(st[j.name]), UniqueRootValue(j.value));
+                vm.insert_or_assign(std::string(st[j.name]), RootValue(j.value));
         } else {
             // iterate through staticenv bindings and add them.
             for (auto & i : se.vars)
-                vm.insert_or_assign(std::string(st[i.first]), UniqueRootValue(env.values[i.second]));
+                vm.insert_or_assign(std::string(st[i.first]), RootValue(env.values[i.second]));
         }
     }
 }
@@ -1169,7 +1169,7 @@ void EvalState::evalFile(const SourcePath & path, Value & v, bool mustBeTrivial)
 
     fileEvalCache->try_emplace_and_cvisit(
         *resolvedPath,
-        UniqueRootValue(nullptr),
+        RootValue(nullptr),
         [&](auto & i) {
             vExpr = allocValue();
             vExpr->mkThunk(&baseEnv, expr);

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -106,7 +106,42 @@ const StringData & StringData::make(EvalMemory & mem, std::string_view s)
 
 RootValue allocRootValue(Value * v)
 {
-    return std::allocate_shared<Value *>(traceable_allocator<Value *>(), v);
+#if NIX_USE_BOEHMGC
+    /* Root slots are carved out of uncollectable slabs, which are
+       permanently part of the GC root set, and recycled through a free
+       list. This avoids doing a GC_MALLOC_UNCOLLECTABLE() / GC_FREE()
+       pair per root value, which requires taking the global GC
+       allocation lock — a significant source of contention during
+       parallel evaluation. Never destroyed since root values held by
+       other statics may be released after us during shutdown. */
+    static auto & pool = *new Sync<std::vector<Value **>>;
+
+    Value ** slot;
+    {
+        auto pool_(pool.lock());
+        if (pool_->empty()) {
+            constexpr size_t slabSize = 4096;
+            auto slab = (Value **) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Value *));
+            if (!slab)
+                throw std::bad_alloc();
+            pool_->reserve(slabSize);
+            for (size_t i = 0; i < slabSize; ++i)
+                pool_->push_back(slab + i);
+        }
+        slot = pool_->back();
+        pool_->pop_back();
+    }
+
+    *slot = v;
+
+    return RootValue(slot, [](Value ** slot) {
+        /* Clear the slot so it doesn't keep the value alive. */
+        *slot = nullptr;
+        pool.lock()->push_back(slot);
+    });
+#else
+    return std::make_shared<Value *>(v);
+#endif
 }
 
 // Pretty print types for assertion errors

--- a/src/libexpr/include/nix/expr/eval-cache.hh
+++ b/src/libexpr/include/nix/expr/eval-cache.hh
@@ -8,6 +8,7 @@
 
 #include <functional>
 #include <variant>
+#include "nix/expr/root-value.hh"
 
 namespace nix::eval_cache {
 
@@ -41,7 +42,7 @@ class EvalCache : public std::enable_shared_from_this<EvalCache>
     EvalState & state;
     typedef fun<Value *()> RootLoader;
     RootLoader rootLoader;
-    RootValue value;
+    UniqueRootValue value;
 
     Value * getRootValue();
 
@@ -105,7 +106,7 @@ class AttrCursor : public std::enable_shared_from_this<AttrCursor>
     ref<EvalCache> root;
     using Parent = std::optional<std::pair<ref<AttrCursor>, Symbol>>;
     Parent parent;
-    RootValue _value;
+    UniqueRootValue _value;
     std::optional<std::pair<AttrId, AttrValue>> cachedValue;
 
     AttrKey getKey();

--- a/src/libexpr/include/nix/expr/eval-cache.hh
+++ b/src/libexpr/include/nix/expr/eval-cache.hh
@@ -42,7 +42,7 @@ class EvalCache : public std::enable_shared_from_this<EvalCache>
     EvalState & state;
     typedef fun<Value *()> RootLoader;
     RootLoader rootLoader;
-    UniqueRootValue value;
+    RootValue value;
 
     Value * getRootValue();
 
@@ -106,7 +106,7 @@ class AttrCursor : public std::enable_shared_from_this<AttrCursor>
     ref<EvalCache> root;
     using Parent = std::optional<std::pair<ref<AttrCursor>, Symbol>>;
     Parent parent;
-    UniqueRootValue _value;
+    RootValue _value;
     std::optional<std::pair<AttrId, AttrValue>> cachedValue;
 
     AttrKey getKey();

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -6,6 +6,7 @@
 #include "nix/expr/eval-profiler.hh"
 #include "nix/util/types.hh"
 #include "nix/expr/value.hh"
+#include "nix/expr/root-value.hh"
 #include "nix/expr/nixexpr.hh"
 #include "nix/expr/symbol-table.hh"
 #include "nix/util/configuration.hh"
@@ -165,9 +166,7 @@ struct Constant
     bool impureOnly = false;
 };
 
-typedef std::
-    map<std::string, Value *, std::less<std::string>, traceable_allocator<std::pair<const std::string, Value *>>>
-        ValMap;
+typedef std::map<std::string, UniqueRootValue> ValMap;
 
 typedef boost::unordered_flat_map<PosIdx, DocComment, std::hash<PosIdx>> DocCommentMap;
 
@@ -468,13 +467,7 @@ private:
     /**
      * A cache from resolved paths to values.
      */
-    const ref<boost::concurrent_flat_map<
-        SourcePath,
-        Value *,
-        std::hash<SourcePath>,
-        std::equal_to<SourcePath>,
-        traceable_allocator<std::pair<const SourcePath, Value *>>>>
-        fileEvalCache;
+    const ref<boost::concurrent_flat_map<SourcePath, UniqueRootValue>> fileEvalCache;
 
     /**
      * Associate source positions of certain AST nodes with their preceding doc comment, if they have one.
@@ -833,13 +826,7 @@ public:
     /**
      * Internal primops not exposed to the user.
      */
-    boost::unordered_flat_map<
-        std::string,
-        Value *,
-        StringViewHash,
-        std::equal_to<>,
-        traceable_allocator<std::pair<const std::string, Value *>>>
-        internalPrimOps;
+    boost::unordered_flat_map<std::string, UniqueRootValue, StringViewHash> internalPrimOps;
 
     /**
      * Name and documentation about every constant.

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -166,7 +166,7 @@ struct Constant
     bool impureOnly = false;
 };
 
-typedef std::map<std::string, UniqueRootValue> ValMap;
+typedef std::map<std::string, RootValue> ValMap;
 
 typedef boost::unordered_flat_map<PosIdx, DocComment, std::hash<PosIdx>> DocCommentMap;
 
@@ -467,7 +467,7 @@ private:
     /**
      * A cache from resolved paths to values.
      */
-    const ref<boost::concurrent_flat_map<SourcePath, UniqueRootValue>> fileEvalCache;
+    const ref<boost::concurrent_flat_map<SourcePath, RootValue>> fileEvalCache;
 
     /**
      * Associate source positions of certain AST nodes with their preceding doc comment, if they have one.
@@ -826,7 +826,7 @@ public:
     /**
      * Internal primops not exposed to the user.
      */
-    boost::unordered_flat_map<std::string, UniqueRootValue, StringViewHash> internalPrimOps;
+    boost::unordered_flat_map<std::string, RootValue, StringViewHash> internalPrimOps;
 
     /**
      * Name and documentation about every constant.

--- a/src/libexpr/include/nix/expr/get-drvs.hh
+++ b/src/libexpr/include/nix/expr/get-drvs.hh
@@ -32,6 +32,7 @@ private:
      */
     bool failed = false;
 
+    // FIXME: make this a UniqueRootValue.
     const Bindings *attrs = nullptr, *meta = nullptr;
 
     const Bindings * getMeta();

--- a/src/libexpr/include/nix/expr/get-drvs.hh
+++ b/src/libexpr/include/nix/expr/get-drvs.hh
@@ -32,7 +32,7 @@ private:
      */
     bool failed = false;
 
-    // FIXME: make this a UniqueRootValue.
+    // FIXME: make this a RootValue.
     const Bindings *attrs = nullptr, *meta = nullptr;
 
     const Bindings * getMeta();

--- a/src/libexpr/include/nix/expr/meson.build
+++ b/src/libexpr/include/nix/expr/meson.build
@@ -32,6 +32,7 @@ headers = [ config_pub_h ] + files(
   'print-options.hh',
   'print.hh',
   'repl-exit-status.hh',
+  'root-value.hh',
   'search-path.hh',
   'static-string-data.hh',
   'symbol-table.hh',

--- a/src/libexpr/include/nix/expr/root-value.hh
+++ b/src/libexpr/include/nix/expr/root-value.hh
@@ -11,7 +11,7 @@ struct Value;
 /**
  * Allocate a slot from the root value pool, i.e. a GC-visible
  * `Value *` cell that keeps the value it points to alive across
- * garbage collections. Use `UniqueRootValue`/`RootValue` rather than
+ * garbage collections. Use `RootValue`/`RootValue` rather than
  * calling this directly.
  */
 Value ** allocRootValueSlot(Value * v);
@@ -27,27 +27,27 @@ void freeRootValueSlot(Value ** slot);
  * over `RootValue` unless the handle must be copyable (e.g. when it's
  * captured in a `std::function`-backed lambda).
  */
-class UniqueRootValue
+class RootValue
 {
     Value ** slot = nullptr;
 
 public:
-    UniqueRootValue() = default;
+    RootValue() = default;
 
-    explicit UniqueRootValue(Value * v)
+    explicit RootValue(Value * v)
         : slot(allocRootValueSlot(v))
     {
     }
 
-    UniqueRootValue(const UniqueRootValue &) = delete;
-    UniqueRootValue & operator=(const UniqueRootValue &) = delete;
+    RootValue(const RootValue &) = delete;
+    RootValue & operator=(const RootValue &) = delete;
 
-    UniqueRootValue(UniqueRootValue && other) noexcept
+    RootValue(RootValue && other) noexcept
         : slot(std::exchange(other.slot, nullptr))
     {
     }
 
-    UniqueRootValue & operator=(UniqueRootValue && other) noexcept
+    RootValue & operator=(RootValue && other) noexcept
     {
         if (slot)
             freeRootValueSlot(slot);
@@ -55,7 +55,7 @@ public:
         return *this;
     }
 
-    ~UniqueRootValue()
+    ~RootValue()
     {
         if (slot)
             freeRootValueSlot(slot);

--- a/src/libexpr/include/nix/expr/root-value.hh
+++ b/src/libexpr/include/nix/expr/root-value.hh
@@ -1,0 +1,94 @@
+#pragma once
+///@file
+
+#include <memory>
+#include <utility>
+
+namespace nix {
+
+struct Value;
+
+/**
+ * Allocate a slot from the root value pool, i.e. a GC-visible
+ * `Value *` cell that keeps the value it points to alive across
+ * garbage collections. Use `UniqueRootValue`/`RootValue` rather than
+ * calling this directly.
+ */
+Value ** allocRootValueSlot(Value * v);
+
+/**
+ * Clear the given slot and return it to the root value pool.
+ */
+void freeRootValueSlot(Value ** slot);
+
+/**
+ * A move-only handle rooting a Value, i.e. keeping it and everything
+ * reachable from it alive across garbage collections. Prefer this
+ * over `RootValue` unless the handle must be copyable (e.g. when it's
+ * captured in a `std::function`-backed lambda).
+ */
+class UniqueRootValue
+{
+    Value ** slot = nullptr;
+
+public:
+    UniqueRootValue() = default;
+
+    explicit UniqueRootValue(Value * v)
+        : slot(allocRootValueSlot(v))
+    {
+    }
+
+    UniqueRootValue(const UniqueRootValue &) = delete;
+    UniqueRootValue & operator=(const UniqueRootValue &) = delete;
+
+    UniqueRootValue(UniqueRootValue && other) noexcept
+        : slot(std::exchange(other.slot, nullptr))
+    {
+    }
+
+    UniqueRootValue & operator=(UniqueRootValue && other) noexcept
+    {
+        if (slot)
+            freeRootValueSlot(slot);
+        slot = std::exchange(other.slot, nullptr);
+        return *this;
+    }
+
+    ~UniqueRootValue()
+    {
+        if (slot)
+            freeRootValueSlot(slot);
+    }
+
+    /**
+     * Release the slot, i.e. stop rooting the value.
+     */
+    void reset()
+    {
+        if (slot) {
+            freeRootValueSlot(slot);
+            slot = nullptr;
+        }
+    }
+
+    Value *& operator*() const
+    {
+        return *slot;
+    }
+
+    explicit operator bool() const
+    {
+        return slot != nullptr;
+    }
+};
+
+/**
+ * A copyable, shared handle rooting a Value. Only use this instead of
+ * `UniqueRootValue` if the handle must be copyable.
+ */
+typedef std::shared_ptr<Value *> RootValue;
+
+RootValue allocRootValue(Value * v);
+
+} // namespace nix

--- a/src/libexpr/include/nix/expr/root-value.hh
+++ b/src/libexpr/include/nix/expr/root-value.hh
@@ -83,12 +83,4 @@ public:
     }
 };
 
-/**
- * A copyable, shared handle rooting a Value. Only use this instead of
- * `UniqueRootValue` if the handle must be copyable.
- */
-typedef std::shared_ptr<Value *> RootValue;
-
-RootValue allocRootValue(Value * v);
-
 } // namespace nix

--- a/src/libexpr/include/nix/expr/root-value.hh
+++ b/src/libexpr/include/nix/expr/root-value.hh
@@ -9,19 +9,6 @@ namespace nix {
 struct Value;
 
 /**
- * Allocate a slot from the root value pool, i.e. a GC-visible
- * `Value *` cell that keeps the value it points to alive across
- * garbage collections. Use `RootValue`/`RootValue` rather than
- * calling this directly.
- */
-Value ** allocRootValueSlot(Value * v);
-
-/**
- * Clear the given slot and return it to the root value pool.
- */
-void freeRootValueSlot(Value ** slot);
-
-/**
  * A move-only handle rooting a Value, i.e. keeping it and everything
  * reachable from it alive across garbage collections. Prefer this
  * over `RootValue` unless the handle must be copyable (e.g. when it's
@@ -31,13 +18,21 @@ class RootValue
 {
     Value ** slot = nullptr;
 
+    /**
+     * Clear the given slot and return it to the root value pool.
+     */
+    void freeRootValueSlot();
+
 public:
     RootValue() = default;
 
-    explicit RootValue(Value * v)
-        : slot(allocRootValueSlot(v))
-    {
-    }
+    /**
+     * Allocate a slot from the root value pool, i.e. a GC-visible
+     * `Value *` cell that keeps the value it points to alive across
+     * garbage collections. Use `RootValue`/`RootValue` rather than
+     * calling this directly.
+     */
+    explicit RootValue(Value * v);
 
     RootValue(const RootValue &) = delete;
     RootValue & operator=(const RootValue &) = delete;
@@ -50,15 +45,14 @@ public:
     RootValue & operator=(RootValue && other) noexcept
     {
         if (slot)
-            freeRootValueSlot(slot);
+            freeRootValueSlot();
         slot = std::exchange(other.slot, nullptr);
         return *this;
     }
 
     ~RootValue()
     {
-        if (slot)
-            freeRootValueSlot(slot);
+        reset();
     }
 
     /**
@@ -66,10 +60,8 @@ public:
      */
     void reset()
     {
-        if (slot) {
-            freeRootValueSlot(slot);
-            slot = nullptr;
-        }
+        if (slot)
+            freeRootValueSlot();
     }
 
     Value *& operator*() const

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -9,6 +9,7 @@
 #include <memory_resource>
 #include <exception>
 #include <span>
+#include <utility>
 #include <string_view>
 #include <type_traits>
 #include <concepts>
@@ -1575,13 +1576,6 @@ typedef boost::unordered_flat_map<
     ValueMap;
 typedef std::map<Symbol, ValueVector, std::less<Symbol>, traceable_allocator<std::pair<const Symbol, ValueVector>>>
     ValueVectorMap;
-
-/**
- * A value allocated in traceable memory.
- */
-typedef std::shared_ptr<Value *> RootValue;
-
-RootValue allocRootValue(Value * v);
 
 void forceNoNullByte(std::string_view s, std::function<Pos()> = nullptr);
 } // namespace nix

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -19,7 +19,7 @@ class JSONSax : nlohmann::json_sax<json>
     {
     protected:
         std::unique_ptr<JSONState> parent;
-        UniqueRootValue v;
+        RootValue v;
     public:
         virtual std::unique_ptr<JSONState> resolve(EvalState &)
         {
@@ -32,7 +32,7 @@ class JSONSax : nlohmann::json_sax<json>
         }
 
         explicit JSONState(Value * v)
-            : v(UniqueRootValue(v))
+            : v(RootValue(v))
         {
         }
 
@@ -41,7 +41,7 @@ class JSONSax : nlohmann::json_sax<json>
         Value & value(EvalState & state)
         {
             if (!v)
-                v = UniqueRootValue(state.allocValue());
+                v = RootValue(state.allocValue());
             return **v;
         }
 

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -19,7 +19,7 @@ class JSONSax : nlohmann::json_sax<json>
     {
     protected:
         std::unique_ptr<JSONState> parent;
-        RootValue v;
+        UniqueRootValue v;
     public:
         virtual std::unique_ptr<JSONState> resolve(EvalState &)
         {
@@ -32,7 +32,7 @@ class JSONSax : nlohmann::json_sax<json>
         }
 
         explicit JSONState(Value * v)
-            : v(allocRootValue(v))
+            : v(UniqueRootValue(v))
         {
         }
 
@@ -41,7 +41,7 @@ class JSONSax : nlohmann::json_sax<json>
         Value & value(EvalState & state)
         {
             if (!v)
-                v = allocRootValue(state.allocValue());
+                v = UniqueRootValue(state.allocValue());
             return **v;
         }
 
@@ -66,7 +66,7 @@ class JSONSax : nlohmann::json_sax<json>
 
         void add() override
         {
-            v = nullptr;
+            v.reset();
         }
     public:
         void key(string_t & name, EvalState & state)
@@ -92,7 +92,7 @@ class JSONSax : nlohmann::json_sax<json>
         void add() override
         {
             values.push_back(*v);
-            v = nullptr;
+            v.reset();
         }
     public:
         JSONListState(std::unique_ptr<JSONState> && p, std::size_t reserve)

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -173,6 +173,7 @@ sources = files(
   'primops.cc',
   'print-ambiguous.cc',
   'print.cc',
+  'root-value.cc',
   'search-path.cc',
   'value-to-json.cc',
   'value-to-xml.cc',

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -785,9 +785,9 @@ struct CompareValues
 
 static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
-    /* The values are rooted via UniqueRootValue, so the lists themselves
+    /* The values are rooted via RootValue, so the lists themselves
        don't need to be visible to the GC. */
-    using ValueList = std::list<UniqueRootValue>;
+    using ValueList = std::list<RootValue>;
 
     state.forceAttrs(*args[0], noPos, "while evaluating the first argument passed to builtins.genericClosure");
 
@@ -802,7 +802,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
 
     ValueList workSet;
     for (auto elem : startSet->value->listView())
-        workSet.push_back(UniqueRootValue(elem));
+        workSet.push_back(RootValue(elem));
 
     if (startSet->value->listSize() == 0) {
         v = *startSet->value;
@@ -868,7 +868,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
             }
             throw;
         }
-        res.push_back(UniqueRootValue(e));
+        res.push_back(RootValue(e));
 
         /* Call the `operator' function with `e' as argument. */
         Value newElements;
@@ -883,7 +883,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
             for (auto elem : newElements.listView()) {
                 state.forceValue(*elem, noPos); // "while evaluating one one of the elements returned by the `operator`
                                                 // passed to builtins.genericClosure");
-                workSet.push_back(UniqueRootValue(elem));
+                workSet.push_back(RootValue(elem));
             }
         } catch (Error & err) {
             err.addTrace(

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -783,10 +783,12 @@ struct CompareValues
     }
 };
 
-typedef std::list<Value *, gc_allocator<Value *>> ValueList;
-
 static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
+    /* The values are rooted via UniqueRootValue, so the lists themselves
+       don't need to be visible to the GC. */
+    using ValueList = std::list<UniqueRootValue>;
+
     state.forceAttrs(*args[0], noPos, "while evaluating the first argument passed to builtins.genericClosure");
 
     /* Get the start set. */
@@ -800,7 +802,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
 
     ValueList workSet;
     for (auto elem : startSet->value->listView())
-        workSet.push_back(elem);
+        workSet.push_back(UniqueRootValue(elem));
 
     if (startSet->value->listSize() == 0) {
         v = *startSet->value;
@@ -821,7 +823,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
     auto cmp = CompareValues(state, noPos, "");
     std::map<Value *, Value *, decltype(cmp)> keyToElem(cmp);
     while (!workSet.empty()) {
-        Value * e = *(workSet.begin());
+        Value * e = **workSet.begin();
         workSet.pop_front();
 
         try {
@@ -866,7 +868,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
             }
             throw;
         }
-        res.push_back(e);
+        res.push_back(UniqueRootValue(e));
 
         /* Call the `operator' function with `e' as argument. */
         Value newElements;
@@ -881,7 +883,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
             for (auto elem : newElements.listView()) {
                 state.forceValue(*elem, noPos); // "while evaluating one one of the elements returned by the `operator`
                                                 // passed to builtins.genericClosure");
-                workSet.push_back(elem);
+                workSet.push_back(UniqueRootValue(elem));
             }
         } catch (Error & err) {
             err.addTrace(
@@ -896,7 +898,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
     /* Create the result list. */
     auto list = state.buildList(res.size());
     for (const auto & [n, i] : enumerate(res))
-        list[n] = i;
+        list[n] = *i;
     v.mkList(list);
 }
 

--- a/src/libexpr/root-value.cc
+++ b/src/libexpr/root-value.cc
@@ -78,9 +78,4 @@ void freeRootValueSlot(Value ** slot)
 #endif
 }
 
-RootValue allocRootValue(Value * v)
-{
-    return RootValue(allocRootValueSlot(v), freeRootValueSlot);
-}
-
 } // namespace nix

--- a/src/libexpr/root-value.cc
+++ b/src/libexpr/root-value.cc
@@ -2,43 +2,63 @@
 #include "nix/expr/eval-gc.hh"
 #include "nix/util/sync.hh"
 
-#include <vector>
-
 namespace nix {
 
 #if NIX_USE_BOEHMGC
-/* The pool of root value slots. Slots are carved out of uncollectable
-   slabs, which are permanently part of the GC root set, and recycled
-   through this free list. This avoids doing a GC_MALLOC_UNCOLLECTABLE()
-   / GC_FREE() pair per root value, which requires taking the global GC
-   allocation lock — a significant source of contention during parallel
-   evaluation. Never destroyed since root values held by statics may be
-   released after us during shutdown. */
-static auto & rootValuePool = *new Sync<std::vector<Value **>>;
+
+namespace {
+/**
+ * A root value slot: either in use (rooting a value) or on the
+ * freelist. Slots are carved out of uncollectable slabs, which are
+ * permanently part of the GC root set. This avoids doing a
+ * GC_MALLOC_UNCOLLECTABLE() / GC_FREE() pair per root value, which
+ * requires taking the global GC allocation lock — a significant
+ * source of contention during parallel evaluation.
+ *
+ * GC safety: the slabs are conservatively scanned. In-use slots
+ * contain a `Value *`, which roots the value. Free slots contain a
+ * pointer to the next free slot (or null), i.e. a pointer into a
+ * slab, which is scanned harmlessly since slabs are never freed
+ * anyway.
+ */
+union Slot
+{
+    Value * value;
+    Slot * nextFree;
+};
+
+static_assert(sizeof(Slot) == sizeof(Value *));
+} // namespace
+
+/* Head of the freelist of slots. Never destroyed since root values
+   held by statics may be released after us during shutdown. */
+static auto & freeSlots = *new Sync<Slot *>{nullptr};
+
 #endif
 
 Value ** allocRootValueSlot(Value * v)
 {
 #if NIX_USE_BOEHMGC
-    Value ** slot;
+    Slot * slot;
     {
-        auto pool(rootValuePool.lock());
-        if (pool->empty()) {
+        auto head(freeSlots.lock());
+        if (!*head) {
             constexpr size_t slabSize = 4096;
-            auto slab = (Value **) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Value *));
+            auto slab = (Slot *) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Slot));
             if (!slab)
                 throw std::bad_alloc();
-            pool->reserve(slabSize);
-            for (size_t i = 0; i < slabSize; ++i)
-                pool->push_back(slab + i);
+            for (size_t i = 0; i + 1 < slabSize; ++i)
+                slab[i].nextFree = &slab[i + 1];
+            slab[slabSize - 1].nextFree = nullptr;
+            *head = slab;
         }
-        slot = pool->back();
-        pool->pop_back();
+        slot = *head;
+        *head = slot->nextFree;
     }
 
-    *slot = v;
+    slot->value = v;
 
-    return slot;
+    return &slot->value;
 #else
     return new Value *(v);
 #endif
@@ -47,9 +67,12 @@ Value ** allocRootValueSlot(Value * v)
 void freeRootValueSlot(Value ** slot)
 {
 #if NIX_USE_BOEHMGC
-    /* Clear the slot so it doesn't keep the value alive. */
-    *slot = nullptr;
-    rootValuePool.lock()->push_back(slot);
+    /* Note: writing `nextFree` overwrites the `Value *`, so this also
+       stops the slot from keeping the value alive. */
+    auto s = reinterpret_cast<Slot *>(slot);
+    auto head(freeSlots.lock());
+    s->nextFree = *head;
+    *head = s;
 #else
     delete slot;
 #endif

--- a/src/libexpr/root-value.cc
+++ b/src/libexpr/root-value.cc
@@ -1,0 +1,63 @@
+#include "nix/expr/root-value.hh"
+#include "nix/expr/eval-gc.hh"
+#include "nix/util/sync.hh"
+
+#include <vector>
+
+namespace nix {
+
+#if NIX_USE_BOEHMGC
+/* The pool of root value slots. Slots are carved out of uncollectable
+   slabs, which are permanently part of the GC root set, and recycled
+   through this free list. This avoids doing a GC_MALLOC_UNCOLLECTABLE()
+   / GC_FREE() pair per root value, which requires taking the global GC
+   allocation lock — a significant source of contention during parallel
+   evaluation. Never destroyed since root values held by statics may be
+   released after us during shutdown. */
+static auto & rootValuePool = *new Sync<std::vector<Value **>>;
+#endif
+
+Value ** allocRootValueSlot(Value * v)
+{
+#if NIX_USE_BOEHMGC
+    Value ** slot;
+    {
+        auto pool(rootValuePool.lock());
+        if (pool->empty()) {
+            constexpr size_t slabSize = 4096;
+            auto slab = (Value **) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Value *));
+            if (!slab)
+                throw std::bad_alloc();
+            pool->reserve(slabSize);
+            for (size_t i = 0; i < slabSize; ++i)
+                pool->push_back(slab + i);
+        }
+        slot = pool->back();
+        pool->pop_back();
+    }
+
+    *slot = v;
+
+    return slot;
+#else
+    return new Value *(v);
+#endif
+}
+
+void freeRootValueSlot(Value ** slot)
+{
+#if NIX_USE_BOEHMGC
+    /* Clear the slot so it doesn't keep the value alive. */
+    *slot = nullptr;
+    rootValuePool.lock()->push_back(slot);
+#else
+    delete slot;
+#endif
+}
+
+RootValue allocRootValue(Value * v)
+{
+    return RootValue(allocRootValueSlot(v), freeRootValueSlot);
+}
+
+} // namespace nix

--- a/src/libexpr/root-value.cc
+++ b/src/libexpr/root-value.cc
@@ -36,7 +36,7 @@ static auto & freeSlots = *new Sync<Slot *>{nullptr};
 
 #endif
 
-Value ** allocRootValueSlot(Value * v)
+RootValue::RootValue(Value * v)
 {
 #if NIX_USE_BOEHMGC
     Slot * slot;
@@ -58,13 +58,13 @@ Value ** allocRootValueSlot(Value * v)
 
     slot->value = v;
 
-    return &slot->value;
+    this->slot = &slot->value;
 #else
-    return new Value *(v);
+    this->slot = new Value *(v);
 #endif
 }
 
-void freeRootValueSlot(Value ** slot)
+void RootValue::freeRootValueSlot()
 {
 #if NIX_USE_BOEHMGC
     /* Note: writing `nextFree` overwrites the `Value *`, so this also
@@ -76,6 +76,7 @@ void freeRootValueSlot(Value ** slot)
 #else
     delete slot;
 #endif
+    slot = nullptr;
 }
 
 } // namespace nix

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -974,7 +974,7 @@ void callFlake(EvalState & state, const LockedFlake & lockedFlake, Value & vRes)
     auto vFetchFinalTree = get(state.internalPrimOps, "fetchFinalTree");
     assert(vFetchFinalTree);
 
-    Value * args[] = {vLocks, &vOverrides, *vFetchFinalTree};
+    Value * args[] = {vLocks, &vOverrides, **vFetchFinalTree};
     state.callFunction(*vCallFlake, args, vRes, noPos);
 }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Taken from https://github.com/DeterminateSystems/nix-src/pull/546. This is mostly useful for parallel eval but may also improve single-threaded eval slightly by avoiding a lot of `std::shared_ptr` allocations and calls to `traceable_allocator` (23.60s -> 23.49s on `nix search nixpkgs fizzbuzz --no-eval-cache`).

`RootValue`s were expensive for parallel eval, since each `RootValue` caused a Boehm GC call to allocate traceable-but-uncollectable memory while holding the global GC root. We now allocate slabs of uncollectable memory from which the `RootValue`s are allocated. 

Also, `RootValue` is not a `std::shared_ptr` anymore but a pointer directly into the `traceable_allocator` slab, so that saves a heap allocation per root value.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
