### PR TITLE
Tighten NUL bytes usage in syscalls, ban them in stringsToCharPtrs

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1099,11 +1099,14 @@ static std::unique_ptr<PostBuildHookState> runPostBuildHook(
             Strings args_;
             args_.push_front(hook);
 
+            /* FIXME: This will also close the mountns descriptor, and
+               restoreProcessContext() will silently swallow the error. Should
+               be the other way around. */
             unix::closeExtraFDs();
 
             restoreProcessContext();
 
-            execvp(hook.c_str(), stringsToCharPtrs(args_).data());
+            execvp(requireCString(hook), stringsToCharPtrs(args_).data());
 
             throw SysError("executing %s", PathFmt(hook));
         },

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1087,7 +1087,7 @@ void DerivationBuilderImpl::setUser()
 
 void DerivationBuilderImpl::execBuilder(const Strings & args, const Strings & envStrs)
 {
-    execve(drv.builder.c_str(), stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
+    execve(requireCString(drv.builder), stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
 }
 
 SingleDrvOutputs DerivationBuilderImpl::registerOutputs()

--- a/src/libstore/unix/build/hook-instance.cc
+++ b/src/libstore/unix/build/hook-instance.cc
@@ -65,7 +65,7 @@ HookInstance::HookInstance(const Strings & _buildHook)
         if (dup2(builderOut.readSide.get(), 5) == -1)
             throw SysError("dupping builder's stdout/stderr");
 
-        execv(buildHook.native().c_str(), stringsToCharPtrs(args).data());
+        execv(requireCString(buildHook.native()), stringsToCharPtrs(args).data());
 
         throw SysError("executing %s", PathFmt(buildHook));
     });

--- a/src/libutil-tests/util.cc
+++ b/src/libutil-tests/util.cc
@@ -1,8 +1,13 @@
 #include "nix/util/util.hh"
 #include "nix/util/types.hh"
+#include "nix/util/tests/gmock-matchers.hh"
 
 #include <limits.h>
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <string>
+#include <string_view>
 
 namespace nix {
 
@@ -415,6 +420,19 @@ TEST(markLast, mutateThroughReference)
         if (last)
             x = 99;
     ASSERT_EQ(v, (std::vector<int>{1, 2, 99}));
+}
+
+/* ----------------------------------------------------------------------------
+ * stringsToCharPtrs
+ * --------------------------------------------------------------------------*/
+
+TEST(stringsToCharPtrs, rejectsNulBytes)
+{
+    using namespace std::string_literals;
+    ASSERT_THAT(
+        [&]() { stringsToCharPtrs({"aaa\0bbb"s}); },
+        ::testing::ThrowsMessage<nix::Error>(
+            testing::HasSubstrIgnoreANSIMatcher("string 'aaa␀bbb' with null (␀) bytes used where it's not allowed"s)));
 }
 
 } // namespace nix

--- a/src/libutil/strings.cc
+++ b/src/libutil/strings.cc
@@ -155,7 +155,7 @@ const char * requireCString(const std::string & s)
     if (std::memchr(s.data(), '\0', s.size())) [[unlikely]] {
         using namespace std::string_view_literals;
         auto str = replaceStrings(s, "\0"sv, "␀"sv);
-        throw Error("string '%s' with null (\\0) bytes used where it's not allowed", str);
+        throw Error("string '%s' with null (␀) bytes used where it's not allowed", str);
     }
     return s.c_str();
 }

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -50,9 +50,9 @@ void initLibUtil()
 std::vector<char *> stringsToCharPtrs(const Strings & ss)
 {
     std::vector<char *> res;
-    for (auto & s : ss)
-        res.push_back((char *) s.c_str());
-    res.push_back(0);
+    for (const auto & s : ss)
+        res.push_back(const_cast<char *>(requireCString(s)));
+    res.push_back(nullptr);
     return res;
 }
 

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -678,6 +678,8 @@ static void main_nix_build(int argc, char ** argv)
 
         Strings envStrs;
         for (auto & i : env)
+            /* TODO: Check that `i.first` doesn't contain an `=` sign. Or maybe factor out the environment
+               strings preparation code. */
             envStrs.push_back(i.first + "=" + i.second);
 
         auto args = interactive ? Strings{"bash", "--rcfile", rcfile} : Strings{"bash", rcfile};
@@ -692,7 +694,7 @@ static void main_nix_build(int argc, char ** argv)
 
         logger->stop();
 
-        execvp(shell->c_str(), argPtrs.data());
+        execvp(requireCString(shell.value()), argPtrs.data());
 
         throw SysError("executing shell '%s'", *shell);
     }

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -83,6 +83,7 @@ void execProgramInStore(
         for (auto & arg : args)
             helperArgs.push_back(arg);
 
+        /* TODO: Gate this behind __linux__ and just exec /proc/self/exe. */
         execve(getSelfExe().value_or("nix").string().c_str(), stringsToCharPtrs(helperArgs).data(), envp);
 
         throw SysError("could not execute chroot helper");
@@ -99,9 +100,9 @@ void execProgramInStore(
     if (useLookupPath == UseLookupPath::Use) {
         // We have to set `environ` by hand because there is no `execvpe` on macOS.
         environ = envp;
-        execvp(program.c_str(), stringsToCharPtrs(args).data());
+        execvp(requireCString(program), stringsToCharPtrs(args).data());
     } else
-        execve(program.c_str(), stringsToCharPtrs(args).data(), envp);
+        execve(requireCString(program), stringsToCharPtrs(args).data(), envp);
 
     throw SysError("unable to execute '%s'", program);
 }
@@ -252,7 +253,7 @@ void chrootHelper(int argc, char ** argv)
         });
 #  endif
 
-    execvp(cmd.c_str(), stringsToCharPtrs(args).data());
+    execvp(requireCString(cmd), stringsToCharPtrs(args).data());
 
     throw SysError("unable to exec '%s'", cmd);
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Partially working towards https://github.com/NixOS/nix/issues/16237, just deep in the call stack as the last line of defense. Parsing should also validate more of this stuff.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
