### PR TITLE
Appropriate exclusion of rl-next.md when officialRelease = true

### DIFF
--- a/doc/manual/source/meson.build
+++ b/doc/manual/source/meson.build
@@ -8,10 +8,10 @@ summary_rl_next = custom_target(
     'pipefail',
     '-c',
     '''
-      if [ -e "@INPUT@" ]; then
+      if [ '@0@' = 'false' ]; then
         echo '  - [Upcoming release](release-notes/rl-next.md)'
       fi
-    ''',
+    '''.format(official_release),
   ],
   input : [
     rl_next_generated,


### PR DESCRIPTION
## Motivation

The `officialRelease` flag is supposed to exclude `rl-next.md` from official manual builds. However, the upcoming-release entry was still included when `officialRelease = true`.

## Context

The summary-generation step did not check the `officialRelease` flag directly. Instead, it checked whether the generated input file existed. Meson materialized that file even for official releases, so the check succeeded and included the upcoming-release entry.

This change checks the release mode directly when deciding whether to include the entry.

Closes #16135