### PR TITLE
filetransfer: rewrite gs:// to HTTPS and attach GCP bearer token

### DIFF
--- a/src/libstore-tests/filetransfer-request.cc
+++ b/src/libstore-tests/filetransfer-request.cc
@@ -1,8 +1,19 @@
 #include <gtest/gtest.h>
 
 #include "nix/store/filetransfer.hh"
+#include "nix/store/gcp-creds.hh"
 
 namespace nix {
+
+namespace {
+std::optional<std::string> findHeader(const Headers & hs, std::string_view name)
+{
+    for (auto & [k, v] : hs)
+        if (k == name)
+            return v;
+    return std::nullopt;
+}
+} // anonymous namespace
 
 TEST(FileTransferRequest, displayUriStripsUserinfo)
 {
@@ -15,5 +26,80 @@ TEST(FileTransferRequest, displayUriStripsUserinfo)
     FileTransferRequest plain(VerbatimURL{std::string{"https://example.org/file"}});
     EXPECT_EQ(plain.displayUri(), "https://example.org/file");
 }
+
+#if NIX_WITH_GCS_AUTH
+namespace {
+struct FixedTokenProvider : GcpCredentialProvider
+{
+    std::optional<GcpCredentials> result;
+
+    std::optional<GcpCredentials> maybeGetCredentials() override
+    {
+        return result;
+    }
+
+    std::optional<GcpCredentials> tryRefreshCredentials(FileTransfer &) noexcept override
+    {
+        return result;
+    }
+};
+} // anonymous namespace
+#endif
+
+/**
+ * Requests only authenticate through an attached provider.
+ * These tests never touch the network or host ADC files.
+ */
+class FileTransferRequestGCS : public ::testing::Test
+{
+protected:
+#if NIX_WITH_GCS_AUTH
+    ref<FixedTokenProvider> stub = make_ref<FixedTokenProvider>();
+
+    void attach(FileTransferRequest & req)
+    {
+        req.gcpCredentialProvider = stub.get_ptr();
+    }
+#endif
+};
+
+TEST_F(FileTransferRequestGCS, rewritesUrlAndUserProject)
+{
+    FileTransferRequest req(VerbatimURL{std::string{"gs://my-bucket/nar/abc.nar.xz?user-project=billing"}});
+    req.setupForGCS();
+
+    EXPECT_EQ(req.uri.to_string(), "https://storage.googleapis.com/my-bucket/nar/abc.nar.xz");
+    EXPECT_EQ(findHeader(req.headers, "x-goog-user-project"), std::optional<std::string>{"billing"});
+}
+
+#if NIX_WITH_GCS_AUTH
+
+TEST_F(FileTransferRequestGCS, usesProviderToken)
+{
+    stub->result = GcpCredentials{.accessToken = "provider-token", .expiresAt = {}};
+
+    FileTransferRequest req(VerbatimURL{std::string{"gs://b/k"}});
+    attach(req);
+    req.setupForGCS();
+
+    EXPECT_EQ(req.bearerToken, std::optional<std::string>{"provider-token"});
+    ASSERT_TRUE(req.refreshBearerToken);
+
+    stub->result = GcpCredentials{.accessToken = "refreshed-token", .expiresAt = {}};
+    EXPECT_EQ(req.refreshBearerToken(), std::optional<std::string>{"refreshed-token"});
+}
+
+TEST_F(FileTransferRequestGCS, anonymousWhenNoCredentials)
+{
+    stub->result = std::nullopt;
+
+    FileTransferRequest req(VerbatimURL{std::string{"gs://b/k"}});
+    attach(req);
+    req.setupForGCS();
+
+    EXPECT_FALSE(req.bearerToken.has_value());
+}
+
+#endif
 
 } // namespace nix

