### PR TITLE
Use `std::span<Logger::Field>` instead of vector reference

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -17,18 +17,18 @@ namespace nix {
 
 namespace {
 
-static std::optional<std::string_view> getS(const std::vector<Logger::Field> & fields, size_t n)
+static std::optional<std::string_view> getS(std::span<const Logger::Field> fields, size_t n)
 {
-    if (n >= fields.size() || fields[n].type != Logger::Field::tString)
+    if (n >= fields.size() || !std::holds_alternative<std::string>(fields[n]))
         return std::nullopt;
-    return fields[n].s;
+    return std::get<std::string>(fields[n]);
 }
 
-static std::optional<uint64_t> getI(const std::vector<Logger::Field> & fields, size_t n)
+static std::optional<uint64_t> getI(std::span<const Logger::Field> fields, size_t n)
 {
-    if (n >= fields.size() || fields[n].type != Logger::Field::tInt)
+    if (n >= fields.size() || !std::holds_alternative<uint64_t>(fields[n]))
         return std::nullopt;
-    return fields[n].i;
+    return std::get<uint64_t>(fields[n]);
 }
 
 static std::string_view storePathToName(std::string_view path)
@@ -237,7 +237,7 @@ public:
         Verbosity lvl,
         ActivityType type,
         const std::string & s,
-        const Fields & fields,
+        std::span<const Field> fields,
         ActivityId parent) noexcept override
     {
         auto state(state_.lock());
@@ -335,7 +335,7 @@ public:
         update(*state);
     }
 
-    void result(ActivityId act, ResultType type, const std::vector<Field> & fields) noexcept override
+    void result(ActivityId act, ResultType type, std::span<const Field> fields) noexcept override
     {
         auto state(state_.lock());
 

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <future>
+#include <array>
 #include <regex>
 #include <sstream>
 #include <variant>
@@ -575,7 +576,7 @@ void BinaryCacheStore::queryPathInfoUncached(
             lvlTalkative,
             actQueryPathInfo,
             fmt("querying info about '%s' on '%s'", storePathS, uri),
-            Logger::Fields{storePathS, uri});
+            std::to_array<Logger::Field>({storePathS, uri}));
         PushActivity pact(act->id);
 
         auto narInfoFile = narInfoFileFor(storePath);

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -22,6 +22,8 @@
 
 #include <chrono>
 #include <algorithm>
+#include <array>
+
 #include <sys/types.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -127,7 +129,7 @@ struct PostBuildHookState
               lvlTalkative,
               actPostBuildHook,
               fmt("running post-build-hook '%s'", hook),
-              Logger::Fields{drvPath})
+              std::to_array<Logger::Field>({drvPath}))
         , out(std::make_unique<Pipe>())
     {
         out->create();
@@ -651,7 +653,11 @@ Goal::Co DerivationBuildingGoal::buildWithHook(
     std::unique_ptr<BuildLog> buildLog = std::make_unique<BuildLog>(
         worker.settings.logLines,
         std::make_unique<Activity>(
-            *logger, lvlInfo, actBuild, msg, Logger::Fields{worker.store.printStorePath(drvPath), machineName, 1, 1}));
+            *logger,
+            lvlInfo,
+            actBuild,
+            msg,
+            std::to_array<Logger::Field>({worker.store.printStorePath(drvPath), machineName, 1, 1})));
     mcRunningBuilds = std::make_unique<MaintainCount<uint64_t>>(worker.runningBuilds);
     worker.updateProgress();
 
@@ -831,7 +837,11 @@ Goal::Co DerivationBuildingGoal::buildLocally(
         buildLog = std::make_unique<BuildLog>(
             worker.settings.logLines,
             std::make_unique<Activity>(
-                *logger, lvlInfo, actBuild, msg, Logger::Fields{worker.store.printStorePath(drvPath), "", 1, 1}));
+                *logger,
+                lvlInfo,
+                actBuild,
+                msg,
+                std::to_array<Logger::Field>({worker.store.printStorePath(drvPath), "", 1, 1})));
         mcRunningBuilds = std::make_unique<MaintainCount<uint64_t>>(worker.runningBuilds);
         worker.updateProgress();
     };

--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -4,6 +4,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <array>
+
 namespace nix {
 
 DerivationResolutionGoal::DerivationResolutionGoal(
@@ -145,10 +147,10 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
                 lvlInfo,
                 actBuildWaiting,
                 msg,
-                Logger::Fields{
+                std::to_array<Logger::Field>({
                     worker.store.printStorePath(drvPath),
                     worker.store.printStorePath(pathResolved),
-                });
+                }));
 
             resolvedDrv =
                 std::make_unique<std::pair<StorePath, BasicDerivation>>(std::move(pathResolved), *std::move(attempt));

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -7,6 +7,8 @@
 #include "nix/util/signals.hh"
 #include "nix/util/callback.hh"
 
