### PR TITLE
libexpr: Properly handle list elements in unstructured attrs

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1539,15 +1539,19 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
         auto key = state.symbols[i->name];
         vomit("processing attribute '%1%'", key);
 
+        // A trace with the derivation's position and name.
+        auto drvTrace = [&]() -> Trace {
+            return {.pos = state.positions[pos], .hint = HintFmt{"while evaluating derivation '%1%'", drvName}};
+        };
+
         // Like `warn`, but with the position of the attribute and the derivation name as an added trace.
         auto warnAttr = [&](HintFmt msg) {
-            ErrorInfo info{
+            logWarning({
                 .level = lvlWarn,
                 .msg = std::move(msg),
                 .pos = state.positions[i->pos],
-            };
-            info.traces.push_back(Trace{.hint = HintFmt{"while evaluating derivation '%1%'", drvName}});
-            logWarning(info);
+                .traces = {drvTrace()},
+            });
         };
 
         auto handleHashMode = [&](const std::string_view s) {
@@ -1697,13 +1701,50 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
                 } else {
                     auto s = state.coerceToString(pos, *i->value, context, context_below, true).toOwned();
 
-                    /* Re-interpret the attribute's value as a list of
-                       strings.
+                    /* Force the attribute's value as a list of strings.
 
-                       We may wish to warn here better future-compat
-                       later, e.g. requiring that it be a list of
-                       strings without spaces to begin with. */
-                    auto forceStringList = [&] { return tokenizeString<Strings>(s); };
+                       For backwards compatability, either a list or a
+                       space-separated string is accepted */
+                    auto forceStringList = [&] {
+                        if (i->value->type() == nList) {
+                            Strings ss;
+                            for (auto elem : i->value->listView()) {
+                                /* An element's own position is only known while
+                                   it is still an unevaluated thunk; grab it
+                                   before forcing. */
+                                auto elemPos = elem->isThunk() ? elem->thunk().expr->getPos() : noPos;
+                                // no need to use the main context because we've already processed this attribute
+                                NixStringContext scratchContext;
+                                auto elemS = state.forceString(*elem, scratchContext, pos, context_below);
+                                auto tokens = tokenizeString<Strings>(elemS);
+                                if (tokens.size() != 1)
+                                    logWarning({
+                                        .level = lvlWarn,
+                                        .msg = HintFmt(
+                                            "the item '%s' in the '%s' attribute list will be split into multiple elements. "
+                                            "This behaviour is deprecated, and may change in a future version of Nix; split into separate list items instead.",
+                                            elemS,
+                                            key),
+                                        /* No fallback: the attribute's position
+                                           is in the trace below already. */
+                                        .pos = elemPos ? std::shared_ptr<const Pos>{state.positions[elemPos]} : nullptr,
+                                        .traces{
+                                            drvTrace(),
+                                            Trace{
+                                                .pos = state.positions[i->pos],
+                                                .hint = HintFmt{"while evaluating the derivation attribute '%s'", key},
+                                            },
+                                        },
+                                    });
+                                ss.splice(ss.end(), tokens);
+                            }
+                            return ss;
+                        }
+                        warnAttr(HintFmt(
+                            "setting the '%s' attribute to a space-separated string is deprecated, and may be disallowed in future versions of Nix. Set it to a list of strings instead.",
+                            key));
+                        return tokenizeString<Strings>(s);
+                    };
 
                     if (i->name == state.s.json) {
                         warnAttr(HintFmt(

--- a/tests/functional/lang/eval-fail-derivationStrict-11.err.exp
+++ b/tests/functional/lang/eval-fail-derivationStrict-11.err.exp
@@ -11,7 +11,7 @@ error:
        … while evaluating attribute 'outputs' of derivation 'foo'
          at /pwd/lang/eval-fail-derivationStrict-11.nix:5:3:
             4|   system = 1;
-            5|   outputs = "drvPath";
+            5|   outputs = [ "drvPath" ];
              |   ^
             6| }
 

--- a/tests/functional/lang/eval-fail-derivationStrict-11.nix
+++ b/tests/functional/lang/eval-fail-derivationStrict-11.nix
@@ -2,5 +2,5 @@ builtins.derivationStrict {
   name = "foo";
   builder = 1;
   system = 1;
-  outputs = "drvPath";
+  outputs = [ "drvPath" ];
 }

--- a/tests/functional/lang/eval-fail-derivationStrict-16.err.exp
+++ b/tests/functional/lang/eval-fail-derivationStrict-16.err.exp
@@ -10,7 +10,7 @@ error:
 
        … while evaluating attribute '__contentAddressed' of derivation 'foo'
          at /pwd/lang/eval-fail-derivationStrict-16.nix:6:3:
-            5|   outputs = "out";
+            5|   outputs = [ "out" ];
             6|   __contentAddressed = "true";
              |   ^
             7| }

--- a/tests/functional/lang/eval-fail-derivationStrict-16.nix
+++ b/tests/functional/lang/eval-fail-derivationStrict-16.nix
@@ -2,6 +2,6 @@ builtins.derivationStrict {
   name = "foo";
   builder = 1;
   system = 1;
-  outputs = "out";
+  outputs = [ "out" ];
   __contentAddressed = "true";
 }

--- a/tests/functional/lang/eval-fail-derivationStrict-17.err.exp
+++ b/tests/functional/lang/eval-fail-derivationStrict-17.err.exp
@@ -10,7 +10,7 @@ error:
 
        … while evaluating attribute '__impure' of derivation 'foo'
          at /pwd/lang/eval-fail-derivationStrict-17.nix:6:3:
-            5|   outputs = "out";
+            5|   outputs = [ "out" ];
             6|   __impure = "true";
              |   ^
             7| }

--- a/tests/functional/lang/eval-fail-derivationStrict-17.nix
+++ b/tests/functional/lang/eval-fail-derivationStrict-17.nix
@@ -2,6 +2,6 @@ builtins.derivationStrict {
   name = "foo";
   builder = 1;
   system = 1;
-  outputs = "out";
+  outputs = [ "out" ];
   __impure = "true";
 }

--- a/tests/functional/lang/eval-fail-derivationStrict-19.err.exp
+++ b/tests/functional/lang/eval-fail-derivationStrict-19.err.exp
@@ -10,7 +10,7 @@ error:
 
        … while evaluating attribute 'args' of derivation 'foo'
          at /pwd/lang/eval-fail-derivationStrict-19.nix:6:3:
-            5|   outputs = "out";
+            5|   outputs = [ "out" ];
             6|   args = "foo";
              |   ^
             7| }