--- a/src/libstore-tests/gcp-creds.cc
+++ b/src/libstore-tests/gcp-creds.cc
@@ -1,0 +1,201 @@
+#include "nix/store/gcp-creds.hh"
+
+#if NIX_WITH_GCS_AUTH
+
+#  include "nix/util/base-n.hh"
+#  include "nix/util/environment-variables.hh"
+#  include "nix/util/file-system.hh"
+
+#  include <gtest/gtest.h>
+#  include <nlohmann/json.hpp>
+#  include <openssl/evp.h>
+#  include <openssl/pem.h>
+
+namespace nix {
+
+namespace {
+
+/** Reverse of `gcp_detail::base64url` for inspecting JWT segments in tests. */
+std::string base64urlDecode(std::string s)
+{
+    for (auto & c : s) {
+        if (c == '-')
+            c = '+';
+        else if (c == '_')
+            c = '/';
+    }
+    while (s.size() % 4 != 0)
+        s.push_back('=');
+    return base64::decode(s);
+}
+
+/** RAII env-var override that restores the previous value on destruction. */
+struct ScopedEnv
+{
+    std::string name;
+    std::optional<std::string> prev;
+
+    ScopedEnv(const char * name_, std::optional<std::string> value)
+        : name(name_)
+        , prev(getEnv(name_))
+    {
+        if (value)
+            setEnv(name_, value->c_str());
+        else
+            unsetenv(name_);
+    }
+
+    ~ScopedEnv()
+    {
+        if (prev)
+            setEnv(name.c_str(), prev->c_str());
+        else
+            unsetenv(name.c_str());
+    }
+};
+
+/** Generate a throwaway RSA keypair and return (private PEM, EVP_PKEY*). */
+std::pair<std::string, std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>> generateRsaKey()
+{
+    std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pkey(EVP_RSA_gen(2048), EVP_PKEY_free); // OpenSSL 3 helper
+    if (!pkey)
+        throw std::runtime_error("EVP_RSA_gen failed");
+
+    std::unique_ptr<BIO, decltype(&BIO_free)> bio(BIO_new(BIO_s_mem()), BIO_free);
+    PEM_write_bio_PrivateKey(bio.get(), pkey.get(), nullptr, nullptr, 0, nullptr, nullptr);
+    char * data = nullptr;
+    long len = BIO_get_mem_data(bio.get(), &data);
+    return {std::string(data, len), std::move(pkey)};
+}
+
+bool verifyRS256(EVP_PKEY * pkey, std::string_view payload, std::string_view sig)
+{
+    std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+    EVP_DigestVerifyInit(ctx.get(), nullptr, EVP_sha256(), nullptr, pkey);
+    EVP_DigestVerifyUpdate(ctx.get(), payload.data(), payload.size());
+    return EVP_DigestVerifyFinal(ctx.get(), reinterpret_cast<const unsigned char *>(sig.data()), sig.size()) == 1;
+}
+
+} // anonymous namespace
+
+TEST(GcpCreds, base64urlUsesUrlAlphabet)
+{
+    // 0xfb 0xff 0xfe → standard base64 "+//+"; URL alphabet swaps +/ for -_
+    // and drops padding, so we must get exactly "-__-".
+    std::byte raw[]{std::byte{0xfb}, std::byte{0xff}, std::byte{0xfe}};
+    EXPECT_EQ(gcp_detail::base64url(std::span{raw}), "-__-");
+    // Padding stripped for non-multiple-of-3 input.
+    EXPECT_EQ(gcp_detail::base64url("fo"), "Zm8");
+}
+
+TEST(GcpCreds, parseTokenResponseHappyPath)
+{
+    auto before = std::chrono::steady_clock::now();
+    auto creds =
+        gcp_detail::parseTokenResponse(R"({"access_token":"ya29.abc","expires_in":3600,"token_type":"Bearer"})");
+    auto after = std::chrono::steady_clock::now();
+
+    EXPECT_EQ(creds.accessToken, "ya29.abc");
+    // expires_in=3600 minus 225s slack ⇒ ~56 minutes from now.
+    EXPECT_GT(creds.expiresAt, before + std::chrono::minutes(55));
+    EXPECT_LT(creds.expiresAt, after + std::chrono::minutes(58));
+}
+
+TEST(GcpCreds, parseTokenResponseClampsShortExpiry)
+{
+    auto before = std::chrono::steady_clock::now();
+    auto creds = gcp_detail::parseTokenResponse(R"({"access_token":"t","expires_in":60})");
+    // 60s - 225s would be in the past; clamp to ≥30s.
+    EXPECT_GE(creds.expiresAt, before + std::chrono::seconds(30));
+    EXPECT_LT(creds.expiresAt, before + std::chrono::seconds(60));
+}
+
+TEST(GcpCreds, parseTokenResponseRejectsMissingToken)
+{
+    EXPECT_THROW(gcp_detail::parseTokenResponse(R"({"expires_in":3600})"), GcpAuthError);
+}
+
+TEST(GcpCreds, parseTokenResponseRejectsBadJson)
+{
+    EXPECT_THROW(gcp_detail::parseTokenResponse("not json"), GcpAuthError);
+}
+
+TEST(GcpCreds, buildServiceAccountJwtSigningInput)
+{
+    auto input = gcp_detail::buildServiceAccountJwtSigningInput(
+        "sa@project.iam.gserviceaccount.com", "https://oauth2.googleapis.com/token", 1000, 4600);
+
+    auto dot = input.find('.');
+    ASSERT_NE(dot, std::string::npos);
+    auto header = nlohmann::json::parse(base64urlDecode(input.substr(0, dot)));
+    auto claims = nlohmann::json::parse(base64urlDecode(input.substr(dot + 1)));
+
+    EXPECT_EQ(header["alg"], "RS256");
+    EXPECT_EQ(header["typ"], "JWT");
+    EXPECT_EQ(claims["iss"], "sa@project.iam.gserviceaccount.com");
+    EXPECT_EQ(claims["aud"], "https://oauth2.googleapis.com/token");
+    EXPECT_EQ(claims["scope"], "https://www.googleapis.com/auth/devstorage.read_write");
+    EXPECT_EQ(claims["iat"], 1000);
+    EXPECT_EQ(claims["exp"], 4600);
+}
+
+TEST(GcpCreds, signRS256RoundTrip)
+{
+    auto [pem, pkey] = generateRsaKey();
+    constexpr std::string_view payload = "header.claims";
+
+    auto sig = gcp_detail::signRS256(pem, payload);
+    EXPECT_FALSE(sig.empty());
+    EXPECT_TRUE(verifyRS256(pkey.get(), payload, sig));
+    // Tampered payload must not verify.
+    EXPECT_FALSE(verifyRS256(pkey.get(), "header.other", sig));
+}
+
+TEST(GcpCreds, signRS256RejectsBadPem)
+{
+    EXPECT_THROW(gcp_detail::signRS256("not a key", "payload"), GcpAuthError);
+}
+
+TEST(GcpCreds, findAdcFilePrefersExplicitEnv)
+{
+    ScopedEnv gac("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/creds.json");
+    ScopedEnv cdk("CLOUDSDK_CONFIG", std::nullopt);
+
+    auto found = gcp_detail::findAdcFile();
+    // The env var wins regardless of whether the file exists; the caller is
+    // responsible for surfacing a useful error if it doesn't.
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(found->string(), "/nonexistent/creds.json");
+}
+
+TEST(GcpCreds, findAdcFileFallsBackToCloudSdkConfig)
+{
+    auto tmp = createTempDir();
+    auto adc = tmp / "application_default_credentials.json";
+    writeFile(adc, "{}");
+
+    ScopedEnv gac("GOOGLE_APPLICATION_CREDENTIALS", std::nullopt);
+    ScopedEnv cdk("CLOUDSDK_CONFIG", tmp.string());
+
+    auto found = gcp_detail::findAdcFile();
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(*found, adc);
+
+    deletePath(tmp);
+}
+
+TEST(GcpCreds, findAdcFileNoneAvailable)
+{
+    auto tmp = createTempDir(); // empty dir, no ADC file inside
+
+    ScopedEnv gac("GOOGLE_APPLICATION_CREDENTIALS", std::nullopt);
+    ScopedEnv cdk("CLOUDSDK_CONFIG", tmp.string());
+
+    EXPECT_FALSE(gcp_detail::findAdcFile().has_value());
+
+    deletePath(tmp);
+}
+
+} // namespace nix
+
+#endif

