### PR TITLE
Use std::to_array when calling callFunction()

### DIFF
--- a/src/libexpr/eval-profiler.cc
+++ b/src/libexpr/eval-profiler.cc
@@ -5,14 +5,18 @@
 
 namespace nix {
 
-void EvalProfiler::preFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) {}
+void EvalProfiler::preFunctionCallHook(
+    EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos)
+{
+}
 
-void EvalProfiler::postFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+void EvalProfiler::postFunctionCallHook(
+    EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos)
 {
 }
 
 void MultiEvalProfiler::preFunctionCallHook(
-    EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+    EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos)
 {
     for (auto & profiler : profilers) {
         if (profiler->getNeededHooks().test(Hook::preFunctionCall))
@@ -21,7 +25,7 @@ void MultiEvalProfiler::preFunctionCallHook(
 }
 
 void MultiEvalProfiler::postFunctionCallHook(
-    EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+    EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos)
 {
     for (auto & profiler : profilers) {
         if (profiler->getNeededHooks().test(Hook::postFunctionCall))
@@ -130,7 +134,7 @@ class SampleStack : public EvalProfiler
         return Hooks().set(preFunctionCall).set(postFunctionCall);
     }
 
-    FrameInfo getPrimOpFrameInfo(const PrimOp & primOp, std::span<Value *> args, PosIdx pos);
+    FrameInfo getPrimOpFrameInfo(const PrimOp & primOp, std::span<Value * const> args, PosIdx pos);
 
 public:
     SampleStack(EvalState & state, const std::filesystem::path & profileFile, std::chrono::nanoseconds period)
@@ -153,13 +157,13 @@ public:
     }
 
     [[gnu::noinline]] void
-    preFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) override;
+    preFunctionCallHook(EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos) override;
     [[gnu::noinline]] void
-    postFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) override;
+    postFunctionCallHook(EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos) override;
 
     void maybeSaveProfile(std::chrono::time_point<std::chrono::high_resolution_clock> now);
     void saveProfile();
-    FrameInfo getFrameInfoFromValueAndPos(const Value & v, std::span<Value *> args, PosIdx pos);
+    FrameInfo getFrameInfoFromValueAndPos(const Value & v, std::span<Value * const> args, PosIdx pos);
 
     SampleStack(SampleStack &&) = default;
     SampleStack & operator=(SampleStack &&) = delete;
@@ -179,7 +183,7 @@ private:
     PosCache posCache;
 };
 
