### PR TITLE
Fix incorrect skipping of derivations with nix flake check

### DIFF
--- a/doc/manual/rl-next/fix-flake-check-remote-store.md
+++ b/doc/manual/rl-next/fix-flake-check-remote-store.md
@@ -1,0 +1,16 @@
+---
+synopsis: "`nix flake check --store` no longer silently skips checks the store cannot recognise"
+prs: [16125]
+---
+
+Since 2.32, `nix flake check` skips derivations whose outputs are already
+valid or substitutable in the target store. When the target store was not
+the eval store (e.g. `--store ssh-ng://builder --eval-store auto`), the
+freshly evaluated `.drv` files were never copied to the target store, so it
+classified every check as "unknown" — and unknown derivations were silently
+skipped. As a result, `nix flake check --store <store>` reported "all checks
+passed" without building anything, including checks that would have failed.
+
+Now, derivations whose outputs the store cannot determine are built rather
+than skipped, and the derivation closures are copied to the target store
+first (as `nix build` already did).

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -822,10 +822,27 @@ struct CmdFlakeCheck : FlakeCommand, MixPrintOutPaths, MixOutLinkBase
                     });
             }
 
+            /* Derivations whose outputs the store could not determine —
+               typically because the store is remote and does not have the
+               freshly evaluated .drv files yet — cannot be assumed
+               substitutable, so they must be built rather than skipped. */
+            for (auto & path : missing.unknown) {
+                if (path.isDerivation()) {
+                    toBuild.emplace_back(
+                        DerivedPath::Built{
+                            .drvPath = makeConstantStorePathRef(path),
+                            .outputs = OutputsSpec::All{},
+                        });
+                }
+            }
+
             Activity act(*logger, lvlInfo, actUnknown, fmt("running %d flake checks", toBuild.size()));
 
             // once we get rid of the temporary hack above, this tenary operator will also go away
-            results = store->buildPathsWithResults((printOutputPaths || outLink) ? drvPaths : toBuild);
+            /* Pass the eval store so that the .drv closures are copied to
+               the build store if they are not already there. */
+            results = store->buildPathsWithResults(
+                (printOutputPaths || outLink) ? drvPaths : toBuild, bmNormal, getEvalStore());
 
             // Report build failures with attribute paths
             for (auto & result : results) {

--- a/tests/functional/flakes/check-store.sh
+++ b/tests/functional/flakes/check-store.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+# Regression test: `nix flake check --store <dest> --eval-store <eval>` must
+# build the checks even though the destination store has never seen the
+# freshly evaluated .drv files. queryMissing classifies such derivations as
+# "unknown"; they used to be silently skipped, so a failing check "passed"
+# without anything being built.
+
+requireSandboxSupport
+requiresUnprivilegedUserNamespaces
+[[ "${busybox-}" =~ busybox ]] || skipTest "no busybox"
+
+# Diverted stores need the logical store dir to not live inside the sandbox
+# build dir (see build-remote.sh); every invocation below passes an explicit
+# --store / --eval-store instead.
+unset NIX_STORE_DIR
+
+flakeDir=$TEST_ROOT/flake-check-store
+evalStore=$TEST_ROOT/check-store-eval
+mkdir -p "$flakeDir"
+
+checkStore() {
+    local destStore=$1
+    local destStoreLocal=$2
+
+    cat > "$flakeDir"/flake.nix <<EOF
+{
+  outputs = { self }: {
+    checks.$system.failing = derivation {
+      name = "failing-check";
+      system = "$system";
+      builder = "$busybox";
+      args = [ "sh" "-e" (builtins.toFile "builder.sh" "echo the failing check ran; exit 1") ];
+    };
+  };
+}
+EOF
+
+    # shellcheck disable=SC2015
+    checkRes=$(nix flake check --store "$destStore" --eval-store "$evalStore" "$flakeDir" 2>&1 \
+        && fail "nix flake check with a failing check should have failed against store $destStore" || true)
+    echo "$checkRes" | grepQuiet "failing-check"
+
+    cat > "$flakeDir"/flake.nix <<EOF
+{
+  outputs = { self }: {
+    checks.$system.passing = derivation {
+      name = "passing-check";
+      system = "$system";
+      builder = "$busybox";
+      args = [ "sh" "-e" (builtins.toFile "builder.sh" "echo ok > \$out") ];
+    };
+  };
+}
+EOF
+
+    nix flake check --store "$destStore" --eval-store "$evalStore" "$flakeDir"
+
+    # The check must have actually been built in the destination store.
+    outPath=$(nix eval --store "$evalStore" --raw "$flakeDir#checks.$system.passing.outPath")
+    nix path-info --store "$destStoreLocal" "$outPath"
+    grepQuiet ok "$destStoreLocal/$outPath"
+}
+
+# Once against a local diverted store...
+checkStore "$TEST_ROOT/check-store-dest" "$TEST_ROOT/check-store-dest"
+
+# ...and once over the worker protocol (ssh-ng://localhost bypasses ssh and
+# talks to a `nix daemon --stdio` child, testing RemoteStore::queryMissing
+# and RemoteStore::buildPathsWithResults with an eval store).
+checkStore "ssh-ng://localhost?remote-store=$TEST_ROOT/check-store-dest-ng" "$TEST_ROOT/check-store-dest-ng"

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -13,6 +13,7 @@ suites += {
     'follow-paths.sh',
     'bundle.sh',
     'check.sh',
+    'check-store.sh',
     'unlocked-override.sh',
     'absolute-paths.sh',
     'absolute-attr-paths.sh',


### PR DESCRIPTION
## Motivation

A not-uncommon pattern in continuous integration is to have a local store for evaluation, but a remote store for builds (like `--eval-store auto --store ssh-ng://my-remote-builder.com`. This can avoid a lot of back-and-forth I/O vs remote builders because remote builders receive input and output closures over the wire, whilst remote stores only receive derivations over the wire. There's a description of this use case
[here](http://docs.nixbuild.net/remote-builds/).

Unfortunately, this is currently bugged, by some logic which attempts to skip flake checks that don't need to be computed. Roughly, the logic at present asks the remote whether paths exist, and then skips derivations where they are. The problem is that it assumes that the derivations are already present, and if they are not, the remote returns 'unknown'. This is then ignored. So, all flake checks will be skipped when the local eval, remote build pattern is used.

I used agentic AI for this pull request and have manually reviewed its output. I am confident in the changes to flake.cc, and am less personally familiar with Nix's test suite.

## Context

The change is a little bit 'hacks on hacks', as it's sitting on top of ecdda5798c0147edee01835e2be88b4415f34db8 which itself is a bit of a hack. However, it seems sensible as it's basically just more fully handling the results of that code. It's a small change, but with a full test.