--- a/tests/functional/lang/eval-fail-derivationStrict-19.nix
+++ b/tests/functional/lang/eval-fail-derivationStrict-19.nix
@@ -2,6 +2,6 @@ builtins.derivationStrict {
   name = "foo";
   builder = 1;
   system = 1;
-  outputs = "out";
+  outputs = [ "out" ];
   args = "foo";
 }

--- a/tests/functional/lang/eval-fail-derivationStrict-20.err.exp
+++ b/tests/functional/lang/eval-fail-derivationStrict-20.err.exp
@@ -10,7 +10,7 @@ error:
 
        … while evaluating attribute 'args' of derivation 'foo'
          at /pwd/lang/eval-fail-derivationStrict-20.nix:6:3:
-            5|   outputs = "out";
+            5|   outputs = [ "out" ];
             6|   args = [ { } ];
              |   ^
             7| }

--- a/tests/functional/lang/eval-fail-derivationStrict-20.nix
+++ b/tests/functional/lang/eval-fail-derivationStrict-20.nix
@@ -2,6 +2,6 @@ builtins.derivationStrict {
   name = "foo";
   builder = 1;
   system = 1;
-  outputs = "out";
+  outputs = [ "out" ];
   args = [ { } ];
 }

--- a/tests/functional/lang/eval-fail-derivationStrict-21.err.exp
+++ b/tests/functional/lang/eval-fail-derivationStrict-21.err.exp
@@ -10,7 +10,7 @@ error:
 
        … while evaluating attribute 'args' of derivation 'foo'
          at /pwd/lang/eval-fail-derivationStrict-21.nix:6:3:
-            5|   outputs = "out";
+            5|   outputs = [ "out" ];
             6|   args = [
              |   ^
             7|     "a"

--- a/tests/functional/lang/eval-fail-derivationStrict-21.nix
+++ b/tests/functional/lang/eval-fail-derivationStrict-21.nix
@@ -2,7 +2,7 @@ builtins.derivationStrict {
   name = "foo";
   builder = 1;
   system = 1;
-  outputs = "out";
+  outputs = [ "out" ];
   args = [
     "a"
     { }

--- a/tests/functional/lang/eval-fail-derivationStrict-22.err.exp
+++ b/tests/functional/lang/eval-fail-derivationStrict-22.err.exp
@@ -10,7 +10,7 @@ error:
 
        … while evaluating attribute 'FOO' of derivation 'foo'
          at /pwd/lang/eval-fail-derivationStrict-22.nix:6:3:
-            5|   outputs = "out";
+            5|   outputs = [ "out" ];
             6|   FOO = { };
              |   ^
             7| }

--- a/tests/functional/lang/eval-fail-derivationStrict-22.nix
+++ b/tests/functional/lang/eval-fail-derivationStrict-22.nix
@@ -2,6 +2,6 @@ builtins.derivationStrict {
   name = "foo";
   builder = 1;
   system = 1;
-  outputs = "out";
+  outputs = [ "out" ];
   FOO = { };
 }

--- a/tests/functional/lang/eval-okay-derivation-outputs-list-spaces.err.exp
+++ b/tests/functional/lang/eval-okay-derivation-outputs-list-spaces.err.exp
@@ -1,0 +1,11 @@
+warning:
+         … while evaluating derivation 'eval-okay-derivation-outputs-list-spaces'
+
+         … while evaluating the derivation attribute 'outputs'
+           at /pwd/lang/eval-okay-derivation-outputs-list-spaces.nix:6:3:
+              5|   builder = "/dontcare";
+              6|   outputs = [
+               |   ^
+              7|     "out dev"
+
+         warning: the item 'out dev' in the 'outputs' attribute list will be split into multiple elements. This behaviour is deprecated, and may change in a future version of Nix; split into separate list items instead.

--- a/tests/functional/lang/eval-okay-derivation-outputs-list-spaces.exp
+++ b/tests/functional/lang/eval-okay-derivation-outputs-list-spaces.exp
@@ -1,0 +1,1 @@
+"/nix/store/4qb1r2klrqb5hhvla0fbqvkjacxqgziw-eval-okay-derivation-outputs-list-spaces"

--- a/tests/functional/lang/eval-okay-derivation-outputs-list-spaces.nix
+++ b/tests/functional/lang/eval-okay-derivation-outputs-list-spaces.nix
@@ -1,0 +1,10 @@
+# Intentionally exercises the deprecated splitting of `outputs` list items that contain spaces
+(builtins.derivationStrict {
+  name = "eval-okay-derivation-outputs-list-spaces";
+  system = "x86_64-linux";
+  builder = "/dontcare";
+  outputs = [
+    "out dev"
+    "bin"
+  ];
+}).out

--- a/tests/functional/lang/eval-okay-derivation-outputs-string.err.exp
+++ b/tests/functional/lang/eval-okay-derivation-outputs-string.err.exp
@@ -1,0 +1,9 @@
+warning:
+         … while evaluating derivation 'eval-okay-derivation-outputs-string'
+
+         warning: setting the 'outputs' attribute to a space-separated string is deprecated, and may be disallowed in future versions of Nix. Set it to a list of strings instead.
+         at /pwd/lang/eval-okay-derivation-outputs-string.nix:6:3:
+              5|   builder = "/dontcare";
+              6|   outputs = "out dev";
+               |   ^
+              7| }).out

--- a/tests/functional/lang/eval-okay-derivation-outputs-string.exp
+++ b/tests/functional/lang/eval-okay-derivation-outputs-string.exp
@@ -1,0 +1,1 @@
+"/nix/store/alg18dpspa2shljcfgm549p6wpbgk9gw-eval-okay-derivation-outputs-string"

--- a/tests/functional/lang/eval-okay-derivation-outputs-string.nix
+++ b/tests/functional/lang/eval-okay-derivation-outputs-string.nix
@@ -1,0 +1,7 @@
+# Intentionally exercises the deprecated space-separated-string form of `outputs`
+(builtins.derivationStrict {
+  name = "eval-okay-derivation-outputs-string";
+  system = "x86_64-linux";
+  builder = "/dontcare";
+  outputs = "out dev";
+}).out

--- a/tests/functional/lang/eval-okay-derivation-required-system-features-list-spaces.err.exp
+++ b/tests/functional/lang/eval-okay-derivation-required-system-features-list-spaces.err.exp
@@ -1,0 +1,11 @@
+warning:
+         … while evaluating derivation 'eval-okay-derivation-required-system-features-list-spaces'
+
+         … while evaluating the derivation attribute 'requiredSystemFeatures'
+           at /pwd/lang/eval-okay-derivation-required-system-features-list-spaces.nix:6:3:
+              5|   builder = "/dontcare";
+              6|   requiredSystemFeatures = [
+               |   ^
+              7|     "foo bar"
+
+         warning: the item 'foo bar' in the 'requiredSystemFeatures' attribute list will be split into multiple elements. This behaviour is deprecated, and may change in a future version of Nix; split into separate list items instead.

--- a/tests/functional/lang/eval-okay-derivation-required-system-features-list-spaces.exp
+++ b/tests/functional/lang/eval-okay-derivation-required-system-features-list-spaces.exp
@@ -1,0 +1,1 @@
+"/nix/store/0xddyqq7idjnf71ayqmqrg35z5vskryr-eval-okay-derivation-required-system-features-list-spaces"

--- a/tests/functional/lang/eval-okay-derivation-required-system-features-list-spaces.flags
+++ b/tests/functional/lang/eval-okay-derivation-required-system-features-list-spaces.flags
@@ -1,0 +1,1 @@
+--extra-experimental-features dynamic-derivations

--- a/tests/functional/lang/eval-okay-derivation-required-system-features-list-spaces.nix
+++ b/tests/functional/lang/eval-okay-derivation-required-system-features-list-spaces.nix
@@ -1,0 +1,10 @@
+# Intentionally exercises the deprecated splitting of `requiredSystemFeatures` list items that contain spaces
+(builtins.derivationStrict {
+  name = "eval-okay-derivation-required-system-features-list-spaces";
+  system = "x86_64-linux";
+  builder = "/dontcare";
+  requiredSystemFeatures = [
+    "foo bar"
+    "baz"
+  ];
+}).out

--- a/tests/functional/lang/eval-okay-derivation-required-system-features-string.err.exp
+++ b/tests/functional/lang/eval-okay-derivation-required-system-features-string.err.exp
@@ -1,0 +1,9 @@
+warning:
+         … while evaluating derivation 'eval-okay-derivation-required-system-features-string'
+
+         warning: setting the 'requiredSystemFeatures' attribute to a space-separated string is deprecated, and may be disallowed in future versions of Nix. Set it to a list of strings instead.
+         at /pwd/lang/eval-okay-derivation-required-system-features-string.nix:6:3:
+              5|   builder = "/dontcare";
+              6|   requiredSystemFeatures = "foo bar";
+               |   ^
+              7| }).out

