### PR TITLE
lazy paths prep: Peel and coerce

### DIFF
--- a/src/libexpr-tests/json.cc
+++ b/src/libexpr-tests/json.cc
@@ -76,4 +76,50 @@ TEST_F(JSONValueTest, DISABLED_Path)
     v.mkPath(state.rootPath(CanonPath("/test")), state.mem);
     ASSERT_EQ(getJSONValue(v), "\"/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-x\"");
 }
+
+/* Fixture for JSONValueTest/ToStringAcceptsExternal */
+namespace {
+class MyExternal : public ExternalValueBase
+{
+    std::string showType() const override
+    {
+        return "an-external";
+    }
+
+    std::string typeOf() const override
+    {
+        return "an-external";
+    }
+
+    std::ostream & print(std::ostream & str) const override
+    {
+        return str << "<external>";
+    }
+
+    nlohmann::json printValueAsJSON(EvalState &, bool, NixStringContext &, bool) const override
+    {
+        return "external-json";
+    }
+};
+} // namespace
+
+TEST_F(JSONValueTest, ToStringAcceptsExternal)
+{
+    MyExternal ext;
+
+    PrimOp primOp{
+        .name = "toStringReturningExternal",
+        .arity = 1,
+        .impl = [&](EvalState &, CallSite, Value * const *, Value & v) { v.mkExternal(&ext); },
+    };
+    Value vPrimOp;
+    vPrimOp.mkPrimOp(&primOp);
+
+    BindingsBuilder builder = state.buildBindings(1);
+    builder.insert(state.s.toString, &vPrimOp);
+    Value vAttrs;
+    vAttrs.mkAttrs(builder.finish());
+
+    ASSERT_EQ(getJSONValue(vAttrs), "\"external-json\"");
+}
 } /* namespace nix */

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -116,6 +116,13 @@ std::ostream & operator<<(std::ostream & os, const ValueType t)
     return os;
 }
 
+std::ostream & operator<<(std::ostream & os, WhileTryingToUse w)
+{
+    /* Reset color first: `HintFmt` wraps arguments in `Magenta` by
+       default, but this word is sentence structure, not a value. */
+    return os << ANSI_NORMAL << ((w.v->isThunk() || w.v->isFailed() || w.v->type() == nThunk) ? "evaluating" : "using");
+}
+
 std::string printValue(EvalState & state, Value & v)
 {
     std::ostringstream out;

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -120,7 +120,7 @@ std::ostream & operator<<(std::ostream & os, WhileTryingToUse w)
 {
     /* Reset color first: `HintFmt` wraps arguments in `Magenta` by
        default, but this word is sentence structure, not a value. */
-    return os << ANSI_NORMAL << ((w.v.isThunk() || w.v.isFailed() || w.v.type() == nThunk) ? "evaluating" : "using");
+    return os << ANSI_NORMAL << (w.v.isWHNF() ? "using" : "evaluating");
 }
 
 std::string printValue(EvalState & state, Value & v)

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -120,7 +120,7 @@ std::ostream & operator<<(std::ostream & os, WhileTryingToUse w)
 {
     /* Reset color first: `HintFmt` wraps arguments in `Magenta` by
        default, but this word is sentence structure, not a value. */
-    return os << ANSI_NORMAL << ((w.v->isThunk() || w.v->isFailed() || w.v->type() == nThunk) ? "evaluating" : "using");
+    return os << ANSI_NORMAL << ((w.v.isThunk() || w.v.isFailed() || w.v.type() == nThunk) ? "evaluating" : "using");
 }
 
 std::string printValue(EvalState & state, Value & v)

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2479,26 +2479,6 @@ bool EvalState::isDerivation(Value & v)
     return i->value->string_view().compare("derivation") == 0;
 }
 
