### PR TITLE
libstore/filetransfer: Drop ancient ETag hacks for github handling of…

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -402,17 +402,6 @@ struct curlFileTransfer : public FileTransfer
 
                     if (name == "etag") {
                         result.etag = trim(line.substr(i + 1));
-                        /* Hack to work around a GitHub bug: it sends
-                           ETags, but ignores If-None-Match. So if we get
-                           the expected ETag on a 200 response, then shut
-                           down the connection because we already have the
-                           data. */
-                        long httpStatus = 0;
-                        curl_easy_getinfo(req, CURLINFO_RESPONSE_CODE, &httpStatus);
-                        if (result.etag == request.expectedETag && httpStatus == HttpStatus::Ok) {
-                            debug("shutting down on 200 HTTP response with expected ETag");
-                            return 0;
-                        }
                     }
 
                     else if (name == "content-encoding") {
@@ -442,7 +431,7 @@ struct curlFileTransfer : public FileTransfer
                             time_t now = time(nullptr);
                             retryAfterMs = saturateMs(std::chrono::seconds{date > now ? date - now : 0});
                         } else {
-                            debug("ignoring unparseable Retry-After header: '%s'", value);
+                            debug("ignoring unparsable Retry-After header: '%s'", value);
                         }
                     }
                 }
@@ -766,13 +755,6 @@ struct curlFileTransfer : public FileTransfer
 
             else if (code == CURLE_OK && successfulStatuses.count(httpStatus)) {
                 result.cached = (httpStatus == HttpStatus::NotModified);
-
-                // In 2021, GitHub responds to If-None-Match with 304,
-                // but omits ETag. We just use the If-None-Match etag
-                // since 304 implies they are the same.
-                if (httpStatus == HttpStatus::NotModified && result.etag == "")
-                    result.etag = request.expectedETag;
-
                 curl_off_t dlSize = 0;
                 curl_easy_getinfo(req, CURLINFO_SIZE_DOWNLOAD_T, &dlSize);
                 act().progress(dlSize, dlSize);


### PR DESCRIPTION
… ETag and If-None-Match

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Nowadays github implements this stuff properly.

The hacks have been with us for a very long time, in particular since 60340ce3e2f and a7668246606. Both of those do appear to be fixed and the handling of `ETag`s now a bit more robust on our side too.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
