### PR TITLE
docs: replace obsolete nix.dev manual links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -46,7 +46,7 @@ assignees: ''
 - [ ] checked [open bug issues and pull requests] for possible duplicates
 - [ ] reviewed the [contributing guide]
 
-[latest Nix manual]: https://nix.dev/manual/nix/development/
+[latest Nix manual]: https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open bug issues and pull requests]: https://github.com/NixOS/nix/labels/bug
 [contributing guide]: https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -31,7 +31,7 @@ assignees: ''
 - [ ] checked [open feature issues and pull requests] for possible duplicates
 - [ ] reviewed the [contributing guide]
 
-[latest Nix manual]: https://nix.dev/manual/nix/development/
+[latest Nix manual]: https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open feature issues and pull requests]: https://github.com/NixOS/nix/labels/feature
 [contributing guide]: https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

--- a/.github/ISSUE_TEMPLATE/installer.md
+++ b/.github/ISSUE_TEMPLATE/installer.md
@@ -39,7 +39,7 @@ assignees: ''
 - [ ] checked [open installer issues and pull requests] for possible duplicates
 - [ ] reviewed the [contributing guide]
 
-[latest Nix manual]: https://nix.dev/manual/nix/development/
+[latest Nix manual]: https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open installer issues and pull requests]: https://github.com/NixOS/nix/labels/installer
 [contributing guide]: https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

--- a/.github/ISSUE_TEMPLATE/missing_documentation.md
+++ b/.github/ISSUE_TEMPLATE/missing_documentation.md
@@ -23,7 +23,7 @@ assignees: ''
 - [ ] checked [open documentation issues and pull requests] for possible duplicates
 - [ ] reviewed the [contributing guide]
 
-[latest Nix manual]: https://nix.dev/manual/nix/development/
+[latest Nix manual]: https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open documentation issues and pull requests]: https://github.com/NixOS/nix/labels/documentation
 [contributing guide]: https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,9 @@ Check out the [security policy](https://github.com/NixOS/nix/security/policy).
    There are many open pull requests that might already do what you intend to work on.
    You can use [labels](https://github.com/NixOS/nix/labels) to filter for relevant topics.
 
-3. Check the [Nix reference manual](https://nix.dev/manual/nix/development/development/building.html) for information on building Nix and running its tests.
+3. Check the [Nix reference manual](https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/development/building.html) for information on building Nix and running its tests.
 
-   For contributions to the command line interface, please check the [CLI guidelines](https://nix.dev/manual/nix/development/development/cli-guideline.html).
+   For contributions to the command line interface, please check the [CLI guidelines](https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/development/cli-guideline.html).
 
 4. Make your change!
 
@@ -84,7 +84,7 @@ Check out the [security policy](https://github.com/NixOS/nix/security/policy).
    - [ ] API documentation in header files
    - [ ] Code and comments are self-explanatory
    - [ ] Commit message explains **why** the change was made
-   - [ ] New feature or incompatible change: [add a release note](https://nix.dev/manual/nix/development/development/contributing.html#add-a-release-note)
+   - [ ] New feature or incompatible change: [add a release note](https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/development/contributing.html#add-a-release-note)
 
 7. If you need additional feedback or help to getting pull request into shape, ask other contributors using [@mentions](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#mentioning-people-and-teams).
 
@@ -153,7 +153,7 @@ The following situations are fully or partially exempt:
 The Nix reference manual is hosted on https://nix.dev/manual/nix.
 The underlying source files are located in [`doc/manual/source`](./doc/manual/source).
 For small changes you can [use GitHub to edit these files](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files)
-For larger changes see the [Nix reference manual](https://nix.dev/manual/nix/development/development/contributing.html).
+For larger changes see the [Nix reference manual](https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/development/contributing.html).
 
 You're encouraged to add line breaks at semantic boundaries, per [sembr](https://sembr.org).
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Full reference documentation can be found in the [Nix manual](https://nix.dev/re
 
 ## Building and developing
 
-Follow instructions in the Nix reference manual to [set up a development environment and build Nix from source](https://nix.dev/manual/nix/development/development/building.html).
+Follow instructions in the Nix reference manual to [set up a development environment and build Nix from source](https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/development/building.html).
 
 ## Contributing
 

--- a/src/libcmd/include/nix/cmd/common-eval-args.hh
+++ b/src/libcmd/include/nix/cmd/common-eval-args.hh
@@ -83,7 +83,7 @@ private:
 };
 
 /**
- * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary#gloss-base-directory)
+ * @param baseDir Optional [base directory](https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/glossary#gloss-base-directory)
  */
 SourcePath lookupFileArg(EvalState & state, std::string_view s, const std::filesystem::path * baseDir = nullptr);
 

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -92,7 +92,7 @@ struct FlakeRef
 std::ostream & operator<<(std::ostream & str, const FlakeRef & flakeRef);
 
 /**
- * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory)
+ * @param baseDir Optional [base directory](https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/glossary.html#gloss-base-directory)
  */
 FlakeRef parseFlakeRef(
     const fetchers::Settings & fetchSettings,
@@ -103,7 +103,7 @@ FlakeRef parseFlakeRef(
     bool preserveRelativePaths = false);
 
 /**
- * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory)
+ * @param baseDir Optional [base directory](https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/glossary.html#gloss-base-directory)
  */
 std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
     const fetchers::Settings & fetchSettings,
@@ -114,7 +114,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
     bool preserveRelativePaths = false);
 
 /**
- * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory)
+ * @param baseDir Optional [base directory](https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/glossary.html#gloss-base-directory)
  */
 std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragmentAndExtendedOutputsSpec(
     const fetchers::Settings & fetchSettings,

--- a/src/libmain/include/nix/main/common-args.hh
+++ b/src/libmain/include/nix/main/common-args.hh
@@ -82,7 +82,7 @@ struct MixPrintJSON : virtual Args
      * to avoid mistakenly passing an already serialized JSON to this function.
      *
      * It is not recommended to print a JSON string - see the data modeling guidelines
-     * about extensibility, https://nix.dev/manual/nix/development/development/data-modeling.html -
+     * about extensibility, https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/development/data-modeling.html -
      * but you _can_ print a sole JSON string by explicitly coercing it to
      * `nlohmann::json` first.
      */

--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -52,7 +52,7 @@ public:
     }
 
     /**
-     * @brief Get the [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory) for
+     * @brief Get the [base directory](https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/glossary.html#gloss-base-directory) for
      * the command.
      *
      * @return Generally the working directory, but in case of a shebang


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Fix broken and obsolete links.

## Context

The `https://nix.dev/manual/nix/development/` prefix is broken; the development manual now lives under Hydra. Replace all occurrences with the correct base URL.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
