### PR TITLE
libutil: add missing <new> include to bump-memory-resource.hh

### DIFF
--- a/src/libutil/include/nix/util/bump-memory-resource.hh
+++ b/src/libutil/include/nix/util/bump-memory-resource.hh
@@ -3,6 +3,7 @@
 
 #include <atomic>
 #include <memory_resource>
+#include <new>
 
 namespace nix {
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
Include `<new>` explicitly for `std::hardware_destructive_interference_size`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context
Following a libc++ change("Granularize \<new\> includes", see llvm/llvm-project#119964), `<memory_resource>` no longer transitively includes `<new>`.

```
FAILED: src/libutil/libnixutil.so.2.35.1.p/bump-memory-resource.cc.o

  In file included from
  ../nix-2.35.1/src/libutil/bump-memory-resource.cc:1:

  ../nix-2.35.1/src/libutil/include/nix/util/bump-memory-resource.hh:21:18:
  error: no member named 'hardware_destructive_interference_size'
  in namespace 'std'

     21 | alignas(std::hardware_destructive_interference_size)
        |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  1 error generated.
  ninja: build stopped: subcommand failed.
```

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
