### PR TITLE
Make logging functions noexcept

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -203,7 +203,7 @@ public:
         return printBuildLogs;
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         if (lvl > verbosity)
             return;
@@ -211,7 +211,7 @@ public:
         log(*state, lvl, s);
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         auto state(state_.lock());
 
@@ -221,7 +221,7 @@ public:
         log(*state, ei.level, oss.view());
     }
 
-    void log(State & state, Verbosity lvl, std::string_view s)
+    void log(State & state, Verbosity lvl, std::string_view s) noexcept
     {
         if (state.active) {
             invalidateRedrawCache();
@@ -238,7 +238,7 @@ public:
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent) noexcept override
     {
         auto state(state_.lock());
 
@@ -257,12 +257,6 @@ public:
             auto machineName = getS(fields, 1);
             if (machineName != "")
                 i->s += fmt(" on " ANSI_BOLD "%s" ANSI_NORMAL, machineName);
-
-            // Used to be curRound and nrRounds, but the
-            // implementation was broken for a long time.
-            if (getI(fields, 2) != 1 || getI(fields, 3) != 1) {
-                throw Error("log message indicated repeating builds, but this is not currently implemented");
-            }
             i->name = DrvName(name).name;
         }
 
@@ -310,7 +304,7 @@ public:
         return false;
     }
 
-    void stopActivity(ActivityId act) override
+    void stopActivity(ActivityId act) noexcept override
     {
         auto state(state_.lock());
 
@@ -332,7 +326,7 @@ public:
         update(*state);
     }
 
-    void result(ActivityId act, ResultType type, const std::vector<Field> & fields) override
+    void result(ActivityId act, ResultType type, const std::vector<Field> & fields) noexcept override
     {
         auto state(state_.lock());
 
@@ -411,7 +405,7 @@ public:
         }
     }
 
