### PR TITLE
fix: libexpr: Don't silently terminate on failure in mkFailed

### DIFF
--- a/nix-meson-build-support/common/clang-tidy/.clang-tidy
+++ b/nix-meson-build-support/common/clang-tidy/.clang-tidy
@@ -55,10 +55,6 @@ Checks:
   - -bugprone-nondeterministic-pointer-iteration-order
   # 9 warnings - intentional std::bit_cast/memcpy on Value* arrays (evaluator hot path)
   - -bugprone-bitwise-pointer-cast
-  # 1 warning (header) - value.hh mkFailed: GC alloc in noexcept. Boehm's
-  # gc_cleanup::operator new isn't marked noexcept but aborts on OOM rather
-  # than throws; std::terminate here is the intended behavior anyway.
-  - -bugprone-unhandled-exception-at-new
   # 1 warning (header) - fmt.hh Magenta<T>::operator<<: generic colorizer
   # template; fires when T=unsigned char but that instantiation is correct.
   - -bugprone-unintended-char-ostream-output

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -4,6 +4,8 @@
 #include <bit>
 #include <cassert>
 #include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <memory_resource>
@@ -1427,7 +1429,40 @@ public:
 
     inline void mkFailed(std::exception_ptr e, Value * recovery) noexcept
     {
-        setStorage(new Value::Failed(e, recovery));
+        try {
+            setStorage(new Value::Failed(e, recovery));
+        } catch (...) {
+            /* Most likely a std::bad_alloc from the GC heap.
+               This is called while handling an evaluation error,
+               and recording that failure is itself what just failed,
+               so there is no way to recover.
+               Report and bail out, using only static strings to avoid touching the heap again. */
+            std::fputs("error: failed to record an evaluation error", stderr);
+            try {
+                throw;
+            } catch (const std::exception & allocEx) {
+                std::fputs(": ", stderr);
+                std::fputs(allocEx.what(), stderr);
+            } catch (...) {
+            }
+            std::fputc('\n', stderr);
+
+            /* Best effort: show the evaluation error that was being recorded.
+               Formatting it (e.g. BaseError::what) may itself allocate and terminate on failure,
+               hence printing the message above first. */
+            try {
+                std::rethrow_exception(e);
+            } catch (const std::exception & evalEx) {
+                std::fputs("the evaluation error was: ", stderr);
+                std::fputs(evalEx.what(), stderr);
+                std::fputc('\n', stderr);
+            } catch (...) {
+                std::fputs("the evaluation error was of an unknown type\n", stderr);
+            }
+
+            // Abort not exception but function.
+            std::abort();
+        }
     }
 
     bool isList() const noexcept

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -17,6 +17,7 @@
 
 #include "nix/expr/eval-gc.hh"
 #include "nix/expr/value/context.hh"
+#include "nix/util/error.hh"
 #include "nix/util/source-path.hh"
 #include "nix/expr/print-options.hh"
 #include "nix/util/checked-arithmetic.hh"
@@ -1432,36 +1433,32 @@ public:
         try {
             setStorage(new Value::Failed(e, recovery));
         } catch (...) {
-            /* Most likely a std::bad_alloc from the GC heap.
+            /* Most likely a `std::bad_alloc` from the GC heap.
                This is called while handling an evaluation error,
                and recording that failure is itself what just failed,
                so there is no way to recover.
-               Report and bail out, using only static strings to avoid touching the heap again. */
-            std::fputs("error: failed to record an evaluation error", stderr);
-            try {
-                throw;
-            } catch (const std::exception & allocEx) {
-                std::fputs(": ", stderr);
-                std::fputs(allocEx.what(), stderr);
-            } catch (...) {
-            }
-            std::fputc('\n', stderr);
 
-            /* Best effort: show the evaluation error that was being recorded.
-               Formatting it (e.g. BaseError::what) may itself allocate and terminate on failure,
-               hence printing the message above first. */
+               Static context first: formatting the evaluation error below
+               (e.g. `BaseError::what`) may itself allocate and terminate. */
+            std::fputs("\nerror: allocation failed while recording an evaluation error\n", stderr);
+
+            /* This is a best-effort attempt,
+               because `BaseError::what` may allocate and terminate. */
             try {
                 std::rethrow_exception(e);
             } catch (const std::exception & evalEx) {
                 std::fputs("the evaluation error was: ", stderr);
-                std::fputs(evalEx.what(), stderr);
+                std::fputs(evalEx.what(), stderr); // may allocate
                 std::fputc('\n', stderr);
             } catch (...) {
                 std::fputs("the evaluation error was of an unknown type\n", stderr);
             }
 
-            // Abort not exception but function.
-            std::abort();
+            /* `panic()` writes without touching the heap,
+               and the `std::terminate()` it calls reports
+               the allocation failure still active in this catch block,
+               along with a stack trace. */
+            panic("failed to record an evaluation error");
         }
     }
 


### PR DESCRIPTION
`mkFailed` is `noexcept`,
but the `Value::Failed` allocation inside it can actually throw:
it allocates on the Boehm GC heap,
and our OOM handler (`GC_set_oom_fn`) converts allocation failure into `std::bad_alloc`,
contrary to the old comment in `.clang-tidy`,
which claimed Boehm aborts rather than throws.
When that happened,
the exception hit the `noexcept` boundary and the process died in `std::terminate`,
with no indication of what went wrong or which evaluation error was being recorded,
which made the actual cause of such failures very hard to diagnose.

Instead,
catch everything inside `mkFailed`,
print a diagnostic to stderr and abort.
The error path uses only `fputs` with static strings,
since the heap is exactly what just failed.
Printing the original evaluation error is best-effort,
because formatting it with functions like `BaseError::what` may itself allocate;
the static message is printed first so that at least the context is never lost.

Since `mkFailed` no longer lets an exception escape a `new` expression,
this also fixes the only `bugprone-unhandled-exception-at-new` warning in the codebase,
so re-enable that check in `.clang-tidy`.

ref https://github.com/NixOS/nix/issues/16023

Assisted-by: claude-fable-5
