### PR TITLE
manual: document derivation options in the store section

### DIFF
--- a/doc/manual/source/language/advanced-attributes.md
+++ b/doc/manual/source/language/advanced-attributes.md
@@ -5,15 +5,9 @@ Derivations can declare some infrequently used optional attributes.
 ## Inputs
 
   - [`exportReferencesGraph`]{#adv-attr-exportReferencesGraph}\
-    This attribute allows builders access to the references graph of
-    their inputs. The attribute is a list of inputs in the Nix store
-    whose references graph the builder needs to know. The value of
-    this attribute should be a list of pairs `[ name1 path1 name2
-    path2 ...  ]`. The references graph of each *pathN* will be stored
-    in a text file *nameN* in the temporary build directory. The text
-    files have the format used by [`nix-store --register-validity`](@docroot@/command-ref/nix-store/register-validity.md)
-    (with the deriver fields left empty). For example, when the
-    following derivation is built:
+    Specifies the [*export references graph*](@docroot@/store/derivation/index.md#export-references-graph) option.
+    The value of this attribute should be a list of pairs `[ name1 path1 name2 path2 ...  ]`.
+    For example, when the following derivation is built:
 
     ```nix
     derivation {
@@ -25,17 +19,10 @@ Derivations can declare some infrequently used optional attributes.
     the references graph of `libfoo` is placed in the file
     `libfoo-graph` in the temporary build directory.
 
-    `exportReferencesGraph` is useful for builders that want to do
-    something with the closure of a store path. Examples include the
-    builders in NixOS that generate the initial ramdisk for booting
-    Linux (a `cpio` archive containing the closure of the boot script)
-    and the ISO-9660 image for the installation CD (which is populated
-    with a Nix store containing the closure of a bootable NixOS
-    configuration).
-
   - [`passAsFile`]{#adv-attr-passAsFile}\
-    A list of names of attributes that should be passed via files rather
-    than environment variables. For example, if you have
+    A list of names of attributes whose environment variables should be marked
+    [*pass as file*](@docroot@/store/derivation/index.md#pass-as-file).
+    For example, if you have
 
     ```nix
     passAsFile = ["big"];
@@ -44,36 +31,29 @@ Derivations can declare some infrequently used optional attributes.
 
     then when the builder runs, the environment variable `bigPath`
     will contain the absolute path to a temporary file containing `a
-    very long string`. That is, for any attribute *x* listed in
-    `passAsFile`, Nix will pass an environment variable `xPath`
-    holding the path of the file containing the value of attribute
-    *x*. This is useful when you need to pass large strings to a
-    builder, since most operating systems impose a limit on the size
-    of the environment (typically, a few hundred kilobyte).
+    very long string`.
 
   - [`__structuredAttrs`]{#adv-attr-structuredAttrs}\
     If the special attribute `__structuredAttrs` is set to `true`, the other derivation
     attributes are serialised into a file in JSON format.
 
-    This obviates the need for [`passAsFile`](#adv-attr-passAsFile) since JSON files have no size restrictions, unlike process environments.
-    It also makes it possible to tweak derivation settings in a structured way;
-    see [`outputChecks`](#adv-attr-outputChecks) for example.
-
     See the [corresponding section in the derivation page](@docroot@/store/derivation/index.md#structured-attrs) for further details.
 
     > **Warning**
     >
-    > If set to `true`, other advanced attributes such as [`allowedReferences`](#adv-attr-allowedReferences), [`allowedRequisites`](#adv-attr-allowedRequisites),
-    [`disallowedReferences`](#adv-attr-disallowedReferences) and [`disallowedRequisites`](#adv-attr-disallowedRequisites), maxSize, and maxClosureSize.
-    will have no effect.
+    > If set to `true`, the top-level attributes [`allowedReferences`](#adv-attr-allowedReferences), [`allowedRequisites`](#adv-attr-allowedRequisites),
+    > [`disallowedReferences`](#adv-attr-disallowedReferences) and [`disallowedRequisites`](#adv-attr-disallowedRequisites)
+    > will have no effect; use [`outputChecks`](#adv-attr-outputChecks) instead.
 
 ## Output checks
 
-See the [corresponding section in the derivation output page](@docroot@/store/derivation/outputs/index.md).
+These attributes specify [checks on the derivation's outputs](@docroot@/store/derivation/outputs/index.md#output-checks).
+The concepts behind them are documented there; this section gives the syntax for specifying them from the Nix language.
+
+Store paths in these lists may be given as strings with context (i.e. by interpolating a derivation), and outputs of the derivation itself are denoted by their plain output names, e.g. `"out"`.
 
   - [`allowedReferences`]{#adv-attr-allowedReferences}\
-    The optional attribute `allowedReferences` specifies a list of legal
-    references (dependencies) of the output of the builder. For example,
+    Specifies the [*allowed references*](@docroot@/store/derivation/outputs/index.md#allowed-references) check. For example,
 
     ```nix
     allowedReferences = [];
@@ -81,15 +61,10 @@ See the [corresponding section in the derivation output page](@docroot@/store/de
 
     enforces that the output of a derivation cannot have any runtime
     dependencies on its inputs. To allow an output to have a runtime
-    dependency on itself, use `"out"` as a list item. This is used in
-    NixOS to check that generated files such as initial ramdisks for
-    booting Linux don’t have accidental dependencies on other paths in
-    the Nix store.
+    dependency on itself, use `"out"` as a list item.
 
   - [`allowedRequisites`]{#adv-attr-allowedRequisites}\
-    This attribute is similar to `allowedReferences`, but it specifies
-    the legal requisites of the whole closure, so all the dependencies
-    recursively. For example,
+    Specifies the [*allowed requisites*](@docroot@/store/derivation/outputs/index.md#allowed-requisites) check. For example,
 
     ```nix
     allowedRequisites = [ foobar ];
@@ -100,21 +75,17 @@ See the [corresponding section in the derivation output page](@docroot@/store/de
     `foobar` itself doesn't introduce any other dependency itself.
 
   - [`disallowedReferences`]{#adv-attr-disallowedReferences}\
-    The optional attribute `disallowedReferences` specifies a list of
-    illegal references (dependencies) of the output of the builder. For
-    example,
+    Specifies the [*disallowed references*](@docroot@/store/derivation/outputs/index.md#disallowed-references) check. For example,
 
     ```nix
     disallowedReferences = [ foo ];
     ```
 
     enforces that the output of a derivation cannot have a direct
-    runtime dependencies on the derivation `foo`.
+    runtime dependency on the derivation `foo`.
 
   - [`disallowedRequisites`]{#adv-attr-disallowedRequisites}\
-    This attribute is similar to `disallowedReferences`, but it
-    specifies illegal requisites for the whole closure, so all the
-    dependencies recursively. For example,
+    Specifies the [*disallowed requisites*](@docroot@/store/derivation/outputs/index.md#disallowed-requisites) check. For example,
 
     ```nix
     disallowedRequisites = [ foobar ];
@@ -133,10 +104,9 @@ See the [corresponding section in the derivation output page](@docroot@/store/de
     [`disallowedReferences`](#adv-attr-disallowedReferences) and [`disallowedRequisites`](#adv-attr-disallowedRequisites),
     the following attributes are available:
 
-    - `maxSize` defines the maximum size of the resulting [store object](@docroot@/store/store-object.md).
-    - `maxClosureSize` defines the maximum size of the output's closure.
-    - `ignoreSelfRefs` controls whether self-references should be considered when
-      checking for allowed references/requisites.
+    - `maxSize` specifies the [*max size*](@docroot@/store/derivation/outputs/index.md#max-size) check.
+    - `maxClosureSize` specifies the [*max closure size*](@docroot@/store/derivation/outputs/index.md#max-closure-size) check.
+    - `ignoreSelfRefs` controls the [*ignore self references*](@docroot@/store/derivation/outputs/index.md#ignore-self-refs) behavior.
 
     Example:
 
@@ -162,7 +132,9 @@ See the [corresponding section in the derivation output page](@docroot@/store/de
   - [`unsafeDiscardReferences`]{#adv-attr-unsafeDiscardReferences}\
     When using [structured attributes](#adv-attr-structuredAttrs), the
     attribute `unsafeDiscardReferences` is an attribute set with a boolean value for each output name.
-    If set to `true`, it disables scanning the output for runtime dependencies.
+    If set to `true`, it enables the
+    [*unsafe discard references*](@docroot@/store/derivation/outputs/index.md#unsafe-discard-references)
+    behavior for that output.
 
     Example:
 
@@ -171,30 +143,19 @@ See the [corresponding section in the derivation output page](@docroot@/store/de
     unsafeDiscardReferences.out = true;
     ```
 
-    This is useful, for example, when generating self-contained filesystem images with
-    their own embedded Nix store: hashes found inside such an image refer
-    to the embedded store and not to the host's Nix store.
-
 ## Build scheduling
 
   - [`preferLocalBuild`]{#adv-attr-preferLocalBuild}\
-    If this attribute is set to `true` and [distributed building is enabled](@docroot@/command-ref/conf-file.md#conf-builders), then, if possible, the derivation will be built locally instead of being forwarded to a remote machine.
+    If set to `true`, enables the [*prefer local build*](@docroot@/store/derivation/index.md#prefer-local-build) option.
     This is useful for derivations that are cheapest to build locally.
 
   - [`allowSubstitutes`]{#adv-attr-allowSubstitutes}\
-    If this attribute is set to `false`, then Nix will always build this derivation (locally or remotely); it will not try to substitute its outputs.
+    If set to `false`, disables the [*allow substitutes*](@docroot@/store/derivation/index.md#allow-substitutes) option, so Nix will always build this derivation (locally or remotely) rather than substituting its outputs.
     This is useful for derivations that are cheaper to build than to substitute.
 
-    This attribute can be ignored by setting [`always-allow-substitutes`](@docroot@/command-ref/conf-file.md#conf-always-allow-substitutes) to `true`.
-
-    > **Note**
-    >
-    > If set to `false`, the [`builder`] should be able to run on the system type specified in the [`system` attribute](./derivations.md#attr-system), since the derivation cannot be substituted.
-
-    [`builder`]: ./derivations.md#attr-builder
-
 - [`requiredSystemFeatures`]{#adv-attr-requiredSystemFeatures}\
-  If a derivation has the `requiredSystemFeatures` attribute, then Nix will only build it on a machine that has the corresponding features set in its [`system-features` configuration](@docroot@/command-ref/conf-file.md#conf-system-features).
+  Specifies the [*required system features*](@docroot@/store/derivation/index.md#required-system-features) option:
+  Nix will only build the derivation on a machine that has the corresponding features set in its [`system-features` configuration](@docroot@/command-ref/conf-file.md#conf-system-features).
 
   For example, setting
 
@@ -207,11 +168,8 @@ See the [corresponding section in the derivation output page](@docroot@/store/de
 # Impure builder configuration
 
   - [`impureEnvVars`]{#adv-attr-impureEnvVars}\
-    This attribute allows you to specify a list of environment variables
-    that should be passed from the environment of the calling user to
-    the builder. Usually, the environment is cleared completely when the
-    builder is executed, but with this attribute you can allow specific
-    environment variables to be passed unmodified. For example,
+    Specifies the [*impure environment variables*](@docroot@/store/derivation/index.md#impure-env-vars) option: a list of environment variables
+    that should be passed from the environment of the calling user to the builder. For example,
     `fetchurl` in Nixpkgs has the line
 
     ```nix
@@ -220,26 +178,6 @@ See the [corresponding section in the derivation output page](@docroot@/store/de
 
     to make it use the proxy server configuration specified by the user
     in the environment variables `http_proxy` and friends.
-
-    This attribute is only allowed in [fixed-output derivations][fixed-output derivation],
-    where impurities such as these are okay since (the hash
-    of) the output is known in advance. It is ignored for all other
-    derivations.
-
-    > **Warning**
-    >
-    > `impureEnvVars` implementation takes environment variables from
-    > the current builder process. When a daemon is building its
-    > environmental variables are used. Without the daemon, the
-    > environmental variables come from the environment of the
-    > `nix-build`.
-
-    If the [`configurable-impure-env` experimental
-    feature](@docroot@/development/experimental-features.md#xp-feature-configurable-impure-env)
-    is enabled, these environment variables can also be controlled
-    through the
-    [`impure-env`](@docroot@/command-ref/conf-file.md#conf-impure-env)
-    configuration setting.
 
 ## Setting the derivation type
 

--- a/doc/manual/source/protocols/json/schema/store-object-info-v3.yaml
+++ b/doc/manual/source/protocols/json/schema/store-object-info-v3.yaml
@@ -84,7 +84,8 @@ $defs:
         minimum: 0
         title: NAR Size
         description: |
-          Size of the [file system object](@docroot@/store/file-system-object.md) part of the store object when serialized as a [Nix Archive](@docroot@/store/file-system-object/content-address.md#serial-nix-archive).
+          The [*NAR size*](@docroot@/store/store-object.md#nar-size) of the store object:
+          the size of its [file system object](@docroot@/store/file-system-object.md) part when serialized as a [Nix Archive](@docroot@/store/file-system-object/content-address.md#serial-nix-archive).
 
       references:
         type: array
@@ -184,7 +185,8 @@ $defs:
         minimum: 0
         title: Closure Size
         description: |
-          The total size of this store object and every other object in its [closure](@docroot@/glossary.md#gloss-closure).
+          The [*closure NAR size*](@docroot@/store/store-object.md#closure-nar-size) of the store object:
+          the total size of this store object and every other object in its [closure](@docroot@/glossary.md#gloss-closure).
 
           > This field is not stored at all, but computed by traversing the other fields across all the store objects in a closure.
     additionalProperties: false

--- a/doc/manual/source/store/building.md
+++ b/doc/manual/source/store/building.md
@@ -187,11 +187,13 @@ This involves two steps:
   The files must conform to the model described in the [Exposing in OS file systems](./file-system-object/os-file-system.md) section.
   For example, timestamps and permissions are canonicalised.
 
-- **Calculate the references**
+- [**Calculate the references**]{#scanning-for-references}
 
   Nix scans each output path for [references] to input store objects by looking for the [digest][store path digest] of each input.
   (The name part and the [store directory path] are ignored when scanning; an input's hash part that is neither followed by a `-` nor proceeded by a `/` still scans as a reference.)
   Since these are potential runtime dependencies, Nix will register them as references of the output store object they occur in.
+
+  This scanning can be disabled per output with the [*unsafe discard references*](derivation/outputs/index.md#unsafe-discard-references) setting.
 
 ### Traditional (post-build) processing
 

--- a/doc/manual/source/store/derivation/index.md
+++ b/doc/manual/source/store/derivation/index.md
@@ -138,9 +138,19 @@ See [Wikipedia](https://en.wikipedia.org/wiki/Argv) for details.
 
 Environment variables which will be passed to the [builder](#builder) executable.
 
+Each environment variable additionally has a [*pass as file*]{#pass-as-file} flag.
+When it is set, rather than passing the value directly in the environment, the value is written to a temporary file in the build directory, and an environment variable named like the original but with a `Path` suffix is set to the path of that file.
+For example, a variable `big` with *pass as file* set results in an environment variable `bigPath` pointing to a file containing the value of `big`.
+This is useful for large values, since most operating systems impose a limit on the size of the process environment (typically a few hundred kilobytes).
+
+This flag has no effect when [structured attributes](#structured-attrs) are used, as attributes are then not passed through the environment in the first place, so there is no size constraint to avoid.
+
 #### Structured Attributes {#structured-attrs}
 
 Nix also has special support for embedding JSON in the derivations.
+
+Structured attributes obviate the need for the [*pass as file*](#pass-as-file) flag, since JSON files have no size restrictions, unlike process environments.
+They also allow [options](#options) and [output checks](outputs/index.md#output-checks) to be expressed in a structured way, rather than string-encoded in environment variables.
 
 The environment variable `NIX_ATTRS_JSON_FILE` points to the exact location of that file both in a build and a [`nix-shell`](@docroot@/command-ref/nix-shell.md).
 
@@ -148,6 +158,76 @@ As a convenience to Bash builders, Nix writes a script that initialises shell va
 The environment variable `NIX_ATTRS_SH_FILE` points to the exact location of the script, both in a build and a [`nix-shell`](@docroot@/command-ref/nix-shell.md).
 This includes non-nested (associative) arrays.
 For example, the attribute `hardening.format = true` ends up as the Bash associative array element `${hardening[format]}`.
+
+### Options {#options}
+
+Derivations carry a number of *options* influencing how they are built and scheduled.
+Historically, these were encoded with specially-named [environment variables](#env) or [structured attributes](#structured-attrs); they are, however, fields of the derivation in their own right.
+
+Options that apply to individual outputs — [output checks](outputs/index.md#output-checks) and [reference scanning](outputs/index.md#reference-scanning) — are documented with [derivation outputs](outputs/index.md).
+The remaining options apply to the derivation as a whole:
+
+- [*export references graph*]{#export-references-graph}:
+  A map from file names to sets of [deriving paths][deriving path].
+  For each entry, the *references graph* of the given store objects — each store object in their [closure], along with its references — is made available to the builder:
+  as a file of the given name in the build directory (in the textual format understood by [`nix-store --register-validity`](@docroot@/command-ref/nix-store/register-validity.md), with the deriver fields left empty and no hashes),
+  or, with [structured attributes](#structured-attrs), under the given key in the JSON attributes file (as a list of store object infos).
+  <!-- TODO: link a schema for the structured-attributes list-of-store-object-infos format. It cannot simply link the store object info JSON schema, because this format is frozen (it is part of the derivation semantics, consumed by existing builders) and differs slightly from that evolving format. -->
+
+
+  This lets a builder do something with the closure of its inputs.
+
+  > **Usage note**
+  >
+  > Examples of builders using this include the builders in NixOS that generate the initial ramdisk for booting Linux (a `cpio` archive containing the closure of the boot script)
+  > and the ISO-9660 image for the installation CD (which is populated with a Nix store containing the closure of a bootable NixOS configuration).
+
+- [*required system features*]{#required-system-features}:
+  A set of features that Nix must have among its [`system-features`](@docroot@/command-ref/conf-file.md#conf-system-features) for the derivation to be scheduled on it, in addition to the [system](#system) type matching.
+
+- [*prefer local build*]{#prefer-local-build}:
+  A hint that the derivation is cheapest to build locally: when [distributed building is enabled](@docroot@/command-ref/conf-file.md#conf-builders), it will, if possible, be built locally rather than forwarded to a remote machine.
+
+- [*allow substitutes*]{#allow-substitutes}:
+  Whether the derivation's outputs may be [substituted](@docroot@/glossary.md#gloss-substitute).
+  When disabled, the derivation is always built (locally or remotely); this is useful for derivations that are cheaper to build than to substitute.
+  Nix may ignore this option via the [`always-allow-substitutes`](@docroot@/command-ref/conf-file.md#conf-always-allow-substitutes) configuration option.
+
+  > **Note**
+  >
+  > When disabled, some Nix instance must be able to run the [builder](#builder) on the specified [system](#system) type, since the derivation cannot be substituted.
+
+- [*impure environment variables*]{#impure-env-vars}:
+  A set of environment variables passed from the environment of the calling user to the builder, which otherwise starts from a cleared environment.
+  This is only allowed for [fixed-output derivations][fixed-output derivation], where such impurities are tolerable because (the hash of) the output is known in advance.
+  It is ignored for all other derivations.
+
+  > **Warning**
+  >
+  > The variables are taken from the environment of the building process itself:
+  > when building via a daemon, from the daemon's environment, and only otherwise from the environment of the calling command, e.g. `nix-build`.
+
+  If the [`configurable-impure-env` experimental feature](@docroot@/development/experimental-features.md#xp-feature-configurable-impure-env) is enabled,
+  these environment variables can also be controlled through the [`impure-env`](@docroot@/command-ref/conf-file.md#conf-impure-env) configuration option.
+
+- Sandbox-related options:
+
+  - [*no chroot*]{#no-chroot}:
+    The derivation asks to be built without [sandboxing](@docroot@/command-ref/conf-file.md#conf-sandbox).
+    Only under certain configurations will this wish actually be respected, however.
+    Nix may instead simply fail the build, rather than try to perform it without sandboxing.
+
+  - [*additional sandbox profile*]{#additional-sandbox-profile}:
+    (Darwin only) Additional sandbox profile text, granting the build extra permissions inside the sandbox.
+
+  - [*impure host dependencies*]{#impure-host-deps}:
+    (Darwin only) A set of host system paths made available inside the sandbox.
+
+  - [*allow local networking*]{#allow-local-networking}:
+    (Darwin only) Whether the build may access the local network inside the sandbox.
+
+[closure]: @docroot@/glossary.md#gloss-closure
+[fixed-output derivation]: @docroot@/glossary.md#gloss-fixed-output-derivation
 
 ### Placeholders
 

--- a/doc/manual/source/store/derivation/outputs/index.md
+++ b/doc/manual/source/store/derivation/outputs/index.md
@@ -45,6 +45,83 @@ In particular, the specification decides:
 
 - if the content is content-addressed, [what is its content address](./content-address.md#fixed) (and thus what is its [store path])
 
+## Output checks {#output-checks}
+
+In addition to the output specification above, a derivation may mandate additional *checks* on its outputs:
+properties that must hold for the produced store objects in order for the build to be considered successful.
+Checks may be specified separately for each output, or once for all outputs of the derivation.
+
+### Reference checks
+
+The main checks constrain the [references][reference] of an output.
+These checks vary along two axes, yielding 4 possible checks:
+
+- Whether the check applies to the *direct* references of the output, or to its entire [closure] via *transitive* references ([requisites][requisite]).
+
+- Whether the check *allows* a set of references (every reference must be a member of the set, though not every member needs to be referenced), or *disallows* a set of references (no reference may be a member of the set).
+
+The four checks are:
+
+- [*allowed references*]{#allowed-references}:
+  An optional set; the output's references must be a subset of it.
+  When the set is absent the check is skipped, i.e. every reference is allowed.
+
+  For example, the empty set enforces that the output has no runtime dependencies at all.
+
+  > **Usage note**
+  >
+  > This is used in NixOS to check that generated files such as initial ramdisks for booting Linux don't have accidental dependencies on other paths in the Nix store.
+
+- [*allowed requisites*]{#allowed-requisites}:
+  Like *allowed references*, but applying to the whole closure of the output:
+  every transitive dependency must be a member of the set.
+
+- [*disallowed references*]{#disallowed-references}:
+  A set of which no member may be a direct reference of the output.
+  (There is no need for this check to be optional: disallowing nothing is the same as skipping the check.)
+
+- [*disallowed requisites*]{#disallowed-requisites}:
+  Like *disallowed references*, but applying to the whole closure of the output:
+  no member of the set may appear anywhere in the output's transitive dependencies.
+
+The references of a store object are always store paths.
+However, if every element of these sets had to be a store path, it would be hard-to-impossible to constrain references from outputs *to other outputs* of the same derivation, because in general the store paths of outputs are not known until the derivation is built.
+For this reason, an element of these sets may also be an *output name* of the derivation being checked, standing for the store path of that output, whatever it turns out to be.
+For example, an output can be permitted to reference itself by including its own name in its *allowed references*.
+
+### Size checks
+
+- [*max size*]{#max-size}:
+  The [NAR size][nar size] of the output's store object may not exceed the given number of bytes.
+
+- [*max closure size*]{#max-closure-size}:
+  The [closure NAR size][closure nar size] of the output's store object may not exceed the given number of bytes.
+
+### Self-reference handling
+
+- [*ignore self references*]{#ignore-self-refs}:
+  Whether references of an output to itself are exempted from the reference checks above.
+
+## Reference scanning {#reference-scanning}
+
+Besides the output checks, there is one more per-output setting.
+It is *not* a check — nothing is verified about the produced store object — but it is configured in the same per-output manner, so it is documented here:
+
+- [*unsafe discard references*]{#unsafe-discard-references}:
+  Disables [scanning the output for run-time references](../../building.md#scanning-for-references) altogether.
+  The output is then registered as having no references, regardless of its contents.
+
+  This is useful, for example, when generating self-contained filesystem images with their own embedded Nix store:
+  hashes found inside such an image refer to the embedded store and not to the host's Nix store.
+
+  As the name suggests, this is unsafe: discarding references that are in fact needed at run time makes the closure incomplete, so copying the output elsewhere will not bring its dependencies along.
+
+[closure]: @docroot@/glossary.md#gloss-closure
+[nar size]: @docroot@/store/store-object.md#nar-size
+[closure nar size]: @docroot@/store/store-object.md#closure-nar-size
+[reference]: @docroot@/glossary.md#gloss-reference
+[requisite]: @docroot@/store/store-object.md#references
+
 ## Types of derivations
 
 The sections on each type of derivation output addressing ended up discussing other attributes of the derivation besides its outputs, such as purity, scheduling, determinism, etc.

--- a/doc/manual/source/store/store-object.md
+++ b/doc/manual/source/store/store-object.md
@@ -40,10 +40,10 @@ The *referrers closure* of a store object are the store objects that can reach t
 > We can create graphs from the store objects in a store, but the contents of the store is not, in general fixed, and may instead change over time.
 >
 > - The references of a store object --- the set of store paths called the references --- is a field of a store object, and thus intrinsic by definition.
-    Regardless of what store contains the store object in question, and what else that store may or may not contain, the references are the same.
+>   Regardless of what store contains the store object in question, and what else that store may or may not contain, the references are the same.
 >
 > - The requisites of a store object are almost intrinsic --- some store paths do not precisely refer to a unique single store object.
-> Exactly what store object is being referenced, and what in turn *its* references are, depends on the store in question.
+>   Exactly what store object is being referenced, and what in turn *its* references are, depends on the store in question.
 >   Different stores may disagree on what a given store path refers to.
 >
 > - The referrers of a store object are completely extrinsic, and depends solely on the store which contains that store object, not the store object itself.
@@ -71,4 +71,24 @@ A store can only contain a store object if it also contains all the store object
 
 [Store implementations](@docroot@/store/types/index.md) currently associate more information than described above with a store object.
 Quite arguably some of this information doesn't belong here, because it conflates concerns.
+
+Two such properties are sizes:
+
+- [*NAR size*]{#nar-size}:
+  The size in bytes of the store object's [file system object](./file-system-object.md), serialised as a [Nix Archive](./file-system-object/content-address.md#serial-nix-archive).
+
+  This is an intrinsic property of the store object itself, and not of the way any particular store happens to store it.
+  In particular, it is unrelated to the space the store object occupies on disk, which varies with compression, deduplication, and file system overheads.
+
+- [*closure NAR size*]{#closure-nar-size}:
+  The sum of the [*NAR size*](#nar-size) of every store object in the [closure] of the store object, including itself.
+
+  Unlike the *NAR size*, this is not quite an intrinsic property.
+  As a consequence of the [requisites](#references) being slightly ambiguous as described above, the *closure NAR size* is also slightly ambiguous;
+  both depend on the store in question and the exact closure in that store.
+
+  Because of these issues, implementations currently typically compute this on the fly rather than storing it.
+
 For details see the [store object info](@docroot@/protocols/json/store-object-info.md) JSON format or the [narinfo](@docroot@/protocols/binary-cache/narinfo.md) format.
+
+[closure]: @docroot@/glossary.md#gloss-closure

--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -116,14 +116,15 @@ struct CmdPathInfo : StorePathsCommand, MixJSON
         addFlag({
             .longName = "size",
             .shortName = 's',
-            .description = "Print the size of the NAR serialisation of each path.",
+            .description = "Print the [*NAR size*](@docroot@/store/store-object.md#nar-size) of each store object.",
             .handler = {&showSize, true},
         });
 
         addFlag({
             .longName = "closure-size",
             .shortName = 'S',
-            .description = "Print the sum of the sizes of the NAR serialisations of the closure of each path.",
+            .description =
+                "Print the [*closure NAR size*](@docroot@/store/store-object.md#closure-nar-size) of each store object, i.e. the sum over its whole closure.",
             .handler = {&showClosureSize, true},
         });
 


### PR DESCRIPTION
## Motivation

The various derivation options ("advanced attributes") are concepts of the store layer: they exist on the derivation itself, regardless of which language front-end produced it. Document their *semantics* in the store section of the manual: a new "Options" section for the whole-derivation options, an "Output checks" section for the per-output checks, and *pass as file* as part of the environment section.

The language "advanced attributes" page now documents just the Nix-language syntax for setting each option via `builtins.derivation`, with an example, linking to the store section for the concepts. All its existing anchors are preserved.

## Context

Depends on #5538

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
