### PR TITLE
cli(flake update): add flag to exclude inputs

### DIFF
--- a/doc/manual/rl-next/flake-update-exclude-inputs.md
+++ b/doc/manual/rl-next/flake-update-exclude-inputs.md
@@ -1,0 +1,11 @@
+---
+synopsis: The `flake update` command now has a `--exclude` flag to exclude inputs from an update.
+issues: 10215
+prs: 16189
+---
+
+Use the new flag with to update all inputs except for the specified ones (effectively switches from whitelist to blacklist):
+
+```shell
+nix flake update -x nixpkgs home-manager
+```

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -117,7 +117,7 @@ MixFlakeOptions::MixFlakeOptions()
             if (!path)
                 throw UsageError(
                     "--update-input was passed a zero-length input path, which would refer to the flake itself, not an input");
-            lockFlags.inputUpdates.insert(*path);
+            lockFlags.inputSpec.insert(*path);
         }},
         .completer = {[&](AddCompletions & completions, size_t, std::string_view prefix) {
             completeFlakeInputAttrPath(completions, getEvalState(), getFlakeRefsForCompletion(), prefix);

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -600,12 +600,15 @@ LockedFlake lockFlake(
                     };
 
                     /* Do we have an entry in the existing lock file?
-                       And the input is not in inputSpec? */
+                       And the input is not excluded? */
                     std::shared_ptr<LockedNode> oldLock;
 
                     updatesUsed.insert(inputAttrPath);
 
-                    if (oldNode && !lockFlags.inputSpec.count(nonEmptyInputAttrPath))
+                    bool listed = lockFlags.inputSpec.count(nonEmptyInputAttrPath);
+                    auto keepOldLock = lockFlags.exclude ? listed : !listed;
+
+                    if (oldNode && keepOldLock)
                         if (auto oldLock2 = get(oldNode->inputs, id))
                             if (auto oldLock3 = std::get_if<0>(&*oldLock2))
                                 oldLock = *oldLock3;
@@ -622,12 +625,16 @@ LockedFlake lockFlake(
 
                         node->inputs.insert_or_assign(id, childNode);
 
-                        /* If we have this input in inputSpec, then we
-                           must fetch the flake to update it. */
-                        auto lb = lockFlags.inputSpec.lower_bound(nonEmptyInputAttrPath);
+                        bool mustRefetch = false;
 
-                        auto mustRefetch = lb != lockFlags.inputSpec.end() && lb->get().size() > inputAttrPath.size()
-                                           && std::equal(inputAttrPath.begin(), inputAttrPath.end(), lb->get().begin());
+                        if (!lockFlags.exclude) {
+                            /* If we have this input in inputSpec, then we
+                           must fetch the flake to update it. */
+                            auto lb = lockFlags.inputSpec.lower_bound(nonEmptyInputAttrPath);
+
+                            mustRefetch = lb != lockFlags.inputSpec.end() && lb->get().size() > inputAttrPath.size()
+                                          && std::equal(inputAttrPath.begin(), inputAttrPath.end(), lb->get().begin());
+                        }
 
                         FlakeInputs fakeInputs;
 

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -600,12 +600,12 @@ LockedFlake lockFlake(
                     };
 
                     /* Do we have an entry in the existing lock file?
-                       And the input is not in updateInputs? */
+                       And the input is not in inputSpec? */
                     std::shared_ptr<LockedNode> oldLock;
 
                     updatesUsed.insert(inputAttrPath);
 
-                    if (oldNode && !lockFlags.inputUpdates.count(nonEmptyInputAttrPath))
+                    if (oldNode && !lockFlags.inputSpec.count(nonEmptyInputAttrPath))
                         if (auto oldLock2 = get(oldNode->inputs, id))
                             if (auto oldLock3 = std::get_if<0>(&*oldLock2))
                                 oldLock = *oldLock3;
@@ -622,11 +622,11 @@ LockedFlake lockFlake(
 
                         node->inputs.insert_or_assign(id, childNode);
 
-                        /* If we have this input in updateInputs, then we
+                        /* If we have this input in inputSpec, then we
                            must fetch the flake to update it. */
-                        auto lb = lockFlags.inputUpdates.lower_bound(nonEmptyInputAttrPath);
+                        auto lb = lockFlags.inputSpec.lower_bound(nonEmptyInputAttrPath);
 
-                        auto mustRefetch = lb != lockFlags.inputUpdates.end() && lb->get().size() > inputAttrPath.size()
+                        auto mustRefetch = lb != lockFlags.inputSpec.end() && lb->get().size() > inputAttrPath.size()
                                            && std::equal(inputAttrPath.begin(), inputAttrPath.end(), lb->get().begin());
 
                         FlakeInputs fakeInputs;
@@ -787,7 +787,7 @@ LockedFlake lockFlake(
                     printInputAttrPath(i.first),
                     i.second);
 
-        for (auto & i : lockFlags.inputUpdates)
+        for (auto & i : lockFlags.inputSpec)
             if (!updatesUsed.count(i))
                 warn("'%s' does not match any input of this flake", printInputAttrPath(i));
 

--- a/src/libflake/include/nix/flake/flake.hh
+++ b/src/libflake/include/nix/flake/flake.hh
@@ -208,10 +208,15 @@ struct LockFlags
     std::map<NonEmptyInputAttrPath, FlakeRef> inputOverrides;
 
     /**
-     * Flake inputs to be updated. This means that any existing lock
-     * for those inputs will be ignored.
+     * Inputs specified to be updated or excluded. If exclude is true, then any existing locks for these inputs will be
+     * respected. If exclude is false, then any existing locks will be ignored.
      */
-    std::set<NonEmptyInputAttrPath> inputUpdates;
+    std::set<NonEmptyInputAttrPath> inputSpec;
+
+    /**
+     * Update all inputs except for the specified ones.
+     */
+    bool exclude = false;
 };
 
 /*

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -647,7 +647,7 @@ struct CmdDevelop : Common, MixEnvironment
 
             auto nixpkgsLockFlags = lockFlags;
             nixpkgsLockFlags.inputOverrides = {};
-            nixpkgsLockFlags.inputUpdates = {};
+            nixpkgsLockFlags.inputSpec = {};
 
             auto nixpkgs = defaultNixpkgsFlakeRef();
             if (auto * i = dynamic_cast<const InstallableFlake *>(&*installable))

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -86,6 +86,12 @@ public:
                 completeFlakeRef(completions, getStore(), prefix);
             }},
         });
+        addFlag({
+            .longName = "exclude",
+            .shortName = 'x',
+            .description = "Update all inputs except the specified ones.",
+            .handler = {&lockFlags.exclude, true},
+        });
         expectArgs({
             .label = "inputs",
             .optional = true,
@@ -96,7 +102,7 @@ public:
                         inputAttrPath = flake::NonEmptyInputAttrPath::parse(inputToUpdate);
                         if (!inputAttrPath)
                             throw UsageError(
-                                "input path to be updated cannot be zero-length; it would refer to the flake itself, not an input");
+                                "input path cannot be zero-length; it would refer to the flake itself, not an input");
                     } catch (Error & e) {
                         warn(
                             "Invalid flake input '%s'. To update a specific flake, use 'nix flake update --flake %s' instead.",
@@ -104,11 +110,11 @@ public:
                             inputToUpdate);
                         throw e;
                     }
-                    if (lockFlags.inputUpdates.contains(*inputAttrPath))
+                    if (lockFlags.inputSpec.contains(*inputAttrPath))
                         warn(
                             "Input '%s' was specified multiple times. You may have done this by accident.",
                             printInputAttrPath(*inputAttrPath));
-                    lockFlags.inputUpdates.insert(*inputAttrPath);
+                    lockFlags.inputSpec.insert(*inputAttrPath);
                 }
             }},
             .completer = {[&](AddCompletions & completions, size_t, std::string_view prefix) {
@@ -131,7 +137,7 @@ public:
     void run(nix::ref<nix::Store> store) override
     {
         fetchSettings.tarballTtl = 0;
-        auto updateAll = lockFlags.inputUpdates.empty();
+        auto updateAll = lockFlags.inputSpec.empty();
 
         lockFlags.recreateLockFile = updateAll;
         lockFlags.writeLockFile = true;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I often find, when making updates to my NixOS configuration, I want to temporarily pin one or more inputs to whatever hash they happen to currently be on, often as a troubleshooting measure. I _could_ inspect the lockfile, get the rev, and then adjust the input in flake.nix to pin to that, but oftentimes what I go with instead is updating everything, viewing the list of updated inputs, rolling back, then manually providing the list of everything _but_ what I want to exclude. Either of these options are cumbersome.

I figure, alongside the existing whitelist option, a blacklist makes sense as well.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Closes #10215.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
