### PR TITLE
tests/nixos: add gcs-binary-cache-store VM test

### DIFF
--- a/doc/manual/rl-next/gcs-binary-cache-store.md
+++ b/doc/manual/rl-next/gcs-binary-cache-store.md
@@ -1,0 +1,14 @@
+---
+synopsis: Google Cloud Storage binary cache (`gs://`)
+prs: []
+issues: []
+---
+
+Nix can now use a Google Cloud Storage bucket as a binary cache via the new `gs://bucket-name` store URI.
+Reads and writes go through the GCS XML API (S3-compatible),
+so multipart uploads and the existing `multipart-*` settings work unchanged.
+
+Authentication uses Google [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+(service-account keys, `gcloud auth application-default login`, or the GCE/GKE metadata server)
+
+`builtins.fetchurl` and substituters also accept plain `gs://bucket/object` URLs.

--- a/doc/manual/source/protocols/binary-cache/index.md
+++ b/doc/manual/source/protocols/binary-cache/index.md
@@ -17,3 +17,4 @@ The following [store types](@docroot@/store/types/index.md) use the binary cache
 - [HTTP Binary Cache Store](@docroot@/store/types/http-binary-cache-store.md) — served over HTTP(S)
 - [Local Binary Cache Store](@docroot@/store/types/local-binary-cache-store.md) — stored on the file system
 - [S3 Binary Cache Store](@docroot@/store/types/s3-binary-cache-store.md) — stored in an AWS S3 bucket
+- [GCS Binary Cache Store](@docroot@/store/types/gcs-binary-cache-store.md) — stored in a Google Cloud Storage bucket

--- a/src/libstore-tests/filetransfer-request.cc
+++ b/src/libstore-tests/filetransfer-request.cc
@@ -1,8 +1,19 @@
 #include <gtest/gtest.h>
 
 #include "nix/store/filetransfer.hh"
+#include "nix/store/gcp-creds.hh"
 
 namespace nix {
+
+namespace {
+std::optional<std::string> findHeader(const Headers & hs, std::string_view name)
+{
+    for (auto & [k, v] : hs)
+        if (k == name)
+            return v;
+    return std::nullopt;
+}
+} // anonymous namespace
 
 TEST(FileTransferRequest, displayUriStripsUserinfo)
 {
@@ -15,5 +26,80 @@ TEST(FileTransferRequest, displayUriStripsUserinfo)
     FileTransferRequest plain(VerbatimURL{std::string{"https://example.org/file"}});
     EXPECT_EQ(plain.displayUri(), "https://example.org/file");
 }
+
+#if NIX_WITH_GCS_AUTH
+namespace {
+struct FixedTokenProvider : GcpCredentialProvider
+{
+    std::optional<GcpCredentials> result;
+
+    std::optional<GcpCredentials> maybeGetCredentials() override
+    {
+        return result;
+    }
+
+    std::optional<GcpCredentials> tryRefreshCredentials(FileTransfer &) noexcept override
+    {
+        return result;
+    }
+};
+} // anonymous namespace
+#endif
+
+/**
+ * Requests only authenticate through an attached provider.
+ * These tests never touch the network or host ADC files.
+ */
+class FileTransferRequestGCS : public ::testing::Test
+{
+protected:
+#if NIX_WITH_GCS_AUTH
+    ref<FixedTokenProvider> stub = make_ref<FixedTokenProvider>();
+
+    void attach(FileTransferRequest & req)
+    {
+        req.gcpCredentialProvider = stub.get_ptr();
+    }
+#endif
+};
+
+TEST_F(FileTransferRequestGCS, rewritesUrlAndUserProject)
+{
+    FileTransferRequest req(VerbatimURL{std::string{"gs://my-bucket/nar/abc.nar.xz?user-project=billing"}});
+    req.setupForGCS();
+
+    EXPECT_EQ(req.uri.to_string(), "https://storage.googleapis.com/my-bucket/nar/abc.nar.xz");
+    EXPECT_EQ(findHeader(req.headers, "x-goog-user-project"), std::optional<std::string>{"billing"});
+}
+
+#if NIX_WITH_GCS_AUTH
+
+TEST_F(FileTransferRequestGCS, usesProviderToken)
+{
+    stub->result = GcpCredentials{.accessToken = "provider-token", .expiresAt = {}};
+
+    FileTransferRequest req(VerbatimURL{std::string{"gs://b/k"}});
+    attach(req);
+    req.setupForGCS();
+
+    EXPECT_EQ(req.bearerToken, std::optional<std::string>{"provider-token"});
+    ASSERT_TRUE(req.refreshBearerToken);
+
+    stub->result = GcpCredentials{.accessToken = "refreshed-token", .expiresAt = {}};
+    EXPECT_EQ(req.refreshBearerToken(), std::optional<std::string>{"refreshed-token"});
+}
+
+TEST_F(FileTransferRequestGCS, anonymousWhenNoCredentials)
+{
+    stub->result = std::nullopt;
+
+    FileTransferRequest req(VerbatimURL{std::string{"gs://b/k"}});
+    attach(req);
+    req.setupForGCS();
+
+    EXPECT_FALSE(req.bearerToken.has_value());
+}
+
+#endif
 
 } // namespace nix

--- a/src/libstore-tests/gcp-creds.cc
+++ b/src/libstore-tests/gcp-creds.cc
@@ -1,0 +1,201 @@
+#include "nix/store/gcp-creds.hh"
+
+#if NIX_WITH_GCS_AUTH
+
+#  include "nix/util/base-n.hh"
+#  include "nix/util/environment-variables.hh"
+#  include "nix/util/file-system.hh"
+
+#  include <gtest/gtest.h>
+#  include <nlohmann/json.hpp>
+#  include <openssl/evp.h>
+#  include <openssl/pem.h>
+
+namespace nix {
+
+namespace {
+
+/** Reverse of `gcp_detail::base64url` for inspecting JWT segments in tests. */
+std::string base64urlDecode(std::string s)
+{
+    for (auto & c : s) {
+        if (c == '-')
+            c = '+';
+        else if (c == '_')
+            c = '/';
+    }
+    while (s.size() % 4 != 0)
+        s.push_back('=');
+    return base64::decode(s);
+}
+
+/** RAII env-var override that restores the previous value on destruction. */
+struct ScopedEnv
+{
+    std::string name;
+    std::optional<std::string> prev;
+
+    ScopedEnv(const char * name_, std::optional<std::string> value)
+        : name(name_)
+        , prev(getEnv(name_))
+    {
+        if (value)
+            setEnv(name_, value->c_str());
+        else
+            unsetenv(name_);
+    }
+
+    ~ScopedEnv()
+    {
+        if (prev)
+            setEnv(name.c_str(), prev->c_str());
+        else
+            unsetenv(name.c_str());
+    }
+};
+
+/** Generate a throwaway RSA keypair and return (private PEM, EVP_PKEY*). */
+std::pair<std::string, std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>> generateRsaKey()
+{
+    std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pkey(EVP_RSA_gen(2048), EVP_PKEY_free); // OpenSSL 3 helper
+    if (!pkey)
+        throw std::runtime_error("EVP_RSA_gen failed");
+
+    std::unique_ptr<BIO, decltype(&BIO_free)> bio(BIO_new(BIO_s_mem()), BIO_free);
+    PEM_write_bio_PrivateKey(bio.get(), pkey.get(), nullptr, nullptr, 0, nullptr, nullptr);
+    char * data = nullptr;
+    long len = BIO_get_mem_data(bio.get(), &data);
+    return {std::string(data, len), std::move(pkey)};
+}
+
+bool verifyRS256(EVP_PKEY * pkey, std::string_view payload, std::string_view sig)
+{
+    std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+    EVP_DigestVerifyInit(ctx.get(), nullptr, EVP_sha256(), nullptr, pkey);
+    EVP_DigestVerifyUpdate(ctx.get(), payload.data(), payload.size());
+    return EVP_DigestVerifyFinal(ctx.get(), reinterpret_cast<const unsigned char *>(sig.data()), sig.size()) == 1;
+}
+
+} // anonymous namespace
+
+TEST(GcpCreds, base64urlUsesUrlAlphabet)
+{
+    // 0xfb 0xff 0xfe → standard base64 "+//+"; URL alphabet swaps +/ for -_
+    // and drops padding, so we must get exactly "-__-".
+    std::byte raw[]{std::byte{0xfb}, std::byte{0xff}, std::byte{0xfe}};
+    EXPECT_EQ(gcp_detail::base64url(std::span{raw}), "-__-");
+    // Padding stripped for non-multiple-of-3 input.
+    EXPECT_EQ(gcp_detail::base64url("fo"), "Zm8");
+}
+
+TEST(GcpCreds, parseTokenResponseHappyPath)
+{
+    auto before = std::chrono::steady_clock::now();
+    auto creds =
+        gcp_detail::parseTokenResponse(R"({"access_token":"ya29.abc","expires_in":3600,"token_type":"Bearer"})");
+    auto after = std::chrono::steady_clock::now();
+
+    EXPECT_EQ(creds.accessToken, "ya29.abc");
+    // expires_in=3600 minus 225s slack ⇒ ~56 minutes from now.
+    EXPECT_GT(creds.expiresAt, before + std::chrono::minutes(55));
+    EXPECT_LT(creds.expiresAt, after + std::chrono::minutes(58));
+}
+
+TEST(GcpCreds, parseTokenResponseClampsShortExpiry)
+{
+    auto before = std::chrono::steady_clock::now();
+    auto creds = gcp_detail::parseTokenResponse(R"({"access_token":"t","expires_in":60})");
+    // 60s - 225s would be in the past; clamp to ≥30s.
+    EXPECT_GE(creds.expiresAt, before + std::chrono::seconds(30));
+    EXPECT_LT(creds.expiresAt, before + std::chrono::seconds(60));
+}
+
+TEST(GcpCreds, parseTokenResponseRejectsMissingToken)
+{
+    EXPECT_THROW(gcp_detail::parseTokenResponse(R"({"expires_in":3600})"), GcpAuthError);
+}
+
+TEST(GcpCreds, parseTokenResponseRejectsBadJson)
+{
+    EXPECT_THROW(gcp_detail::parseTokenResponse("not json"), GcpAuthError);
+}
+
+TEST(GcpCreds, buildServiceAccountJwtSigningInput)
+{
+    auto input = gcp_detail::buildServiceAccountJwtSigningInput(
+        "sa@project.iam.gserviceaccount.com", "https://oauth2.googleapis.com/token", 1000, 4600);
+
+    auto dot = input.find('.');
+    ASSERT_NE(dot, std::string::npos);
+    auto header = nlohmann::json::parse(base64urlDecode(input.substr(0, dot)));
+    auto claims = nlohmann::json::parse(base64urlDecode(input.substr(dot + 1)));
+
+    EXPECT_EQ(header["alg"], "RS256");
+    EXPECT_EQ(header["typ"], "JWT");
+    EXPECT_EQ(claims["iss"], "sa@project.iam.gserviceaccount.com");
+    EXPECT_EQ(claims["aud"], "https://oauth2.googleapis.com/token");
+    EXPECT_EQ(claims["scope"], "https://www.googleapis.com/auth/devstorage.read_write");
+    EXPECT_EQ(claims["iat"], 1000);
+    EXPECT_EQ(claims["exp"], 4600);
+}
+
+TEST(GcpCreds, signRS256RoundTrip)
+{
+    auto [pem, pkey] = generateRsaKey();
+    constexpr std::string_view payload = "header.claims";
+
+    auto sig = gcp_detail::signRS256(pem, payload);
+    EXPECT_FALSE(sig.empty());
+    EXPECT_TRUE(verifyRS256(pkey.get(), payload, sig));
+    // Tampered payload must not verify.
+    EXPECT_FALSE(verifyRS256(pkey.get(), "header.other", sig));
+}
+
+TEST(GcpCreds, signRS256RejectsBadPem)
+{
+    EXPECT_THROW(gcp_detail::signRS256("not a key", "payload"), GcpAuthError);
+}
+
+TEST(GcpCreds, findAdcFilePrefersExplicitEnv)
+{
+    ScopedEnv gac("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/creds.json");
+    ScopedEnv cdk("CLOUDSDK_CONFIG", std::nullopt);
+
+    auto found = gcp_detail::findAdcFile();
+    // The env var wins regardless of whether the file exists; the caller is
+    // responsible for surfacing a useful error if it doesn't.
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(found->string(), "/nonexistent/creds.json");
+}
+
+TEST(GcpCreds, findAdcFileFallsBackToCloudSdkConfig)
+{
+    auto tmp = createTempDir();
+    auto adc = tmp / "application_default_credentials.json";
+    writeFile(adc, "{}");
+
+    ScopedEnv gac("GOOGLE_APPLICATION_CREDENTIALS", std::nullopt);
+    ScopedEnv cdk("CLOUDSDK_CONFIG", tmp.string());
+
+    auto found = gcp_detail::findAdcFile();
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(*found, adc);
+
+    deletePath(tmp);
+}
+
+TEST(GcpCreds, findAdcFileNoneAvailable)
+{
+    auto tmp = createTempDir(); // empty dir, no ADC file inside
+
+    ScopedEnv gac("GOOGLE_APPLICATION_CREDENTIALS", std::nullopt);
+    ScopedEnv cdk("CLOUDSDK_CONFIG", tmp.string());
+
+    EXPECT_FALSE(gcp_detail::findAdcFile().has_value());
+
+    deletePath(tmp);
+}
+
+} // namespace nix
+
+#endif

--- a/src/libstore-tests/gcs-binary-cache-store.cc
+++ b/src/libstore-tests/gcs-binary-cache-store.cc
@@ -1,0 +1,30 @@
+#include "nix/store/gcs-binary-cache-store.hh"
+
+#include <gtest/gtest.h>
+
+namespace nix {
+
+TEST(GCSBinaryCacheStore, resolvesEndpointFromParams)
+{
+    Store::Config::Params params{
+        {"endpoint", "http://localhost:4443"},
+        {"user-project", "billing-proj"},
+        {"storage-class", "NEARLINE"},
+    };
+    GCSBinaryCacheStoreConfig config{"my-bucket", params};
+
+    EXPECT_EQ(config.cacheUri.scheme, "gs");
+    EXPECT_TRUE(config.cacheUri.query.empty());
+    EXPECT_EQ(config.resolvedEndpoint, parseURL("http://localhost:4443"));
+    EXPECT_EQ(config.userProject.get(), "billing-proj");
+    EXPECT_EQ(config.storageClass.get(), std::optional<std::string>{"NEARLINE"});
+}
+
+TEST(GCSBinaryCacheStore, rejectsTooSmallChunkSize)
+{
+    EXPECT_THROW(
+        (GCSBinaryCacheStoreConfig{"foobar", {{"multipart-upload", "true"}, {"multipart-chunk-size", "1048576"}}}),
+        UsageError);
+}
+
+} // namespace nix

--- a/src/libstore-tests/gcs-url.cc
+++ b/src/libstore-tests/gcs-url.cc
@@ -1,0 +1,111 @@
+#include "nix/store/gcs-url.hh"
+#include "nix/util/tests/gmock-matchers.hh"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace nix {
+
+struct ParsedGCSURLTestCase
+{
+    std::string url;
+    ParsedGCSURL expected;
+    std::string description;
+};
+
+class ParsedGCSURLTest : public ::testing::WithParamInterface<ParsedGCSURLTestCase>, public ::testing::Test
+{};
+
+TEST_P(ParsedGCSURLTest, parseGCSURLSuccessfully)
+{
+    const auto & testCase = GetParam();
+    auto parsed = ParsedGCSURL::parse(parseURL(testCase.url));
+    ASSERT_EQ(parsed, testCase.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    QueryParams,
+    ParsedGCSURLTest,
+    ::testing::Values(
+        ParsedGCSURLTestCase{
+            "gs://my-bucket/my-key.txt",
+            {
+                .bucket = "my-bucket",
+                .key = {"my-key.txt"},
+            },
+            "basic_gs_bucket",
+        },
+        ParsedGCSURLTestCase{
+            "gs://prod-cache/nix/store/abc123.nar.xz",
+            {
+                .bucket = "prod-cache",
+                .key = {"nix", "store", "abc123.nar.xz"},
+            },
+            "nested_key",
+        },
+        ParsedGCSURLTestCase{
+            "gs://bucket/key?user-project=proj&generation=42",
+            {
+                .bucket = "bucket",
+                .key = {"key"},
+                .userProject = "proj",
+                .generation = "42",
+            },
+            "all_params",
+        }),
+    [](const ::testing::TestParamInfo<ParsedGCSURLTestCase> & info) { return info.param.description; });
+
+struct InvalidGCSURLTestCase
+{
+    std::string url;
+    std::string expectedErrorSubstring;
+    std::string description;
+};
+
+class InvalidParsedGCSURLTest : public ::testing::WithParamInterface<InvalidGCSURLTestCase>, public ::testing::Test
+{};
+
+TEST_P(InvalidParsedGCSURLTest, parseGCSURLErrors)
+{
+    const auto & testCase = GetParam();
+
+    ASSERT_THAT(
+        [&testCase]() { ParsedGCSURL::parse(parseURL(testCase.url)); },
+        ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher(testCase.expectedErrorSubstring)));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    InvalidUrls,
+    InvalidParsedGCSURLTest,
+    ::testing::Values(
+        InvalidGCSURLTestCase{"gs:///key", "error: URI has a missing or invalid bucket name", "empty_bucket"},
+        InvalidGCSURLTestCase{"gs://127.0.0.1", "error: URI has a missing or invalid bucket name", "ip_address_bucket"},
+        InvalidGCSURLTestCase{"gs://", "error: URI has a missing or invalid bucket name", "completely_empty"},
+        InvalidGCSURLTestCase{"gs://bucket", "error: URI has a missing or invalid key", "missing_key"},
+        InvalidGCSURLTestCase{"s3://bucket/key", "error: URI scheme 's3' is not 'gs'", "wrong_scheme"},
+        /* Bearer tokens are host-independent. Refusing here is the security boundary that keeps fetchurl from
+           exfiltrating one. */
+        InvalidGCSURLTestCase{
+            "gs://bucket/key?endpoint=attacker.example", "not accepted in a gs:// URL", "endpoint_in_url_rejected"},
+        InvalidGCSURLTestCase{"gs://bucket/key?scheme=http", "not accepted in a gs:// URL", "scheme_in_url_rejected"},
+        InvalidGCSURLTestCase{
+            "gs://bucket/key?user-project=p%0d%0aX-Evil:1", "invalid 'user-project' value", "user_project_crlf"},
+        InvalidGCSURLTestCase{
+            "gs://bucket/../other-bucket/key", "URI key has an invalid path segment", "dotdot_escapes_bucket"}),
+    [](const ::testing::TestParamInfo<InvalidGCSURLTestCase> & info) { return info.param.description; });
+
+TEST(ParsedGCSURL, toHttpsUrl)
+{
+    auto p = ParsedGCSURL::parse(parseURL("gs://prod-cache/nix/store/abc.nar.xz?generation=42"));
+    EXPECT_EQ(
+        p.toHttpsUrl().to_string(), "https://storage.googleapis.com/prod-cache/nix/store/abc.nar.xz?generation=42");
+}
+
+TEST(ParsedGCSURL, toHttpsUrlCustomEndpoint)
+{
+    ParsedGCSURL p{.bucket = "b", .key = {"k"}};
+    EXPECT_EQ(p.toHttpsUrl(parseURL("http://emu.internal:4443")).to_string(), "http://emu.internal:4443/b/k");
+    EXPECT_EQ(p.toHttpsUrl(parseURL("http://server:9000/prefix")).to_string(), "http://server:9000/prefix/b/k");
+}
+
+} // namespace nix

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -74,6 +74,7 @@ sources = files(
   'filetransfer-request.cc',
   'filetransfer-retry.cc',
   'gcp-creds.cc',
+  'gcs-binary-cache-store.cc',
   'gcs-url.cc',
   'http-binary-cache-store.cc',
   'legacy-ssh-store.cc',

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -32,6 +32,13 @@ subdir('nix-meson-build-support/windows-version')
 sqlite = dependency('sqlite3', 'sqlite', version : '>=3.6.19')
 deps_private += sqlite
 
+# Needed by gcp-creds.cc tests (RSA keygen + signature verification). The test
+# bodies are guarded by NIX_WITH_GCS_AUTH so this is harmless when disabled.
+openssl = dependency('libcrypto', 'openssl', required : false)
+if openssl.found()
+  deps_private += openssl
+endif
+
 rapidcheck = dependency('rapidcheck')
 deps_private += rapidcheck
 
@@ -66,6 +73,7 @@ sources = files(
   'dummy-store.cc',
   'filetransfer-request.cc',
   'filetransfer-retry.cc',
+  'gcp-creds.cc',
   'gcs-url.cc',
   'http-binary-cache-store.cc',
   'legacy-ssh-store.cc',

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -66,6 +66,7 @@ sources = files(
   'dummy-store.cc',
   'filetransfer-request.cc',
   'filetransfer-retry.cc',
+  'gcs-url.cc',
   'http-binary-cache-store.cc',
   'legacy-ssh-store.cc',
   'local-binary-cache-store.cc',

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -45,6 +45,7 @@ mkMesonExecutable (finalAttrs: {
 
   buildInputs = [
     sqlite
+    openssl
     rapidcheck
     gtest
     nix-store

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -7,6 +7,8 @@
 #include "nix/util/signals.hh"
 #include "nix/util/util.hh"
 
+#include "nix/store/gcp-creds.hh"
+#include "nix/store/gcs-url.hh"
 #include "nix/store/s3-url.hh"
 #include <optional>
 #if NIX_WITH_AWS_AUTH
@@ -27,6 +29,7 @@
 #include <cstring>
 #include <queue>
 #include <random>
+#include <future>
 #include <thread>
 #include <utility>
 #include <regex>
@@ -204,6 +207,10 @@ struct curlFileTransfer : public FileTransfer
          */
         bool hasContentEncoding:1 = false;
 
+        bool bearerRefreshed:1 = false;
+
+        std::optional<std::future<std::optional<std::string>>> pendingBearerRefresh;
+
         /**
          * Server-provided minimum retry delay, parsed from the `Retry-After`
          * response header. Reset on each new HTTP status line, and consumed
@@ -275,14 +282,19 @@ struct curlFileTransfer : public FileTransfer
             })
         {
             result.urls.push_back(request.uri.to_string());
+        }
 
+        void buildRequestHeaders()
+        {
+            requestHeaders.reset();
             if (!request.expectedETag.empty())
                 appendHeaders("If-None-Match: " + request.expectedETag);
             if (!request.mimeType.empty())
                 appendHeaders("Content-Type: " + request.mimeType);
-            for (auto it = request.headers.begin(); it != request.headers.end(); ++it) {
-                appendHeaders(fmt("%s: %s", it->first, it->second));
-            }
+            for (const auto & [name, value] : request.headers)
+                appendHeaders(fmt("%s: %s", name, value));
+            if (request.bearerToken)
+                appendHeaders("Authorization: Bearer " + *request.bearerToken);
         }
 
         ~TransferItem()
@@ -584,6 +596,15 @@ struct curlFileTransfer : public FileTransfer
 
             curl_easy_reset(req);
 
+            if (pendingBearerRefresh
+                && pendingBearerRefresh->wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+                if (auto t = pendingBearerRefresh->get())
+                    request.bearerToken = std::move(t);
+                pendingBearerRefresh.reset();
+                bearerRefreshed = true;
+            }
+            buildRequestHeaders();
+
             if (verbosity >= lvlVomit) {
                 curl_easy_setopt(req, CURLOPT_VERBOSE, 1);
                 curl_easy_setopt(req, CURLOPT_DEBUGFUNCTION, TransferItem::debugCallback);
@@ -819,7 +840,9 @@ struct curlFileTransfer : public FileTransfer
                     || code == CURLE_FILE_COULDNT_READ_FILE) {
                     // The file is definitely not there
                     err = NotFound;
-                } else if (httpStatus == HttpStatus::Unauthorized || httpStatus == HttpStatus::ProxyAuthRequired) {
+                } else if (httpStatus == HttpStatus::Unauthorized) {
+                    err = (request.refreshBearerToken && !bearerRefreshed) ? Transient : Unauthorized;
+                } else if (httpStatus == HttpStatus::ProxyAuthRequired) {
                     err = Unauthorized;
                 } else if (httpStatus == HttpStatus::Forbidden) {
                     // Don't retry on authentication/authorization failures.
@@ -939,8 +962,30 @@ struct curlFileTransfer : public FileTransfer
             }();
 
             if (!canRetry) {
+                if (httpStatus == HttpStatus::Unauthorized && exc.error == Transient)
+                    exc.error = Unauthorized;
                 fail(std::move(exc));
                 return;
+            }
+
+            if (httpStatus != HttpStatus::Unauthorized)
+                bearerRefreshed = false;
+            else if (request.refreshBearerToken && !bearerRefreshed && !pendingBearerRefresh) {
+                try {
+                    auto promise = std::make_shared<std::promise<std::optional<std::string>>>();
+                    std::thread([refresh = request.refreshBearerToken, promise]() noexcept {
+                        try {
+                            promise->set_value(refresh());
+                        } catch (...) {
+                            try {
+                                promise->set_value(std::nullopt);
+                            } catch (...) {
+                            }
+                        }
+                    }).detach();
+                    pendingBearerRefresh = promise->get_future();
+                } catch (const std::system_error &) {
+                }
             }
 
             auto delay = computeRetryDelayMs(
@@ -1199,7 +1244,7 @@ struct curlFileTransfer : public FileTransfer
     ItemHandle enqueueItem(ref<TransferItem> item)
     {
         if (item->request.data && item->request.uri.scheme() != "http" && item->request.uri.scheme() != "https"
-            && item->request.uri.scheme() != "s3")
+            && item->request.uri.scheme() != "s3" && item->request.uri.scheme() != "gs")
             throw nix::Error("uploading to '%s' is not supported", item->request.displayUri());
 
         {
@@ -1216,10 +1261,15 @@ struct curlFileTransfer : public FileTransfer
 
     ItemHandle enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) override
     {
-        /* Handle s3:// URIs by converting to HTTPS and optionally adding auth */
+        /* Handle s3:// and gs:// URIs by converting to HTTPS and optionally adding auth */
         if (request.uri.scheme() == "s3") {
             auto modifiedRequest = request;
             modifiedRequest.setupForS3();
+            return enqueueItem(make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback)));
+        }
+        if (request.uri.scheme() == "gs") {
+            auto modifiedRequest = request;
+            modifiedRequest.setupForGCS();
             return enqueueItem(make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback)));
         }
 
@@ -1314,6 +1364,33 @@ void FileTransferRequest::setupForS3()
 #else
     // When built without AWS support, just try as public bucket
     debug("S3 request without authentication (built without AWS support)");
+#endif
+}
+
+void FileTransferRequest::setupForGCS()
+{
+    auto parsed = ParsedGCSURL::parse(uri.parsed());
+    uri = parsed.toHttpsUrl();
+
+    /* Requester-pays buckets reject requests without a billing project. */
+    if (parsed.userProject)
+        headers.emplace_back("x-goog-user-project", *parsed.userProject);
+
+#if NIX_WITH_GCS_AUTH
+    if (gcpCredentialProvider) {
+        if (auto creds = gcpCredentialProvider->maybeGetCredentials())
+            bearerToken = creds->accessToken;
+        refreshBearerToken = [p = gcpCredentialProvider,
+                              wft = std::weak_ptr(getFileTransfer().get_ptr())]() -> std::optional<std::string> {
+            if (auto ft = wft.lock())
+                if (auto creds = p->tryRefreshCredentials(*ft))
+                    return creds->accessToken;
+            return std::nullopt;
+        };
+    } else
+        debug("GCS request without credential provider");
+#else
+    debug("GCS request without authentication (built without GCS auth support)");
 #endif
 }
 

--- a/src/libstore/gcp-creds.cc
+++ b/src/libstore/gcp-creds.cc
@@ -361,31 +361,11 @@ public:
     }
 };
 
