### PR TITLE
Test `unix::closeExtraFDs`, call it in more places and fix `post-build-hook` `restoreProcessContext`

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1100,12 +1100,11 @@ static std::unique_ptr<PostBuildHookState> runPostBuildHook(
             Strings args_;
             args_.push_front(hook);
 
-            /* FIXME: This will also close the mountns descriptor, and
-               restoreProcessContext() will silently swallow the error. Should
-               be the other way around. */
-            unix::closeExtraFDs();
-
             restoreProcessContext();
+
+            /* On Linux, it's crucial that this is done after restoreProcessContext() since
+               that needs an open mountns file descriptor (fdSavedMountNamespace). */
+            unix::closeExtraFDs();
 
             execvp(requireCString(hook), stringsToCharPtrs(args_).data());
 

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -145,6 +145,7 @@ if host_machine.system() == 'linux'
       args : [
         '--syscall', 'openat2',
         '--syscall', 'fchmodat2',
+        '--syscall', 'close_range',
         '--',
         this_exe,
       ],

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -92,6 +92,7 @@ mkMesonExecutable (finalAttrs: {
                 enosys \
                   --syscall openat2 \
                   --syscall fchmodat2 \
+                  --syscall close_range \
                   -- ${lib.getExe finalAttrs.finalPackage}
                 touch $out
               '';

--- a/src/libutil-tests/unix/file-descriptor.cc
+++ b/src/libutil-tests/unix/file-descriptor.cc
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "nix/util/file-descriptor.hh"
+#include "nix/util/processes.hh"
+
+#include <unistd.h>
+
+namespace nix {
+
+TEST(closeExtraFDs, works)
+{
+    Pipe pipe;
+    pipe.create();
+    Pid pid = startProcess([&]() {
+        unix::closeExtraFDs();
+
+        /* File descriptors should already be closed by unix::closeExtraFDs(). */
+        for (int fd : {pipe.readSide.get(), pipe.writeSide.get()}) {
+            if (::close(fd) == 0 || errno != EBADF)
+                _exit(1);
+        }
+
+        /* stdin, stdout and stderr should not be closed. */
+        for (int fd : {STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO}) {
+            if (::close(fd) == -1)
+                _exit(2);
+        }
+
+        _exit(0);
+    });
+
+    ASSERT_NE(pid_t(pid), -1);
+    ASSERT_TRUE(statusOk(pid.wait()));
+}
+
+} // namespace nix

--- a/src/libutil-tests/unix/meson.build
+++ b/src/libutil-tests/unix/meson.build
@@ -1,4 +1,5 @@
 sources += files(
+  'file-descriptor.cc',
   'file-system-at.cc',
   'unix-domain-socket.cc',
 )

--- a/src/libutil/linux/linux-namespaces.cc
+++ b/src/libutil/linux/linux-namespaces.cc
@@ -184,6 +184,8 @@ void restoreMountNamespace()
         if (chdir(savedCwd.c_str()) == -1)
             throw SysError("restoring cwd");
     } catch (Error & e) {
+        /* TODO: Why are we swallowing errors? This can trivially lead to bugs like
+           https://github.com/NixOS/nix/issues/16246. Can we stop doing this?? */
         debug(e.msg());
     }
 }

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -72,14 +72,20 @@ void Pipe::create(bool nonBlocking)
 #else
     if (pipe(fds) != 0)
         throw SysError("creating pipe");
+#endif
+    readSide = fds[0];
+    writeSide = fds[1];
+#if !HAVE_PIPE2
+    /* Assign the members *before* trying to make them non-blocking and
+       close-on-exec since technically that can fail and we should still clean
+       up those descriptors on destruction. Mostly pedantic exception safety, I
+       can't envision a case this would fail on a freshly created pipe. */
     for (auto fd : fds) {
         unix::closeOnExec(fd);
         if (nonBlocking && ::fcntl(fd, F_SETFL, O_NONBLOCK) == -1)
             throw SysError("making pipe non-blocking");
     }
 #endif
-    readSide = fds[0];
-    writeSide = fds[1];
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -342,6 +342,12 @@ void runProgram2(const RunOptions & options)
 
             restoreProcessContext();
 
+            /* Unlike the Linux case, it doesn't matter much that we are closing
+               the FDs before or after restoreProcessContext(), but on Linux
+               it's crucial that it happens *after* restoreProcessContext() call
+               because that re-enters the saved mountns. */
+            unix::closeExtraFDs();
+
             if (options.lookupPath)
                 execvp(options.program.c_str(), stringsToCharPtrs(args_).data());
             // This allows you to refer to a program with a pathname relative


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

A bunch of bug fixes and tests for `unix::closeExtraFDs`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Depends on https://github.com/NixOS/nix/pull/16245.
Fixes https://github.com/NixOS/nix/issues/16246.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