-FrameInfo SampleStack::getPrimOpFrameInfo(const PrimOp & primOp, std::span<Value *> args, PosIdx pos)
+FrameInfo SampleStack::getPrimOpFrameInfo(const PrimOp & primOp, std::span<Value * const> args, PosIdx pos)
 {
     auto derivationInfo = [&]() -> std::optional<FrameInfo> {
         /* Here we rely a bit on the implementation details of libexpr/primops/derivation.nix
@@ -205,7 +209,7 @@ FrameInfo SampleStack::getPrimOpFrameInfo(const PrimOp & primOp, std::span<Value
     return derivationInfo.value_or(PrimOpFrameInfo{.expr = &primOp, .callPos = pos});
 }
 
-FrameInfo SampleStack::getFrameInfoFromValueAndPos(const Value & v, std::span<Value *> args, PosIdx pos)
+FrameInfo SampleStack::getFrameInfoFromValueAndPos(const Value & v, std::span<Value * const> args, PosIdx pos)
 {
     /* NOTE: No actual references to garbage collected values are not held in
        the profiler. */
@@ -229,7 +233,7 @@ FrameInfo SampleStack::getFrameInfoFromValueAndPos(const Value & v, std::span<Va
 }
 
 [[gnu::noinline]] void
-SampleStack::preFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+SampleStack::preFunctionCallHook(EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos)
 {
     stack.push_back(getFrameInfoFromValueAndPos(v, args, pos));
 
@@ -246,7 +250,7 @@ SampleStack::preFunctionCallHook(EvalState & state, const Value & v, std::span<V
 }
 
 [[gnu::noinline]] void
-SampleStack::postFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+SampleStack::postFunctionCallHook(EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos)
 {
     if (!stack.empty())
         stack.pop_back();

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -652,14 +652,13 @@ std::optional<EvalState::Doc> EvalState::getDoc(Value & v)
     if (isFunctor(v)) {
         try {
             Value & functor = *v.attrs()->get(s.functor)->value;
-            Value * vp[] = {&v};
             Value partiallyApplied;
             // The first parameter is not user-provided, and may be
             // handled by code that is opaque to the user, like lib.const = x: y: y;
             // So preferably we show docs that are relevant to the
             // "partially applied" function returned by e.g. `const`.
             // We apply the first argument:
-            callFunction(functor, vp, partiallyApplied, noPos);
+            callFunction(functor, std::to_array({&v}), partiallyApplied, noPos);
             auto _level = addCallDepth(noPos);
             return getDoc(partiallyApplied);
         } catch (Error & e) {
@@ -1546,7 +1545,7 @@ void ExprLambda::eval(EvalState & state, Env & env, Value & v)
     v.mkLambda(&env, this);
 }
 
-void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes, const PosIdx pos)
+void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value & vRes, const PosIdx pos)
 {
     auto _level = addCallDepth(pos);
 
@@ -1699,7 +1698,7 @@ void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes,
                     primOpCalls[fn->name]++;
 
                 try {
-                    fn->impl(*this, vCur.determinePos(noPos), args.data(), vCur);
+                    fn->impl(*this, vCur.determinePos(noPos), const_cast<Value **>(args.data()), vCur);
                 } catch (Error & e) {
                     if (fn->addTrace)
                         addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);
@@ -1764,10 +1763,8 @@ void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes,
             /* 'vCur' may be allocated on the stack of the calling
                function, but for functors we may keep a reference, so
                heap-allocate a copy and use that instead. */
-            Value * args2[] = {allocValue(), args[0]};
-            *args2[0] = vCur;
             try {
-                callFunction(*functor->value, args2, vCur, functor->pos);
+                callFunction(*functor->value, std::to_array({&(*allocValue() = vCur), args[0]}), vCur, functor->pos);
             } catch (Error & e) {
                 e.addTrace(positions[pos], "while calling a functor (an attribute set with a '__functor' attribute)");
                 throw;

--- a/src/libexpr/function-trace.cc
+++ b/src/libexpr/function-trace.cc
@@ -4,7 +4,7 @@
 namespace nix {
 
 void FunctionCallTrace::preFunctionCallHook(
-    EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+    EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos)
 {
     auto duration = std::chrono::high_resolution_clock::now().time_since_epoch();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
@@ -12,7 +12,7 @@ void FunctionCallTrace::preFunctionCallHook(
 }
 
 void FunctionCallTrace::postFunctionCallHook(
-    EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+    EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos)
 {
     auto duration = std::chrono::high_resolution_clock::now().time_since_epoch();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);

--- a/src/libexpr/include/nix/expr/eval-profiler.hh
+++ b/src/libexpr/include/nix/expr/eval-profiler.hh
@@ -62,7 +62,8 @@ public:
      * @param args Function arguments.
      * @param pos Function position.
      */
-    virtual void preFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos);
+    virtual void
+    preFunctionCallHook(EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos);
 
     /**
      * Hook called on EvalState::callFunction exit.
@@ -73,7 +74,8 @@ public:
      * @param args Function arguments.
      * @param pos Function position.
      */
-    virtual void postFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos);
+    virtual void
+    postFunctionCallHook(EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos);
 
     virtual ~EvalProfiler() = default;
 
@@ -104,9 +106,9 @@ public:
     void addProfiler(ref<EvalProfiler> profiler);
 
     [[gnu::noinline]] void
-    preFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) override;
+    preFunctionCallHook(EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos) override;
     [[gnu::noinline]] void
-    postFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) override;
+    postFunctionCallHook(EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos) override;
 };
 
 ref<EvalProfiler> makeSampleStackProfiler(EvalState & state, std::filesystem::path profileFile, uint64_t frequency);

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -79,6 +79,7 @@ public:
 
 /**
  * Function that implements a primop.
+ * FIXME: `args` should be `Value * const *` instead of `Value **`, but that would be a big tedious diff.
  */
 using PrimOpFun = void(EvalState & state, const PosIdx pos, Value ** args, Value & v);
 
@@ -950,12 +951,11 @@ public:
 
     bool isFunctor(const Value & fun) const;
 
-    void callFunction(Value & fun, std::span<Value *> args, Value & vRes, const PosIdx pos);
+    void callFunction(Value & fun, std::span<Value * const> args, Value & vRes, const PosIdx pos);
 
     void callFunction(Value & fun, Value & arg, Value & vRes, const PosIdx pos)
     {
-        Value * args[] = {&arg};
-        callFunction(fun, args, vRes, pos);
+        callFunction(fun, std::to_array({&arg}), vRes, pos);
     }
 
     /**

--- a/src/libexpr/include/nix/expr/function-trace.hh
+++ b/src/libexpr/include/nix/expr/function-trace.hh
@@ -17,9 +17,9 @@ public:
     FunctionCallTrace() = default;
 
     [[gnu::noinline]] void
-    preFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) override;
+    preFunctionCallHook(EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos) override;
     [[gnu::noinline]] void
-    postFunctionCallHook(EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) override;
+    postFunctionCallHook(EvalState & state, const Value & v, std::span<Value * const> args, const PosIdx pos) override;
 };
 
 } // namespace nix

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -874,7 +874,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
         /* Call the `operator' function with `e' as argument. */
         Value newElements;
         try {
-            state.callFunction(*op->value, {&e, 1}, newElements, noPos);
+            state.callFunction(*op->value, std::to_array({e}), newElements, noPos);
             state.forceList(
                 newElements,
                 noPos,
@@ -2863,9 +2863,8 @@ bool EvalState::callPathFilter(Value * filterFun, const SourcePath & path, PosId
     arg1.mkString(path.path.abs(), mem);
 
     // assert that type is not "unknown"
-    Value * args[]{&arg1, const_cast<Value *>(&fileTypeToString(*this, st.type))};
     Value res;
-    callFunction(*filterFun, args, res, pos);
+    callFunction(*filterFun, std::to_array({&arg1, const_cast<Value *>(&fileTypeToString(*this, st.type))}), res, pos);
 
     return forceBool(res, pos, "while evaluating the return value of the path filter function");
 }
@@ -3972,7 +3971,7 @@ static void prim_foldlStrict(EvalState & state, const PosIdx pos, Value ** args,
 
         auto listView = args[2]->listView();
         for (auto [n, elem] : enumerate(listView)) {
-            Value * vs[]{vCur, elem};
+            auto vs = std::to_array({vCur, elem});
             vCur = n == args[2]->listSize() - 1 ? &v : state.allocValue();
             state.callFunction(*args[0], vs, *vCur, pos);
         }
@@ -4149,9 +4148,8 @@ static void prim_sort(EvalState & state, const PosIdx pos, Value ** args, Value 
                     a, b);
         }
 
-        Value * vs[] = {a, b};
         Value vBool;
-        state.callFunction(*args[0], vs, vBool, noPos);
+        state.callFunction(*args[0], std::to_array({a, b}), vBool, noPos);
         return state.forceBool(
             vBool, pos, "while evaluating the return value of the sorting function passed to builtins.sort");
     };

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -975,8 +975,7 @@ void callFlake(EvalState & state, const LockedFlake & lockedFlake, Value & vRes)
     auto vFetchFinalTree = get(state.internalPrimOps, "fetchFinalTree");
     assert(vFetchFinalTree);
 
-    Value * args[] = {vLocks, &vOverrides, *vFetchFinalTree};
-    state.callFunction(*vCallFlake, args, vRes, noPos);
+    state.callFunction(*vCallFlake, std::to_array({vLocks, &vOverrides, *vFetchFinalTree}), vRes, noPos);
 }
 
 std::optional<Fingerprint> LockedFlake::getFingerprint(Store & store, const fetchers::Settings & fetchSettings) const

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -285,8 +285,7 @@ static void showHelp(std::vector<std::string> subcommand, NixArgs & toplevel)
     vDump->mkString(toplevel.dumpCli(), state.mem);
 
     auto vRes = state.allocValue();
-    Value * args[]{&state.getBuiltin("false"), vDump};
-    state.callFunction(*vGenerateManpage, args, *vRes, noPos);
+    state.callFunction(*vGenerateManpage, std::to_array({&state.getBuiltin("false"), vDump}), *vRes, noPos);
 
     auto attr = vRes->attrs()->get(state.symbols.create(mdName + ".md"));
     if (!attr)


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This required tightening the type of `callFunction()` from taking a `std::span<Value *>` to a `std::span<Value * const>` (which more correctly expresses that the value pointers themselves cannot change. We should do the same for the type of primop arguments, but that would be a big diff.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
