### PR TITLE
Use C23 `embed` instead of `gen_headers`

### DIFF
--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -26,6 +26,8 @@ warning_flags = [
   '-Werror=non-virtual-dtor',
   '-Wignored-qualifiers',
   '-Wimplicit-fallthrough',
+  # Clang complains about #embed even though it's now standard in C23. In C++ it's an extension, but meh.
+  '-Wno-c23-extensions',
   '-Wno-deprecated-declarations',
   '-Wno-interference-size', # Used for C++ ABI only. We don't provide any guarantees about different march tunings.
   '-Wno-subobject-linkage', # GCC doesn't like unity builds.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -296,12 +296,14 @@ EvalState::EvalState(
     , internalFS(make_ref<MemorySourceAccessor>())
     , derivationInternal{internalFS->addFile(
           CanonPath("derivation-internal.nix"),
-#include "primops/derivation.nix.gen.hh"
-          )}
+          {
+#embed "primops/derivation.nix"
+          })}
     , importedDrvToDerivation{internalFS->addFile(
           CanonPath("imported-drv-to-derivation.nix"),
-#include "imported-drv-to-derivation.nix.gen.hh"
-          )}
+          {
+#embed "imported-drv-to-derivation.nix"
+          })}
     , store(store)
     , buildStore(buildStore ? buildStore : store)
     , inputCache(fetchers::InputCache::create())
@@ -363,8 +365,9 @@ EvalState::EvalState(
 
     corepkgsFS->addFile(
         CanonPath("fetchurl.nix"),
-#include "fetchurl.nix.gen.hh"
-    );
+        {
+#embed "fetchurl.nix"
+        });
 
     createBaseEnv(settings);
 

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -144,16 +144,6 @@ lexer_tab = custom_target(
   install_dir : get_option('includedir') / 'nix',
 )
 
-subdir('nix-meson-build-support/generate-header')
-
-generated_headers = []
-foreach header : [
-  'imported-drv-to-derivation.nix',
-  'fetchurl.nix',
-]
-  generated_headers += gen_header.process(header)
-endforeach
-
 sources = files(
   'attr-path.cc',
   'attr-set.cc',
@@ -240,7 +230,6 @@ this_library = library(
   config_priv_h,
   parser_tab[1],
   lexer_tab[1],
-  generated_headers,
   soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -251,7 +251,7 @@ void derivationToValue(
     state.evalFile(state.importedDrvToDerivation, *vImportedDrvToDerivation); // has caching
 
     v.mkApp(vImportedDrvToDerivation, w);
-    state.forceAttrs(v, pos, "while calling imported-drv-to-derivation.nix.gen.hh");
+    state.forceAttrs(v, pos, "while calling imported-drv-to-derivation.nix");
 }
 
 /**

--- a/src/libexpr/primops/derivation.nix
+++ b/src/libexpr/primops/derivation.nix
@@ -1,5 +1,5 @@
-# This is the implementation of the ‘derivation’ builtin function.
-# It's actually a wrapper around the ‘derivationStrict’ primop.
+# This is the implementation of the `derivation` builtin function.
+# It's actually a wrapper around the `derivationStrict` primop.
 # Note that the following comment will be shown in :doc in the repl, but not in the manual.
 
 /**

--- a/src/libexpr/primops/meson.build
+++ b/src/libexpr/primops/meson.build
@@ -1,8 +1,3 @@
-generated_headers += gen_header.process(
-  'derivation.nix',
-  preserve_path_from : meson.project_source_root(),
-)
-
 sources += files(
   'context.cc',
   'fetchClosure.cc',

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -916,8 +916,9 @@ static ref<SourceAccessor> makeInternalFS()
     internalFS->setPathDisplay("«flakes-internal»", "");
     internalFS->addFile(
         CanonPath("call-flake.nix"),
-#include "call-flake.nix.gen.hh" // IWYU pragma: keep
-    );
+        {
+#embed "call-flake.nix"
+        });
     return internalFS;
 }
 

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -32,13 +32,6 @@ subdir('nix-meson-build-support/common')
 
 subdir('nix-meson-build-support/generate-header')
 
-generated_headers = []
-foreach header : [
-  'call-flake.nix',
-]
-  generated_headers += gen_header.process(header)
-endforeach
-
 sources = files(
   'config.cc',
   'flake-primops.cc',
@@ -57,7 +50,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixflake',
   sources,
-  generated_headers,
   soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,

--- a/src/libstore/linux/build/linux-derivation-builder.cc
+++ b/src/libstore/linux/build/linux-derivation-builder.cc
@@ -815,11 +815,10 @@ void ChrootLinuxDerivationBuilder::enterChroot()
     for (auto & i : pathsInChroot) {
         if (i.second.source == "/proc")
             continue; // backwards compatibility
-
 #if HAVE_EMBEDDED_SANDBOX_SHELL
         if (i.second.source == "__embedded_sandbox_shell__") {
-            static unsigned char sh[] = {
-#  include "embedded-sandbox-shell.gen.hh"
+            static constexpr unsigned char sh[] = {
+#  embed EMBEDDED_SANDBOX_SHELL_PATH
             };
             auto dst = chrootRootDir / i.first.relative_path();
             createDirs(dst.parent_path());

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -572,10 +572,9 @@ void LocalStore::openDB(State & state, bool create)
 
     /* Initialise the database schema, if necessary. */
     if (create) {
-        static const char schema[] =
-#include "schema.sql.gen.hh"
-            ;
-        db.exec(schema);
+        db.exec({
+#embed "schema.sql"
+        });
     }
 }
 
@@ -629,11 +628,13 @@ bool LocalStore::upgradeDBSchema(State & state, bool dryRun)
         schemaMigrations.insert(migrationName);
     };
 