+#include <array>
+
 namespace nix {
 
 PathSubstitutionGoal::PathSubstitutionGoal(
@@ -230,7 +232,8 @@ Goal::Co PathSubstitutionGoal::tryToRun(
             Activity act(
                 *logger,
                 actSubstitute,
-                Logger::Fields{workerStore->printStorePath(storePath), sub->config.getHumanReadableURI()});
+                std::to_array<Logger::Field>(
+                    {workerStore->printStorePath(storePath), sub->config.getHumanReadableURI()}));
             PushActivity pact(act.id);
 
             copyStorePath(*sub, *workerStore, subPath, repair, sub->config.isTrusted ? NoCheckSigs : CheckSigs);

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -31,17 +31,21 @@
 
 namespace nix::daemon {
 
-Sink & operator<<(Sink & sink, const Logger::Fields & fields)
+Sink & operator<<(Sink & sink, std::span<const Logger::Field> fields)
 {
     sink << fields.size();
     for (auto & f : fields) {
-        sink << f.type;
-        if (f.type == Logger::Field::tInt)
-            sink << f.i;
-        else if (f.type == Logger::Field::tString)
-            sink << f.s;
-        else
-            unreachable();
+        std::visit(
+            overloaded{
+                [&sink](uint64_t i) {
+                    sink << 0;
+                    sink << i;
+                },
+                [&sink](const std::string & s) {
+                    sink << 1;
+                    sink << s;
+                }},
+            f);
     }
     return sink;
 }
@@ -155,7 +159,7 @@ struct TunnelLogger : public Logger
         Verbosity lvl,
         ActivityType type,
         const std::string & s,
-        const Fields & fields,
+        std::span<const Field> fields,
         ActivityId parent) noexcept override
     {
         if (clientVersion.number < WorkerProto::Version::Number{1, 20}) {
@@ -178,7 +182,7 @@ struct TunnelLogger : public Logger
         enqueueMsg(buf.s);
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
+    void result(ActivityId act, ResultType type, std::span<const Field> fields) noexcept override
     {
         if (clientVersion.number < WorkerProto::Version::Number{1, 20})
             return;

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -472,7 +472,7 @@ struct curlFileTransfer : public FileTransfer
                     lvlTalkative,
                     actFileTransfer,
                     fmt("%s '%s'", request.verb(/*continuous=*/true), request.displayUri()),
-                    Logger::Fields{request.displayUri()},
+                    std::to_array<Logger::Field>({request.displayUri()}),
                     request.parentAct);
                 // Reset the start time to when we actually started the download.
                 startTime = std::chrono::steady_clock::now();

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -25,6 +25,8 @@
 #include "store-config-private.hh"
 
 #include <filesystem>
+#include <array>
+
 #include <nlohmann/json.hpp>
 
 #ifdef _WIN32
@@ -931,7 +933,7 @@ void copyStorePath(
         lvlInfo,
         actCopyPath,
         makeCopyPathMessage(srcCfg, dstCfg, storePathS),
-        {storePathS, srcCfg.getHumanReadableURI(), dstCfg.getHumanReadableURI()});
+        std::to_array<Logger::Field>({storePathS, srcCfg.getHumanReadableURI(), dstCfg.getHumanReadableURI()}));
     PushActivity pact(act.id);
 
     auto info = srcStore.queryPathInfo(storePath);
@@ -1088,7 +1090,7 @@ std::map<StorePath, StorePath> copyPaths(
                 lvlInfo,
                 actCopyPath,
                 makeCopyPathMessage(srcCfg, dstCfg, storePathS),
-                {storePathS, srcCfg.getHumanReadableURI(), dstCfg.getHumanReadableURI()});
+                std::to_array<Logger::Field>({storePathS, srcCfg.getHumanReadableURI(), dstCfg.getHumanReadableURI()}));
             PushActivity pact(act.id);
 
             LambdaSink progressSink([&](std::string_view data) {

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -15,18 +15,22 @@ WorkerProto::BasicClientConnection::~BasicClientConnection()
     }
 }
 
-static Logger::Fields readFields(Source & from)
+static auto readFields(Source & from)
 {
-    Logger::Fields fields;
+    std::vector<Logger::Field> fields;
     size_t size = readInt(from);
     for (size_t n = 0; n < size; n++) {
-        auto type = (decltype(Logger::Field::type)) readInt(from);
-        if (type == Logger::Field::tInt)
+        auto type = readInt(from);
+        switch (type) {
+        case 0:
             fields.push_back(readNum<uint64_t>(from));
-        else if (type == Logger::Field::tString)
+            break;
+        case 1:
             fields.push_back(readString(from));
-        else
+            break;
+        default:
             throw Error("got unsupported field type %x from Nix daemon", (int) type);
+        }
     }
     return fields;
 }

--- a/src/libutil/include/nix/util/logging.hh
+++ b/src/libutil/include/nix/util/logging.hh
@@ -8,6 +8,8 @@
 #include "nix/util/fun.hh"
 
 #include <filesystem>
+#include <span>
+#include <type_traits>
 
 #include <nlohmann/json_fwd.hpp>
 
@@ -78,35 +80,31 @@ class Logger
     friend struct Activity;
 
 public:
-
-    struct Field
+    /* Note that there are no members and invariants in the class itself
+       inheriting is fine, because slicing won't post any issues. There are
+       public constructors for implicit conversions and convenience. */
+    struct Field : public std::variant<uint64_t, std::string>
     {
-        // FIXME: use std::variant.
-        enum { tInt = 0, tString = 1 } type;
-
-        uint64_t i = 0;
-        std::string s;
-
         Field(const std::string & s)
-            : type(tString)
-            , s(s)
+            : variant(s)
+        {
+        }
+
+        Field(std::string && s)
+            : variant(std::move(s))
         {
         }
 
         Field(const char * s)
-            : type(tString)
-            , s(s)
+            : variant(s)
         {
         }
 
-        Field(const uint64_t & i)
-            : type(tInt)
-            , i(i)
+        Field(uint64_t i)
+            : variant(i)
         {
         }
     };
-
-    typedef std::vector<Field> Fields;
 
     virtual ~Logger();
 
@@ -160,14 +158,16 @@ public:
         Verbosity lvl,
         ActivityType type,
         const std::string & s,
-        const Fields & fields,
-        ActivityId parent) noexcept {};
+        std::span<const Field> fields,
+        ActivityId parent) noexcept
+    {
+    }
 
     virtual void stopActivity(ActivityId act) noexcept {};
 