--- a/tests/functional/lang/eval-okay-derivation-required-system-features-string.exp
+++ b/tests/functional/lang/eval-okay-derivation-required-system-features-string.exp
@@ -1,0 +1,1 @@
+"/nix/store/1czc8bgnz14lllyiixn07b00parnx5bf-eval-okay-derivation-required-system-features-string"

--- a/tests/functional/lang/eval-okay-derivation-required-system-features-string.flags
+++ b/tests/functional/lang/eval-okay-derivation-required-system-features-string.flags
@@ -1,0 +1,1 @@
+--extra-experimental-features dynamic-derivations

--- a/tests/functional/lang/eval-okay-derivation-required-system-features-string.nix
+++ b/tests/functional/lang/eval-okay-derivation-required-system-features-string.nix
@@ -1,0 +1,7 @@
+# Intentionally exercises the deprecated space-separated-string form of `requiredSystemFeatures`
+(builtins.derivationStrict {
+  name = "eval-okay-derivation-required-system-features-string";
+  system = "x86_64-linux";
+  builder = "/dontcare";
+  requiredSystemFeatures = "foo bar";
+}).out


### PR DESCRIPTION
## Motivation

In the non-`__structuredAttrs` code path, Nix was concatenating lists to strings and then re-tokenizing them, which does not necessarily reproduce the original list elements. Rework the `forceStringList` helper from the previous commit (used for `outputs` and `requiredSystemFeatures`) to do this right, processing list elements individually.

Cases to warn on:

1. `"foo bar"`, which should be `["foo" "bar"]`

   The value should be a list of strings instead, as it is with `__structuredAttrs`. The old string form still works, but emits a deprecation warning (in the same vein as the `__json` check), and may be disallowed in future versions of Nix.

2. `["foo bar" "baz"]`, which should be `["foo" "bar" "baz"]`

   Additionally, warn when an item *within* the list itself contains a space. Such values are joined with spaces into the environment and re-tokenized on the build side, so `[ "out a" "b" ]` currently behaves the same as `[ "out" "a" "b" ]`.

Both warnings live in the shared `forceStringList` helper, which can be reused for other space-separated list attributes of a derivation.

## Context

The warnings carry the best position information available: the string-form warning points at the attribute, while the per-item warning points at the offending list element when its position is known (only the case while the element is still an unevaluated thunk — string literals carry no position), plus traces for the attribute and for the derivation as a whole. To support this, the derivation trace that `warnAttr` appended is factored out into a `drvTrace` helper, so warnings can be assembled declaratively; it now also records the derivation's position.

Tests:

* The `eval-fail-derivationStrict-*` fixtures that used the string form incidentally are converted to the list form, so they keep testing their original failure modes without picking up the new warning.

* New `eval-okay-derivation-*` tests intentionally exercise the deprecated forms — the space-separated string and the list item containing a space — for both `outputs` and (with `dynamic-derivations` enabled) `requiredSystemFeatures`, pinning the warning text and that evaluation still succeeds.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