--- a/src/libstore-tests/gcs-url.cc
+++ b/src/libstore-tests/gcs-url.cc
@@ -1,0 +1,111 @@
+#include "nix/store/gcs-url.hh"
+#include "nix/util/tests/gmock-matchers.hh"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace nix {
+
+struct ParsedGCSURLTestCase
+{
+    std::string url;
+    ParsedGCSURL expected;
+    std::string description;
+};
+
+class ParsedGCSURLTest : public ::testing::WithParamInterface<ParsedGCSURLTestCase>, public ::testing::Test
+{};
+
+TEST_P(ParsedGCSURLTest, parseGCSURLSuccessfully)
+{
+    const auto & testCase = GetParam();
+    auto parsed = ParsedGCSURL::parse(parseURL(testCase.url));
+    ASSERT_EQ(parsed, testCase.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    QueryParams,
+    ParsedGCSURLTest,
+    ::testing::Values(
+        ParsedGCSURLTestCase{
+            "gs://my-bucket/my-key.txt",
+            {
+                .bucket = "my-bucket",
+                .key = {"my-key.txt"},
+            },
+            "basic_gs_bucket",
+        },
+        ParsedGCSURLTestCase{
+            "gs://prod-cache/nix/store/abc123.nar.xz",
+            {
+                .bucket = "prod-cache",
+                .key = {"nix", "store", "abc123.nar.xz"},
+            },
+            "nested_key",
+        },
+        ParsedGCSURLTestCase{
+            "gs://bucket/key?user-project=proj&generation=42",
+            {
+                .bucket = "bucket",
+                .key = {"key"},
+                .userProject = "proj",
+                .generation = "42",
+            },
+            "all_params",
+        }),
+    [](const ::testing::TestParamInfo<ParsedGCSURLTestCase> & info) { return info.param.description; });
+
+struct InvalidGCSURLTestCase
+{
+    std::string url;
+    std::string expectedErrorSubstring;
+    std::string description;
+};
+
+class InvalidParsedGCSURLTest : public ::testing::WithParamInterface<InvalidGCSURLTestCase>, public ::testing::Test
+{};
+
+TEST_P(InvalidParsedGCSURLTest, parseGCSURLErrors)
+{
+    const auto & testCase = GetParam();
+
+    ASSERT_THAT(
+        [&testCase]() { ParsedGCSURL::parse(parseURL(testCase.url)); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher(testCase.expectedErrorSubstring)));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    InvalidUrls,
+    InvalidParsedGCSURLTest,
+    ::testing::Values(
+        InvalidGCSURLTestCase{"gs:///key", "error: URI has a missing or invalid bucket name", "empty_bucket"},
+        InvalidGCSURLTestCase{"gs://127.0.0.1", "error: URI has a missing or invalid bucket name", "ip_address_bucket"},
+        InvalidGCSURLTestCase{"gs://", "error: URI has a missing or invalid bucket name", "completely_empty"},
+        InvalidGCSURLTestCase{"gs://bucket", "error: URI has a missing or invalid key", "missing_key"},
+        InvalidGCSURLTestCase{"s3://bucket/key", "error: URI scheme 's3' is not 'gs'", "wrong_scheme"},
+        /* Bearer tokens are host-independent. Refusing here is the security boundary that keeps fetchurl from
+           exfiltrating one. */
+        InvalidGCSURLTestCase{
+            "gs://bucket/key?endpoint=attacker.example", "not accepted in a gs:// URL", "endpoint_in_url_rejected"},
+        InvalidGCSURLTestCase{"gs://bucket/key?scheme=http", "not accepted in a gs:// URL", "scheme_in_url_rejected"},
+        InvalidGCSURLTestCase{
+            "gs://bucket/key?user-project=p%0d%0aX-Evil:1", "invalid 'user-project' value", "user_project_crlf"},
+        InvalidGCSURLTestCase{
+            "gs://bucket/../other-bucket/key", "URI key has an invalid path segment", "dotdot_escapes_bucket"}),
+    [](const ::testing::TestParamInfo<InvalidGCSURLTestCase> & info) { return info.param.description; });
+
+TEST(ParsedGCSURL, toHttpsUrl)
+{
+    auto p = ParsedGCSURL::parse(parseURL("gs://prod-cache/nix/store/abc.nar.xz?generation=42"));
+    EXPECT_EQ(
+        p.toHttpsUrl().to_string(), "https://storage.googleapis.com/prod-cache/nix/store/abc.nar.xz?generation=42");
+}
+
+TEST(ParsedGCSURL, toHttpsUrlCustomEndpoint)
+{
+    ParsedGCSURL p{.bucket = "b", .key = {"k"}};
+    EXPECT_EQ(p.toHttpsUrl(parseURL("http://emu.internal:4443")).to_string(), "http://emu.internal:4443/b/k");
+    EXPECT_EQ(p.toHttpsUrl(parseURL("http://server:9000/prefix")).to_string(), "http://server:9000/prefix/b/k");
+}
+
+} // namespace nix

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -32,6 +32,13 @@ subdir('nix-meson-build-support/windows-version')
 sqlite = dependency('sqlite3', 'sqlite', version : '>=3.6.19')
 deps_private += sqlite
 
+# Needed by gcp-creds.cc tests (RSA keygen + signature verification). The test
+# bodies are guarded by NIX_WITH_GCS_AUTH so this is harmless when disabled.
+openssl = dependency('libcrypto', 'openssl', required : false)
+if openssl.found()
+  deps_private += openssl
+endif
+
 rapidcheck = dependency('rapidcheck')
 deps_private += rapidcheck
 
