### PR TITLE
Add support for scanning dependencies in `nix store add`

### DIFF
--- a/src/libstore/content-address.cc
+++ b/src/libstore/content-address.cc
@@ -1,5 +1,6 @@
 #include "nix/util/args.hh"
 #include "nix/store/content-address.hh"
+#include "nix/util/file-content-address.hh"
 #include "nix/util/split.hh"
 #include "nix/util/json-utils.hh"
 
@@ -128,6 +129,20 @@ FileIngestionMethod ContentAddressMethod::getFileIngestionMethod() const
         return FileIngestionMethod::Git;
     case ContentAddressMethod::Raw::Text:
         return FileIngestionMethod::Flat;
+    default:
+        assert(false);
+    }
+}
+
+FileSerialisationMethod ContentAddressMethod::getFileSerialisationMethod() const
+{
+    switch (raw) {
+    case ContentAddressMethod::Raw::Flat:
+    case ContentAddressMethod::Raw::Text:
+        return FileSerialisationMethod::Flat;
+    case ContentAddressMethod::Raw::NixArchive:
+    case ContentAddressMethod::Raw::Git:
+        return FileSerialisationMethod::NixArchive;
     default:
         assert(false);
     }

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -1,4 +1,5 @@
 #include "nix/store/daemon.hh"
+#include "nix/util/file-content-address.hh"
 #include "nix/util/signals.hh"
 #include "nix/store/worker-protocol.hh"
 #include "nix/store/worker-protocol-connection.hh"
@@ -11,6 +12,7 @@
 #include "nix/store/indirect-root-store.hh"
 #include "nix/store/remote-store.hh"
 #include "nix/store/path-with-outputs.hh"
+#include "nix/store/submit-store.hh"
 #include "nix/util/finally.hh"
 #include "nix/util/archive.hh"
 #include "nix/store/derivations.hh"
@@ -1014,6 +1016,37 @@ static void performOp(
         break;
     }
 
+    case WorkerProto::Op::AddToStoreScanning: {
+        auto name = readString(conn.from);
+        auto camStr = readString(conn.from);
+
+        experimentalFeatureSettings.require(Xp::DynamicDerivations);
+
+        if (!conn.protoVersion.features.contains(WorkerProto::featureAddToStoreScanning))
+            throw Error("Adding to store with scanning was requested, but not supported in negotiated protocol");
+
+        if (!recursive)
+            throw Error("AddToStoreScanning only valid inside a `recursive-nix` derivation builder");
+
+        auto & submitStore = require<SubmitStore>(*store);
+
+        logger->startWork();
+        auto pathInfo = [&]() {
+            // NB: FramedSource must be out of scope before logger->stopWork();
+            // FIXME: this means that if there is an error
+            // half-way through, the client will keep sending
+            // data, since we haven't sent it the error yet.
+            auto [contentAddressMethod, hashAlgo] = ContentAddressMethod::parseWithAlgo(camStr);
+            FramedSource source(conn.from);
+            FileSerialisationMethod dumpMethod = contentAddressMethod.getFileSerialisationMethod();
+            return submitStore.addToStoreScanning(source, name, dumpMethod, contentAddressMethod, hashAlgo);
+        }();
+        logger->stopWork();
+
+        WorkerProto::Serialise<ValidPathInfo>::write(*store, wconn, *pathInfo);
+        break;
+    }
+
     default:
         throw Error("invalid operation %1%", op);
     }
