### PR TITLE
clang-tidy: Add lint for using namespace in namespace scope to make unity builds more sound 

### DIFF
--- a/nix-meson-build-support/common/clang-tidy/.clang-tidy
+++ b/nix-meson-build-support/common/clang-tidy/.clang-tidy
@@ -80,7 +80,7 @@ Checks:
   - cppcoreguidelines-missing-std-forward
   - android-cloexec-open
   - android-cloexec-pipe2
-  # Custom nix checks (when added)
+  # Custom nix checks
   - nix-*
 
 CheckOptions:

--- a/src/clang-tidy-plugin/meson.build
+++ b/src/clang-tidy-plugin/meson.build
@@ -20,6 +20,7 @@ llvm_dep = dependency('LLVM', version : '>= 16', required : true)
 
 sources = files(
   'nix-clang-tidy-checks.cc',
+  'nix-using-namespace.cc',
 )
 
 # Build as a shared module (plugin) that can be loaded by clang-tidy --load

--- a/src/clang-tidy-plugin/nix-clang-tidy-checks.cc
+++ b/src/clang-tidy-plugin/nix-clang-tidy-checks.cc
@@ -13,22 +13,19 @@
 #include <clang-tidy/ClangTidyModule.h>
 #include <clang-tidy/ClangTidyModuleRegistry.h>
 
+#include "nix-using-namespace.hh"
+
 namespace nix::clang_tidy {
 
-using namespace clang;
-using namespace clang::tidy;
-
-class NixClangTidyChecks : public ClangTidyModule
+class NixClangTidyChecks : public clang::tidy::ClangTidyModule
 {
 public:
-    void addCheckFactories([[maybe_unused]] ClangTidyCheckFactories & CheckFactories) override
+    void addCheckFactories([[maybe_unused]] clang::tidy::ClangTidyCheckFactories & CheckFactories) override
     {
-        // Custom checks will be registered here.
-        // Example:
-        // CheckFactories.registerCheck<MyCustomCheck>("nix-my-custom-check");
+        CheckFactories.registerCheck<UsingNamespaceInNamespaceScopeCheck>("nix-using-namespace");
     }
 };
 
-static ClangTidyModuleRegistry::Add<NixClangTidyChecks> X("nix-module", "Adds Nix-specific checks");
+static clang::tidy::ClangTidyModuleRegistry::Add<NixClangTidyChecks> X("nix-module", "Adds Nix-specific checks");
 
 } // namespace nix::clang_tidy

--- a/src/clang-tidy-plugin/nix-using-namespace.cc
+++ b/src/clang-tidy-plugin/nix-using-namespace.cc
@@ -1,0 +1,26 @@
+#include "nix-using-namespace.hh"
+
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/ASTMatchers/ASTMatchers.h>
+
+namespace nix::clang_tidy {
+
+void UsingNamespaceInNamespaceScopeCheck::registerMatchers(clang::ast_matchers::MatchFinder * Finder)
+{
+    Finder->addMatcher(clang::ast_matchers::usingDirectiveDecl().bind("usingNamespace"), this);
+}
+
+void UsingNamespaceInNamespaceScopeCheck::check(const clang::ast_matchers::MatchFinder::MatchResult & Result)
+{
+    const auto * U = Result.Nodes.getNodeAs<clang::UsingDirectiveDecl>("usingNamespace");
+    const clang::SourceLocation Loc = U->getBeginLoc();
+    if (U->isImplicit() || !Loc.isValid() || U->getParentFunctionOrMethod())
+        return;
+
+    diag(
+        Loc,
+        "do not use using namespace directive in namespace scopes - keep those local to functions or explicitly qualify names."
+        "This is to reduce namespace pollution with unity builds.");
+}
+
+} // namespace nix::clang_tidy

--- a/src/clang-tidy-plugin/nix-using-namespace.hh
+++ b/src/clang-tidy-plugin/nix-using-namespace.hh
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <clang-tidy/ClangTidyCheck.h>
+
+namespace nix::clang_tidy {
+
+/**
+ * Check that forbids instances on `using namespace ...;` in a namespace
+ * scope.
+ *
+ * This is because we rely on unity builds in certain situations (faster
+ * non-incremental builds, static initialiser issues), and the common pattern of
+ * doing `using namespace` in a translation unit is a big footgun.
+ *
+ * Based on `google-build-using-namespace`, modulo that `using namespace` in a
+ * non-namespace scope is fine (like in a function).
+ */
+class UsingNamespaceInNamespaceScopeCheck : public clang::tidy::ClangTidyCheck
+{
+public:
+    UsingNamespaceInNamespaceScopeCheck(llvm::StringRef Name, clang::tidy::ClangTidyContext * Context)
+        : ClangTidyCheck(Name, Context)
+    {
+    }
+
+    bool isLanguageVersionSupported(const clang::LangOptions & LangOpts) const override
+    {
+        return LangOpts.CPlusPlus;
+    }
+
+    void registerMatchers(clang::ast_matchers::MatchFinder * Finder) override;
+
+    void check(const clang::ast_matchers::MatchFinder::MatchResult & Result) override;
+};
+
+} // namespace nix::clang_tidy

