### PR TITLE
Add boost.context patch for std::uncaught_exceptions() misreporting 0 while abandoning the coroutine

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -126,6 +126,9 @@ scope: {
         "--with-iostreams"
         "--with-url"
       ];
+      patches = [
+        ./patches/0001-Fix-uncaught_exceptions-not-accounting-for-forced_un.patch
+      ];
       enableIcu = false;
     }).overrideAttrs
       (old: {

--- a/packaging/patches/0001-Fix-uncaught_exceptions-not-accounting-for-forced_un.patch
+++ b/packaging/patches/0001-Fix-uncaught_exceptions-not-accounting-for-forced_un.patch
@@ -1,0 +1,102 @@
+From 5883212311535a0046031d74d1568ae173c1e35b Mon Sep 17 00:00:00 2001
+From: Sergei Zimmerman <sergei@zimmerman.foo>
+Date: Tue, 21 Jul 2026 21:15:51 +0000
+Subject: [PATCH] Fix uncaught_exceptions() not accounting for forced_unwind
+
+Unwound fibers would see std::uncaught_exceptions() == 0, while a
+forced_unwind exception is in "flight". This goes against the contract
+of std::uncaught_exceptions() that scope guards rely upon. Failing
+to report the correct number of uncaught exceptions (especially
+misreporting zero) will lead to scope guards to misbehave badly and skip
+running cleanup code which branches on whether the destructor is called
+during stack unwinding or not.
+
+This is because the "throw" would happen before the destructor is run on
+the fiber stack being switched to, but the increment would be clobbered
+by the destructor of manage_exception_state.
+
+I'm not sure what the contract of run ontop_fcontext is wrt to whether
+the the caller provided function can throw or not, but in my best
+understanding the forced_unwind mechanism is mostly internal and so is
+throwing from ontop_fcontext in the switched-to fiber. Thus, I've kept
+the catch block scoped to detail::forced_unwind.
+---
+ include/boost/context/fiber_fcontext.hpp | 37 +++++++++++++++++-------
+ test/test_fiber.cpp                      | 24 +++++++++++++++
+ 2 files changed, 51 insertions(+), 10 deletions(-)
+
+diff --git a/include/boost/context/fiber_fcontext.hpp b/include/boost/context/fiber_fcontext.hpp
+index 543ba6c..38476c9 100644
+--- a/boost/context/fiber_fcontext.hpp
++++ b/boost/context/fiber_fcontext.hpp
+@@ -70,7 +70,9 @@ namespace context {
+ namespace detail {
+ 
+ // manage_exception_state is a dummy struct unless we have specific support
+-struct manage_exception_state {};
++struct manage_exception_state {
++    void from_forced_unwind() noexcept {}
++};
+ 
+ } // namespace detail
+ } // namespace context
+@@ -90,6 +92,11 @@ public:
+     manage_exception_state() {
+         exception_state_ = *__cxa_get_globals();
+     }
++    // Hack to account for the forced_unwind exception thrown in fiber_unwind
++    // that's run ontop before the destructor.
++    void from_forced_unwind() noexcept {
++        exception_state_.uncaughtExceptions += 1;
++    }
+     ~manage_exception_state() {
+         *__cxa_get_globals() = exception_state_;
+     }
+@@ -376,13 +383,18 @@ public:
+         BOOST_ASSERT( nullptr != fctx_);
+         detail::manage_exception_state exstate;
+         boost::ignore_unused(exstate);
+-        return { detail::jump_fcontext(
++        try {
++            return { detail::jump_fcontext(
+ #if defined(BOOST_NO_CXX14_STD_EXCHANGE)
+-                    detail::exchange( fctx_, nullptr),
++                        detail::exchange( fctx_, nullptr),
+ #else
+-                    std::exchange( fctx_, nullptr),
++                        std::exchange( fctx_, nullptr),
+ #endif
+-                    nullptr).fctx };
++                        nullptr).fctx };
++        } catch ( detail::forced_unwind const& ) {
++            exstate.from_forced_unwind();
++            throw;
++        }
+     }
+ 
+     template< typename Fn >
+@@ -391,14 +403,19 @@ public:
+         detail::manage_exception_state exstate;
+         boost::ignore_unused(exstate);
+         auto p = std::forward< Fn >( fn);
+-        return { detail::ontop_fcontext(
++        try {
++            return { detail::ontop_fcontext(
+ #if defined(BOOST_NO_CXX14_STD_EXCHANGE)
+-                    detail::exchange( fctx_, nullptr),
++                        detail::exchange( fctx_, nullptr),
+ #else
+-                    std::exchange( fctx_, nullptr),
++                        std::exchange( fctx_, nullptr),
+ #endif
+-                    & p,
+-                    detail::fiber_ontop< fiber, decltype(p) >).fctx };
++                        & p,
++                        detail::fiber_ontop< fiber, decltype(p) >).fctx };
++        } catch ( detail::forced_unwind const& ) {
++            exstate.from_forced_unwind();
++            throw;
++        }
+     }
+ 
+     explicit operator bool() const noexcept {

--- a/src/libutil-tests/serialise.cc
+++ b/src/libutil-tests/serialise.cc
@@ -1,4 +1,5 @@
 #include "nix/util/serialise.hh"
+#include "nix/util/config.hh"
 
 #include <boost/context/detail/exception.hpp>
 #include <gtest/gtest.h>
@@ -38,6 +39,13 @@ TEST(readPadding, works)
     }
 }
 
