### PR TITLE
Make build-hook kill timeout configurable

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -20,6 +20,7 @@
 #include "nix/store/globals.hh"
 #include "nix/util/current-process.hh"
 
+#include <chrono>
 #include <algorithm>
 #include <sys/types.h>
 #include <fcntl.h>
@@ -1159,7 +1160,8 @@ HookReply DerivationBuildingGoal::tryBuildHook(const DerivationOptions<StorePath
         return rpDecline;
 
     if (!worker.hook)
-        worker.hook = std::make_unique<HookInstance>(worker.settings.buildHook);
+        worker.hook = std::make_unique<HookInstance>(
+            worker.settings.buildHook, std::chrono::milliseconds(worker.settings.buildHookKillTimeout));
 
     try {
 

--- a/src/libstore/include/nix/store/worker-settings.hh
+++ b/src/libstore/include/nix/store/worker-settings.hh
@@ -132,6 +132,12 @@ public:
           > Change this setting only if you really know what you’re doing.
         )"};
 
+    Setting<uint32_t> buildHookKillTimeout{
+        this,
+        500,
+        "build-hook-kill-timeout",
+        "How long to wait in milliseconds for build hooks to exit on interrupt before sending SIGKILL."};
+
     Setting<std::string> builders{
         this,
         "@" + (nixConfDir() / "machines").string(),

--- a/src/libstore/unix/build/hook-instance.cc
+++ b/src/libstore/unix/build/hook-instance.cc
@@ -3,10 +3,11 @@
 #include "nix/store/build/child.hh"
 #include "nix/util/strings.hh"
 #include "nix/util/executable-path.hh"
+#include <chrono>
 
 namespace nix {
 
-HookInstance::HookInstance(const Strings & _buildHook)
+HookInstance::HookInstance(const Strings & _buildHook, std::chrono::milliseconds timeout)
 {
     debug("starting build hook '%s'", concatStringsSep(" ", _buildHook));
 
@@ -74,7 +75,7 @@ HookInstance::HookInstance(const Strings & _buildHook)
 
     /* Give custom build hooks the chance to cleanup. */
     pid.setKillSignal(SIGTERM);
-    pid.setKillTimeout(500ms);
+    pid.setKillTimeout(timeout);
 
     pid.setSeparatePG(true);
     fromHook.writeSide = -1;

--- a/src/libstore/unix/include/nix/store/build/hook-instance.hh
+++ b/src/libstore/unix/include/nix/store/build/hook-instance.hh
@@ -5,6 +5,7 @@
 #include "nix/util/serialise.hh"
 #include "nix/util/processes.hh"
 
+#include <chrono>
 #include <functional>
 
 namespace nix {
@@ -49,7 +50,7 @@ struct HookInstance
      */
     std::function<void()> onKillChild;
 
-    HookInstance(const Strings & buildHook);
+    HookInstance(const Strings & buildHook, std::chrono::milliseconds timeout);
 
     ~HookInstance();
 };


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

We're finding that with our slurm build hook we actually sometimes need more than 500ms to implement job cancellation correctly. This is to avoid keeping a connection open for each hook instance, which can otherwise exhaust slurmrestd's maximum concurrent connection limit of 124 for large build graphs.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
