### PR TITLE
libstore: fix bare S3 endpoint parsing and deprecate it plus 'scheme'

### DIFF
--- a/doc/manual/rl-next/s3-endpoint-url.md
+++ b/doc/manual/rl-next/s3-endpoint-url.md
@@ -1,0 +1,8 @@
+---
+synopsis: "S3: `endpoint=host:port` fixed, deprecated in favour of full URLs"
+---
+
+Bare `host:port` values for the `endpoint` parameter of `s3://` store URLs
+were misparsed (the host was taken as a URL scheme). This is fixed, but the
+bare form and the separate `scheme` parameter are deprecated: use a full URL
+such as `endpoint=https://minio.example.com` instead.

--- a/src/libstore-tests/s3-url.cc
+++ b/src/libstore-tests/s3-url.cc
@@ -106,6 +106,16 @@ INSTANTIATE_TEST_SUITE_P(
             "with_absolute_endpoint_uri",
         },
         ParsedS3URLTestCase{
+            /* Bare host:port must parse as an authority. */
+            "s3://bucket/key?endpoint=localhost:9000",
+            {
+                .bucket = "bucket",
+                .key = {"key"},
+                .endpoint = ParsedURL::Authority{.host = "localhost", .port = 9000},
+            },
+            "bare_host_port_endpoint",
+        },
+        ParsedS3URLTestCase{
             "s3://bucket/key?addressing-style=virtual",
             {
                 .bucket = "bucket",

--- a/src/libstore/include/nix/store/s3-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/s3-binary-cache-store.hh
@@ -43,6 +43,9 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
         "https",
         "scheme",
         R"(
+          Deprecated: specify the scheme as part of the `endpoint` URL
+          instead, e.g. `endpoint=http://localhost:9000`.
+
           The scheme used for S3 requests, `https` (default) or `http`. This
           option allows you to disable HTTPS for binary caches which don't
           support it.
@@ -60,7 +63,8 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
         R"(
           The S3 endpoint to use. When empty (default), uses AWS S3 with
           region-specific endpoints. For S3-compatible services such as
-          MinIO, set this to your service's endpoint.
+          MinIO, set this to your service's endpoint as a full URL,
+          e.g. `https://minio.example.com` or `http://localhost:9000`.
         )"};
 
     Setting<S3AddressingStyle> addressingStyle{

--- a/src/libstore/s3-binary-cache-store.md
+++ b/src/libstore/s3-binary-cache-store.md
@@ -99,7 +99,7 @@ With bucket policies and authentication set up as described above, uploading wor
 
   ```console
   $ nix copy nixpkgs.hello --to \
-    's3://example-nix-cache?profile=cache-upload&scheme=https&endpoint=minio.example.com'
+    's3://example-nix-cache?profile=cache-upload&endpoint=https://minio.example.com'
   ```
 
 )"

--- a/src/libstore/s3-url.cc
+++ b/src/libstore/s3-url.cc
@@ -68,6 +68,27 @@ try {
     };
 
     auto endpoint = getOptionalParam("endpoint");
+    auto scheme = getOptionalParam("scheme");
+
+    if (scheme) {
+        static std::atomic<bool> warnedScheme{false};
+        warnOnce(
+            warnedScheme,
+            "the S3 'scheme' parameter is deprecated; "
+            "specify the scheme in the 'endpoint' URL instead, e.g. 'endpoint=%s://...'",
+            *scheme);
+    }
+
+    if (endpoint && endpoint->find("://") == std::string::npos) {
+        static std::atomic<bool> warnedBareEndpoint{false};
+        warnOnce(
+            warnedBareEndpoint,
+            "the S3 'endpoint' value '%s' does not specify a scheme; "
+            "this form is deprecated, use a full URL such as 'https://%s' instead",
+            *endpoint,
+            *endpoint);
+    }
+
     if (parsed.path.size() <= 1 || !parsed.path.front().empty())
         throw BadURL("URI has a missing or invalid key");
 
@@ -78,7 +99,7 @@ try {
         .key = std::move(path),
         .profile = getOptionalParam("profile"),
         .region = getOptionalParam("region"),
-        .scheme = getOptionalParam("scheme"),
+        .scheme = std::move(scheme),
         .versionId = getOptionalParam("versionId"),
         .addressingStyle = getOptionalParam("addressing-style").transform([](const std::string & s) {
             return parseS3AddressingStyle(s);
@@ -87,12 +108,11 @@ try {
             if (!endpoint)
                 return std::monostate();
 
-            /* Try to parse the endpoint as a full-fledged URL with a scheme. */
-            try {
+            /* Without "://" treat the value as an authority.
+             * parseURL would misparse "host:port" as a URL with scheme "host".
+             */
+            if (endpoint->find("://") != std::string::npos)
                 return parseURL(*endpoint);
-            } catch (BadURL &) {
-            }
-
             return ParsedURL::Authority::parse(*endpoint);
         }(),
     };


### PR DESCRIPTION
We were not able to parse a bare host:port as the authority was interpreted as a scheme, which produced nonsensical endpoint like s3://bucket?endpoint=localhost:9000.

That's why we make a clean cut and only accept full URLs for endpoint.

This also soft-deprecates the schema parameter.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
