### PR TITLE
libexpr-c: Add C API function nix_eval_state_builder_set_setting

### DIFF
--- a/src/libexpr-c/nix_api_expr.cc
+++ b/src/libexpr-c/nix_api_expr.cc
@@ -152,6 +152,18 @@ nix_err nix_eval_state_builder_set_lookup_path(
     NIXC_CATCH_ERRS
 }
 
+nix_err nix_eval_state_builder_set_setting(
+    nix_c_context * context, nix_eval_state_builder * builder, const char * key, const char * value)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        if (!builder->settings.set(key, value))
+            return nix_set_err_msg(context, NIX_ERR_KEY, "Setting not found");
+    }
+    NIXC_CATCH_ERRS
+}
+
 EvalState * nix_eval_state_build(nix_c_context * context, nix_eval_state_builder * builder)
 {
     if (context)

--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -230,6 +230,21 @@ nix_err nix_eval_state_builder_set_lookup_path(
     nix_c_context * context, nix_eval_state_builder * builder, const char ** lookupPath);
 
 /**
+ * @brief Set an evaluator setting on the builder
+ * @ingroup libexpr_init
+ *
+ * Sets a single evaluator setting (as documented in the Nix manual) on the builder.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] builder The builder to modify.
+ * @param[in] key The setting name.
+ * @param[in] value The setting value.
+ * @return NIX_OK if successful, NIX_ERR_KEY if the setting does not exist, an error code otherwise.
+ */
+nix_err nix_eval_state_builder_set_setting(
+    nix_c_context * context, nix_eval_state_builder * builder, const char * key, const char * value);
+
+/**
  * @brief Create a new Nix language evaluator state
  * @ingroup libexpr_init
  *

--- a/src/libexpr-tests/nix_api_expr.cc
+++ b/src/libexpr-tests/nix_api_expr.cc
@@ -54,6 +54,61 @@ TEST_F(nix_api_expr_test, nix_eval_state_lookup_path)
     nix_gc_decref(nullptr, value);
 }
 
+TEST_F(nix_api_expr_test, nix_eval_state_builder_set_setting)
+{
+    // Test whether setting eval settings via the C-api actually apply.
+
+    // Presence of builtins.currentSystem is used as an indicater whether pure-eval is used or not.
+    auto hasCurrentSystem = [&](EvalState * es) {
+        Value * v = nix_alloc_value(ctx, es);
+        nix_expr_eval_from_string(ctx, es, "builtins ? currentSystem", ".", v);
+        assert_ctx_ok();
+        nix_value_force(ctx, es, v);
+        assert_ctx_ok();
+        bool b = nix_get_bool(ctx, v);
+        assert_ctx_ok();
+        nix_gc_decref(nullptr, v);
+        return b;
+    };
+
+    // A builder with no settings evaluates impurely.
+    {
+        auto builder = nix_eval_state_builder_new(ctx, store);
+        assert_ctx_ok();
+        auto impureState = nix_eval_state_build(ctx, builder);
+        assert_ctx_ok();
+        nix_eval_state_builder_free(builder);
+        ASSERT_TRUE(hasCurrentSystem(impureState));
+        nix_state_free(impureState);
+    }
+
+    // A builder with pure-eval applied has no builtins.currentSystem
+    {
+        auto builder = nix_eval_state_builder_new(ctx, store);
+        assert_ctx_ok();
+        ASSERT_EQ(NIX_OK, nix_eval_state_builder_set_setting(ctx, builder, "pure-eval", "true"));
+        assert_ctx_ok();
+
+        auto pureEvalState = nix_eval_state_build(ctx, builder);
+        assert_ctx_ok();
+        nix_eval_state_builder_free(builder);
+        ASSERT_FALSE(hasCurrentSystem(pureEvalState));
+        nix_state_free(pureEvalState);
+    }
+}
+
+TEST_F(nix_api_expr_test, nix_eval_state_builder_set_setting_unknown)
+{
+    auto builder = nix_eval_state_builder_new(ctx, store);
+    assert_ctx_ok();
+
+    // An unknown setting errors out.
+    ASSERT_EQ(NIX_ERR_KEY, nix_eval_state_builder_set_setting(ctx, builder, "not-a-nix-setting", "x"));
+    ASSERT_EQ(NIX_ERR_KEY, nix_err_code(ctx));
+
+    nix_eval_state_builder_free(builder);
+}
+
 TEST_F(nix_api_expr_test, nix_expr_eval_from_string)
 {
     nix_expr_eval_from_string(nullptr, state, "builtins.nixVersion", ".", value);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

To be able to drive evaluator settings from the C API. My motivation is to be able to set `pure-eval` without having global config state.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
