### PR TITLE
Fix crash in restricted store queryRealisationUncached

### DIFF
--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -283,8 +283,10 @@ void RestrictedStore::queryRealisationUncached(
 // XXX: This should probably be allowed if the realisation corresponds to
 // an allowed derivation
 {
-    if (!goal.isAllowed(id))
+    if (!goal.isAllowed(id)) {
         callback(nullptr);
+        return;
+    }
     next->queryRealisation(id, std::move(callback));
 }
 


### PR DESCRIPTION
Ensure the callback is only called once.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Extracted from https://github.com/NixOS/nix/pull/15542

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
