### PR TITLE
On Linux, don't hang if the sandbox helper dies before opening the pty slave

### DIFF
--- a/src/libstore/linux/build/linux-derivation-builder.cc
+++ b/src/libstore/linux/build/linux-derivation-builder.cc
@@ -591,7 +591,12 @@ void ChrootLinuxDerivationBuilder::startChild()
     sendPid.writeSide.close();
 
     if (auto status = helper.wait(); !statusOk(status)) {
+        // Ensure the slave side of the pseudoterminal has been opened at least once so that reading from the master
+        // doesn't hang.
+        openSlaveNoDup();
+
         processSandboxSetupMessages();
+
         // Only reached if the child process didn't send an exception.
         throw Error("unable to start build process: %s", statusToString(status));
     }

--- a/src/libstore/unix/build/derivation-builder-impl.hh
+++ b/src/libstore/unix/build/derivation-builder-impl.hh
@@ -288,9 +288,22 @@ protected:
     }
 
     /**
-     * Open the slave side of the pseudoterminal and use it as stderr.
+     * Open the slave side of the pseudoterminal.
      */
-    void openSlave();
+    AutoCloseFD openSlaveNoDup();
+
+    /**
+     * Open the slave side of the pseudoterminal and use it as stderr.
+     * FIXME: This is called in the child. It should really be called in the parent (except for the dup to stderr),
+     * since if the child fails before opening the slave, the parent will hang forever reading from the master. However,
+     * opening the slave in the parent causes random failures on macOS. See c536e00c9deeac58bc4b3299dbc702604c32adbe.
+     */
+    void openSlave()
+    {
+        auto builderOut = openSlaveNoDup();
+        if (dup2(builderOut.get(), STDERR_FILENO) == -1)
+            throw SysError("cannot pipe standard error into log file");
+    }
 
     /**
      * Called by prepareBuild() to start the child process for the

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -609,7 +609,7 @@ void DerivationBuilderImpl::prepareSandbox()
         throw Error("feature 'uid-range' is not supported on this platform");
 }
 
-void DerivationBuilderImpl::openSlave()
+AutoCloseFD DerivationBuilderImpl::openSlaveNoDup()
 {
     std::string slaveName = getPtsName(builderOut.get());
 
@@ -627,8 +627,7 @@ void DerivationBuilderImpl::openSlave()
     if (tcsetattr(builderOut.get(), TCSANOW, &term))
         throw SysError("putting pseudoterminal into raw mode");
 
-    if (dup2(builderOut.get(), STDERR_FILENO) == -1)
-        throw SysError("cannot pipe standard error into log file");
+    return builderOut;
 }
 
 #if NIX_WITH_AWS_AUTH


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

We should really open the slave in the parent, but we can't because that causes random failures on macOS.

Taken from https://github.com/DeterminateSystems/nix-src/pull/559.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