@@ -1039,8 +1072,10 @@ void processConnection(ref<Store> store, FdSource && from, FdSink && to, Trusted
 
     /* Exchange the greeting. */
     auto localVersion = WorkerProto::latest;
-    if (recursive)
+    if (recursive) {
         localVersion.features.insert(std::string{WorkerProto::featureDisableSetOptions});
+        localVersion.features.insert(std::string{WorkerProto::featureAddToStoreScanning});
+    }
 
     WorkerProto::BasicServerConnection conn;
     conn.protoVersion = WorkerProto::BasicServerConnection::handshake(to, from, localVersion);

--- a/src/libstore/include/nix/store/content-address.hh
+++ b/src/libstore/include/nix/store/content-address.hh
@@ -131,6 +131,15 @@ struct ContentAddressMethod
      * for hashing file systeme objects.
      */
     FileIngestionMethod getFileIngestionMethod() const;
+
+    /**
+     * The FileSerialisationMethod that is recommended for this content addressing method.
+     * In some circumstances, other methods are also valid.
+     * Note that `Git` is mapped to `NixArchive`, even though it could represent a single file.
+     * There is no support for flat serialisation of merkle objects; and even if there were,
+     * it would be unable to represent executable files.
+     */
+    FileSerialisationMethod getFileSerialisationMethod() const;
 };
 
 /*

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -304,6 +304,19 @@ public:
         const StorePathSet & references,
         RepairFlag repair) override;
 
+    // Designed to be used from RestrictedStore,
+    // allows filtering the references while scanning.
+    // Not an entirely separate function in order to reduce duplication
+    StorePath addToStoreFromDump(
+        Source & dump,
+        std::string_view name,
+        FileSerialisationMethod dumpMethod,
+        ContentAddressMethod hashMethod,
+        HashAlgorithm hashAlgo,
+        const StorePathSet & references,
+        RepairFlag repair,
+        bool filterReferences);
+
     void addTempRoot(const StorePath & path) override;
 
 private:

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -93,6 +93,7 @@ headers = [ config_pub_h ] + files(
   'store-open.hh',
   'store-reference.hh',
   'store-registration.hh',
+  'submit-store.hh',
   'uds-remote-store.hh',
   'worker-protocol-connection.hh',
   'worker-protocol-impl.hh',

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "nix/store/store-api.hh"
+#include "nix/store/submit-store.hh"
 #include "nix/util/sync.hh"
 #include "nix/util/file-descriptor.hh"
 #include "nix/store/gc-store.hh"
@@ -46,7 +47,7 @@ public:
  * \todo RemoteStore is a misnomer - should be something like
  * DaemonStore.
  */