-    void update(State & state)
+    void update(State & state) noexcept
     {
         state.haveUpdate = true;
         updateCV.notify_one();
@@ -424,7 +418,7 @@ public:
      * with text selection in some terminals, including libvte-based terminal
      * emulators.
      */
-    void redraw(std::string newOutput)
+    void redraw(std::string newOutput) noexcept
     {
         auto lastOutput(lastOutput_.lock());
         if (newOutput != *lastOutput) {
@@ -444,7 +438,7 @@ public:
         writeToStderr("\r\e[K");
     }
 
-    std::chrono::milliseconds draw(State & state)
+    std::chrono::milliseconds draw(State & state) noexcept
     {
         auto nextWakeup = std::chrono::milliseconds::max();
 
@@ -508,7 +502,7 @@ public:
         return nextWakeup;
     }
 
-    std::string getStatus(State & state)
+    std::string getStatus(State & state) noexcept
     {
         std::string res;
 

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -17,17 +17,17 @@ namespace nix {
 
 namespace {
 
-static std::string_view getS(const std::vector<Logger::Field> & fields, size_t n)
+static std::optional<std::string_view> getS(const std::vector<Logger::Field> & fields, size_t n)
 {
     if (n >= fields.size() || fields[n].type != Logger::Field::tString)
-        throw Error("could not get expected log field of type 'string' at index %d", n);
+        return std::nullopt;
     return fields[n].s;
 }
 
-static uint64_t getI(const std::vector<Logger::Field> & fields, size_t n)
+static std::optional<uint64_t> getI(const std::vector<Logger::Field> & fields, size_t n)
 {
     if (n >= fields.size() || fields[n].type != Logger::Field::tInt)
-        throw Error("could not get expected log field of type 'int' at index %d", n);
+        return std::nullopt;
     return fields[n].i;
 }
 
@@ -252,33 +252,42 @@ public:
         state->activitiesByType[type].its.emplace(act, i);
 
         if (type == actBuild) {
-            auto name = storePathToNameWithoutDrvSuffix(getS(fields, 0));
-            i->s = fmt("building " ANSI_BOLD "%s" ANSI_NORMAL, name);
-            auto machineName = getS(fields, 1);
-            if (machineName != "")
-                i->s += fmt(" on " ANSI_BOLD "%s" ANSI_NORMAL, machineName);
-            i->name = DrvName(name).name;
+            if (auto path = getS(fields, 0)) {
+                auto name = storePathToNameWithoutDrvSuffix(*path);
+                i->s = fmt("building " ANSI_BOLD "%s" ANSI_NORMAL, name);
+                auto machineName = getS(fields, 1);
+                if (machineName && *machineName != "")
+                    i->s += fmt(" on " ANSI_BOLD "%s" ANSI_NORMAL, *machineName);
+                i->name = DrvName(name).name;
+            }
         }
 
         if (type == actSubstitute) {
-            auto name = storePathToName(getS(fields, 0));
+            auto path = getS(fields, 0);
             auto sub = getS(fields, 1);
-            i->s =
-                fmt(hasPrefix(sub, "local") ? "copying " ANSI_BOLD "%s" ANSI_NORMAL " from %s"
-                                            : "fetching " ANSI_BOLD "%s" ANSI_NORMAL " from %s",
-                    name,
-                    sub);
+            if (path && sub) {
+                auto name = storePathToName(*path);
+                i->s =
+                    fmt(hasPrefix(*sub, "local") ? "copying " ANSI_BOLD "%s" ANSI_NORMAL " from %s"
+                                                 : "fetching " ANSI_BOLD "%s" ANSI_NORMAL " from %s",
+                        name,
+                        *sub);
+            }
         }
 
         if (type == actPostBuildHook) {
-            auto name = storePathToNameWithoutDrvSuffix(getS(fields, 0));
-            i->s = fmt("post-build " ANSI_BOLD "%s" ANSI_NORMAL, name);
-            i->name = DrvName(name).name;
+            if (auto path = getS(fields, 0)) {
+                auto name = storePathToNameWithoutDrvSuffix(*path);
+                i->s = fmt("post-build " ANSI_BOLD "%s" ANSI_NORMAL, name);
+                i->name = DrvName(name).name;
+            }
         }
 
         if (type == actQueryPathInfo) {
-            auto name = storePathToName(getS(fields, 0));
-            i->s = fmt("querying " ANSI_BOLD "%s" ANSI_NORMAL " on %s", name, getS(fields, 1));
+            auto path = getS(fields, 0);
+            auto sub = getS(fields, 1);
+            if (path && sub)
+                i->s = fmt("querying " ANSI_BOLD "%s" ANSI_NORMAL " on %s", storePathToName(*path), *sub);
         }
 
         if ((type == actFileTransfer && hasAncestor(*state, actCopyPath, parent))
@@ -332,12 +341,15 @@ public:
 
         if (type == resFileLinked) {
             state->filesLinked++;
-            state->bytesLinked += getI(fields, 0);
+            state->bytesLinked += getI(fields, 0).value_or(0);
             update(*state);
         }
 
         else if (type == resBuildLogLine || type == resPostBuildLogLine) {
-            auto lastLine = chomp(getS(fields, 0));
+            auto line = getS(fields, 0);
+            if (!line)
+                return;
+            auto lastLine = chomp(*line);
             auto i = state->its.find(act);
             assert(i != state->its.end());
             ActInfo info = *i->second;
@@ -367,40 +379,56 @@ public:
         }
 
         else if (type == resSetPhase) {
+            auto phase = getS(fields, 0);
+            if (!phase)
+                return;
             auto i = state->its.find(act);
             assert(i != state->its.end());
-            i->second->phase = getS(fields, 0);
+            i->second->phase = *phase;
             update(*state);
         }
 
         else if (type == resProgress) {
+            auto done = getI(fields, 0);
+            auto expected = getI(fields, 1);
+            auto running = getI(fields, 2);
+            auto failed = getI(fields, 3);
+            if (!done || !expected || !running || !failed)
+                return;
             auto i = state->its.find(act);
             assert(i != state->its.end());
             ActInfo & actInfo = *i->second;
-            actInfo.done = getI(fields, 0);
-            actInfo.expected = getI(fields, 1);
-            actInfo.running = getI(fields, 2);
-            actInfo.failed = getI(fields, 3);
+            actInfo.done = *done;
+            actInfo.expected = *expected;
+            actInfo.running = *running;
+            actInfo.failed = *failed;
             update(*state);
         }
 
         else if (type == resSetExpected) {
+            auto expectedType = getI(fields, 0);
+            auto expected = getI(fields, 1);
+            if (!expectedType || !expected)
+                return;
             auto i = state->its.find(act);
             assert(i != state->its.end());
             ActInfo & actInfo = *i->second;
-            auto type = (ActivityType) getI(fields, 0);
+            auto type = (ActivityType) *expectedType;
             auto & j = actInfo.expectedByType[type];
             state->activitiesByType[type].expected -= j;
-            j = getI(fields, 1);
+            j = *expected;
             state->activitiesByType[type].expected += j;
             update(*state);
         }
 
         else if (type == resFetchStatus) {
+            auto lastLine = getS(fields, 0);
+            if (!lastLine)
+                return;
             auto i = state->its.find(act);
             assert(i != state->its.end());
             ActInfo & actInfo = *i->second;
-            actInfo.lastLine = getS(fields, 0);
+            actInfo.lastLine = *lastLine;
             update(*state);
         }
     }

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -70,7 +70,7 @@ struct TunnelLogger : public Logger
     {
     }
 
-    void enqueueMsg(const std::string & s)
+    void enqueueMsg(const std::string & s) noexcept
     {
         auto state(state_.lock());
 
@@ -81,15 +81,18 @@ struct TunnelLogger : public Logger
                 to.flush();
             } catch (...) {
                 /* Write failed; that means that the other side is
-                   gone. */
+                   gone, so stop sending it messages. Note that we
+                   don't propagate the error, since logging must not
+                   throw. The client's death will be detected
+                   elsewhere (e.g. by `MonitorFdHup` or by the next
+                   protocol read/write). */
                 state->canSendStderr = false;
-                throw;
             }
         } else
             state->pendingMsgs.push_back(s);
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         if (lvl > verbosity)
             return;
@@ -99,7 +102,7 @@ struct TunnelLogger : public Logger
         enqueueMsg(buf.s);
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         if (ei.level > verbosity)
             return;
@@ -152,7 +155,7 @@ struct TunnelLogger : public Logger
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent) noexcept override
     {
         if (clientVersion.number < WorkerProto::Version::Number{1, 20}) {
             if (!s.empty())
@@ -165,7 +168,7 @@ struct TunnelLogger : public Logger
         enqueueMsg(buf.s);
     }
 
-    void stopActivity(ActivityId act) override
+    void stopActivity(ActivityId act) noexcept override
     {
         if (clientVersion.number < WorkerProto::Version::Number{1, 20})
             return;
@@ -174,7 +177,7 @@ struct TunnelLogger : public Logger
         enqueueMsg(buf.s);
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) override
+    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
     {
         if (clientVersion.number < WorkerProto::Version::Number{1, 20})
             return;

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -292,12 +292,8 @@ struct curlFileTransfer : public FileTransfer
                     curl_multi_remove_handle(fileTransfer.curlm.get(), req);
                 curl_easy_cleanup(req);
             }
-            try {
-                if (!done && enqueued)
-                    failInterruptedOrCancelled();
-            } catch (...) {
-                ignoreExceptionInDestructor();
-            }
+            if (!done && enqueued)
+                failInterruptedOrCancelled();
         }
 
         void failEx(std::exception_ptr ex) noexcept
@@ -323,7 +319,7 @@ struct curlFileTransfer : public FileTransfer
             failEx(std::make_exception_ptr(std::forward<T>(e)));
         }
 
-        void failInterruptedOrCancelled()
+        void failInterruptedOrCancelled() noexcept
         {
             HintFmt fmt("%s of '%s' was interrupted", Uncolored(request.noun()), request.displayUri());
 

--- a/src/libutil-test-support/include/nix/util/tests/capture-logging.hh
+++ b/src/libutil-test-support/include/nix/util/tests/capture-logging.hh
@@ -18,12 +18,12 @@ public:
         return oss.str();
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         oss << s << std::endl;
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         showErrorInfo(oss, ei, loggerSettings.showTrace.get());
     }

--- a/src/libutil/include/nix/util/logging.hh
+++ b/src/libutil/include/nix/util/logging.hh
@@ -133,22 +133,27 @@ public:
         return false;
     }
 
-    virtual void log(Verbosity lvl, std::string_view s) = 0;
+    /* Note: logging functions must be noexcept, since they're often
+       called in contexts where exceptions cannot be handled (such as
+       in completion callbacks or destructors). Implementations should
+       handle failure to write the message (e.g. by ignoring it or
+       disabling the logger). */
+    virtual void log(Verbosity lvl, std::string_view s) noexcept = 0;
 
-    void log(std::string_view s)
+    void log(std::string_view s) noexcept
     {
         log(lvlInfo, s);
     }
 
-    virtual void logEI(const ErrorInfo & ei) = 0;
+    virtual void logEI(const ErrorInfo & ei) noexcept = 0;
 
-    void logEI(Verbosity lvl, ErrorInfo ei)
+    void logEI(Verbosity lvl, ErrorInfo ei) noexcept
     {
         ei.level = lvl;
         logEI(ei);
     }
 
-    virtual void warn(const std::string & msg);
+    virtual void warn(const std::string & msg) noexcept;
 
     virtual void startActivity(
         ActivityId act,
@@ -156,11 +161,13 @@ public:
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) {};
+        ActivityId parent) noexcept {};
 
