### PR TITLE
libutil: Fix Config::toKeyValue, make libutil-tests less noisy

### DIFF
--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -4,47 +4,10 @@
 #include "nix/expr/eval-settings.hh"
 #include "nix/util/memory-source-accessor.hh"
 
+#include "nix/util/tests/capture-logging.hh"
 #include "nix/expr/tests/libexpr.hh"
 
 namespace nix {
-class CaptureLogger : public Logger
-{
-    std::ostringstream oss;
-
-public:
-    CaptureLogger() {}
-
-    std::string get() const
-    {
-        return oss.str();
-    }
-
-    void log(Verbosity lvl, std::string_view s) override
-    {
-        oss << s << std::endl;
-    }
-
-    void logEI(const ErrorInfo & ei) override
-    {
-        showErrorInfo(oss, ei, loggerSettings.showTrace.get());
-    }
-};
-
-class CaptureLogging
-{
-    Logger * oldLogger;
-public:
-    CaptureLogging()
-    {
-        oldLogger = logger;
-        logger = new CaptureLogger();
-    }
-
-    ~CaptureLogging()
-    {
-        logger = oldLogger;
-    }
-};
 
 // Testing eval of PrimOp's
 class PrimOpTest : public LibExprTest
@@ -141,11 +104,10 @@ TEST_F(PrimOpTest, deepSeq)
 
 TEST_F(PrimOpTest, trace)
 {
-    CaptureLogging l;
+    testing::CaptureLogging l;
     auto v = eval("builtins.trace \"test string 123\" 123");
     ASSERT_THAT(v, IsIntEq(123));
-    auto text = (dynamic_cast<CaptureLogger *>(logger))->get();
-    ASSERT_NE(text.find("test string 123"), std::string::npos);
+    ASSERT_THAT(l.get(), ::testing::HasSubstr("test string 123"));
 }
 
 TEST_F(PrimOpTest, placeholder)

--- a/src/libutil-test-support/include/nix/util/tests/capture-logging.hh
+++ b/src/libutil-test-support/include/nix/util/tests/capture-logging.hh
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "nix/util/logging.hh"
+
+#include <sstream>
+
+namespace nix::testing {
+
+class CaptureLogger : public Logger
+{
+    std::ostringstream oss;
+
+public:
+    CaptureLogger() {}
+
+    std::string get() const
+    {
+        return oss.str();
+    }
+
+    void log(Verbosity lvl, std::string_view s) override
+    {
+        oss << s << std::endl;
+    }
+
+    void logEI(const ErrorInfo & ei) override
+    {
+        showErrorInfo(oss, ei, loggerSettings.showTrace.get());
+    }
+};
+
+class CaptureLogging
+{
+    std::unique_ptr<CaptureLogger> logger;
+    Logger * oldLogger;
+
+public:
+    CaptureLogging()
+    {
+        oldLogger = nix::logger;
+        logger = std::make_unique<CaptureLogger>();
+        nix::logger = logger.get();
+    }
+
+    std::string get() const
+    {
+        return logger->get();
+    }
+
+    CaptureLogging(CaptureLogging &&) = delete;
+    CaptureLogging(const CaptureLogging &) = delete;
+    CaptureLogging & operator=(CaptureLogging &&) = delete;
+    CaptureLogging & operator=(const CaptureLogging &) = delete;
+
+    ~CaptureLogging()
+    {
+        nix::logger = oldLogger;
+    }
+};
+
+} // namespace nix::testing

--- a/src/libutil-test-support/include/nix/util/tests/meson.build
+++ b/src/libutil-test-support/include/nix/util/tests/meson.build
@@ -3,6 +3,7 @@
 include_dirs = [ include_directories('../../..') ]
 
 headers = files(
+  'capture-logging.hh',
   'characterization.hh',
   'gmock-matchers.hh',
   'gtest-with-params.hh',

--- a/src/libutil-tests/compression.cc
+++ b/src/libutil-tests/compression.cc
@@ -29,8 +29,9 @@ TEST_P(CompressionDecompressionTest, roundtrip)
 TEST_P(CompressionDecompressionTest, empty)
 {
     auto compressed = compress(GetParam(), "");
-    if (GetParam() != CompressionAlgo::none)
+    if (GetParam() != CompressionAlgo::none) {
         ASSERT_FALSE(compressed.empty());
+    }
     auto o = decompress(GetParam(), compressed);
     ASSERT_EQ(o, "");
 }

--- a/src/libutil-tests/config.cc
+++ b/src/libutil-tests/config.cc
@@ -325,4 +325,12 @@ TEST(Config, applyConfigInvalidThrows)
     ASSERT_THROW(config.applyConfig("value == key"), UsageError);
     ASSERT_THROW(config.applyConfig("value "), UsageError);
 }
+
+TEST(Config, toKeyValue)
+{
+    Config config;
+    Setting<std::string> foo{&config, "default", "name-of-the-setting", "description", {"alias-of-the-setting"}};
+    ASSERT_EQ(config.toKeyValue(), "name-of-the-setting = default\n");
+}
+
 } // namespace nix

--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -1,9 +1,12 @@
 #include "nix/util/url.hh"