@@ -66,6 +73,7 @@ sources = files(
   'dummy-store.cc',
   'filetransfer-request.cc',
   'filetransfer-retry.cc',
+  'gcp-creds.cc',
   'gcs-url.cc',
   'http-binary-cache-store.cc',
   'legacy-ssh-store.cc',

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -66,6 +66,7 @@ sources = files(
   'dummy-store.cc',
   'filetransfer-request.cc',
   'filetransfer-retry.cc',
+  'gcs-url.cc',
   'http-binary-cache-store.cc',
   'legacy-ssh-store.cc',
   'local-binary-cache-store.cc',

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -45,6 +45,7 @@ mkMesonExecutable (finalAttrs: {
 
   buildInputs = [
     sqlite
+    openssl
     rapidcheck
     gtest
     nix-store

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -7,6 +7,8 @@
 #include "nix/util/signals.hh"
 #include "nix/util/util.hh"
 
+#include "nix/store/gcp-creds.hh"
+#include "nix/store/gcs-url.hh"
 #include "nix/store/s3-url.hh"
 #include <optional>
 #if NIX_WITH_AWS_AUTH
@@ -27,6 +29,7 @@
 #include <cstring>
 #include <queue>
 #include <random>
+#include <future>
 #include <thread>
 #include <utility>
 #include <regex>
@@ -204,6 +207,10 @@ struct curlFileTransfer : public FileTransfer
          */
         bool hasContentEncoding:1 = false;
 
+        bool bearerRefreshed:1 = false;
+
+        std::optional<std::future<std::optional<std::string>>> pendingBearerRefresh;
+
         /**
          * Server-provided minimum retry delay, parsed from the `Retry-After`
          * response header. Reset on each new HTTP status line, and consumed
@@ -275,14 +282,19 @@ struct curlFileTransfer : public FileTransfer
             })
         {
             result.urls.push_back(request.uri.to_string());
+        }
 
+        void buildRequestHeaders()
+        {
+            requestHeaders.reset();
             if (!request.expectedETag.empty())
                 appendHeaders("If-None-Match: " + request.expectedETag);
             if (!request.mimeType.empty())
                 appendHeaders("Content-Type: " + request.mimeType);
-            for (auto it = request.headers.begin(); it != request.headers.end(); ++it) {
-                appendHeaders(fmt("%s: %s", it->first, it->second));
-            }
+            for (const auto & [name, value] : request.headers)
+                appendHeaders(fmt("%s: %s", name, value));
+            if (request.bearerToken)
+                appendHeaders("Authorization: Bearer " + *request.bearerToken);
         }
 
         ~TransferItem()
@@ -584,6 +596,15 @@ struct curlFileTransfer : public FileTransfer
 
             curl_easy_reset(req);
 
+            if (pendingBearerRefresh
+                && pendingBearerRefresh->wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+                if (auto t = pendingBearerRefresh->get())
+                    request.bearerToken = std::move(t);
+                pendingBearerRefresh.reset();
+                bearerRefreshed = true;
+            }
+            buildRequestHeaders();
+
             if (verbosity >= lvlVomit) {
                 curl_easy_setopt(req, CURLOPT_VERBOSE, 1);
                 curl_easy_setopt(req, CURLOPT_DEBUGFUNCTION, TransferItem::debugCallback);
@@ -819,7 +840,9 @@ struct curlFileTransfer : public FileTransfer
                     || code == CURLE_FILE_COULDNT_READ_FILE) {
                     // The file is definitely not there
                     err = NotFound;
-                } else if (httpStatus == HttpStatus::Unauthorized || httpStatus == HttpStatus::ProxyAuthRequired) {
+                } else if (httpStatus == HttpStatus::Unauthorized) {
+                    err = (request.refreshBearerToken && !bearerRefreshed) ? Transient : Unauthorized;
+                } else if (httpStatus == HttpStatus::ProxyAuthRequired) {
                     err = Unauthorized;
                 } else if (httpStatus == HttpStatus::Forbidden) {
                     // Don't retry on authentication/authorization failures.
@@ -939,8 +962,30 @@ struct curlFileTransfer : public FileTransfer
             }();
 
             if (!canRetry) {
+                if (httpStatus == HttpStatus::Unauthorized && exc.error == Transient)
+                    exc.error = Unauthorized;
                 fail(std::move(exc));
                 return;
+            }
+
+            if (httpStatus != HttpStatus::Unauthorized)
+                bearerRefreshed = false;
+            else if (request.refreshBearerToken && !bearerRefreshed && !pendingBearerRefresh) {
+                try {
+                    auto promise = std::make_shared<std::promise<std::optional<std::string>>>();
+                    std::thread([refresh = request.refreshBearerToken, promise]() noexcept {
+                        try {
+                            promise->set_value(refresh());
+                        } catch (...) {
+                            try {
+                                promise->set_value(std::nullopt);
+                            } catch (...) {
+                            }
+                        }
+                    }).detach();
+                    pendingBearerRefresh = promise->get_future();
+                } catch (const std::system_error &) {
+                }
             }
 
             auto delay = computeRetryDelayMs(
@@ -1199,7 +1244,7 @@ struct curlFileTransfer : public FileTransfer
     ItemHandle enqueueItem(ref<TransferItem> item)
     {
         if (item->request.data && item->request.uri.scheme() != "http" && item->request.uri.scheme() != "https"
-            && item->request.uri.scheme() != "s3")
+            && item->request.uri.scheme() != "s3" && item->request.uri.scheme() != "gs")
             throw nix::Error("uploading to '%s' is not supported", item->request.displayUri());
 
         {
@@ -1216,10 +1261,15 @@ struct curlFileTransfer : public FileTransfer
 
     ItemHandle enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) override
     {
-        /* Handle s3:// URIs by converting to HTTPS and optionally adding auth */
+        /* Handle s3:// and gs:// URIs by converting to HTTPS and optionally adding auth */
         if (request.uri.scheme() == "s3") {
             auto modifiedRequest = request;
             modifiedRequest.setupForS3();
+            return enqueueItem(make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback)));
+        }
+        if (request.uri.scheme() == "gs") {
+            auto modifiedRequest = request;
+            modifiedRequest.setupForGCS();
             return enqueueItem(make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback)));
         }
 
@@ -1314,6 +1364,33 @@ void FileTransferRequest::setupForS3()
 #else
     // When built without AWS support, just try as public bucket
     debug("S3 request without authentication (built without AWS support)");
+#endif
+}
+
+void FileTransferRequest::setupForGCS()
+{
+    auto parsed = ParsedGCSURL::parse(uri.parsed());
+    uri = parsed.toHttpsUrl();
+
+    /* Requester-pays buckets reject requests without a billing project. */
+    if (parsed.userProject)
+        headers.emplace_back("x-goog-user-project", *parsed.userProject);
+
+#if NIX_WITH_GCS_AUTH
+    if (gcpCredentialProvider) {
+        if (auto creds = gcpCredentialProvider->maybeGetCredentials())
+            bearerToken = creds->accessToken;
+        refreshBearerToken = [p = gcpCredentialProvider,
+                              wft = std::weak_ptr(getFileTransfer().get_ptr())]() -> std::optional<std::string> {
+            if (auto ft = wft.lock())
+                if (auto creds = p->tryRefreshCredentials(*ft))
+                    return creds->accessToken;
+            return std::nullopt;
+        };
+    } else
+        debug("GCS request without credential provider");
+#else
+    debug("GCS request without authentication (built without GCS auth support)");
 #endif
 }
 

--- a/src/libstore/gcp-creds.cc
+++ b/src/libstore/gcp-creds.cc
@@ -361,31 +361,11 @@ public:
     }
 };
 
-Sync<std::shared_ptr<GcpCredentialProvider>> & providerSlot()
-{
-    static Sync<std::shared_ptr<GcpCredentialProvider>> slot;
-    return slot;
-}
-
 } // anonymous namespace
 
 ref<GcpCredentialProvider> makeGcpCredentialsProvider()
 {
     return make_ref<GcpCredentialProviderImpl>();
-}
-
-ref<GcpCredentialProvider> getGcpCredentialsProvider()
-{
-    auto slot(providerSlot().lock());
-    if (!*slot)
-        *slot = makeGcpCredentialsProvider().get_ptr();
-    return ref(*slot);
-}
-
-void setGcpCredentialsProviderForTesting(ref<GcpCredentialProvider> provider)
-{
-    auto slot(providerSlot().lock());
-    *slot = provider.get_ptr();
 }
 
 } // namespace nix