-Sync<std::shared_ptr<GcpCredentialProvider>> & providerSlot()
-{
-    static Sync<std::shared_ptr<GcpCredentialProvider>> slot;
-    return slot;
-}
-
 } // anonymous namespace
 
 ref<GcpCredentialProvider> makeGcpCredentialsProvider()
 {
     return make_ref<GcpCredentialProviderImpl>();
-}
-
-ref<GcpCredentialProvider> getGcpCredentialsProvider()
-{
-    auto slot(providerSlot().lock());
-    if (!*slot)
-        *slot = makeGcpCredentialsProvider().get_ptr();
-    return ref(*slot);
-}
-
-void setGcpCredentialsProviderForTesting(ref<GcpCredentialProvider> provider)
-{
-    auto slot(providerSlot().lock());
-    *slot = provider.get_ptr();
 }
 
 } // namespace nix

--- a/src/libstore/gcp-creds.cc
+++ b/src/libstore/gcp-creds.cc
@@ -1,0 +1,393 @@
+#include "nix/store/gcp-creds.hh"
+
+#if NIX_WITH_GCS_AUTH
+
+#  include "nix/store/filetransfer.hh"
+#  include "nix/util/base-n.hh"
+#  include "nix/util/environment-variables.hh"
+#  include "nix/util/file-system.hh"
+#  include "nix/util/logging.hh"
+#  include "nix/util/sync.hh"
+#  include "nix/util/url.hh"
+#  include "nix/util/users.hh"
+#  ifdef _WIN32
+#    include "nix/util/windows-known-folders.hh"
+#  endif
+
+#  include <nlohmann/json.hpp>
+#  include <openssl/err.h>
+#  include <openssl/evp.h>
+#  include <openssl/pem.h>
+
+#  include <algorithm>
+#  include <chrono>
+
+namespace nix {
+
+void GcpAuthError::anchor() {}
+
+GcpCredentialProvider::~GcpCredentialProvider() {}
+
+/* Refresh tokens this long before their nominal expiry.
+ * A request started just before expiry doesn't race with revocation on the server side.
+ */
+static constexpr auto kExpirySlack = std::chrono::seconds{225};
+static constexpr auto kMinCacheLifetime = std::chrono::seconds{30};
+
+static constexpr std::string_view kOauthScope = "https://www.googleapis.com/auth/devstorage.read_write";
+static constexpr std::string_view kDefaultTokenUri = "https://oauth2.googleapis.com/token";
+static constexpr std::string_view kMetadataHost = "metadata.google.internal";
+static constexpr std::string_view kMetadataTokenPath = "/computeMetadata/v1/instance/service-accounts/default/token";
+
+namespace gcp_detail {
+
+std::string base64url(std::span<const std::byte> bytes)
+{
+    auto s = base64::encode(bytes);
+    for (auto & c : s) {
+        if (c == '+')
+            c = '-';
+        else if (c == '/')
+            c = '_';
+    }
+    while (!s.empty() && s.back() == '=')
+        s.pop_back();
+    return s;
+}
+
+std::string base64url(std::string_view s)
+{
+    return base64url(std::span{reinterpret_cast<const std::byte *>(s.data()), s.size()});
+}
+
+[[noreturn]] static void throwOpenSSLError(std::string_view what)
+{
+    auto code = ERR_get_error();
+    char buf[256];
+    ERR_error_string_n(code, buf, sizeof(buf));
+    throw GcpAuthError("OpenSSL error while %s: %s", what, buf);
+}
+
+std::string signRS256(const std::string & privateKeyPem, std::string_view payload)
+{
+    auto * bio = BIO_new_mem_buf(privateKeyPem.data(), static_cast<int>(privateKeyPem.size()));
+    if (!bio)
+        throwOpenSSLError("allocating BIO for private key");
+    std::unique_ptr<BIO, decltype(&BIO_free)> bioGuard(bio, BIO_free);
+
+    std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pkey(
+        PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr), EVP_PKEY_free);
+    if (!pkey)
+        throwOpenSSLError("parsing PEM private key");
+
+    std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+    if (!ctx)
+        throwOpenSSLError("allocating EVP_MD_CTX");
+
+    if (EVP_DigestSignInit(ctx.get(), nullptr, EVP_sha256(), nullptr, pkey.get()) != 1)
+        throwOpenSSLError("EVP_DigestSignInit");
+    if (EVP_DigestSignUpdate(ctx.get(), payload.data(), payload.size()) != 1)
+        throwOpenSSLError("EVP_DigestSignUpdate");
+
+    size_t sigLen = 0;
+    if (EVP_DigestSignFinal(ctx.get(), nullptr, &sigLen) != 1)
+        throwOpenSSLError("EVP_DigestSignFinal (sizing)");
+    std::string sig(sigLen, '\0');
+    if (EVP_DigestSignFinal(ctx.get(), reinterpret_cast<unsigned char *>(sig.data()), &sigLen) != 1)
+        throwOpenSSLError("EVP_DigestSignFinal");
+    sig.resize(sigLen);
+    return sig;
+}
+
+std::string
+buildServiceAccountJwtSigningInput(std::string_view clientEmail, std::string_view tokenUri, long iat, long exp)
+{
+    nlohmann::json header = {{"alg", "RS256"}, {"typ", "JWT"}};
+    nlohmann::json claims = {
+        {"iss", clientEmail},
+        {"scope", std::string{kOauthScope}},
+        {"aud", tokenUri},
+        {"iat", iat},
+        {"exp", exp},
+    };
+    return base64url(header.dump()) + "." + base64url(claims.dump());
+}
+
+GcpCredentials parseTokenResponse(const std::string & body)
+{
+    nlohmann::json j;
+    try {
+        j = nlohmann::json::parse(body);
+    } catch (nlohmann::json::exception & e) {
+        throw GcpAuthError("GCP token endpoint returned invalid JSON: %s", e.what());
+    }
+    auto token = j.value("access_token", std::string{});
+    if (token.empty()) {
+        debug("GCP token endpoint response: %s", body);
+        throw GcpAuthError("GCP token endpoint response missing 'access_token'");
+    }
+    auto expiresIn = std::chrono::seconds(j.value("expires_in", 3600));
+    auto now = std::chrono::steady_clock::now();
+    return GcpCredentials{
+        .accessToken = std::move(token),
+        .expiresAt = std::max(now + expiresIn - kExpirySlack, now + kMinCacheLifetime),
+    };
+}
+
+std::optional<std::filesystem::path> findAdcFile()
+{
+    if (auto p = getEnv("GOOGLE_APPLICATION_CREDENTIALS"))
+        return std::filesystem::path{*p};
+
+    /* gcloud's well-known location.
+     * `$CLOUDSDK_CONFIG` overrides the gcloud config dir as a whole
+     * Otherwise we use ~/.config/gcloud on Unix and %APPDATA%\gcloud on Windows
+     * (gcloud is not XDG-aware).
+     */
+    auto gcloudDir = [&]() -> std::filesystem::path {
+        if (auto d = getEnv("CLOUDSDK_CONFIG"))
+            return *d;
+#  ifndef _WIN32
+        return getHome() / ".config" / "gcloud";
+#  else
+        return windows::known_folders::getRoamingAppData() / "gcloud";
+#  endif
+    }();
+    auto wellKnown = gcloudDir / "application_default_credentials.json";
+    if (pathExists(wellKnown))
+        return wellKnown;
+
+    return std::nullopt;
+}
+
+} // namespace gcp_detail
+
+namespace {
+
+FileTransferResult httpGet(FileTransfer & ft, std::string_view url, Headers headers, std::optional<uint32_t> attempts)
+{
+    FileTransferRequest req{VerbatimURL{url}};
+    req.headers = std::move(headers);
+    req.retryAttempts = attempts;
+    return ft.download(req);
+}
+
+FileTransferResult httpPostForm(FileTransfer & ft, std::string_view url, std::string body)
+{
+    FileTransferRequest req{VerbatimURL{url}};
+    req.method = HttpMethod::Post;
+    StringSource src{body};
+    req.data = {src};
+    req.mimeType = "application/x-www-form-urlencoded";
+    /* Token endpoints are stateless. Let the normal retry policy apply. */
+    return ft.upload(req);
+}
+
+/**
+ * GCE/GKE metadata server
+ * Outside of GCP `metadata.google.internal` does not
+ * resolve and the request fails fast at DNS level.
+ * We therefore don't add an extra resolvability probe.
+ * Users can also point at a local stub via `$GCE_METADATA_HOST` (honoured by all Google SDKs).
+ */
+std::optional<GcpCredentials> metadataServerCredentials(FileTransfer & ft)
+{
+    auto host = getEnv("GCE_METADATA_HOST").value_or(std::string{kMetadataHost});
+    auto url = "http://" + host + std::string{kMetadataTokenPath};
+    Headers hdrs{{"Metadata-Flavor", "Google"}};
+    try {
+        return gcp_detail::parseTokenResponse(httpGet(ft, url, hdrs, /*attempts=*/1).data);
+    } catch (FileTransferError & e) {
+        if (!e.response || e.error != FileTransfer::Transient) {
+            debug("GCP metadata server not available: %s", e.what());
+            return std::nullopt;
+        }
+    }
+    try {
+        return gcp_detail::parseTokenResponse(httpGet(ft, url, hdrs, /*attempts=*/std::nullopt).data);
+    } catch (FileTransferError & e) {
+        throw GcpAuthError("GCP metadata server error: %s", e.message());
+    }
+}
+
+std::string requireField(const nlohmann::json & j, std::string_view credType, const char * key)
+{
+    auto v = j.value(key, std::string{});
+    if (v.empty())
+        throw GcpAuthError("%s credentials missing '%s'", credType, key);
+    return v;
+}
+
+/** `"type":"authorized_user"` is a refresh-token flow used by `gcloud auth application-default login`. */
+GcpCredentials authorizedUserCredentials(FileTransfer & ft, const nlohmann::json & j)
+{
+    auto require = [&](const char * k) { return requireField(j, "authorized_user", k); };
+    auto body = encodeQuery({
+        {"grant_type", "refresh_token"},
+        {"client_id", require("client_id")},
+        {"client_secret", require("client_secret")},
+        {"refresh_token", require("refresh_token")},
+    });
+    auto tokenUri = j.value("token_uri", std::string{kDefaultTokenUri});
+    return gcp_detail::parseTokenResponse(httpPostForm(ft, tokenUri, std::move(body)).data);
+}
+
+/** `"type":"service_account"` is a self-signed JWT exchanged for an access token. */
+GcpCredentials serviceAccountCredentials(FileTransfer & ft, const nlohmann::json & j)
+{
+    auto require = [&](const char * k) { return requireField(j, "service_account", k); };
+    auto clientEmail = require("client_email");
+    auto privateKey = require("private_key");
+    auto tokenUri = j.value("token_uri", std::string{kDefaultTokenUri});
+
+    auto now = std::chrono::system_clock::now();
+    auto iat = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+
+    auto signingInput = gcp_detail::buildServiceAccountJwtSigningInput(clientEmail, tokenUri, iat, iat + 3600);
+    auto sig = gcp_detail::signRS256(privateKey, signingInput);
+    auto assertion = signingInput + "."
+                     + gcp_detail::base64url(std::span{reinterpret_cast<const std::byte *>(sig.data()), sig.size()});
+
+    auto body = encodeQuery({
+        {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"},
+        {"assertion", assertion},
+    });
+    return gcp_detail::parseTokenResponse(httpPostForm(ft, tokenUri, std::move(body)).data);
+}
+
+std::optional<GcpCredentials> fileCredentials(FileTransfer & ft, const std::filesystem::path & path)
+{
+    std::string content;
+    try {
+        content = readFile(path);
+    } catch (SysError & e) {
+        /* e.g. GOOGLE_APPLICATION_CREDENTIALS points at a missing file.
+         * Rewrap so the caller's GcpAuthError to add GCP-context rather a bare "No such file".
+         */
+        throw GcpAuthError("failed to read GCP credentials '%s': %s", path.string(), e.what());
+    }
+    nlohmann::json j;
+    try {
+        j = nlohmann::json::parse(content);
+    } catch (nlohmann::json::exception &) {
+        /* nlohmann's e.what() quotes an excerpt of the input, so we don't log it to avoid leaking credentials. */
+        throw GcpAuthError("GCP credentials '%s' are not valid JSON", path.string());
+    }
+    auto type = j.value("type", std::string{});
+    if (type == "service_account")
+        return serviceAccountCredentials(ft, j);
+    if (type == "authorized_user")
+        return authorizedUserCredentials(ft, j);
+    /* `external_account` (workload identity federation) is intentionally
+       unsupported to avoid pulling in the heavy google-cloud-cpp SDK.
+       Surface a clear error rather than silently skipping so the user knows
+       why auth failed. */
+    throw GcpAuthError("GCP credentials '%s' have unsupported type '%s'", path.string(), type);
+}
+
+/* How long a negative result (no credentials available) is cached
+ * before the ADC chain (including the metadata-server probe) is retried.
+ * Without this a public-bucket copy of N paths re-probes metadata.google.internal N times.
+ */
+static constexpr auto negativeCacheTtl = std::chrono::seconds(60);
+
+class GcpCredentialProviderImpl final : public GcpCredentialProvider
+{
+    struct CacheEntry
+    {
+        std::optional<GcpCredentials> creds; // nullopt = no credentials available
+        std::chrono::steady_clock::time_point validUntil;
+    };
+
+    Sync<std::optional<CacheEntry>> cached_;
+
+    std::optional<GcpCredentials> resolve(FileTransfer & ft)
+    {
+        if (auto path = gcp_detail::findAdcFile()) {
+            debug("using GCP credentials from '%s'", path->string());
+            try {
+                return fileCredentials(ft, *path);
+            } catch (FileTransferError & e) {
+                throw GcpAuthError("failed to obtain GCP access token: %s", e.message());
+            }
+        }
+        return metadataServerCredentials(ft);
+    }
+
+    std::optional<GcpCredentials> store(std::optional<GcpCredentials> fresh, std::chrono::steady_clock::time_point now)
+    {
+        auto validUntil = fresh ? fresh->expiresAt : now + negativeCacheTtl;
+        auto cached(cached_.lock());
+        if (fresh || !*cached || (*cached)->validUntil <= now)
+            *cached = CacheEntry{fresh, validUntil};
+        else
+            return (*cached)->creds;
+        return fresh;
+    }
+
+public:
+    std::optional<GcpCredentials> maybeGetCredentials() override
+    {
+        auto now = std::chrono::steady_clock::now();
+        {
+            auto cached(cached_.lock());
+            if (*cached && (*cached)->validUntil > now)
+                return (*cached)->creds;
+        }
+        /* Drop the lock across the (potentially slow) network call so concurrent callers don't serialise on it. */
+        std::optional<GcpCredentials> fresh;
+        try {
+            fresh = resolve(*getFileTransfer());
+        } catch (GcpAuthError & e) {
+            /* A broken/unsupported ADC file should surface to the user (so they don't just see a bare 403),
+             * but not once per request. Instead treat it as a negative result so it is cached like "no credentials".
+             */
+            warn("GCP authentication failed, proceeding without credentials: %s", e.message());
+        } catch (nlohmann::json::exception & e) {
+            warn("GCP authentication failed (malformed JSON field): %s", e.what());
+        }
+        return store(std::move(fresh), now);
+    }
+
+    std::optional<GcpCredentials> tryRefreshCredentials(FileTransfer & ft) noexcept override
+    {
+        auto now = std::chrono::steady_clock::now();
+        cached_.lock()->reset();
+        try {
+            return store(resolve(ft), now);
+        } catch (...) {
+            return store(std::nullopt, now);
+        }
+    }
+};
+
+Sync<std::shared_ptr<GcpCredentialProvider>> & providerSlot()
+{
+    static Sync<std::shared_ptr<GcpCredentialProvider>> slot;
+    return slot;
+}
+
+} // anonymous namespace
+
+ref<GcpCredentialProvider> makeGcpCredentialsProvider()
+{
+    return make_ref<GcpCredentialProviderImpl>();
+}
+
+ref<GcpCredentialProvider> getGcpCredentialsProvider()
+{
+    auto slot(providerSlot().lock());
+    if (!*slot)
+        *slot = makeGcpCredentialsProvider().get_ptr();
+    return ref(*slot);
+}
+
+void setGcpCredentialsProviderForTesting(ref<GcpCredentialProvider> provider)
+{
+    auto slot(providerSlot().lock());
+    *slot = provider.get_ptr();
+}
+
+} // namespace nix
+
+#endif