-struct RemoteStore : public virtual Store, public virtual GcStore, public virtual LogStore
+struct RemoteStore : public virtual Store, public virtual GcStore, public virtual LogStore, public virtual SubmitStore
 {
 private:
     void anchor() override;
@@ -112,6 +113,13 @@ public:
     addMultipleToStore(PathsSource && pathsToCopy, Activity & act, RepairFlag repair, CheckSigsFlag checkSigs) override;
 
     void registerDrvOutput(const Realisation & info) override;
+
+    ref<const ValidPathInfo> addToStoreScanning(
+        Source & dump,
+        std::string_view name,
+        FileSerialisationMethod dumpMethod,
+        ContentAddressMethod hashMethod,
+        HashAlgorithm hashAlgo) override;
 
     void queryRealisationUncached(
         const DrvOutput &, Callback<std::shared_ptr<const UnkeyedRealisation>> callback) noexcept override;

--- a/src/libstore/include/nix/store/submit-store.hh
+++ b/src/libstore/include/nix/store/submit-store.hh
@@ -1,0 +1,31 @@
+#pragma once
+///@file
+
+#include "nix/store/store-api.hh"
+
+namespace nix {
+
+struct SubmitStore : public virtual Store
+{
+private:
+    void anchor() override;
+
+public:
+    inline static std::string operationName = "Submit outputs for a currently running derivation";
+
+    /**
+     * Add to store, scanning references.
+     * Only within a recursive-nix derivation, as there would otherwise be no known
+     * set of valid store paths
+     */
+    virtual ref<const ValidPathInfo> addToStoreScanning(
+        Source & dump,
+        std::string_view name,
+        FileSerialisationMethod dumpMethod = FileSerialisationMethod::NixArchive,
+        ContentAddressMethod hashMethod = ContentAddressMethod::Raw::NixArchive,
+        HashAlgorithm hashAlgo = HashAlgorithm::SHA256) = 0;
+
+    static SubmitStore & require(Store & store);
+};
+
+} // namespace nix

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -136,6 +136,11 @@ struct WorkerProto
     static constexpr std::string_view featureDisableSetOptions = "disable-set-options";
 
     /**
+     * Feature for enabling the `AddToStoreScanning` operation
+     */
+    static constexpr std::string_view featureAddToStoreScanning = "add-to-store-scanning";
+
+    /**
      * A unidirectional read connection, to be used by the read half of the
      * canonical serializers below.
      */
@@ -256,6 +261,7 @@ enum struct WorkerProto::Op : uint64_t {
     AddBuildLog = 45,
     BuildPathsWithResults = 46,
     AddPermRoot = 47,
+    AddToStoreScanning = 1001,
 };
 
 struct WorkerProto::ClientHandshakeInfo

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1,5 +1,6 @@
 #include "nix/store/local-store.hh"
 #include "nix/store/globals.hh"
+#include "nix/store/path-references.hh"
 #include "nix/util/git.hh"
 #include "nix/util/archive.hh"
 #include "nix/store/pathlocks.hh"
@@ -1181,9 +1182,29 @@ StorePath LocalStore::addToStoreFromDump(
     const StorePathSet & references,
     RepairFlag repair)
 {
+    return addToStoreFromDump(source0, name, dumpMethod, hashMethod, hashAlgo, references, repair, false);
+}
+
+StorePath LocalStore::addToStoreFromDump(
+    Source & source0,
+    std::string_view name,
+    FileSerialisationMethod dumpMethod,
+    ContentAddressMethod hashMethod,
+    HashAlgorithm hashAlgo,
+    const StorePathSet & originalReferences,
+    RepairFlag repair,
+    bool filterReferences)
+{
     /* For computing the store path. */
-    auto hashSink = std::make_unique<HashSink>(hashAlgo);
-    TeeSource source{source0, *hashSink};
+    auto hashSink = std::make_shared<HashSink>(hashAlgo);
+    std::shared_ptr<Sink> sink = hashSink;
+    std::optional<PathRefScanSink> refSink = std::nullopt;
+    if (filterReferences) {
+        // Only scan if we really need to, since it's slower.
+        refSink = PathRefScanSink::fromPaths(originalReferences);
+        sink = std::make_shared<TeeSink>(*hashSink, *refSink);
+    }
+    TeeSource source{source0, *sink};
     const LocalSettings & localSettings = config->getLocalSettings();
 
     /* Read the source path into memory, but only if it's up to
@@ -1236,8 +1257,9 @@ StorePath LocalStore::addToStoreFromDump(
     bool methodsMatch = static_cast<FileIngestionMethod>(dumpMethod) == hashMethod.getFileIngestionMethod();
 
     /* If the methods don't match, our streaming hash of the dump is the
-       wrong sort, and we need to rehash. */
-    bool inMemoryAndDontNeedRestore = inMemory && methodsMatch;
+       wrong sort, and we need to rehash.
+       References are also in store path, if scanning we will need to move */
+    bool inMemoryAndDontNeedRestore = inMemory && methodsMatch && !filterReferences;
 
     if (!inMemoryAndDontNeedRestore) {
         /* Drain what we pulled so far, and then keep on pulling */
@@ -1255,6 +1277,13 @@ StorePath LocalStore::addToStoreFromDump(
     }
 
     auto [dumpHash, size] = hashSink->finish();
+
+    StorePathSet references;
+    if (refSink.has_value()) {
+        references = refSink->getResultPaths();
+    } else {
+        references = originalReferences;
+    }
 
     auto desc = ContentAddressWithReferences::fromParts(
         hashMethod,

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -356,6 +356,7 @@ sources = files(
   'store-dir-config.cc',
   'store-reference.cc',
   'store-registration.cc',
+  'submit-store.cc',
   'uds-remote-store.cc',
   'worker-protocol-connection.cc',
   'worker-protocol.cc',

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -1,5 +1,6 @@
 #include "nix/store/path.hh"
 #include "nix/store/store-api.hh"
+#include "nix/util/file-content-address.hh"
 #include "nix/util/serialise.hh"
 #include "nix/util/util.hh"
 #include "nix/store/path-with-outputs.hh"
@@ -89,10 +90,12 @@ void RemoteStore::initConnection(Connection & conn)
         StringSink saved;
         TeeSource tee(conn.from, saved);
         try {
-            // The DisableSetOptions feature isn't in the `latest` constant because it is shared with the daemon,
-            // which only adds the feature under certain conditions. Adding is easier than removing.
+            // The DisableSetOptions and `AddToStoreScanning` features aren't in the `latest` constant because it is
+            // shared with the daemon, which only adds the feature under certain conditions.
+            // Adding is easier than removing.
             auto localVersion = WorkerProto::latest;
             localVersion.features.insert(std::string{WorkerProto::featureDisableSetOptions});
+            localVersion.features.insert(std::string{WorkerProto::featureAddToStoreScanning});
 
             conn.protoVersion = WorkerProto::BasicClientConnection::handshake(conn.to, tee, localVersion);
             if (conn.protoVersion.number < WorkerProto::minimum.number)
@@ -422,22 +425,7 @@ StorePath RemoteStore::addToStoreFromDump(
     const StorePathSet & references,
     RepairFlag repair)
 {
-    FileSerialisationMethod fsm;
-    switch (hashMethod.getFileIngestionMethod()) {
-    case FileIngestionMethod::Flat:
-        fsm = FileSerialisationMethod::Flat;
-        break;
-    case FileIngestionMethod::NixArchive:
-        fsm = FileSerialisationMethod::NixArchive;
-        break;
-    case FileIngestionMethod::Git:
-        // Use NAR; Git is not a serialization method
-        fsm = FileSerialisationMethod::NixArchive;
-        break;
-    default:
-        assert(false);
-    }
-    if (fsm != dumpMethod)
+    if (hashMethod.getFileSerialisationMethod() != dumpMethod)
         unsupported("RemoteStore::addToStoreFromDump doesn't support this `dumpMethod` `hashMethod` combination");
     auto storePath = addCAToStore(dump, name, hashMethod, hashAlgo, references, repair)->path;
     invalidatePathInfoCacheFor(storePath);
@@ -515,6 +503,32 @@ void RemoteStore::registerDrvOutput(const Realisation & info)
     conn->to << WorkerProto::Op::RegisterDrvOutput;
     WorkerProto::write(*this, *conn, info);
     conn.processStderr();
+}
+
+ref<const ValidPathInfo> RemoteStore::addToStoreScanning(
+    Source & dump,
+    std::string_view name,
+    FileSerialisationMethod dumpMethod,
+    ContentAddressMethod hashMethod,
+    HashAlgorithm hashAlgo)
+{
+    if (hashMethod.getFileSerialisationMethod() != dumpMethod)
+        unsupported("RemoteStore::addToStoreScanning doesn't support this `dumpMethod` `hashMethod` combination");
+
+    auto conn(getConnection());
+    if (!conn->protoVersion.features.contains(WorkerProto::featureAddToStoreScanning))
+        throw Error("the daemon does not support AddToStoreScanning, perhaps this is not in a recursive-nix builder?");
+
+    conn->to << WorkerProto::Op::AddToStoreScanning << name << hashMethod.renderWithAlgo(hashAlgo);
+
+    // The dump source may invoke the store, so we need to make some room.
+    connections->incCapacity();
+    {
+        Finally cleanup([&]() { connections->decCapacity(); });
+        conn.withFramedSink([&](Sink & sink) { dump.drainInto(sink); });
+    }
+
+    return make_ref<ValidPathInfo>(WorkerProto::Serialise<ValidPathInfo>::read(*this, *conn));
 }
 
 void RemoteStore::queryRealisationUncached(

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -1,8 +1,10 @@
 #include "nix/store/restricted-store.hh"
 #include "nix/store/build-result.hh"
+#include "nix/store/submit-store.hh"
 #include "nix/util/callback.hh"
 #include "nix/store/realisation.hh"
 #include "nix/store/local-store.hh"
+#include "nix/util/repair-flag.hh"
 
 namespace nix {
 
@@ -38,7 +40,7 @@ bool RestrictionContext::isAllowed(const DerivedPath & req)
  * paths that are in the input closures of the build or were added via
  * recursive Nix calls.
  */
-struct RestrictedStore : public virtual IndirectRootStore, public virtual GcStore
+struct RestrictedStore : public virtual IndirectRootStore, public virtual GcStore, public virtual SubmitStore
 {
 private:
     void anchor() override;
@@ -111,6 +113,13 @@ public:
     void ensurePath(const StorePath & path) override;
 
     void registerDrvOutput(const Realisation & info) override;
+
+    ref<const ValidPathInfo> addToStoreScanning(
+        Source & dump,
+        std::string_view name,
+        FileSerialisationMethod dumpMethod,
+        ContentAddressMethod hashMethod,
+        HashAlgorithm hashAlgo) override;
 
     void queryRealisationUncached(
         const DrvOutput & id, Callback<std::shared_ptr<const UnkeyedRealisation>> callback) noexcept override;
@@ -254,6 +263,19 @@ void RestrictedStore::registerDrvOutput(const Realisation & info)
 // corresponds to an allowed derivation
 {
     throw Error("registerDrvOutput");
+}
+
+ref<const ValidPathInfo> RestrictedStore::addToStoreScanning(
+    Source & dump,
+    std::string_view name,
+    FileSerialisationMethod dumpMethod,
+    ContentAddressMethod hashMethod,
+    HashAlgorithm hashAlgo)
+{
+    auto path = next->addToStoreFromDump(
+        dump, name, dumpMethod, hashMethod, hashAlgo, queryAllValidPaths(), RepairFlag::NoRepair, true);
+
+    return queryPathInfo(path);
 }
 
 void RestrictedStore::queryRealisationUncached(

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -274,7 +274,7 @@ ref<const ValidPathInfo> RestrictedStore::addToStoreScanning(
 {
     auto path = next->addToStoreFromDump(
         dump, name, dumpMethod, hashMethod, hashAlgo, queryAllValidPaths(), RepairFlag::NoRepair, true);
-
+    goal.addDependency(path);
     return queryPathInfo(path);
 }
 

--- a/src/libstore/submit-store.cc
+++ b/src/libstore/submit-store.cc
@@ -1,0 +1,7 @@
+#include "nix/store/submit-store.hh"
+
+namespace nix {
+
+void SubmitStore::anchor() {}
+
+} // namespace nix

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -2,6 +2,9 @@
 #include "nix/main/common-args.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/source-accessor.hh"
+#include "nix/store/store-cast.hh"
+#include "nix/store/submit-store.hh"
+#include "nix/util/file-system.hh"
 #include "nix/cmd/misc-store-flags.hh"
 
 namespace nix {
@@ -12,6 +15,7 @@ struct CmdAddToStore : MixDryRun, StoreCommand
     std::optional<std::string> namePart;
     ContentAddressMethod caMethod = ContentAddressMethod::Raw::NixArchive;
     HashAlgorithm hashAlgo = HashAlgorithm::SHA256;
+    bool scan = false;
 
     CmdAddToStore()
     {
@@ -29,18 +33,49 @@ struct CmdAddToStore : MixDryRun, StoreCommand
         addFlag(flag::contentAddressMethod(&caMethod));
 
         addFlag(flag::hashAlgo(&hashAlgo));
+
+        addFlag({
+            .longName = "scan",
+            .description = "Scan for references. Only works within a `recursive-nix` derivation builder.",
+            .handler = {&scan, true},
+        });
     }
 
     void run(ref<Store> store) override
     {
+        // Although this would be convenient, if we are scanning then we are connecting to a daemon.
+        // A dry-run scan would require either daemon-support for scanning a path for references
+        // or listing referenceable paths, both of which come with downsides.
+        if (dryRun && scan)
+            throw UsageError("Cannot dry-run while scanning");
+
         if (!namePart)
             namePart = path.filename().string();
 
         auto sourcePath = makeFSSourceAccessor(absPath(path));
 
-        auto storePath = dryRun ? store->computeStorePath(*namePart, sourcePath, caMethod, hashAlgo, {}).first
-                                : store->addToStoreSlow(*namePart, sourcePath, caMethod, hashAlgo, {}).path;
+        auto storePath = ([&]() {
+            if (scan) {
+                auto & submitStore = require<SubmitStore>(*store);
 
+                auto serialisationMethod = caMethod.getFileSerialisationMethod();
+
+                std::optional<StorePath> storePath;
+                auto sink = sourceToSink([&](Source & source) {
+                    auto info =
+                        submitStore.addToStoreScanning(source, *namePart, serialisationMethod, caMethod, hashAlgo);
+                    storePath = info->path;
+                });
+                dumpPath(sourcePath, *sink, serialisationMethod, defaultPathFilter);
+                sink->finish();
+
+                return storePath.value();
+            } else if (dryRun) {
+                return store->computeStorePath(*namePart, sourcePath, caMethod, hashAlgo, {}).first;
+            } else {
+                return store->addToStoreSlow(*namePart, sourcePath, caMethod, hashAlgo, {}).path;
+            }
+        })();
         logger->cout("%s", store->printStorePath(storePath));
     }
 };

--- a/tests/functional/add-scanning.nix
+++ b/tests/functional/add-scanning.nix
@@ -1,0 +1,38 @@
+with import ./config.nix;
+
+let
+  dependency = mkDerivation {
+    name = "dependency";
+    buildCommand = ''
+      mkdir $out
+      echo "this is a dependency" > $out/foo
+    '';
+  };
+in
+mkDerivation {
+  name = "add-scanning";
+
+  requiredSystemFeatures = [ "recursive-nix" ];
+
+  buildCommand = ''
+    set -euo pipefail
+
+    PATH=${builtins.getEnv "EXTRA_PATH"}:$PATH
+    export NIX_CONFIG='extra-experimental-features = nix-command'
+
+    mkdir mao
+    echo "miao" > mao/foo
+    echo "${dependency}" > mao/reference
+    mao="$(nix store add --scan ./mao)"
+
+    mkdir felis
+    echo "miau" > felis/foo
+    echo "$mao" > felis/reference
+    felis="$(nix store add --scan -n reference ./felis)"
+
+    nix-store -qR "$felis" | grep "$mao"
+    nix-store -qR "$felis" | grep "${dependency}"
+
+    nix-store -qR "$felis" > "$out"
+  '';
+}

--- a/tests/functional/add-scanning.sh
+++ b/tests/functional/add-scanning.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+TODO_NixOS
+
+requireDaemonNewerThan "2.36.0pre20260716"
+
+enableFeatures 'recursive-nix dynamic-derivations'
+restartDaemon
+
+# grep is overridden with a function in this shell, is not in a new subshell
+EXTRA_PATH=$(dirname "$(type -p nix)"):$(dirname "$(sh -c 'type -p grep')")
+export EXTRA_PATH
+
+nix build -L --file ./add-scanning.nix --no-link

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -53,6 +53,7 @@ suites = [
     'tests' : [
       'absolute-path-literals.sh',
       'add.sh',
+      'add-scanning.sh',
       'bash-profile.sh',
       'binary-cache-build-remote.sh',
       'binary-cache-compression.sh',


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
When running in `recursive-nix` mode, a package may create several filesystem objects that contain links to each other. However, without scanning, these will not be reflected in the store object metadata, breaking garbage collection and creation of archives based on the contents of a closure.

Add a new protocol command `AddToStoreScanning` and flag `--scan` to `nix store add` that uses it.

This PR is one component of #15793, since `builder-rpc-v0` outputs would not be able to reference other store objects without a method of scanning at add time.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context
In order to reduce complexity and reuse scanning logic, the `AddToStoreScanning` operation only works within recursive-nix derivations. Only a `RestrictedStore` provided to a recursive derivation builder has a list of all known packages for which it can search.

Although it is possible to submit references with the existing `AddToStore` protocol, this would add substantial complexity to the program running the add. It would need to either search for everything that looked like a store path or discover every possible path on its own, not relying in the information already available to the daemon.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
