### PR TITLE
libstore: cache AWS credentials across S3 requests

### DIFF
--- a/doc/manual/rl-next/aws-credential-caching.md
+++ b/doc/manual/rl-next/aws-credential-caching.md
@@ -1,0 +1,14 @@
+---
+synopsis: AWS credentials are now cached across S3 requests
+prs: [16209]
+---
+
+Nix now caches the AWS credentials it resolves for S3 binary caches instead of
+re-running the full credential provider chain on every request. Previously,
+credential sources that require a network round trip (IMDS instance profiles,
+ECS container credentials, STS WebIdentity, SSO) were queried once per
+substitution. Credentials with an expiration timestamp are refreshed
+automatically 5 minutes before they expire; credentials without one (e.g.
+static credentials from the environment or `~/.aws/credentials`) are re-read
+every 15 minutes, matching the behavior of the AWS SDK's default credential
+provider chain.

--- a/src/libstore/aws-creds.cc
+++ b/src/libstore/aws-creds.cc
@@ -425,7 +425,23 @@ AwsCredentialProviderImpl::createProviderForProfile(const std::string & profile,
             profileDisplayName);
     }
 
-    return Aws::Crt::Auth::CredentialsProvider::CreateCredentialsProviderChain(chainConfig, allocator);
+    auto chain = Aws::Crt::Auth::CredentialsProvider::CreateCredentialsProviderChain(chainConfig, allocator);
+    if (!chain)
+        return nullptr;
+
+    // Wrap the chain in a caching provider, like aws-c-auth's own default chain
+    // does. Without this, every GetCredentials call re-runs the whole chain,
+    // including HTTP round trips to IMDS/ECS/STS — i.e. once per substitution.
+    // The cached provider refreshes after the TTL or 5 minutes before the
+    // credentials' expiration timestamp, whichever comes first; the TTL only
+    // matters for credentials without an expiration (e.g. static env/profile
+    // credentials). 15 minutes matches DEFAULT_CREDENTIAL_PROVIDER_REFRESH_MS
+    // in aws-c-auth's default chain.
+    Aws::Crt::Auth::CredentialsProviderCachedConfig cachedConfig;
+    cachedConfig.Provider = std::move(chain);
+    cachedConfig.CachedCredentialTTL = std::chrono::minutes(15);
+
+    return Aws::Crt::Auth::CredentialsProvider::CreateCredentialsProviderCached(cachedConfig, allocator);
 }
 
 AwsCredentials AwsCredentialProviderImpl::getCredentialsRaw(const std::string & profile, const std::string & region)


### PR DESCRIPTION
The custom credential provider chain (Environment -> SSO -> Profile -> STS WebIdentity -> ECS -> IMDS) was re-run for every S3 request, so credential sources that need a network round trip (IMDS instance profiles, ECS container credentials, STS WebIdentity, SSO) were queried once per substitution. aws-c-auth's default chain avoids this by wrapping the whole chain in a caching provider; that wrapper was lost in a4e792cba and 508d4463e.

Wrap chain in aws_credentials_provider_new_cached (via the aws-crt-cpp wrapper) with the same 15-minute refresh interval the SDK default chain uses. Credentials carrying an expiration timestamp are refreshed 5 minutes before they expire; the TTL only governs credentials without one (e.g. static environment or profile credentials). Concurrent requests during a fetch now also coalesce onto a single query instead of each hitting the credential source.

On auth failure the existing cache-entry eviction in getCredentials() discards the cached wrapper together with the chain, so stale credentials cannot get pinned.

This commit was written with the assistance of agentic AI, and was tested with a fake S3 endpoint and counting of credential requests. Before the change, each request comes with a cred request, after there is just the one at the start.