--- a/src/libstore/gcs-binary-cache-store.cc
+++ b/src/libstore/gcs-binary-cache-store.cc
@@ -1,0 +1,128 @@
+#include "nix/store/gcs-binary-cache-store.hh"
+#include "nix/store/gcp-creds.hh"
+#include "nix/store/gcs-url.hh"
+#include "nix/store/store-registration.hh"
+
+#include <cassert>
+
+namespace nix {
+
+class GCSBinaryCacheStore : public virtual S3CompatBinaryCacheStore
+{
+    void anchor() override;
+
+public:
+    GCSBinaryCacheStore(ref<GCSBinaryCacheStoreConfig> config)
+        : Store{*config}
+        , BinaryCacheStore{*config}
+        , HttpBinaryCacheStore{config}
+        , S3CompatBinaryCacheStore{config}
+        , gcsConfig{config}
+    {
+    }
+
+protected:
+    std::string_view backendName() const override
+    {
+        return "GCS";
+    }
+
+    /**
+     * Produce an `http(s)://<endpoint>/<bucket>/<path>` request with the
+     * bearer token attached. This is where the store's configured endpoint is
+     * applied; a `gs://` URL cannot carry one (see `ParsedGCSURL`).
+     */
+    FileTransferRequest makeRequest(std::string_view path) override
+    {
+        auto req = HttpBinaryCacheStore::makeRequest(path);
+        req.uri = ParsedGCSURL::parse(req.uri.parsed()).toHttpsUrl(gcsConfig->resolvedEndpoint);
+
+        if (auto up = gcsConfig->userProject.get(); !up.empty())
+            req.headers.emplace_back("x-goog-user-project", up);
+
+#if NIX_WITH_GCS_AUTH
+        if (auto creds = credentialProvider->maybeGetCredentials())
+            req.bearerToken = creds->accessToken;
+        req.refreshBearerToken = [p = credentialProvider,
+                                  wft = std::weak_ptr(getFileTransfer().get_ptr())]() -> std::optional<std::string> {
+            if (auto ft = wft.lock())
+                if (auto creds = p->tryRefreshCredentials(*ft))
+                    return creds->accessToken;
+            return std::nullopt;
+        };
+#endif
+        return req;
+    }
+
+    void prepareRequest(FileTransferRequest &) const override
+    {
+        /* makeRequest() already rewrote the URL and attached credentials;
+           nothing left for the multipart path to do. */
+    }
+
+    void addUploadHeaders(Headers & headers) const override
+    {
+        if (auto storageClass = gcsConfig->storageClass.get())
+            headers.emplace_back("x-goog-storage-class", *storageClass);
+    }
+
+private:
+    ref<GCSBinaryCacheStoreConfig> gcsConfig;
+
+#if NIX_WITH_GCS_AUTH
+    /** Caches tokens for the store's lifetime. */
+    ref<GcpCredentialProvider> credentialProvider = makeGcpCredentialsProvider();
+#endif
+};
+
+void GCSBinaryCacheStore::anchor() {}
+
+StringSet GCSBinaryCacheStoreConfig::uriSchemes()
+{
+    return {"gs"};
+}
+
+GCSBinaryCacheStoreConfig::GCSBinaryCacheStoreConfig(ParsedURL cacheUri_, const Params & params)
+    : StoreConfig(params, FilePathType::Unix)
+    , S3CompatBinaryCacheStoreConfig(std::move(cacheUri_), params)
+{
+    assert(cacheUri.query.empty());
+    assert(cacheUri.scheme == "gs");
+
+    if (auto ep = endpoint.get(); !ep.empty()) {
+        if (ep.find("://") == std::string::npos)
+            throw UsageError("GCS 'endpoint' must be a full URL including the scheme, e.g. 'http://localhost:4443'");
+        resolvedEndpoint = parseURL(ep);
+    }
+
+    validateMultipartSettings();
+}
+
+GCSBinaryCacheStoreConfig::GCSBinaryCacheStoreConfig(std::string_view bucketName, const Params & params)
+    : GCSBinaryCacheStoreConfig(
+          ParsedURL{.scheme = "gs", .authority = ParsedURL::Authority{.host = std::string(bucketName)}}, params)
+{
+}
+
+std::string GCSBinaryCacheStoreConfig::getHumanReadableURI() const
+{
+    return renderHumanReadableUri({&endpoint, &userProject});
+}
+
+std::string GCSBinaryCacheStoreConfig::doc()
+{
+    return
+#include "gcs-binary-cache-store.md"
+        ;
+}
+
+ref<Store> GCSBinaryCacheStoreConfig::openStore() const
+{
+    auto sharedThis = std::const_pointer_cast<GCSBinaryCacheStoreConfig>(
+        std::static_pointer_cast<const GCSBinaryCacheStoreConfig>(shared_from_this()));
+    return make_ref<GCSBinaryCacheStore>(ref{sharedThis});
+}
+
+static RegisterStoreImplementation<GCSBinaryCacheStoreConfig> registerGCSBinaryCacheStore;
+
+} // namespace nix

