### PR TITLE
CA Security Fix

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -679,7 +679,7 @@ void BinaryCacheStore::queryRealisationUncached(
     getFile(outputInfoFilePath, std::move(newCallback));
 }
 
-void BinaryCacheStore::registerDrvOutput(const Realisation & info)
+void BinaryCacheStore::registerDrvOutputUnchecked(const Realisation & info)
 {
     if (diskCache)
         diskCache->upsertRealisation(config.getReference().render(/*FIXME withParams=*/false), info);

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1342,7 +1342,8 @@ DerivationBuildingGoal::checkPathValidity(std::map<std::string, InitialOutput> &
                             .outPath = info.known->path,
                         },
                         drvOutput,
-                    });
+                    },
+                    NoCheckSigs);
             }
         }
         if (info.known && info.known->isValid())

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -100,7 +100,7 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
                     trace("output path substituted");
 
                     if (nrFailed == 0)
-                        worker.store.registerDrvOutput({*g->outputInfo, id}, NoCheckSigs);
+                        worker.store.registerDrvOutput({*g->outputInfo, id}, CheckSigs);
                     else
                         debug("The output path of the derivation output '%s' could not be substituted", id.to_string());
                 }

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -100,7 +100,7 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
                     trace("output path substituted");
 
                     if (nrFailed == 0)
-                        worker.store.registerDrvOutput({*g->outputInfo, id});
+                        worker.store.registerDrvOutput({*g->outputInfo, id}, NoCheckSigs);
                     else
                         debug("The output path of the derivation output '%s' could not be substituted", id.to_string());
                 }
@@ -453,7 +453,8 @@ std::optional<std::pair<UnkeyedRealisation, PathStatus>> DerivationGoal::checkPa
                         .drvPath = drvPath,
                         .outputName = wantedOutput,
                     },
-                });
+                },
+                NoCheckSigs);
         }
 
         return {{*mRealisation, status}};

--- a/src/libstore/build/drv-output-substitution-goal.cc
+++ b/src/libstore/build/drv-output-substitution-goal.cc
@@ -41,6 +41,15 @@ Goal::Co DrvOutputSubstitutionGoal::init()
         if (!outputInfo)
             continue;
 
+        if (!sub->config.isTrusted && worker.store.realisationIsUntrusted(Realisation{*outputInfo, this->id})) {
+            warn(
+                "ignoring substitute for build trace '%s' -> '%s' from '%s', as it's not signed by any of the keys in 'trusted-public-keys'",
+                this->id.render(worker.store),
+                worker.store.printStorePath(outputInfo->outPath),
+                sub->config.getHumanReadableURI());
+            continue;
+        }
+
         trace("finished");
         co_return amDone(ecSuccess);
     }

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -1016,7 +1016,7 @@ static void performOp(
     case WorkerProto::Op::RegisterDrvOutput: {
         logger->startWork();
         auto realisation = WorkerProto::Serialise<Realisation>::read(*store, rconn);
-        store->registerDrvOutput(realisation);
+        store->registerDrvOutput(realisation, CheckSigs);
         logger->stopWork();
         break;
     }

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -342,7 +342,7 @@ public:
         return readDerivation(drvPath);
     }
 
