### PR TITLE
clang-format: Enforce "west const" style consistently

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,3 +33,4 @@ PPIndentWidth: 2
 BinPackArguments: false
 BreakBeforeTernaryOperators: true
 SeparateDefinitionBlocks: Always
+QualifierAlignment: Left

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -67,7 +67,7 @@ struct NixRepl : AbstractNixRepl, detail::ReplCompleterMixin, gc
     Strings loadedFlakes;
     fun<AnnotatedValues()> getValues;
 
-    const static int envSize = 32768;
+    static const int envSize = 32768;
     std::shared_ptr<StaticEnv> staticEnv;
     std::optional<Value> lastLoaded;
     Env * env;

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -378,7 +378,7 @@ static RegisterPrimOp primop_fetchTree({
           `type` or an attribute like `builtins.fetchTree.git`! -->
         )");
 
-        auto indentString = [](std::string const & str, std::string const & indent) {
+        auto indentString = [](const std::string & str, const std::string & indent) {
             std::string result;
             std::istringstream stream(str);
             std::string line;

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -22,7 +22,7 @@ struct DownloadUrl
 };
 
 // A github, gitlab, or sourcehut host
-const static std::string hostRegexS = "[a-zA-Z0-9.-]*"; // FIXME: check
+static const std::string hostRegexS = "[a-zA-Z0-9.-]*"; // FIXME: check
 std::regex hostRegex(hostRegexS, std::regex::ECMAScript);
 
 struct GitArchiveInputScheme : InputScheme

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -123,7 +123,7 @@ std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragment
     bool allowMissing = false,
     bool isFlake = true);
 
-const static std::string flakeIdRegexS = "[a-zA-Z][a-zA-Z0-9_-]*";
+static const std::string flakeIdRegexS = "[a-zA-Z][a-zA-Z0-9_-]*";
 extern std::regex flakeIdRegex;
 
 } // namespace nix