--- a/src/libstore/gcs-binary-cache-store.md
+++ b/src/libstore/gcs-binary-cache-store.md
@@ -1,0 +1,52 @@
+R"(
+
+**Store URL format**: `gs://`*bucket-name*
+
+This store allows reading and writing a [binary cache](@docroot@/protocols/binary-cache/index.md) stored in a Google Cloud Storage bucket.
+It speaks the GCS [XML API], which is wire-compatible with S3, so it shares its multipart upload implementation and limits with the [S3 Binary Cache Store](@docroot@/store/types/s3-binary-cache-store.md).
+
+[XML API]: https://cloud.google.com/storage/docs/xml-api/overview
+
+### Authentication
+
+Nix authenticates to GCS using [Application Default Credentials][adc].
+The following sources are tried in order:
+
+1. The file pointed to by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable (a service-account key or `gcloud` user credentials).
+2. `$CLOUDSDK_CONFIG/application_default_credentials.json`, otherwise `~/.config/gcloud/application_default_credentials.json` (created by `gcloud auth application-default login`).
+3. The GCE/GKE metadata server, when running on Google Cloud.
+
+If no credentials are found, requests are sent unauthenticated, which works for public buckets.
+Workload-identity federation (`external_account` credentials) is not yet supported.
+
+[adc]: https://cloud.google.com/docs/authentication/application-default-credentials
+
+### Permissions
+
+For reading, the principal needs the `storage.objects.get` permission on the bucket (e.g. the `roles/storage.objectViewer` role).
+
+For writing, the principal additionally needs `storage.objects.create` and `storage.objects.delete` (e.g. the `roles/storage.objectAdmin` role); the latter is required so multipart uploads can be aborted on failure.
+
+### Examples
+
+- To upload to a GCS bucket using the ambient ADC credentials:
+
+  ```console
+  $ nix copy nixpkgs.hello --to gs://example-nix-cache
+  ```
+
+- To use a requester-pays bucket, billing the access to your project:
+
+  ```console
+  $ nix copy nixpkgs.hello \
+    --to 'gs://example-nix-cache?user-project=my-billing-project'
+  ```
+
+- To target a GCS-compatible emulator:
+
+  ```console
+  $ nix copy nixpkgs.hello \
+    --to 'gs://example-nix-cache?endpoint=http://localhost:4443'
+  ```
+
+)"

--- a/src/libstore/gcs-url.cc
+++ b/src/libstore/gcs-url.cc
@@ -1,0 +1,86 @@
+#include "nix/store/gcs-url.hh"
+#include "nix/util/error.hh"
+#include "nix/util/util.hh"
+
+#include <ranges>
+#include <string_view>
+
+namespace nix {
+
+ParsedGCSURL ParsedGCSURL::parse(const ParsedURL & parsed)
+try {
+    if (parsed.scheme != "gs")
+        throw BadURL("URI scheme '%s' is not 'gs'", parsed.scheme);
+
+    /* Like S3, the bucket name is the URI authority.
+     * Only reject the cases that would make the resulting HTTPS URL malformed. */
+    if (!parsed.authority || parsed.authority->host.empty()
+        || parsed.authority->hostType != ParsedURL::Authority::HostType::Name)
+        throw BadURL("URI has a missing or invalid bucket name");
+
+    auto getOptionalParam = [&](std::string_view key) -> std::optional<std::string> {
+        auto it = parsed.query.find(key);
+        if (it == parsed.query.end())
+            return std::nullopt;
+        return it->second;
+    };
+
+    /* See the struct docstring:
+     * Refusing here means a `gs://` URL cannot name a non-Google host,
+     * so the bearer token can never be leaked elsewhere.
+     */
+    if (getOptionalParam("endpoint") || getOptionalParam("scheme"))
+        throw BadURL("'endpoint' and 'scheme' are not accepted in a gs:// URL; configure them on the store instead");
+
+    if (parsed.path.size() <= 1 || !parsed.path.front().empty())
+        throw BadURL("URI has a missing or invalid key");
+
+    auto path = std::views::drop(parsed.path, 1) | std::ranges::to<std::vector<std::string>>();
+
+    for (auto & seg : path)
+        if (seg.empty() || seg == "." || seg == "..")
+            throw BadURL("URI key has an invalid path segment '%s'", seg);
+
+    return ParsedGCSURL{
+        .bucket = parsed.authority->host,
+        .key = std::move(path),
+        /* Goes verbatim into the `x-goog-user-project` header.
+         * Restrict to the GCP project-id charset so it cannot smuggle CR/LF from a URL.
+         */
+        .userProject = [&]() -> std::optional<std::string> {
+            auto v = getOptionalParam("user-project");
+            if (v && v->find_first_not_of("abcdefghijklmnopqrstuvwxyz0123456789-") != std::string::npos)
+                throw BadURL("invalid 'user-project' value '%s' in GCS URL", *v);
+            return v;
+        }(),
+        .generation = getOptionalParam("generation"),
+    };
+} catch (BadURL & e) {
+    e.addTrace({}, "while parsing GCS URI: '%s'", parsed.to_string());
+    throw;
+}
+
+ParsedURL ParsedGCSURL::toHttpsUrl(const std::optional<ParsedURL> & endpoint) const
+{
+    /* We always use path-style as it is supported for all bucket names including dotted ones and emulators.
+     * GCS also supports virtual-hosted-style (`bucket.storage.googleapis.com`)
+     */
+    auto resolved = endpoint.value_or(
+        ParsedURL{
+            .scheme = "https",
+            .authority = ParsedURL::Authority{.host = "storage.googleapis.com"},
+            .path = {""},
+        });
+
+    resolved.path.push_back(bucket);
+    resolved.path.insert(resolved.path.end(), key.begin(), key.end());
+
+    /* GCS' XML API accepts the object generation as a query parameter on GET/HEAD.
+       We allow it to pass it through so callers can pin a specific version. */
+    if (generation)
+        resolved.query["generation"] = *generation;
+
+    return resolved;
+}
+
+} // namespace nix

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -21,6 +21,8 @@
 
 namespace nix {
 
+class GcpCredentialProvider;
+
 const std::filesystem::path & nixConfDir();
 
 class FileTransferSettings : public Config
@@ -314,6 +316,15 @@ struct FileTransferRequest
     std::optional<std::string> preResolvedAwsSessionToken;
 #endif
 
+    /**
+     * Credential provider for `gs://` requests. Unset means anonymous.
+     */
+    std::shared_ptr<GcpCredentialProvider> gcpCredentialProvider;
+
+    std::optional<std::string> bearerToken;
+
+    std::function<std::optional<std::string>()> refreshBearerToken;
+
     FileTransferRequest(VerbatimURL uri)
         : uri(std::move(uri))
         , parentAct(getCurActivity())
@@ -364,6 +375,7 @@ struct FileTransferRequest
     }
 
     void setupForS3();
+    void setupForGCS();
 
 private:
     friend struct curlFileTransfer;

--- a/src/libstore/include/nix/store/gcp-creds.hh
+++ b/src/libstore/include/nix/store/gcp-creds.hh
@@ -1,0 +1,98 @@
+#pragma once
+///@file
+#include "nix/store/config.hh"
+
+#if NIX_WITH_GCS_AUTH
+
+#  include "nix/util/error.hh"
+#  include "nix/util/ref.hh"
+
+#  include <chrono>
+#  include <filesystem>
+#  include <optional>
+#  include <span>
+#  include <string>
+
+namespace nix {
+
+struct FileTransfer;
+
+/**
+ * OAuth2 access token for Google Cloud APIs.
+ *
+ * Unlike AWS SigV4 (key id + secret signed per request), GCP uses a
+ * short-lived bearer token sent verbatim in `Authorization: Bearer <token>`.
+ * Tokens typically expire after one hour and must be refreshed.
+ */
+struct GcpCredentials
+{
+    std::string accessToken;
+    /** When the token should be considered expired (with safety margin already applied). */
+    std::chrono::steady_clock::time_point expiresAt;
+};
+
+MakeError(GcpAuthError, Error);
+
+class GcpCredentialProvider
+{
+public:
+    /**
+     * Resolve a fresh-enough access token, or `std::nullopt` if no
+     * credentials are available (e.g. running outside GCP without an ADC
+     * file). Throws `GcpAuthError` only on hard failures (malformed key,
+     * token endpoint rejection).
+     */
+    virtual std::optional<GcpCredentials> maybeGetCredentials() = 0;
+
+    virtual std::optional<GcpCredentials> tryRefreshCredentials(FileTransfer & ft) noexcept = 0;
+
+    virtual ~GcpCredentialProvider();
+};
+
+/**
+ * Build the default Application Default Credentials chain:
+ *
+ *  1. `$GOOGLE_APPLICATION_CREDENTIALS` → service-account or authorized-user JSON
+ *  2. `$CLOUDSDK_CONFIG/application_default_credentials.json`, else
+ * `~/.config/gcloud/application_default_credentials.json`
+ *  3. GCE/GKE metadata server (`metadata.google.internal` or `$GCE_METADATA_HOST`)
+ *
+ * Tokens are cached and refreshed when close to expiry.
+ */
+ref<GcpCredentialProvider> makeGcpCredentialsProvider();
+
+/**
+ * Process-wide singleton wrapping `makeGcpCredentialsProvider()`.
+ * Tests may override it via `setGcpCredentialsProviderForTesting()`.
+ */
+ref<GcpCredentialProvider> getGcpCredentialsProvider();
+void setGcpCredentialsProviderForTesting(ref<GcpCredentialProvider> provider);
+
+/**
+ * Implementation details exposed for unit testing only.
+ * Not part of the stable API; may change without notice.
+ */
+namespace gcp_detail {
+
+/** RFC 4648 §5 base64url without padding (JWT encoding). */
+std::string base64url(std::span<const std::byte> bytes);
+std::string base64url(std::string_view s);
+
+/** RSASSA-PKCS1-v1_5-SHA256 signature over `payload`. Throws GcpAuthError on bad keys. */
+std::string signRS256(const std::string & privateKeyPem, std::string_view payload);
+
+/** Build the unsigned JWT (`header.claims`, both base64url) for a service-account assertion. */
+std::string
+buildServiceAccountJwtSigningInput(std::string_view clientEmail, std::string_view tokenUri, long iat, long exp);
+
+/** Parse `{"access_token":..., "expires_in":...}` from a token endpoint. */
+GcpCredentials parseTokenResponse(const std::string & body);
+
+/** Locate the ADC JSON file from env vars / well-known path. */
+std::optional<std::filesystem::path> findAdcFile();
+
+} // namespace gcp_detail
+
+} // namespace nix
+
+#endif