+#include "nix/util/tests/capture-logging.hh"
 #include "nix/util/tests/gmock-matchers.hh"
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
 #include <ranges>
+#include <optional>
 
 namespace nix {
 
@@ -25,7 +28,19 @@ std::ostream & operator<<(std::ostream & os, const FixGitURLParam & param)
 }
 
 class FixGitURLTestSuite : public ::testing::TestWithParam<FixGitURLParam>
-{};
+{
+    std::optional<testing::CaptureLogging> captureLogging;
+
+    void SetUp() override
+    {
+        captureLogging.emplace();
+    }
+
+    void TearDown() override
+    {
+        captureLogging.reset();
+    }
+};
 
 INSTANTIATE_TEST_SUITE_P(
     FixGitURLs,
@@ -366,7 +381,7 @@ TEST_P(FixGitURLTestSuite, parsedNormalized)
     EXPECT_EQ(actual.to_string(), p.expected);
 }
 
-TEST(FixGitURLTestSuite, rejectFileURLWithAuthority)
+TEST_F(FixGitURLTestSuite, rejectFileURLWithAuthority)
 {
     /* From the underlying `parseURL` validations. */
     EXPECT_THAT(
@@ -375,7 +390,7 @@ TEST(FixGitURLTestSuite, rejectFileURLWithAuthority)
             testing::HasSubstrIgnoreANSIMatcher("file:// URL 'file://var/repos/x' has unexpected authority 'var'")));
 }
 
-TEST(FixGitURLTestSuite, rejectRelativePath)
+TEST_F(FixGitURLTestSuite, rejectRelativePath)
 {
     /* From the underlying `parseURL` validations. */
     EXPECT_THAT(
@@ -383,7 +398,7 @@ TEST(FixGitURLTestSuite, rejectRelativePath)
         ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("doesn't have a scheme")));
 }
 
-TEST(FixGitURLTestSuite, rejectEmptyPathGitScp)
+TEST_F(FixGitURLTestSuite, rejectEmptyPathGitScp)
 {
     /* Reject SCP-style URLs with no path component. */
     EXPECT_THAT(
@@ -392,7 +407,7 @@ TEST(FixGitURLTestSuite, rejectEmptyPathGitScp)
             testing::HasSubstrIgnoreANSIMatcher("SCP-style Git URL 'host:' has an empty path")));
 }
 
-TEST(FixGitURLTestSuite, rejectMalformedBracketedURLs)
+TEST_F(FixGitURLTestSuite, rejectMalformedBracketedURLs)
 {
     /* Brackets not in host position go through the colon-based path,
        consistent with git (which also finds the first colon). These
@@ -418,7 +433,7 @@ TEST(FixGitURLTestSuite, rejectMalformedBracketedURLs)
     EXPECT_EQ(parsed3.authority->user, "user:");
 }
 
-TEST(FixGitURLTestSuite, mismatchedBrackets)
+TEST_F(FixGitURLTestSuite, mismatchedBrackets)
 {
     /* Missing `]`: git's `host_end()` falls back to `end = host` and
        finds the first `:` as separator. We do the same — fall through
@@ -454,7 +469,7 @@ TEST(FixGitURLTestSuite, mismatchedBrackets)
         ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("is not a valid IPv6 address")));
 }
 
-TEST(FixGitURLTestSuite, slashBeforeColonIsNotScp)
+TEST_F(FixGitURLTestSuite, slashBeforeColonIsNotScp)
 {
     /* A slash before the first colon means it's not SCP — consistent
        with git's `url_is_local_not_ssh()`. */
@@ -463,7 +478,7 @@ TEST(FixGitURLTestSuite, slashBeforeColonIsNotScp)
         ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("doesn't have a scheme")));
 }
 
-TEST(FixGitURLTestSuite, noColonIsNotScp)
+TEST_F(FixGitURLTestSuite, noColonIsNotScp)
 {
     /* No `:` at all means not SCP — consistent with git's
        `url_is_local_not_ssh()` in `connect.c`.
@@ -479,7 +494,7 @@ TEST(FixGitURLTestSuite, noColonIsNotScp)
         ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("is not a valid URL")));
 }
 
-TEST(FixGitURLTestSuite, gitBugDiscardedCharsBetweenBracketAndColon)
+TEST_F(FixGitURLTestSuite, gitBugDiscardedCharsBetweenBracketAndColon)
 {
     /* Git's `host_end()` returns `end` past `]`, then `strchr(end, ':')`
        finds `:` anywhere after — silently discarding characters between

--- a/src/libutil/configuration.cc
+++ b/src/libutil/configuration.cc
@@ -216,7 +216,7 @@ std::string Config::toKeyValue()
 {
     std::string res;
     for (const auto & s : _settings)
-        if (s.second.isAlias)
+        if (!s.second.isAlias)
             res += fmt("%s = %s\n", s.first, s.second.setting->to_string());
     return res;
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fixes a bug in the `Config::toKeyValue` introduced in 450e5ec6185e2e1102e67ec7a348a0dc8955692d (not really used for now though). Also cleans up CaptureLogging machinery slightly by moving it into libutil-test-support, since it's useful in more places. Also makes url tests not barf to stderr and capture the warnings instead (ideally those would be tested too).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