-    virtual void stopActivity(ActivityId act) {};
+    virtual void stopActivity(ActivityId act) noexcept {};
 
-    virtual void result(ActivityId act, ResultType type, const Fields & fields) {};
+    virtual void result(ActivityId act, ResultType type, const Fields & fields) noexcept {};
+
+    virtual void result(ActivityId act, ResultType type, const nlohmann::json & json) noexcept {};
 
     virtual void writeToStdout(std::string_view s);
 
@@ -360,6 +367,6 @@ inline void warn(const std::string & fs, const Args &... args)
         warn(args);                   \
     }
 
-void writeToStderr(std::string_view s);
+void writeToStderr(std::string_view s) noexcept;
 
 } // namespace nix

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -40,7 +40,7 @@ Logger * logger = makeSimpleLogger(true).release();
 
 Logger::~Logger() {}
 
-void Logger::warn(const std::string & msg)
+void Logger::warn(const std::string & msg) noexcept
 {
     log(lvlWarn, ANSI_WARNING "warning:" ANSI_NORMAL " " + msg);
 }
@@ -86,7 +86,7 @@ public:
         return printBuildLogs;
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         if (lvl > verbosity)
             return;
@@ -124,7 +124,7 @@ public:
         writeToStderr(prefix + filterANSIEscapes(s, !tty) + "\n");
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         std::ostringstream oss;
         showErrorInfo(oss, ei, loggerSettings.showTrace.get());
