### PR TITLE
Use vfork() in a safer manner in runProgram2

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1123,7 +1123,6 @@ static std::unique_ptr<PostBuildHookState> runPostBuildHook(
     hookEnvironment.emplace(OS_STR("NIX_CONFIG"), string_to_os_string(globalConfig.toKeyValue()));
 
     ProcessOptions processOptions;
-    processOptions.allowVfork = false;
 
     state->pid = startProcess(
         [&] {

--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -8,6 +8,10 @@
 #include "nix/util/environment-variables.hh"
 #include <math.h>
 
+#ifndef _WIN32
+#  include "unix/current-process-private.hh"
+#endif
+
 #ifdef __APPLE__
 #  include <mach-o/dyld.h>
 #endif
@@ -55,44 +59,6 @@ unsigned int getMaxCPU()
 
 //////////////////////////////////////////////////////////////////////
 
-#ifndef _WIN32
-size_t savedStackSize = 0;
-
-void ensureStackSizeAtLeast(size_t stackSize)
-{
-    struct rlimit limit;
-    if (getrlimit(RLIMIT_STACK, &limit) == 0 && static_cast<size_t>(limit.rlim_cur) < stackSize) {
-        savedStackSize = limit.rlim_cur;
-        if (limit.rlim_max < static_cast<rlim_t>(stackSize)) {
-            if (getEnv("_NIX_TEST_NO_ENVIRONMENT_WARNINGS") != "1") {
-                logger->log(
-                    lvlWarn,
-                    HintFmt(
-                        "Stack size hard limit is %1%, which is less than the desired %2%. If possible, increase the hard limit, e.g. with 'ulimit -Hs %3%'.",
-                        limit.rlim_max,
-                        stackSize,
-                        stackSize / 1024)
-                        .str());
-            }
-        }
-        auto requestedSize = std::min(static_cast<rlim_t>(stackSize), limit.rlim_max);
-        limit.rlim_cur = requestedSize;
-        if (setrlimit(RLIMIT_STACK, &limit) != 0) {
-            logger->log(
-                lvlError,
-                HintFmt(
-                    "Failed to increase stack size from %1% to %2% (desired: %3%, maximum allowed: %4%): %5%",
-                    savedStackSize,
-                    requestedSize,
-                    stackSize,
-                    limit.rlim_max,
-                    std::strerror(errno))
-                    .str());
-        }
-    }
-}
-#endif
-
 void restoreProcessContext(bool restoreMounts)
 {
 #ifndef _WIN32
@@ -105,10 +71,10 @@ void restoreProcessContext(bool restoreMounts)
     }
 
 #ifndef _WIN32
-    if (savedStackSize) {
+    if (unix::savedStackSize) {
         struct rlimit limit;
         if (getrlimit(RLIMIT_STACK, &limit) == 0) {
-            limit.rlim_cur = savedStackSize;
+            limit.rlim_cur = unix::savedStackSize;
             setrlimit(RLIMIT_STACK, &limit);
         }
     }

--- a/src/libutil/file-descriptor.cc
+++ b/src/libutil/file-descriptor.cc
@@ -257,7 +257,7 @@ AutoCloseFD::~AutoCloseFD()
     }
 }
 
-Descriptor AutoCloseFD::get() const
+Descriptor AutoCloseFD::get() const noexcept
 {
     return fd;
 }
@@ -288,12 +288,12 @@ void AutoCloseFD::startFsync() const
 #endif
 }
 
-AutoCloseFD::operator bool() const
+AutoCloseFD::operator bool() const noexcept
 {
     return fd != INVALID_DESCRIPTOR;
 }
 
-Descriptor AutoCloseFD::release()
+Descriptor AutoCloseFD::release() noexcept
 {
     Descriptor oldFD = fd;
     fd = INVALID_DESCRIPTOR;

--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -264,9 +264,9 @@ public:
     AutoCloseFD & operator=(const AutoCloseFD & fd) = delete;
     // NOLINTNEXTLINE(performance-noexcept-move-constructor) - technically can throw because of close()
     AutoCloseFD & operator=(AutoCloseFD && fd);
-    Descriptor get() const;
-    explicit operator bool() const;
-    Descriptor release();
+    Descriptor get() const noexcept;
+    explicit operator bool() const noexcept;
+    Descriptor release() noexcept;
     void close();
 
     /**

--- a/src/libutil/include/nix/util/processes.hh
+++ b/src/libutil/include/nix/util/processes.hh
@@ -97,7 +97,6 @@ struct ProcessOptions
     std::string errorPrefix = "";
     bool dieWithParent = true;
     bool runExitHandlers = false;
-    bool allowVfork = false;
     /**
      * use clone() with the specified flags (Linux only)
      */

--- a/src/libutil/linux/linux-namespaces-private.hh
+++ b/src/libutil/linux/linux-namespaces-private.hh
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "nix/util/file-descriptor.hh"
+
+namespace nix {
+
+extern AutoCloseFD fdSavedMountNamespace;
+extern AutoCloseFD fdSavedRoot;
+extern bool havePrivateMountNs;
+
+} // namespace nix

--- a/src/libutil/linux/linux-namespaces.cc
+++ b/src/libutil/linux/linux-namespaces.cc
@@ -161,25 +161,12 @@ void remountReadOnlyWritable(const std::filesystem::path & path)
         throw SysError("remounting %s writable", PathFmt(path));
 }
 
-/* This code runs in a (possibly) vfork-ed child, so technically everything you see below is beyond
-   broken because vfork()-ed child:
-
-   * Must not trample parent's memory in any way shape or form. That includes (but not limited to)
-     * Throwing any exceptions (because that would unwind into the parent stack frame and do who knows what).
-     * Modify any state - obviously that includes global state.
-     * Not allocate any memory, since that can also lead to a deadlock if some thread in the (now stopped) parent
-       holds a lock while we are running. That's because *all* of the parent tasks are suspended for the duration
-       of the vfork.
-
-   As it stands now, this code should be considered incredibly fragile and slated for a complete rework.
-   */
 void restoreMountNamespace()
 {
     if (!havePrivateMountNs)
         return;
 
     try {
-        /* FIXME: Allocation in a possibly vforked child. */
         auto savedCwd = std::filesystem::current_path();
 
         if (setns(fdSavedMountNamespace.get(), CLONE_NEWNS) == -1)
@@ -194,9 +181,6 @@ void restoreMountNamespace()
 
         if (chdir(savedCwd.c_str()) == -1)
             throw SysError("restoring cwd");
-
-        /* Do not reset havePrivateMountNs! This code can run in a vfork-ed child and we absolutely
-           must not trample any of the parent's state. */
     } catch (Error & e) {
         debug(e.msg());
     }

--- a/src/libutil/linux/linux-namespaces.cc
+++ b/src/libutil/linux/linux-namespaces.cc
@@ -3,6 +3,8 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/processes.hh"
 
+#include "linux-namespaces-private.hh"
+
 #include <mutex>
 #include <sys/resource.h>
 
@@ -89,9 +91,9 @@ bool mountAndPidNamespacesSupported()
 
 //////////////////////////////////////////////////////////////////////
 
-static AutoCloseFD fdSavedMountNamespace;
-static AutoCloseFD fdSavedRoot;
-static bool havePrivateMountNs = false;
+AutoCloseFD fdSavedMountNamespace;
+AutoCloseFD fdSavedRoot;
+bool havePrivateMountNs = false;
 
 /* Save the current mount namespace so restoreMountNamespace() can return
    to it later. Ignored if called more than once. */

--- a/src/libutil/linux/meson.build
+++ b/src/libutil/linux/meson.build
@@ -1,6 +1,7 @@
 sources += files(
   'cgroup.cc',
   'linux-namespaces.cc',
+  'processes.cc',
 )
 
 subdir('include/nix/util')

--- a/src/libutil/linux/processes.cc
+++ b/src/libutil/linux/processes.cc
@@ -4,14 +4,236 @@
 #include "nix/util/environment-variables.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/util.hh"
+#include "nix/util/serialise.hh"
 
-#include <grp.h>
+#include "linux/linux-namespaces-private.hh"
+#include "unix/signals-private.hh"
+#include "unix/current-process-private.hh"
+#include "util-unix-config-private.hh"
+
+#include <cstring>
+#include <cerrno>
+
+#include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/syscall.h>
+#include <sys/prctl.h>
+#include <grp.h>
 #include <unistd.h>
+#include <limits.h>
+#include <sched.h>
+
+extern char ** environ __attribute__((weak));
 
 namespace nix {
 
+namespace {
+
+/* This structure intentionally doesn't have any fancy classes from C++ like
+   std::optional, because I don't trust those. Only plain pointers or integral
+   types. */
+struct ExecChildParams
+{
+    const char * program;
+    const char * chdir;
+    char * const * environment;
+    char * const * args;
+    bool mergeStderrToStdout;
+    bool lookupPath;
+    Descriptor stdoutFd;
+    Descriptor errorPipe;
+    bool setGid;
+    gid_t gid;
+    bool setUid;
+    uid_t uid;
+    bool dieWithParent;
+};
+
+/*
+ * This code is supposed to run in the child right after vfork(). We never
+ * return from this function through normal means, but rather always _exit() or
+ * execv[e] from it.
+ *
+ * We shouldn't allow any exceptions to escape and shouldn't allocate any memory,
+ * or in general do anything that's not async-signal-safe.
+ *
+ * There's a slight wrinkle in that in a multithreaded program on Linux, only
+ * the thread calling vfork() is suspended while other threads of the parent
+ * continue running.
+ *
+ * This also presents a problem with signals, since those will also arrive in
+ * the child, which shares the address space. Thankfully, we don't have many
+ * signal handlers that would be negatively affected by this, so we punt on
+ * the issue.
+ *
+ * Another thing worth mentioning is that apparently, WSL and QEMU userspace
+ * emulation both implement vfork() as plain fork() so the regular footguns of
+ * fork() apply.
+ *
+ * Don't call any functions defined in other translations units from here!
+ * (for auditability purposes and avoiding accidentally calling something you
+ * shouldn't).
+ *
+ * Even calling libc functions is quite sketchy in general because of lazy
+ * binding with dynamic linking. Whatever the libc is doing in the dynamic
+ * linker is likely to not really be safe with vfork().
+ *
+ * Luckily, nixpkgs now builds with eager binding (-z now) so our builds won't
+ * be affected. TODO: Just build libutil with -z now too, instead of relying on
+ * hardening defaults.
+ */
+[[gnu::noinline, noreturn]] static void doExecChild(const ExecChildParams & params) noexcept
+{
+    auto die = [&params] [[noreturn]] (int err, const char * msg) {
+        [[maybe_unused]] ssize_t ret; /* Swallow all errors. */
+        ret = ::write(params.errorPipe, reinterpret_cast<const char *>(&err), sizeof(err));
+        ret = ::write(params.errorPipe, msg, ::strlen(msg));
+        ::_exit(1);
+    };
+
+    auto dieWithErrno = [&die] [[noreturn]] (const char * msg) { die(errno, msg); };
+
+    /* TODO: Do something with stdin if we don't want to keep it? */
+
+    if (params.stdoutFd != INVALID_DESCRIPTOR && ::dup2(params.stdoutFd, STDOUT_FILENO) == -1)
+        dieWithErrno("dupping stdout");
+
+    if (params.mergeStderrToStdout && ::dup2(STDOUT_FILENO, STDERR_FILENO) == -1)
+        dieWithErrno("cannot dup stdout into stderr");
+
+    if (params.chdir && ::chdir(params.chdir) == -1)
+        dieWithErrno("chdir failed");
+
+    /* Restore saved process context. Much like nix::restoreProcessContext, but inlined
+       and without any possibility of throwing exceptions. */
+
+    if (havePrivateMountNs) {
+        char savedCwd[PATH_MAX];
+
+        /* On Linux, it seems like cwd can't ever be larger than PATH_MAX (as
+           restricted by the syscall itself). Once again, intentionally not
+           calling into libc. */
+        if (::syscall(SYS_getcwd, savedCwd, sizeof(savedCwd)) == -1)
+            dieWithErrno("getcwd failed");
+
+        if (::setns(fdSavedMountNamespace.get(), CLONE_NEWNS) == -1)
+            dieWithErrno("restoring parent mount namespace");
+
+        if (fdSavedRoot) {
+            if (::fchdir(fdSavedRoot.get()))
+                dieWithErrno("chdir into saved root");
+
+            if (::chroot("."))
+                dieWithErrno("chroot into saved root");
+        }
+
+        if (::chdir(savedCwd) == -1)
+            dieWithErrno("restoring cwd");
+    }
+
+    /* Important! Calling syscalls directly and not libc functions because of a
+       discrepancy in POSIX specification (i.e. POSIX setgid/setuid has to apply
+       to all threads, while the syscall only applies to a task).
+       A huge footgun is apparently the fact that glibc defines SYS_setgid to the 16 bit
+       version of the syscall, while musl "fixes it up" to use the 32 bit version.
+       The end result is that we have to make sure to use the right one still. */
+
+#ifdef SYS_setuid32
+#  define NIX_SYS_setuid SYS_setuid32
+#  define NIX_SYS_setgid SYS_setgid32
+#  define NIX_SYS_setgroups SYS_setgroups32
+#else
+#  define NIX_SYS_setuid SYS_setuid
+#  define NIX_SYS_setgid SYS_setgid
+#  define NIX_SYS_setgroups SYS_setgroups
+#endif
+
+    if (params.setGid && ::syscall(NIX_SYS_setgid, params.gid) == -1)
+        dieWithErrno("setgid failed");
+
+    /* Drop all other groups if we're setgid. */
+    if (params.setGid && ::syscall(NIX_SYS_setgroups, 0, 0) == -1)
+        dieWithErrno("setgroups failed");
+
+    if (params.setUid && ::syscall(NIX_SYS_setuid, params.uid) == -1)
+        dieWithErrno("setuid failed");
+
+    /* Technically slightly racy, we might want to do something like what
+       preserveDeathSignal does. */
+    if (params.dieWithParent && prctl(PR_SET_PDEATHSIG, SIGKILL) == -1)
+        dieWithErrno("setting death signal");
+
+#undef NIX_SYS_setuid
+#undef NIX_SYS_setgid
+#undef NIX_SYS_setgroups
+
+    if (unix::savedStackSize) {
+        struct ::rlimit limit;
+        if (::getrlimit(RLIMIT_STACK, &limit) == 0) {
+            limit.rlim_cur = unix::savedStackSize;
+            ::setrlimit(RLIMIT_STACK, &limit);
+            /* TODO: Why do we ignore all errors here? */
+        }
+    }
+
+    /* Like unix::restoreSignals(), but safe to do in a vfork child. */
+    if (unix::savedSignalMaskIsSet && sigprocmask(SIG_SETMASK, &unix::savedSignalMask, nullptr) == -1)
+        dieWithErrno("restoring signals");
+
+    /* TODO: Close leaked file descriptors? The best way is with close_range(). */
+
+    if (params.lookupPath)
+        /* Nonstandard, but both musl and glibc have it and it doesn't
+           seem to do anything weird or allocate memory, so it should
+           be fine-ish? The use of execvp has some footguns though (see
+           https://github.com/NixOS/nix/pull/9494) and maybe we should get rid
+           of it entirely and do executable path resolution in the parent.
+           The hacky ENOEXEC handling also doesn't seem to exist in musl.
+
+           This does path lookup in the global environment of the parent, and
+           not in the params.environment like it's done in runProgram2 for other
+           unixes (arguably a bugfix)!
+
+           Don't accidentally call nix::execvpe! */
+        ::execvpe(params.program, params.args, params.environment);
+    else
+        ::execve(params.program, params.args, params.environment);
+
+    dieWithErrno("could not exec program");
+}
+
+[[gnu::noinline]] static pid_t startExecChildInVFork(const ExecChildParams & params) noexcept
+{
+    pid_t pid = ::vfork();
+
+    /* In the unlikely scenario that vfork() fails we return -1 here too. */
+    if (pid != 0)
+        return pid;
+
+    /* Now run the actual child. */
+    doExecChild(params);
+}
+
+/* TODO: This can be factored out if this becomes useful for other platforms? */
+static Strings prepareEnvironmentStrings(const StringMap & environment)
+{
+    Strings env;
+    for (auto & [name, value] : environment) {
+        std::string var;
+        var.reserve(name.size() + value.size() + 1);
+        var += name;
+        var += "=";
+        var += value;
+        env.push_back(std::move(var));
+    }
+    return env;
+}
+
+} // namespace
+
+/* TODO: Factor this out into a `launchProgram` that returns a pid. That would be
+   much more useful in more places. */
 void runProgram2(const RunOptions & options)
 {
     checkInterrupt();
@@ -21,48 +243,78 @@ void runProgram2(const RunOptions & options)
     if (options.standardOut)
         out.create();
 
-    ProcessOptions processOptions;
+    /* Pipe that the child reports errors through. */
+    Pipe childErrorPipe;
+    childErrorPipe.create();
+
+    /* Prepare arguments and environment for the child. */
+    Strings args_(options.args);
+    args_.push_front(options.program.native());
+    const Strings env_ = options.environment ? prepareEnvironmentStrings(*options.environment) : Strings{};
+    const auto env = stringsToCharPtrs(env_);
+    const auto args = stringsToCharPtrs(args_);
+
+    const ExecChildParams params = {
+        .program = options.program.c_str(),
+        .chdir = options.chdir ? options.chdir->c_str() : nullptr,
+        .environment = options.environment ? env.data() : environ,
+        .args = args.data(),
+        .mergeStderrToStdout = options.mergeStderrToStdout,
+        .lookupPath = options.lookupPath,
+        .stdoutFd = options.standardOut ? out.writeSide.get() : INVALID_DESCRIPTOR,
+        .errorPipe = childErrorPipe.writeSide.get(),
+        .setGid = options.gid.has_value(),
+        /* The default is not used, but a bit sketchy to leave zero initialised so "nobody". */
+        .gid = options.gid.value_or(65534),
+        .setUid = options.uid.has_value(),
+        /* The default is not used, but a bit sketchy to leave zero initialised so "nobody". */
+        .uid = options.uid.value_or(65534),
+        .dieWithParent = true, /* TODO: Maybe we might want to expose this in RunOptions? */
+    };
 
     auto suspension = logger->suspendIf(options.isInteractive);
 
+    const auto savedErrno = errno;
+
     /* Fork. */
-    Pid pid = startProcess(
-        [&] {
-            if (options.environment)
-                replaceEnv(*options.environment);
-            if (options.standardOut && dup2(out.writeSide.get(), STDOUT_FILENO) == -1)
-                throw SysError("dupping stdout");
-            if (options.mergeStderrToStdout)
-                if (dup2(STDOUT_FILENO, STDERR_FILENO) == -1)
-                    throw SysError("cannot dup stdout into stderr");
+    Pid pid = startExecChildInVFork(params);
 
-            if (options.chdir && chdir((*options.chdir).c_str()) == -1)
-                throw SysError("chdir failed");
-            if (options.gid && setgid(*options.gid) == -1)
-                throw SysError("setgid failed");
-            /* Drop all other groups if we're setgid. */
-            if (options.gid && setgroups(0, 0) == -1)
-                throw SysError("setgroups failed");
-            if (options.uid && setuid(*options.uid) == -1)
-                throw SysError("setuid failed");
+    /* errno is also shared with the child, so it can trample it. Restoring it
+       doesn't necessarily matter much though. */
+    const auto forkErrno = errno;
+    errno = savedErrno;
 
-            Strings args_(options.args);
-            args_.push_front(options.program.native());
-
-            restoreProcessContext();
-
-            if (options.lookupPath)
-                execvp(options.program.c_str(), stringsToCharPtrs(args_).data());
-            // This allows you to refer to a program with a pathname relative
-            // to the PATH variable.
-            else
-                execv(options.program.c_str(), stringsToCharPtrs(args_).data());
-
-            throw SysError("executing %s", PathFmt(options.program));
-        },
-        processOptions);
+    if (pid == -1)
+        throw SysError(forkErrno, "unable to vfork");
 
     out.writeSide.close();
+    childErrorPipe.writeSide.close();
+
+    StringSink childErrorSink;
+    drainFD(childErrorPipe.readSide.get(), childErrorSink);
+
+    /* We don't write anything to the pipe on success. */
+    if (const auto & errorContent = childErrorSink.s; errorContent.size()) {
+        int status = pid.wait();
+
+        auto execErr = ExecError(status, "could not start program %1%", PathFmt(options.program));
+
+        /* The child returned garbage through the error pipe. I think it's
+           pretty unlikely that this will happen, but maybe a signal arriving
+           could result in ::write failing with EINTR. It's unclear to me
+           whether that that can happen with writes under PIPE_BUF? */
+        if (errorContent.size() >= sizeof(int)) {
+            auto intBytes = errorContent.substr(0, sizeof(int));
+            int errNo;
+            std::memcpy(&errNo, intBytes.data(), sizeof(errNo));
+            auto errMsg = errorContent.substr(sizeof(int));
+            /* It's a bit strange, but the interface of runProgram2 reports
+               spawn helper errors as ExecError. */
+            execErr.addTrace({}, HintFmt("spawn helper process failed: %1%: %2%", errMsg, ::strerror(errNo)));
+        }
+
+        throw std::move(execErr);
+    }
 
     if (options.standardOut)
         drainFD(out.readSide.get(), *options.standardOut);

--- a/src/libutil/linux/processes.cc
+++ b/src/libutil/linux/processes.cc
@@ -1,0 +1,76 @@
+#include "nix/util/processes.hh"
+#include "nix/util/current-process.hh"
+#include "nix/util/file-descriptor.hh"
+#include "nix/util/environment-variables.hh"
+#include "nix/util/signals.hh"
+#include "nix/util/util.hh"
+
+#include <grp.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace nix {
+
+void runProgram2(const RunOptions & options)
+{
+    checkInterrupt();
+
+    /* Create a pipe. */
+    Pipe out;
+    if (options.standardOut)
+        out.create();
+
+    ProcessOptions processOptions;
+
+    auto suspension = logger->suspendIf(options.isInteractive);
+
+    /* Fork. */
+    Pid pid = startProcess(
+        [&] {
+            if (options.environment)
+                replaceEnv(*options.environment);
+            if (options.standardOut && dup2(out.writeSide.get(), STDOUT_FILENO) == -1)
+                throw SysError("dupping stdout");
+            if (options.mergeStderrToStdout)
+                if (dup2(STDOUT_FILENO, STDERR_FILENO) == -1)
+                    throw SysError("cannot dup stdout into stderr");
+
+            if (options.chdir && chdir((*options.chdir).c_str()) == -1)
+                throw SysError("chdir failed");
+            if (options.gid && setgid(*options.gid) == -1)
+                throw SysError("setgid failed");
+            /* Drop all other groups if we're setgid. */
+            if (options.gid && setgroups(0, 0) == -1)
+                throw SysError("setgroups failed");
+            if (options.uid && setuid(*options.uid) == -1)
+                throw SysError("setuid failed");
+
+            Strings args_(options.args);
+            args_.push_front(options.program.native());
+
+            restoreProcessContext();
+
+            if (options.lookupPath)
+                execvp(options.program.c_str(), stringsToCharPtrs(args_).data());
+            // This allows you to refer to a program with a pathname relative
+            // to the PATH variable.
+            else
+                execv(options.program.c_str(), stringsToCharPtrs(args_).data());
+
+            throw SysError("executing %s", PathFmt(options.program));
+        },
+        processOptions);
+
+    out.writeSide.close();
+
+    if (options.standardOut)
+        drainFD(out.readSide.get(), *options.standardOut);
+
+    /* Wait for the child to finish. */
+    int status = pid.wait();
+    if (status)
+        throw ExecError(status, "program %1% %2%", PathFmt(options.program), statusToString(status));
+}
+
+} // namespace nix

--- a/src/libutil/unix/current-process-private.hh
+++ b/src/libutil/unix/current-process-private.hh
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstddef>
+
+namespace nix {
+namespace unix {
+
+extern size_t savedStackSize;
+
+} // namespace unix
+} // namespace nix

--- a/src/libutil/unix/current-process.cc
+++ b/src/libutil/unix/current-process.cc
@@ -1,5 +1,10 @@
 #include "nix/util/current-process.hh"
+#include "nix/util/environment-variables.hh"
 #include "nix/util/error.hh"
+#include "nix/util/logging.hh"
+
+#include "unix/current-process-private.hh"
+
 #include <cmath>
 
 #include <sys/resource.h>
@@ -18,6 +23,42 @@ std::chrono::microseconds getCpuUserTime()
     std::chrono::microseconds microseconds(buf.ru_utime.tv_usec);
 
     return seconds + microseconds;
+}
+
+size_t unix::savedStackSize = 0;
+
+void ensureStackSizeAtLeast(size_t stackSize)
+{
+    struct rlimit limit;
+    if (getrlimit(RLIMIT_STACK, &limit) == 0 && static_cast<size_t>(limit.rlim_cur) < stackSize) {
+        unix::savedStackSize = limit.rlim_cur;
+        if (limit.rlim_max < static_cast<rlim_t>(stackSize)) {
+            if (getEnv("_NIX_TEST_NO_ENVIRONMENT_WARNINGS") != "1") {
+                logger->log(
+                    lvlWarn,
+                    HintFmt(
+                        "Stack size hard limit is %1%, which is less than the desired %2%. If possible, increase the hard limit, e.g. with 'ulimit -Hs %3%'.",
+                        limit.rlim_max,
+                        stackSize,
+                        stackSize / 1024)
+                        .str());
+            }
+        }
+        auto requestedSize = std::min(static_cast<rlim_t>(stackSize), limit.rlim_max);
+        limit.rlim_cur = requestedSize;
+        if (setrlimit(RLIMIT_STACK, &limit) != 0) {
+            logger->log(
+                lvlError,
+                HintFmt(
+                    "Failed to increase stack size from %1% to %2% (desired: %3%, maximum allowed: %4%): %5%",
+                    unix::savedStackSize,
+                    requestedSize,
+                    stackSize,
+                    limit.rlim_max,
+                    std::strerror(errno))
+                    .str());
+        }
+    }
 }
 
 } // namespace nix

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -298,6 +298,8 @@ std::string runProgram(std::filesystem::path program, bool lookupPath, const OsS
     return res.second;
 }
 
+#ifndef __linux__
+
 void runProgram2(const RunOptions & options)
 {
     checkInterrupt();
@@ -358,6 +360,8 @@ void runProgram2(const RunOptions & options)
     if (status)
         throw ExecError(status, "program %1% %2%", PathFmt(options.program), statusToString(status));
 }
+
+#endif // __linux__
 
 //////////////////////////////////////////////////////////////////////
 

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -207,17 +207,9 @@ void killUser(uid_t uid)
 
 using ChildWrapperFunction = fun<void()>;
 
-/* Wrapper around vfork to prevent the child process from clobbering
-   the caller's stack frame in the parent. */
-static pid_t doFork(bool allowVfork, ChildWrapperFunction & fun) __attribute__((noinline));
-
-static pid_t doFork(bool allowVfork, ChildWrapperFunction & fun)
+static pid_t doFork(ChildWrapperFunction & fun)
 {
-#ifdef __linux__
-    pid_t pid = allowVfork ? vfork() : fork();
-#else
     pid_t pid = fork();
-#endif
     if (pid != 0)
         return pid;
     fun();
@@ -237,14 +229,12 @@ pid_t startProcess(fun<void()> processMain, const ProcessOptions & options)
 {
     auto newLogger = makeSimpleLogger().release();
     ChildWrapperFunction wrapper = [&] {
-        if (!options.allowVfork) {
-            /* Set a simple logger, while leaking (not destroying)
-               the parent logger. We don't want to run the parent
-               logger's destructor since that will crash (e.g. when
-               ~ProgressBar() tries to join a thread that doesn't
-               exist. */
-            logger = newLogger;
-        }
+        /* Set a simple logger, while leaking (not destroying)
+           the parent logger. We don't want to run the parent
+           logger's destructor since that will crash (e.g. when
+           ~ProgressBar() tries to join a thread that doesn't
+           exist. */
+        logger = newLogger;
         try {
 #ifdef __linux__
             if (options.dieWithParent && prctl(PR_SET_PDEATHSIG, SIGKILL) == -1)
@@ -284,7 +274,7 @@ pid_t startProcess(fun<void()> processMain, const ProcessOptions & options)
         throw Error("clone flags are only supported on Linux");
 #endif
     } else
-        pid = doFork(options.allowVfork, wrapper);
+        pid = doFork(wrapper);
 
     if (pid == -1)
         throw SysError("unable to fork");
@@ -318,10 +308,6 @@ void runProgram2(const RunOptions & options)
         out.create();
 
     ProcessOptions processOptions;
-    // vfork implies that the environment of the main process and the fork will
-    // be shared (technically this is undefined, but in practice that's the
-    // case), so we can't use it if we alter the environment
-    processOptions.allowVfork = !options.environment;
 
     auto suspension = logger->suspendIf(options.isInteractive);
 

--- a/src/libutil/unix/signals-private.hh
+++ b/src/libutil/unix/signals-private.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <signal.h>
+
+namespace nix {
+namespace unix {
+
+extern sigset_t savedSignalMask;
+extern bool savedSignalMaskIsSet;
+
+} // namespace unix
+} // namespace nix

--- a/src/libutil/unix/signals.cc
+++ b/src/libutil/unix/signals.cc
@@ -5,6 +5,8 @@
 #include "nix/util/sync.hh"
 #include "nix/util/terminal.hh"
 
+#include "unix/signals-private.hh"
+
 #include <thread>
 
 namespace nix {
@@ -101,8 +103,8 @@ void unix::triggerInterrupt()
     }
 }
 
-static sigset_t savedSignalMask;
-static bool savedSignalMaskIsSet = false;
+sigset_t unix::savedSignalMask;
+bool unix::savedSignalMaskIsSet = false;
 
 void unix::saveSignalMask()
 {

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -354,7 +354,6 @@ static void daemonLoop(
                 options.errorPrefix = "unexpected Nix daemon error: ";
                 options.dieWithParent = false;
                 options.runExitHandlers = true;
-                options.allowVfork = false;
                 startProcess(
                     [&, storeConfig, closeListeners = std::move(closeListeners)]() {
                         closeListeners();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is a lot. Previously we had used vfork() in a very careless manner -
we trampled all over the parent process address space without a care in the world.
That used to work ok-ish, but stuff like https://github.com/NixOS/nix/commit/9640ab1fa4a88def1c5be31e45cd819caa24a638 shows
just how easily broken the status quo is.

Some valuable references for this change are:

* https://ewontfix.com/7/ - I got some details about vfork() in https://github.com/NixOS/nix/commit/9640ab1fa4a88def1c5be31e45cd819caa24a638
  wrong. Only the calling thread is suspended - at least on Linux. It's hard to tell what
  other systems do. At least according to [1] this is a common misconception and actually isn't
  the case on some other systems??
* Python's migration to vfork https://bugs.python.org/issue35823
* Glibc and musl sources.
* https://github.com/python/cpython/blob/main/Modules/_posixsubprocess.c

Fixes some bugs along the way:

* setuid/setgid and friends reset PDEATHSIG prctl and runProgram2 would set it *before*
  doing setuid in the child. That could and would lead to orphaned processes as we have seen
  in https://github.com/NixOS/nix/commit/34688ecf5f7af84b969cb72971ef151b63330718. It's still slightly racy, but this change is very
  large and possibly full of footguns still.
* runProgram2 would take use the PATH from the environment that the child is supposed to use, not
  the outer process. This is most certainly a bug that could blow up in our face. Thankfully, it
  doesn't seem like it was an issue anywhere in the codebase.

[1]: https://gist.github.com/nicowilliams/a8a07b0fc75df05f684c23c18d7db234

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Partially addresses https://github.com/NixOS/nix/issues/16119.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