--- a/src/libstore/freebsd/build/freebsd-derivation-builder.cc
+++ b/src/libstore/freebsd/build/freebsd-derivation-builder.cc
@@ -56,7 +56,7 @@ static constexpr HASHINFO dbFlags = {
 // Version 4 has been current since 2003
 static const uint8_t dbVersion = 4;
 
-static void serializeString(std::vector<uint8_t> & buf, std::string const & str)
+static void serializeString(std::vector<uint8_t> & buf, const std::string & str)
 {
     buf.insert(buf.end(), str.begin(), str.end());
     buf.push_back(0);
@@ -71,7 +71,7 @@ static void serializeInt(std::vector<uint8_t> & buf, uint32_t num)
     buf.push_back((num >> 0) & 0xff);
 }
 
-static std::vector<uint8_t> byNameKey(std::string const & name)
+static std::vector<uint8_t> byNameKey(const std::string & name)
 {
     std::vector<uint8_t> buf{_PW_VERSIONED(_PW_KEYBYNAME, dbVersion)};
     buf.reserve(1 + name.size());

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -115,9 +115,9 @@ protected:
      * the build trace entries themselves than the entire directory, for
      * a smoother migration path.
      */
-    constexpr const static std::string realisationsPrefix = "build-trace-v2";
+    constexpr static const std::string realisationsPrefix = "build-trace-v2";
 
-    constexpr const static std::string cacheInfoFile = "nix-cache-info";
+    constexpr static const std::string cacheInfoFile = "nix-cache-info";
 
     BinaryCacheStore(Config &);
 

--- a/src/libstore/include/nix/store/local-fs-store.hh
+++ b/src/libstore/include/nix/store/local-fs-store.hh
@@ -99,7 +99,7 @@ public:
 
     inline static std::string operationName = "Local Filesystem Store";
 
-    const static std::filesystem::path drvsLogDir;
+    static const std::filesystem::path drvsLogDir;
 
     LocalFSStore(const Config & params);
 

--- a/src/libstore/unix/build/child.cc
+++ b/src/libstore/unix/build/child.cc
@@ -11,7 +11,7 @@ void commonChildInit()
 {
     logger = makeSimpleLogger().release();
 
-    const static std::string pathNullDevice = "/dev/null";
+    static const std::string pathNullDevice = "/dev/null";
     restoreProcessContext(false);
 
     /* Put the child in a separate session (and thus a separate

--- a/src/libstore/unix/build/derivation-builder-impl.hh
+++ b/src/libstore/unix/build/derivation-builder-impl.hh
@@ -138,7 +138,7 @@ protected:
      */
     Sync<OutputPathMap> submittedOutputs;
 
-    const static std::filesystem::path homeDir;
+    static const std::filesystem::path homeDir;
 
     /**
      * The recursive Nix daemon socket.

--- a/src/libutil-tests/checked-arithmetic.cc
+++ b/src/libutil-tests/checked-arithmetic.cc
@@ -26,7 +26,7 @@ namespace nix::checked {
 
 // Pointer to member function! Mildly gross.
 template<std::integral T>
-using Oper = Checked<T>::Result (Checked<T>::*)(T const other) const;
+using Oper = Checked<T>::Result (Checked<T>::*)(const T other) const;
 
 template<std::integral T>
 using ReferenceOper = T (*)(T a, T b);
@@ -97,7 +97,7 @@ void checkDivision(TSmall a_, TSmall b)
  * extremely cheap tests such as arithmetic tests */
 static rc::detail::TestParams makeParams()
 {
-    auto const & conf = rc::detail::configuration();
+    const auto & conf = rc::detail::configuration();
     auto newParams = conf.testParams;
     newParams.maxSuccess = 10000;
     return newParams;

--- a/src/libutil-tests/git.cc
+++ b/src/libutil-tests/git.cc
@@ -101,7 +101,7 @@ TEST_F(GitTest, blob_write)
  * so that we can check our test data in a small shell script test test
  * (`src/libutil-tests/data/git/check-data.sh`).
  */
-const static git::Tree treeSha1 = {
+static const git::Tree treeSha1 = {
     {
         "Foo",
         {
@@ -141,7 +141,7 @@ const static git::Tree treeSha1 = {
  * Same conceptual object as `treeSha1`, just different hash algorithm.
  * See that one for details.
  */
-const static git::Tree treeSha256 = {
+static const git::Tree treeSha256 = {
     {
         "Foo",
         {

--- a/src/libutil/git.cc
+++ b/src/libutil/git.cc
@@ -327,7 +327,7 @@ TreeEntry dumpHash(HashAlgorithm ha, const SourcePath & path, PathFilter & filte
 
 std::optional<LsRemoteRefLine> parseLsRemoteLine(std::string_view line)
 {
-    const static std::regex line_regex("^(ref: *)?([^\\s]+)(?:\\t+(.*))?$");
+    static const std::regex line_regex("^(ref: *)?([^\\s]+)(?:\\t+(.*))?$");
     std::match_results<std::string_view::const_iterator> match;
     if (!std::regex_match(line.cbegin(), line.cend(), match, line_regex))
         return std::nullopt;

--- a/src/libutil/include/nix/util/base-nix-32.hh
+++ b/src/libutil/include/nix/util/base-nix-32.hh
@@ -19,7 +19,7 @@ struct BaseNix32
 private:
     static const std::array<uint8_t, 256> reverseMap;
 
-    const static constexpr uint8_t invalid = 0xFF;
+    static constexpr const uint8_t invalid = 0xFF;
 
 public:
     static inline std::optional<uint8_t> lookupReverse(char base32)

--- a/src/libutil/include/nix/util/canon-path.hh
+++ b/src/libutil/include/nix/util/canon-path.hh
@@ -108,7 +108,7 @@ public:
      */
     const std::string & absOrEmpty() const
     {
-        const static std::string epsilon;
+        static const std::string epsilon;
         return isRoot() ? epsilon : path;
     }
 

--- a/src/libutil/include/nix/util/checked-arithmetic.hh
+++ b/src/libutil/include/nix/util/checked-arithmetic.hh
@@ -41,18 +41,18 @@ struct Checked
 
     Checked() = default;
 
-    explicit Checked(T const value)
+    explicit Checked(const T value)
         : value{value}
     {
     }
 
-    Checked(Checked<T> const & other) = default;
+    Checked(const Checked<T> & other) = default;
     Checked(Checked<T> && other) = default;
-    Checked<T> & operator=(Checked<T> const & other) = default;
+    Checked<T> & operator=(const Checked<T> & other) = default;
 
-    std::strong_ordering operator<=>(Checked<T> const & other) const = default;
+    std::strong_ordering operator<=>(const Checked<T> & other) const = default;
 
-    std::strong_ordering operator<=>(T const & other) const
+    std::strong_ordering operator<=>(const T & other) const
     {
         return value <=> other;
     }
@@ -124,43 +124,43 @@ struct Checked
         }
     };
 
-    Result operator+(Checked<T> const other) const
+    Result operator+(const Checked<T> other) const
     {
         return (*this) + other.value;
     }
 
-    Result operator+(T const other) const
+    Result operator+(const T other) const
     {
         T result;
         bool overflowed = __builtin_add_overflow(value, other, &result);
         return Result{result, overflowed};
     }
 
-    Result operator-(Checked<T> const other) const
+    Result operator-(const Checked<T> other) const
     {
         return (*this) - other.value;
     }
 
-    Result operator-(T const other) const
+    Result operator-(const T other) const
     {
         T result;
         bool overflowed = __builtin_sub_overflow(value, other, &result);
         return Result{result, overflowed};
     }
 
-    Result operator*(Checked<T> const other) const
+    Result operator*(const Checked<T> other) const
     {
         return (*this) * other.value;
     }
 
-    Result operator*(T const other) const
+    Result operator*(const T other) const
     {
         T result;
         bool overflowed = __builtin_mul_overflow(value, other, &result);
         return Result{result, overflowed};
     }
 
-    Result operator/(Checked<T> const other) const
+    Result operator/(const Checked<T> other) const
     {
         return (*this) / other.value;
     }
@@ -171,9 +171,9 @@ struct Checked
      * If the right hand side is zero, the result is marked as a DivByZero and
      * valueWrapping will throw.
      */
-    Result operator/(T const other) const
+    Result operator/(const T other) const
     {
-        constexpr T const minV = std::numeric_limits<T>::min();
+        constexpr const T minV = std::numeric_limits<T>::min();
 
         // It's only possible to overflow with signed division since doing so
         // requires crossing the two's complement limits by MIN / -1 (since

--- a/src/libutil/include/nix/util/fmt.hh
+++ b/src/libutil/include/nix/util/fmt.hh
@@ -224,7 +224,7 @@ public:
         return *this;
     }
 
-    HintFmt & operator=(HintFmt const & rhs) = default;
+    HintFmt & operator=(const HintFmt & rhs) = default;
 
     std::string str() const
     {

--- a/src/libutil/include/nix/util/url-parts.hh
+++ b/src/libutil/include/nix/util/url-parts.hh
@@ -7,23 +7,23 @@
 namespace nix {
 
 // URI stuff.
-const static std::string pctEncoded = "(?:%[0-9a-fA-F][0-9a-fA-F])";
-const static std::string unreservedRegex = "(?:[a-zA-Z0-9-._~])";
-const static std::string subdelimsRegex = "(?:[!$&'\"()*+,;=])";
-const static std::string pcharRegex = "(?:" + unreservedRegex + "|" + pctEncoded + "|" + subdelimsRegex + "|[:@])";
-const static std::string fragmentRegex = "(?:" + pcharRegex + "|[/? \"^])*";
+static const std::string pctEncoded = "(?:%[0-9a-fA-F][0-9a-fA-F])";
+static const std::string unreservedRegex = "(?:[a-zA-Z0-9-._~])";
+static const std::string subdelimsRegex = "(?:[!$&'\"()*+,;=])";
+static const std::string pcharRegex = "(?:" + unreservedRegex + "|" + pctEncoded + "|" + subdelimsRegex + "|[:@])";
+static const std::string fragmentRegex = "(?:" + pcharRegex + "|[/? \"^])*";
 
 /// A Git ref (i.e. branch or tag name).
 /// \todo check that this is correct.
 /// This regex incomplete. See https://git-scm.com/docs/git-check-ref-format
-const static std::string refRegexS = "[a-zA-Z0-9@][a-zA-Z0-9_.\\/@+-]*";
+static const std::string refRegexS = "[a-zA-Z0-9@][a-zA-Z0-9_.\\/@+-]*";
 extern std::regex refRegex;
 
 /// A Git revision (a SHA-1 commit hash).
-const static std::string revRegexS = "[0-9a-fA-F]{40}";
+static const std::string revRegexS = "[0-9a-fA-F]{40}";
 extern std::regex revRegex;
 
 /// A ref or revision, or a ref followed by a revision.
-const static std::string refAndOrRevRegex = "(?:(" + revRegexS + ")|(?:(" + refRegexS + ")(?:/(" + revRegexS + "))?))";
+static const std::string refAndOrRevRegex = "(?:(" + revRegexS + ")|(?:(" + refRegexS + ")(?:/(" + revRegexS + "))?))";
 
 } // namespace nix

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -299,8 +299,8 @@ try {
     throw BadURL("invalid URI query '%s': %s", query, e.code().message());
 }
 
-const static std::string allowedInQuery = ":@/?";
-const static std::string allowedInPath = ":@";
+static const std::string allowedInQuery = ":@/?";
+static const std::string allowedInPath = ":@";
 
 std::string encodeUrlPath(std::span<const std::string> urlPath)
 {
@@ -713,7 +713,7 @@ ParsedURL fixGitURL(std::string url)
 // https://www.rfc-editor.org/rfc/rfc3986#section-3.1
 bool isValidSchemeName(std::string_view s)
 {
-    const static std::string schemeNameRegex = "(?:[a-z][a-z0-9+.-]*)";
+    static const std::string schemeNameRegex = "(?:[a-z][a-z0-9+.-]*)";
     static std::regex regex(schemeNameRegex, std::regex::ECMAScript);
 
     return std::regex_match(s.begin(), s.end(), regex, std::regex_constants::match_default);

--- a/src/nix/crash-handler.cc
+++ b/src/nix/crash-handler.cc
@@ -22,7 +22,7 @@ namespace nix {
 
 namespace {
 
-void logFatal(std::string const & s)
+void logFatal(const std::string & s)
 {
     writeToStderr(s + "\n");
     // std::string for guaranteed null termination

--- a/src/nix/diff-closures.cc
+++ b/src/nix/diff-closures.cc
@@ -28,14 +28,14 @@ GroupedPaths getClosureInfo(ref<Store> store, const StorePath & toplevel)
 
     GroupedPaths groupedPaths;
 
-    for (auto const & path : closure) {
+    for (const auto & path : closure) {
         /* Strip the output name. Unfortunately this is ambiguous (we
            can't distinguish between output names like "bin" and
            version suffixes like "unstable"). */
         static std::regex regex("(.*)-([a-z]+|lib32|lib64)");
         std::cmatch match;
         std::string name{path.name()};
-        std::string_view const origName = path.name();
+        const std::string_view origName = path.name();
         std::string outputName;
 
         if (std::regex_match(origName.begin(), origName.end(), match, regex)) {

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -110,7 +110,7 @@ struct CmdWhyDepends : SourceExprCommand, MixOperateOnOptions
         auto dependencyPath = *optDependencyPath;
         auto dependencyPathHash = dependencyPath.hashPart();
 
-        auto const inf = std::numeric_limits<size_t>::max();
+        const auto inf = std::numeric_limits<size_t>::max();
 
         struct Node
         {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The current codebase uses west const quite consistently, so enforce that. Even though it would be preferable to use east const, the diff for that is quite large (+-6kloc).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
