### PR TITLE
libutil: open parent dirs with O_PATH in PosixDirectorySourceAccessor

### DIFF
--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -168,6 +168,7 @@ suites = [
       'short-path-literals.sh',
       'signing.sh',
       'simple.sh',
+      'source-accessor-traverse-only.sh',
       'ssh-relay.sh',
       'store-info.sh',
       'store-print-env.sh',

--- a/tests/functional/source-accessor-traverse-only.sh
+++ b/tests/functional/source-accessor-traverse-only.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Regression test for the filesystem source accessor: statting or reading a
+# file beneath a directory must require only *search* ("x") permission on the
+# ancestor directories, not *read* ("r") permission.
+#
+# The fd-based PosixSourceAccessor once opened the parent directory `O_RDONLY`
+# in `PosixDirectorySourceAccessor::openParent`, which requires read
+# permission and broke stores whose backing directory is deliberately
+# traversable but not listable (e.g. `/nix/store` hardened to mode `--x`, as
+# used with a remote store's `real` directory). It should only require
+# traversal, matching the old path-based `lstat` behaviour.
+
+source common.sh
+
+# `chmod`-based; the read-only bits don't behave as expected under the NixOS
+# test sandbox.
+TODO_NixOS
+
+# The permission distinction (traverse vs. list) is only enforced where the
+# accessor uses `O_PATH` (Linux). Elsewhere it still opens ancestors `O_RDONLY`.
+[[ "$(uname -s)" = Linux ]] || skipTest "requires O_PATH (Linux)"
+
+# Not meaningful as root, which bypasses directory permission checks.
+[[ "$(id -u)" != 0 ]] || skipTest "does not work as root"
+
+dir="$TEST_ROOT/traverse-only"
+rm -rf "$dir"
+mkdir -p "$dir/sub"
+echo -n "hi there" > "$dir/sub/file"
+
+# Make the parent (and an intermediate) directory traversable but not listable.
+chmod 0111 "$dir/sub"
+chmod 0111 "$dir"
+
+cleanup() { chmod -R u+rwx "$dir" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# `maybeLstat` through the accessor: existence checks must not list the dir.
+[[ "$(nix eval --impure --expr "builtins.pathExists $dir/sub/file")" = true ]]
+
+# `readFile` through the accessor: reading the file needs read on the file and
+# only traversal on its ancestors.
+[[ "$(nix eval --impure --raw --expr "builtins.readFile $dir/sub/file")" = "hi there" ]]


### PR DESCRIPTION
The fd-based `PosixSourceAccessor` (introduced in "libutil: Implement unix source accessors that work with file descriptors", first released in 2.35.0) resolves a path by opening its parent directory and then operating relative to that fd (`fstatat` for `maybeLstat`, `openat` for `readFile`/`openSubdirectory`, `readlinkat` for `readLink`). `openParent` opened the parent with `O_DIRECTORY | O_RDONLY`, which requires *read* permission on the parent directory.

The previous path-based implementation used `lstat(2)` on the absolute path, which only requires *search* ("x") permission on the ancestor directories. Requiring read permission is therefore a regression: it breaks stores whose backing directory is deliberately traversable but not listable. A concrete case is a daemon/remote store configured with

    store = unix:///...?real=/real/store

where the logical `/nix/store` is hardened to mode `--x` (traversable, not listable); evaluation then fails with

    error: opening directory '/nix/store': Permission denied

when the evaluator's root accessor stats a `/nix/store/...` path (before falling through to the mounted store accessor).

The parent fd is only ever used as an anchor for `fstatat`/`openat`/ `readlinkat`; it is never `fdopendir`ed, so search permission suffices. Open it with `O_PATH` on Linux -- the same optimization, and the same `#ifdef __linux__` gating, already applied to the intermediate path components in `openFileEnsureBeneathNoSymlinks`. This restores the search-only permission requirement for the whole walk.

Deliberately out of scope: directory *listing* (`openSubdirectory`) and the accessor's own root fd still open `O_RDONLY` and so still require read permission by design. Non-Linux platforms keep the `O_RDONLY` behavior, matching the intermediate-component gating.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