--- a/src/libstore/gcp-creds.cc
+++ b/src/libstore/gcp-creds.cc
@@ -1,0 +1,393 @@
+#include "nix/store/gcp-creds.hh"
+
+#if NIX_WITH_GCS_AUTH
+
+#  include "nix/store/filetransfer.hh"
+#  include "nix/util/base-n.hh"
+#  include "nix/util/environment-variables.hh"
+#  include "nix/util/file-system.hh"
+#  include "nix/util/logging.hh"
+#  include "nix/util/sync.hh"
+#  include "nix/util/url.hh"
+#  include "nix/util/users.hh"
+#  ifdef _WIN32
+#    include "nix/util/windows-known-folders.hh"
+#  endif
+
+#  include <nlohmann/json.hpp>
+#  include <openssl/err.h>
+#  include <openssl/evp.h>
+#  include <openssl/pem.h>
+
+#  include <algorithm>
+#  include <chrono>
+
+namespace nix {
+
+void GcpAuthError::anchor() {}
+
+GcpCredentialProvider::~GcpCredentialProvider() {}
+
+/* Refresh tokens this long before their nominal expiry.
+ * A request started just before expiry doesn't race with revocation on the server side.
+ */
+static constexpr auto kExpirySlack = std::chrono::seconds{225};
+static constexpr auto kMinCacheLifetime = std::chrono::seconds{30};
+
+static constexpr std::string_view kOauthScope = "https://www.googleapis.com/auth/devstorage.read_write";
+static constexpr std::string_view kDefaultTokenUri = "https://oauth2.googleapis.com/token";
+static constexpr std::string_view kMetadataHost = "metadata.google.internal";
+static constexpr std::string_view kMetadataTokenPath = "/computeMetadata/v1/instance/service-accounts/default/token";
+
+namespace gcp_detail {
+
+std::string base64url(std::span<const std::byte> bytes)
+{
+    auto s = base64::encode(bytes);
+    for (auto & c : s) {
+        if (c == '+')
+            c = '-';
+        else if (c == '/')
+            c = '_';
+    }
+    while (!s.empty() && s.back() == '=')
+        s.pop_back();
+    return s;
+}
+
+std::string base64url(std::string_view s)
+{
+    return base64url(std::span{reinterpret_cast<const std::byte *>(s.data()), s.size()});
+}
+
+[[noreturn]] static void throwOpenSSLError(std::string_view what)
+{
+    auto code = ERR_get_error();
+    char buf[256];
+    ERR_error_string_n(code, buf, sizeof(buf));
+    throw GcpAuthError("OpenSSL error while %s: %s", what, buf);
+}
+
+std::string signRS256(const std::string & privateKeyPem, std::string_view payload)
+{
+    auto * bio = BIO_new_mem_buf(privateKeyPem.data(), static_cast<int>(privateKeyPem.size()));
+    if (!bio)
+        throwOpenSSLError("allocating BIO for private key");
+    std::unique_ptr<BIO, decltype(&BIO_free)> bioGuard(bio, BIO_free);
+
+    std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pkey(
+        PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr), EVP_PKEY_free);
+    if (!pkey)
+        throwOpenSSLError("parsing PEM private key");
+
+    std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+    if (!ctx)
+        throwOpenSSLError("allocating EVP_MD_CTX");
+
+    if (EVP_DigestSignInit(ctx.get(), nullptr, EVP_sha256(), nullptr, pkey.get()) != 1)
+        throwOpenSSLError("EVP_DigestSignInit");
+    if (EVP_DigestSignUpdate(ctx.get(), payload.data(), payload.size()) != 1)
+        throwOpenSSLError("EVP_DigestSignUpdate");
+
+    size_t sigLen = 0;
+    if (EVP_DigestSignFinal(ctx.get(), nullptr, &sigLen) != 1)
+        throwOpenSSLError("EVP_DigestSignFinal (sizing)");
+    std::string sig(sigLen, '\0');
+    if (EVP_DigestSignFinal(ctx.get(), reinterpret_cast<unsigned char *>(sig.data()), &sigLen) != 1)
+        throwOpenSSLError("EVP_DigestSignFinal");
+    sig.resize(sigLen);
+    return sig;
+}
+
+std::string
+buildServiceAccountJwtSigningInput(std::string_view clientEmail, std::string_view tokenUri, long iat, long exp)
+{
+    nlohmann::json header = {{"alg", "RS256"}, {"typ", "JWT"}};
+    nlohmann::json claims = {
+        {"iss", clientEmail},
+        {"scope", std::string{kOauthScope}},
+        {"aud", tokenUri},
+        {"iat", iat},
+        {"exp", exp},
+    };
+    return base64url(header.dump()) + "." + base64url(claims.dump());
+}
+
+GcpCredentials parseTokenResponse(const std::string & body)
+{
+    nlohmann::json j;
+    try {
+        j = nlohmann::json::parse(body);
+    } catch (nlohmann::json::exception & e) {
+        throw GcpAuthError("GCP token endpoint returned invalid JSON: %s", e.what());
+    }
+    auto token = j.value("access_token", std::string{});
+    if (token.empty()) {
+        debug("GCP token endpoint response: %s", body);
+        throw GcpAuthError("GCP token endpoint response missing 'access_token'");
+    }
+    auto expiresIn = std::chrono::seconds(j.value("expires_in", 3600));
+    auto now = std::chrono::steady_clock::now();
+    return GcpCredentials{
+        .accessToken = std::move(token),
+        .expiresAt = std::max(now + expiresIn - kExpirySlack, now + kMinCacheLifetime),
+    };
+}
+
+std::optional<std::filesystem::path> findAdcFile()
+{
+    if (auto p = getEnv("GOOGLE_APPLICATION_CREDENTIALS"))
+        return std::filesystem::path{*p};
+
+    /* gcloud's well-known location.
+     * `$CLOUDSDK_CONFIG` overrides the gcloud config dir as a whole
+     * Otherwise we use ~/.config/gcloud on Unix and %APPDATA%\gcloud on Windows
+     * (gcloud is not XDG-aware).
+     */
+    auto gcloudDir = [&]() -> std::filesystem::path {
+        if (auto d = getEnv("CLOUDSDK_CONFIG"))
+            return *d;
+#  ifndef _WIN32
+        return getHome() / ".config" / "gcloud";
+#  else
+        return windows::known_folders::getRoamingAppData() / "gcloud";
+#  endif
+    }();
+    auto wellKnown = gcloudDir / "application_default_credentials.json";
+    if (pathExists(wellKnown))
+        return wellKnown;
+
+    return std::nullopt;
+}
+
+} // namespace gcp_detail
+
+namespace {
+
+FileTransferResult httpGet(FileTransfer & ft, std::string_view url, Headers headers, std::optional<uint32_t> attempts)
+{
+    FileTransferRequest req{VerbatimURL{url}};
+    req.headers = std::move(headers);
+    req.retryAttempts = attempts;
+    return ft.download(req);
+}
+
+FileTransferResult httpPostForm(FileTransfer & ft, std::string_view url, std::string body)
+{
+    FileTransferRequest req{VerbatimURL{url}};
+    req.method = HttpMethod::Post;
+    StringSource src{body};
+    req.data = {src};
+    req.mimeType = "application/x-www-form-urlencoded";
+    /* Token endpoints are stateless. Let the normal retry policy apply. */
+    return ft.upload(req);
+}
+
+/**
+ * GCE/GKE metadata server
+ * Outside of GCP `metadata.google.internal` does not
+ * resolve and the request fails fast at DNS level.
+ * We therefore don't add an extra resolvability probe.
+ * Users can also point at a local stub via `$GCE_METADATA_HOST` (honoured by all Google SDKs).
+ */
+std::optional<GcpCredentials> metadataServerCredentials(FileTransfer & ft)
+{
+    auto host = getEnv("GCE_METADATA_HOST").value_or(std::string{kMetadataHost});
+    auto url = "http://" + host + std::string{kMetadataTokenPath};
+    Headers hdrs{{"Metadata-Flavor", "Google"}};
+    try {
+        return gcp_detail::parseTokenResponse(httpGet(ft, url, hdrs, /*attempts=*/1).data);
+    } catch (FileTransferError & e) {
+        if (!e.response || e.error != FileTransfer::Transient) {
+            debug("GCP metadata server not available: %s", e.what());
+            return std::nullopt;
+        }
+    }
+    try {
+        return gcp_detail::parseTokenResponse(httpGet(ft, url, hdrs, /*attempts=*/std::nullopt).data);
+    } catch (FileTransferError & e) {
+        throw GcpAuthError("GCP metadata server error: %s", e.message());
+    }
+}
+
+std::string requireField(const nlohmann::json & j, std::string_view credType, const char * key)
+{
+    auto v = j.value(key, std::string{});
+    if (v.empty())
+        throw GcpAuthError("%s credentials missing '%s'", credType, key);
+    return v;
+}
+
+/** `"type":"authorized_user"` is a refresh-token flow used by `gcloud auth application-default login`. */
+GcpCredentials authorizedUserCredentials(FileTransfer & ft, const nlohmann::json & j)
+{
+    auto require = [&](const char * k) { return requireField(j, "authorized_user", k); };
+    auto body = encodeQuery({
+        {"grant_type", "refresh_token"},
+        {"client_id", require("client_id")},
+        {"client_secret", require("client_secret")},
+        {"refresh_token", require("refresh_token")},
+    });
+    auto tokenUri = j.value("token_uri", std::string{kDefaultTokenUri});
+    return gcp_detail::parseTokenResponse(httpPostForm(ft, tokenUri, std::move(body)).data);
+}
+
+/** `"type":"service_account"` is a self-signed JWT exchanged for an access token. */
+GcpCredentials serviceAccountCredentials(FileTransfer & ft, const nlohmann::json & j)
+{
+    auto require = [&](const char * k) { return requireField(j, "service_account", k); };
+    auto clientEmail = require("client_email");
+    auto privateKey = require("private_key");
+    auto tokenUri = j.value("token_uri", std::string{kDefaultTokenUri});
+
+    auto now = std::chrono::system_clock::now();
+    auto iat = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+
+    auto signingInput = gcp_detail::buildServiceAccountJwtSigningInput(clientEmail, tokenUri, iat, iat + 3600);
+    auto sig = gcp_detail::signRS256(privateKey, signingInput);
+    auto assertion = signingInput + "."
+                     + gcp_detail::base64url(std::span{reinterpret_cast<const std::byte *>(sig.data()), sig.size()});
+
+    auto body = encodeQuery({
+        {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"},
+        {"assertion", assertion},
+    });
+    return gcp_detail::parseTokenResponse(httpPostForm(ft, tokenUri, std::move(body)).data);
+}
+
+std::optional<GcpCredentials> fileCredentials(FileTransfer & ft, const std::filesystem::path & path)
+{
+    std::string content;
+    try {
+        content = readFile(path);
+    } catch (SysError & e) {
+        /* e.g. GOOGLE_APPLICATION_CREDENTIALS points at a missing file.
+         * Rewrap so the caller's GcpAuthError to add GCP-context rather a bare "No such file".
+         */
+        throw GcpAuthError("failed to read GCP credentials '%s': %s", path.string(), e.what());
+    }
+    nlohmann::json j;
+    try {
+        j = nlohmann::json::parse(content);
+    } catch (nlohmann::json::exception &) {
+        /* nlohmann's e.what() quotes an excerpt of the input, so we don't log it to avoid leaking credentials. */
+        throw GcpAuthError("GCP credentials '%s' are not valid JSON", path.string());
+    }
+    auto type = j.value("type", std::string{});
+    if (type == "service_account")
+        return serviceAccountCredentials(ft, j);
+    if (type == "authorized_user")
+        return authorizedUserCredentials(ft, j);
+    /* `external_account` (workload identity federation) is intentionally
+       unsupported to avoid pulling in the heavy google-cloud-cpp SDK.
+       Surface a clear error rather than silently skipping so the user knows
+       why auth failed. */
+    throw GcpAuthError("GCP credentials '%s' have unsupported type '%s'", path.string(), type);
+}
+
+/* How long a negative result (no credentials available) is cached
+ * before the ADC chain (including the metadata-server probe) is retried.
+ * Without this a public-bucket copy of N paths re-probes metadata.google.internal N times.
+ */
+static constexpr auto negativeCacheTtl = std::chrono::seconds(60);
+
+class GcpCredentialProviderImpl final : public GcpCredentialProvider
+{
+    struct CacheEntry
+    {
+        std::optional<GcpCredentials> creds; // nullopt = no credentials available
+        std::chrono::steady_clock::time_point validUntil;
+    };
+
+    Sync<std::optional<CacheEntry>> cached_;
+
+    std::optional<GcpCredentials> resolve(FileTransfer & ft)
+    {
+        if (auto path = gcp_detail::findAdcFile()) {
+            debug("using GCP credentials from '%s'", path->string());
+            try {
+                return fileCredentials(ft, *path);
+            } catch (FileTransferError & e) {
+                throw GcpAuthError("failed to obtain GCP access token: %s", e.message());
+            }
+        }
+        return metadataServerCredentials(ft);
+    }
+
+    std::optional<GcpCredentials> store(std::optional<GcpCredentials> fresh, std::chrono::steady_clock::time_point now)
+    {
+        auto validUntil = fresh ? fresh->expiresAt : now + negativeCacheTtl;
+        auto cached(cached_.lock());
+        if (fresh || !*cached || (*cached)->validUntil <= now)
+            *cached = CacheEntry{fresh, validUntil};
+        else
+            return (*cached)->creds;
+        return fresh;
+    }
+
+public:
+    std::optional<GcpCredentials> maybeGetCredentials() override
+    {
+        auto now = std::chrono::steady_clock::now();
+        {
+            auto cached(cached_.lock());
+            if (*cached && (*cached)->validUntil > now)
+                return (*cached)->creds;
+        }
+        /* Drop the lock across the (potentially slow) network call so concurrent callers don't serialise on it. */
+        std::optional<GcpCredentials> fresh;
+        try {
+            fresh = resolve(*getFileTransfer());
+        } catch (GcpAuthError & e) {
+            /* A broken/unsupported ADC file should surface to the user (so they don't just see a bare 403),
+             * but not once per request. Instead treat it as a negative result so it is cached like "no credentials".
+             */
+            warn("GCP authentication failed, proceeding without credentials: %s", e.message());
+        } catch (nlohmann::json::exception & e) {
+            warn("GCP authentication failed (malformed JSON field): %s", e.what());
+        }
+        return store(std::move(fresh), now);
+    }
+
+    std::optional<GcpCredentials> tryRefreshCredentials(FileTransfer & ft) noexcept override
+    {
+        auto now = std::chrono::steady_clock::now();
+        cached_.lock()->reset();
+        try {
+            return store(resolve(ft), now);
+        } catch (...) {
+            return store(std::nullopt, now);
+        }
+    }
+};
+
+Sync<std::shared_ptr<GcpCredentialProvider>> & providerSlot()
+{
+    static Sync<std::shared_ptr<GcpCredentialProvider>> slot;
+    return slot;
+}
+
+} // anonymous namespace
+
+ref<GcpCredentialProvider> makeGcpCredentialsProvider()
+{
+    return make_ref<GcpCredentialProviderImpl>();
+}
+
+ref<GcpCredentialProvider> getGcpCredentialsProvider()
+{
+    auto slot(providerSlot().lock());
+    if (!*slot)
+        *slot = makeGcpCredentialsProvider().get_ptr();
+    return ref(*slot);
+}
+
+void setGcpCredentialsProviderForTesting(ref<GcpCredentialProvider> provider)
+{
+    auto slot(providerSlot().lock());
+    *slot = provider.get_ptr();
+}
+
+} // namespace nix
+
+#endif

