### PR TITLE
Don't run OPENSSL_cleanup() on exit

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -6,6 +6,7 @@
 #include <array>
 #include <cctype>
 
+#include <openssl/crypto.h>
 #include <sodium.h>
 #include <boost/lexical_cast.hpp>
 #include <stdint.h>
@@ -22,6 +23,10 @@ bad_ref_cast::~bad_ref_cast() {}
 
 void initLibUtil()
 {
+    static std::atomic_flag done = ATOMIC_FLAG_INIT;
+    if (done.test_and_set())
+        return;
+
     // Check that exception handling works. Exception handling has been observed
     // not to work on darwin when the linker flags aren't quite right.
     // In this case we don't want to expose the user to some unrelated uncaught
@@ -43,6 +48,21 @@ void initLibUtil()
 
     if (sodium_init() == -1)
         throw Error("could not initialise libsodium");
+
+    /* Prevent OpenSSL from registering its atexit() handler
+       (OPENSSL_cleanup()). If we exit() while other threads that use
+       OpenSSL are still running, OPENSSL_cleanup() frees OpenSSL's
+       thread-local state handlers; when those threads then exit, their
+       thread-specific-data destructors (init_thread_stop()) crash on
+       the freed state. This happens in particular in nix-daemon
+       connection children, where library destructors run by _dl_fini()
+       (e.g. aws-crt-cpp's) stop their worker threads *after*
+       OPENSSL_cleanup() has already run. Since we're exiting anyway,
+       skipping the cleanup is harmless. This must run before any other
+       use of OpenSSL, since only the first initialisation takes
+       effect. */
+    if (OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, nullptr) != 1)
+        throw Error("could not initialise OpenSSL");
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cctype>
+#include <mutex>
 
 #include <openssl/crypto.h>
 #include <sodium.h>
@@ -23,46 +24,45 @@ bad_ref_cast::~bad_ref_cast() {}
 
 void initLibUtil()
 {
-    static std::atomic_flag done = ATOMIC_FLAG_INIT;
-    if (done.test_and_set())
-        return;
+    static std::once_flag done;
+    std::call_once(done, []() {
+        // Check that exception handling works. Exception handling has been observed
+        // not to work on darwin when the linker flags aren't quite right.
+        // In this case we don't want to expose the user to some unrelated uncaught
+        // exception, but rather tell them exactly that exception handling is
+        // broken.
+        // When exception handling fails, the message tends to be printed by the
+        // C++ runtime, followed by an abort.
+        // For example on macOS we might see an error such as
+        // libc++abi: terminating with uncaught exception of type nix::SystemError: error: C++ exception handling is
+        // broken. This would appear to be a problem with the way Nix was compiled and/or linked and/or loaded.
+        bool caught = false;
+        try {
+            throwExceptionSelfCheck();
+        } catch (const nix::Error & _e) {
+            caught = true;
+        }
+        // This is not actually the main point of this check, but let's make sure anyway:
+        assert(caught);
 
-    // Check that exception handling works. Exception handling has been observed
-    // not to work on darwin when the linker flags aren't quite right.
-    // In this case we don't want to expose the user to some unrelated uncaught
-    // exception, but rather tell them exactly that exception handling is
-    // broken.
-    // When exception handling fails, the message tends to be printed by the
-    // C++ runtime, followed by an abort.
-    // For example on macOS we might see an error such as
-    // libc++abi: terminating with uncaught exception of type nix::SystemError: error: C++ exception handling is broken.
-    // This would appear to be a problem with the way Nix was compiled and/or linked and/or loaded.
-    bool caught = false;
-    try {
-        throwExceptionSelfCheck();
-    } catch (const nix::Error & _e) {
-        caught = true;
-    }
-    // This is not actually the main point of this check, but let's make sure anyway:
-    assert(caught);
+        if (sodium_init() == -1)
+            throw Error("could not initialise libsodium");
 
-    if (sodium_init() == -1)
-        throw Error("could not initialise libsodium");
-
-    /* Prevent OpenSSL from registering its atexit() handler
-       (OPENSSL_cleanup()). If we exit() while other threads that use
-       OpenSSL are still running, OPENSSL_cleanup() frees OpenSSL's
-       thread-local state handlers; when those threads then exit, their
-       thread-specific-data destructors (init_thread_stop()) crash on
-       the freed state. This happens in particular in nix-daemon
-       connection children, where library destructors run by _dl_fini()
-       (e.g. aws-crt-cpp's) stop their worker threads *after*
-       OPENSSL_cleanup() has already run. Since we're exiting anyway,
-       skipping the cleanup is harmless. This must run before any other
-       use of OpenSSL, since only the first initialisation takes
-       effect. */
-    if (OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, nullptr) != 1)
-        throw Error("could not initialise OpenSSL");
+        /* Prevent OpenSSL from registering its atexit() handler
+           (OPENSSL_cleanup()). If we exit() while other threads that use
+           OpenSSL are still running, OPENSSL_cleanup() frees OpenSSL's
+           thread-local state handlers; when those threads then exit, their
+           thread-specific-data destructors (init_thread_stop()) crash on
+           the freed state. This happens in particular in nix-daemon
+           connection children, where library destructors run by _dl_fini()
+           (e.g. aws-crt-cpp's) stop their worker threads *after*
+           OPENSSL_cleanup() has already run. Since we're exiting anyway,
+           skipping the cleanup is harmless. This must run before any other
+           use of OpenSSL, since only the first initialisation takes
+           effect. */
+        if (OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, nullptr) != 1)
+            throw Error("could not initialise OpenSSL");
+    });
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -386,6 +386,9 @@ void mainWrapped(int argc, char ** argv)
     }
 #endif
 
+    /* This must be called before Sentry since both initialize OpenSSL. */
+    initLibUtil();
+
     /* Set the build hook location
 
        For builds we perform a self-invocation, so Nix has to be


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This fixed the vast majority of crashes reported via Sentry. Nix (usually the daemon) crashes on exit because OpenSSL cleanup runs while other threads (like aws-crt-cpp) are still using it. The fix is to not run OpenSSL cleanup.

Taken from https://github.com/DeterminateSystems/nix-src/pull/560, https://github.com/DeterminateSystems/nix-src/pull/566.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
