### PR TITLE
libfetchers/path: implement getFingerprint() for PathInputScheme

### DIFF
--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -49,6 +49,7 @@ sources = files(
   'git.cc',
   'input.cc',
   'nix_api_fetchers.cc',
+  'path-fingerprint.cc',
   'public-key.cc',
 )
 

--- a/src/libfetchers-tests/path-fingerprint.cc
+++ b/src/libfetchers-tests/path-fingerprint.cc
@@ -1,0 +1,81 @@
+#include "nix/fetchers/fetchers.hh"
+#include "nix/fetchers/fetch-settings.hh"
+#include "nix/store/dummy-store-impl.hh"
+#include "nix/store/globals.hh"
+#include "nix/store/tests/libstore.hh"
+#include "nix/util/configuration.hh"
+#include "nix/util/memory-source-accessor.hh"
+
+#include <gtest/gtest.h>
+
+namespace nix {
+
+class PathFingerprintTest : public LibStoreTest
+{
+protected:
+    fetchers::Settings fetchSettings;
+
+    PathFingerprintTest()
+        : LibStoreTest([] {
+            auto config = make_ref<DummyStoreConfig>(DummyStoreConfig::Params{});
+            config->readOnly = false;
+            return config->openDummyStore();
+        }())
+    {
+    }
+
+    void SetUp() override
+    {
+        LibStoreTest::SetUp();
+        experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
+    }
+};
+
+TEST_F(PathFingerprintTest, valid_store_path_returns_fingerprint)
+{
+    auto storePath = store->addToStore(
+        "source",
+        SourcePath{
+            [] {
+                auto sc = make_ref<MemorySourceAccessor>();
+                sc->root = MemorySourceAccessor::File{MemorySourceAccessor::File::Regular{
+                    .executable = false,
+                    .contents = "test content",
+                }};
+                return sc;
+            }(),
+        },
+        ContentAddressMethod::Raw::NixArchive,
+        HashAlgorithm::SHA256);
+
+    auto input = fetchers::Input::fromAttrs(
+        fetchSettings, fetchers::Attrs{{"type", "path"}, {"path", store->printStorePath(storePath)}});
+
+    auto fingerprint = input.getFingerprint(*store);
+    ASSERT_TRUE(fingerprint.has_value());
+    EXPECT_TRUE(fingerprint->starts_with("path:"));
+}
+
+TEST_F(PathFingerprintTest, relative_path_returns_nullopt)
+{
+    auto input =
+        fetchers::Input::fromAttrs(fetchSettings, fetchers::Attrs{{"type", "path"}, {"path", "./relative/path"}});
+
+    EXPECT_NO_THROW({
+        auto fingerprint = input.getFingerprint(*store);
+        EXPECT_FALSE(fingerprint.has_value());
+    });
+}
+
+TEST_F(PathFingerprintTest, non_store_path_returns_nullopt)
+{
+    auto input = fetchers::Input::fromAttrs(
+        fetchSettings, fetchers::Attrs{{"type", "path"}, {"path", "/nonexistent/store/path"}});
+
+    EXPECT_NO_THROW({
+        auto fingerprint = input.getFingerprint(*store);
+        EXPECT_FALSE(fingerprint.has_value());
+    });
+}
+
+} // namespace nix

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -180,6 +180,22 @@ struct PathInputScheme : InputScheme
         return {accessor, std::move(input)};
     }
 
+    std::optional<std::string> getFingerprint(Store & store, const Input & input) const override
+    {
+        if (isRelative(input).has_value())
+            return std::nullopt;
+
+        try {
+            auto absPath = getAbsPath(input);
+            auto storePath = store.maybeParseStorePath(absPath.string());
+            if (storePath && store.isValidPath(*storePath)) {
+                return fmt("path:%s", store.queryPathInfo(*storePath)->narHash.to_string(HashFormat::SRI, true));
+            }
+        } catch (Error &) {
+        }
+        return std::nullopt;
+    }
+
     std::optional<ExperimentalFeature> experimentalFeature() const override
     {
         return Xp::Flakes;


### PR DESCRIPTION
TL;DR: PathInputScheme needs getFingerprint for caching. currently fetchToStore() re-copies every time. Now it doesn't.

---

PathInputScheme was the only InputScheme that didn't implement getFingerprint(). This caused the substitution path in getAccessorUnchecked() to return an accessor with a null fingerprint, which prevented the fetcher cache from creating an entry. As a result, fetchToStore() couldn't find a cache hit and re-copied path inputs that were already valid in the Nix store.

This is a continuation of the fix in #14041 which added cache entries for substituted inputs, but relied on getFingerprint() returning non-null. PathInputScheme broke that contract.

The implementation is conservative: it only returns a fingerprint for paths that are valid store paths (/nix/store/...). While i can think of use cases for relative paths or non-store paths, I stuck with keeping it returns nullopt. The fingerprint format matches the one used in getAccessor() ("path:<narHash>").

---

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Testing
Used `nix flake lock --override-input nixpkgs flake:nixpkgs` and `nix develop --override-input nixpkgs flake:nixpkgs` in a system where `nix.registry.nixpkgs` is pointing to a store path. Before this fix, `fetchToStore()` re-copies the path on every invocation. After, it's cached as expected.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
