### PR TITLE
libexpr: Give better warning messages for derivation attributes

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1536,6 +1536,17 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
         auto key = state.symbols[i->name];
         vomit("processing attribute '%1%'", key);
 
+        // Like `warn`, but with the position of the attribute and the derivation name as an added trace.
+        auto warnAttr = [&](HintFmt msg) {
+            ErrorInfo info{
+                .level = lvlWarn,
+                .msg = std::move(msg),
+                .pos = state.positions[i->pos],
+            };
+            info.traces.push_back(Trace{.hint = HintFmt{"while evaluating derivation '%1%'", drvName}});
+            logWarning(info);
+        };
+
         auto handleHashMode = [&](const std::string_view s) {
             if (s == "recursive") {
                 // back compat, new name is "nar"
@@ -1651,34 +1662,14 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
 
                     switch (i->name.getId()) {
                     case EvalState::s.allowedReferences.getId():
-                        warn(
-                            "In a derivation named '%s', 'structuredAttrs' disables the effect of the derivation attribute 'allowedReferences'; use 'outputChecks.<output>.allowedReferences' instead",
-                            drvName);
-                        break;
                     case EvalState::s.allowedRequisites.getId():
-                        warn(
-                            "In a derivation named '%s', 'structuredAttrs' disables the effect of the derivation attribute 'allowedRequisites'; use 'outputChecks.<output>.allowedRequisites' instead",
-                            drvName);
-                        break;
                     case EvalState::s.disallowedReferences.getId():
-                        warn(
-                            "In a derivation named '%s', 'structuredAttrs' disables the effect of the derivation attribute 'disallowedReferences'; use 'outputChecks.<output>.disallowedReferences' instead",
-                            drvName);
-                        break;
                     case EvalState::s.disallowedRequisites.getId():
-                        warn(
-                            "In a derivation named '%s', 'structuredAttrs' disables the effect of the derivation attribute 'disallowedRequisites'; use 'outputChecks.<output>.disallowedRequisites' instead",
-                            drvName);
-                        break;
                     case EvalState::s.maxSize.getId():
-                        warn(
-                            "In a derivation named '%s', 'structuredAttrs' disables the effect of the derivation attribute 'maxSize'; use 'outputChecks.<output>.maxSize' instead",
-                            drvName);
-                        break;
                     case EvalState::s.maxClosureSize.getId():
-                        warn(
-                            "In a derivation named '%s', 'structuredAttrs' disables the effect of the derivation attribute 'maxClosureSize'; use 'outputChecks.<output>.maxClosureSize' instead",
-                            drvName);
+                        warnAttr(HintFmt(
+                            "'structuredAttrs' disables the effect of the derivation attribute '%1%'; use 'outputChecks.<output>.%1%' instead",
+                            key));
                         break;
                     default:
                         break;
@@ -1687,9 +1678,8 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
                 } else {
                     auto s = state.coerceToString(pos, *i->value, context, context_below, true).toOwned();
                     if (i->name == state.s.json) {
-                        warn(
-                            "In derivation '%s': setting structured attributes via '__json' is deprecated, and may be disallowed in future versions of Nix. Set '__structuredAttrs = true' instead.",
-                            drvName);
+                        warnAttr(HintFmt(
+                            "setting structured attributes via '__json' is deprecated, and may be disallowed in future versions of Nix. Set '__structuredAttrs = true' instead."));
                         drv.structuredAttrs = StructuredAttrs::parse(s);
                     } else {
                         drv.env.emplace(key, s);

--- a/tests/functional/lang/eval-okay-derivation-legacy.err.exp
+++ b/tests/functional/lang/eval-okay-derivation-legacy.err.exp
@@ -1,6 +1,54 @@
-warning: In a derivation named 'eval-okay-derivation-legacy', 'structuredAttrs' disables the effect of the derivation attribute 'allowedReferences'; use 'outputChecks.<output>.allowedReferences' instead
-warning: In a derivation named 'eval-okay-derivation-legacy', 'structuredAttrs' disables the effect of the derivation attribute 'allowedRequisites'; use 'outputChecks.<output>.allowedRequisites' instead
-warning: In a derivation named 'eval-okay-derivation-legacy', 'structuredAttrs' disables the effect of the derivation attribute 'disallowedReferences'; use 'outputChecks.<output>.disallowedReferences' instead
-warning: In a derivation named 'eval-okay-derivation-legacy', 'structuredAttrs' disables the effect of the derivation attribute 'disallowedRequisites'; use 'outputChecks.<output>.disallowedRequisites' instead
-warning: In a derivation named 'eval-okay-derivation-legacy', 'structuredAttrs' disables the effect of the derivation attribute 'maxClosureSize'; use 'outputChecks.<output>.maxClosureSize' instead
-warning: In a derivation named 'eval-okay-derivation-legacy', 'structuredAttrs' disables the effect of the derivation attribute 'maxSize'; use 'outputChecks.<output>.maxSize' instead
+warning:
+         … while evaluating derivation 'eval-okay-derivation-legacy'
+
+         warning: 'structuredAttrs' disables the effect of the derivation attribute 'allowedReferences'; use 'outputChecks.<output>.allowedReferences' instead
+         at /pwd/lang/eval-okay-derivation-legacy.nix:6:3:
+              5|   __structuredAttrs = true;
+              6|   allowedReferences = [ ];
+               |   ^
+              7|   disallowedReferences = [ ];
+warning:
+         … while evaluating derivation 'eval-okay-derivation-legacy'
+
+         warning: 'structuredAttrs' disables the effect of the derivation attribute 'allowedRequisites'; use 'outputChecks.<output>.allowedRequisites' instead
+         at /pwd/lang/eval-okay-derivation-legacy.nix:8:3:
+              7|   disallowedReferences = [ ];
+              8|   allowedRequisites = [ ];
+               |   ^
+              9|   disallowedRequisites = [ ];
+warning:
+         … while evaluating derivation 'eval-okay-derivation-legacy'
+
+         warning: 'structuredAttrs' disables the effect of the derivation attribute 'disallowedReferences'; use 'outputChecks.<output>.disallowedReferences' instead
+         at /pwd/lang/eval-okay-derivation-legacy.nix:7:3:
+              6|   allowedReferences = [ ];
+              7|   disallowedReferences = [ ];
+               |   ^
+              8|   allowedRequisites = [ ];
+warning:
+         … while evaluating derivation 'eval-okay-derivation-legacy'
+
+         warning: 'structuredAttrs' disables the effect of the derivation attribute 'disallowedRequisites'; use 'outputChecks.<output>.disallowedRequisites' instead
+         at /pwd/lang/eval-okay-derivation-legacy.nix:9:3:
+              8|   allowedRequisites = [ ];
+              9|   disallowedRequisites = [ ];
+               |   ^
+             10|   maxSize = 1234;
+warning:
+         … while evaluating derivation 'eval-okay-derivation-legacy'
+
+         warning: 'structuredAttrs' disables the effect of the derivation attribute 'maxClosureSize'; use 'outputChecks.<output>.maxClosureSize' instead
+         at /pwd/lang/eval-okay-derivation-legacy.nix:11:3:
+             10|   maxSize = 1234;
+             11|   maxClosureSize = 12345;
+               |   ^
+             12| }).out
+warning:
+         … while evaluating derivation 'eval-okay-derivation-legacy'
+
+         warning: 'structuredAttrs' disables the effect of the derivation attribute 'maxSize'; use 'outputChecks.<output>.maxSize' instead
+         at /pwd/lang/eval-okay-derivation-legacy.nix:10:3:
+              9|   disallowedRequisites = [ ];
+             10|   maxSize = 1234;
+               |   ^
+             11|   maxClosureSize = 12345;

--- a/tests/functional/structured-attrs.sh
+++ b/tests/functional/structured-attrs.sh
@@ -41,7 +41,7 @@ test "$(<<<"$jsonOut" jq '.variables.outputs.value.out' -r)" = "$(<<<"$jsonOut" 
 hackyExpr='derivation { name = "a"; system = "foo"; builder = "/bin/sh"; __json = builtins.toJSON { a = 1; }; }'
 
 # Check for deprecation message
-expectStderr 0 nix-instantiate --expr "$hackyExpr" --eval --strict | grepQuiet "In derivation 'a': setting structured attributes via '__json' is deprecated, and may be disallowed in future versions of Nix. Set '__structuredAttrs = true' instead."
+expectStderr 0 nix-instantiate --expr "$hackyExpr" --eval --strict | grepQuiet "setting structured attributes via '__json' is deprecated, and may be disallowed in future versions of Nix. Set '__structuredAttrs = true' instead."
 
 # Check it works with the expected structured attrs
 hacky=$(nix-instantiate --expr "$hackyExpr")


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The previous code had excessive message duplication yet did not include the line of the attribute.
Replace with a new `warnAttr` closure to simplify.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