--- a/src/libstore/gcs-url.cc
+++ b/src/libstore/gcs-url.cc
@@ -1,0 +1,86 @@
+#include "nix/store/gcs-url.hh"
+#include "nix/util/error.hh"
+#include "nix/util/util.hh"
+
+#include <ranges>
+#include <string_view>
+
+namespace nix {
+
+ParsedGCSURL ParsedGCSURL::parse(const ParsedURL & parsed)
+try {
+    if (parsed.scheme != "gs")
+        throw BadURL("URI scheme '%s' is not 'gs'", parsed.scheme);
+
+    /* Like S3, the bucket name is the URI authority.
+     * Only reject the cases that would make the resulting HTTPS URL malformed. */
+    if (!parsed.authority || parsed.authority->host.empty()
+        || parsed.authority->hostType != ParsedURL::Authority::HostType::Name)
+        throw BadURL("URI has a missing or invalid bucket name");
+
+    auto getOptionalParam = [&](std::string_view key) -> std::optional<std::string> {
+        auto it = parsed.query.find(key);
+        if (it == parsed.query.end())
+            return std::nullopt;
+        return it->second;
+    };
+
+    /* See the struct docstring:
+     * Refusing here means a `gs://` URL cannot name a non-Google host,
+     * so the bearer token can never be leaked elsewhere.
+     */
+    if (getOptionalParam("endpoint") || getOptionalParam("scheme"))
+        throw BadURL("'endpoint' and 'scheme' are not accepted in a gs:// URL; configure them on the store instead");
+
+    if (parsed.path.size() <= 1 || !parsed.path.front().empty())
+        throw BadURL("URI has a missing or invalid key");
+
+    auto path = std::views::drop(parsed.path, 1) | std::ranges::to<std::vector<std::string>>();
+
+    for (auto & seg : path)
+        if (seg.empty() || seg == "." || seg == "..")
+            throw BadURL("URI key has an invalid path segment '%s'", seg);
+
+    return ParsedGCSURL{
+        .bucket = parsed.authority->host,
+        .key = std::move(path),
+        /* Goes verbatim into the `x-goog-user-project` header.
+         * Restrict to the GCP project-id charset so it cannot smuggle CR/LF from a URL.
+         */
+        .userProject = [&]() -> std::optional<std::string> {
+            auto v = getOptionalParam("user-project");
+            if (v && v->find_first_not_of("abcdefghijklmnopqrstuvwxyz0123456789-") != std::string::npos)
+                throw BadURL("invalid 'user-project' value '%s' in GCS URL", *v);
+            return v;
+        }(),
+        .generation = getOptionalParam("generation"),
+    };
+} catch (BadURL & e) {
+    e.addTrace({}, "while parsing GCS URI: '%s'", parsed.to_string());
+    throw;
+}
+
+ParsedURL ParsedGCSURL::toHttpsUrl(const std::optional<ParsedURL> & endpoint) const
+{
+    /* We always use path-style as it is supported for all bucket names including dotted ones and emulators.
+     * GCS also supports virtual-hosted-style (`bucket.storage.googleapis.com`)
+     */
+    auto resolved = endpoint.value_or(
+        ParsedURL{
+            .scheme = "https",
+            .authority = ParsedURL::Authority{.host = "storage.googleapis.com"},
+            .path = {""},
+        });
+
+    resolved.path.push_back(bucket);
+    resolved.path.insert(resolved.path.end(), key.begin(), key.end());
+
+    /* GCS' XML API accepts the object generation as a query parameter on GET/HEAD.
+       We allow it to pass it through so callers can pin a specific version. */
+    if (generation)
+        resolved.query["generation"] = *generation;
+
+    return resolved;
+}
+
+} // namespace nix

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -21,6 +21,8 @@
 
 namespace nix {
 
+class GcpCredentialProvider;
+
 const std::filesystem::path & nixConfDir();
 
 class FileTransferSettings : public Config
@@ -314,6 +316,15 @@ struct FileTransferRequest
     std::optional<std::string> preResolvedAwsSessionToken;
 #endif
 
+    /**
+     * Credential provider for `gs://` requests. Unset means anonymous.
+     */
+    std::shared_ptr<GcpCredentialProvider> gcpCredentialProvider;
+
+    std::optional<std::string> bearerToken;
+
+    std::function<std::optional<std::string>()> refreshBearerToken;
+
     FileTransferRequest(VerbatimURL uri)
         : uri(std::move(uri))
         , parentAct(getCurActivity())
@@ -364,6 +375,7 @@ struct FileTransferRequest
     }
 
     void setupForS3();
