### PR TITLE
libstore: Actually check that hash part is followed by a dash in Stor…

### DIFF
--- a/src/libstore-tests/path.cc
+++ b/src/libstore-tests/path.cc
@@ -139,6 +139,15 @@ RC_GTEST_FIXTURE_PROP(StorePathTest, prop_check_regex_eq_parse, ())
     RC_ASSERT(parsed == std::regex_match(std::string{name}, nameRegex));
 }
 
+TEST_F(StorePathTest, mustBeDashAfterHashPart)
+{
+    std::string hashPart = "575s52sh487i0ylmbs9pvi606ljdszr0";
+    for (char c : {'_', '\0'}) {
+        EXPECT_THROW(StorePath(hashPart + c + "name"), BadStorePath);
+    }
+    EXPECT_NO_THROW(StorePath(hashPart + "-" + "name"));
+}
+
 /* ----------------------------------------------------------------------------
  * JSON
  * --------------------------------------------------------------------------*/

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -51,6 +51,8 @@ StorePath::StorePath(std::string_view _baseName)
 {
     if (baseName.size() < HashLen + 1)
         throw BadStorePath("'%s' is too short to be a valid store path", baseName);
+    if (baseName[HashLen] != '-')
+        throw BadStorePath("'%s' can't name a store path because the hash part is not followed by a '-'", baseName);
     for (auto c : hashPart())
         if (c == 'e' || c == 'o' || c == 'u' || c == 't' || !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')))
             throw BadStorePath("store path '%s' contains illegal base-32 character '%s'", baseName, c);


### PR DESCRIPTION
…ePath

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This was missing validation and meant that potentially any byte could be included after the dash (even NUL one - though it probably would have segfaulted earlier due to std::filesystem::path). The latter is also very much necessary to fix, but let's start here.

This will be covered by fuzzing in a non-backportable commit in a follow-up.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