-    void registerDrvOutput(const Realisation & output) override
+    void registerDrvOutputUnchecked(const Realisation & output) override
     {
         buildTrace.insert_or_visit({output.id.drvPath, {{output.id.outputName, output}}}, [&](auto & kv) {
             kv.second.insert_or_assign(output.id.outputName, output);

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -241,7 +241,7 @@ public:
         PathFilter & filter,
         RepairFlag repair) override;
 
-    void registerDrvOutput(const Realisation & info) override;
+    void registerDrvOutputUnchecked(const Realisation & info) override;
 
     void queryRealisationUncached(
         const DrvOutput &, Callback<std::shared_ptr<const UnkeyedRealisation>> callback) noexcept override;

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -132,7 +132,7 @@ public:
         unsupported("addToStore");
     }
 
-    void registerDrvOutput(const Realisation & output) override
+    void registerDrvOutputUnchecked(const Realisation & output) override
     {
         unsupported("registerDrvOutput");
     }

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -138,7 +138,7 @@ private:
      * First copy up any lower store realisation with the same key, so we
      * merge rather than mask it.
      */
-    void registerDrvOutput(const Realisation & info) override;
+    void registerDrvOutputUnchecked(const Realisation & info) override;
 
     /**
      * Check lower store if upper DB does not have.

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -456,7 +456,7 @@ public:
      * Register the store path 'output' as the output named 'outputName' of
      * derivation 'deriver'.
      */
-    void registerDrvOutput(const Realisation & info) override;
+    void registerDrvOutputUnchecked(const Realisation & info) override;
     void registerDrvOutput(const Realisation & info, CheckSigsFlag checkSigs) override;
     void cacheDrvOutputMapping(
         State & state, const uint64_t deriver, const std::string & outputName, const StorePath & output);

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -112,7 +112,7 @@ public:
     void
     addMultipleToStore(PathsSource && pathsToCopy, Activity & act, RepairFlag repair, CheckSigsFlag checkSigs) override;
 
-    void registerDrvOutput(const Realisation & info) override;
+    void registerDrvOutputUnchecked(const Realisation & info) override;
 
     void submitOutput(const SingleDerivedPath & path, const OutputName & output) override;
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -750,12 +750,17 @@ public:
      * as this information is already present in the drv file, but necessary for
      * floating-ca derivations and their dependencies as there's no way to
      * retrieve this information otherwise.
+     *
+     * The method that does not perform signature checks is internal only, users should
+     * explicitly set the `checkSigs` argument to `NoCheckSigs`.
      */
-    virtual void registerDrvOutput(const Realisation & output) = 0;
+protected:
+    virtual void registerDrvOutputUnchecked(const Realisation & output) = 0;
 
+public:
     virtual void registerDrvOutput(const Realisation & output, CheckSigsFlag checkSigs)
     {
-        return registerDrvOutput(output);
+        return registerDrvOutputUnchecked(output);
     }
 
     /**

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -79,14 +79,14 @@ LocalOverlayStore::LocalOverlayStore(ref<const Config> config)
     }
 }
 
-void LocalOverlayStore::registerDrvOutput(const Realisation & info)
+void LocalOverlayStore::registerDrvOutputUnchecked(const Realisation & info)
 {
     // First do queryRealisation on lower layer to populate DB
     auto res = lowerStore->queryRealisation(info.id);
     if (res)
-        LocalStore::registerDrvOutput({*res, info.id});
+        LocalStore::registerDrvOutputUnchecked({*res, info.id});
 
-    LocalStore::registerDrvOutput(info);
+    LocalStore::registerDrvOutputUnchecked(info);
 }
 
 void LocalOverlayStore::queryPathInfoUncached(

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -669,13 +669,13 @@ void LocalStore::registerDrvOutput(const Realisation & info, CheckSigsFlag check
 {
     experimentalFeatureSettings.require(Xp::CaDerivations);
     if (checkSigs == NoCheckSigs || !realisationIsUntrusted(info))
-        registerDrvOutput(info);
+        registerDrvOutputUnchecked(info);
     else
         throw Error(
             "cannot register realisation '%s' because it lacks a signature by a trusted key", info.outPath.to_string());
 }
 
-void LocalStore::registerDrvOutput(const Realisation & info)
+void LocalStore::registerDrvOutputUnchecked(const Realisation & info)
 {
     experimentalFeatureSettings.require(Xp::CaDerivations);
     retrySQLite<void>([&]() {

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -499,7 +499,7 @@ void RemoteStore::addMultipleToStore(
     conn.withFramedSink([&](Sink & sink) { source->drainInto(sink); });
 }
 
-void RemoteStore::registerDrvOutput(const Realisation & info)
+void RemoteStore::registerDrvOutputUnchecked(const Realisation & info)
 {
     auto conn(getConnection());
     conn->to << WorkerProto::Op::RegisterDrvOutput;

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -113,7 +113,7 @@ public:
 
     void narFromPath(const StorePath & path, Sink & sink) override;
 
-    void registerDrvOutput(const Realisation & info) override;
+    void registerDrvOutputUnchecked(const Realisation & info) override;
 
     void submitOutput(const SingleDerivedPath & path, const OutputName & output) override;
 
@@ -279,7 +279,7 @@ void RestrictedBuilder::ensurePath(const StorePath & path)
     /* Nothing to be done; 'path' must already be valid. */
 }
 
