### PR TITLE
fix(flakes): support `?dir=` on relative `path:` inputs

### DIFF
--- a/src/libflake/call-flake.nix
+++ b/src/libflake/call-flake.nix
@@ -56,11 +56,17 @@ let
 
       subdir = overrides.${key}.dir or node.locked.dir or "";
 
-      outPath =
+      /**
+        The path before appending the `?subdir` value.
+        Usually a source root, except when it's a relative `path:` input.
+      */
+      subdirBase =
         if !hasOverride && isRelative then
           parentNode.outPath + (if node.locked.path == "" then "" else "/" + node.locked.path)
         else
-          sourceInfo.outPath + (if subdir == "" then "" else "/" + subdir);
+          sourceInfo.outPath;
+
+      outPath = subdirBase + (if subdir == "" then "" else "/" + subdir);
 
       flake = import (outPath + "/flake.nix");
 

--- a/tests/functional/flakes/relative-paths.sh
+++ b/tests/functional/flakes/relative-paths.sh
@@ -171,3 +171,43 @@ EOF
   nix eval --json .#nestedFlake1.nestedFlake2 --no-eval-cache
   nix eval --json .#nestedFlake1.nestedFlake2 --no-eval-cache
 )
+
+# A flake input is some location defined by the input plus a subdir (where
+# `flake.nix` should be in that location). Subdir composes uniformly across
+# schemes: `github:foo/bar?dir=x`, `path:/abs?dir=x`, and `path:./rel?dir=x`
+# all locate the flake at `<exposed-source>/x/flake.nix`. So the flake for
+# `path:./sub?dir=inner` lives at `<parent>/sub/inner`, despite the quirk
+# described in https://github.com/NixOS/nix/issues/16214
+mkdir -p "$TEST_ROOT/reldir/sub/inner" "$TEST_ROOT/reldir/alt/deep"
+(
+  initGitRepo "$TEST_ROOT/reldir"
+  cd "$TEST_ROOT/reldir"
+  cat >sub/inner/flake.nix <<EOF
+{
+  outputs = { ... }: { tag = "correct"; };
+}
+EOF
+  cat >flake.nix <<EOF
+{
+  inputs.sub.url = "path:./sub?dir=inner";
+  outputs = { sub, ... }: { tag = sub.tag; };
+}
+EOF
+  git add flake.nix sub/inner/flake.nix
+  nix flake lock
+  [[ $(nix eval --raw .#tag) = "correct" ]]
+
+  # The subdir must also compose when the input is replaced via
+  # --override-input by a ref that itself carries a `?dir=` subdir. This
+  # exercises the `hasOverride` branch of call-flake.nix, where the subdir
+  # comes from the override's `dir` attribute rather than the lock file.
+  # We can't produce a relative path through the CLI yet, so we only test the
+  # `--override-input` with an absolute path here.
+  cat >alt/deep/flake.nix <<EOF
+{
+  outputs = { ... }: { tag = "overridden"; };
+}
+EOF
+  git add alt/deep/flake.nix
+  [[ $(nix eval --raw --override-input sub "path:$TEST_ROOT/reldir/alt?dir=deep" .#tag) = "overridden" ]]
+)


### PR DESCRIPTION
We overlooked the ability to add `?subdir` to a relative path flake input. It should just work according to the pattern that the subdir is appended.

The C++ locking path (getFlake + resolveRelativePath in flake.cc) seems to handle subdir correctly, so `nix flake lock` succeeds and only later evaluation fails.

The hasOverride test with absolute path already worked.

Assisted-By: Claude Opus 4.7, 4.8

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

It's difficult to build on broken code.

## Context

- Discovered via STF project
- This is a bit weird. You might want to decide #16214

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