@@ -138,13 +138,13 @@ public:
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent) noexcept override
     {
         if (lvl <= verbosity && !s.empty())
             log(lvl, s + "...");
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) override
+    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
     {
         if (type == resBuildLogLine && printBuildLogs) {
             auto lastLine = fields[0].s;
@@ -160,7 +160,7 @@ public:
 
 Verbosity verbosity = lvlInfo;
 
-static void writeFullLogging(Descriptor fd, std::string_view s)
+static void writeFullLogging(Descriptor fd, std::string_view s) noexcept
 {
     try {
         writeFull(fd, s, false);
@@ -172,7 +172,7 @@ static void writeFullLogging(Descriptor fd, std::string_view s)
     }
 }
 
-void writeToStderr(std::string_view s)
+void writeToStderr(std::string_view s) noexcept
 {
     writeFullLogging(getStandardError(), s);
 }
@@ -281,7 +281,7 @@ struct JSONLogger : Logger
         }
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         nlohmann::json json;
         json["action"] = "msg";
@@ -290,7 +290,7 @@ struct JSONLogger : Logger
         write(json);
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         std::ostringstream oss;
         showErrorInfo(oss, ei, loggerSettings.showTrace.get());
@@ -323,7 +323,7 @@ struct JSONLogger : Logger
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent) noexcept override
     {
         nlohmann::json json;
         json["action"] = "start";
@@ -336,7 +336,7 @@ struct JSONLogger : Logger
         write(json);
     }
 
-    void stopActivity(ActivityId act) override
+    void stopActivity(ActivityId act) noexcept override
     {
         nlohmann::json json;
         json["action"] = "stop";
@@ -344,7 +344,7 @@ struct JSONLogger : Logger
         write(json);
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) override
+    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
     {
         nlohmann::json json;
         json["action"] = "result";

--- a/src/libutil/tee-logger.cc
+++ b/src/libutil/tee-logger.cc
@@ -32,13 +32,13 @@ public:
             logger->resume();
     };
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         for (auto & logger : loggers)
             logger->log(lvl, s);
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         for (auto & logger : loggers)
             logger->logEI(ei);
@@ -50,19 +50,19 @@ public:
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent) noexcept override
     {
         for (auto & logger : loggers)
             logger->startActivity(act, lvl, type, s, fields, parent);
     }
 
-    void stopActivity(ActivityId act) override
+    void stopActivity(ActivityId act) noexcept override
     {
         for (auto & logger : loggers)
             logger->stopActivity(act);
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) override
+    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
     {
         for (auto & logger : loggers)
             logger->result(act, type, fields);


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Make the logging functions `noexcept`, and in particular, make sure that `TunnelLogger` doesn't throw. This (probably) fixes a daemon crash (seen a fair number of times in Sentry) where the client has disconnected, and `~TransferItem()` calls a `HttpBinaryCacheStore` callback which in turn calls `printError()` in `HttpBinaryCacheStore::maybeDisable()`.

Taken from https://github.com/DeterminateSystems/nix-src/pull/561.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