-void RestrictedStore::registerDrvOutput(const Realisation & info)
+void RestrictedStore::registerDrvOutputUnchecked(const Realisation & info)
 // XXX: This should probably be allowed as a no-op if the realisation
 // corresponds to an allowed derivation
 {

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1690,7 +1690,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         };
         if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations) && !drv.type().isImpure()) {
             store.signRealisation(thisRealisation);
-            store.registerDrvOutput(thisRealisation);
+            store.registerDrvOutput(thisRealisation, NoCheckSigs);
         }
         builtOutputs.emplace(outputName, thisRealisation);
     }
@@ -1745,7 +1745,7 @@ SingleDrvOutputs DerivationBuilderImpl::checkSubmittedOutputs()
         };
 
         store.signRealisation(realisation);
-        store.registerDrvOutput(realisation);
+        store.registerDrvOutput(realisation, NoCheckSigs);
         builtOutputs.emplace(outputName, realisation);
 
         // TODO: handle --check

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -411,7 +411,7 @@ static int main_build_remote(int argc, char ** argv)
             // Should hold, because if the feature isn't enabled the set
             // of missing realisations should be empty
             experimentalFeatureSettings.require(Xp::CaDerivations);
-            store->registerDrvOutput(realisation);
+            store->registerDrvOutput(realisation, NoCheckSigs);
         }
 
         return 0;

--- a/tests/functional/ca/build-cache.sh
+++ b/tests/functional/ca/build-cache.sh
@@ -2,6 +2,8 @@
 
 source common.sh
 
+needLocalStore "Daemon not configured to sign build traces, would cause signature errors"
+
 # The substituters didn't work prior to this time.
 requireDaemonNewerThan "2.18.0pre20230808"
 

--- a/tests/functional/ca/build-cache.sh
+++ b/tests/functional/ca/build-cache.sh
@@ -2,7 +2,7 @@
 
 source common.sh
 
-needLocalStore "Daemon not configured to sign build traces, would cause signature errors"
+signIfNeeded
 
 # The substituters didn't work prior to this time.
 requireDaemonNewerThan "2.18.0pre20230808"

--- a/tests/functional/ca/common.sh
+++ b/tests/functional/ca/common.sh
@@ -6,6 +6,19 @@ requireDaemonNewerThan "2.35.0pre20260303"
 
 enableFeatures "ca-derivations"
 
+signIfNeeded() {
+    # Daemon signature checking
+    if [[ "$NIX_REMOTE" == "daemon" ]]; then
+        nix-store --generate-binary-cache-key cache.example.org "$TEST_ROOT/sk" "$TEST_ROOT/pk"
+        pk=$(cat "$TEST_ROOT/pk")
+        cat <<EOF >> "$test_nix_conf"
+secret-key-files = $TEST_ROOT/sk
+trusted-public-keys = $pk
+EOF
+        restartDaemon
+    fi
+}
+
 TODO_NixOS
 
 restartDaemon

--- a/tests/functional/ca/nix-copy.sh
+++ b/tests/functional/ca/nix-copy.sh
@@ -2,7 +2,7 @@
 
 source common.sh
 
-needLocalStore "Daemon not configured to sign build traces, would cause signature errors"
+signIfNeeded
 
 export REMOTE_STORE="file://$cacheDir"
 