--- a/src/libexpr-test-support/tests/value/context.cc
+++ b/src/libexpr-test-support/tests/value/context.cc
@@ -4,10 +4,10 @@
 #include "nix/expr/tests/value/context.hh"
 
 namespace rc {
-using namespace nix;
 
-Gen<NixStringContextElem::DrvDeep> Arbitrary<NixStringContextElem::DrvDeep>::arbitrary()
+Gen<nix::NixStringContextElem::DrvDeep> Arbitrary<nix::NixStringContextElem::DrvDeep>::arbitrary()
 {
+    using namespace nix;
     return gen::map(gen::arbitrary<StorePath>(), [](StorePath drvPath) {
         return NixStringContextElem::DrvDeep{
             .drvPath = drvPath,
@@ -15,8 +15,9 @@ Gen<NixStringContextElem::DrvDeep> Arbitrary<NixStringContextElem::DrvDeep>::arb
     });
 }
 
-Gen<NixStringContextElem> Arbitrary<NixStringContextElem>::arbitrary()
+Gen<nix::NixStringContextElem> Arbitrary<nix::NixStringContextElem>::arbitrary()
 {
+    using namespace nix;
     return gen::mapcat(
         gen::inRange<uint8_t>(0, std::variant_size_v<NixStringContextElem::Raw>),
         [](uint8_t n) -> Gen<NixStringContextElem> {

--- a/src/libexpr-tests/error_traces.cc
+++ b/src/libexpr-tests/error_traces.cc
@@ -5,14 +5,14 @@
 
 namespace nix {
 
-using namespace testing;
-
 // Testing eval of PrimOp's
 class ErrorTraceTest : public LibExprTest
 {};
 
 TEST_F(ErrorTraceTest, TraceBuilder)
 {
+    using namespace testing;
+
     ASSERT_THROW(state.error<EvalError>("puppy").debugThrow(), EvalError);
 
     ASSERT_THROW(state.error<EvalError>("puppy").withTrace(noPos, "doggy").debugThrow(), EvalError);

--- a/src/libexpr-tests/value/print.cc
+++ b/src/libexpr-tests/value/print.cc
@@ -6,8 +6,6 @@
 
 namespace nix {
 
-using namespace testing;
-
 struct ValuePrintingTests : LibExprTest
 {
     template<class... A>

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -525,12 +525,11 @@ std::string publicKeys_to_string(const std::vector<PublicKey> & publicKeys)
 
 namespace nlohmann {
 
-using namespace nix;
-
 #ifndef DOXYGEN_SKIP
 
-fetchers::PublicKey adl_serializer<fetchers::PublicKey>::from_json(const json & json)
+nix::fetchers::PublicKey adl_serializer<nix::fetchers::PublicKey>::from_json(const json & json)
 {
+    using namespace nix;
     fetchers::PublicKey res = {};
     auto & obj = getObject(json);
     if (auto * type = optionalValueAt(obj, "type"))
@@ -541,7 +540,7 @@ fetchers::PublicKey adl_serializer<fetchers::PublicKey>::from_json(const json & 
     return res;
 }
 
-void adl_serializer<fetchers::PublicKey>::to_json(json & json, const fetchers::PublicKey & p)
+void adl_serializer<nix::fetchers::PublicKey>::to_json(json & json, const nix::fetchers::PublicKey & p)
 {
     json["type"] = p.type;
     json["key"] = p.key;

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -22,8 +22,6 @@
 #  include <sys/wait.h>
 #endif
 
-using namespace std::string_literals;
-
 namespace nix::fetchers {
 
 namespace {

--- a/src/libfetchers/include/nix/fetchers/fetchers.hh
+++ b/src/libfetchers/include/nix/fetchers/fetchers.hh
@@ -296,4 +296,4 @@ std::string publicKeys_to_string(const std::vector<PublicKey> &);
 
 } // namespace nix::fetchers
 
-JSON_IMPL(fetchers::PublicKey)
+JSON_IMPL(nix::fetchers::PublicKey)

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -14,8 +14,6 @@
 #include <sys/time.h>
 #include <variant>
 
-using namespace std::string_literals;
-
 namespace nix::fetchers {
 
 static RunOptions hgOptions(OsStrings args)
@@ -226,6 +224,8 @@ struct MercurialInputScheme : InputScheme
                     warn("Mercurial tree '%s' is unclean", PathFmt{localPath});
 
                 input.attrs.insert_or_assign("ref", chomp(runHg({OS_STR("branch"), OS_STR("-R"), localPath.native()})));
+
+                using namespace std::string_literals;
 
                 auto files = tokenizeString<StringSet>(
                     runHg({

--- a/src/libstore-test-support/derived-path.cc
+++ b/src/libstore-test-support/derived-path.cc
@@ -4,10 +4,10 @@
 #include "nix/store/tests/derived-path.hh"
 
 namespace rc {
-using namespace nix;
 
-Gen<SingleDerivedPath::Opaque> Arbitrary<SingleDerivedPath::Opaque>::arbitrary()
+Gen<nix::SingleDerivedPath::Opaque> Arbitrary<nix::SingleDerivedPath::Opaque>::arbitrary()
 {
+    using namespace nix;
     return gen::map(gen::arbitrary<StorePath>(), [](StorePath path) {
         return DerivedPath::Opaque{
             .path = path,
@@ -15,8 +15,9 @@ Gen<SingleDerivedPath::Opaque> Arbitrary<SingleDerivedPath::Opaque>::arbitrary()
     });
 }
 
-Gen<SingleDerivedPath::Built> Arbitrary<SingleDerivedPath::Built>::arbitrary()
+Gen<nix::SingleDerivedPath::Built> Arbitrary<nix::SingleDerivedPath::Built>::arbitrary()
 {
+    using namespace nix;
     return gen::mapcat(gen::arbitrary<SingleDerivedPath>(), [](SingleDerivedPath drvPath) {
         return gen::map(gen::arbitrary<StorePathName>(), [drvPath](StorePathName outputPath) {
             return SingleDerivedPath::Built{
@@ -27,8 +28,9 @@ Gen<SingleDerivedPath::Built> Arbitrary<SingleDerivedPath::Built>::arbitrary()
     });
 }
 
-Gen<DerivedPath::Built> Arbitrary<DerivedPath::Built>::arbitrary()
+Gen<nix::DerivedPath::Built> Arbitrary<nix::DerivedPath::Built>::arbitrary()
 {
+    using namespace nix;
     return gen::mapcat(gen::arbitrary<SingleDerivedPath>(), [](SingleDerivedPath drvPath) {
         return gen::map(gen::arbitrary<OutputsSpec>(), [drvPath](OutputsSpec outputs) {
             return DerivedPath::Built{
@@ -39,8 +41,9 @@ Gen<DerivedPath::Built> Arbitrary<DerivedPath::Built>::arbitrary()
     });
 }
 
-Gen<SingleDerivedPath> Arbitrary<SingleDerivedPath>::arbitrary()
+Gen<nix::SingleDerivedPath> Arbitrary<nix::SingleDerivedPath>::arbitrary()
 {
+    using namespace nix;
     return gen::mapcat(gen::inRange<uint8_t>(0, std::variant_size_v<SingleDerivedPath::Raw>), [](uint8_t n) {
         switch (n) {
         case 0:
@@ -53,8 +56,9 @@ Gen<SingleDerivedPath> Arbitrary<SingleDerivedPath>::arbitrary()
     });
 }
 
-Gen<DerivedPath> Arbitrary<DerivedPath>::arbitrary()
+Gen<nix::DerivedPath> Arbitrary<nix::DerivedPath>::arbitrary()
 {
+    using namespace nix;
     return gen::mapcat(gen::inRange<uint8_t>(0, std::variant_size_v<DerivedPath::Raw>), [](uint8_t n) {
         switch (n) {
         case 0:

--- a/src/libstore-test-support/path.cc
+++ b/src/libstore-test-support/path.cc
@@ -55,7 +55,7 @@ Gen<nix::StorePathName> Arbitrary<nix::StorePathName>::arbitrary()
         }));
 }
 
-Gen<StorePath> Arbitrary<nix::StorePath>::arbitrary()
+Gen<nix::StorePath> Arbitrary<nix::StorePath>::arbitrary()
 {
     return gen::construct<nix::StorePath>(
         gen::arbitrary<nix::Hash>(),

--- a/src/libstore-tests/build-result.cc
+++ b/src/libstore-tests/build-result.cc
@@ -36,8 +36,6 @@ TEST_P(BuildResultJsonTest, to_json)
     writeJsonTest(name, value);
 }
 
-using namespace std::literals::chrono_literals;
-
 INSTANTIATE_TEST_SUITE_P(
     BuildResultJSON,
     BuildResultJsonTest,
@@ -89,8 +87,8 @@ INSTANTIATE_TEST_SUITE_P(
                 .timesBuilt = 3,
                 .startTime = 30,
                 .stopTime = 50,
-                .cpuUser = std::chrono::microseconds(500s),
-                .cpuSystem = std::chrono::microseconds(604s),
+                .cpuUser = std::chrono::seconds(500),
+                .cpuSystem = std::chrono::seconds(604),
             },
         }));
 

--- a/src/libstore-tests/derivation-advanced-attrs.cc
+++ b/src/libstore-tests/derivation-advanced-attrs.cc
@@ -12,8 +12,6 @@
 
 namespace nix {
 
-using namespace nlohmann;
-
 class DerivationAdvancedAttrsTest : public JsonCharacterizationTest<Derivation>, public LibStoreTest
 {
 protected:
@@ -83,6 +81,7 @@ TYPED_TEST_SUITE(DerivationAdvancedAttrsBothTest, BothFixtures);
 #define TEST_ATERM_JSON(STEM, NAME)                                                                      \
     TYPED_TEST(DerivationAdvancedAttrsBothTest, Derivation_##STEM##_from_json)                           \
     {                                                                                                    \
+        using namespace nlohmann;                                                                        \
         this->readTest(NAME ".json", [&](const auto & encoded_) {                                        \
             auto encoded = json::parse(encoded_);                                                        \
             /* Use DRV file instead of C++ literal as source of truth. */                                \
@@ -95,6 +94,7 @@ TYPED_TEST_SUITE(DerivationAdvancedAttrsBothTest, BothFixtures);
                                                                                                          \
     TYPED_TEST(DerivationAdvancedAttrsBothTest, Derivation_##STEM##_to_json)                             \
     {                                                                                                    \
+        using namespace nlohmann;                                                                        \
         this->writeTest(                                                                                 \
             NAME ".json",                                                                                \
             [&]() -> json {                                                                              \
@@ -108,6 +108,7 @@ TYPED_TEST_SUITE(DerivationAdvancedAttrsBothTest, BothFixtures);
                                                                                                          \
     TYPED_TEST(DerivationAdvancedAttrsBothTest, Derivation_##STEM##_from_aterm)                          \
     {                                                                                                    \
+        using namespace nlohmann;                                                                        \
         this->readTest(NAME ".drv", [&](auto encoded) {                                                  \
             /* Use JSON file instead of C++ literal as source of truth. */                               \
             auto j = json::parse(readFile(this->goldenMaster(NAME ".json")));                            \

--- a/src/libstore-tests/http-binary-cache-store.cc
+++ b/src/libstore-tests/http-binary-cache-store.cc
@@ -57,13 +57,10 @@ TEST(HttpBinaryCacheStore, constructConfigWithParamsAndUrlWithParams)
 using testing::HttpsBinaryCacheStoreMtlsTest;
 using testing::HttpsBinaryCacheStoreTest;
 
-using namespace std::string_view_literals;
-using namespace std::string_literals;
-
 TEST_F(HttpsBinaryCacheStoreTest, queryPathInfo)
 {
     auto store = openStore(makeConfig());
-    StringSource dump{"test"sv};
+    StringSource dump{std::string_view("test")};
     auto path = localCacheStore->addToStoreFromDump(dump, "test-name", FileSerialisationMethod::Flat);
     EXPECT_NO_THROW(store->queryPathInfo(path));
 }
@@ -74,7 +71,7 @@ TEST_F(HttpsBinaryCacheStoreMtlsTest, queryPathInfo)
     config->tlsCert = clientCert;
     config->tlsKey = clientKey;
     auto store = openStore(config);
-    StringSource dump{"test"sv};
+    StringSource dump{std::string_view("test")};
     auto path = localCacheStore->addToStoreFromDump(dump, "test-name", FileSerialisationMethod::Flat);
     EXPECT_NO_THROW(store->queryPathInfo(path));
 }
@@ -104,7 +101,7 @@ TEST_F(HttpsBinaryCacheStoreMtlsTest, rejectsWrongClientCert)
 
 TEST_F(HttpsBinaryCacheStoreMtlsTest, doesNotSendCertOnRedirectToDifferentAuthority)
 {
-    StringSource dump{"test"sv};
+    StringSource dump{std::string_view("test")};
     auto path = localCacheStore->addToStoreFromDump(dump, "test-name", FileSerialisationMethod::Flat);
 
     for (auto & entry : DirectoryIterator{cacheDir})

--- a/src/libstore/build-result.cc
+++ b/src/libstore/build-result.cc
@@ -145,10 +145,10 @@ std::strong_ordering BuildError::operator<=>(const BuildError & other) const noe
 
 namespace nlohmann {
 
-using namespace nix;
-
-void adl_serializer<BuildResult>::to_json(json & res, const BuildResult & br)
+void adl_serializer<nix::BuildResult>::to_json(json & res, const nix::BuildResult & br)
 {
+    using namespace nix;
+
     res = json::object();
 
     // Common fields
@@ -181,8 +181,10 @@ void adl_serializer<BuildResult>::to_json(json & res, const BuildResult & br)
         br.inner);
 }
 
-BuildResult adl_serializer<BuildResult>::from_json(const json & _json)
+nix::BuildResult adl_serializer<nix::BuildResult>::from_json(const json & _json)
 {
+    using namespace nix;
+
     auto & json = getObject(_json);
 
     BuildResult br;
@@ -219,8 +221,10 @@ BuildResult adl_serializer<BuildResult>::from_json(const json & _json)
     return br;
 }
 
-KeyedBuildResult adl_serializer<KeyedBuildResult>::from_json(const json & json0)
+nix::KeyedBuildResult adl_serializer<nix::KeyedBuildResult>::from_json(const json & json0)
 {
+    using namespace nix;
+
     auto json = getObject(json0);
 
     return KeyedBuildResult{
@@ -229,8 +233,9 @@ KeyedBuildResult adl_serializer<KeyedBuildResult>::from_json(const json & json0)
     };
 }
 
-void adl_serializer<KeyedBuildResult>::to_json(json & json, const KeyedBuildResult & kbr)
+void adl_serializer<nix::KeyedBuildResult>::to_json(json & json, const nix::KeyedBuildResult & kbr)
 {
+    using namespace nix;
     adl_serializer<BuildResult>::to_json(json, kbr);
     json["path"] = kbr.path;
 }

--- a/src/libstore/build/derivation-builder.cc
+++ b/src/libstore/build/derivation-builder.cc
@@ -3,10 +3,9 @@
 
 namespace nlohmann {
 
-using namespace nix;
-
-ExternalBuilder adl_serializer<ExternalBuilder>::from_json(const json & json)
+nix::ExternalBuilder adl_serializer<nix::ExternalBuilder>::from_json(const json & json)
 {
+    using namespace nix;
     auto obj = getObject(json);
     return {
         .systems = valueAt(obj, "systems"),
@@ -15,7 +14,7 @@ ExternalBuilder adl_serializer<ExternalBuilder>::from_json(const json & json)
     };
 }
 
-void adl_serializer<ExternalBuilder>::to_json(json & json, const ExternalBuilder & eb)
+void adl_serializer<nix::ExternalBuilder>::to_json(json & json, const nix::ExternalBuilder & eb)
 {
     json = {
         {"systems", eb.systems},

--- a/src/libstore/content-address.cc
+++ b/src/libstore/content-address.cc
@@ -304,20 +304,19 @@ Hash ContentAddressWithReferences::getHash() const
 
 namespace nlohmann {
 
-using namespace nix;
-
-ContentAddressMethod adl_serializer<ContentAddressMethod>::from_json(const json & json)
+nix::ContentAddressMethod adl_serializer<nix::ContentAddressMethod>::from_json(const json & json)
 {
-    return ContentAddressMethod::parse(getString(json));
+    return nix::ContentAddressMethod::parse(nix::getString(json));
 }
 
-void adl_serializer<ContentAddressMethod>::to_json(json & json, const ContentAddressMethod & m)
+void adl_serializer<nix::ContentAddressMethod>::to_json(json & json, const nix::ContentAddressMethod & m)
 {
     json = m.render();
 }
 
-ContentAddress adl_serializer<ContentAddress>::from_json(const json & json)
+nix::ContentAddress adl_serializer<nix::ContentAddress>::from_json(const json & json)
 {
+    using namespace nix;
     auto obj = getObject(json);
     return {
         .method = adl_serializer<ContentAddressMethod>::from_json(valueAt(obj, "method")),
@@ -325,7 +324,7 @@ ContentAddress adl_serializer<ContentAddress>::from_json(const json & json)
     };
 }
 
-void adl_serializer<ContentAddress>::to_json(json & json, const ContentAddress & ca)
+void adl_serializer<nix::ContentAddress>::to_json(json & json, const nix::ContentAddress & ca)
 {
     json = {
         {"method", ca.method},

--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -536,11 +536,11 @@ template struct DerivationOptions<SingleDerivedPath>;
 
 namespace nlohmann {
 
-using namespace nix;
-
 template<typename Inputs>
-static DerivationOptions<Inputs> derivationOptionsFromJson(const nlohmann::json & json_)
+static nix::DerivationOptions<Inputs> derivationOptionsFromJson(const nlohmann::json & json_)
 {
+    using namespace nix;
+
     auto & json = getObject(json_);
 
     return {
@@ -576,8 +576,10 @@ static DerivationOptions<Inputs> derivationOptionsFromJson(const nlohmann::json 
 }
 
 template<typename Inputs>
-static void derivationOptionsToJson(nlohmann::json & json, const DerivationOptions<Inputs> & o)
+static void derivationOptionsToJson(nlohmann::json & json, const nix::DerivationOptions<Inputs> & o)
 {
+    using namespace nix;
+
     json["outputChecks"] = std::visit(
         overloaded{
             [&](const OutputChecks<Inputs> & checks) {
@@ -609,8 +611,10 @@ static void derivationOptionsToJson(nlohmann::json & json, const DerivationOptio
 }
 
 template<typename Inputs>
-static OutputChecks<Inputs> outputChecksFromJson(const nlohmann::json & json_)
+static nix::OutputChecks<Inputs> outputChecksFromJson(const nlohmann::json & json_)
 {
+    using namespace nix;
+
     auto & json = getObject(json_);
 
     return {
@@ -625,7 +629,7 @@ static OutputChecks<Inputs> outputChecksFromJson(const nlohmann::json & json_)
 }
 
 template<typename Inputs>
-static void outputChecksToJson(nlohmann::json & json, const OutputChecks<Inputs> & c)
+static void outputChecksToJson(nlohmann::json & json, const nix::OutputChecks<Inputs> & c)
 {
     json["ignoreSelfRefs"] = c.ignoreSelfRefs;
     json["maxSize"] = c.maxSize;
@@ -636,45 +640,51 @@ static void outputChecksToJson(nlohmann::json & json, const OutputChecks<Inputs>
     json["disallowedRequisites"] = c.disallowedRequisites;
 }
 
-DerivationOptions<SingleDerivedPath> adl_serializer<DerivationOptions<SingleDerivedPath>>::from_json(const json & json_)
+nix::DerivationOptions<nix::SingleDerivedPath>
+adl_serializer<nix::DerivationOptions<nix::SingleDerivedPath>>::from_json(const json & json_)
 {
-    return derivationOptionsFromJson<SingleDerivedPath>(json_);
+    return derivationOptionsFromJson<nix::SingleDerivedPath>(json_);
 }
 
-void adl_serializer<DerivationOptions<SingleDerivedPath>>::to_json(
-    json & json, const DerivationOptions<SingleDerivedPath> & o)
+void adl_serializer<nix::DerivationOptions<nix::SingleDerivedPath>>::to_json(
+    json & json, const nix::DerivationOptions<nix::SingleDerivedPath> & o)
 {
-    derivationOptionsToJson<SingleDerivedPath>(json, o);
+    derivationOptionsToJson<nix::SingleDerivedPath>(json, o);
 }
 
-DerivationOptions<StorePath> adl_serializer<DerivationOptions<StorePath>>::from_json(const json & json_)
+nix::DerivationOptions<nix::StorePath>
+adl_serializer<nix::DerivationOptions<nix::StorePath>>::from_json(const json & json_)
 {
-    return derivationOptionsFromJson<StorePath>(json_);
+    return derivationOptionsFromJson<nix::StorePath>(json_);
 }
 
-void adl_serializer<DerivationOptions<StorePath>>::to_json(json & json, const DerivationOptions<StorePath> & o)
+void adl_serializer<nix::DerivationOptions<nix::StorePath>>::to_json(
+    json & json, const nix::DerivationOptions<nix::StorePath> & o)
 {
-    derivationOptionsToJson<StorePath>(json, o);
+    derivationOptionsToJson<nix::StorePath>(json, o);
 }
 
-OutputChecks<SingleDerivedPath> adl_serializer<OutputChecks<SingleDerivedPath>>::from_json(const json & json_)
+nix::OutputChecks<nix::SingleDerivedPath>
+adl_serializer<nix::OutputChecks<nix::SingleDerivedPath>>::from_json(const json & json_)
 {
-    return outputChecksFromJson<SingleDerivedPath>(json_);
+    return outputChecksFromJson<nix::SingleDerivedPath>(json_);
 }
 
-void adl_serializer<OutputChecks<SingleDerivedPath>>::to_json(json & json, const OutputChecks<SingleDerivedPath> & c)
+void adl_serializer<nix::OutputChecks<nix::SingleDerivedPath>>::to_json(
+    json & json, const nix::OutputChecks<nix::SingleDerivedPath> & c)
 {
-    outputChecksToJson<SingleDerivedPath>(json, c);
+    outputChecksToJson<nix::SingleDerivedPath>(json, c);
 }
 
-OutputChecks<StorePath> adl_serializer<OutputChecks<StorePath>>::from_json(const json & json_)
+nix::OutputChecks<nix::StorePath> adl_serializer<nix::OutputChecks<nix::StorePath>>::from_json(const json & json_)
 {
-    return outputChecksFromJson<StorePath>(json_);
+    return outputChecksFromJson<nix::StorePath>(json_);
 }
 
-void adl_serializer<OutputChecks<StorePath>>::to_json(json & json, const OutputChecks<StorePath> & c)
+void adl_serializer<nix::OutputChecks<nix::StorePath>>::to_json(
+    json & json, const nix::OutputChecks<nix::StorePath> & c)
 {
-    outputChecksToJson<StorePath>(json, c);
+    outputChecksToJson<nix::StorePath>(json, c);
 }
 
 } // namespace nlohmann

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -15,8 +15,6 @@
 
 namespace nix {
 
-using namespace std::literals::string_view_literals;
-
 BasicDerivation::~BasicDerivation() {}
 
 Derivation::~Derivation() {}
@@ -316,6 +314,8 @@ static DerivationOutput parseDerivationOutput(
     std::string_view hashS,
     const ExperimentalFeatureSettings & xpSettings)
 {
+    using namespace std::literals::string_view_literals;
+
     if (!hashAlgoStr.empty()) {
         ContentAddressMethod method = ContentAddressMethod::parsePrefix(hashAlgoStr);
         if (method == ContentAddressMethod::Raw::Text)
@@ -395,6 +395,8 @@ enum struct DerivationATermVersion {
 static DerivedPathMap<StringSet>::ChildNode
 parseDerivedPathMapNode(const StoreDirConfig & store, StringViewStream & str, DerivationATermVersion version)
 {
+    using namespace std::literals::string_view_literals;
+
     DerivedPathMap<StringSet>::ChildNode node;
 
     auto parseNonDynamic = [&]() { node.value = parseStrings(str, false); };
@@ -440,6 +442,8 @@ Derivation parseDerivation(
     std::string_view name,
     const ExperimentalFeatureSettings & xpSettings)
 {
+    using namespace std::literals::string_view_literals;
+
     Derivation drv;
     drv.name = name;
 
@@ -600,6 +604,8 @@ static void printUnquotedStrings(std::string & res, ForwardIterator i, ForwardIt
 static void unparseDerivedPathMapNode(
     const StoreDirConfig & store, std::string & s, const DerivedPathMap<StringSet>::ChildNode & node)
 {
+    using namespace std::literals::string_view_literals;
+
     s += ',';
     if (node.childMap.empty()) {
         printUnquotedStrings(s, node.value.begin(), node.value.end());
@@ -643,6 +649,8 @@ static bool hasDynamicDrvDep(const Derivation & drv)
 std::string Derivation::unparse(
     const StoreDirConfig & store, bool maskOutputs, DerivedPathMap<StringSet>::ChildNode::Map * actualInputs) const
 {
+    using namespace std::literals::string_view_literals;
+
     std::string s;
     s.reserve(65536);
 
@@ -790,6 +798,8 @@ bool isDerivation(std::string_view fileName)
 
 std::string outputPathName(std::string_view drvName, OutputNameView outputName)
 {
+    using namespace std::literals::string_view_literals;
+
     std::string res{drvName};
     if (outputName != "out"sv) {
         res += '-';
@@ -800,6 +810,8 @@ std::string outputPathName(std::string_view drvName, OutputNameView outputName)
 
 DerivationType BasicDerivation::type() const
 {
+    using namespace std::literals::string_view_literals;
+
     std::optional<HashAlgorithm> floatingHashAlgo;
     std::optional<DerivationType> ty;
 
@@ -1435,10 +1447,9 @@ const Hash impureOutputHash = hashString(HashAlgorithm::SHA256, "impure");
 
 namespace nlohmann {
 
-using namespace nix;
-
-void adl_serializer<DerivationOutput>::to_json(json & res, const DerivationOutput & o)
+void adl_serializer<nix::DerivationOutput>::to_json(json & res, const nix::DerivationOutput & o)
 {
+    using namespace nix;
     res = nlohmann::json::object();
     std::visit(
         overloaded{
@@ -1466,9 +1477,10 @@ void adl_serializer<DerivationOutput>::to_json(json & res, const DerivationOutpu
         o.raw);
 }
 
-DerivationOutput
-adl_serializer<DerivationOutput>::from_json(const json & _json, const ExperimentalFeatureSettings & xpSettings)
+nix::DerivationOutput adl_serializer<nix::DerivationOutput>::from_json(
+    const json & _json, const nix::ExperimentalFeatureSettings & xpSettings)
 {
+    using namespace nix;
     std::set<std::string_view> keys;
     auto & json = getObject(_json);
 
@@ -1532,15 +1544,16 @@ adl_serializer<DerivationOutput>::from_json(const json & _json, const Experiment
     }
 }
 
-static void inputSrcsToJson(json & res, const StorePathSet & inputSrcs)
+static void inputSrcsToJson(json & res, const nix::StorePathSet & inputSrcs)
 {
     res = nlohmann::json::array();
     for (auto & input : inputSrcs)
         res.emplace_back(input);
 }
 
-static void basicDerivationToJson(json & res, const BasicDerivation & d)
+static void basicDerivationToJson(json & res, const nix::BasicDerivation & d)
 {
+    using namespace nix;
     res = nlohmann::json::object();
 
     res["name"] = d.name;
@@ -1562,15 +1575,17 @@ static void basicDerivationToJson(json & res, const BasicDerivation & d)
         res["structuredAttrs"] = d.structuredAttrs->structuredAttrs;
 }
 
-void adl_serializer<BasicDerivation>::to_json(json & res, const BasicDerivation & d)
+void adl_serializer<nix::BasicDerivation>::to_json(json & res, const nix::BasicDerivation & d)
 {
     basicDerivationToJson(res, d);
 
     inputSrcsToJson(res["inputs"], d.inputSrcs);
 }
 
-void adl_serializer<Derivation>::to_json(json & res, const Derivation & d)
+void adl_serializer<nix::Derivation>::to_json(json & res, const nix::Derivation & d)
 {
+    using namespace nix;
+
     basicDerivationToJson(res, d);
 
     {
@@ -1598,16 +1613,18 @@ void adl_serializer<Derivation>::to_json(json & res, const Derivation & d)
     }
 }
 
-static void inputSrcsFromJson(const json & inputSrcsJson, StorePathSet & inputSrcs)
+static void inputSrcsFromJson(const json & inputSrcsJson, nix::StorePathSet & inputSrcs)
 {
-    auto arr = getArray(inputSrcsJson);
+    auto arr = nix::getArray(inputSrcsJson);
     for (auto & input : arr)
         inputSrcs.insert(input);
 }
 
 static void basicDerivationFromJson(
-    const json::object_t & json, BasicDerivation & res, const ExperimentalFeatureSettings & xpSettings)
+    const json::object_t & json, nix::BasicDerivation & res, const nix::ExperimentalFeatureSettings & xpSettings)
 {
+    using namespace nix;
+
     res.name = getString(valueAt(json, "name"));
 
     {
@@ -1645,9 +1662,11 @@ static void basicDerivationFromJson(
         res.structuredAttrs = StructuredAttrs{*structuredAttrs};
 }
 
-BasicDerivation
-adl_serializer<BasicDerivation>::from_json(const json & _json, const ExperimentalFeatureSettings & xpSettings)
+nix::BasicDerivation
+adl_serializer<nix::BasicDerivation>::from_json(const json & _json, const nix::ExperimentalFeatureSettings & xpSettings)
 {
+    using namespace nix;
+
     BasicDerivation res;
     auto & json = getObject(_json);
     basicDerivationFromJson(json, res, xpSettings);
@@ -1662,8 +1681,11 @@ adl_serializer<BasicDerivation>::from_json(const json & _json, const Experimenta
     return res;
 }
 
-Derivation adl_serializer<Derivation>::from_json(const json & _json, const ExperimentalFeatureSettings & xpSettings)
+nix::Derivation
+adl_serializer<nix::Derivation>::from_json(const json & _json, const nix::ExperimentalFeatureSettings & xpSettings)
 {
+    using namespace nix;
+
     Derivation res;
     auto & json = getObject(_json);
     basicDerivationFromJson(json, res, xpSettings);

--- a/src/libstore/derived-path.cc
+++ b/src/libstore/derived-path.cc
@@ -224,17 +224,17 @@ const StorePath & DerivedPath::getBaseStorePath() const
 
 namespace nlohmann {
 
-void adl_serializer<SingleDerivedPath::Opaque>::to_json(json & json, const SingleDerivedPath::Opaque & o)
+void adl_serializer<nix::SingleDerivedPath::Opaque>::to_json(json & json, const nix::SingleDerivedPath::Opaque & o)
 {
     json = o.path;
 }
 
-SingleDerivedPath::Opaque adl_serializer<SingleDerivedPath::Opaque>::from_json(const json & json)
+nix::SingleDerivedPath::Opaque adl_serializer<nix::SingleDerivedPath::Opaque>::from_json(const json & json)
 {
-    return SingleDerivedPath::Opaque{json};
+    return {json};
 }
 
-void adl_serializer<SingleDerivedPath::Built>::to_json(json & json, const SingleDerivedPath::Built & sdpb)
+void adl_serializer<nix::SingleDerivedPath::Built>::to_json(json & json, const nix::SingleDerivedPath::Built & sdpb)
 {
     json = {
         {"drvPath", *sdpb.drvPath},
@@ -242,7 +242,7 @@ void adl_serializer<SingleDerivedPath::Built>::to_json(json & json, const Single
     };
 }
 
-void adl_serializer<DerivedPath::Built>::to_json(json & json, const DerivedPath::Built & dbp)
+void adl_serializer<nix::DerivedPath::Built>::to_json(json & json, const nix::DerivedPath::Built & dbp)
 {
     json = {
         {"drvPath", *dbp.drvPath},
@@ -250,9 +250,10 @@ void adl_serializer<DerivedPath::Built>::to_json(json & json, const DerivedPath:
     };
 }
 
-SingleDerivedPath::Built
-adl_serializer<SingleDerivedPath::Built>::from_json(const json & json0, const ExperimentalFeatureSettings & xpSettings)
+nix::SingleDerivedPath::Built adl_serializer<nix::SingleDerivedPath::Built>::from_json(
+    const json & json0, const nix::ExperimentalFeatureSettings & xpSettings)
 {
+    using namespace nix;
     auto & json = getObject(json0);
     auto drvPath = make_ref<SingleDerivedPath>(static_cast<SingleDerivedPath>(valueAt(json, "drvPath")));
     drvRequireExperiment(*drvPath, xpSettings);
@@ -262,9 +263,10 @@ adl_serializer<SingleDerivedPath::Built>::from_json(const json & json0, const Ex
     };
 }
 
-DerivedPath::Built
-adl_serializer<DerivedPath::Built>::from_json(const json & json0, const ExperimentalFeatureSettings & xpSettings)
+nix::DerivedPath::Built adl_serializer<nix::DerivedPath::Built>::from_json(
+    const json & json0, const nix::ExperimentalFeatureSettings & xpSettings)
 {
+    using namespace nix;
     auto & json = getObject(json0);
     auto drvPath = make_ref<SingleDerivedPath>(static_cast<SingleDerivedPath>(valueAt(json, "drvPath")));
     drvRequireExperiment(*drvPath, xpSettings);
@@ -274,31 +276,32 @@ adl_serializer<DerivedPath::Built>::from_json(const json & json0, const Experime
     };
 }
 
-void adl_serializer<SingleDerivedPath>::to_json(json & json, const SingleDerivedPath & sdp)
+void adl_serializer<nix::SingleDerivedPath>::to_json(json & json, const nix::SingleDerivedPath & sdp)
 {
     std::visit([&](const auto & buildable) { json = buildable; }, sdp.raw());
 }
 
-void adl_serializer<DerivedPath>::to_json(json & json, const DerivedPath & sdp)
+void adl_serializer<nix::DerivedPath>::to_json(json & json, const nix::DerivedPath & sdp)
 {
     std::visit([&](const auto & buildable) { json = buildable; }, sdp.raw());
 }
 
-SingleDerivedPath
-adl_serializer<SingleDerivedPath>::from_json(const json & json, const ExperimentalFeatureSettings & xpSettings)
+nix::SingleDerivedPath adl_serializer<nix::SingleDerivedPath>::from_json(
+    const json & json, const nix::ExperimentalFeatureSettings & xpSettings)
 {
     if (json.is_string())
-        return static_cast<SingleDerivedPath::Opaque>(json);
+        return static_cast<nix::SingleDerivedPath::Opaque>(json);
     else
-        return adl_serializer<SingleDerivedPath::Built>::from_json(json, xpSettings);
+        return adl_serializer<nix::SingleDerivedPath::Built>::from_json(json, xpSettings);
 }
 
-DerivedPath adl_serializer<DerivedPath>::from_json(const json & json, const ExperimentalFeatureSettings & xpSettings)
+nix::DerivedPath
+adl_serializer<nix::DerivedPath>::from_json(const json & json, const nix::ExperimentalFeatureSettings & xpSettings)
 {
     if (json.is_string())
-        return static_cast<DerivedPath::Opaque>(json);
+        return static_cast<nix::DerivedPath::Opaque>(json);
     else
-        return adl_serializer<DerivedPath::Built>::from_json(json, xpSettings);
+        return adl_serializer<nix::DerivedPath::Built>::from_json(json, xpSettings);
 }
 
 } // namespace nlohmann

--- a/src/libstore/downstream-placeholder.cc
+++ b/src/libstore/downstream-placeholder.cc
@@ -53,11 +53,11 @@ DownstreamPlaceholder DownstreamPlaceholder::fromSingleDerivedPathBuilt(
 
 namespace nlohmann {
 
-using namespace nix;
-
 template<typename Item>
-DrvRef<Item> adl_serializer<DrvRef<Item>>::from_json(const json & json)
+nix::DrvRef<Item> adl_serializer<nix::DrvRef<Item>>::from_json(const json & json)
 {
+    using namespace nix;
+
     // OutputName case: { "drvPath": "self", "output": <output> }
     if (json.type() == nlohmann::json::value_t::object) {
         auto & obj = getObject(json);
@@ -74,8 +74,10 @@ DrvRef<Item> adl_serializer<DrvRef<Item>>::from_json(const json & json)
 }
 
 template<typename Item>
-void adl_serializer<DrvRef<Item>>::to_json(json & json, const DrvRef<Item> & ref)
+void adl_serializer<nix::DrvRef<Item>>::to_json(json & json, const nix::DrvRef<Item> & ref)
 {
+    using namespace nix;
+
     std::visit(
         overloaded{
             [&](const OutputName & outputName) {
@@ -88,7 +90,7 @@ void adl_serializer<DrvRef<Item>>::to_json(json & json, const DrvRef<Item> & ref
         ref);
 }
 
-template struct adl_serializer<nix::DrvRef<StorePath>>;
-template struct adl_serializer<nix::DrvRef<SingleDerivedPath>>;
+template struct adl_serializer<nix::DrvRef<nix::StorePath>>;
+template struct adl_serializer<nix::DrvRef<nix::SingleDerivedPath>>;
 
 } // namespace nlohmann

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -404,10 +404,9 @@ static RegisterStoreImplementation<DummyStore::Config> regDummyStore;
 
 namespace nlohmann {
 
-using namespace nix;
-
-DummyStore::PathInfoAndContents adl_serializer<DummyStore::PathInfoAndContents>::from_json(const json & json)
+nix::DummyStore::PathInfoAndContents adl_serializer<nix::DummyStore::PathInfoAndContents>::from_json(const json & json)
 {
+    using namespace nix;
     auto & obj = getObject(json);
     return DummyStore::PathInfoAndContents{
         .info = valueAt(obj, "info"),
@@ -415,7 +414,8 @@ DummyStore::PathInfoAndContents adl_serializer<DummyStore::PathInfoAndContents>:
     };
 }
 
-void adl_serializer<DummyStore::PathInfoAndContents>::to_json(json & json, const DummyStore::PathInfoAndContents & val)
+void adl_serializer<nix::DummyStore::PathInfoAndContents>::to_json(
+    json & json, const nix::DummyStore::PathInfoAndContents & val)
 {
     json = {
         {"info", val.info},
@@ -423,8 +423,9 @@ void adl_serializer<DummyStore::PathInfoAndContents>::to_json(json & json, const
     };
 }
 
-ref<DummyStoreConfig> adl_serializer<ref<DummyStore::Config>>::from_json(const json & json)
+nix::ref<nix::DummyStoreConfig> adl_serializer<nix::ref<nix::DummyStore::Config>>::from_json(const json & json)
 {
+    using namespace nix;
     auto & obj = getObject(json);
     auto cfg = make_ref<DummyStore::Config>(DummyStore::Config::Params{});
     cfg->storeDir_.set(getString(valueAt(obj, "store")));
@@ -432,15 +433,16 @@ ref<DummyStoreConfig> adl_serializer<ref<DummyStore::Config>>::from_json(const j
     return cfg;
 }
 
-void adl_serializer<DummyStoreConfig>::to_json(json & json, const DummyStoreConfig & val)
+void adl_serializer<nix::DummyStoreConfig>::to_json(json & json, const nix::DummyStoreConfig & val)
 {
     json = {
         {"store", val.storeDir},
     };
 }
 
-ref<DummyStore> adl_serializer<ref<DummyStore>>::from_json(const json & json)
+nix::ref<nix::DummyStore> adl_serializer<nix::ref<nix::DummyStore>>::from_json(const json & json)
 {
+    using namespace nix;
     auto & obj = getObject(json);
     ref<DummyStore> res = adl_serializer<ref<DummyStoreConfig>>::from_json(valueAt(obj, "config"))->openDummyStore();
     for (auto & [k, v] : getObject(valueAt(obj, "contents")))
@@ -457,8 +459,9 @@ ref<DummyStore> adl_serializer<ref<DummyStore>>::from_json(const json & json)
     return res;
 }
 
-void adl_serializer<DummyStore>::to_json(json & json, const DummyStore & val)
+void adl_serializer<nix::DummyStore>::to_json(json & json, const nix::DummyStore & val)
 {
+    using namespace nix;
     json = {
         {"config", *val.config},
         {"contents",

--- a/src/libstore/include/nix/store/outputs-spec.hh
+++ b/src/libstore/include/nix/store/outputs-spec.hh
@@ -140,5 +140,5 @@ struct ExtendedOutputsSpec
 
 } // namespace nix
 
-JSON_IMPL(OutputsSpec)
-JSON_IMPL(ExtendedOutputsSpec)
+JSON_IMPL(nix::OutputsSpec)
+JSON_IMPL(nix::ExtendedOutputsSpec)

--- a/src/libstore/include/nix/store/store-reference.hh
+++ b/src/libstore/include/nix/store/store-reference.hh
@@ -135,4 +135,4 @@ NIX_DECLARE_CONFIG_SERIALISER(std::set<StoreReference>)
 
 } // namespace nix
 
-JSON_IMPL(StoreReference)
+JSON_IMPL(nix::StoreReference)

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -443,14 +443,13 @@ OutputPathMap resolveDerivedPath(Store & store, const DerivedPath::Built & bfd)
 
 namespace nlohmann {
 
-using namespace nix;
-
-TrustedFlag adl_serializer<TrustedFlag>::from_json(const json & json)
+nix::TrustedFlag adl_serializer<nix::TrustedFlag>::from_json(const json & json)
 {
+    using namespace nix;
     return getBoolean(json) ? TrustedFlag::Trusted : TrustedFlag::NotTrusted;
 }
 
-void adl_serializer<TrustedFlag>::to_json(json & json, const TrustedFlag & trustedFlag)
+void adl_serializer<nix::TrustedFlag>::to_json(json & json, const nix::TrustedFlag & trustedFlag)
 {
     json = static_cast<bool>(trustedFlag);
 }

--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -202,16 +202,14 @@ UnkeyedNarInfo UnkeyedNarInfo::fromJSON(const StoreDirConfig * store, const nloh
 
 namespace nlohmann {
 
-using namespace nix;
-
-UnkeyedNarInfo adl_serializer<UnkeyedNarInfo>::from_json(const json & json)
+nix::UnkeyedNarInfo adl_serializer<nix::UnkeyedNarInfo>::from_json(const json & json)
 {
-    return UnkeyedNarInfo::fromJSON(nullptr, json);
+    return nix::UnkeyedNarInfo::fromJSON(nullptr, json);
 }
 
-void adl_serializer<UnkeyedNarInfo>::to_json(json & json, const UnkeyedNarInfo & c)
+void adl_serializer<nix::UnkeyedNarInfo>::to_json(json & json, const nix::UnkeyedNarInfo & c)
 {
-    json = c.toJSON(nullptr, true, PathInfoJsonFormat::V2);
+    json = c.toJSON(nullptr, true, nix::PathInfoJsonFormat::V2);
 }
 
 } // namespace nlohmann

--- a/src/libstore/outputs-spec.cc
+++ b/src/libstore/outputs-spec.cc
@@ -133,21 +133,21 @@ bool OutputsSpec::isSubsetOf(const OutputsSpec & that) const
 
 namespace nlohmann {
 
-using namespace nix;
-
 #ifndef DOXYGEN_SKIP
 
-OutputsSpec adl_serializer<OutputsSpec>::from_json(const json & json)
+nix::OutputsSpec adl_serializer<nix::OutputsSpec>::from_json(const json & json)
 {
-    auto names = json.get<StringSet>();
+    using namespace nix;
+    auto names = json.get<nix::StringSet>();
     if (names == StringSet({"*"}))
         return OutputsSpec::All{};
     else
         return OutputsSpec::Names{std::move(names)};
 }
 
-void adl_serializer<OutputsSpec>::to_json(json & json, const OutputsSpec & t)
+void adl_serializer<nix::OutputsSpec>::to_json(json & json, const nix::OutputsSpec & t)
 {
+    using namespace nix;
     std::visit(
         overloaded{
             [&](const OutputsSpec::All &) { json = std::vector<std::string>({"*"}); },
@@ -156,8 +156,9 @@ void adl_serializer<OutputsSpec>::to_json(json & json, const OutputsSpec & t)
         t.raw);
 }
 
-ExtendedOutputsSpec adl_serializer<ExtendedOutputsSpec>::from_json(const json & json)
+nix::ExtendedOutputsSpec adl_serializer<nix::ExtendedOutputsSpec>::from_json(const json & json)
 {
+    using namespace nix;
     if (json.is_null())
         return ExtendedOutputsSpec::Default{};
     else {
@@ -165,8 +166,9 @@ ExtendedOutputsSpec adl_serializer<ExtendedOutputsSpec>::from_json(const json & 
     }
 }
 
-void adl_serializer<ExtendedOutputsSpec>::to_json(json & json, const ExtendedOutputsSpec & t)
+void adl_serializer<nix::ExtendedOutputsSpec>::to_json(json & json, const nix::ExtendedOutputsSpec & t)
 {
+    using namespace nix;
     std::visit(
         overloaded{
             [&](const ExtendedOutputsSpec::Default &) { json = nullptr; },

--- a/src/libstore/path-info.cc
+++ b/src/libstore/path-info.cc
@@ -306,30 +306,29 @@ UnkeyedValidPathInfo UnkeyedValidPathInfo::fromJSON(const StoreDirConfig * store
 
 namespace nlohmann {
 
-using namespace nix;
-
-PathInfoJsonFormat adl_serializer<PathInfoJsonFormat>::from_json(const json & json)
+nix::PathInfoJsonFormat adl_serializer<nix::PathInfoJsonFormat>::from_json(const json & json)
 {
-    return parsePathInfoJsonFormat(getUnsigned(json));
+    return nix::parsePathInfoJsonFormat(nix::getUnsigned(json));
 }
 
-void adl_serializer<PathInfoJsonFormat>::to_json(json & json, const PathInfoJsonFormat & format)
+void adl_serializer<nix::PathInfoJsonFormat>::to_json(json & json, const nix::PathInfoJsonFormat & format)
 {
     json = static_cast<int>(format);
 }
 
-UnkeyedValidPathInfo adl_serializer<UnkeyedValidPathInfo>::from_json(const json & json)
+nix::UnkeyedValidPathInfo adl_serializer<nix::UnkeyedValidPathInfo>::from_json(const json & json)
 {
-    return UnkeyedValidPathInfo::fromJSON(nullptr, json);
+    return nix::UnkeyedValidPathInfo::fromJSON(nullptr, json);
 }
 
-void adl_serializer<UnkeyedValidPathInfo>::to_json(json & json, const UnkeyedValidPathInfo & c)
+void adl_serializer<nix::UnkeyedValidPathInfo>::to_json(json & json, const nix::UnkeyedValidPathInfo & c)
 {
-    json = c.toJSON(nullptr, true, PathInfoJsonFormat::V3);
+    json = c.toJSON(nullptr, true, nix::PathInfoJsonFormat::V3);
 }
 
-ValidPathInfo adl_serializer<ValidPathInfo>::from_json(const json & json0)
+nix::ValidPathInfo adl_serializer<nix::ValidPathInfo>::from_json(const json & json0)
 {
+    using namespace nix;
     auto json = getObject(json0);
 
     return ValidPathInfo{
@@ -338,8 +337,9 @@ ValidPathInfo adl_serializer<ValidPathInfo>::from_json(const json & json0)
     };
 }
 
-void adl_serializer<ValidPathInfo>::to_json(json & json, const ValidPathInfo & v)
+void adl_serializer<nix::ValidPathInfo>::to_json(json & json, const nix::ValidPathInfo & v)
 {
+    using namespace nix;
     adl_serializer<UnkeyedValidPathInfo>::to_json(json, v);
     json["path"] = v.path;
 }

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -85,14 +85,12 @@ StorePath StorePath::random(std::string_view name)
 
 namespace nlohmann {
 
-using namespace nix;
-
-StorePath adl_serializer<StorePath>::from_json(const json & json)
+nix::StorePath adl_serializer<nix::StorePath>::from_json(const json & json)
 {
-    return StorePath{getString(json)};
+    return nix::StorePath{nix::getString(json)};
 }
 
-void adl_serializer<StorePath>::to_json(json & json, const StorePath & storePath)
+void adl_serializer<nix::StorePath>::to_json(json & json, const nix::StorePath & storePath)
 {
     json = storePath.to_string();
 }

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -97,10 +97,9 @@ MissingRealisation::MissingRealisation(
 
 namespace nlohmann {
 
-using namespace nix;
-
-DrvOutput adl_serializer<DrvOutput>::from_json(const json & json)
+nix::DrvOutput adl_serializer<nix::DrvOutput>::from_json(const json & json)
 {
+    using namespace nix;
     auto obj = getObject(json);
 
     return {
@@ -109,7 +108,7 @@ DrvOutput adl_serializer<DrvOutput>::from_json(const json & json)
     };
 }
 
-void adl_serializer<DrvOutput>::to_json(json & json, const DrvOutput & drvOutput)
+void adl_serializer<nix::DrvOutput>::to_json(json & json, const nix::DrvOutput & drvOutput)
 {
     json = {
         {"drvPath", drvOutput.drvPath},
@@ -117,8 +116,9 @@ void adl_serializer<DrvOutput>::to_json(json & json, const DrvOutput & drvOutput
     };
 }
 
-UnkeyedRealisation adl_serializer<UnkeyedRealisation>::from_json(const json & json0)
+nix::UnkeyedRealisation adl_serializer<nix::UnkeyedRealisation>::from_json(const json & json0)
 {
+    using namespace nix;
     auto json = getObject(json0);
 
     return UnkeyedRealisation{
@@ -131,7 +131,7 @@ UnkeyedRealisation adl_serializer<UnkeyedRealisation>::from_json(const json & js
     };
 }
 
-void adl_serializer<UnkeyedRealisation>::to_json(json & json, const UnkeyedRealisation & r)
+void adl_serializer<nix::UnkeyedRealisation>::to_json(json & json, const nix::UnkeyedRealisation & r)
 {
     json = {
         {"outPath", r.outPath},
@@ -139,8 +139,9 @@ void adl_serializer<UnkeyedRealisation>::to_json(json & json, const UnkeyedReali
     };
 }
 
-Realisation adl_serializer<Realisation>::from_json(const json & json)
+nix::Realisation adl_serializer<nix::Realisation>::from_json(const json & json)
 {
+    using namespace nix;
     auto obj = getObject(json);
 
     return {
@@ -149,11 +150,11 @@ Realisation adl_serializer<Realisation>::from_json(const json & json)
     };
 }
 
-void adl_serializer<Realisation>::to_json(json & json, const Realisation & r)
+void adl_serializer<nix::Realisation>::to_json(json & json, const nix::Realisation & r)
 {
     json = {
         {"key", r.id},
-        {"value", static_cast<const UnkeyedRealisation &>(r)},
+        {"value", static_cast<const nix::UnkeyedRealisation &>(r)},
     };
 }
 

--- a/src/libstore/s3-url.cc
+++ b/src/libstore/s3-url.cc
@@ -11,8 +11,6 @@
 #include <ranges>
 #include <string_view>
 
-using namespace std::string_view_literals;
-
 namespace nix {
 
 void InvalidS3AddressingStyle::anchor() {}
@@ -43,6 +41,8 @@ std::string_view showS3AddressingStyle(S3AddressingStyle style)
 
 ParsedS3URL ParsedS3URL::parse(const ParsedURL & parsed)
 try {
+    using namespace std::string_view_literals;
+
     if (parsed.scheme != "s3"sv)
         throw BadURL("URI scheme '%s' is not 's3'", parsed.scheme);
 

--- a/src/libstore/store-reference.cc
+++ b/src/libstore/store-reference.cc
@@ -189,14 +189,12 @@ std::pair<std::string, StoreReference::Params> splitUriAndParams(const std::stri
 
 namespace nlohmann {
 
-using namespace nix;
-
-StoreReference adl_serializer<StoreReference>::from_json(const json & json)
+nix::StoreReference adl_serializer<nix::StoreReference>::from_json(const json & json)
 {
-    return StoreReference::parse(json.get<std::string>());
+    return nix::StoreReference::parse(json.get<std::string>()); // FIXME: getString
 }
 
-void adl_serializer<StoreReference>::to_json(json & json, const StoreReference & ref)
+void adl_serializer<nix::StoreReference>::to_json(json & json, const nix::StoreReference & ref)
 {
     json = ref.render();
 }

--- a/src/libstore/unix/build/hook-instance.cc
+++ b/src/libstore/unix/build/hook-instance.cc
@@ -4,8 +4,6 @@
 #include "nix/util/strings.hh"
 #include "nix/util/executable-path.hh"
 
-using namespace std::chrono_literals;
-
 namespace nix {
 
 HookInstance::HookInstance(const Strings & _buildHook)
@@ -71,6 +69,8 @@ HookInstance::HookInstance(const Strings & _buildHook)
 
         throw SysError("executing %s", PathFmt(buildHook));
     });
+
+    using namespace std::chrono_literals;
 
     /* Give custom build hooks the chance to cleanup. */
     pid.setKillSignal(SIGTERM);

--- a/src/libutil-test-support/hash.cc
+++ b/src/libutil-test-support/hash.cc
@@ -7,10 +7,9 @@
 
 namespace rc {
 
-using namespace nix;
-
-Gen<Hash> Arbitrary<Hash>::arbitrary()
+Gen<nix::Hash> Arbitrary<nix::Hash>::arbitrary()
 {
+    using namespace nix;
     Hash prototype(HashAlgorithm::SHA1);
     return gen::apply(
         [](const std::vector<uint8_t> & v) {

--- a/src/libutil-test-support/include/nix/util/tests/hash.hh
+++ b/src/libutil-test-support/include/nix/util/tests/hash.hh
@@ -7,12 +7,10 @@
 
 namespace rc {
 
-using namespace nix;
-
 template<>
-struct Arbitrary<Hash>
+struct Arbitrary<nix::Hash>
 {
-    static Gen<Hash> arbitrary();
+    static Gen<nix::Hash> arbitrary();
 };
 
 } // namespace rc

--- a/src/libutil-tests/checked-arithmetic.cc
+++ b/src/libutil-tests/checked-arithmetic.cc
@@ -11,8 +11,6 @@
 
 namespace rc {
 
-using namespace nix;
-
 template<std::integral T>
 struct Arbitrary<nix::checked::Checked<T>>
 {

--- a/src/libutil-tests/closure.cc
+++ b/src/libutil-tests/closure.cc
@@ -3,9 +3,7 @@
 
 namespace nix {
 
-using namespace std;
-
-map<string, set<string>> testGraph = {
+std::map<std::string, std::set<std::string>> testGraph = {
     {"A", {"B", "C", "G"}},
     {"B", {"A"}}, // Loops back to A
     {"C", {"F"}}, // Indirect reference
@@ -17,9 +15,9 @@ map<string, set<string>> testGraph = {
 
 TEST(closure, correctClosure)
 {
-    set<string> aClosure;
-    set<string> expectedClosure = {"A", "B", "C", "F", "G"};
-    computeClosure<string>(
+    std::set<std::string> aClosure;
+    std::set<std::string> expectedClosure = {"A", "B", "C", "F", "G"};
+    computeClosure<std::string>(
         {"A"}, aClosure, [&](const std::string & currentNode) -> asio::awaitable<std::set<std::string>> {
             co_return testGraph[currentNode];
         });
@@ -32,10 +30,10 @@ TEST(closure, properlyHandlesDirectExceptions)
     struct TestExn
     {};
 
-    set<string> aClosure;
+    std::set<std::string> aClosure;
     std::size_t callCount = 0;
     EXPECT_THROW(
-        computeClosure<string>(
+        computeClosure<std::string>(
             {"A", "B"},
             aClosure,
             [&](const std::string &) -> asio::awaitable<std::set<std::string>> {

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -5,8 +5,6 @@
 #include <gtest/gtest.h>
 #include <rapidcheck/gtest.h>
 
-using namespace std::string_view_literals;
-
 #ifdef _WIN32
 #  define FS_SEP L"\\"
 #  define FS_ROOT_NO_TRAILING_SLASH L"C:" // Need a mounted one, C drive is likely
@@ -111,6 +109,8 @@ TEST(canonPath, removesDots2)
 
 TEST(canonPath, requiresAbsolutePath)
 {
+    using namespace std::string_view_literals;
+
     ASSERT_ANY_THROW(canonPath("."sv));
     ASSERT_ANY_THROW(canonPath(".."sv));
     ASSERT_ANY_THROW(canonPath("../"sv));

--- a/src/libutil-tests/memory-source-accessor.cc
+++ b/src/libutil-tests/memory-source-accessor.cc
@@ -11,7 +11,6 @@ namespace nix {
 
 namespace memory_source_accessor {
 
-using namespace std::literals;
 using File = MemorySourceAccessor::File;
 
 ref<MemorySourceAccessor> exampleSimple()
@@ -26,6 +25,7 @@ ref<MemorySourceAccessor> exampleSimple()
 
 ref<MemorySourceAccessor> exampleComplex()
 {
+    using namespace std::literals;
     auto files = make_ref<MemorySourceAccessor>();
     files->root = File::Directory{
         .entries{

--- a/src/libutil/base-n.cc
+++ b/src/libutil/base-n.cc
@@ -4,8 +4,6 @@
 #include "nix/util/util.hh"
 #include "nix/util/base-n.hh"
 
-using namespace std::literals;
-
 namespace nix {
 
 constexpr static const std::array<char, 16> base16Chars = "0123456789abcdef"_arrayNoNull;

--- a/src/libutil/git.cc
+++ b/src/libutil/git.cc
@@ -12,9 +12,6 @@
 
 namespace nix::git {
 
-using namespace nix;
-using namespace std::string_literals;
-
 std::optional<Mode> decodeMode(RawMode m)
 {
     switch (m) {
@@ -230,6 +227,7 @@ void restore(FileSystemObjectSink & sink, Source & source, HashAlgorithm hashAlg
 
 void dumpBlobPrefix(uint64_t size, Sink & sink, const ExperimentalFeatureSettings & xpSettings)
 {
+    using namespace std::string_literals;
     xpSettings.require(Xp::GitHashing);
     auto s = fmt("blob %d\0"s, std::to_string(size));
     sink(s);
@@ -237,6 +235,7 @@ void dumpBlobPrefix(uint64_t size, Sink & sink, const ExperimentalFeatureSetting
 
 void dumpTree(const Tree & entries, Sink & sink, const ExperimentalFeatureSettings & xpSettings)
 {
+    using namespace std::string_literals;
     xpSettings.require(Xp::GitHashing);
 
     std::string v1;

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -519,17 +519,15 @@ std::string_view printHashAlgo(HashAlgorithm ha)
 
 namespace nlohmann {
 
-using namespace nix;
-
-Hash adl_serializer<Hash>::from_json(const json & json, const ExperimentalFeatureSettings & xpSettings)
+nix::Hash adl_serializer<nix::Hash>::from_json(const json & json, const nix::ExperimentalFeatureSettings & xpSettings)
 {
-    auto & s = getString(json);
-    return Hash::parseSRI(s, xpSettings);
+    auto & s = nix::getString(json);
+    return nix::Hash::parseSRI(s, xpSettings);
 }
 
-void adl_serializer<Hash>::to_json(json & json, const Hash & hash)
+void adl_serializer<nix::Hash>::to_json(json & json, const nix::Hash & hash)
 {
-    json = hash.to_string(HashFormat::SRI, true);
+    json = hash.to_string(nix::HashFormat::SRI, true);
 }
 
 } // namespace nlohmann

--- a/src/libutil/include/nix/util/hash.hh
+++ b/src/libutil/include/nix/util/hash.hh
@@ -265,4 +265,4 @@ inline std::size_t hash_value(const Hash & hash)
 
 } // namespace nix
 
-JSON_IMPL_WITH_XP_FEATURES(Hash)
+JSON_IMPL_WITH_XP_FEATURES(nix::Hash)

--- a/src/libutil/include/nix/util/json-impls.hh
+++ b/src/libutil/include/nix/util/json-impls.hh
@@ -27,19 +27,18 @@
 
 #define JSON_IMPL(TYPE)    \
     namespace nlohmann {   \
-    using namespace nix;   \
     template<>             \
     JSON_IMPL_INNER(TYPE); \
     }
 
-#define JSON_IMPL_WITH_XP_FEATURES(TYPE)                                                                            \
-    namespace nlohmann {                                                                                            \
-    using namespace nix;                                                                                            \
-    template<>                                                                                                      \
-    struct adl_serializer<TYPE>                                                                                     \
-    {                                                                                                               \
-        static TYPE                                                                                                 \
-        from_json(const json & json, const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings); \
-        static void to_json(json & json, const TYPE & t);                                                           \
-    };                                                                                                              \
+#define JSON_IMPL_WITH_XP_FEATURES(TYPE)                                                             \
+    namespace nlohmann {                                                                             \
+    template<>                                                                                       \
+    struct adl_serializer<TYPE>                                                                      \
+    {                                                                                                \
+        static TYPE from_json(                                                                       \
+            const json & json,                                                                       \
+            const nix::ExperimentalFeatureSettings & xpSettings = nix::experimentalFeatureSettings); \
+        static void to_json(json & json, const TYPE & t);                                            \
+    };                                                                                               \
     }

--- a/src/libutil/include/nix/util/memory-source-accessor.hh
+++ b/src/libutil/include/nix/util/memory-source-accessor.hh
@@ -194,29 +194,27 @@ struct json_avoids_null<MemorySourceAccessor> : std::true_type
 
 namespace nlohmann {
 
-using namespace nix;
-
-#define ARG fso::Regular<RegularContents>
+#define ARG nix::fso::Regular<RegularContents>
 template<typename RegularContents>
 JSON_IMPL_INNER(ARG);
 #undef ARG
 
-#define ARG fso::DirectoryT<Child>
+#define ARG nix::fso::DirectoryT<Child>
 template<typename Child>
 JSON_IMPL_INNER(ARG);
 #undef ARG
 
 template<>
-JSON_IMPL_INNER(fso::Symlink);
+JSON_IMPL_INNER(nix::fso::Symlink);
 
 template<>
-JSON_IMPL_INNER(fso::Opaque);
+JSON_IMPL_INNER(nix::fso::Opaque);
 
-#define ARG fso::VariantT<RegularContents, recur>
+#define ARG nix::fso::VariantT<RegularContents, recur>
 template<typename RegularContents, bool recur>
 JSON_IMPL_INNER(ARG);
 #undef ARG
 
 } // namespace nlohmann
 
-JSON_IMPL(MemorySourceAccessor)
+JSON_IMPL(nix::MemorySourceAccessor)

--- a/src/libutil/memory-source-accessor/json.cc
+++ b/src/libutil/memory-source-accessor/json.cc
@@ -6,22 +6,22 @@
 
 namespace nlohmann {
 
-using namespace nix;
-
 // fso::Regular<RegularContents>
 template<>
-MemorySourceAccessor::File::Regular adl_serializer<MemorySourceAccessor::File::Regular>::from_json(const json & json)
+nix::MemorySourceAccessor::File::Regular
+adl_serializer<nix::MemorySourceAccessor::File::Regular>::from_json(const json & json)
 {
+    using namespace nix;
     auto & obj = getObject(json);
-    return MemorySourceAccessor::File::Regular{
+    return {
         .executable = getBoolean(valueAt(obj, "executable")),
         .contents = getString(valueAt(obj, "contents")),
     };
 }
 
 template<>
-void adl_serializer<MemorySourceAccessor::File::Regular>::to_json(
-    json & json, const MemorySourceAccessor::File::Regular & r)
+void adl_serializer<nix::MemorySourceAccessor::File::Regular>::to_json(
+    json & json, const nix::MemorySourceAccessor::File::Regular & r)
 {
     json = {
         {"executable", r.executable},
@@ -30,8 +30,9 @@ void adl_serializer<MemorySourceAccessor::File::Regular>::to_json(
 }
 
 template<>
-NarListing::Regular adl_serializer<NarListing::Regular>::from_json(const json & json)
+nix::NarListing::Regular adl_serializer<nix::NarListing::Regular>::from_json(const json & json)
 {
+    using namespace nix;
     auto & obj = getObject(json);
     auto * execPtr = optionalValueAt(obj, "executable");
     auto * sizePtr = optionalValueAt(obj, "size");
@@ -47,7 +48,7 @@ NarListing::Regular adl_serializer<NarListing::Regular>::from_json(const json & 
 }
 
 template<>
-void adl_serializer<NarListing::Regular>::to_json(json & j, const NarListing::Regular & r)
+void adl_serializer<nix::NarListing::Regular>::to_json(json & j, const nix::NarListing::Regular & r)
 {
     if (r.contents.fileSize)
         j["size"] = *r.contents.fileSize;
@@ -57,30 +58,32 @@ void adl_serializer<NarListing::Regular>::to_json(json & j, const NarListing::Re
 }
 
 template<typename Child>
-void adl_serializer<fso::DirectoryT<Child>>::to_json(json & j, const fso::DirectoryT<Child> & d)
+void adl_serializer<nix::fso::DirectoryT<Child>>::to_json(json & j, const nix::fso::DirectoryT<Child> & d)
 {
     j["entries"] = d.entries;
 }
 
 template<typename Child>
-fso::DirectoryT<Child> adl_serializer<fso::DirectoryT<Child>>::from_json(const json & json)
+nix::fso::DirectoryT<Child> adl_serializer<nix::fso::DirectoryT<Child>>::from_json(const json & json)
 {
+    using namespace nix;
     auto & obj = getObject(json);
-    return fso::DirectoryT<Child>{
+    return {
         .entries = valueAt(obj, "entries"),
     };
 }
 
 // fso::Symlink
-fso::Symlink adl_serializer<fso::Symlink>::from_json(const json & json)
+nix::fso::Symlink adl_serializer<nix::fso::Symlink>::from_json(const json & json)
 {
+    using namespace nix;
     auto & obj = getObject(json);
-    return fso::Symlink{
+    return {
         .target = getString(valueAt(obj, "target")),
     };
 }
 
-void adl_serializer<fso::Symlink>::to_json(json & json, const fso::Symlink & s)
+void adl_serializer<nix::fso::Symlink>::to_json(json & json, const nix::fso::Symlink & s)
 {
     json = {
         {"target", s.target},
@@ -88,21 +91,22 @@ void adl_serializer<fso::Symlink>::to_json(json & json, const fso::Symlink & s)
 }
 
 // fso::Opaque
-fso::Opaque adl_serializer<fso::Opaque>::from_json(const json &)
+nix::fso::Opaque adl_serializer<nix::fso::Opaque>::from_json(const json &)
 {
-    return fso::Opaque{};
+    return {};
 }
 
-void adl_serializer<fso::Opaque>::to_json(json & j, const fso::Opaque &)
+void adl_serializer<nix::fso::Opaque>::to_json(json & j, const nix::fso::Opaque &)
 {
     j = nlohmann::json::object();
 }
 
 // fso::VariantT<RegularContents, recur> - generic implementation
 template<typename RegularContents, bool recur>
-void adl_serializer<fso::VariantT<RegularContents, recur>>::to_json(
-    json & j, const fso::VariantT<RegularContents, recur> & val)
+void adl_serializer<nix::fso::VariantT<RegularContents, recur>>::to_json(
+    json & j, const nix::fso::VariantT<RegularContents, recur> & val)
 {
+    using namespace nix;
     using Variant = fso::VariantT<RegularContents, recur>;
     j = nlohmann::json::object();
     std::visit(
@@ -124,9 +128,10 @@ void adl_serializer<fso::VariantT<RegularContents, recur>>::to_json(
 }
 
 template<typename RegularContents, bool recur>
-fso::VariantT<RegularContents, recur>
-adl_serializer<fso::VariantT<RegularContents, recur>>::from_json(const json & json)
+nix::fso::VariantT<RegularContents, recur>
+adl_serializer<nix::fso::VariantT<RegularContents, recur>>::from_json(const json & json)
 {
+    using namespace nix;
     using Variant = fso::VariantT<RegularContents, recur>;
     auto & obj = getObject(json);
     auto type = getString(valueAt(obj, "type"));
@@ -141,19 +146,19 @@ adl_serializer<fso::VariantT<RegularContents, recur>>::from_json(const json & js
 }
 
 // Explicit instantiations for VariantT types we use
-template struct adl_serializer<MemorySourceAccessor::File>;
-template struct adl_serializer<NarListing>;
-template struct adl_serializer<ShallowNarListing>;
+template struct adl_serializer<nix::MemorySourceAccessor::File>;
+template struct adl_serializer<nix::NarListing>;
+template struct adl_serializer<nix::ShallowNarListing>;
 
 // MemorySourceAccessor
-MemorySourceAccessor adl_serializer<MemorySourceAccessor>::from_json(const json & json)
+nix::MemorySourceAccessor adl_serializer<nix::MemorySourceAccessor>::from_json(const json & json)
 {
-    MemorySourceAccessor res;
+    nix::MemorySourceAccessor res;
     res.root = json;
     return res;
 }
 
-void adl_serializer<MemorySourceAccessor>::to_json(json & json, const MemorySourceAccessor & val)
+void adl_serializer<nix::MemorySourceAccessor>::to_json(json & json, const nix::MemorySourceAccessor & val)
 {
     json = val.root;
 }

--- a/src/libutil/signature/local-keys.cc
+++ b/src/libutil/signature/local-keys.cc
@@ -176,16 +176,17 @@ bool verifyDetached(std::string_view data, const Signature & sig, const PublicKe
 } // namespace nix
 
 namespace nlohmann {
-void adl_serializer<Signature>::to_json(json & j, const Signature & s)
+void adl_serializer<nix::Signature>::to_json(json & j, const nix::Signature & s)
 {
     j = {
         {"keyName", s.keyName},
-        {"sig", base64::encode(std::as_bytes(std::span<const char>{s.sig}))},
+        {"sig", nix::base64::encode(std::as_bytes(std::span<const char>{s.sig}))},
     };
 }
 
-Signature adl_serializer<Signature>::from_json(const json & j)
+nix::Signature adl_serializer<nix::Signature>::from_json(const json & j)
 {
+    using namespace nix;
     if (j.is_string())
         return Signature::parse(getString(j));
     auto obj = getObject(j);

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -14,7 +14,6 @@
 #include <future>
 #include <iostream>
 #include <atomic>
-using namespace std::chrono_literals;
 
 #include <grp.h>
 #include <sys/types.h>
@@ -79,6 +78,8 @@ int Pid::kill(bool allowInterrupts)
     debug("killing process %1%", pid);
 
     std::atomic<bool> killed = false;
+
+    using namespace std::chrono_literals;
 
     if (killTimeout > 0ms && killSignal != SIGKILL)
         killThread = std::thread([&]() {

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -31,8 +31,6 @@
 #include "nix/util/fun.hh"
 #include "man-pages.hh"
 
-using namespace std::string_literals;
-
 extern char ** environ __attribute__((weak));
 
 namespace nix {
@@ -636,6 +634,9 @@ static void main_nix_build(int argc, char ** argv)
         auto rcfile = (tmpDir.path() / "rc").string();
         auto tz = getEnv("TZ");
         auto tzExport = tz ? "export TZ=" + escapeShellArgAlways(*tz) + "; " : "";
+
+        using namespace std::string_literals;
+
         std::string rc = fmt(
                 (R"(_nix_shell_clean_tmpdir() { command rm -rf %1%; };)"s
                   "trap _nix_shell_clean_tmpdir EXIT; "

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -40,7 +40,7 @@
 
 namespace nix_store {
 
-using namespace nix;
+using namespace nix; // NOLINT(nix-using-namespace)
 
 typedef void (*Operation)(Strings opFlags, Strings opArgs);
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

In https://github.com/NixOS/nix/commit/a60d54c1a53eafd93756b2f1e24338fff02a5922 I introduced a bit of tech
debt around the fact that with unity builds it's very ill-advised to use
namespace-level using namespace directives (due to the simple fact that they
leak into every other translation unit that's merged lexically).

The previous commit introduced a custom linter to diagnose problematic instances
of this pattern and issues identified by it are fixed now.

This is a bit annoying, but it doesn't seem to be that high of a cost considering
we get so much out of unity builds (i.e. yet to be merged static builds on darwin
with static initialisers, much faster compilation etc.).

The linter explains the reasoning pretty well, so the ongoing maintenance is going
to be pretty minimal.

See https://github.com/NixOS/nix/pull/15656 for a previous whack-a-mole style removal
of top-level using namespace directives.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