-std::optional<std::string>
-EvalState::tryAttrsToString(const PosIdx pos, Value & v, NixStringContext & context, bool coerceMore, bool copyToStore)
-{
-    auto i = v.attrs()->get(s.toString);
-    if (i) {
-        Value v1;
-        callFunction(*i->value, v, v1, pos);
-        return coerceToString(
-                   pos,
-                   v1,
-                   context,
-                   "while evaluating the result of the `__toString` attribute",
-                   coerceMore,
-                   copyToStore)
-            .toOwned();
-    }
-
-    return {};
-}
-
 BackedStringView EvalState::coerceToString(
     const PosIdx pos,
     Value & v,
@@ -2530,17 +2510,27 @@ BackedStringView EvalState::coerceToString(
     }
 
     if (v.type() == nAttrs) {
-        auto maybeString = tryAttrsToString(pos, v, context, coerceMore, copyToStore);
-        if (maybeString)
-            return std::move(*maybeString);
-        auto i = v.attrs()->get(s.outPath);
-        if (!i) {
-            error<TypeError>(
-                "cannot coerce %1% to a string: %2%", showType(v), ValuePrinter(*this, v, errorPrintOptions))
-                .withTrace(pos, errorCtx)
-                .debugThrow();
-        }
-        return coerceToString(pos, *i->value, context, errorCtx, coerceMore, copyToStore, canonicalizePath);
+        const bool checkToStringReturn = false; // Historical quirk
+        return peelToStringOutPath(pos, v, checkToStringReturn, [&](Value * peeled, bool) -> BackedStringView {
+            if (peeled->type() == nAttrs) {
+                error<TypeError>(
+                    "cannot coerce %1% to a string: %2%",
+                    showType(*peeled),
+                    ValuePrinter(*this, *peeled, errorPrintOptions))
+                    .withTrace(pos, errorCtx)
+                    .debugThrow();
+            }
+            /* `canonicalizePath=false` is `ExprConcat`'s hack for
+               preserving the trailing slash on source-parsed path
+               literals like the `/foo/` in `/foo/${x}`. Any attrset
+               in that slot is a computed value with no
+               source-fidelity intent — the peeled path came from
+               user code, not from the interpolation syntax. Force
+               canonicalisation on the peel result regardless of
+               which peel path (`__toString` or `outPath`) got us
+               here. */
+            return coerceToString(pos, *peeled, context, errorCtx, coerceMore, copyToStore, /*canonicalizePath=*/true);
+        });
     }
 
     if (v.type() == nExternal) {

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2609,34 +2609,18 @@ StorePath EvalState::copyPathToStore(NixStringContext & context, const SourcePat
 
 SourcePath EvalState::coerceToPath(const PosIdx pos, Value & v, NixStringContext & context, std::string_view errorCtx)
 {
-    try {
-        forceValue(v, pos);
-    } catch (Error & e) {
-        e.addTrace(positions[pos], errorCtx);
-        throw;
-    }
-
-    /* Handle path values directly, without coercing to a string. */
-    if (v.type() == nPath)
-        return v.path();
-
-    /* Similarly, handle __toString where the result may be a path
-       value. */
-    if (v.type() == nAttrs) {
-        auto i = v.attrs()->get(s.toString);
-        if (i) {
-            Value v1;
-            callFunction(*i->value, v, v1, pos);
-            return coerceToPath(pos, v1, context, errorCtx);
-        }
-    }
-
-    /* Any other value should be coercible to a string, interpreted
-       relative to the root filesystem. */
-    auto path = coerceToString(pos, v, context, errorCtx, false, false, true).toOwned();
-    if (path == "" || path[0] != '/')
-        error<EvalError>("string '%1%' doesn't represent an absolute path", path).withTrace(pos, errorCtx).debugThrow();
-    return rootPath(CanonPath(path));
+    const bool checkToStringReturn = false; // Historical quirk
+    return peelToStringOutPath(pos, v, checkToStringReturn, [&](Value * peeled, bool) -> SourcePath {
+        Value & effective = *peeled;
+        if (effective.type() == nPath)
+            return effective.path();
+        auto path = coerceToString(pos, effective, context, errorCtx, false, false, true).toOwned();
+        if (path == "" || path[0] != '/')
+            error<EvalError>("string '%1%' doesn't represent an absolute path", path)
+                .withTrace(pos, errorCtx)
+                .debugThrow();
+        return rootPath(CanonPath(path));
+    });
 }
 
 StorePath

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2517,27 +2517,31 @@ BackedStringView EvalState::coerceToString(
     }
 
     if (v.type() == nAttrs) {
-        const bool checkToStringReturn = false; // Historical quirk
-        return peelToStringOutPath(pos, v, checkToStringReturn, [&](Value * peeled, bool) -> BackedStringView {
-            if (peeled->type() == nAttrs) {
-                error<TypeError>(
-                    "cannot coerce %1% to a string: %2%",
-                    showType(*peeled),
-                    ValuePrinter(*this, *peeled, errorPrintOptions))
-                    .withTrace(pos, errorCtx)
-                    .debugThrow();
-            }
-            /* `canonicalizePath=false` is `ExprConcat`'s hack for
-               preserving the trailing slash on source-parsed path
-               literals like the `/foo/` in `/foo/${x}`. Any attrset
-               in that slot is a computed value with no
-               source-fidelity intent — the peeled path came from
-               user code, not from the interpolation syntax. Force
-               canonicalisation on the peel result regardless of
-               which peel path (`__toString` or `outPath`) got us
-               here. */
-            return coerceToString(pos, *peeled, context, errorCtx, coerceMore, copyToStore, /*canonicalizePath=*/true);
-        });
+        return peelToStringOutPath(
+            pos,
+            v,
+            /*checkToStringReturn=*/false, // Historical quirk
+            [&](Value * peeled, bool) -> BackedStringView {
+                if (peeled->type() == nAttrs) {
+                    error<TypeError>(
+                        "cannot coerce %1% to a string: %2%",
+                        showType(*peeled),
+                        ValuePrinter(*this, *peeled, errorPrintOptions))
+                        .withTrace(pos, errorCtx)
+                        .debugThrow();
+                }
+                /* `canonicalizePath=false` is `ExprConcat`'s hack for
+                   preserving the trailing slash on source-parsed path
+                   literals like the `/foo/` in `/foo/${x}`. Any attrset
+                   in that slot is a computed value with no
+                   source-fidelity intent — the peeled path came from
+                   user code, not from the interpolation syntax. Force
+                   canonicalisation on the peel result regardless of
+                   which peel path (`__toString` or `outPath`) got us
+                   here. */
+                return coerceToString(
+                    pos, *peeled, context, errorCtx, coerceMore, copyToStore, /*canonicalizePath=*/true);
+            });
     }
 
     if (v.type() == nExternal) {
@@ -2616,18 +2620,21 @@ StorePath EvalState::copyPathToStore(NixStringContext & context, const SourcePat
 
 SourcePath EvalState::coerceToPath(const PosIdx pos, Value & v, NixStringContext & context, std::string_view errorCtx)
 {
-    const bool checkToStringReturn = false; // Historical quirk
-    return peelToStringOutPath(pos, v, checkToStringReturn, [&](Value * peeled, bool) -> SourcePath {
-        Value & effective = *peeled;
-        if (effective.type() == nPath)
-            return effective.path();
-        auto path = coerceToString(pos, effective, context, errorCtx, false, false, true).toOwned();
-        if (path == "" || path[0] != '/')
-            error<EvalError>("string '%1%' doesn't represent an absolute path", path)
-                .withTrace(pos, errorCtx)
-                .debugThrow();
-        return rootPath(CanonPath(path));
-    });
+    return peelToStringOutPath(
+        pos,
+        v,
+        /*checkToStringReturn=*/false, // Historical quirk
+        [&](Value * peeled, bool) -> SourcePath {
+            Value & effective = *peeled;
+            if (effective.type() == nPath)
+                return effective.path();
+            auto path = coerceToString(pos, effective, context, errorCtx, false, false, true).toOwned();
+            if (path == "" || path[0] != '/')
+                error<EvalError>("string '%1%' doesn't represent an absolute path", path)
+                    .withTrace(pos, errorCtx)
+                    .debugThrow();
+            return rootPath(CanonPath(path));
+        });
 }
 
 StorePath

--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -189,9 +189,9 @@ EvalState::peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringRe
             return std::forward<Cb>(cb)(&v, cameThroughToString);
         }
         if (auto i = v.attrs()->get(state.s.toString)) {
-            Value * v1 = state.allocValue();
+            Value & v1 = *state.allocValue();
             try {
-                state.callFunction(*i->value, v, *v1, i->pos);
+                state.callFunction(*i->value, v, v1, i->pos);
             } catch (Error & e) {
                 e.addTrace(state.positions[i->pos], "while calling the `__toString` attribute");
                 throw;
@@ -199,7 +199,7 @@ EvalState::peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringRe
             cameThroughToString = true;
             try {
                 auto _level = state.addCallDepth(pos);
-                return peel(i->pos, *v1);
+                return peel(i->pos, v1);
             } catch (Error & e) {
                 e.addTrace(
                     state.positions[i->pos], "while %s the result of the `__toString` attribute", WhileTryingToUse{v1});
@@ -212,7 +212,7 @@ EvalState::peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringRe
                 auto _level = state.addCallDepth(pos);
                 return peel(i->pos, *i->value);
             } catch (Error & e) {
-                e.addTrace(state.positions[i->pos], "while %s the `outPath` attribute", WhileTryingToUse{i->value});
+                e.addTrace(state.positions[i->pos], "while %s the `outPath` attribute", WhileTryingToUse{*i->value});
                 throw;
             }
         }

--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -172,16 +172,18 @@ EvalState::peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringRe
         state.forceValue(v, pos);
         auto vType = v.type();
         if (vType != nAttrs) {
-            /* String and path terminate happily; external delegates its
-               serialisation to the caller (`printValueAsJSON` routes into
-               `ExternalValueBase::printValueAsJSON`, `coerceToString` into
-               `ExternalValueBase::coerceToString`) so we let it through
-               too. Everything else violates the "`__toString` returns a
-               string" contract. */
+            /* Trivially string-coercible types (i.e. coerceMore = false compatible)
+               get to return happily.
+               String and path terminate happily. External needs to be handled
+               by caller. E.g. `printValueAsJSON` routes to `ExternalValueBase::printValueAsJSON`,
+               `coerceToString` to `ExternalValueBase::coerceToString`).
+               Everything else violates the "`__toString` returns a
+               string" contract.
+               */
             if (checkToStringReturn && cameThroughToString && vType != nString && vType != nPath && vType != nExternal)
                 state
                     .error<TypeError>(
-                        "`__toString` must return a string, but got %1%: %2%",
+                        "`__toString` should return a string, but got %1%: %2%",
                         showType(v),
                         ValuePrinter(state, v, errorPrintOptions))
                     .atPos(pos)

--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -201,19 +201,20 @@ EvalState::peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringRe
                 auto _level = state.addCallDepth(pos);
                 return peel(i->pos, *v1);
             } catch (Error & e) {
-                e.addTrace(state.positions[i->pos], "while evaluating the result of the `__toString` attribute");
+                e.addTrace(
+                    state.positions[i->pos], "while %s the result of the `__toString` attribute", WhileTryingToUse{v1});
                 throw;
             }
         }
         if (auto i = v.attrs()->get(state.s.outPath)) {
             try {
                 state.forceValue(*i->value, i->pos);
+                auto _level = state.addCallDepth(pos);
+                return peel(i->pos, *i->value);
             } catch (Error & e) {
-                e.addTrace(state.positions[i->pos], "while evaluating the `outPath` attribute");
+                e.addTrace(state.positions[i->pos], "while %s the `outPath` attribute", WhileTryingToUse{i->value});
                 throw;
             }
-            auto _level = state.addCallDepth(pos);
-            return peel(i->pos, *i->value);
         }
         /* Can't peel more. (no `__toString`, no `outPath`).
            If we came through a `__toString` call at any depth, this violates

--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -170,15 +170,15 @@ EvalState::peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringRe
 
     auto peel = [&, &state = *this](this const auto & peel, const PosIdx pos, Value & v) -> R {
         state.forceValue(v, pos);
-        if (v.type() != nAttrs) {
+        auto vType = v.type();
+        if (vType != nAttrs) {
             /* String and path terminate happily; external delegates its
                serialisation to the caller (`printValueAsJSON` routes into
                `ExternalValueBase::printValueAsJSON`, `coerceToString` into
                `ExternalValueBase::coerceToString`) so we let it through
                too. Everything else violates the "`__toString` returns a
                string" contract. */
-            if (checkToStringReturn && cameThroughToString && v.type() != nString && v.type() != nPath
-                && v.type() != nExternal)
+            if (checkToStringReturn && cameThroughToString && vType != nString && vType != nPath && vType != nExternal)
                 state
                     .error<TypeError>(
                         "`__toString` must return a string, but got %1%: %2%",

--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -161,4 +161,74 @@ inline CallDepth EvalState::addCallDepth(const PosIdx pos)
     return CallDepth(callDepth);
 };
 
+template<typename Cb>
+std::invoke_result_t<Cb, Value *, bool>
+EvalState::peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringReturn, Cb && cb)
+{
+    using R = std::invoke_result_t<Cb, Value *, bool>;
+    bool cameThroughToString = false;
+
+    auto peel = [&, &state = *this](this const auto & peel, const PosIdx pos, Value & v) -> R {
+        state.forceValue(v, pos);
+        if (v.type() != nAttrs) {
+            /* String and path terminate happily; external delegates its
+               serialisation to the caller (`printValueAsJSON` routes into
+               `ExternalValueBase::printValueAsJSON`, `coerceToString` into
+               `ExternalValueBase::coerceToString`) so we let it through
+               too. Everything else violates the "`__toString` returns a
+               string" contract. */
+            if (checkToStringReturn && cameThroughToString && v.type() != nString && v.type() != nPath
+                && v.type() != nExternal)
+                state
+                    .error<TypeError>(
+                        "`__toString` must return a string, but got %1%: %2%",
+                        showType(v),
+                        ValuePrinter(state, v, errorPrintOptions))
+                    .atPos(pos)
+                    .debugThrow();
+            return std::forward<Cb>(cb)(&v, cameThroughToString);
+        }
+        if (auto i = v.attrs()->get(state.s.toString)) {
+            Value * v1 = state.allocValue();
+            try {
+                state.callFunction(*i->value, v, *v1, i->pos);
+            } catch (Error & e) {
+                e.addTrace(state.positions[i->pos], "while calling the `__toString` attribute");
+                throw;
+            }
+            cameThroughToString = true;
+            try {
+                auto _level = state.addCallDepth(pos);
+                return peel(i->pos, *v1);
+            } catch (Error & e) {
+                e.addTrace(state.positions[i->pos], "while evaluating the result of the `__toString` attribute");
+                throw;
+            }
+        }
+        if (auto i = v.attrs()->get(state.s.outPath)) {
+            try {
+                state.forceValue(*i->value, i->pos);
+            } catch (Error & e) {
+                e.addTrace(state.positions[i->pos], "while evaluating the `outPath` attribute");
+                throw;
+            }
+            auto _level = state.addCallDepth(pos);
+            return peel(i->pos, *i->value);
+        }
+        /* Can't peel more. (no `__toString`, no `outPath`).
+           If we came through a `__toString` call at any depth, this violates
+           the string-return contract. (usually not enforced) */
+        if (checkToStringReturn && cameThroughToString)
+            state
+                .error<TypeError>(
+                    "`__toString` must return a string, but got %1%: %2%",
+                    showType(v),
+                    ValuePrinter(state, v, errorPrintOptions))
+                .atPos(pos)
+                .debugThrow();
+        return std::forward<Cb>(cb)(&v, cameThroughToString);
+    };
+    return peel(pos, v);
+}
+
 } // namespace nix

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -212,6 +212,22 @@ void copyContext(
 std::string printValue(EvalState & state, Value & v);
 std::ostream & operator<<(std::ostream & os, const ValueType t);
 
+/**
+ * Trace-message stage marker for "we tried to reach a usable value
+ * from `v` but failed".
+ * Renders as `using` when it has evaluated to a proper value, and
+ * `evaluating` otherwise.
+ *
+ * Use in a `%s` in `addTrace`, e.g.:
+ * `"while %s the result of the %s attribute"`.
+ */
+struct WhileTryingToUse
+{
+    const Value * v;
+};
+
+std::ostream & operator<<(std::ostream & os, WhileTryingToUse w);
+
 struct RegexCache;
 
 ref<RegexCache> makeRegexCache();

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -753,8 +753,35 @@ public:
      */
     bool isDerivation(Value & v);
 
-    std::optional<std::string> tryAttrsToString(
-        const PosIdx pos, Value & v, NixStringContext & context, bool coerceMore = false, bool copyToStore = true);
+    /**
+     * Force `v` and peel through `__toString` and `outPath` attributes
+     * repeatedly until reaching a terminal value: either a non-attrset,
+     * or an attrset that has neither attribute. Invoke
+     * `cb(peeled, cameThroughToString)` on that terminal value.
+     *
+     * `cb` runs while the peel's call stack is still live, so errors it
+     * raises carry a trace reflecting which `__toString` and `outPath`
+     * attributes were traversed to reach `peeled`. Relying on the stack
+     * to preserve that context avoids the cost and complexity of
+     * tracking provenance in the hot path at runtime.
+     *
+     * `__toString` takes precedence over a sibling `outPath` at each
+     * step, matching string-interpolation coercion in the language.
+     *
+     * `peeled` is always a valid, forced Value; in the terminal-attrset
+     * case it is that attrset.
+     *
+     * `cameThroughToString` is true iff the peel invoked at least one
+     * `__toString`.
+     *
+     * With `checkToStringReturn`, if any `__toString` was traversed the
+     * terminal value must be a string, path, or external value;
+     * otherwise a `TypeError` is thrown before `cb` runs. Pure `outPath`
+     * peels are exempt.
+     */
+    template<typename Cb>
+    auto peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringReturn, Cb && cb)
+        -> std::invoke_result_t<Cb, Value *, bool>;
 
     enum class CopyLazyPaths : bool {
         PreserveLazy = false,

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -223,7 +223,7 @@ std::ostream & operator<<(std::ostream & os, const ValueType t);
  */
 struct WhileTryingToUse
 {
-    const Value * v;
+    const Value & v;
 };
 
 std::ostream & operator<<(std::ostream & os, WhileTryingToUse w);

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -1323,6 +1323,40 @@ public:
         return !isa<tUninitialized>();
     }
 
+    /**
+     * Whether the value has been evaluated to WHNF, i.e. non-deep successful
+     * evaluation result, or successful "root of a value".
+     * See https://nix.dev/manual/nix/latest/language/evaluation.html?highlight=whnf#values
+     */
+    inline bool isWHNF() const noexcept
+    {
+        switch (getInternalType()) {
+        case tUninitialized:
+            panic("attempt to use uninitialized Value");
+        case tFailed:
+        case tApp:
+        case tThunk:
+            return false;
+        case tInt:
+        case tBool:
+        case tNull:
+        case tFloat:
+        case tExternal:
+        case tPrimOp:
+        case tAttrs:
+        case tListSmall:
+        case tPrimOpApp: // primop-app is known to be a function, which is WHNF
+        case tLambda:
+        case tListN:
+        case tString:
+        case tPath:
+            return true;
+        case tNumberOfInternalTypes:
+            unreachable();
+        }
+        unreachable();
+    }
+
     inline void mkInt(NixInt::Inner n) noexcept
     {
         mkInt(NixInt{n});

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -49,27 +49,33 @@ json printValueAsJSON(
         break;
 
     case nAttrs: {
-        auto maybeString = state.tryAttrsToString(pos, v, context, false, false);
-        if (maybeString) {
-            out = *maybeString;
-            break;
-        }
-        if (auto i = v.attrs()->get(state.s.outPath))
-            return printValueAsJSON(state, strict, *i->value, i->pos, context, copyToStore);
-        else {
-            out = json::object();
-            for (auto & a : v.attrs()->lexicographicOrder(state.symbols)) {
-                try {
-                    out.emplace(
-                        state.symbols[a->name],
-                        printValueAsJSON(state, strict, *a->value, a->pos, context, copyToStore));
-                } catch (Error & e) {
-                    e.addTrace(
-                        state.positions[a->pos], HintFmt("while evaluating attribute '%1%'", state.symbols[a->name]));
-                    throw;
+        out = state.peelToStringOutPath(
+            pos, v, /*checkToStringReturn=*/true, [&](Value * peeled, bool cameThroughToString) -> json {
+                if (peeled->type() != nAttrs) {
+                    // Historical quirk preserved here for reproducibility:
+                    // In some coercions, Nix would coerce paths to a raw string
+                    // if they came from a __toString result.
+                    auto copyToStore2 = copyToStore && !cameThroughToString;
+                    return printValueAsJSON(state, strict, *peeled, pos, context, copyToStore2);
                 }
-            }
-        }
+                // Peelable attrs handled. Returned attrs are not peelable.
+                // Quirk: builtins.toJSON { outPath.foo = true; } == "{\"foo\":true}"
+                // All that remains is to return a JSON object.
+                json obj = json::object();
+                for (auto & a : peeled->attrs()->lexicographicOrder(state.symbols)) {
+                    try {
+                        obj.emplace(
+                            state.symbols[a->name],
+                            printValueAsJSON(state, strict, *a->value, a->pos, context, copyToStore));
+                    } catch (Error & e) {
+                        e.addTrace(
+                            state.positions[a->pos],
+                            HintFmt("while evaluating attribute '%1%'", state.symbols[a->name]));
+                        throw;
+                    }
+                }
+                return obj;
+            });
         break;
     }
 

--- a/tests/functional/lang/eval-fail-interpolation-list.err.exp
+++ b/tests/functional/lang/eval-fail-interpolation-list.err.exp
@@ -1,5 +1,12 @@
 error:
        … while evaluating the result of the `__toString` attribute
+         at /pwd/lang/eval-fail-interpolation-list.nix:3:3:
+            2| "${{
+            3|   __toString = self: [
+             |   ^
+            4|     "1"
+
+       … while evaluating a path segment
          at /pwd/lang/eval-fail-interpolation-list.nix:2:2:
             1| # Interpolation does weak coercion after peeling.
             2| "${{

--- a/tests/functional/lang/eval-fail-interpolation-list.err.exp
+++ b/tests/functional/lang/eval-fail-interpolation-list.err.exp
@@ -1,0 +1,9 @@
+error:
+       … while evaluating the result of the `__toString` attribute
+         at /pwd/lang/eval-fail-interpolation-list.nix:2:2:
+            1| # Interpolation does weak coercion after peeling.
+            2| "${{
+             |  ^
+            3|   __toString = self: [
+
+       error: cannot coerce a list to a string: [ "1" "2" ]

--- a/tests/functional/lang/eval-fail-interpolation-list.err.exp
+++ b/tests/functional/lang/eval-fail-interpolation-list.err.exp
@@ -1,5 +1,5 @@
 error:
-       … while evaluating the result of the `__toString` attribute
+       … while using the result of the `__toString` attribute
          at /pwd/lang/eval-fail-interpolation-list.nix:3:3:
             2| "${{
             3|   __toString = self: [

--- a/tests/functional/lang/eval-fail-interpolation-list.nix
+++ b/tests/functional/lang/eval-fail-interpolation-list.nix
@@ -1,0 +1,7 @@
+# Interpolation does weak coercion after peeling.
+"${{
+  __toString = self: [
+    "1"
+    "2"
+  ];
+}}"

--- a/tests/functional/lang/eval-fail-outPath-abort.err.exp
+++ b/tests/functional/lang/eval-fail-outPath-abort.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while calling the 'abort' builtin
+         at /pwd/lang/eval-fail-outPath-abort.nix:1:16:
+            1| "${{ outPath = abort "some failure"; }}"
+             |                ^
+            2|
+
+       error: evaluation aborted with the following error message: 'some failure'

--- a/tests/functional/lang/eval-fail-outPath-abort.err.exp
+++ b/tests/functional/lang/eval-fail-outPath-abort.err.exp
@@ -1,4 +1,10 @@
 error:
+       … while evaluating the `outPath` attribute
+         at /pwd/lang/eval-fail-outPath-abort.nix:1:6:
+            1| "${{ outPath = abort "some failure"; }}"
+             |      ^
+            2|
+
        … while calling the 'abort' builtin
          at /pwd/lang/eval-fail-outPath-abort.nix:1:16:
             1| "${{ outPath = abort "some failure"; }}"

--- a/tests/functional/lang/eval-fail-outPath-abort.nix
+++ b/tests/functional/lang/eval-fail-outPath-abort.nix
@@ -1,0 +1,1 @@
+"${{ outPath = abort "some failure"; }}"

--- a/tests/functional/lang/eval-fail-readFileType-outPath-abort.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-outPath-abort.err.exp
@@ -1,0 +1,20 @@
+error:
+       … while calling the 'readFileType' builtin
+         at /pwd/lang/eval-fail-readFileType-outPath-abort.nix:1:1:
+            1| builtins.readFileType { outPath = abort "some failure"; }
+             | ^
+            2|
+
+       … while evaluating the `outPath` attribute
+         at /pwd/lang/eval-fail-readFileType-outPath-abort.nix:1:25:
+            1| builtins.readFileType { outPath = abort "some failure"; }
+             |                         ^
+            2|
+
+       … while calling the 'abort' builtin
+         at /pwd/lang/eval-fail-readFileType-outPath-abort.nix:1:35:
+            1| builtins.readFileType { outPath = abort "some failure"; }
+             |                                   ^
+            2|
+
+       error: evaluation aborted with the following error message: 'some failure'

--- a/tests/functional/lang/eval-fail-readFileType-outPath-abort.nix
+++ b/tests/functional/lang/eval-fail-readFileType-outPath-abort.nix
@@ -1,0 +1,1 @@
+builtins.readFileType { outPath = abort "some failure"; }

--- a/tests/functional/lang/eval-fail-readFileType-outPath-non-absolute.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-outPath-non-absolute.err.exp
@@ -1,0 +1,16 @@
+error:
+       … while calling the 'readFileType' builtin
+         at /pwd/lang/eval-fail-readFileType-outPath-non-absolute.nix:1:1:
+            1| builtins.readFileType { outPath = "not-absolute"; }
+             | ^
+            2|
+
+       … while using the `outPath` attribute
+         at /pwd/lang/eval-fail-readFileType-outPath-non-absolute.nix:1:25:
+            1| builtins.readFileType { outPath = "not-absolute"; }
+             |                         ^
+            2|
+
+       … while realising the context of a path
+
+       error: string 'not-absolute' doesn't represent an absolute path

--- a/tests/functional/lang/eval-fail-readFileType-outPath-non-absolute.nix
+++ b/tests/functional/lang/eval-fail-readFileType-outPath-non-absolute.nix
@@ -1,0 +1,1 @@
+builtins.readFileType { outPath = "not-absolute"; }

--- a/tests/functional/lang/eval-fail-readFileType-toString-non-absolute.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-toString-non-absolute.err.exp
@@ -1,0 +1,10 @@
+error:
+       … while calling the 'readFileType' builtin
+         at /pwd/lang/eval-fail-readFileType-toString-non-absolute.nix:1:1:
+            1| builtins.readFileType { __toString = self: "not-absolute"; }
+             | ^
+            2|
+
+       … while realising the context of a path
+
+       error: string 'not-absolute' doesn't represent an absolute path

--- a/tests/functional/lang/eval-fail-readFileType-toString-non-absolute.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-toString-non-absolute.err.exp
@@ -5,7 +5,7 @@ error:
              | ^
             2|
 
-       … while evaluating the result of the `__toString` attribute
+       … while using the result of the `__toString` attribute
          at /pwd/lang/eval-fail-readFileType-toString-non-absolute.nix:1:25:
             1| builtins.readFileType { __toString = self: "not-absolute"; }
              |                         ^

--- a/tests/functional/lang/eval-fail-readFileType-toString-non-absolute.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-toString-non-absolute.err.exp
@@ -5,6 +5,12 @@ error:
              | ^
             2|
 
+       … while evaluating the result of the `__toString` attribute
+         at /pwd/lang/eval-fail-readFileType-toString-non-absolute.nix:1:25:
+            1| builtins.readFileType { __toString = self: "not-absolute"; }
+             |                         ^
+            2|
+
        … while realising the context of a path
 
        error: string 'not-absolute' doesn't represent an absolute path

--- a/tests/functional/lang/eval-fail-readFileType-toString-non-absolute.nix
+++ b/tests/functional/lang/eval-fail-readFileType-toString-non-absolute.nix
@@ -1,0 +1,1 @@
+builtins.readFileType { __toString = self: "not-absolute"; }

--- a/tests/functional/lang/eval-fail-readFileType-toString-not-function.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-toString-not-function.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while calling the 'readFileType' builtin
+         at /pwd/lang/eval-fail-readFileType-toString-not-function.nix:1:1:
+            1| builtins.readFileType { __toString = "not a function"; }
+             | ^
+            2|
+
+       error: attempt to call something which is not a function but a string: "not a function"

--- a/tests/functional/lang/eval-fail-readFileType-toString-not-function.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-toString-not-function.err.exp
@@ -5,4 +5,14 @@ error:
              | ^
             2|
 
+       … while calling the `__toString` attribute
+         at /pwd/lang/eval-fail-readFileType-toString-not-function.nix:1:25:
+            1| builtins.readFileType { __toString = "not a function"; }
+             |                         ^
+            2|
+
        error: attempt to call something which is not a function but a string: "not a function"
+       at /pwd/lang/eval-fail-readFileType-toString-not-function.nix:1:25:
+            1| builtins.readFileType { __toString = "not a function"; }
+             |                         ^
+            2|

--- a/tests/functional/lang/eval-fail-readFileType-toString-not-function.nix
+++ b/tests/functional/lang/eval-fail-readFileType-toString-not-function.nix
@@ -1,0 +1,1 @@
+builtins.readFileType { __toString = "not a function"; }

--- a/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.err.exp
@@ -6,7 +6,14 @@ error:
              | ^
             5|   outPath = {
 
-       … while evaluating the result of the `__toString` attribute
+       … while using the `outPath` attribute
+         at /pwd/lang/eval-fail-toJSON-outPath-through-toString.nix:5:3:
+            4| builtins.toJSON {
+            5|   outPath = {
+             |   ^
+            6|     __toString = self: 42;
+
+       … while using the result of the `__toString` attribute
          at /pwd/lang/eval-fail-toJSON-outPath-through-toString.nix:6:5:
             5|   outPath = {
             6|     __toString = self: 42;

--- a/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.err.exp
@@ -20,7 +20,7 @@ error:
              |     ^
             7|   };
 
-       error: `__toString` must return a string, but got an integer: 42
+       error: `__toString` should return a string, but got an integer: 42
        at /pwd/lang/eval-fail-toJSON-outPath-through-toString.nix:6:5:
             5|   outPath = {
             6|     __toString = self: 42;

--- a/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.err.exp
@@ -7,10 +7,15 @@ error:
             5|   outPath = {
 
        … while evaluating the result of the `__toString` attribute
-         at /pwd/lang/eval-fail-toJSON-outPath-through-toString.nix:5:3:
-            4| builtins.toJSON {
+         at /pwd/lang/eval-fail-toJSON-outPath-through-toString.nix:6:5:
             5|   outPath = {
-             |   ^
             6|     __toString = self: 42;
+             |     ^
+            7|   };
 
-       error: cannot coerce an integer to a string: 42
+       error: `__toString` must return a string, but got an integer: 42
+       at /pwd/lang/eval-fail-toJSON-outPath-through-toString.nix:6:5:
+            5|   outPath = {
+            6|     __toString = self: 42;
+             |     ^
+            7|   };

--- a/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.err.exp
@@ -1,0 +1,16 @@
+error:
+       … while calling the 'toJSON' builtin
+         at /pwd/lang/eval-fail-toJSON-outPath-through-toString.nix:4:1:
+            3| # fails, even though the outer `outPath` traversal could otherwise succeed.
+            4| builtins.toJSON {
+             | ^
+            5|   outPath = {
+
+       … while evaluating the result of the `__toString` attribute
+         at /pwd/lang/eval-fail-toJSON-outPath-through-toString.nix:5:3:
+            4| builtins.toJSON {
+            5|   outPath = {
+             |   ^
+            6|     __toString = self: 42;
+
+       error: cannot coerce an integer to a string: 42

--- a/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.nix
+++ b/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.nix
@@ -1,0 +1,8 @@
+# `outPath` recursion reaches an inner attrset whose `__toString`
+# returns a non-string. Coercion of the `__toString` result then
+# fails, even though the outer `outPath` traversal could otherwise succeed.
+builtins.toJSON {
+  outPath = {
+    __toString = self: 42;
+  };
+}

--- a/tests/functional/lang/eval-fail-toJSON-toString-not-string.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-toString-not-string.err.exp
@@ -6,5 +6,13 @@ error:
             2|
 
        … while evaluating the result of the `__toString` attribute
+         at /pwd/lang/eval-fail-toJSON-toString-not-string.nix:1:19:
+            1| builtins.toJSON { __toString = self: 42; }
+             |                   ^
+            2|
 
-       error: cannot coerce an integer to a string: 42
+       error: `__toString` must return a string, but got an integer: 42
+       at /pwd/lang/eval-fail-toJSON-toString-not-string.nix:1:19:
+            1| builtins.toJSON { __toString = self: 42; }
+             |                   ^
+            2|

--- a/tests/functional/lang/eval-fail-toJSON-toString-not-string.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-toString-not-string.err.exp
@@ -1,0 +1,10 @@
+error:
+       … while calling the 'toJSON' builtin
+         at /pwd/lang/eval-fail-toJSON-toString-not-string.nix:1:1:
+            1| builtins.toJSON { __toString = self: 42; }
+             | ^
+            2|
+
+       … while evaluating the result of the `__toString` attribute
+
+       error: cannot coerce an integer to a string: 42

--- a/tests/functional/lang/eval-fail-toJSON-toString-not-string.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-toString-not-string.err.exp
@@ -5,7 +5,7 @@ error:
              | ^
             2|
 
-       … while evaluating the result of the `__toString` attribute
+       … while using the result of the `__toString` attribute
          at /pwd/lang/eval-fail-toJSON-toString-not-string.nix:1:19:
             1| builtins.toJSON { __toString = self: 42; }
              |                   ^

--- a/tests/functional/lang/eval-fail-toJSON-toString-not-string.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-toString-not-string.err.exp
@@ -11,7 +11,7 @@ error:
              |                   ^
             2|
 
-       error: `__toString` must return a string, but got an integer: 42
+       error: `__toString` should return a string, but got an integer: 42
        at /pwd/lang/eval-fail-toJSON-toString-not-string.nix:1:19:
             1| builtins.toJSON { __toString = self: 42; }
              |                   ^

--- a/tests/functional/lang/eval-fail-toJSON-toString-not-string.nix
+++ b/tests/functional/lang/eval-fail-toJSON-toString-not-string.nix
@@ -1,0 +1,1 @@
+builtins.toJSON { __toString = self: 42; }

--- a/tests/functional/lang/eval-fail-toJSON-toString-returns-attrs.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-toString-returns-attrs.err.exp
@@ -6,7 +6,7 @@ error:
              | ^
             3|
 
-       … while evaluating the result of the `__toString` attribute
+       … while using the result of the `__toString` attribute
          at /pwd/lang/eval-fail-toJSON-toString-returns-attrs.nix:2:19:
             1| # toJSON checks the return type of __toString
             2| builtins.toJSON { __toString = self: { a = 1; }; }

--- a/tests/functional/lang/eval-fail-toJSON-toString-returns-attrs.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-toString-returns-attrs.err.exp
@@ -1,0 +1,11 @@
+error:
+       … while calling the 'toJSON' builtin
+         at /pwd/lang/eval-fail-toJSON-toString-returns-attrs.nix:2:1:
+            1| # toJSON checks the return type of __toString
+            2| builtins.toJSON { __toString = self: { a = 1; }; }
+             | ^
+            3|
+
+       … while evaluating the result of the `__toString` attribute
+
+       error: cannot coerce a set to a string: { a = 1; }

--- a/tests/functional/lang/eval-fail-toJSON-toString-returns-attrs.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-toString-returns-attrs.err.exp
@@ -7,5 +7,15 @@ error:
             3|
 
        … while evaluating the result of the `__toString` attribute
+         at /pwd/lang/eval-fail-toJSON-toString-returns-attrs.nix:2:19:
+            1| # toJSON checks the return type of __toString
+            2| builtins.toJSON { __toString = self: { a = 1; }; }
+             |                   ^
+            3|
 
-       error: cannot coerce a set to a string: { a = 1; }
+       error: `__toString` must return a string, but got a set: { a = 1; }
+       at /pwd/lang/eval-fail-toJSON-toString-returns-attrs.nix:2:19:
+            1| # toJSON checks the return type of __toString
+            2| builtins.toJSON { __toString = self: { a = 1; }; }
+             |                   ^
+            3|

--- a/tests/functional/lang/eval-fail-toJSON-toString-returns-attrs.nix
+++ b/tests/functional/lang/eval-fail-toJSON-toString-returns-attrs.nix
@@ -1,0 +1,2 @@
+# toJSON checks the return type of __toString
+builtins.toJSON { __toString = self: { a = 1; }; }

--- a/tests/functional/lang/eval-fail-toString-not-function.err.exp
+++ b/tests/functional/lang/eval-fail-toString-not-function.err.exp
@@ -1,0 +1,5 @@
+error: attempt to call something which is not a function but a string: "not a function"
+       at /pwd/lang/eval-fail-toString-not-function.nix:1:2:
+            1| "${{ __toString = "not a function"; }}"
+             |  ^
+            2|

--- a/tests/functional/lang/eval-fail-toString-not-function.err.exp
+++ b/tests/functional/lang/eval-fail-toString-not-function.err.exp
@@ -1,5 +1,12 @@
-error: attempt to call something which is not a function but a string: "not a function"
-       at /pwd/lang/eval-fail-toString-not-function.nix:1:2:
+error:
+       … while calling the `__toString` attribute
+         at /pwd/lang/eval-fail-toString-not-function.nix:1:6:
             1| "${{ __toString = "not a function"; }}"
-             |  ^
+             |      ^
+            2|
+
+       error: attempt to call something which is not a function but a string: "not a function"
+       at /pwd/lang/eval-fail-toString-not-function.nix:1:6:
+            1| "${{ __toString = "not a function"; }}"
+             |      ^
             2|

--- a/tests/functional/lang/eval-fail-toString-not-function.nix
+++ b/tests/functional/lang/eval-fail-toString-not-function.nix
@@ -1,0 +1,1 @@
+"${{ __toString = "not a function"; }}"

--- a/tests/functional/lang/eval-fail-toString-returns-non-coercible.err.exp
+++ b/tests/functional/lang/eval-fail-toString-returns-non-coercible.err.exp
@@ -1,5 +1,5 @@
 error:
-       … while evaluating the result of the `__toString` attribute
+       … while using the result of the `__toString` attribute
          at /pwd/lang/eval-fail-toString-returns-non-coercible.nix:2:6:
             1| # interpolation checks the return type of __toString
             2| "${{ __toString = self: null; }}"

--- a/tests/functional/lang/eval-fail-toString-returns-non-coercible.err.exp
+++ b/tests/functional/lang/eval-fail-toString-returns-non-coercible.err.exp
@@ -1,0 +1,9 @@
+error:
+       … while evaluating the result of the `__toString` attribute
+         at /pwd/lang/eval-fail-toString-returns-non-coercible.nix:2:2:
+            1| # interpolation checks the return type of __toString
+            2| "${{ __toString = self: null; }}"
+             |  ^
+            3|
+
+       error: cannot coerce null to a string: null

--- a/tests/functional/lang/eval-fail-toString-returns-non-coercible.err.exp
+++ b/tests/functional/lang/eval-fail-toString-returns-non-coercible.err.exp
@@ -1,5 +1,12 @@
 error:
        … while evaluating the result of the `__toString` attribute
+         at /pwd/lang/eval-fail-toString-returns-non-coercible.nix:2:6:
+            1| # interpolation checks the return type of __toString
+            2| "${{ __toString = self: null; }}"
+             |      ^
+            3|
+
+       … while evaluating a path segment
          at /pwd/lang/eval-fail-toString-returns-non-coercible.nix:2:2:
             1| # interpolation checks the return type of __toString
             2| "${{ __toString = self: null; }}"

--- a/tests/functional/lang/eval-fail-toString-returns-non-coercible.nix
+++ b/tests/functional/lang/eval-fail-toString-returns-non-coercible.nix
@@ -1,0 +1,2 @@
+# interpolation checks the return type of __toString
+"${{ __toString = self: null; }}"

--- a/tests/functional/lang/eval-okay-toJSON-peel.exp
+++ b/tests/functional/lang/eval-okay-toJSON-peel.exp
@@ -1,0 +1,1 @@
+{ outPathDeadEnd = "{\"a\":1,\"b\":2}"; outPathInt = "42"; outPathList = "[\"1\",{\"a\":1,\"b\":[\"/nix/store/m1a49k28kbvny5dnbkymp1nia4b403q8-a.nix\"]},42,[\"42\"],\"hello\"]"; outPathNested = "\"nested\""; outPathString = "\"hello\""; plainAttrs = "{\"a\":1,\"b\":\"two\"}"; toStringPrecedes = "\"won\""; toStringReturnsPeelableAttrs = "\"deep\""; }

--- a/tests/functional/lang/eval-okay-toJSON-peel.nix
+++ b/tests/functional/lang/eval-okay-toJSON-peel.nix
@@ -1,0 +1,59 @@
+# Characterise `builtins.toJSON`'s peeling of `__toString` and `outPath` attrs
+#
+# You'll see quirky behaviors acknowledged with a comment, but those are no
+# excuse to start making breaking changes.
+{
+  outPathString = builtins.toJSON { outPath = "hello"; };
+
+  # Quirky: just 42
+  outPathInt = builtins.toJSON { outPath = 42; };
+
+  outPathNested = builtins.toJSON {
+    outPath = {
+      outPath = "nested";
+    };
+  };
+
+  # Quirky: just the inner attrs
+  outPathDeadEnd = builtins.toJSON {
+    outPath = {
+      a = 1;
+      b = 2;
+    };
+  };
+
+  toStringPrecedes = builtins.toJSON {
+    __toString = self: "won";
+    # Show that it's unused
+    outPath = abort "unreached";
+  };
+
+  toStringReturnsPeelableAttrs = builtins.toJSON {
+    __toString = self: { outPath = "deep"; };
+  };
+
+  outPathList = builtins.toJSON {
+    outPath = [
+      "1"
+      {
+        a = 1;
+        b = {
+          outPath = [ ./dir1/a.nix ];
+        };
+      }
+      42
+      [ "42" ]
+      {
+        __toString = self: self.other;
+        other = {
+          __toString = self2: "hello";
+        };
+      }
+    ];
+  };
+
+  plainAttrs = builtins.toJSON {
+    a = 1;
+    b = "two";
+  };
+}

--- a/tests/functional/lang/eval-okay-toString-peel.exp
+++ b/tests/functional/lang/eval-okay-toString-peel.exp
@@ -1,0 +1,1 @@
+"/nix/store/m1a49k28kbvny5dnbkymp1nia4b403q8-a.nix"

--- a/tests/functional/lang/eval-okay-toString-peel.nix
+++ b/tests/functional/lang/eval-okay-toString-peel.nix
@@ -1,0 +1,1 @@
+"${{ __toString = self: ./dir1/a.nix; }}"

--- a/tests/functional/lang/eval-okay-toString-returning-path.exp
+++ b/tests/functional/lang/eval-okay-toString-returning-path.exp
@@ -1,0 +1,1 @@
+"/pwd/lang/dir1/a.nix"

--- a/tests/functional/lang/eval-okay-toString-returning-path.nix
+++ b/tests/functional/lang/eval-okay-toString-returning-path.nix
@@ -1,0 +1,1 @@
+toString { __toString = self: ./dir1/a.nix; }

--- a/tests/functional/structured-attrs.sh
+++ b/tests/functional/structured-attrs.sh
@@ -47,6 +47,41 @@ expectStderr 0 nix-instantiate --expr "$hackyExpr" --eval --strict | grepQuiet "
 hacky=$(nix-instantiate --expr "$hackyExpr")
 nix derivation show "$hacky" | jq --exit-status '.derivations."'"$(basename "$hacky")"'".structuredAttrs | . == {"a": 1}'
 
+# Quirk:
+# A path reached through a `__toString` call inside `__structuredAttrs` must
+# NOT be copied to the store: the JSON keeps the path in its raw string form
+# and the derivation gains no `srcs` reference. Any change that starts copying
+# would alter the drv hash and add a dependency to every derivation using this
+# pattern.
+#
+# This is the unfortunate consequence of a lack of proper `__toString` return
+# value checking in previous releases.
+# We could emit a warning about this, but the benefit would be marginal.
+#
+# This behavior is due to any `__toString` regardless of `outPath` attributes,
+# so check both nesting orders.
+toStringPathDir=$TEST_ROOT/toString-path-src
+mkdir -p "$toStringPathDir"
+for myPath in \
+    "{ __toString = self: $toStringPathDir; }" \
+    "{ outPath = { __toString = self: $toStringPathDir; }; }" \
+    "{ __toString = self: { outPath = $toStringPathDir; }; }"; do
+    drv=$(nix-instantiate --expr "
+      derivation {
+        name = \"toString-path\";
+        system = \"foo\";
+        builder = \"/bin/sh\";
+        __structuredAttrs = true;
+        myPath = $myPath;
+      }
+    ")
+    nix derivation show "$drv" | jq --exit-status \
+        --arg raw "$toStringPathDir" \
+        '.derivations[].structuredAttrs.myPath == $raw'
+    nix derivation show "$drv" | jq --exit-status \
+        '.derivations[].inputs.srcs == []'
+done
+
 if isDaemonNewer "2.34pre"; then
     # Test warning for non-object exportReferencesGraph in structured attrs
     # shellcheck disable=SC2016


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

1. Take a non-committal step towards lazy-paths by letting `coerceToPath` return path values unadulterated, also when peeled.
2. Take inventory of the differences between coercions and make them explicit through DRY.
3. Unify the coercions modulo those parameters
4. Improve error messages (more traces near error site, and more accurate traces)
5. Improve test coverage

## Context

More motivation, I guess.
This is a preparatory step towards lazy-paths, which I prepared in the context of STF.
Dogfooding realistically required Flakes for me, and a fine-grained cache requires that we don't pollute the heap with hashes of absolutely everything.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