+// The following test catches the bug only under fcontext backend,
+// but Boost.Coroutine2 stack switching when abandoning confuses the
+// hell out of ASan. The workaround to getting ASan working isn't
+// immediately useful because it works only with ucontext implementation.
+// https://www.boost.org/doc/libs/1_89_0/libs/coroutine2/doc/html/coroutine2/stack/sanitizers.html
+#if !NIX_ASAN_ENABLED
+
 TEST(sourceToSink, forcedUnwindUcaughtExceptions)
 {
     int uncaughtExceptions = 42;
@@ -67,5 +75,7 @@ TEST(sourceToSink, forcedUnwindUcaughtExceptions)
     // uses fiber-specific exception states and messes with __cxa_get_globals().
     ASSERT_EQ(uncaughtExceptions, 1);
 }
+
+#endif
 
 } // namespace nix

--- a/src/libutil-tests/serialise.cc
+++ b/src/libutil-tests/serialise.cc
@@ -1,5 +1,6 @@
 #include "nix/util/serialise.hh"
 
+#include <boost/context/detail/exception.hpp>
 #include <gtest/gtest.h>
 
 namespace nix {
@@ -35,6 +36,36 @@ TEST(readPadding, works)
             EXPECT_THROW(readPadding(len, *makeNumSource(val)), SerialisationError);
         }
     }
+}
+
+TEST(sourceToSink, forcedUnwindUcaughtExceptions)
+{
+    int uncaughtExceptions = 42;
+    bool caught = false;
+
+    auto sink = sourceToSink([&](Source & source) {
+        auto recordUncaughtExceptions = Finally([&]() { uncaughtExceptions = std::uncaught_exceptions(); });
+        try {
+            StringSink s;
+            source.drainInto(s, 8);
+            source.drainInto(s, 8);
+        } catch (const boost::context::detail::forced_unwind &) {
+            caught = true;
+            throw;
+        }
+    });
+
+    *sink << 42;
+
+    // Abandon the coroutine. This will trigger it to unwind with boost::context::detail::forced_unwind.
+    sink.reset();
+
+    ASSERT_TRUE(caught);
+    // This is a test for boost.context regression fixed by https://github.com/boostorg/context/pull/337.
+    // Without the fix std::uncaught_exceptions() *misreports* 0 while there's stack unwinding in progress.
+    // The issue only surfaces with libstdc++ and fcontext when boost.context
+    // uses fiber-specific exception states and messes with __cxa_get_globals().
+    ASSERT_EQ(uncaughtExceptions, 0);
 }
 
 } // namespace nix

--- a/src/libutil-tests/serialise.cc
+++ b/src/libutil-tests/serialise.cc
@@ -65,7 +65,7 @@ TEST(sourceToSink, forcedUnwindUcaughtExceptions)
     // Without the fix std::uncaught_exceptions() *misreports* 0 while there's stack unwinding in progress.
     // The issue only surfaces with libstdc++ and fcontext when boost.context
     // uses fiber-specific exception states and messes with __cxa_get_globals().
-    ASSERT_EQ(uncaughtExceptions, 0);
+    ASSERT_EQ(uncaughtExceptions, 1);
 }
 
 } // namespace nix

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -44,6 +44,12 @@ configdata_pub.set(
   description : 'Whether nix has been built with UBSan enabled',
 )
 
+configdata_pub.set(
+  'NIX_ASAN_ENABLED',
+  ('address' in get_option('b_sanitize')).to_int(),
+  description : 'Whether nix has been built with ASan enabled',
+)
+
 subdir('nix-meson-build-support/libatomic')
 
 if host_machine.system() == 'windows'


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Applies a patch to our boost.context dependency to fix
https://github.com/NixOS/nix/issues/16174. An alternative would be to
apply basically the same workaround to our suspension points, but that
would be more fragile. Other packagers might want to apply the boost
patch too (maybe once that's merged upstream), since the issue is likely
to affect more stuff than just nix.

The bug is subtle enough that it went unnoticed for quite some time.

Also adds a test that surfaces this bug so that (rather few) people running out unit tests don't silently build with a busted boost.

The patch isn't merged upstream yet, but we've discussed this during today's meeting and it seems best to apply these fixes to nixpkgs packaging instead of rolling a gazillion point releases adding workarounds for this stuff everywhere.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