+    void setupForGCS();
 
 private:
     friend struct curlFileTransfer;

--- a/src/libstore/include/nix/store/gcp-creds.hh
+++ b/src/libstore/include/nix/store/gcp-creds.hh
@@ -1,0 +1,98 @@
+#pragma once
+///@file
+#include "nix/store/config.hh"
+
+#if NIX_WITH_GCS_AUTH
+
+#  include "nix/util/error.hh"
+#  include "nix/util/ref.hh"
+
+#  include <chrono>
+#  include <filesystem>
+#  include <optional>
+#  include <span>
+#  include <string>
+
+namespace nix {
+
+struct FileTransfer;
+
+/**
+ * OAuth2 access token for Google Cloud APIs.
+ *
+ * Unlike AWS SigV4 (key id + secret signed per request), GCP uses a
+ * short-lived bearer token sent verbatim in `Authorization: Bearer <token>`.
+ * Tokens typically expire after one hour and must be refreshed.
+ */
+struct GcpCredentials
+{
+    std::string accessToken;
+    /** When the token should be considered expired (with safety margin already applied). */
+    std::chrono::steady_clock::time_point expiresAt;
+};
+
+MakeError(GcpAuthError, Error);
+
+class GcpCredentialProvider
+{
+public:
+    /**
+     * Resolve a fresh-enough access token, or `std::nullopt` if no
+     * credentials are available (e.g. running outside GCP without an ADC
+     * file). Throws `GcpAuthError` only on hard failures (malformed key,
+     * token endpoint rejection).
+     */
+    virtual std::optional<GcpCredentials> maybeGetCredentials() = 0;
+
+    virtual std::optional<GcpCredentials> tryRefreshCredentials(FileTransfer & ft) noexcept = 0;
+
+    virtual ~GcpCredentialProvider();
+};
+
+/**
+ * Build the default Application Default Credentials chain:
+ *
+ *  1. `$GOOGLE_APPLICATION_CREDENTIALS` → service-account or authorized-user JSON
+ *  2. `$CLOUDSDK_CONFIG/application_default_credentials.json`, else
+ * `~/.config/gcloud/application_default_credentials.json`
+ *  3. GCE/GKE metadata server (`metadata.google.internal` or `$GCE_METADATA_HOST`)
+ *
+ * Tokens are cached and refreshed when close to expiry.
+ */
+ref<GcpCredentialProvider> makeGcpCredentialsProvider();
+
+/**
+ * Process-wide singleton wrapping `makeGcpCredentialsProvider()`.
+ * Tests may override it via `setGcpCredentialsProviderForTesting()`.
+ */
+ref<GcpCredentialProvider> getGcpCredentialsProvider();
+void setGcpCredentialsProviderForTesting(ref<GcpCredentialProvider> provider);
+
+/**
+ * Implementation details exposed for unit testing only.
+ * Not part of the stable API; may change without notice.
+ */
+namespace gcp_detail {
+
+/** RFC 4648 §5 base64url without padding (JWT encoding). */
+std::string base64url(std::span<const std::byte> bytes);
+std::string base64url(std::string_view s);
+
+/** RSASSA-PKCS1-v1_5-SHA256 signature over `payload`. Throws GcpAuthError on bad keys. */
+std::string signRS256(const std::string & privateKeyPem, std::string_view payload);
+
+/** Build the unsigned JWT (`header.claims`, both base64url) for a service-account assertion. */
+std::string
+buildServiceAccountJwtSigningInput(std::string_view clientEmail, std::string_view tokenUri, long iat, long exp);
+
+/** Parse `{"access_token":..., "expires_in":...}` from a token endpoint. */
+GcpCredentials parseTokenResponse(const std::string & body);
+
+/** Locate the ADC JSON file from env vars / well-known path. */
+std::optional<std::filesystem::path> findAdcFile();
+
+} // namespace gcp_detail
+
+} // namespace nix
+
+#endif

