### PR TITLE
Make multi-call self-exec work with single file static installations

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -391,7 +391,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         auto packFilesPath = std::filesystem::path(git_repository_path(repo.get())) / "objects/pack";
 
         Indexer indexer;
-        if (git_indexer_new(Setter(indexer), packFilesPath.c_str(), 0, nullptr, nullptr))
+        if (git_indexer_new(Setter(indexer), packFilesPath.string().c_str(), 0, nullptr, nullptr))
             throw GitError("creating git packfile indexer");
 
         struct State

--- a/src/libutil/include/nix/util/processes.hh
+++ b/src/libutil/include/nix/util/processes.hh
@@ -123,6 +123,7 @@ struct RunOptions
     bool lookupPath = true;
     OsStrings args;
 #ifndef _WIN32
+    std::optional<std::string> argv0;
     std::optional<uid_t> uid;
     std::optional<uid_t> gid;
 #endif

--- a/src/libutil/linux/processes.cc
+++ b/src/libutil/linux/processes.cc
@@ -249,7 +249,9 @@ void runProgram2(const RunOptions & options)
 
     /* Prepare arguments and environment for the child. */
     Strings args_(options.args);
-    args_.push_front(options.program.native());
+    /* Allow the caller to specify an alternative argv[0]. Useful for self-exec
+       trickery. */
+    args_.push_front(options.argv0.value_or(options.program.native()));
     const Strings env_ = options.environment ? prepareEnvironmentStrings(*options.environment) : Strings{};
     const auto env = stringsToCharPtrs(env_);
     const auto args = stringsToCharPtrs(args_);

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -336,7 +336,9 @@ void runProgram2(const RunOptions & options)
                 throw SysError("setuid failed");
 
             Strings args_(options.args);
-            args_.push_front(options.program.native());
+            /* Allow the caller to specify an alternative argv[0]. Useful for self-exec
+               trickery. */
+            args_.push_front(options.argv0.value_or(options.program.native()));
 
             restoreProcessContext();
 

--- a/src/nix/nix-channel/nix-channel.cc
+++ b/src/nix/nix-channel/nix-channel.cc
@@ -78,9 +78,8 @@ static void removeChannel(const std::string & name)
     channels.erase(name);
     writeChannels();
 
