### PR TITLE
libutil/linux/processes: Close leaked file descriptors in doExecChild

### DIFF
--- a/src/libstore-test-support/https-store.cc
+++ b/src/libstore-test-support/https-store.cc
@@ -92,7 +92,8 @@ void HttpsBinaryCacheStoreTest::SetUp()
 void HttpsBinaryCacheStoreTest::TearDown()
 {
 #ifndef _WIN32 /* FIXME: Can't yet start background processes on windows */
-    serverPid.kill();
+    if (serverPid != -1)
+        serverPid.kill();
 #endif
     delTmpDir.reset();
     testFileTransferSettings.reset();

--- a/src/libutil/linux/processes.cc
+++ b/src/libutil/linux/processes.cc
@@ -21,6 +21,7 @@
 #include <sys/prctl.h>
 #include <grp.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <sched.h>
 
@@ -85,10 +86,12 @@ struct ExecChildParams
  */
 [[gnu::noinline, noreturn]] static void doExecChild(const ExecChildParams & params) noexcept
 {
-    auto die = [&params] [[noreturn]] (int err, const char * msg) {
+    Descriptor errorPipe = params.errorPipe;
+
+    auto die = [&errorPipe] [[noreturn]] (int err, const char * msg) {
         [[maybe_unused]] ssize_t ret; /* Swallow all errors. */
-        ret = ::write(params.errorPipe, reinterpret_cast<const char *>(&err), sizeof(err));
-        ret = ::write(params.errorPipe, msg, ::strlen(msg));
+        ret = ::write(errorPipe, reinterpret_cast<const char *>(&err), sizeof(err));
+        ret = ::write(errorPipe, msg, ::strlen(msg));
         ::_exit(1);
     };
 
@@ -131,6 +134,34 @@ struct ExecChildParams
         if (::chdir(savedCwd) == -1)
             dieWithErrno("restoring cwd");
     }
+
+    /* Now we can safely close all (possibly) leaked file descriptors. Note that
+       we try to open most things as O_CLOEXEC, but we don't control external
+       libraries and some facilities (e.g. libcurl) lack an atomic open with
+       O_CLOEXEC that doesn't race via subsequent fcntl. But for error reporting
+       purposes we should dup (and mark as O_CLOEXEC) the error pipe descriptor.
+       */
+
+    static constexpr int relocatedErrorPipeFD = STDERR_FILENO + 1;
+
+    /* dup3 fails if oldfd == newfd, so skip that case. */
+    if (errorPipe != relocatedErrorPipeFD) {
+        if (::dup3(errorPipe, relocatedErrorPipeFD, O_CLOEXEC) == -1)
+            dieWithErrno("dupping error pipe");
+        errorPipe = relocatedErrorPipeFD;
+    }
+
+#if HAVE_CLOSEFROM
+    /* glibc uses this in its posix_spawn implementation and also exposes it
+       in <unistd.h>. Notably, it has a fallback for kernels that don't support
+       close_range. */
+    ::closefrom(relocatedErrorPipeFD + 1);
+#elifdef SYS_close_range
+    /* This is mostly best-effort. This code should only be used on musl and it
+       would only fail on older kernels. Reimplementing /proc/self/fd iteration
+       like what glibc does in __closefrom_fallback is a lot of complex code. */
+    ::syscall(SYS_close_range, relocatedErrorPipeFD + 1, ~0u, 0);
+#endif
 
     /* Important! Calling syscalls directly and not libc functions because of a
        discrepancy in POSIX specification (i.e. POSIX setgid/setuid has to apply
@@ -180,8 +211,6 @@ struct ExecChildParams
     /* Like unix::restoreSignals(), but safe to do in a vfork child. */
     if (unix::savedSignalMaskIsSet && sigprocmask(SIG_SETMASK, &unix::savedSignalMask, nullptr) == -1)
         dieWithErrno("restoring signals");
-
-    /* TODO: Close leaked file descriptors? The best way is with close_range(). */
 
     if (params.lookupPath)
         /* Nonstandard, but both musl and glibc have it and it doesn't

--- a/src/libutil/unix/meson.build
+++ b/src/libutil/unix/meson.build
@@ -22,6 +22,10 @@ check_funcs_unix = [
     'For closing many file descriptors after forking.',
   ],
   [
+    'closefrom',
+    'For closing many file descriptors after forking.',
+  ],
+  [
     'lutimes',
     'Optionally used for changing the mtime of symlinks.',
   ],


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Rough examples of what the child now does:

(without close_range on glibc):

```
dup2(4, 1)                = 1
dup3(6, 3, O_CLOEXEC)     = 3
close_range(4, 4294967295, 0) = -1 ENOSYS (Function not implemented)
openat(AT_FDCWD, "/proc/self/fd/", O_RDONLY|O_DIRECTORY) = 7
getdents64(7, 0x7ffccbe264b0 /* 10 entries */, 1024) = 240
close(4)                  = 0
close(5)                  = 0
close(6)                  = 0
lseek(7, 0, SEEK_SET)     = 0
getdents64(7, 0x7ffccbe264b0 /* 7 entries */, 1024) = 168
getdents64(7, 0x7ffccbe264b0 /* 0 entries */, 1024) = 0
close(7)                  = 0
prctl(PR_SET_PDEATHSIG, SIGKILL) = 0
```

(with close_range on a kernel that supports it)

```
dup2(4, 1)                = 1
dup3(6, 3, O_CLOEXEC)     = 3
close_range(4, 4294967295, 0) = 0
prctl(PR_SET_PDEATHSIG, SIGKILL) = 0
```

Also fixes an assert in the http binary cache store tests in case spawning the server process fails (noticed while testing out various error code paths).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Partially addresses https://github.com/NixOS/nix/issues/16248.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
