### PR TITLE
libstore: dedup RemoteStore::addTempRoot per connection

### DIFF
--- a/src/libstore/include/nix/store/remote-store-connection.hh
+++ b/src/libstore/include/nix/store/remote-store-connection.hh
@@ -5,6 +5,7 @@
 #include "nix/store/worker-protocol.hh"
 #include "nix/store/worker-protocol-connection.hh"
 #include "nix/util/pool.hh"
+#include "nix/util/lru-cache.hh"
 
 namespace nix {
 
@@ -27,6 +28,15 @@ public:
      * Time this connection was established.
      */
     std::chrono::time_point<std::chrono::steady_clock> startTime;
+
+    /**
+     * Paths already pinned as temp roots on this connection.
+     * Temp roots persist for the duration of the connection, so retransmission
+     * is not required.
+     * Skipping the wire call is an optional but worthwhile optimization that
+     * reduces communication overhead. LRU eviction would cost a round-trip.
+     */
+    LRUCache<StorePath, bool> tempRootsPinned{65536};
 };
 
 /**

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -747,7 +747,10 @@ ref<Builder> RemoteStore::getBuilder(std::shared_ptr<Store> evalStore)
 void RemoteStore::addTempRoot(const StorePath & path)
 {
     auto conn(getConnection());
+    if (conn->tempRootsPinned.get(path))
+        return;
     conn->addTempRoot(*this, &conn.daemonException, path);
+    conn->tempRootsPinned.upsert(path, true);
 }
 
 Roots RemoteStore::findRoots(bool censor)


### PR DESCRIPTION
Not as extensive as: https://github.com/NixOS/nix/pull/15546#issuecomment-4171236201
Related: https://github.com/NixOS/nix/pull/16113

There is lots of duplication in addTempRoot, cache it in the client before sending to daemon?

Measurements:
  AddTempRoot: 58,137 → 6,215 ops (-89.3%)
  Total ops:  118,772 → 66,850 ops (-43.7%)

Hyperfine, 10 runs each:
  Warm cache: 14.98 s → 14.17 s (-5.4%, 1.06x faster ±0.04)
  Cold cache: 18.29 s → 16.52 s (-9.7%, 1.11x faster ±0.02)

Assisted-By: Claude Opus 4.7