### PR TITLE
libstore: ship build inputs with the build request

### DIFF
--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -1,7 +1,9 @@
 #include "nix/store/derivations.hh"
 #include "nix/store/build/worker.hh"
+#include "nix/store/worker-settings.hh"
 #include "nix/store/build/substitution-goal.hh"
 #include "nix/store/build/derivation-trampoline-goal.hh"
+#include "nix/store/store-open.hh"
 #include "nix/util/strings.hh"
 #include <memory>
 
@@ -21,6 +23,18 @@ LocalBuilder::buildPathsWithResults(const std::vector<DerivedPath> & reqs, Build
 BuildResult LocalBuilder::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
 {
     return getWorker()->buildDerivation(drvPath, drv, buildMode);
+}
+
+BuildResult LocalBuilder::buildDerivation(
+    const StorePath & drvPath, const BasicDerivation & drv, const StorePathSet & inputs, BuildMode buildMode)
+{
+    return getWorker()->buildDerivation(drvPath, drv, inputs, buildMode);
+}
+
+std::vector<KeyedBuildResult> LocalBuilder::buildPathsWithResults(
+    const std::vector<DerivedPath> & reqs, const StorePathSet & inputs, BuildMode buildMode)
+{
+    return getWorker()->buildPathsWithResults(reqs, inputs, buildMode);
 }
 
 void LocalBuilder::ensurePath(const StorePath & path)
@@ -119,6 +133,24 @@ BuildResult Worker::buildDerivation(const StorePath & drvPath, const BasicDeriva
                 .msg = e.msg(),
             }}};
     };
+}
+
+BuildResult Worker::buildDerivation(
+    const StorePath & drvPath, const BasicDerivation & drv, const StorePathSet & inputs, BuildMode buildMode)
+{
+    auto substitute = settings.buildersUseSubstitutes ? Substitute : NoSubstitute;
+    auto srcStore = openStore();
+    copyPaths(*srcStore, store, inputs, NoRepair, NoCheckSigs, substitute);
+    return buildDerivation(drvPath, drv, buildMode);
+}
+
+std::vector<KeyedBuildResult>
+Worker::buildPathsWithResults(const std::vector<DerivedPath> & reqs, const StorePathSet & inputs, BuildMode buildMode)
+{
+    auto substitute = settings.buildersUseSubstitutes ? Substitute : NoSubstitute;
+    auto srcStore = openStore();
+    copyPaths(*srcStore, store, inputs, NoRepair, NoCheckSigs, substitute);
+    return buildPathsWithResults(reqs, buildMode);
 }
 
 void Worker::ensurePath(const StorePath & path)

