### PR TITLE
Error out when flake checks are missing `drvPath`

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -625,7 +625,9 @@ struct CmdFlakeCheck : FlakeCommand, MixPrintOutPaths, MixOutLinkBase
                                         fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
                                         *attr2.value,
                                         attr2.pos);
-                                    if (drvPath && attr_name == settings.thisSystem.get()) {
+                                    if (!drvPath) {
+                                        reportError(Error("'%s.%s.drvPath' does not exist", name, attr_name));
+                                    } else if (attr_name == settings.thisSystem.get()) {
                                         auto path = DerivedPath::Built{
                                             .drvPath = makeConstantStorePathRef(*drvPath),
                                             .outputs = OutputsSpec::All{},

--- a/tests/functional/flakes/check.sh
+++ b/tests/functional/flakes/check.sh
@@ -224,3 +224,24 @@ EOF
 checkRes=$(nix flake check --keep-going "$flakeDir" 2>&1 && fail "nix flake check should have failed" || true)
 echo "$checkRes" | grepQuiet "checks.${system}.failingCheck"
 echo "$checkRes" | grepQuiet "checks.${system}.anotherFailingCheck"
+
+# Test that missing `drvPath` is an error.
+cat > "$flakeDir"/flake.nix <<EOF
+{
+  outputs = { self }: {
+    checks.${system}.missingDrvPath = {
+      name = "missing-drvPath";
+      type = "derivation";
+    };
+    checks.${system}.anotherMissingDrvPath = {
+      name = "another-missing-drvPath";
+      type = "derivation";
+    };
+  };
+}
+EOF
+
+# shellcheck disable=SC2015
+checkRes=$(nix flake check --keep-going "$flakeDir" 2>&1 && fail "nix flake check should have failed" || true)
+echo "$checkRes" | grepQuiet "checks.${system}.missingDrvPath"
+echo "$checkRes" | grepQuiet "checks.${system}.anotherMissingDrvPath"


### PR DESCRIPTION
## Motivation

Previously, we'd silently ignore them, now we treat them as errors.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

This `if (drvPath` clause was added in
d12b12a15ba5cda49baacd22fbf7f9f526ed74e4 as part of implementing the `--keep-going` flag for `nix flake check`.

I noticed this because `buildbot-nix` behaves a bit differently and tries and fails to build these checks. This is because it uses `nix-eval-jobs` under the hood, which reports these unbuildable derivations:

`flake.nix`:

```nix
{
  outputs = _:
    let
      system = "x86_64-linux";
    in
    {
      checks.${system} = {
        missingDrvPath = {
          name = "missing-drvPath";
          type = "derivation";
        };
        anotherMissingDrvPath = {
          name = "another-missing-drvPath";
          type = "derivation";
        };
      };
    };
}
```

```console
$ nix flake show
path:/home/jeremy/tmp/flake-checking?lastModified=1785164239&narHash=sha256-iTBSwIt2gS8PHe4RmkTfh/kewOzaECp9JWLywFpCX20%3D
└───checks
    └───x86_64-linux
        ├───anotherMissingDrvPath: derivation 'another-missing-drvPath'
        └───missingDrvPath: derivation 'missing-drvPath'

$ nix flake check

$ nix run nixpkgs#nix-eval-jobs -- --force-recurse --flake '.#checks'
error: derivation does not contain a 'drvPath' attribute
{"attr":"x86_64-linux.anotherMissingDrvPath","attrPath":["x86_64-linux","anotherMissingDrvPath"],"error":"error: derivation does not contain a 'drvPath' attribute","fatal":false}
error: derivation does not contain a 'drvPath' attribute
{"attr":"x86_64-linux.missingDrvPath","attrPath":["x86_64-linux","missingDrvPath"],"error":"error: derivation does not contain a 'drvPath' attribute","fatal":false}
```
---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