-    if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations))
+    if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations)) {
         maybeUpgrade(
             "20251017-ca-derivations",
-#include "ca-specific-schema.sql.gen.hh"
-        );
+            {
+#embed "ca-specific-schema.sql"
+            });
+    }
 
     maybeUpgrade("20260309-drop-redundant-indexreferrer", "drop index if exists IndexReferrer");
 

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -176,40 +176,15 @@ endif
 
 configdata_pub.set('NIX_WITH_AWS_AUTH', s3_aws_auth.enabled().to_int())
 
-subdir('nix-meson-build-support/generate-header')
-
-generated_headers = []
-foreach header : [
-  'schema.sql',
-  'ca-specific-schema.sql',
-]
-  generated_headers += gen_header.process(header)
-endforeach
-
 busybox = find_program(get_option('sandbox-shell'), required : false)
-
-configdata_priv.set(
-  'HAVE_EMBEDDED_SANDBOX_SHELL',
-  get_option('embedded-sandbox-shell').to_int(),
-)
 
 if get_option('embedded-sandbox-shell')
   configdata_priv.set_quoted('SANDBOX_SHELL', '__embedded_sandbox_shell__')
+  configdata_priv.set_quoted('EMBEDDED_SANDBOX_SHELL_PATH', busybox.full_path())
+  configdata_priv.set('HAVE_EMBEDDED_SANDBOX_SHELL', 1)
 elif busybox.found()
   configdata_priv.set_quoted('SANDBOX_SHELL', busybox.full_path())
-endif
-
-if get_option('embedded-sandbox-shell')
-  hexdump = find_program('hexdump', native : true)
-  embedded_sandbox_shell_gen = custom_target(
-    'embedded-sandbox-shell.gen.hh',
-    command : [ hexdump, '-v', '-e', '1/1 "0x%x," "\n"' ],
-    input : busybox.full_path(),
-    output : 'embedded-sandbox-shell.gen.hh',
-    capture : true,
-    feed : true,
-  )
-  generated_headers += embedded_sandbox_shell_gen
+  configdata_priv.set('HAVE_EMBEDDED_SANDBOX_SHELL', 0)
 endif
 
 fs = import('fs')
@@ -391,7 +366,6 @@ subdir('nix-meson-build-support/windows-version')
 
 this_library = library(
   'nixstore',
-  generated_headers,
   sources,
   config_priv_h,
   soversion : nix_soversion,

--- a/src/libutil/include/nix/util/memory-source-accessor.hh
+++ b/src/libutil/include/nix/util/memory-source-accessor.hh
@@ -144,6 +144,10 @@ public:
      */
     File * open(const CanonPath & path, std::optional<File> create);
 
+    /**
+     * @brief Insert a new regular file into with the specified @p contents.
+     * @todo Have a way to insert "borrowed" std::string_view without copying.
+     */
     SourcePath addFile(CanonPath path, std::string && contents);
 };
 

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -219,9 +219,9 @@ struct BuildEnvironment
     }
 };
 