-    runProgram(
-        getNixBin("nix-env"),
-        true,
+    runNixBin(
+        "nix-env",
         {
             OS_STR("--profile"),
             profile.native(),
@@ -140,9 +139,8 @@ static void update(const StringSet & channelNames)
 
             bool unpacked = false;
             if (std::regex_search(std::string{result.storePath.to_string()}, std::regex("\\.tar\\.(gz|bz2|xz)$"))) {
-                runProgram(
-                    getNixBin("nix-build"),
-                    false,
+                runNixBin(
+                    "nix-build",
                     {
                         OS_STR("--no-out-link"),
                         OS_STR("--expr"),
@@ -184,7 +182,7 @@ static void update(const StringSet & channelNames)
     for (auto & expr : exprs)
         envArgs.push_back(string_to_os_string(std::move(expr)));
     envArgs.push_back(OS_STR("--quiet"));
-    runProgram(getNixBin("nix-env"), false, envArgs);
+    runNixBin("nix-env", envArgs);
 
     // Make the channels appear in nix-env.
     PosixStat st;
@@ -278,9 +276,8 @@ static int main_nix_channel(int argc, char ** argv)
         case cListGenerations:
             if (!args.empty())
                 throw UsageError("'--list-generations' expects no arguments");
-            std::cout << runProgram(
-                getNixBin("nix-env"),
-                false,
+            std::cout << runNixBin(
+                "nix-env",
                 {
                     OS_STR("--profile"),
                     profile.native(),
@@ -297,7 +294,7 @@ static int main_nix_channel(int argc, char ** argv)
             } else {
                 envArgs.push_back(OS_STR("--rollback"));
             }
-            runProgram(getNixBin("nix-env"), false, envArgs);
+            runNixBin("nix-env", envArgs);
             break;
         }
 

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -5,7 +5,6 @@
 #include "nix/cmd/installable-value.hh"
 #include "nix/cmd/repl.hh"
 #include "nix/util/os-string.hh"
-#include "nix/util/processes.hh"
 #include "nix/util/environment-variables.hh"
 #include "self-exe.hh"
 
@@ -14,17 +13,11 @@ namespace nix {
 void runNix(const std::string & program, OsStrings args)
 {
     auto subprocessEnv = getEnvOs();
+    /* TODO: Maybe we should pass only overridden settings? */
     subprocessEnv[OS_STR("NIX_CONFIG")] = string_to_os_string(globalConfig.toKeyValue());
+    /* FIXME: What about NIX_REMOTE? */
     // isInteractive avoid grabling interactive commands
-    runProgram2(
-        RunOptions{
-            .program = getNixBin(program).string(),
-            .args = std::move(args),
-            .environment = subprocessEnv,
-            .isInteractive = true,
-        });
-
-    return;
+    runNixBin2(program, args, /*isInteractive=*/true, subprocessEnv);
 }
 
 struct CmdRepl : RawInstallablesCommand

--- a/src/nix/self-exe.cc
+++ b/src/nix/self-exe.cc
@@ -1,5 +1,7 @@
 #include "nix/util/current-process.hh"
 #include "nix/util/environment-variables.hh"
+#include "nix/util/processes.hh"
+#include "nix/util/serialise.hh"
 
 #include "self-exe.hh"
 #include "cli-config-private.hh"
@@ -33,6 +35,65 @@ std::filesystem::path getNixBin(std::optional<std::string_view> binaryNameOpt)
 
     // return just the name, hoping the exe is on the `PATH`
     return getBinaryName();
+}
+
+void runNixBin2(
+    std::optional<std::string_view> binaryNameOpt,
+    const OsStrings & args,
+    bool isInteractive,
+    std::optional<OsStringMap> environment,
+    Sink * standardOut)
+{
+    /* This is what will end up being passed as argv[0] to the multi-call
+       executable.
+
+       Note that the currently running executable might be a single relocatable
+       static binary, without the accompanying `nix-` symlinks located under the
+       same directory.
+
+       But we can bypass this restriction, since argv[0] is supplied by the parent
+       process before execve. */
+    auto binaryName = std::string(binaryNameOpt.value_or("nix"));
+
+    /* TODO: Figure out whether it's possible to do argv[0]-style trickery on windows proper. */
+#ifndef _WIN32
+    std::optional<std::filesystem::path> selfProgramPath;
+
+#  if defined(__linux__) || defined(__CYGWIN__) || defined(__gnu_hurd__)
+    /* When /proc/self/exe is available, execute it directly. */
+    selfProgramPath = "/proc/self/exe";
+#  else
+    selfProgramPath = getSelfExe();
+#  endif
+
+    /* Intentionally don't do any sort of static guessing (i.e. looking up the compile-time NIX_BIN_DIR etc.). */
+    if (!selfProgramPath)
+        throw Error("can't figure out the path to current executable to exec oneself");
+
+    try {
+        runProgram2(
+            RunOptions{
+                .program = *selfProgramPath,
+                .lookupPath = false,
+                .args = args,
+                .argv0 = binaryName,
+                .environment = std::move(environment),
+                .standardOut = standardOut,
+                .isInteractive = isInteractive,
+            });
+    } catch (ExecError & e) {
+        throw ExecError(e.status, "'%1%' %2%", binaryName, statusToString(e.status));
+    }
+#else
+    throw UnimplementedError("self-exec is not implemented on Windows");
+#endif
+}
+
+std::string runNixBin(std::optional<std::string_view> binaryNameOpt, const OsStrings & args)
+{
+    StringSink sink;
+    runNixBin2(binaryNameOpt, args, /*isInteractive=*/false, /*environment=*/std::nullopt, &sink);
+    return std::move(sink.s);
 }
 
 } // namespace nix

--- a/src/nix/self-exe.hh
+++ b/src/nix/self-exe.hh
@@ -1,11 +1,15 @@
 #pragma once
 ///@file
 
+#include "nix/util/os-string.hh"
+
 #include <filesystem>
 #include <optional>
 #include <string_view>
 
 namespace nix {
+
+struct Sink;
 
 /**
  * Get a path to the given Nix binary.
@@ -29,5 +33,26 @@ namespace nix {
  * current binary name.
  */
 std::filesystem::path getNixBin(std::optional<std::string_view> binary_name = {});
+
+/**
+ * Execute oneself with a given argv[0].
+ *
+ * Note that unlike getNixBin we don't need to figure out an actual location
+ * on disk where the binary resides (at least on systems with /proc/self/exe).
+ * The executed binary can even be unlinked from the filesystem and this would
+ * still work.
+ *
+ * This also has the benefit of being able to run multicall binary commands
+ * (like nix2-style nix-) without needing the symlinks being located anywhere on
+ * the filesystem. We just spoof the argv[0] before execv-ing the current binary.
+ */
+void runNixBin2(
+    std::optional<std::string_view> binaryNameOpt,
+    const OsStrings & args,
+    bool isInteractive = false,
+    std::optional<OsStringMap> environment = std::nullopt,
+    Sink * standardOut = nullptr);
+
+std::string runNixBin(std::optional<std::string_view> binaryNameOpt, const OsStrings & args);
 
 } // namespace nix

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -136,9 +136,8 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
                 fmt("installing '%s' into profile %s...", store->printStorePath(storePath), PathFmt(profileDir)));
 
             // FIXME: don't call an external process.
-            runProgram(
-                getNixBin("nix-env"),
-                false,
+            runNixBin(
+                "nix-env",
                 {
                     OS_STR("--profile"),
                     profileDir.native(),


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Some things (notably the repl and a bit of other commands) need the ability to re-exec the nix binary with a specified argv[0] (like with `nix-env` etc.). This works now by looking up the symlink location in the directory of the `nix` binary - but it's fragile since we also want a single binary nix installation to work.

Instead we can specify the expected argv[0] before execing. We can also execute `/proc/self/exe` directly instead of reading the magic link.

This might open the door to having more internal exec-helpers for internal needs - like having the daemon re-exec itself for each connection to provide fresh ASLR entropy for each worker.

The refactor is also valuable by itself, since we have quite a few places that benefit from the deduplication.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

This makes stuff like `nix repl` and subsequent commands like `:u hello` (enters a nix-shell) work by just copying a single static nix executable. This is pretty valueable IMO.
It can also harmonise our self-exec tricks for internal helpers and the like.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
