### PR TITLE
libutil: Don't trample parent's havePrivateMountNs in restoreMountNam…

### DIFF
--- a/src/libutil/linux/linux-namespaces.cc
+++ b/src/libutil/linux/linux-namespaces.cc
@@ -161,12 +161,25 @@ void remountReadOnlyWritable(const std::filesystem::path & path)
         throw SysError("remounting %s writable", PathFmt(path));
 }
 
+/* This code runs in a (possibly) vfork-ed child, so technically everything you see below is beyond
+   broken because vfork()-ed child:
+
+   * Must not trample parent's memory in any way shape or form. That includes (but not limited to)
+     * Throwing any exceptions (because that would unwind into the parent stack frame and do who knows what).
+     * Modify any state - obviously that includes global state.
+     * Not allocate any memory, since that can also lead to a deadlock if some thread in the (now stopped) parent
+       holds a lock while we are running. That's because *all* of the parent tasks are suspended for the duration
+       of the vfork.
+
+   As it stands now, this code should be considered incredibly fragile and slated for a complete rework.
+   */
 void restoreMountNamespace()
 {
     if (!havePrivateMountNs)
         return;
 
     try {
+        /* FIXME: Allocation in a possibly vforked child. */
         auto savedCwd = std::filesystem::current_path();
 
         if (setns(fdSavedMountNamespace.get(), CLONE_NEWNS) == -1)
@@ -182,7 +195,8 @@ void restoreMountNamespace()
         if (chdir(savedCwd.c_str()) == -1)
             throw SysError("restoring cwd");
 
-        havePrivateMountNs = false;
+        /* Do not reset havePrivateMountNs! This code can run in a vfork-ed child and we absolutely
+           must not trample any of the parent's state. */
     } catch (Error & e) {
         debug(e.msg());
     }


### PR DESCRIPTION
…espace

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is only a band-aid, see the comment for the explanation why the current code sucks in an indescribable way.

A much better solution would be to get rid of `vfork()` entirely (or pay the incredible cost of making it safe for each libc we target) by replacing that with a zygote process. That's a huge change though, so let's cross our fingers and pray that this sucky code won't lead to a security issue (in the time it takes to ship a proper solution).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

I filed https://github.com/NixOS/nix/issues/16119 describing the current clusterfuck.
See https://hydra.nixos.org/build/337104501/log for the reproducer. The child was modifying parent's state.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
