### PR TITLE
Fix state directories getting ownership overriden by hardcoded root in systemd config

### DIFF
--- a/misc/systemd/nix-daemon.conf.in
+++ b/misc/systemd/nix-daemon.conf.in
@@ -1,2 +1,2 @@
-d @localstatedir@/nix/daemon-socket 0755 root root -  -
-d @localstatedir@/nix/builds        0755 root root 7d -
+d @localstatedir@/nix/daemon-socket 0755 - - -  -
+d @localstatedir@/nix/builds        0755 - - 7d -


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

As described in #16122, an update of `nix` package (from a non-NixOS) yet again changed the ownership of directories under `/nix/var/nix/`. <s>This PR replaces hardcoded `root` with `-` to have the directories inherit ownership of parent directory.</s>

## Context

Closes: #16122

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
