### PR TITLE
libutil: Use O_PATH when opening parent dirFds

### DIFF
--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -383,8 +383,20 @@ std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> PosixDirectorySourceAccessor
     }
 
     try {
-        AutoCloseFD parentFdOwning =
-            openFileEnsureBeneathNoSymlinks(startFd, relPath, O_DIRECTORY | O_RDONLY | O_CLOEXEC, 0, std::move(cb));
+        AutoCloseFD parentFdOwning = openFileEnsureBeneathNoSymlinks(
+            startFd,
+            relPath,
+#  ifdef O_PATH
+            /* As to not require read permissions on the directory. */
+            O_PATH |
+#  else
+            /* Sadly this will require read permissison for path resolution,
+               but without O_PATH that's unavoidable. */
+            O_RDONLY |
+#  endif
+                O_DIRECTORY | O_CLOEXEC,
+            0,
+            std::move(cb));
         return {parentFdOwning.get(), make_ref<AutoCloseFD>(std::move(parentFdOwning))};
     } catch (SymlinkNotAllowed & e) {
         /* Need to fixup the error message to include the actual path relative to the (possibly) cached fd. */

--- a/tests/nixos/functional/symlinked-home.nix
+++ b/tests/nixos/functional/symlinked-home.nix
@@ -1,9 +1,11 @@
 /**
   This test runs the functional tests on a NixOS system where the home directory
-  is symlinked to another location.
+  is symlinked to another location that also happens to reside in parent directory
+  that we don't have read permissions for (only execute).
 
   The purpose of this test is to find cases where Nix uses low-level operations
-  that don't support symlinks on paths that include them.
+  that don't support symlinks on paths that include them or requires excessive
+  permissions for path resolution.
 
   It is not a substitute for more intricate, use case-specific tests, but helps
   catch common issues.
@@ -27,8 +29,12 @@
       machine.succeed("""
         (
           set -x
-          mv /home/alice /home/alice.real
-          ln -s alice.real /home/alice
+          mkdir -p /home/alice.parent
+          chown alice:users /home/alice.parent
+          # Make the parent unreadable for good measure
+          chmod 0110 /home/alice.parent
+          mv /home/alice /home/alice.parent/alice.real
+          ln -s alice.parent/alice.real /home/alice
         ) 1>&2
       """)
     machine.succeed("""


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

https://github.com/NixOS/nix/issues/16164

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
