### PR TITLE
Make NIX_COUNT_CALLS thread-safe and fix `attributes` 

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -320,6 +320,10 @@ EvalState::EvalState(
     , baseEnv(mem.allocEnv(BASE_ENV_SIZE))
 #endif
     , staticBaseEnv{std::make_shared<StaticEnv>(nullptr, nullptr)}
+    , countCalls(getEnv("NIX_COUNT_CALLS").value_or("0") != "0")
+    , primOpCalls(make_ref<decltype(primOpCalls)::element_type>())
+    , functionCalls(make_ref<decltype(functionCalls)::element_type>())
+    , attrSelects(make_ref<decltype(attrSelects)::element_type>())
 {
 #ifndef _WIN32
     static std::once_flag stackSizeBumped;
@@ -334,8 +338,6 @@ EvalState::EvalState(
 
     corepkgsFS->setPathDisplay("<nix", ">");
     internalFS->setPathDisplay("«nix-internal»", "");
-
-    countCalls = getEnv("NIX_COUNT_CALLS").value_or("0") != "0";
 
     static_assert(sizeof(Env) <= 16, "environment must be <= 16 bytes");
 
@@ -938,7 +940,7 @@ void Value::mkPath(const SourcePath & path, EvalMemory & mem)
         forceAttrs(*env->values[0], fromWith->pos, "while evaluating the first subexpression of a with expression");
         if (auto j = env->values[0]->attrs()->get(var.name)) {
             if (countCalls) [[unlikely]]
-                attrSelects[j->pos]++;
+                attrSelects->try_emplace_or_visit(j->pos, 1, [](auto & i) { i.second++; });
             return j->value;
         }
         if (!fromWith->parentWith) [[unlikely]]
@@ -1481,7 +1483,7 @@ void ExprSelect::eval(EvalState & state, Env & env, Value & v)
             vAttrs = j->value;
             pos2 = j->pos;
             if (state.countCalls)
-                state.attrSelects[pos2]++;
+                state.attrSelects->try_emplace_or_visit(pos2, 1, [](auto & i) { i.second++; });
         }
 
         state.forceValue(*vAttrs, (pos2 ? pos2 : this->pos));
@@ -1693,7 +1695,7 @@ void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes,
 
                 nrPrimOpCalls++;
                 if (countCalls)
-                    primOpCalls[fn->name]++;
+                    primOpCalls->try_emplace_or_visit(fn->name, 1, [](auto & i) { i.second++; });
 
                 try {
                     fn->impl(*this, vCur.determinePos(noPos), args.data(), vCur);
@@ -1738,7 +1740,7 @@ void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes,
                 auto fn = primOp->primOp();
                 nrPrimOpCalls++;
                 if (countCalls)
-                    primOpCalls[fn->name]++;
+                    primOpCalls->try_emplace_or_visit(fn->name, 1, [](auto & i) { i.second++; });
 
                 try {
                     // TODO:
@@ -1809,7 +1811,7 @@ void ExprCall::eval(EvalState & state, Env & env, Value & v)
 // prevents tail-call optimisation.
 void EvalState::incrFunctionCall(ExprLambda * fun)
 {
-    functionCalls[fun]++;
+    functionCalls->try_emplace_or_visit(fun, 1, [](auto & i) { i.second++; });
 }
 
 void EvalState::autoCallFunction(const Bindings & args, Value & fun, Value & res)
@@ -3136,11 +3138,16 @@ void EvalState::printStatistics()
 #endif
 
     if (countCalls) {
-        topObj["primops"] = primOpCalls;
+        {
+            auto & obj = topObj["primops"];
+            obj = json::object();
+            primOpCalls->visit_all([&](auto & i) { obj[i.first] = i.second; });
+        }
         {
             auto & list = topObj["functions"];
             list = json::array();
-            for (auto & [fun, count] : functionCalls) {
+            functionCalls->visit_all([&](auto & i) {
+                auto & [fun, count] = i;
                 json obj = json::object();
                 if (fun->name)
                     obj["name"] = (std::string_view) symbols[fun->name];
@@ -3154,12 +3161,12 @@ void EvalState::printStatistics()
                 }
                 obj["count"] = count;
                 list.push_back(obj);
-            }
+            });
         }
         {
-            auto list = topObj["attributes"];
+            auto & list = topObj["attributes"];
             list = json::array();
-            for (auto & i : attrSelects) {
+            attrSelects->visit_all([&](auto & i) {
                 json obj = json::object();
                 if (auto pos = positions[i.first]) {
                     if (auto path = std::get_if<SourcePath>(&pos.origin))
@@ -3169,7 +3176,7 @@ void EvalState::printStatistics()
                 }
                 obj["count"] = i.second;
                 list.push_back(obj);
-            }
+            });
         }
     }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -3154,7 +3154,7 @@ void EvalState::printStatistics()
         {
             auto & list = topObj["attributes"];
             list = json::array();
-            attrSelects->visit_all([&](auto & i) {
+            attrSelects->cvisit_all([&](auto & i) {
                 json obj = json::object();
                 if (auto pos = positions[i.first]) {
                     if (auto path = std::get_if<SourcePath>(&pos.origin))

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -329,6 +329,10 @@ EvalState::EvalState(
     , baseEnv(mem.allocEnv(BASE_ENV_SIZE))
 #endif
     , staticBaseEnv{std::make_shared<StaticEnv>(nullptr, nullptr)}
+    , countCalls(getEnv("NIX_COUNT_CALLS").value_or("0") != "0")
+    , primOpCalls(make_ref<decltype(primOpCalls)::element_type>())
+    , functionCalls(make_ref<decltype(functionCalls)::element_type>())
+    , attrSelects(make_ref<decltype(attrSelects)::element_type>())
 {
 #ifndef _WIN32
     static std::once_flag stackSizeBumped;
@@ -343,8 +347,6 @@ EvalState::EvalState(
 
     corepkgsFS->setPathDisplay("<nix", ">");
     internalFS->setPathDisplay("«nix-internal»", "");
-
-    countCalls = getEnv("NIX_COUNT_CALLS").value_or("0") != "0";
 
     static_assert(sizeof(Env) <= 16, "environment must be <= 16 bytes");
 
@@ -947,7 +949,7 @@ void Value::mkPath(const SourcePath & path, EvalMemory & mem)
         forceAttrs(*env->values[0], fromWith->pos, "while evaluating the first subexpression of a with expression");
         if (auto j = env->values[0]->attrs()->get(var.name)) {
             if (countCalls) [[unlikely]]
-                attrSelects[j->pos]++;
+                attrSelects->try_emplace_or_visit(j->pos, 1, [](auto & i) { i.second++; });
             return j->value;
         }
         if (!fromWith->parentWith) [[unlikely]]
@@ -1490,7 +1492,7 @@ void ExprSelect::eval(EvalState & state, Env & env, Value & v)
             vAttrs = j->value;
             pos2 = j->pos;
             if (state.countCalls)
-                state.attrSelects[pos2]++;
+                state.attrSelects->try_emplace_or_visit(pos2, 1, [](auto & i) { i.second++; });
         }
 
         state.forceValue(*vAttrs, (pos2 ? pos2 : this->pos));
@@ -1702,7 +1704,7 @@ void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value &
 
                 nrPrimOpCalls++;
                 if (countCalls)
-                    primOpCalls[fn->name]++;
+                    primOpCalls->try_emplace_or_visit(fn->name, 1, [](auto & i) { i.second++; });
 
                 try {
                     fn->impl(*this, CallSite{pos}, args.data(), vCur);
@@ -1747,7 +1749,7 @@ void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value &
                 auto fn = primOp->primOp();
                 nrPrimOpCalls++;
                 if (countCalls)
-                    primOpCalls[fn->name]++;
+                    primOpCalls->try_emplace_or_visit(fn->name, 1, [](auto & i) { i.second++; });
 
                 try {
                     // TODO:
@@ -1816,7 +1818,7 @@ void ExprCall::eval(EvalState & state, Env & env, Value & v)
 // prevents tail-call optimisation.
 void EvalState::incrFunctionCall(ExprLambda * fun)
 {
-    functionCalls[fun]++;
+    functionCalls->try_emplace_or_visit(fun, 1, [](auto & i) { i.second++; });
 }
 
 void EvalState::autoCallFunction(const Bindings & args, Value & fun, Value & res)
@@ -3124,11 +3126,16 @@ void EvalState::printStatistics()
 #endif
 
     if (countCalls) {
-        topObj["primops"] = primOpCalls;
+        {
+            auto & obj = topObj["primops"];
+            obj = json::object();
+            primOpCalls->visit_all([&](auto & i) { obj[i.first] = i.second; });
+        }
         {
             auto & list = topObj["functions"];
             list = json::array();
-            for (auto & [fun, count] : functionCalls) {
+            functionCalls->visit_all([&](auto & i) {
+                auto & [fun, count] = i;
                 json obj = json::object();
                 if (fun->name)
                     obj["name"] = (std::string_view) symbols[fun->name];
@@ -3142,12 +3149,12 @@ void EvalState::printStatistics()
                 }
                 obj["count"] = count;
                 list.push_back(obj);
-            }
+            });
         }
         {
-            auto list = topObj["attributes"];
+            auto & list = topObj["attributes"];
             list = json::array();
-            for (auto & i : attrSelects) {
+            attrSelects->visit_all([&](auto & i) {
                 json obj = json::object();
                 if (auto pos = positions[i.first]) {
                     if (auto path = std::get_if<SourcePath>(&pos.origin))
@@ -3157,7 +3164,7 @@ void EvalState::printStatistics()
                 }
                 obj["count"] = i.second;
                 list.push_back(obj);
-            }
+            });
         }
     }
 

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -1109,21 +1109,21 @@ private:
     Counter nrPrimOpCalls;
     Counter nrFunctionCalls;
 
-    bool countCalls;
+    const bool countCalls;
 
-    typedef boost::unordered_flat_map<std::string, size_t, StringViewHash, std::equal_to<>> PrimOpCalls;
-    PrimOpCalls primOpCalls;
+    typedef boost::concurrent_flat_map<std::string, size_t, StringViewHash, std::equal_to<>> PrimOpCalls;
+    const ref<PrimOpCalls> primOpCalls;
 
-    typedef boost::unordered_flat_map<ExprLambda *, size_t> FunctionCalls;
-    FunctionCalls functionCalls;
+    typedef boost::concurrent_flat_map<ExprLambda *, size_t> FunctionCalls;
+    const ref<FunctionCalls> functionCalls;
 
     /** Evaluation/call profiler. */
     MultiEvalProfiler profiler;
 
     void incrFunctionCall(ExprLambda * fun);
 
-    typedef boost::unordered_flat_map<PosIdx, size_t, std::hash<PosIdx>> AttrSelects;
-    AttrSelects attrSelects;
+    typedef boost::concurrent_flat_map<PosIdx, size_t, std::hash<PosIdx>> AttrSelects;
+    const ref<AttrSelects> attrSelects;
 
     friend struct ExprOpUpdate;
     friend struct ExprOpConcatLists;

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -1174,21 +1174,21 @@ private:
     Counter nrPrimOpCalls;
     Counter nrFunctionCalls;
 
-    bool countCalls;
+    const bool countCalls;
 
-    typedef boost::unordered_flat_map<std::string, size_t, StringViewHash, std::equal_to<>> PrimOpCalls;
-    PrimOpCalls primOpCalls;
+    typedef boost::concurrent_flat_map<std::string, size_t, StringViewHash, std::equal_to<>> PrimOpCalls;
+    const ref<PrimOpCalls> primOpCalls;
 
-    typedef boost::unordered_flat_map<ExprLambda *, size_t> FunctionCalls;
-    FunctionCalls functionCalls;
+    typedef boost::concurrent_flat_map<ExprLambda *, size_t> FunctionCalls;
+    const ref<FunctionCalls> functionCalls;
 
     /** Evaluation/call profiler. */
     MultiEvalProfiler profiler;
 
     void incrFunctionCall(ExprLambda * fun);
 
-    typedef boost::unordered_flat_map<PosIdx, size_t, std::hash<PosIdx>> AttrSelects;
-    AttrSelects attrSelects;
+    typedef boost::concurrent_flat_map<PosIdx, size_t, std::hash<PosIdx>> AttrSelects;
+    const ref<AttrSelects> attrSelects;
 
     friend struct ExprOpUpdate;
     friend struct ExprOpConcatLists;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3133,7 +3133,7 @@ void prim_getAttr(EvalState & state, const PosIdx pos, Value ** args, Value & v)
     auto i = state.getAttr(state.symbols.create(attr), args[1]->attrs(), "in the attribute set under consideration");
     // !!! add to stack trace?
     if (state.countCalls && i->pos)
-        state.attrSelects[i->pos]++;
+        state.attrSelects->try_emplace_or_visit(i->pos, 1, [](auto & j) { j.second++; });
     state.forceValue(*i->value, pos);
     v = *i->value;
 }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3178,7 +3178,7 @@ void prim_getAttr(EvalState & state, CallSite callSite, Value * const * args, Va
     auto i = state.getAttr(state.symbols.create(attr), args[1]->attrs(), "in the attribute set under consideration");
     // !!! add to stack trace?
     if (state.countCalls && i->pos)
-        state.attrSelects[i->pos]++;
+        state.attrSelects->try_emplace_or_visit(i->pos, 1, [](auto & j) { j.second++; });
     state.forceValue(*i->value, noPos);
     v = *i->value;
 }


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This makes the `NIX_COUNT_CALLS` data structures thread-safe, which is necessary to make them work when parallel eval is enabled.

While working on this, the bot noticed that the `attributes` output of `NIX_COUNT_CALLS` was broken, i.e. it always showed up as null.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
