### PR TITLE
libstore: Drop Store::getStats

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -265,14 +265,8 @@ ref<NarInfo> BinaryCacheStore::uploadData(Source & narSource, RepairFlag repair,
     if (repair || !fileExists(narInfo->url)) {
         FdSource source{fdTemp.get()};
         source.restart(); /* Seek back to the start of the file. */
-        stats.narWrite++;
         upsertFile(narInfo->url, source, "application/x-nix-nar", narInfo->fileSize);
-    } else
-        stats.narWriteAverted++;
-
-    stats.narWriteBytes += info.narSize;
-    stats.narWriteCompressedBytes += fileSize;
-    stats.narWriteCompressionTimeMs += duration;
+    }
 
     return narInfo;
 }
@@ -296,8 +290,6 @@ void BinaryCacheStore::uploadNarInfo(ref<NarInfo> narInfo)
 
     /* Atomically write the NAR info file.*/
     writeNarInfo(narInfo);
-
-    stats.narInfoWrite++;
 }
 
 ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
@@ -552,26 +544,13 @@ void BinaryCacheStore::narFromPath(const StorePath & storePath, Sink & sink)
 {
     auto info = queryPathInfo(storePath).cast<const NarInfo>();
 
-    uint64_t narSize = 0;
-
-    LambdaSink uncompressedSink{
-        [&](std::string_view data) {
-            narSize += data.size();
-            sink(data);
-        },
-        [&]() {
-            stats.narRead++;
-            // stats.narReadCompressedBytes += nar->size(); // FIXME
-            stats.narReadBytes += narSize;
-        }};
-
     /* makeDecompressionSink used to treat empty strings as "none". It seems
        impossible that it would actually end up here with an empty string though
        (since an empty `Compression: ' is treated as bzip2 when parsed from a
        .narinfo file and the narinfo disk cache wouldn't handle empty strings).
        TODO: Revisit this and convert to an assert probably or even made
        compression a non-optional field. */
-    auto decompressor = makeDecompressionSink(info->compression.value_or(CompressionAlgo::none), uncompressedSink);
+    auto decompressor = makeDecompressionSink(info->compression.value_or(CompressionAlgo::none), sink);
 
     try {
         getFile(info->url, *decompressor);
@@ -580,8 +559,6 @@ void BinaryCacheStore::narFromPath(const StorePath & storePath, Sink & sink)
     }
 
     decompressor->finish();
-
-    // Note: don't do anything here because it's never reached if we're called as a coroutine.
 }
 
 void BinaryCacheStore::queryPathInfoUncached(
@@ -608,8 +585,6 @@ void BinaryCacheStore::queryPathInfoUncached(
 
                         if (!data)
                             return (*callbackPtr)({});
-
-                        stats.narInfoRead++;
 
                         (*callbackPtr)(
                             (std::shared_ptr<ValidPathInfo>) std::make_shared<NarInfo>(*this, *data, narInfoFile));

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -946,25 +946,6 @@ public:
      */
     virtual StorePaths topoSortPaths(const StorePathSet & paths);
 
-    struct Stats
-    {
-        std::atomic<uint64_t> narInfoRead{0};
-        std::atomic<uint64_t> narInfoReadAverted{0};
-        std::atomic<uint64_t> narInfoMissing{0};
-        std::atomic<uint64_t> narInfoWrite{0};
-        std::atomic<uint64_t> pathInfoCacheSize{0};
-        std::atomic<uint64_t> narRead{0};
-        std::atomic<uint64_t> narReadBytes{0};
-        std::atomic<uint64_t> narReadCompressedBytes{0};
-        std::atomic<uint64_t> narWrite{0};
-        std::atomic<uint64_t> narWriteAverted{0};
-        std::atomic<uint64_t> narWriteBytes{0};
-        std::atomic<uint64_t> narWriteCompressedBytes{0};
-        std::atomic<uint64_t> narWriteCompressionTimeMs{0};
-    };
-
-    const Stats & getStats();
-
     /**
      * Computes the full closure of of a set of store-paths for e.g.
      * derivations that need this information for `exportReferencesGraph`.
@@ -1023,8 +1004,6 @@ public:
     }
 
 protected:
-
-    Stats stats;
 
     /**
      * Helper for methods that are not unsupported: this is used for

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -534,16 +534,13 @@ StorePathSet Store::querySubstitutablePaths(const StorePathSet & paths)
 bool Store::isValidPath(const StorePath & storePath)
 {
     auto res = pathInfoCache->lock()->get(storePath);
-    if (res && res->isKnownNow(settings.getNarInfoDiskCacheSettings())) {
-        stats.narInfoReadAverted++;
+    if (res && res->isKnownNow(settings.getNarInfoDiskCacheSettings()))
         return res->didExist();
-    }
 
     if (diskCache) {
         auto res = diskCache->lookupNarInfo(
             config.getReference().render(/*FIXME withParams=*/false), std::string(storePath.hashPart()));
         if (res.first != NarInfoDiskCache::oUnknown) {
-            stats.narInfoReadAverted++;
             pathInfoCache->lock()->upsert(
                 storePath,
                 res.first == NarInfoDiskCache::oInvalid ? PathInfoCacheValue{}
@@ -601,7 +598,6 @@ std::optional<std::shared_ptr<const ValidPathInfo>> Store::queryPathInfoFromClie
 
     auto res = pathInfoCache->lock()->get(storePath);
     if (res && res->isKnownNow(settings.getNarInfoDiskCacheSettings())) {
-        stats.narInfoReadAverted++;
         if (res->didExist())
             return std::make_optional(res->value);
         else
@@ -611,7 +607,6 @@ std::optional<std::shared_ptr<const ValidPathInfo>> Store::queryPathInfoFromClie
     if (diskCache) {
         auto res = diskCache->lookupNarInfo(config.getReference().render(/*FIXME withParams=*/false), hashPart);
         if (res.first != NarInfoDiskCache::oUnknown) {
-            stats.narInfoReadAverted++;
             pathInfoCache->lock()->upsert(
                 storePath,
                 res.first == NarInfoDiskCache::oInvalid ? PathInfoCacheValue{}
@@ -655,10 +650,8 @@ void Store::queryPathInfo(const StorePath & storePath, Callback<ref<const ValidP
 
                 pathInfoCache->lock()->upsert(storePath, PathInfoCacheValue{.value = info});
 
-                if (!info || !goodStorePath(storePath, info->path)) {
-                    stats.narInfoMissing++;
+                if (!info || !goodStorePath(storePath, info->path))
                     throw InvalidPath("path '%s' is not valid", printStorePath(storePath));
-                }
 
                 (*callbackPtr)(ref<const ValidPathInfo>(info));
             } catch (...) {
@@ -879,12 +872,6 @@ StorePathSet Store::exportReferences(const StorePathSet & storePaths, const Stor
     }
 
     return paths;
-}
-
-const Store::Stats & Store::getStats()
-{
-    stats.pathInfoCacheSize = pathInfoCache->readLock()->size();
-    return stats;
 }
 
 static std::string

--- a/src/libutil/include/nix/util/serialise.hh
+++ b/src/libutil/include/nix/util/serialise.hh
@@ -466,16 +466,12 @@ class LambdaSink : public Sink
     void anchor() override;
 
 public:
-    typedef fun<void(std::string_view data)> data_t;
-    typedef fun<void()> cleanup_t;
+    typedef fun<void(std::string_view data)> lambda_t;
 
-    data_t dataFun;
-    cleanup_t cleanupFun;
+    lambda_t lambda;
 
-    LambdaSink(
-        const data_t & dataFun, const cleanup_t & cleanupFun = []() {})
-        : dataFun(dataFun)
-        , cleanupFun(cleanupFun)
+    LambdaSink(const lambda_t & lambda)
+        : lambda(lambda)
     {
     }
 
@@ -483,15 +479,11 @@ public:
     LambdaSink(const LambdaSink &) = delete;
     LambdaSink & operator=(LambdaSink &&) = delete;
     LambdaSink & operator=(const LambdaSink &) = delete;
-
-    ~LambdaSink()
-    {
-        cleanupFun();
-    }
+    ~LambdaSink() = default;
 
     void operator()(std::string_view data) override
     {
-        dataFun(data);
+        lambda(data);
     }
 };
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This was only really useful for hydra and only supported with binary
cache store caches. Hydra no longer uses Nix is the library for binary
cache store interactions. Since it wasn't really used in-tree or
implemented for anything other than narinfo interactions or the daemon
store, it seems safe to drop.

There are zero tests for this code too.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