--- a/src/libstore/include/nix/store/gcp-creds.hh
+++ b/src/libstore/include/nix/store/gcp-creds.hh
@@ -62,13 +62,6 @@ public:
 ref<GcpCredentialProvider> makeGcpCredentialsProvider();
 
 /**
- * Process-wide singleton wrapping `makeGcpCredentialsProvider()`.
- * Tests may override it via `setGcpCredentialsProviderForTesting()`.
- */
-ref<GcpCredentialProvider> getGcpCredentialsProvider();
-void setGcpCredentialsProviderForTesting(ref<GcpCredentialProvider> provider);
-
-/**
  * Implementation details exposed for unit testing only.
  * Not part of the stable API; may change without notice.
  */

--- a/src/libstore/include/nix/store/gcs-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/gcs-binary-cache-store.hh
@@ -1,0 +1,71 @@
+#pragma once
+///@file
+
+#include "nix/store/gcs-url.hh"
+#include "nix/store/s3-compat-binary-cache-store.hh"
+
+namespace nix {
+
+struct GCSBinaryCacheStoreConfig : S3CompatBinaryCacheStoreConfig
+{
+    GCSBinaryCacheStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Unix)
+        , S3CompatBinaryCacheStoreConfig(params)
+    {
+    }
+
+    GCSBinaryCacheStoreConfig(ParsedURL cacheUri, const Params & params);
+
+    GCSBinaryCacheStoreConfig(std::string_view bucketName, const Params & params);
+
+    Setting<std::string> endpoint{
+        this,
+        "",
+        "endpoint",
+        R"(
+          The GCS endpoint to use. When empty (default), uses
+          `https://storage.googleapis.com`. For GCS-compatible emulators, set
+          this to your service's endpoint as a full URL, e.g.
+          `http://localhost:4443`.
+        )"};
+
+    Setting<std::string> userProject{
+        this,
+        "",
+        "user-project",
+        R"(
+          The Google Cloud project to bill for access to a requester-pays
+          bucket. Sent as the `x-goog-user-project` header.
+        )"};
+
+    Setting<std::optional<std::string>> storageClass{
+        this,
+        std::nullopt,
+        "storage-class",
+        R"(
+          The GCS storage class to use for uploaded objects. When not set
+          (default), uses the bucket's default storage class. Valid values
+          include `STANDARD`, `NEARLINE`, `COLDLINE`, and `ARCHIVE`.
+
+          See the GCS documentation for details:
+          https://cloud.google.com/storage/docs/storage-classes
+        )"};
+
+    /** `endpoint` parsed once at construction; passed to `toHttpsUrl()`. */
+    std::optional<ParsedURL> resolvedEndpoint;
+
+    static const std::string name()
+    {
+        return "GCS Binary Cache Store";
+    }
+
+    static StringSet uriSchemes();
+
+    static std::string doc();
+
+    std::string getHumanReadableURI() const override;
+
+    ref<Store> openStore() const override;
+};
+
+} // namespace nix

