### PR TITLE
libstore: Avoid pathInfoCache SharedSync in case the cache is disabled

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -133,7 +133,8 @@ void BinaryCacheStore::writeNarInfo(ref<NarInfo> narInfo)
 
     upsertFile(narInfoFile, narInfo->to_string(*this), "text/x-nix-narinfo");
 
-    pathInfoCache->lock()->upsert(narInfo->path, PathInfoCacheValue{.value = std::shared_ptr<NarInfo>(narInfo)});
+    if (pathInfoCache)
+        pathInfoCache->lock()->upsert(narInfo->path, PathInfoCacheValue{.value = std::shared_ptr<NarInfo>(narInfo)});
 
     if (diskCache)
         diskCache->upsertNarInfo(

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -444,9 +444,9 @@ protected:
 
     void invalidatePathInfoCacheFor(const StorePath & path);
 
-    // Note: this is a `ref` to avoid false sharing with immutable
+    // Note: this is a `shared_ptr` to avoid false sharing with immutable
     // bits of `Store`.
-    ref<SharedSync<LRUCache<StorePath, PathInfoCacheValue>>> pathInfoCache;
+    std::shared_ptr<SharedSync<LRUCache<StorePath, PathInfoCacheValue>>> pathInfoCache;
 
     std::shared_ptr<NarInfoDiskCache> diskCache;
 
@@ -965,7 +965,8 @@ public:
      */
     void clearPathInfoCache()
     {
-        pathInfoCache->lock()->clear();
+        if (pathInfoCache)
+            pathInfoCache->lock()->clear();
     }
 
     /**

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -772,7 +772,9 @@ uint64_t LocalStore::addValidPath(State & state, const ValidPathInfo & info)
         }
     }
 
-    pathInfoCache->lock()->upsert(info.path, PathInfoCacheValue{.value = std::make_shared<const ValidPathInfo>(info)});
+    if (pathInfoCache)
+        pathInfoCache->lock()->upsert(
+            info.path, PathInfoCacheValue{.value = std::make_shared<const ValidPathInfo>(info)});
 
     return id;
 }

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -805,7 +805,7 @@ void RemoteStore::collectGarbage(const GCOptions & options, GCResults & results)
     results.bytesFreed = readLongLong(conn->from);
     readLongLong(conn->from); // obsolete
 
-    pathInfoCache->lock()->clear();
+    clearPathInfoCache();
 }
 
 void RemoteStore::optimiseStore()

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -410,7 +410,10 @@ StringSet Store::Config::getDefaultSystemFeatures()
 Store::Store(const Store::Config & config)
     : StoreDirConfig{config}
     , config{config}
-    , pathInfoCache(make_ref<decltype(pathInfoCache)::element_type>((size_t) config.pathInfoCacheSize))
+    , pathInfoCache(
+          config.pathInfoCacheSize
+              ? std::make_shared<decltype(pathInfoCache)::element_type>((size_t) config.pathInfoCacheSize)
+              : nullptr)
 {
     assertLibStoreInitialized();
 }
@@ -435,7 +438,8 @@ bool Store::PathInfoCacheValue::isKnownNow(const NarInfoDiskCacheSettings & sett
 
 void Store::invalidatePathInfoCacheFor(const StorePath & path)
 {
-    pathInfoCache->lock()->erase(path);
+    if (pathInfoCache)
+        pathInfoCache->lock()->erase(path);
 }
 
 std::map<std::string, std::optional<StorePath>> Store::queryStaticPartialDerivationOutputMap(const StorePath & path)
@@ -533,9 +537,11 @@ StorePathSet Store::querySubstitutablePaths(const StorePathSet & paths)
 
 bool Store::isValidPath(const StorePath & storePath)
 {
-    auto res = pathInfoCache->lock()->get(storePath);
-    if (res && res->isKnownNow(settings.getNarInfoDiskCacheSettings()))
-        return res->didExist();
+    if (pathInfoCache) {
+        auto res = pathInfoCache->lock()->get(storePath);
+        if (res && res->isKnownNow(settings.getNarInfoDiskCacheSettings()))
+            return res->didExist();
+    }
 
     if (diskCache) {
         auto res = diskCache->lookupNarInfo(
@@ -596,21 +602,25 @@ std::optional<std::shared_ptr<const ValidPathInfo>> Store::queryPathInfoFromClie
 {
     auto hashPart = std::string(storePath.hashPart());
 
-    auto res = pathInfoCache->lock()->get(storePath);
-    if (res && res->isKnownNow(settings.getNarInfoDiskCacheSettings())) {
-        if (res->didExist())
-            return std::make_optional(res->value);
-        else
-            return std::make_optional(nullptr);
+    if (pathInfoCache) {
+        auto res = pathInfoCache->lock()->get(storePath);
+        if (res && res->isKnownNow(settings.getNarInfoDiskCacheSettings())) {
+            if (res->didExist())
+                return std::make_optional(res->value);
+            else
+                return std::make_optional(nullptr);
+        }
     }
 
     if (diskCache) {
         auto res = diskCache->lookupNarInfo(config.getReference().render(/*FIXME withParams=*/false), hashPart);
         if (res.first != NarInfoDiskCache::oUnknown) {
-            pathInfoCache->lock()->upsert(
-                storePath,
-                res.first == NarInfoDiskCache::oInvalid ? PathInfoCacheValue{}
-                                                        : PathInfoCacheValue{.value = res.second});
+            if (pathInfoCache)
+                pathInfoCache->lock()->upsert(
+                    storePath,
+                    res.first == NarInfoDiskCache::oInvalid ? PathInfoCacheValue{}
+                                                            : PathInfoCacheValue{.value = res.second});
+
             if (res.first == NarInfoDiskCache::oInvalid || !goodStorePath(storePath, res.second->path))
                 return std::make_optional(nullptr);
             assert(res.second);
@@ -648,7 +658,8 @@ void Store::queryPathInfo(const StorePath & storePath, Callback<ref<const ValidP
                 if (diskCache)
                     diskCache->upsertNarInfo(config.getReference().render(/*FIXME withParams=*/false), hashPart, info);
 
-                pathInfoCache->lock()->upsert(storePath, PathInfoCacheValue{.value = info});
+                if (pathInfoCache)
+                    pathInfoCache->lock()->upsert(storePath, PathInfoCacheValue{.value = info});
 
                 if (!info || !goodStorePath(storePath, info->path))
                     throw InvalidPath("path '%s' is not valid", printStorePath(storePath));


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

We were doing pointless work or locking and unlocking a mutex, even though subsequent operations would do absolutely nothing. Make the pathInfoCache optional and first check it for nullptr instead - that avoids the locking entirely and is a bit less confusing. Plus it makes disabling the pathInfoCache in the store constructor quite a bit easier.

(The daemon disables the cache on the remote side).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
