### PR TITLE
packaging: Fix sqlite on mingw

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -90,6 +90,17 @@ scope: {
           ;
       };
 
+  sqlite =
+    if !stdenv.hostPlatform.isWindows then
+      pkgs.sqlite
+    else
+      pkgs.sqlite.overrideAttrs (prevAttrs: {
+        nativeBuildInputs = lib.filter (x: !(x.pname == "tcl")) prevAttrs.nativeBuildInputs or [ ];
+        configureFlags = (lib.filter (x: !(lib.hasPrefix "--with-tcl" x)) prevAttrs.configureFlags) ++ [
+          "--disable-tcl"
+        ];
+      });
+
   libgit2 =
     if lib.versionAtLeast pkgs.libgit2.version "1.9.4" then
       pkgs.libgit2


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

tcl is broken on mingw in nixpkgs and so is sqlite. This makes it build now at least.
`hydraJobs.buildCross.nix-everything.x86_64-w64-mingw32.x86_64-linux` builds with this change.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
