### PR TITLE
fix: Respect parent's `log-format` in `startProcess`

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -712,6 +712,14 @@ public:
     {
         this->printBuildLogs = printBuildLogs;
     }
+
+    std::unique_ptr<Logger> cloneForChild() const override
+    {
+        /* We own a background thread and terminal state that cannot be
+           safely inherited or reconstructed across a fork; fall back
+           to a plain logger in the child. */
+        return makeSimpleLogger(printBuildLogs);
+    }
 };
 
 } // namespace

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -182,6 +182,13 @@ struct TunnelLogger : public Logger
         buf << STDERR_RESULT << act << type << fields;
         enqueueMsg(buf.s);
     }
+
+    std::unique_ptr<Logger> cloneForChild() const override
+    {
+        /* We reference the daemon connection's sink, which isn't
+           meaningful to keep writing to from a forked child. */
+        return makeSimpleLogger();
+    }
 };
 
 struct TunnelSource : BufferedSource

--- a/src/libutil-test-support/include/nix/util/tests/capture-logging.hh
+++ b/src/libutil-test-support/include/nix/util/tests/capture-logging.hh
@@ -27,6 +27,12 @@ public:
     {
         showErrorInfo(oss, ei, loggerSettings.showTrace.get());
     }
+
+    std::unique_ptr<Logger> cloneForChild() const override
+    {
+        /* Not expected to be forked across; a plain logger is fine. */
+        return makeSimpleLogger();
+    }
 };
 
 class CaptureLogging

--- a/src/libutil-tests/processes.cc
+++ b/src/libutil-tests/processes.cc
@@ -1,6 +1,13 @@
 #include "nix/util/processes.hh"
+#include "nix/util/logging.hh"
+#include "nix/util/file-descriptor.hh"
+#include "nix/util/finally.hh"
 
 #include <gtest/gtest.h>
+
+#ifndef _WIN32
+#  include <unistd.h>
+#endif
 
 namespace nix {
 
@@ -13,5 +20,44 @@ TEST(statusOk, zeroIsOk)
     ASSERT_EQ(statusOk(0), true);
     ASSERT_EQ(statusOk(1), false);
 }
+
+#ifndef _WIN32
+/* ----------------------------------------------------------------------------
+ * startProcess -- forked children inherit the parent's log format
+ * --------------------------------------------------------------------------*/
+
+TEST(startProcess, forkedChildPreservesLogFormat)
+{
+    /* Regression test: `startProcess()` used to unconditionally reset
+       the child's logger to a plain `SimpleLogger`, discarding
+       whatever format (e.g. JSON) the parent had configured. It should
+       instead clone the parent's logger via `Logger::cloneForChild()`. */
+    auto prevLogger = logger;
+    Finally restoreLogger([&] { logger = prevLogger; });
+
+    Pipe pipe;
+    pipe.create();
+
+    logger = makeJSONLogger(pipe.writeSide.get(), /*includeNixPrefix=*/true).release();
+
+    ProcessOptions options;
+    options.allowVfork = false;
+
+    Pid pid = startProcess(
+        [&] {
+            logger->log(lvlInfo, "hello from child");
+            _exit(0);
+        },
+        options);
+
+    pipe.writeSide.close();
+    int status = pid.wait();
+    ASSERT_TRUE(statusOk(status));
+
+    auto output = readFile(pipe.readSide.get());
+    ASSERT_TRUE(output.starts_with("@nix "));
+    ASSERT_NE(output.find("hello from child"), std::string::npos);
+}
+#endif
 
 } // namespace nix

--- a/src/libutil/include/nix/util/logging.hh
+++ b/src/libutil/include/nix/util/logging.hh
@@ -176,6 +176,17 @@ public:
     }
 
     virtual void setPrintBuildLogs(bool printBuildLogs) {}
+
+    /**
+     * Create a fresh logger to install in a child process just after
+     * `fork()`. Loggers that can be faithfully reconstructed (e.g. a
+     * JSON logger writing to a file descriptor) should return another
+     * logger of the same kind. Loggers that own resources which cannot
+     * be safely inherited or reconstructed across a fork (e.g.
+     * background threads) must return something simpler instead, such
+     * as `makeSimpleLogger()`.
+     */
+    virtual std::unique_ptr<Logger> cloneForChild() const = 0;
 };
 
 /**

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -154,6 +154,11 @@ public:
             printError("post-build-hook: " + lastLine);
         }
     }
+
+    std::unique_ptr<Logger> cloneForChild() const override
+    {
+        return makeSimpleLogger(printBuildLogs);
+    }
 };
 
 } // namespace
@@ -352,6 +357,11 @@ struct JSONLogger : Logger
         json["type"] = type;
         addFields(json, fields);
         write(json);
+    }
+
+    std::unique_ptr<Logger> cloneForChild() const override
+    {
+        return std::make_unique<JSONLogger>(fd, includeNixPrefix);
     }
 };
 

--- a/src/libutil/tee-logger.cc
+++ b/src/libutil/tee-logger.cc
@@ -95,6 +95,14 @@ public:
         for (auto & logger : loggers)
             logger->setPrintBuildLogs(printBuildLogs);
     }
+
+    std::unique_ptr<Logger> cloneForChild() const override
+    {
+        std::vector<std::unique_ptr<Logger>> cloned;
+        for (auto & logger : loggers)
+            cloned.push_back(logger->cloneForChild());
+        return std::make_unique<TeeLogger>(std::move(cloned));
+    }
 };
 
 } // namespace

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -236,13 +236,14 @@ static int childEntry(void * arg)
 
 pid_t startProcess(fun<void()> processMain, const ProcessOptions & options)
 {
-    auto newLogger = makeSimpleLogger().release();
+    auto newLogger = logger->cloneForChild().release();
     ChildWrapperFunction wrapper = [&] {
         if (!options.allowVfork) {
-            /* Set a simple logger, while leaking (not destroying)
-               the parent logger. We don't want to run the parent
-               logger's destructor since that will crash (e.g. when
-               ~ProgressBar() tries to join a thread that doesn't
+            /* Install a fresh logger of the same kind as the parent's
+               (see `Logger::cloneForChild()`), while leaking (not
+               destroying) the parent logger. We don't want to run the
+               parent logger's destructor since that will crash (e.g.
+               when ~ProgressBar() tries to join a thread that doesn't
                exist. */
             logger = newLogger;
         }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->
Disclaimer: This PR was assisted by Claude Sonnet 5

## Motivation

`startProcess` unconditionally overwrites the existing logger with `makeSimpleLogger`--not respecting the `log-format` setting in the parent process. It is difficult to produce actual issues with `nix` alone, but this manifests clearly in `nix-eval-jobs` workers.

## Context

<!-- Provide context. Reference open issues if available. -->

Upstream fix for https://github.com/NixOS/nix-eval-jobs/pull/431.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