-    virtual void result(ActivityId act, ResultType type, const Fields & fields) noexcept {};
+    virtual void result(ActivityId act, ResultType type, std::span<const Field> fields) noexcept {}
 
-    virtual void result(ActivityId act, ResultType type, const nlohmann::json & json) noexcept {};
+    virtual void result(ActivityId act, ResultType type, const nlohmann::json & json) noexcept {}
 
     virtual void writeToStdout(std::string_view s);
 
@@ -185,19 +185,6 @@ public:
     virtual void setPrintBuildLogs(bool printBuildLogs) {}
 };
 
-/**
- * A variadic template that does nothing.
- *
- * Useful to call a function with each argument in a parameter pack.
- */
-struct nop
-{
-    template<typename... T>
-    nop(T...)
-    {
-    }
-};
-
 ActivityId getCurActivity();
 void setCurActivity(const ActivityId activityId);
 
@@ -212,12 +199,17 @@ struct Activity
         Verbosity lvl,
         ActivityType type,
         const std::string & s = "",
-        const Logger::Fields & fields = {},
+        std::span<const Logger::Field> fields = {},
         ActivityId parent = getCurActivity());
 
     Activity(
-        Logger & logger, ActivityType type, const Logger::Fields & fields = {}, ActivityId parent = getCurActivity())
-        : Activity(logger, lvlError, type, "", fields, parent) {};
+        Logger & logger,
+        ActivityType type,
+        std::span<const Logger::Field> fields = {},
+        ActivityId parent = getCurActivity())
+        : Activity(logger, lvlError, type, "", fields, parent)
+    {
+    }
 
     Activity(const Activity & act) = delete;
 
@@ -234,14 +226,14 @@ struct Activity
     }
 
     template<typename... Args>
-    void result(ResultType type, const Args &... args) const
+        requires(!(std::is_constructible_v<std::span<const Logger::Field>, std::remove_cvref_t<Args>> || ...))
+    void result(ResultType type, Args &&... args) const
     {
-        Logger::Fields fields;
-        nop{(fields.emplace_back(Logger::Field(args)), 1)...};
+        std::array<Logger::Field, sizeof...(args)> fields = {std::forward<Args>(args)...};
         result(type, fields);
     }
 
-    void result(ResultType type, const Logger::Fields & fields) const
+    void result(ResultType type, std::span<const Logger::Field> fields) const
     {
         logger.result(id, type, fields);
     }