--- a/src/libstore/include/nix/store/build.hh
+++ b/src/libstore/include/nix/store/build.hh
@@ -79,6 +79,38 @@ struct Builder
     buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode = bmNormal) = 0;
 
     /**
+     * Like the other buildDerivation(), but additionally copies a set of
+     * input paths into the builder's store before the build is run.
+     *
+     * This lets the caller ship the build inputs together with the build
+     * request, rather than as a separate prior `copyPaths()`. Whether the
+     * inputs are fetched via substitution or copied directly is governed by
+     * the `builders-use-substitutes` setting.
+     *
+     * @param inputs The store paths to make available in the builder's
+     * store before building. For a remote builder these are copied across
+     * the connection; for the local `Worker` they are copied from the eval
+     * store.
+     */
+    virtual BuildResult buildDerivation(
+        const StorePath & drvPath,
+        const BasicDerivation & drv,
+        const StorePathSet & inputs,
+        BuildMode buildMode = bmNormal) = 0;
+
+    /**
+     * Like the other buildPathsWithResults(), but additionally copies a set
+     * of input paths into the builder's store before building.
+     *
+     * @param inputs The store paths to make available in the builder's
+     * store before building, copied subject to the
+     * `builders-use-substitutes` setting (see the buildDerivation() overload
+     * above).
+     */
+    virtual std::vector<KeyedBuildResult> buildPathsWithResults(
+        const std::vector<DerivedPath> & reqs, const StorePathSet & inputs, BuildMode buildMode = bmNormal) = 0;
+
+    /**
      * Ensure that a path is valid.  If it is not currently valid, it
      * may be made valid by running a substitute (if defined for the
      * path).

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -85,6 +85,13 @@ public:
     std::vector<KeyedBuildResult>
     buildPathsWithResults(const std::vector<DerivedPath> & reqs, BuildMode buildMode) override;
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
+    BuildResult buildDerivation(
+        const StorePath & drvPath,
+        const BasicDerivation & drv,
+        const StorePathSet & inputs,
+        BuildMode buildMode) override;
+    std::vector<KeyedBuildResult> buildPathsWithResults(
+        const std::vector<DerivedPath> & reqs, const StorePathSet & inputs, BuildMode buildMode) override;
     void ensurePath(const StorePath & path) override;
     void repairPath(const StorePath & path) override;
 
@@ -431,6 +438,13 @@ public:
     std::vector<KeyedBuildResult>
     buildPathsWithResults(const std::vector<DerivedPath> & reqs, BuildMode buildMode) override;
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
+    BuildResult buildDerivation(
+        const StorePath & drvPath,
+        const BasicDerivation & drv,
+        const StorePathSet & inputs,
+        BuildMode buildMode) override;
+    std::vector<KeyedBuildResult> buildPathsWithResults(
+        const std::vector<DerivedPath> & reqs, const StorePathSet & inputs, BuildMode buildMode) override;
     void ensurePath(const StorePath & path) override;
     void repairPath(const StorePath & path) override;
 };

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -9,6 +9,7 @@
 #include "nix/store/serve-protocol-impl.hh"
 #include "nix/store/build-result.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/store-open.hh"
 #include "nix/store/path-with-outputs.hh"
 #include "nix/store/ssh.hh"
 #include "nix/store/derivations.hh"
@@ -46,6 +47,27 @@ public:
     buildPathsWithResults(const std::vector<DerivedPath> & reqs, BuildMode buildMode) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
+
+    BuildResult buildDerivation(
+        const StorePath & drvPath,
+        const BasicDerivation & drv,
+        const StorePathSet & inputs,
+        BuildMode buildMode) override
+    {
+        auto substitute = settings.getWorkerSettings().buildersUseSubstitutes ? Substitute : NoSubstitute;
+        auto srcStore = openStore();
+        copyPaths(*srcStore, *store, inputs, NoRepair, NoCheckSigs, substitute);
+        return buildDerivation(drvPath, drv, buildMode);
+    }
+
+    std::vector<KeyedBuildResult> buildPathsWithResults(
+        const std::vector<DerivedPath> & reqs, const StorePathSet & inputs, BuildMode buildMode) override
+    {
+        auto substitute = settings.getWorkerSettings().buildersUseSubstitutes ? Substitute : NoSubstitute;
+        auto srcStore = openStore();
+        copyPaths(*srcStore, *store, inputs, NoRepair, NoCheckSigs, substitute);
+        return buildPathsWithResults(reqs, buildMode);
+    }
 
     /**
      * Note, the returned function must only be called once, or we'll

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -2,6 +2,7 @@
 #include "nix/store/path.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/file-content-address.hh"
+#include "nix/store/store-open.hh"
 #include "nix/util/serialise.hh"
 #include "nix/util/util.hh"
 #include "nix/store/path-with-outputs.hh"
@@ -599,6 +600,15 @@ public:
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
 
+    BuildResult buildDerivation(
+        const StorePath & drvPath,
+        const BasicDerivation & drv,
+        const StorePathSet & inputs,
+        BuildMode buildMode) override;
+
+    std::vector<KeyedBuildResult> buildPathsWithResults(
+        const std::vector<DerivedPath> & reqs, const StorePathSet & inputs, BuildMode buildMode) override;
+
     void ensurePath(const StorePath & path) override;
 
     /**
@@ -722,6 +732,24 @@ BuildResult RemoteBuilder::buildDerivation(const StorePath & drvPath, const Basi
     conn->putBuildDerivationRequest(*store, &conn.daemonException, drvPath, drv, buildMode);
     conn.processStderr();
     return WorkerProto::Serialise<BuildResult>::read(*store, *conn);
+}
+
+BuildResult RemoteBuilder::buildDerivation(
+    const StorePath & drvPath, const BasicDerivation & drv, const StorePathSet & inputs, BuildMode buildMode)
+{
+    auto substitute = settings.getWorkerSettings().buildersUseSubstitutes ? Substitute : NoSubstitute;
+    auto srcStore = openStore();
+    copyPaths(*srcStore, *store, inputs, NoRepair, NoCheckSigs, substitute);
+    return buildDerivation(drvPath, drv, buildMode);
+}
+
+std::vector<KeyedBuildResult> RemoteBuilder::buildPathsWithResults(
+    const std::vector<DerivedPath> & reqs, const StorePathSet & inputs, BuildMode buildMode)
+{
+    auto substitute = settings.getWorkerSettings().buildersUseSubstitutes ? Substitute : NoSubstitute;
+    auto srcStore = openStore();
+    copyPaths(*srcStore, *store, inputs, NoRepair, NoCheckSigs, substitute);
+    return buildPathsWithResults(reqs, buildMode);
 }
 
 void RemoteBuilder::ensurePath(const StorePath & path)

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -192,6 +192,15 @@ struct RestrictedBuilder : Builder
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode) override;
 
+    BuildResult buildDerivation(
+        const StorePath & drvPath,
+        const BasicDerivation & drv,
+        const StorePathSet & inputs,
+        BuildMode buildMode) override;
+
+    std::vector<KeyedBuildResult> buildPathsWithResults(
+        const std::vector<DerivedPath> & reqs, const StorePathSet & inputs, BuildMode buildMode) override;
+
     void ensurePath(const StorePath & path) override;
 
     void repairPath(const StorePath & path) override;
@@ -402,6 +411,18 @@ BuildResult
 RestrictedBuilder::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv, BuildMode buildMode)
 {
     throw Unsupported("buildDerivation");
+}
+
+BuildResult RestrictedBuilder::buildDerivation(
+    const StorePath & drvPath, const BasicDerivation & drv, const StorePathSet & inputs, BuildMode buildMode)
+{
+    throw Unsupported("buildDerivation (with inputs)");
+}
+
+std::vector<KeyedBuildResult> RestrictedBuilder::buildPathsWithResults(
+    const std::vector<DerivedPath> & reqs, const StorePathSet & inputs, BuildMode buildMode)
+{
+    throw Unsupported("buildPathsWithResults (with inputs)");
 }
 
 void RestrictedBuilder::repairPath(const StorePath & path)

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -301,14 +301,9 @@ static int main_build_remote(int argc, char ** argv)
             signal(SIGALRM, old);
         }
 
-        auto substitute = settings.getWorkerSettings().buildersUseSubstitutes ? Substitute : NoSubstitute;
-
-        {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying dependencies to '%s'", storeUri));
-            copyPaths(*store, *sshStore, store->parseStorePathSet(inputs), NoRepair, NoCheckSigs, substitute);
-        }
-
         uploadLock = -1;
+
+        auto inputPaths = store->parseStorePathSet(inputs);
 
         auto drv = store->readDerivation(*drvPath);
 
@@ -339,7 +334,7 @@ static int main_build_remote(int argc, char ** argv)
                 //
                 // 2. Changing the `inputSrcs` set changes the
                 //    associated output ids, which break CA derivations
-                .inputs = drv.inputs.drvs.map.empty() ? drv.inputs.srcs : store->parseStorePathSet(inputs),
+                .inputs = drv.inputs.drvs.map.empty() ? drv.inputs.srcs : inputPaths,
                 .platform = drv.platform,
                 .builder = drv.builder,
                 .args = drv.args,
@@ -347,7 +342,7 @@ static int main_build_remote(int argc, char ** argv)
                 .structuredAttrs = drv.structuredAttrs,
                 .name = drv.name,
             };
-            optResult = sshStore->getBuilder()->buildDerivation(*drvPath, resolvedDrv);
+            optResult = sshStore->getBuilder()->buildDerivation(*drvPath, resolvedDrv, inputPaths);
             auto & result = *optResult;
             if (auto * failureP = result.tryGetFailure()) {
                 if (settings.keepFailed) {
@@ -361,11 +356,14 @@ static int main_build_remote(int argc, char ** argv)
                     "build of '%s' on '%s' failed: %s", store->printStorePath(*drvPath), storeUri, failureP->message());
             }
         } else {
-            copyClosure(*store, *sshStore, StorePathSet{*drvPath}, NoRepair, NoCheckSigs, substitute);
-            auto res = sshStore->getBuilder()->buildPathsWithResults({DerivedPath::Built{
-                .drvPath = makeConstantStorePathRef(*drvPath),
-                .outputs = OutputsSpec::All{},
-            }});
+            auto inputPathsWithDrv = inputPaths;
+            store->computeFSClosure(*drvPath, inputPathsWithDrv);
+            auto res = sshStore->getBuilder()->buildPathsWithResults(
+                {DerivedPath::Built{
+                    .drvPath = makeConstantStorePathRef(*drvPath),
+                    .outputs = OutputsSpec::All{},
+                }},
+                inputPathsWithDrv);
             // One path to build should produce exactly one build result
             assert(res.size() == 1);
             optResult = std::move(res[0]);


### PR DESCRIPTION
Add buildDerivation() and buildPathsWithResults() overloads to the Builder interface that take a StorePathSet of inputs and copy them into the builder's store before building, instead of relying on a separate copyPaths() beforehand.

Shipping the inputs together with the build request lets a builder store decide where to build based on those inputs (for example, choosing a machine by total input size) before they are copied. This is not possible when copying and building are two separate calls.

RemoteBuilder and LegacySSHBuilder open the local store as the source and copy the inputs into the builder's store; RestrictedBuilder rejects the operation. The copy honours the builders-use-substitutes setting.

build-remote folds its standalone dependency copy into these overloads: the trusted/CA path calls buildDerivation() with the input paths, and the untrusted path ships the inputs together with the derivation's closure via buildPathsWithResults().

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->
Today a builder store receives the inputs and the build request as two unrelated calls (addMultipleToStore, then buildPathsWithResults). For a store that multiplexes builds across several machines, that ordering is fatal: it has to copy the inputs somewhere before it knows which machine will run the build.

Shipping the inputs together with the build request lets the store decide where to build based on those inputs, for example, by picking the machine that already holds most of the input closure or choosing by total input size, and only then copy. This is the gap that has kept the build hook alive: the hook receives the derivation and its inputs together, and the Store interface has had no equivalent.

Part of #15533, working toward #1221.
## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
The overloads are pure virtual rather than having a default implementation
as sketched in #15533, since each builder needs its own source store to copy
from: Worker and the remote builders open a local store, RestrictedBuilder
rejects the operation outright.

The API is exercised by a real consumer: [nix-scheduler-hook](https://github.com/lisanna-dettwyler/nix-scheduler-hook) implements
these overloads as a builder store plugin (--store nsh://, loaded via
plugin-files) and uses the bundled inputs to pick a Slurm/PBS node before
copying anything to it. Its NixOS VM test suite passes against this branch.

Rebased onto current master after the Builder/BuildStore split.
---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
