### PR TITLE
`nix search` noise reduction

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1269,7 +1269,7 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
 
             auto attrPathS = attrPath.resolve(*state);
 
-            Activity act(*logger, lvlInfo, actUnknown, fmt("evaluating '%s'", attrPath.to_string(*state)));
+            Activity act(*logger, lvlTalkative, actUnknown, fmt("evaluating '%s'", attrPath.to_string(*state)));
 
             try {
                 auto recurse = [&]() {

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -95,7 +95,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
             auto attrPathS = state->symbols.resolve({attrPath});
             auto attrPathStr = attrPath.to_string(*state);
 
-            Activity act(*logger, lvlInfo, actUnknown, fmt("evaluating '%s'", attrPathStr));
+            Activity act(*logger, lvlTalkative, actUnknown, fmt("evaluating '%s'", attrPathStr));
             try {
                 auto recurse = [&]() {
                     for (const auto & attr : cursor.getAttrs()) {


### PR DESCRIPTION
## Motivation
```nix-search``` was returning a lot of noise, 

## Context

Resolves: #15971 

Changes ```lvlInfo``` to ```lvlTalkative``` for the ```evaluating '%s'``` message in search.cc and flake.cc


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