--- a/src/libutil/include/nix/util/variant-wrapper.hh
+++ b/src/libutil/include/nix/util/variant-wrapper.hh
@@ -10,11 +10,10 @@
  */
 #define FORCE_DEFAULT_CONSTRUCTORS(CLASS_NAME)            \
     CLASS_NAME(const CLASS_NAME &) = default;             \
-    CLASS_NAME(CLASS_NAME &) = default;                   \
     CLASS_NAME(CLASS_NAME &&) = default;                  \
                                                           \
     CLASS_NAME & operator=(const CLASS_NAME &) = default; \
-    CLASS_NAME & operator=(CLASS_NAME &) = default;
+    CLASS_NAME & operator=(CLASS_NAME &&) = default;
 
 /**
  * Make a wrapper constructor. All args are forwarded to the

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -137,21 +137,23 @@ public:
         Verbosity lvl,
         ActivityType type,
         const std::string & s,
-        const Fields & fields,
+        std::span<const Field> fields,
         ActivityId parent) noexcept override
     {
         if (lvl <= verbosity && !s.empty())
             log(lvl, s + "...");
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
+    void result(ActivityId act, ResultType type, std::span<const Field> fields) noexcept override
     {
         if (type == resBuildLogLine && printBuildLogs) {
-            auto lastLine = fields[0].s;
-            printError(lastLine);
+            const auto * lastLine = std::get_if<std::string>(&fields[0]);
+            if (lastLine)
+                printError(*lastLine);
         } else if (type == resPostBuildLogLine && printBuildLogs) {
-            auto lastLine = fields[0].s;
-            printError("post-build-hook: " + lastLine);
+            const auto * lastLine = std::get_if<std::string>(&fields[0]);
+            if (lastLine)
+                printError("post-build-hook: " + *lastLine);
         }
     }
 };
@@ -198,7 +200,7 @@ Activity::Activity(
     Verbosity lvl,
     ActivityType type,
     const std::string & s,
-    const Logger::Fields & fields,
+    std::span<const Logger::Field> fields,
     ActivityId parent)
     : logger(logger)
     , id(nextId++ + (((uint64_t) getPid()) << 32))
@@ -239,18 +241,13 @@ struct JSONLogger : Logger
         return true;
     }
 
-    void addFields(nlohmann::json & json, const Fields & fields)
+    void addFields(nlohmann::json & json, std::span<const Field> fields)
     {
         if (fields.empty())
             return;
         auto & arr = json["fields"] = nlohmann::json::array();
         for (auto & f : fields)
-            if (f.type == Logger::Field::tInt)
-                arr.push_back(f.i);
-            else if (f.type == Logger::Field::tString)
-                arr.push_back(f.s);
-            else
-                unreachable();
+            std::visit([&arr](const auto & v) { arr.push_back(v); }, f);
     }
 
     struct State
@@ -322,7 +319,7 @@ struct JSONLogger : Logger
         Verbosity lvl,
         ActivityType type,
         const std::string & s,
-        const Fields & fields,
+        std::span<const Field> fields,
         ActivityId parent) noexcept override
     {
         nlohmann::json json;
@@ -344,7 +341,7 @@ struct JSONLogger : Logger
         write(json);
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
+    void result(ActivityId act, ResultType type, std::span<const Field> fields) noexcept override
     {
         nlohmann::json json;
         json["action"] = "result";
@@ -408,9 +405,9 @@ void applyJSONLogger()
     }
 }
 
-static Logger::Fields getFields(nlohmann::json & json)
+static auto getFields(nlohmann::json & json)
 {
-    Logger::Fields fields;
+    std::vector<Logger::Field> fields;
     for (auto & f : json) {
         if (f.type() == nlohmann::json::value_t::number_unsigned)
             fields.emplace_back(Logger::Field(f.get<uint64_t>()));

--- a/src/libutil/tee-logger.cc
+++ b/src/libutil/tee-logger.cc
@@ -49,7 +49,7 @@ public:
         Verbosity lvl,
         ActivityType type,
         const std::string & s,
-        const Fields & fields,
+        std::span<const Field> fields,
         ActivityId parent) noexcept override
     {
         for (auto & logger : loggers)
@@ -62,7 +62,7 @@ public:
             logger->stopActivity(act);
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
+    void result(ActivityId act, ResultType type, std::span<const Field> fields) noexcept override
     {
         for (auto & logger : loggers)
             logger->result(act, type, fields);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This allows us to pass fields as a std::array in places that know the amount of fields up-front (which is pretty much always). Also cleanups up how variadic templates construct the fields.

Addresses the TODO about switching to std::variant for Logger::Field too.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
