### PR TITLE
libutil: Implement getSelfExe under windows and test trivial runProgram in unit tests

### DIFF
--- a/src/libutil-tests/current-process.cc
+++ b/src/libutil-tests/current-process.cc
@@ -1,0 +1,18 @@
+#include "nix/util/current-process.hh"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace nix {
+
+TEST(getSelfExe, works)
+{
+    auto self = getSelfExe();
+
+    ASSERT_TRUE(self.has_value());
+    ASSERT_TRUE(exists(*self));
+    ASSERT_TRUE(is_regular_file(*self));
+    ASSERT_THAT(self->filename().string(), ::testing::HasSubstr("nix-util-tests"));
+}
+
+} // namespace nix

--- a/src/libutil-tests/main.cc
+++ b/src/libutil-tests/main.cc
@@ -1,0 +1,64 @@
+#include "nix/util/environment-variables.hh"
+#include "nix/util/strings.hh"
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <ranges>
+#include <cstdlib>
+#include <cerrno>
+
+#ifndef _WIN32
+#  include <unistd.h>
+#endif
+
+static int spawnTrivialMain()
+{
+    std::cout << "hello";
+    return EXIT_SUCCESS;
+}
+
+#ifndef _WIN32
+
+static int spawnTestForLeakedFDsMain()
+{
+    /* The parent will open a file descriptor without O_CLOEXEC and we
+       check if it's still open in the child. */
+    auto shouldBeClosed =
+        nix::splitString<std::vector<std::string>>(nix::getEnv("NIX_CHILD_FDS_SHOULD_BE_CLOSED").value(), ",")
+        | std::views::transform([](const std::string & s) { return std::stoi(s); });
+
+    for (auto fd : shouldBeClosed) {
+        if (::close(fd) != -1 || errno != EBADF)
+            return EXIT_FAILURE;
+    }
+
+    /* stdin, stdout and stderr should not be closed. */
+    for (int fd : {STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO}) {
+        if (::close(fd) == -1)
+            return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+#endif
+
+int main(int argc, char ** argv)
+{
+    /* This will get re-execed into from libutil-tests/processes.cc. */
+    if (argc > 1) {
+        auto argv1 = std::string_view(argv[1]);
+
+        if (argv1 == "__util_test_spawn_trivial") {
+            return spawnTrivialMain();
+        } else if (argv1 == "__util_test_spawn_leaked_fds") {
+#ifndef _WIN32
+            return spawnTestForLeakedFDsMain();
+#endif
+        }
+    }
+
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -67,6 +67,7 @@ sources = files(
   'closure.cc',
   'compression.cc',
   'config.cc',
+  'current-process.cc',
   'executable-path.cc',
   'file-content-address.cc',
   'file-descriptor.cc',

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -30,7 +30,7 @@ subdir('nix-meson-build-support/windows-version')
 rapidcheck = dependency('rapidcheck')
 deps_private += rapidcheck
 
-gtest = dependency('gtest', main : true)
+gtest = dependency('gtest', main : false)
 deps_private += gtest
 
 gmock = dependency('gmock')
@@ -81,6 +81,7 @@ sources = files(
   'local-keys.cc',
   'logging.cc',
   'lru-cache.cc',
+  'main.cc',
   'memo.cc',
   'memory-source-accessor.cc',
   'monitorfdhup.cc',

--- a/src/libutil-tests/processes.cc
+++ b/src/libutil-tests/processes.cc
@@ -1,5 +1,7 @@
 #include "nix/util/processes.hh"
+#include "nix/util/current-process.hh"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace nix {
@@ -13,5 +15,90 @@ TEST(statusOk, zeroIsOk)
     ASSERT_EQ(statusOk(0), true);
     ASSERT_EQ(statusOk(1), false);
 }
+
+/* ----------------------------------------------------------------------------
+ * runProgram
+ * --------------------------------------------------------------------------*/
+
+TEST(runProgram, worksTrivial)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    for (bool isInteractive : {false, true}) {
+        std::string output;
+        ASSERT_NO_THROW({
+            output = runProgram(
+                *self,
+                /*lookupPath=*/false,
+                {
+                    OS_STR("__util_test_spawn_trivial"),
+                },
+                /*isInteractive=*/isInteractive);
+        });
+        ASSERT_EQ(output, "hello");
+    }
+}
+
+#ifdef _WIN32
+#  define NIX_EXECUTABLE_EXTENSION ".exe"
+/* FIXME: runProgram reports spawn errors as WinError, while other
+   platforms conflate everything into ExecError. */
+#  define NIX_SPAWN_EXCEPTION windows::WinError
+#else
+#  define NIX_EXECUTABLE_EXTENSION ""
+#  define NIX_SPAWN_EXCEPTION ExecError
+#endif
+
+TEST(runProgram, nonexistent)
+{
+    /* For now spawn failures get reported as ExecError. TODO: Report the proper error that's less
+       confusing. */
+    ASSERT_THROW(
+        runProgram("/this/path/really/should/not/exist/for/real" NIX_EXECUTABLE_EXTENSION), NIX_SPAWN_EXCEPTION);
+}
+
+TEST(runProgram2, nonexistent)
+{
+    ASSERT_THROW(
+        {
+            runProgram2({
+                .program = "/this/path/really/should/not/exist/for/real" NIX_EXECUTABLE_EXTENSION,
+            });
+        },
+        NIX_SPAWN_EXCEPTION);
+}
+
+#ifndef _WIN32 /* Leaking file descriptors into the child isn't a concern on windows. */
+
+TEST(runProgram2, leakedFDsAreClosed)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+    int fds[2];
+    ASSERT_NE(::pipe(fds), -1);
+
+    AutoCloseFD readSide = fds[0];
+    AutoCloseFD writeSide = fds[1];
+
+    /* Test that both fds are closed in the child. Just the one isn't always
+       enough if the read side is assigned to 3 (also the fd of the relocated pipe in
+       the child on linux that gets dup3-ed into). */
+    ASSERT_NO_THROW(runProgram2({
+        .program = *self,
+        .args = {"__util_test_spawn_leaked_fds"},
+        .environment = OsStringMap{{
+            "NIX_CHILD_FDS_SHOULD_BE_CLOSED",
+            fmt("%d,%d", readSide.get(), writeSide.get()),
+        }},
+    }));
+}
+
+#endif
+
+/* TODO: Test a bunch more things. */
+
+#undef NIX_EXECUTABLE_EXTENSION
+#undef NIX_SPAWN_EXCEPTION
 
 } // namespace nix

--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -10,6 +10,10 @@
 
 #ifndef _WIN32
 #  include "unix/current-process-private.hh"
+#else
+#  define WIN32_LEAN_AND_MEAN
+#  include "nix/util/os-string.hh"
+#  include <windows.h>
 #endif
 
 #ifdef __APPLE__
@@ -118,6 +122,13 @@ std::optional<std::filesystem::path> getSelfExe()
         path.pop_back();
 
         return std::string(path.begin(), path.end());
+#elif defined(_WIN32)
+        std::vector<OsChar> buf(32 * 1024);
+        DWORD size = buf.size();
+        if (!::QueryFullProcessImageNameW(
+                ::GetCurrentProcess(), /*dwFlags=*/0, /*lpExeName=*/buf.data(), /*lpdwSize=*/&size))
+            return std::nullopt;
+        return std::filesystem::path{OsString{buf.data(), size}};
 #else
         return std::nullopt;
 #endif


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Since we run libutil-tests in CI under wine, it helps to actually test that code.
There's so many moving pieces with process spawning that it's very important to test that stuff thoroughly and at unit level.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