--- a/src/libstore/include/nix/store/gcs-url.hh
+++ b/src/libstore/include/nix/store/gcs-url.hh
@@ -1,0 +1,45 @@
+#pragma once
+///@file
+#include "nix/util/url.hh"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace nix {
+
+/**
+ * Parsed Google Cloud Storage `gs://` URL.
+ *
+ * We deliberately support no `endpoint`/`scheme` in the URL: bearer tokens are
+ * host-independent, so a URL-supplied endpoint would let e.g. `fetchurl`
+ * exfiltrate the caller's token.
+ * A custom endpoint is a store setting only (see `GCSBinaryCacheStoreConfig`).
+ */
+struct ParsedGCSURL
+{
+    std::string bucket;
+    /**
+     * @see ParsedURL::path. This is a vector for the same reason.
+     * Unlike ParsedURL::path this doesn't include the leading empty segment,
+     * since the bucket name is necessary.
+     */
+    std::vector<std::string> key;
+    /** Billing project for requester-pays buckets (sent as `x-goog-user-project`). */
+    std::optional<std::string> userProject;
+    /** Object generation (GCS object versioning), passed through as a query parameter. */
+    std::optional<std::string> generation;
+
+    static ParsedGCSURL parse(const ParsedURL & uri);
+
+    /**
+     * Convert to an HTTP(S) URL against the GCS XML API.
+     * Without an endpoint this targets `https://storage.googleapis.com`.
+     * Store code passes a custom endpoint URL from operator configuration.
+     */
+    ParsedURL toHttpsUrl(const std::optional<ParsedURL> & endpoint = std::nullopt) const;
+
+    auto operator<=>(const ParsedGCSURL & other) const = default;
+};
+
+} // namespace nix

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -131,7 +131,7 @@ protected:
     void upsertFile(
         const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override;
 
-    FileTransferRequest makeRequest(std::string_view path);
+    virtual FileTransferRequest makeRequest(std::string_view path);
 
     /**
      * Uploads data to the binary cache.

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -86,6 +86,7 @@ headers = [ config_pub_h ] + files(
   'remote-store.hh',
   'restricted-store.hh',
   's3-binary-cache-store.hh',
+  's3-compat-binary-cache-store.hh',
   's3-url.hh',
   'serve-protocol-connection.hh',
   'serve-protocol-impl.hh',

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -48,6 +48,7 @@ headers = [ config_pub_h ] + files(
   'filetransfer.hh',
   'gc-store.hh',
   'gcp-creds.hh',
+  'gcs-binary-cache-store.hh',
   'gcs-url.hh',
   'global-paths.hh',
   'globals.hh',

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -47,6 +47,7 @@ headers = [ config_pub_h ] + files(
   'filetransfer-impl.hh',
   'filetransfer.hh',
   'gc-store.hh',
+  'gcp-creds.hh',
   'gcs-url.hh',
   'global-paths.hh',
   'globals.hh',

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -47,6 +47,7 @@ headers = [ config_pub_h ] + files(
   'filetransfer-impl.hh',
   'filetransfer.hh',
   'gc-store.hh',
+  'gcs-url.hh',
   'global-paths.hh',
   'globals.hh',
   'http-binary-cache-store.hh',

--- a/src/libstore/include/nix/store/s3-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/s3-binary-cache-store.hh
@@ -2,16 +2,16 @@
 ///@file
 
 #include "nix/store/config.hh"
-#include "nix/store/http-binary-cache-store.hh"
 #include "nix/store/s3-url.hh"
+#include "nix/store/s3-compat-binary-cache-store.hh"
 
 namespace nix {
 
-struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
+struct S3BinaryCacheStoreConfig : S3CompatBinaryCacheStoreConfig
 {
     S3BinaryCacheStoreConfig(const Params & params)
         : StoreConfig(params, FilePathType::Unix)
-        , HttpBinaryCacheStoreConfig(params)
+        , S3CompatBinaryCacheStoreConfig(params)
     {
     }
 
@@ -79,38 +79,6 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
           forces path-style addressing (deprecated by AWS). `virtual`
           forces virtual-hosted-style addressing (bucket names must not
           contain dots).
-        )"};
-
-    Setting<bool> multipartUpload{
-        this,
-        false,
-        "multipart-upload",
-        R"(
-          Whether to use multipart uploads for large files. When enabled,
-          files exceeding the multipart threshold will be uploaded in
-          multiple parts, which is required for files larger than 5 GiB and
-          can improve performance and reliability for large uploads.
-        )"};
-
-    Setting<uint64_t> multipartChunkSize{
-        this,
-        5 * 1024 * 1024,
-        "multipart-chunk-size",
-        R"(
-          The size (in bytes) of each part in multipart uploads. Must be
-          at least 5 MiB (AWS S3 requirement). Larger chunk sizes reduce the
-          number of requests but use more memory. Default is 5 MiB.
-        )",
-        {"buffer-size"}};
-
-    Setting<uint64_t> multipartThreshold{
-        this,
-        100 * 1024 * 1024,
-        "multipart-threshold",
-        R"(
-          The minimum file size (in bytes) for using multipart uploads.
-          Files smaller than this threshold will use regular PUT requests.
-          Default is 100 MiB. Only takes effect when multipart-upload is enabled.
         )"};
 
     Setting<std::optional<std::string>> storageClass{

--- a/src/libstore/include/nix/store/s3-compat-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/s3-compat-binary-cache-store.hh
@@ -1,0 +1,139 @@
+#pragma once
+///@file
+
+#include "nix/store/http-binary-cache-store.hh"
+
+#include <set>
+
+namespace nix {
+
+/**
+ * Shared configuration for stores that speak the S3-compatible XML object API (S3 itself and GCS).
+ * In particular the multipart-upload knobs that both backends interpret identically.
+ */
+struct S3CompatBinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
+{
+private:
+    void anchor() override;
+
+public:
+    S3CompatBinaryCacheStoreConfig(const Params & params)
+        : StoreConfig(params, FilePathType::Unix)
+        , HttpBinaryCacheStoreConfig(params)
+    {
+    }
+
+    S3CompatBinaryCacheStoreConfig(ParsedURL cacheUri, const Params & params);
+
+    Setting<bool> multipartUpload{
+        this,
+        false,
+        "multipart-upload",
+        R"(
+          Whether to use multipart uploads for large files. When enabled,
+          files exceeding the multipart threshold will be uploaded in
+          multiple parts, which is required for files larger than 5 GiB and
+          can improve performance and reliability for large uploads.
+        )"};
+
+    Setting<uint64_t> multipartChunkSize{
+        this,
+        5 * 1024 * 1024,
+        "multipart-chunk-size",
+        R"(
+          The size (in bytes) of each part in multipart uploads. Must be
+          at least 5 MiB. Larger chunk sizes reduce the number of requests
+          but use more memory. Default is 5 MiB.
+        )",
+        {"buffer-size"}};
+
+    Setting<uint64_t> multipartThreshold{
+        this,
+        100 * 1024 * 1024,
+        "multipart-threshold",
+        R"(
+          The minimum file size (in bytes) for using multipart uploads.
+          Files smaller than this threshold will use regular PUT requests.
+          Default is 100 MiB. Only takes effect when multipart-upload is enabled.
+        )"};
+
+protected:
+    /** Validate multipart settings against the protocol limits. */
+    void validateMultipartSettings() const;
+
+    /**
+     * Copy the values of `uriSettings` from `params` into `cacheUri.query`, so
+     * that per-request setup (setupForS3()/setupForGCS()) can recover them.
+     * Backends differ in which settings travel in the URL, hence the argument.
+     */
+    void copyUriParams(const Params & params, const std::set<const AbstractSetting *> & uriSettings);
+
+    /** Render the store reference keeping only the overridden `uriSettings`. */
+    std::string renderHumanReadableUri(const std::set<const AbstractSetting *> & uriSettings) const;
+};
+
+/**
+ * Shared upload machinery for binary caches that speak the S3-compatible
+ * XML object API.
+ * In particular this:
+ *  - single-part PUT,
+ *  - the four-call multipart-upload lifecycle,
+ *  - Content-MD5 integrity checking
+ *  - and the compression dispatch around `upsertFile`.
+ *
+ * Subclasses provide the backend-specific request preparation
+ * (`setupForS3()` / `setupForGCS()`) and any extra headers (storage class).
+ */
+class S3CompatBinaryCacheStore : public virtual HttpBinaryCacheStore
+{
+    void anchor() override;
+
+public:
+    S3CompatBinaryCacheStore(ref<S3CompatBinaryCacheStoreConfig> config)
+        : Store{*config}
+        , BinaryCacheStore{*config}
+        , HttpBinaryCacheStore{config}
+        , s3CompatConfig{config}
+    {
+    }
+
+    void upsertFile(
+        const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override;
+
+protected:
+    /** Human-readable backend name for error messages ("S3", "GCS"). */
+    virtual std::string_view backendName() const = 0;
+
+    /** Convert the store-scheme URI on `req` to HTTPS and attach auth. */
+    virtual void prepareRequest(FileTransferRequest & req) const = 0;
+
+    /** Per-upload extra headers (e.g. `x-amz-storage-class`). */
+    virtual void addUploadHeaders(Headers & headers) const {}
+
+private:
+    ref<S3CompatBinaryCacheStoreConfig> s3CompatConfig;
+
+    void upload(
+        std::string_view path,
+        RestartableSource & source,
+        uint64_t sizeHint,
+        std::string_view mimeType,
+        std::optional<Headers> headers);
+
+    void uploadMultipart(
+        std::string_view path,
+        RestartableSource & source,
+        uint64_t sizeHint,
+        std::string_view mimeType,
+        std::optional<Headers> headers);
+
+    struct MultipartSink;
+
+    std::string createMultipartUpload(std::string_view key, std::string_view mimeType, std::optional<Headers> headers);
+    std::string uploadPart(std::string_view key, std::string_view uploadId, uint64_t partNumber, std::string data);
+    void
+    completeMultipartUpload(std::string_view key, std::string_view uploadId, std::span<const std::string> partEtags);
+    void abortMultipartUpload(std::string_view key, std::string_view uploadId) noexcept;
+};
+
+} // namespace nix

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -301,6 +301,7 @@ sources = files(
   'export-import.cc',
   'filetransfer.cc',
   'gc.cc',
+  'gcs-binary-cache-store.cc',
   'gcs-url.cc',
   'globals.cc',
   'http-binary-cache-store.cc',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -176,6 +176,17 @@ endif
 
 configdata_pub.set('NIX_WITH_AWS_AUTH', s3_aws_auth.enabled().to_int())
 
+gcs_auth = get_option('gcs-auth')
+# JWT RS256 signing for service-account credentials needs OpenSSL. It is
+# already a private dep of libutil but must be declared here too so libstore
+# links it directly when GCS auth is enabled.
+openssl = dependency('libcrypto', 'openssl', required : gcs_auth)
+gcs_auth = gcs_auth.require(openssl.found())
+if gcs_auth.allowed()
+  deps_private += openssl
+endif
+configdata_pub.set('NIX_WITH_GCS_AUTH', gcs_auth.allowed().to_int())
+
 busybox = find_program(get_option('sandbox-shell'), required : false)
 
 if get_option('embedded-sandbox-shell')
@@ -345,6 +356,11 @@ sources = files(
 # AWS credentials code requires AWS CRT, so only compile when enabled
 if s3_aws_auth.enabled()
   sources += files('aws-creds.cc')
+endif
+
+# GCP credentials code requires OpenSSL, so only compile when enabled
+if gcs_auth.allowed()
+  sources += files('gcp-creds.cc')
 endif
 
 subdir('include/nix/store')

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -290,6 +290,7 @@ sources = files(
   'export-import.cc',
   'filetransfer.cc',
   'gc.cc',
+  'gcs-url.cc',
   'globals.cc',
   'http-binary-cache-store.cc',
   'indirect-root-store.cc',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -337,6 +337,7 @@ sources = files(
   'remote-store.cc',
   'restricted-store.cc',
   's3-binary-cache-store.cc',
+  's3-compat-binary-cache-store.cc',
   's3-url.cc',
   'serve-protocol-connection.cc',
   'serve-protocol.cc',

--- a/src/libstore/meson.options
+++ b/src/libstore/meson.options
@@ -39,3 +39,9 @@ option(
   type : 'feature',
   description : 'build support for AWS authentication with S3',
 )
+
+option(
+  'gcs-auth',
+  type : 'feature',
+  description : 'build support for Google Cloud authentication with GCS',
+)

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -1,418 +1,46 @@
 #include "nix/store/s3-binary-cache-store.hh"
-#include "nix/store/http-binary-cache-store.hh"
 #include "nix/store/store-registration.hh"
-#include "nix/util/compression.hh"
-#include "nix/util/error.hh"
-#include "nix/util/logging.hh"
-#include "nix/util/serialise.hh"
-#include "nix/util/util.hh"
 
 #include <cassert>
-#include <cstring>
-#include <ranges>
-#include <regex>
-#include <span>
 
 namespace nix {
 
-MakeError(UploadToS3, Error);
-
-void UploadToS3::anchor() {}
-
-static constexpr uint64_t AWS_MIN_PART_SIZE = 5 * 1024 * 1024;           // 5MiB
-static constexpr uint64_t AWS_MAX_PART_SIZE = 5ULL * 1024 * 1024 * 1024; // 5GiB
-static constexpr uint64_t AWS_MAX_PART_COUNT = 10000;
-
-class S3BinaryCacheStore : public virtual HttpBinaryCacheStore
+class S3BinaryCacheStore : public virtual S3CompatBinaryCacheStore
 {
+    void anchor() override;
+
 public:
     S3BinaryCacheStore(ref<S3BinaryCacheStoreConfig> config)
         : Store{*config}
         , BinaryCacheStore{*config}
         , HttpBinaryCacheStore{config}
+        , S3CompatBinaryCacheStore{config}
         , s3Config{config}
     {
     }
 
-    void upsertFile(
-        const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint) override;
+protected:
+    std::string_view backendName() const override
+    {
+        return "S3";
+    }
+
+    void prepareRequest(FileTransferRequest & req) const override
+    {
+        req.setupForS3();
+    }
+
+    void addUploadHeaders(Headers & headers) const override
+    {
+        if (auto storageClass = s3Config->storageClass.get())
+            headers.emplace_back("x-amz-storage-class", *storageClass);
+    }
 
 private:
     ref<S3BinaryCacheStoreConfig> s3Config;
-
-    /**
-     * Uploads a file to S3 using a regular (non-multipart) upload.
-     *
-     * This method is suitable for files up to 5GiB in size. For larger files,
-     * multipart upload should be used instead.
-     *
-     * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
-     */
-    void upload(
-        std::string_view path,
-        RestartableSource & source,
-        uint64_t sizeHint,
-        std::string_view mimeType,
-        std::optional<Headers> headers);
-
-    /**
-     * Uploads a file to S3 using multipart upload.
-     *
-     * This method is suitable for large files that exceed the multipart threshold.
-     * It orchestrates the complete multipart upload process: creating the upload,
-     * splitting the data into parts, uploading each part, and completing the upload.
-     * If any error occurs, the multipart upload is automatically aborted.
-     *
-     * @see https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html
-     */
-    void uploadMultipart(
-        std::string_view path,
-        RestartableSource & source,
-        uint64_t sizeHint,
-        std::string_view mimeType,
-        std::optional<Headers> headers);
-
-    /**
-     * A Sink that manages a complete S3 multipart upload lifecycle.
-     * Creates the upload on construction, buffers and uploads chunks as data arrives,
-     * and completes or aborts the upload appropriately.
-     */
-    struct MultipartSink : Sink
-    {
-        S3BinaryCacheStore & store;
-        std::string_view path;
-        std::string uploadId;
-        std::string::size_type chunkSize;
-
-        std::vector<std::string> partEtags;
-        std::string buffer;
-
-        MultipartSink(
-            S3BinaryCacheStore & store,
-            std::string_view path,
-            uint64_t sizeHint,
-            std::string_view mimeType,
-            std::optional<Headers> headers);
-
-        void operator()(std::string_view data) override;
-        void finish();
-        void uploadChunk(std::string chunk);
-    };
-
-    /**
-     * Creates a multipart upload for large objects to S3.
-     *
-     * @see
-     * https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html#API_CreateMultipartUpload_RequestSyntax
-     */
-    std::string createMultipartUpload(std::string_view key, std::string_view mimeType, std::optional<Headers> headers);
-
-    /**
-     * Uploads a single part of a multipart upload
-     *
-     * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html#API_UploadPart_RequestSyntax
-     *
-     * @returns the [ETag](https://en.wikipedia.org/wiki/HTTP_ETag)
-     */
-    std::string uploadPart(std::string_view key, std::string_view uploadId, uint64_t partNumber, std::string data);
-
-    /**
-     * Completes a multipart upload by combining all uploaded parts.
-     * @see
-     * https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html#API_CompleteMultipartUpload_RequestSyntax
-     */
-    void
-    completeMultipartUpload(std::string_view key, std::string_view uploadId, std::span<const std::string> partEtags);
-
-    /**
-     * Abort a multipart upload
-     *
-     * @see
-     * https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html#API_AbortMultipartUpload_RequestSyntax
-     */
-    void abortMultipartUpload(std::string_view key, std::string_view uploadId) noexcept;
 };
 
-void S3BinaryCacheStore::upsertFile(
-    const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint)
-{
-    auto doUpload = [&](RestartableSource & src, uint64_t size, std::optional<Headers> headers) {
-        Headers uploadHeaders = headers.value_or(Headers());
-        if (auto storageClass = s3Config->storageClass.get()) {
-            uploadHeaders.emplace_back("x-amz-storage-class", *storageClass);
-        }
-
-        {
-            HashSink hashSink(HashAlgorithm::MD5);
-            src.drainInto(hashSink);
-            auto [hash, gotLength] = hashSink.finish();
-            /* Use this opportunity to check that the upload size matches what we expect. */
-            if (gotLength != size)
-                throw Error("unexpected size for upload '%s', expected %d, got: %d", path, size, gotLength);
-            /* The Base64 encoded 128-bit MD5 digest of the message (without the headers) according to RFC 1864:
-               https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html */
-            uploadHeaders.push_back({"Content-MD5", hash.to_string(HashFormat::Base64, /*includeAlgo=*/false)});
-            src.restart(); /* Seek to the beginning. */
-        }
-
-        if (s3Config->multipartUpload && size > s3Config->multipartThreshold) {
-            uploadMultipart(path, src, size, mimeType, std::move(uploadHeaders));
-        } else {
-            upload(path, src, size, mimeType, std::move(uploadHeaders));
-        }
-    };
-
-    try {
-        if (auto compressionMethod = getCompressionMethod(path)) {
-            StringSource compressed(compress(*compressionMethod, source));
-            /* TODO: Validate that this is a valid content encoding. We probably shouldn't set non-standard values here.
-             */
-            Headers headers = {{"Content-Encoding", showCompressionAlgo(*compressionMethod)}};
-            doUpload(compressed, compressed.s.size(), std::move(headers));
-        } else {
-            doUpload(source, sizeHint, std::nullopt);
-        }
-    } catch (FileTransferError & e) {
-        UploadToS3 err(e.message());
-        err.addTrace({}, "while uploading to S3 binary cache at '%s'", config->cacheUri.to_string());
-        throw std::move(err);
-    }
-}
-
-void S3BinaryCacheStore::upload(
-    std::string_view path,
-    RestartableSource & source,
-    uint64_t sizeHint,
-    std::string_view mimeType,
-    std::optional<Headers> headers)
-{
-    debug("using S3 regular upload for '%s' (%d bytes)", path, sizeHint);
-    if (sizeHint > AWS_MAX_PART_SIZE)
-        throw Error(
-            "file too large for S3 upload without multipart: %s would exceed maximum size of %s. Consider enabling multipart-upload.",
-            renderSize(sizeHint),
-            renderSize(AWS_MAX_PART_SIZE));
-
-    HttpBinaryCacheStore::upload(path, source, sizeHint, mimeType, std::move(headers));
-}
-
-void S3BinaryCacheStore::uploadMultipart(
-    std::string_view path,
-    RestartableSource & source,
-    uint64_t sizeHint,
-    std::string_view mimeType,
-    std::optional<Headers> headers)
-{
-    debug("using S3 multipart upload for '%s' (%d bytes)", path, sizeHint);
-    MultipartSink sink(*this, path, sizeHint, mimeType, std::move(headers));
-    source.drainInto(sink);
-    sink.finish();
-}
-
-S3BinaryCacheStore::MultipartSink::MultipartSink(
-    S3BinaryCacheStore & store,
-    std::string_view path,
-    uint64_t sizeHint,
-    std::string_view mimeType,
-    std::optional<Headers> headers)
-    : store(store)
-    , path(path)
-{
-    // Calculate chunk size and estimated parts
-    chunkSize = store.s3Config->multipartChunkSize;
-    uint64_t estimatedParts = (sizeHint + chunkSize - 1) / chunkSize; // ceil division
-
-    if (estimatedParts > AWS_MAX_PART_COUNT) {
-        // Equivalent to ceil(sizeHint / AWS_MAX_PART_COUNT)
-        uint64_t minChunkSize = (sizeHint + AWS_MAX_PART_COUNT - 1) / AWS_MAX_PART_COUNT;
-
-        if (minChunkSize > AWS_MAX_PART_SIZE) {
-            throw Error(
-                "file too large for S3 multipart upload: %s would require chunk size of %s "
-                "(max %s) to stay within %d part limit",
-                renderSize(sizeHint),
-                renderSize(minChunkSize),
-                renderSize(AWS_MAX_PART_SIZE),
-                AWS_MAX_PART_COUNT);
-        }
-
-        warn(
-            "adjusting S3 multipart chunk size from %s to %s "
-            "to stay within %d part limit for %s file",
-            renderSize(store.s3Config->multipartChunkSize.get()),
-            renderSize(minChunkSize),
-            AWS_MAX_PART_COUNT,
-            renderSize(sizeHint));
-
-        chunkSize = minChunkSize;
-        estimatedParts = AWS_MAX_PART_COUNT;
-    }
-
-    buffer.reserve(chunkSize);
-    partEtags.reserve(estimatedParts);
-    uploadId = store.createMultipartUpload(path, mimeType, std::move(headers));
-}
-
-void S3BinaryCacheStore::MultipartSink::operator()(std::string_view data)
-{
-    buffer.append(data);
-
-    while (buffer.size() >= chunkSize) {
-        // Move entire buffer, extract excess, copy back remainder
-        auto chunk = std::move(buffer);
-        auto excessSize = chunk.size() > chunkSize ? chunk.size() - chunkSize : 0;
-        if (excessSize > 0) {
-            buffer.resize(excessSize);
-            std::memcpy(buffer.data(), chunk.data() + chunkSize, excessSize);
-        }
-        chunk.resize(std::min(chunkSize, chunk.size()));
-        uploadChunk(std::move(chunk));
-    }
-}
-
-void S3BinaryCacheStore::MultipartSink::finish()
-{
-    if (!buffer.empty()) {
-        uploadChunk(std::move(buffer));
-    }
-
-    try {
-        if (partEtags.empty()) {
-            throw Error("no data read from stream");
-        }
-        store.completeMultipartUpload(path, uploadId, partEtags);
-    } catch (Error & e) {
-        store.abortMultipartUpload(path, uploadId);
-        e.addTrace({}, "while finishing an S3 multipart upload");
-        throw;
-    }
-}
-
-void S3BinaryCacheStore::MultipartSink::uploadChunk(std::string chunk)
-{
-    auto partNumber = partEtags.size() + 1;
-    try {
-        std::string etag = store.uploadPart(path, uploadId, partNumber, std::move(chunk));
-        partEtags.push_back(std::move(etag));
-    } catch (Error & e) {
-        store.abortMultipartUpload(path, uploadId);
-        e.addTrace({}, "while uploading part %d of an S3 multipart upload", partNumber);
-        throw;
-    }
-}
-
-std::string S3BinaryCacheStore::createMultipartUpload(
-    std::string_view key, std::string_view mimeType, std::optional<Headers> headers)
-{
-    auto req = makeRequest(key);
-
-    // setupForS3() converts s3:// to https:// but strips query parameters
-    // So we call it first, then add our multipart parameters
-    req.setupForS3();
-
-    auto url = req.uri.parsed();
-    url.query["uploads"] = "";
-    req.uri = VerbatimURL(url);
-
-    req.method = HttpMethod::Post;
-    StringSource payload{std::string_view("")};
-    req.data = {payload};
-    req.mimeType = mimeType;
-
-    if (headers) {
-        req.headers.reserve(req.headers.size() + headers->size());
-        std::move(headers->begin(), headers->end(), std::back_inserter(req.headers));
-    }
-
-    auto result = fileTransfer->enqueueFileTransfer(req).get();
-
-    std::regex uploadIdRegex("<UploadId>([^<]+)</UploadId>");
-    std::smatch match;
-
-    if (std::regex_search(result.data, match, uploadIdRegex)) {
-        return match[1];
-    }
-
-    throw Error("S3 CreateMultipartUpload response missing <UploadId>");
-}
-
-std::string
-S3BinaryCacheStore::uploadPart(std::string_view key, std::string_view uploadId, uint64_t partNumber, std::string data)
-{
-    if (partNumber > AWS_MAX_PART_COUNT) {
-        throw Error("S3 multipart upload exceeded %d part limit", AWS_MAX_PART_COUNT);
-    }
-
-    auto req = makeRequest(key);
-    req.method = HttpMethod::Put;
-    req.setupForS3();
-
-    auto url = req.uri.parsed();
-    url.query["partNumber"] = std::to_string(partNumber);
-    url.query["uploadId"] = uploadId;
-    req.uri = VerbatimURL(url);
-    StringSource payload{data};
-    req.data = {payload};
-    req.mimeType = "application/octet-stream";
-
-    auto result = fileTransfer->enqueueFileTransfer(req).get();
-
-    if (result.etag.empty()) {
-        throw Error("S3 UploadPart response missing ETag for part %d", partNumber);
-    }
-
-    debug("Part %d uploaded, ETag: %s", partNumber, result.etag);
-    return std::move(result.etag);
-}
-
-void S3BinaryCacheStore::abortMultipartUpload(std::string_view key, std::string_view uploadId) noexcept
-{
-    try {
-        auto req = makeRequest(key);
-        req.setupForS3();
-
-        auto url = req.uri.parsed();
-        url.query["uploadId"] = uploadId;
-        req.uri = VerbatimURL(url);
-        req.method = HttpMethod::Delete;
-
-        (void) fileTransfer->enqueueFileTransfer(req).get();
-    } catch (...) {
-        ignoreExceptionInDestructor();
-    }
-}
-
-void S3BinaryCacheStore::completeMultipartUpload(
-    std::string_view key, std::string_view uploadId, std::span<const std::string> partEtags)
-{
-    auto req = makeRequest(key);
-    req.setupForS3();
-
-    auto url = req.uri.parsed();
-    url.query["uploadId"] = uploadId;
-    req.uri = VerbatimURL(url);
-    req.method = HttpMethod::Post;
-
-    std::string xml = "<CompleteMultipartUpload>";
-    for (const auto & [idx, etag] : enumerate(partEtags)) {
-        xml += "<Part>";
-        // S3 part numbers are 1-indexed, but vector indices are 0-indexed
-        xml += "<PartNumber>" + std::to_string(idx + 1) + "</PartNumber>";
-        xml += "<ETag>" + etag + "</ETag>";
-        xml += "</Part>";
-    }
-    xml += "</CompleteMultipartUpload>";
-
-    debug("S3 CompleteMultipartUpload XML (%d parts): %s", partEtags.size(), xml);
-
-    StringSource payload{xml};
-    req.data = {payload};
-    req.mimeType = "text/xml";
-
-    (void) fileTransfer->enqueueFileTransfer(req).get();
-
-    debug("S3 multipart upload completed: %d parts uploaded for '%s'", partEtags.size(), key);
-}
+void S3BinaryCacheStore::anchor() {}
 
 StringSet S3BinaryCacheStoreConfig::uriSchemes()
 {
@@ -421,40 +49,13 @@ StringSet S3BinaryCacheStoreConfig::uriSchemes()
 
 S3BinaryCacheStoreConfig::S3BinaryCacheStoreConfig(ParsedURL cacheUri_, const Params & params)
     : StoreConfig(params, FilePathType::Unix)
-    , HttpBinaryCacheStoreConfig(std::move(cacheUri_), params)
+    , S3CompatBinaryCacheStoreConfig(std::move(cacheUri_), params)
 {
     assert(cacheUri.query.empty());
     assert(cacheUri.scheme == "s3");
 
-    for (const auto & [key, value] : params) {
-        auto s3Params =
-            std::views::transform(s3UriSettings, [](const AbstractSetting * setting) { return setting->name; });
-        if (std::ranges::contains(s3Params, key)) {
-            cacheUri.query[key] = value;
-        }
-    }
-
-    if (multipartChunkSize < AWS_MIN_PART_SIZE) {
-        throw UsageError(
-            "multipart-chunk-size must be at least %s, got %s",
-            renderSize(AWS_MIN_PART_SIZE),
-            renderSize(multipartChunkSize.get()));
-    }
-
-    if (multipartChunkSize > AWS_MAX_PART_SIZE) {
-        throw UsageError(
-            "multipart-chunk-size must be at most %s, got %s",
-            renderSize(AWS_MAX_PART_SIZE),
-            renderSize(multipartChunkSize.get()));
-    }
-
-    if (multipartUpload && multipartThreshold < multipartChunkSize) {
-        warn(
-            "multipart-threshold (%s) is less than multipart-chunk-size (%s), "
-            "which may result in single-part multipart uploads",
-            renderSize(multipartThreshold.get()),
-            renderSize(multipartChunkSize.get()));
-    }
+    copyUriParams(params, s3UriSettings);
+    validateMultipartSettings();
 }
 
 S3BinaryCacheStoreConfig::S3BinaryCacheStoreConfig(std::string_view bucketName, const Params & params)
@@ -465,15 +66,7 @@ S3BinaryCacheStoreConfig::S3BinaryCacheStoreConfig(std::string_view bucketName, 
 
 std::string S3BinaryCacheStoreConfig::getHumanReadableURI() const
 {
-    auto reference = getReference();
-    reference.params = [&]() {
-        Params relevantParams;
-        for (auto & setting : s3UriSettings)
-            if (setting->overridden)
-                relevantParams.insert({setting->name, reference.params.at(setting->name)});
-        return relevantParams;
-    }();
-    return reference.render();
+    return renderHumanReadableUri(s3UriSettings);
 }
 
 std::string S3BinaryCacheStoreConfig::doc()

--- a/src/libstore/s3-compat-binary-cache-store.cc
+++ b/src/libstore/s3-compat-binary-cache-store.cc
@@ -268,8 +268,8 @@ std::string S3CompatBinaryCacheStore::createMultipartUpload(
 {
     auto req = makeRequest(key);
 
-    // prepareRequest() converts s3:// / gs:// to https:// but strips query parameters,
-    // so call it first, then add the multipart parameters.
+    // For S3, prepareRequest() converts s3:// to https:// but strips query parameters.
+    // Call it first, then add the multipart parameters.
     prepareRequest(req);
 
     auto url = req.uri.parsed();

--- a/src/libstore/s3-compat-binary-cache-store.cc
+++ b/src/libstore/s3-compat-binary-cache-store.cc
@@ -1,0 +1,379 @@
+#include "nix/store/s3-compat-binary-cache-store.hh"
+#include "nix/util/compression.hh"
+#include "nix/util/serialise.hh"
+#include "nix/util/util.hh"
+
+#include <cstring>
+#include <ranges>
+#include <regex>
+#include <span>
+
+namespace nix {
+
+MakeError(UploadToS3Compat, Error);
+
+void UploadToS3Compat::anchor() {}
+
+void S3CompatBinaryCacheStoreConfig::anchor() {}
+
+void S3CompatBinaryCacheStore::anchor() {}
+
+/* These limits are identical for S3 and the GCS XML API. */
+static constexpr uint64_t S3_MIN_PART_SIZE = 5 * 1024 * 1024;           // 5MiB
+static constexpr uint64_t S3_MAX_PART_SIZE = 5ULL * 1024 * 1024 * 1024; // 5GiB
+static constexpr uint64_t S3_MAX_PART_COUNT = 10000;
+
+S3CompatBinaryCacheStoreConfig::S3CompatBinaryCacheStoreConfig(ParsedURL cacheUri_, const Params & params)
+    : StoreConfig(params, FilePathType::Unix)
+    , HttpBinaryCacheStoreConfig(std::move(cacheUri_), params)
+{
+}
+
+void S3CompatBinaryCacheStoreConfig::validateMultipartSettings() const
+{
+    if (multipartChunkSize < S3_MIN_PART_SIZE)
+        throw UsageError(
+            "multipart-chunk-size must be at least %s, got %s",
+            renderSize(S3_MIN_PART_SIZE),
+            renderSize(multipartChunkSize.get()));
+
+    if (multipartChunkSize > S3_MAX_PART_SIZE)
+        throw UsageError(
+            "multipart-chunk-size must be at most %s, got %s",
+            renderSize(S3_MAX_PART_SIZE),
+            renderSize(multipartChunkSize.get()));
+
+    if (multipartUpload && multipartThreshold < multipartChunkSize)
+        warn(
+            "multipart-threshold (%s) is less than multipart-chunk-size (%s), "
+            "which may result in single-part multipart uploads",
+            renderSize(multipartThreshold.get()),
+            renderSize(multipartChunkSize.get()));
+}
+
+void S3CompatBinaryCacheStoreConfig::copyUriParams(
+    const Params & params, const std::set<const AbstractSetting *> & uriSettings)
+{
+    auto names = std::views::transform(uriSettings, [](const AbstractSetting * s) { return s->name; });
+    for (const auto & [key, value] : params)
+        if (std::ranges::contains(names, key))
+            cacheUri.query[key] = value;
+}
+
+std::string
+S3CompatBinaryCacheStoreConfig::renderHumanReadableUri(const std::set<const AbstractSetting *> & uriSettings) const
+{
+    auto reference = getReference();
+    Params relevantParams;
+    for (const auto * setting : uriSettings)
+        if (setting->overridden)
+            relevantParams.insert({setting->name, reference.params.at(setting->name)});
+    reference.params = std::move(relevantParams);
+    return reference.render();
+}
+
+struct S3CompatBinaryCacheStore::MultipartSink : Sink
+{
+    S3CompatBinaryCacheStore & store;
+    std::string_view path;
+    std::string uploadId;
+    std::string::size_type chunkSize;
+
+    std::vector<std::string> partEtags;
+    std::string buffer;
+
+    MultipartSink(
+        S3CompatBinaryCacheStore & store,
+        std::string_view path,
+        uint64_t sizeHint,
+        std::string_view mimeType,
+        std::optional<Headers> headers);
+
+    void operator()(std::string_view data) override;
+    void finish();
+    void uploadChunk(std::string chunk);
+};
+
+void S3CompatBinaryCacheStore::upsertFile(
+    const std::string & path, RestartableSource & source, const std::string & mimeType, uint64_t sizeHint)
+{
+    auto doUpload = [&](RestartableSource & src, uint64_t size, std::optional<Headers> headers) {
+        Headers uploadHeaders = headers.value_or(Headers());
+        addUploadHeaders(uploadHeaders);
+
+        {
+            HashSink hashSink(HashAlgorithm::MD5);
+            src.drainInto(hashSink);
+            auto [hash, gotLength] = hashSink.finish();
+            /* Use this opportunity to check that the upload size matches what we expect. */
+            if (gotLength != size)
+                throw Error("unexpected size for upload '%s', expected %d, got: %d", path, size, gotLength);
+            /* The Base64 encoded 128-bit MD5 digest of the message (without the headers) according to RFC 1864:
+               https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html */
+            uploadHeaders.push_back({"Content-MD5", hash.to_string(HashFormat::Base64, /*includeAlgo=*/false)});
+            src.restart(); /* Seek to the beginning. */
+        }
+
+        if (s3CompatConfig->multipartUpload && size > s3CompatConfig->multipartThreshold) {
+            uploadMultipart(path, src, size, mimeType, std::move(uploadHeaders));
+        } else {
+            upload(path, src, size, mimeType, std::move(uploadHeaders));
+        }
+    };
+
+    try {
+        if (auto compressionMethod = getCompressionMethod(path)) {
+            StringSource compressed(compress(*compressionMethod, source));
+            /* TODO: Validate that this is a valid content encoding. We probably shouldn't set non-standard values here.
+             */
+            Headers headers = {{"Content-Encoding", showCompressionAlgo(*compressionMethod)}};
+            doUpload(compressed, compressed.s.size(), std::move(headers));
+        } else {
+            doUpload(source, sizeHint, std::nullopt);
+        }
+    } catch (FileTransferError & e) {
+        UploadToS3Compat err(e.message());
+        err.addTrace({}, "while uploading to %s binary cache at '%s'", backendName(), config->cacheUri.to_string());
+        throw std::move(err);
+    }
+}
+
+void S3CompatBinaryCacheStore::upload(
+    std::string_view path,
+    RestartableSource & source,
+    uint64_t sizeHint,
+    std::string_view mimeType,
+    std::optional<Headers> headers)
+{
+    debug("using %s regular upload for '%s' (%d bytes)", backendName(), path, sizeHint);
+    if (sizeHint > S3_MAX_PART_SIZE)
+        throw Error(
+            "file too large for %s upload without multipart: %s would exceed maximum size of %s. Consider enabling multipart-upload.",
+            backendName(),
+            renderSize(sizeHint),
+            renderSize(S3_MAX_PART_SIZE));
+
+    HttpBinaryCacheStore::upload(path, source, sizeHint, mimeType, std::move(headers));
+}
+
+void S3CompatBinaryCacheStore::uploadMultipart(
+    std::string_view path,
+    RestartableSource & source,
+    uint64_t sizeHint,
+    std::string_view mimeType,
+    std::optional<Headers> headers)
+{
+    debug("using %s multipart upload for '%s' (%d bytes)", backendName(), path, sizeHint);
+    MultipartSink sink(*this, path, sizeHint, mimeType, std::move(headers));
+    source.drainInto(sink);
+    sink.finish();
+}
+
+S3CompatBinaryCacheStore::MultipartSink::MultipartSink(
+    S3CompatBinaryCacheStore & store,
+    std::string_view path,
+    uint64_t sizeHint,
+    std::string_view mimeType,
+    std::optional<Headers> headers)
+    : store(store)
+    , path(path)
+{
+    // Calculate chunk size and estimated parts
+    chunkSize = store.s3CompatConfig->multipartChunkSize;
+    uint64_t estimatedParts = (sizeHint + chunkSize - 1) / chunkSize; // ceil division
+
+    if (estimatedParts > S3_MAX_PART_COUNT) {
+        // Equivalent to ceil(sizeHint / S3_MAX_PART_COUNT)
+        uint64_t minChunkSize = (sizeHint + S3_MAX_PART_COUNT - 1) / S3_MAX_PART_COUNT;
+
+        if (minChunkSize > S3_MAX_PART_SIZE) {
+            throw Error(
+                "file too large for %s multipart upload: %s would require chunk size of %s "
+                "(max %s) to stay within %d part limit",
+                store.backendName(),
+                renderSize(sizeHint),
+                renderSize(minChunkSize),
+                renderSize(S3_MAX_PART_SIZE),
+                S3_MAX_PART_COUNT);
+        }
+
+        warn(
+            "adjusting %s multipart chunk size from %s to %s "
+            "to stay within %d part limit for %s file",
+            store.backendName(),
+            renderSize(store.s3CompatConfig->multipartChunkSize.get()),
+            renderSize(minChunkSize),
+            S3_MAX_PART_COUNT,
+            renderSize(sizeHint));
+
+        chunkSize = minChunkSize;
+        estimatedParts = S3_MAX_PART_COUNT;
+    }
+
+    buffer.reserve(chunkSize);
+    partEtags.reserve(estimatedParts);
+    uploadId = store.createMultipartUpload(path, mimeType, std::move(headers));
+}
+
+void S3CompatBinaryCacheStore::MultipartSink::operator()(std::string_view data)
+{
+    buffer.append(data);
+
+    while (buffer.size() >= chunkSize) {
+        // Move entire buffer, extract excess, copy back remainder
+        auto chunk = std::move(buffer);
+        auto excessSize = chunk.size() > chunkSize ? chunk.size() - chunkSize : 0;
+        if (excessSize > 0) {
+            buffer.resize(excessSize);
+            std::memcpy(buffer.data(), chunk.data() + chunkSize, excessSize);
+        }
+        chunk.resize(std::min(chunkSize, chunk.size()));
+        uploadChunk(std::move(chunk));
+    }
+}
+
+void S3CompatBinaryCacheStore::MultipartSink::finish()
+{
+    if (!buffer.empty()) {
+        uploadChunk(std::move(buffer));
+    }
+
+    try {
+        if (partEtags.empty()) {
+            throw Error("no data read from stream");
+        }
+        store.completeMultipartUpload(path, uploadId, partEtags);
+    } catch (Error & e) {
+        store.abortMultipartUpload(path, uploadId);
+        e.addTrace({}, "while finishing %s multipart upload", store.backendName());
+        throw;
+    }
+}
+
+void S3CompatBinaryCacheStore::MultipartSink::uploadChunk(std::string chunk)
+{
+    auto partNumber = partEtags.size() + 1;
+    try {
+        std::string etag = store.uploadPart(path, uploadId, partNumber, std::move(chunk));
+        partEtags.push_back(std::move(etag));
+    } catch (Error & e) {
+        store.abortMultipartUpload(path, uploadId);
+        e.addTrace({}, "while uploading part %d of %s multipart upload", partNumber, store.backendName());
+        throw;
+    }
+}
+
+std::string S3CompatBinaryCacheStore::createMultipartUpload(
+    std::string_view key, std::string_view mimeType, std::optional<Headers> headers)
+{
+    auto req = makeRequest(key);
+
+    // prepareRequest() converts s3:// / gs:// to https:// but strips query parameters,
+    // so call it first, then add the multipart parameters.
+    prepareRequest(req);
+
+    auto url = req.uri.parsed();
+    url.query["uploads"] = "";
+    req.uri = VerbatimURL(url);
+
+    req.method = HttpMethod::Post;
+    StringSource payload{std::string_view("")};
+    req.data = {payload};
+    req.mimeType = mimeType;
+
+    if (headers) {
+        req.headers.reserve(req.headers.size() + headers->size());
+        std::move(headers->begin(), headers->end(), std::back_inserter(req.headers));
+    }
+
+    auto result = fileTransfer->enqueueFileTransfer(req).get();
+
+    std::regex uploadIdRegex("<UploadId>([^<]+)</UploadId>");
+    std::smatch match;
+
+    if (std::regex_search(result.data, match, uploadIdRegex)) {
+        return match[1];
+    }
+
+    throw Error("%s CreateMultipartUpload response missing <UploadId>", backendName());
+}
+
+std::string S3CompatBinaryCacheStore::uploadPart(
+    std::string_view key, std::string_view uploadId, uint64_t partNumber, std::string data)
+{
+    if (partNumber > S3_MAX_PART_COUNT) {
+        throw Error("%s multipart upload exceeded %d part limit", backendName(), S3_MAX_PART_COUNT);
+    }
+
+    auto req = makeRequest(key);
+    req.method = HttpMethod::Put;
+    prepareRequest(req);
+
+    auto url = req.uri.parsed();
+    url.query["partNumber"] = std::to_string(partNumber);
+    url.query["uploadId"] = uploadId;
+    req.uri = VerbatimURL(url);
+    StringSource payload{data};
+    req.data = {payload};
+    req.mimeType = "application/octet-stream";
+
+    auto result = fileTransfer->enqueueFileTransfer(req).get();
+
+    if (result.etag.empty()) {
+        throw Error("%s UploadPart response missing ETag for part %d", backendName(), partNumber);
+    }
+
+    debug("Part %d uploaded, ETag: %s", partNumber, result.etag);
+    return std::move(result.etag);
+}
+
+void S3CompatBinaryCacheStore::abortMultipartUpload(std::string_view key, std::string_view uploadId) noexcept
+{
+    try {
+        auto req = makeRequest(key);
+        prepareRequest(req);
+
+        auto url = req.uri.parsed();
+        url.query["uploadId"] = uploadId;
+        req.uri = VerbatimURL(url);
+        req.method = HttpMethod::Delete;
+
+        (void) fileTransfer->enqueueFileTransfer(req).get();
+    } catch (...) {
+        ignoreExceptionInDestructor();
+    }
+}
+
+void S3CompatBinaryCacheStore::completeMultipartUpload(
+    std::string_view key, std::string_view uploadId, std::span<const std::string> partEtags)
+{
+    auto req = makeRequest(key);
+    prepareRequest(req);
+
+    auto url = req.uri.parsed();
+    url.query["uploadId"] = uploadId;
+    req.uri = VerbatimURL(url);
+    req.method = HttpMethod::Post;
+
+    std::string xml = "<CompleteMultipartUpload>";
+    for (const auto & [idx, etag] : enumerate(partEtags)) {
+        xml += "<Part>";
+        // S3 part numbers are 1-indexed, but vector indices are 0-indexed
+        xml += "<PartNumber>" + std::to_string(idx + 1) + "</PartNumber>";
+        xml += "<ETag>" + etag + "</ETag>";
+        xml += "</Part>";
+    }
+    xml += "</CompleteMultipartUpload>";
+
+    debug("%s CompleteMultipartUpload XML (%d parts): %s", backendName(), partEtags.size(), xml);
+
+    StringSource payload{xml};
+    req.data = {payload};
+    req.mimeType = "text/xml";
+
+    (void) fileTransfer->enqueueFileTransfer(req).get();
+
+    debug("%s multipart upload completed: %d parts uploaded for '%s'", backendName(), partEtags.size(), key);
+}
+
+} // namespace nix

--- a/tests/nixos/default.nix
+++ b/tests/nixos/default.nix
@@ -196,6 +196,8 @@ in
 
   s3-binary-cache-store = runNixOSTest ./s3-binary-cache-store.nix;
 
+  gcs-binary-cache-store = runNixOSTest ./gcs-binary-cache-store.nix;
+
   fsync = runNixOSTest ./fsync.nix;
 
   cgroups = runNixOSTest ./cgroups;

--- a/tests/nixos/gcs-binary-cache-store.nix
+++ b/tests/nixos/gcs-binary-cache-store.nix
@@ -1,0 +1,100 @@
+{ config, ... }:
+
+let
+  pkgs = config.nodes.machine.nixpkgs.pkgs;
+
+  pkgA = pkgs.writeText "gcs-test-pkg-a" "hello from gcs";
+
+  token = "test-access-token";
+  port = 4443;
+
+  # authorized_user ADC file pointing at the mock's /token endpoint.
+  # So we can do the full refresh-token flow runs without needing RS256 signing.
+  adcFile = pkgs.writeText "adc.json" (
+    builtins.toJSON {
+      type = "authorized_user";
+      client_id = "dummy";
+      client_secret = "dummy";
+      refresh_token = "dummy";
+      token_uri = "http://localhost:${toString port}/token";
+    }
+  );
+in
+{
+  name = "gcs-binary-cache-store";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      virtualisation.writableStore = true;
+      virtualisation.additionalPaths = [ pkgA ];
+      nix.extraOptions = ''
+        experimental-features = nix-command
+        substituters =
+      '';
+      systemd.services.gcs-mock = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig.ExecStart = "${pkgs.python3}/bin/python3 ${./gcs-mock-server.py} --port ${toString port} --token ${token} --public-bucket public-cache";
+      };
+    };
+
+  testScript =
+    { nodes }:
+    # python
+    ''
+      PKG_A = "${pkgA}"
+      ENV = "GOOGLE_APPLICATION_CREDENTIALS=${adcFile}"
+      ENDPOINT = "endpoint=http://localhost:${toString port}"
+
+      def store_url(bucket, **extra):
+          q = "&".join([ENDPOINT] + [f"{k}={v}" for k, v in extra.items()])
+          return f"gs://{bucket}?{q}"
+
+      machine.wait_for_unit("gcs-mock.service")
+      machine.wait_for_open_port(${toString port})
+
+      url = store_url("private-cache")
+
+      # === auth is actually enforced (no creds → 401) ===
+      out = machine.fail(f"nix store info --store '{url}' 2>&1")
+      assert "401" in out, out
+
+      # === push/pull round-trip with ADC auth ===
+      machine.succeed(f"{ENV} nix copy --to '{url}' {PKG_A}")
+      machine.succeed(f"nix store delete --ignore-liveness {PKG_A}")
+      machine.fail(f"nix path-info {PKG_A}")
+      machine.succeed(f"{ENV} nix copy --no-check-sigs --from '{url}' {PKG_A}")
+      machine.succeed(f"nix path-info {PKG_A}")
+
+      # === anonymous read from public bucket ===
+      pub = store_url("public-cache")
+      machine.succeed(f"{ENV} nix copy --to '{pub}' {PKG_A}")
+      machine.succeed(f"nix store delete --ignore-liveness {PKG_A}")
+      machine.succeed(f"nix copy --no-check-sigs --from '{pub}' {PKG_A}")
+      machine.succeed(f"nix path-info {PKG_A}")
+
+      # === multipart upload through S3CompatBinaryCacheStore ===
+      large = machine.succeed(
+          "dd if=/dev/urandom of=/tmp/large bs=1M count=10 2>/dev/null && "
+          "nix-store --add /tmp/large"
+      ).strip()
+      mp_url = store_url(
+          "private-cache",
+          **{"multipart-upload": "true", "multipart-threshold": str(5 * 1024 * 1024)}
+      )
+      out = machine.succeed(f"{ENV} nix copy --debug --to '{mp_url}' {large} 2>&1")
+      assert "using GCS multipart upload" in out, out
+      assert "parts uploaded" in out, out
+      machine.succeed(f"nix store delete --ignore-liveness {large}")
+      machine.succeed(f"{ENV} nix copy --no-check-sigs --from '{mp_url}' {large}")
+      machine.succeed(f"nix path-info {large}")
+
+      # === user-project header forwarded ===
+      up_url = store_url("billing-cache", **{"user-project": "billing-proj"})
+      machine.succeed(f"{ENV} nix copy --to '{up_url}' {PKG_A}")
+      machine.wait_until_succeeds(
+          "journalctl -u gcs-mock --no-pager | grep -q user-project=billing-proj",
+          timeout=30,
+      )
+    '';
+}

--- a/tests/nixos/gcs-mock-server.py
+++ b/tests/nixos/gcs-mock-server.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Minimal GCS XML API mock for the gcs-binary-cache-store NixOS test.
+
+This mock implements only, what that store needs and doubles as the OAuth2 token endpoint so the
+authorized_user ADC flow can be tested end-to-end without faking signatures.
+"""
+
+import argparse
+import json
+import sys
+import threading
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlsplit
+
+OBJECTS: dict[str, dict[str, bytes]] = {}
+UPLOADS: dict[str, dict] = {}
+LOCK = threading.Lock()
+
+
+def make_handler(args):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def _parse(self):
+            u = urlsplit(self.path)
+            parts = u.path.lstrip("/").split("/", 1)
+            bucket = parts[0]
+            key = parts[1] if len(parts) > 1 else ""
+            return bucket, key, parse_qs(u.query, keep_blank_values=True)
+
+        def _authed(self, bucket: str) -> bool:
+            if bucket in args.public_buckets:
+                return True
+            got = self.headers.get("Authorization", "")
+            return got == f"Bearer {args.token}"
+
+        def _send(self, code: int, body: bytes = b"", headers: dict | None = None):
+            self.send_response(code)
+            for k, v in (headers or {}).items():
+                self.send_header(k, v)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _body(self) -> bytes:
+            n = int(self.headers.get("Content-Length", "0"))
+            return self.rfile.read(n) if n else b""
+
+        def log_message(self, fmt, *a):
+            # Include the user-project header so the test can assert it was forwarded.
+            up = self.headers.get("x-goog-user-project", "-")
+            print(f"[gcs-mock] {fmt % a} user-project={up}", file=sys.stderr, flush=True)
+
+        # OAuth2 token endpoint (authorized_user refresh flow)
+        def _maybe_token_endpoint(self) -> bool:
+            if urlsplit(self.path).path != "/token":
+                return False
+            self._body()  # drain
+            self._send(
+                200,
+                json.dumps(
+                    {
+                        "access_token": args.token,
+                        "expires_in": 3600,
+                        "token_type": "Bearer",
+                    }
+                ).encode(),
+                {"Content-Type": "application/json"},
+            )
+            return True
+
+        # GCS XML API
+        def do_HEAD(self):
+            bucket, key, _ = self._parse()
+            if not self._authed(bucket):
+                return self._send(401)
+            with LOCK:
+                obj = OBJECTS.get(bucket, {}).get(key)
+            self._send(200 if obj is not None else 404)
+
+        def do_GET(self):
+            bucket, key, _ = self._parse()
+            if not self._authed(bucket):
+                return self._send(401)
+            with LOCK:
+                obj = OBJECTS.get(bucket, {}).get(key)
+            if obj is None:
+                return self._send(404)
+            self._send(200, obj, {"Content-Type": "application/octet-stream"})
+
+        def do_PUT(self):
+            bucket, key, q = self._parse()
+            if not self._authed(bucket):
+                return self._send(401)
+            body = self._body()
+            if "partNumber" in q and "uploadId" in q:
+                uid = q["uploadId"][0]
+                pn = int(q["partNumber"][0])
+                with LOCK:
+                    UPLOADS[uid]["parts"][pn] = body
+                return self._send(200, headers={"ETag": f'"etag-{pn}"'})
+            with LOCK:
+                OBJECTS.setdefault(bucket, {})[key] = body
+            self._send(200)
+
+        def do_POST(self):
+            if self._maybe_token_endpoint():
+                return
+            bucket, key, q = self._parse()
+            if not self._authed(bucket):
+                return self._send(401)
+            self._body()  # drain
+            if "uploads" in q:
+                uid = uuid.uuid4().hex
+                with LOCK:
+                    UPLOADS[uid] = {"bucket": bucket, "key": key, "parts": {}}
+                xml = (
+                    "<InitiateMultipartUploadResult>"
+                    f"<Bucket>{bucket}</Bucket><Key>{key}</Key>"
+                    f"<UploadId>{uid}</UploadId>"
+                    "</InitiateMultipartUploadResult>"
+                )
+                return self._send(
+                    200, xml.encode(), {"Content-Type": "application/xml"}
+                )
+            if "uploadId" in q:
+                uid = q["uploadId"][0]
+                with LOCK:
+                    up = UPLOADS.pop(uid)
+                    blob = b"".join(up["parts"][i] for i in sorted(up["parts"]))
+                    OBJECTS.setdefault(up["bucket"], {})[up["key"]] = blob
+                return self._send(
+                    200,
+                    b"<CompleteMultipartUploadResult/>",
+                    {"Content-Type": "application/xml"},
+                )
+            self._send(400)
+
+        def do_DELETE(self):
+            bucket, key, q = self._parse()
+            if not self._authed(bucket):
+                return self._send(401)
+            if "uploadId" in q:
+                with LOCK:
+                    UPLOADS.pop(q["uploadId"][0], None)
+                return self._send(204)
+            with LOCK:
+                OBJECTS.get(bucket, {}).pop(key, None)
+            self._send(204)
+
+    return Handler
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", type=int, default=4443)
+    p.add_argument("--token", default="test-access-token")
+    p.add_argument(
+        "--public-bucket", dest="public_buckets", action="append", default=[]
+    )
+    args = p.parse_args()
+    ThreadingHTTPServer(("0.0.0.0", args.port), make_handler(args)).serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
End-to-end coverage for the `gs://` store against a self-contained Python mock
of the GCS XML API.

The mock doubles as the OAuth2 token endpoint so the authorized_user ADC flow
runs unmodified, and logs the `x-goog-user-project` header so the test can
assert it was forwarded.

---

Part of #16144.
Depends on #16147