### PR TITLE
libstore: Fix lost waiting for slot goal wakeups

### DIFF
--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -248,19 +248,6 @@ void Worker::childTerminated(Goal * goal, JobCategory jobCategory)
     }
 
     children.erase(i);
-    auto & waiting = jobCategory == JobCategory::Substitution ? wantingToSubstitute : wantingToBuild;
-
-    /* Wake up goals waiting for a build slot. Wake at most one waiter to avoid
-       starting unnecessary work (that is accompanied by coroutine frame allocation). */
-    auto it = waiting.begin();
-    while (it != waiting.end()) {
-        if (auto goal = it->lock()) {
-            waiting.erase(it);
-            wakeUp(goal);
-            break;
-        }
-        it = waiting.erase(it);
-    }
 }
 
 void Worker::waitForBuildSlot(GoalPtr goal)
@@ -336,6 +323,22 @@ void Worker::run(const Goals & _topGoals)
                 if (topGoals.empty())
                     break; // stuff may have been cancelled
             }
+
+            auto wakeSlotWaiters = [this](WeakGoals & waiting, size_t running, size_t limit) {
+                auto it = waiting.begin();
+                while (it != waiting.end() && running < limit) {
+                    auto goal = it->lock();
+                    it = waiting.erase(it);
+                    if (!goal)
+                        continue;
+                    wakeUp(goal);
+                    ++running;
+                }
+            };
+
+            wakeSlotWaiters(
+                wantingToSubstitute, getNrSubstitutions(), std::max<std::size_t>(1, settings.maxSubstitutionJobs));
+            wakeSlotWaiters(wantingToBuild, getNrLocalBuilds(), settings.maxBuildJobs);
         }
 
         if (topGoals.empty())
@@ -364,6 +367,7 @@ void Worker::run(const Goals & _topGoals)
        --keep-going *is* set, then they must all be finished now. */
     assert(!settings.keepGoing || awake.empty());
     assert(!settings.keepGoing || wantingToBuild.empty());
+    assert(!settings.keepGoing || wantingToSubstitute.empty());
     assert(!settings.keepGoing || children.empty());
 }
 

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -362,8 +362,7 @@ public:
         bool respectTimeouts);
 
     /**
-     * Unregisters a running child process. Wakes at most a single goal that is
-     * awaiting on the corresponding build slot type (building or substitution).
+     * Unregisters a running child process.
      *
      * This overload requires `goal` to point to a fully constructed,
      * valid goal object, as it calls `goal->jobCategory()`.


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

In 6fae3a25f1a07472b45c56862c0ffe2050159e0f I neglected the fact that a jobCategory == Build (and less so Substitution) doesn't necessarily use up and free up a build slot.

This apparently led to https://github.com/NixOS/nix/issues/16005.

From attached --debug logs in the issue:

> skipping build of derivation '/nix/store/6gc23jl32lnaqv2ycch1m1igqm6hys35-unit-systemd-journald-.service.drv', someone beat us to it

Which directly precedes the crash, seemingly caused by us failing to wake more goals waiting for build slots when a Build goal terminates while someone else has successfully built the same path.

It's now the responsibility of the `Worker::run` loop to pick up just enough goals waiting for slots - overestimating a bit there is ok since the goal implementations avoid overconsuming slots by waiting more. This way we keep the bounded complexity on each iteration, while hopefully also fixing the root cause of the bug.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Should fix (tm) https://github.com/NixOS/nix/issues/16005.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