--- a/tests/functional/ca/nix-copy.sh
+++ b/tests/functional/ca/nix-copy.sh
@@ -2,6 +2,8 @@
 
 source common.sh
 
+needLocalStore "Daemon not configured to sign build traces, would cause signature errors"
+
 export REMOTE_STORE="file://$cacheDir"
 
 ensureCorrectlyCopied () {

--- a/tests/functional/ca/signatures.sh
+++ b/tests/functional/ca/signatures.sh
@@ -2,8 +2,12 @@
 
 source common.sh
 
+needLocalStore "Daemon not configured to sign build traces, would cause signature errors"
+
 nix-store --generate-binary-cache-key cache1.example.org "$TEST_ROOT/sk1" "$TEST_ROOT/pk1"
 pk1=$(cat "$TEST_ROOT/pk1")
+nix-store --generate-binary-cache-key cache2.example.org "$TEST_ROOT/sk2" "$TEST_ROOT/pk2"
+pk2=$(cat "$TEST_ROOT/pk2")
 
 export REMOTE_STORE="file://$cacheDir"
 
@@ -17,18 +21,43 @@ testOneCopy () {
     clearBinaryCache
 
     attrPath="$1"
-    nix copy -vvvv --to "$REMOTE_STORE" "$attrPath" --file ./content-addressed.nix \
-        --secret-key-files "$TEST_ROOT/sk1" --show-trace
+
+    drvPath=$(nix eval --raw --file ./content-addressed.nix "$attrPath.drvPath")
+    nix build --no-link --secret-key-files "$TEST_ROOT/sk1" "$drvPath^*"
+
+    nix copy -vvvv --to "$REMOTE_STORE" "$drvPath^*"
 
     ensureCorrectlyCopied "$attrPath"
 
-    # Ensure that we can copy back what we put in the store
+    # Copies with the wrong key should fail
+    clearStore
+    expectStderr 1 nix copy --from "$REMOTE_STORE" \
+        --file ./content-addressed.nix "$attrPath" \
+        --trusted-public-keys "$pk2" \
+        | grepQuiet 'lacks a signature by a trusted key'
+
+    # Same logic applies to nix build
+    clearStore
+    expectStderr 1 nix build --file ./content-addressed.nix "$attrPath" \
+        --substitute -j0 --substituters "$REMOTE_STORE" \
+        --trusted-public-keys "$pk2" \
+        --no-link \
+        | grepQuiet 'not signed by any of the keys'
+
+    # Copies with the correct key should succeed
     clearStore
     nix copy --from "$REMOTE_STORE" \
         --file ./content-addressed.nix "$attrPath" \
         --trusted-public-keys "$pk1"
+
+    # Same logic applies to nix build
+    clearStore
+    nix build --file ./content-addressed.nix "$attrPath" \
+        --substitute -j0 --substituters "$REMOTE_STORE" \
+        --trusted-public-keys "$pk1" \
+        --no-link
 }
 
-for attrPath in rootCA dependentCA transitivelyDependentCA dependentNonCA dependentFixedOutput; do
+for attrPath in rootCA dependentCA transitivelyDependentCA dependentNonCA; do
     testOneCopy "$attrPath"
 done

--- a/tests/functional/ca/signatures.sh
+++ b/tests/functional/ca/signatures.sh
@@ -2,7 +2,7 @@
 
 source common.sh
 
-needLocalStore "Daemon not configured to sign build traces, would cause signature errors"
+signIfNeeded
 
 nix-store --generate-binary-cache-key cache1.example.org "$TEST_ROOT/sk1" "$TEST_ROOT/pk1"
 pk1=$(cat "$TEST_ROOT/pk1")


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
The Nix daemon does not verify the signatures on build trace (also called "realisation") objects when submitted by a client calling the registerDrvOutput call. A malicious user with unprivileged access to the Nix daemon socket can therefore inject arbitrary invalid mappings from a content-addressing derivation to its output paths.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context
This PR adds checks in more locations, makes it more clear when users in the nix code are not checking signatures, and adds tests for the checks.


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