-const static std::string getEnvSh =
-#include "get-env.sh.gen.hh"
-    ;
+static constexpr char getEnvSh[] = {
+#embed "get-env.sh"
+};
 
 /**
  * Given an existing derivation, return the shell environment as
@@ -239,7 +239,7 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
         throw Error("'nix develop' only works on derivations that use 'bash' as their builder");
 
     auto getEnvShPath = ({
-        StringSource source{getEnvSh};
+        StringSource source{std::string_view(getEnvSh, sizeof(getEnvSh))};
         evalStore->addToStoreFromDump(
             source,
             "get-env.sh",

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -257,24 +257,29 @@ static void showHelp(std::vector<std::string> subcommand, NixArgs & toplevel)
     auto vGenerateManpage = state.allocValue();
     state.eval(
         state.parseExprFromString(
-#include "generate-manpage.nix.gen.hh"
-            , state.rootPath(CanonPath::root)),
+            {
+#embed "doc/manual/generate-manpage.nix"
+            },
+            state.rootPath(CanonPath::root)),
         *vGenerateManpage);
 
     state.corepkgsFS->addFile(
         CanonPath("utils.nix"),
-#include "utils.nix.gen.hh"
-    );
+        {
+#embed "doc/manual/utils.nix"
+        });
 
     state.corepkgsFS->addFile(
         CanonPath("/generate-settings.nix"),
-#include "generate-settings.nix.gen.hh"
-    );
+        {
+#embed "doc/manual/generate-settings.nix"
+        });
 
     state.corepkgsFS->addFile(
         CanonPath("/generate-store-info.nix"),
-#include "generate-store-info.nix.gen.hh"
-    );
+        {
+#embed "doc/manual/generate-store-info.nix"
+        });
 
     auto vDump = state.allocValue();
     vDump->mkString(toplevel.dumpCli(), state.mem);
@@ -348,9 +353,9 @@ struct CmdHelpStores : Command
 
     std::string doc() override
     {
-        return
-#include "help-stores.md.gen.hh"
-            ;
+        return {
+#embed "help-stores.md"
+        };
     }
 
     Category category() override

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -134,13 +134,9 @@ if host_machine.system() != 'windows'
 endif
 
 nix_sources += [
-  gen_header.process('doc/manual/generate-manpage.nix'),
-  gen_header.process('doc/manual/generate-settings.nix'),
-  gen_header.process('doc/manual/generate-store-info.nix'),
-  gen_header.process('doc/manual/utils.nix'),
-  gen_header.process('get-env.sh'),
+  # TODO: Get rid of this for good. It's used in profile.md with
+  # string literal concatenation.
   gen_header.process('profiles.md'),
-  gen_header.process('help-stores.md'),
 ]
 
 # The rest of the subdirectories aren't separate components,

--- a/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
@@ -1,17 +1,17 @@
 error:
        … while evaluating the attribute 'outPath'
-         at «nix-internal»/derivation-internal.nix:50:7:
-           49|     value = commonAttrs // {
-           50|       outPath = strict.${outputName};
+         at «nix-internal»/derivation-internal.nix:49:7:
+           48|     value = commonAttrs // {
+           49|       outPath = strict.${outputName};
              |       ^
-           51|       drvPath = strict.drvPath;
+           50|       drvPath = strict.drvPath;
 
        … while calling the 'derivationStrict' builtin
-         at «nix-internal»/derivation-internal.nix:37:12:
-           36|
-           37|   strict = derivationStrict drvAttrs;
+         at «nix-internal»/derivation-internal.nix:36:12:
+           35|
+           36|   strict = derivationStrict drvAttrs;
              |            ^
-           38|
+           37|
 
        … while evaluating derivation 'test'
          whose name attribute is located at /pwd/lang/eval-fail-derivation-structuredAttrs-stack-overflow.nix:5:3


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is now quite widely supported in Clang 19 and GCC 15 (both in 26.05 as the default, other distros too):

See: https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html
See: https://developers.redhat.com/articles/2025/01/30/how-implement-c23-embed-gcc-15

This change also caught a slight positioning bug, because we had UTF8 characters in derivation.nix and position tracking really doesn't work with multi-byte codepoints. It is caught because #embed apparently creates an initialiser list and it's a compile-time error to have narrowing conversions there.

We can also simplify quite a lot of our cli documentation and #embed markdown instead of having weird raw-string-literal-in-a.md-file approach.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

I think we discussed this a couple of months ago when @edolstra brought it up to get rid of our preprocessing hacks.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