--- a/src/libstore/include/nix/store/gcp-creds.hh
+++ b/src/libstore/include/nix/store/gcp-creds.hh
@@ -62,13 +62,6 @@ public:
 ref<GcpCredentialProvider> makeGcpCredentialsProvider();
 
 /**
- * Process-wide singleton wrapping `makeGcpCredentialsProvider()`.
- * Tests may override it via `setGcpCredentialsProviderForTesting()`.
- */
-ref<GcpCredentialProvider> getGcpCredentialsProvider();
-void setGcpCredentialsProviderForTesting(ref<GcpCredentialProvider> provider);
-
-/**
  * Implementation details exposed for unit testing only.
  * Not part of the stable API; may change without notice.
  */

--- a/src/libstore/include/nix/store/gcs-url.hh
+++ b/src/libstore/include/nix/store/gcs-url.hh
@@ -1,0 +1,45 @@
+#pragma once
+///@file
+#include "nix/util/url.hh"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace nix {
+
+/**
+ * Parsed Google Cloud Storage `gs://` URL.
+ *
+ * We deliberately support no `endpoint`/`scheme` in the URL: bearer tokens are
+ * host-independent, so a URL-supplied endpoint would let e.g. `fetchurl`
+ * exfiltrate the caller's token.
+ * A custom endpoint is a store setting only (see `GCSBinaryCacheStoreConfig`).
+ */
+struct ParsedGCSURL
+{
+    std::string bucket;
+    /**
+     * @see ParsedURL::path. This is a vector for the same reason.
+     * Unlike ParsedURL::path this doesn't include the leading empty segment,
+     * since the bucket name is necessary.
+     */
+    std::vector<std::string> key;
+    /** Billing project for requester-pays buckets (sent as `x-goog-user-project`). */
+    std::optional<std::string> userProject;
+    /** Object generation (GCS object versioning), passed through as a query parameter. */
+    std::optional<std::string> generation;
+
+    static ParsedGCSURL parse(const ParsedURL & uri);
+
+    /**
+     * Convert to an HTTP(S) URL against the GCS XML API.
+     * Without an endpoint this targets `https://storage.googleapis.com`.
+     * Store code passes a custom endpoint URL from operator configuration.
+     */
+    ParsedURL toHttpsUrl(const std::optional<ParsedURL> & endpoint = std::nullopt) const;
+
+    auto operator<=>(const ParsedGCSURL & other) const = default;
+};
+
+} // namespace nix

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -47,6 +47,7 @@ headers = [ config_pub_h ] + files(
   'filetransfer-impl.hh',
   'filetransfer.hh',
   'gc-store.hh',
+  'gcp-creds.hh',
   'gcs-url.hh',
   'global-paths.hh',
   'globals.hh',

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -47,6 +47,7 @@ headers = [ config_pub_h ] + files(
   'filetransfer-impl.hh',
   'filetransfer.hh',
   'gc-store.hh',
+  'gcs-url.hh',
   'global-paths.hh',
   'globals.hh',
   'http-binary-cache-store.hh',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -176,6 +176,17 @@ endif
 
 configdata_pub.set('NIX_WITH_AWS_AUTH', s3_aws_auth.enabled().to_int())
 
+gcs_auth = get_option('gcs-auth')
+# JWT RS256 signing for service-account credentials needs OpenSSL. It is
+# already a private dep of libutil but must be declared here too so libstore
+# links it directly when GCS auth is enabled.
+openssl = dependency('libcrypto', 'openssl', required : gcs_auth)
+gcs_auth = gcs_auth.require(openssl.found())
+if gcs_auth.allowed()
+  deps_private += openssl
+endif
+configdata_pub.set('NIX_WITH_GCS_AUTH', gcs_auth.allowed().to_int())
+
 busybox = find_program(get_option('sandbox-shell'), required : false)
 
 if get_option('embedded-sandbox-shell')
@@ -345,6 +356,11 @@ sources = files(
 # AWS credentials code requires AWS CRT, so only compile when enabled
 if s3_aws_auth.enabled()
   sources += files('aws-creds.cc')
+endif
+
+# GCP credentials code requires OpenSSL, so only compile when enabled
+if gcs_auth.allowed()
+  sources += files('gcp-creds.cc')
 endif
 
 subdir('include/nix/store')

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -290,6 +290,7 @@ sources = files(
   'export-import.cc',
   'filetransfer.cc',
   'gc.cc',
+  'gcs-url.cc',
   'globals.cc',
   'http-binary-cache-store.cc',
   'indirect-root-store.cc',

--- a/src/libstore/meson.options
+++ b/src/libstore/meson.options
@@ -39,3 +39,9 @@ option(
   type : 'feature',
   description : 'build support for AWS authentication with S3',
 )
+
+option(
+  'gcs-auth',
+  type : 'feature',
+  description : 'build support for Google Cloud authentication with GCS',
+)


### PR DESCRIPTION
Mirror setupForS3(): a `gs://` request is rewritten via ParsedGCSURL to
the GCS XML API, an `x-goog-user-project` header is added for
requester-pays buckets, and an `Authorization: Bearer` header is attached
from the ADC provider when built with gcs-auth. Auth failures fall
through to anonymous access so public buckets keep working.

The existing S3 XML `<Error><Code>` retry parsing is status-based and
already matches GCS responses, so no changes are needed there.

---

Part of #16144.
Depends on #16145