### PR TITLE
Once again follow final symlinks in GitRepoImpl::getAccessor

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1474,13 +1474,15 @@ ref<SourceAccessor> GitRepoImpl::getAccessor(
     const WorkdirInfo & wd, const GitAccessorOptions & options, MakeNotAllowedError makeNotAllowedError)
 {
     auto self = ref<GitRepoImpl>(shared_from_this());
-    ref<SourceAccessor> fileAccessor = AllowListSourceAccessor::create(
-                                           makeFSSourceAccessor(path),
-                                           /*allowedPrefixes=*/wd.files,
-                                           // Always allow access to the root, but not its children.
-                                           /*allowedPaths=*/{CanonPath::root},
-                                           std::move(makeNotAllowedError))
-                                           .cast<SourceAccessor>();
+    ref<SourceAccessor> fileAccessor =
+        AllowListSourceAccessor::create(
+            // Follow the final symlink to the repo. Older nix versions used to do this (maybe somewhat accidentally).
+            makeFSSourceAccessor(path, /*trackLastModified=*/false, FinalSymlink::Follow),
+            /*allowedPrefixes=*/wd.files,
+            // Always allow access to the root, but not its children.
+            /*allowedPaths=*/{CanonPath::root},
+            std::move(makeNotAllowedError))
+            .cast<SourceAccessor>();
     if (options.exportIgnore)
         fileAccessor = make_ref<GitExportIgnoreSourceAccessor>(self, fileAccessor, std::nullopt);
     return fileAccessor;

--- a/tests/functional/git/meson.build
+++ b/tests/functional/git/meson.build
@@ -1,6 +1,9 @@
 suites += {
   'name' : 'git',
   'deps' : [],
-  'tests' : [ 'packed-refs-no-cache.sh' ],
+  'tests' : [
+    'packed-refs-no-cache.sh',
+    'symlinked-repo.sh',
+  ],
   'workdir' : meson.current_source_dir(),
 }

--- a/tests/functional/git/symlinked-repo.sh
+++ b/tests/functional/git/symlinked-repo.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+source ../common.sh
+
+requireGit
+
+repo=$TEST_ROOT/repo
+link=$TEST_ROOT/link
+
+createGitRepo "$repo"
+ln -s "$repo" "$link"
+
+# Dereferencing final symlink component should work and follow it to the directory.
+# Also test various cases of symlink trickery in case that ever changes.
+for path in {repo,link}{,/,/.} {repo,link}/.././repo{,/,/.}; do
+    [ "$(nix-instantiate --eval --expr "builtins.readFileType (builtins.fetchTree \"git+file://$TEST_ROOT/$path\").outPath")" == '"directory"' ]
+done


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This used to be the case before 02e4f4ad75fda707a594ffd8ad511691fc1a311f, and this restores that compatibility. Ideally we'd check that access to that path is allowed, but libfetchers does this now pretty inconsistently.

Also test a lot more things.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
