### PR TITLE
[Backport 2.34-maintenance] daemon: unlink worker's temproots file on exit

### DIFF
--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -351,7 +351,12 @@ static void daemonLoop(ref<const StoreConfig> storeConfig, std::optional<Trusted
                         // Handle the connection.
                         auto store = storeConfig->openStore();
                         store->init();
-                        processConnection(store, FdSource(remote.get()), FdSink(remote.get()), trusted, NotRecursive);
+                        processConnection(
+                            std::move(store),
+                            FdSource(remote.get()),
+                            FdSink(remote.get()),
+                            trusted,
+                            RecursiveFlag::NotRecursive);
 
                         exit(0);
                     },


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Manual backport of https://github.com/NixOS/nix/pull/16223 to 2.34-maintenance.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
