### PR TITLE
Make fuzz target enablement explicit

### DIFF
--- a/ci/gha/tests/default.nix
+++ b/ci/gha/tests/default.nix
@@ -51,8 +51,9 @@ rec {
     final: prev: {
       withASan = withSanitizers;
       withUBSan = withSanitizers;
-      # So that this stuff is at least built in CI.
       withFuzzer = withSanitizers;
+      # Build the fuzz targets in CI.
+      withFuzzTargets = withSanitizers;
 
       nix-store-tests = prev.nix-store-tests.override { withBenchmarks = true; };
       # Boehm is incompatible with ASAN.
@@ -92,8 +93,35 @@ rec {
     packaging-overriding =
       let
         nix = packages'.nix;
+        checkFuzzConfiguration =
+          withFuzzer: withFuzzTargets:
+          let
+            components = nixComponents.overrideScope (
+              _: _: {
+                inherit withFuzzer withFuzzTargets;
+              }
+            );
+          in
+          lib.all
+            (
+              name:
+              let
+                flags = components.${name}.mesonFlags;
+              in
+              ((lib.elem (lib.mesonOption "b_sanitize" "fuzzer-no-link") flags) == withFuzzer)
+              && lib.elem (lib.mesonBool "fuzzers" withFuzzTargets) flags
+              && !(lib.elem (lib.mesonBool "fuzzers" (!withFuzzTargets)) flags)
+            )
+            [
+              "nix-util-tests"
+              "nix-store-tests"
+            ];
       in
       assert (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src.patches == [ pkgs.emptyFile ];
+      assert checkFuzzConfiguration false false;
+      assert checkFuzzConfiguration false true;
+      assert checkFuzzConfiguration true false;
+      assert checkFuzzConfiguration true true;
       if pkgs.stdenv.buildPlatform.isDarwin then
         lib.warn "packaging-overriding check currently disabled because of a permissions issue on macOS" pkgs.emptyFile
       else

--- a/doc/manual/source/development/testing.md
+++ b/doc/manual/source/development/testing.md
@@ -307,11 +307,15 @@ You can run them manually with `nix build .#hydraJobs.tests.{testName}` or `nix-
 
 The project utilises [`libFuzzer`](https://llvm.org/docs/LibFuzzer.html) and LLVM coverage instrumentation to fuzz sensitive pieces of code.
 The harnesses reside in corresponding `-tests` subprojects (e.g. `src/libutil-tests/fuzz`).
-In order to correctly utilise them, the whole project needs to be built with correct flags to ensure that all libraries are instrumented.
+The `fuzzers` option builds the harnesses, while `fuzzer-no-link` instruments the whole project.
+Meson rejects `fuzzers=true` unless `unit-tests=true` and `b_sanitize` includes `fuzzer-no-link`.
 
 ```shell
 nix develop .#native-clangStdenv
+appendToVar mesonFlags "-Dfuzzers=true"
 appendToVar mesonFlags "-Db_sanitize=address,undefined,fuzzer-no-link"
+# Clang sanitizer/shared-library workaround: https://github.com/mesonbuild/meson/issues/764
+appendToVar mesonFlags "-Db_lundef=false"
 appendToVar mesonFlags "-Dlibexpr:gc=disabled" # Because Boehm doesn't play well with ASan
 configurePhase
 buildPhase

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,10 @@ if get_option('doc-gen')
 endif
 
 # Testing
+if get_option('fuzzers') and not get_option('unit-tests')
+  error('fuzzers=true requires unit-tests=true')
+endif
+
 if get_option('unit-tests')
   subproject('libutil-test-support')
   subproject('libutil-tests')

--- a/meson.options
+++ b/meson.options
@@ -15,6 +15,13 @@ option(
 )
 
 option(
+  'fuzzers',
+  type : 'boolean',
+  value : false,
+  description : 'Build libFuzzer targets',
+)
+
+option(
   'functional-tests',
   type : 'boolean',
   value : true,

--- a/nix-meson-build-support/fuzz/meson.build
+++ b/nix-meson-build-support/fuzz/meson.build
@@ -1,13 +1,17 @@
 # To deduplicate the boilerplate of compiling fuzz harnesses, this file provides
 # the shared definitions for that.
 
+sanitizers_for_project = get_option('b_sanitize').split(',')
+if 'fuzzer-no-link' not in sanitizers_for_project
+  error('fuzzers=true requires fuzzer-no-link in b_sanitize')
+endif
+
 if cxx.get_id() != 'clang'
   # Because we use libFuzzer.
-  error('fuzzing is requires an LLVM toolchain')
+  error('fuzzing requires an LLVM toolchain')
 endif
 
 foreach t : fuzz_targets
-  sanitizers_for_project = get_option('b_sanitize').split(',')
   sanitizers = []
   foreach i : sanitizers_for_project
     if i != 'fuzzer-no-link'

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -326,6 +326,11 @@ in
   withFuzzer = false;
 
   /**
+    Whether to build the libFuzzer targets in Meson test components.
+  */
+  withFuzzTargets = false;
+
+  /**
     Whether meson components are checked with [clang-tidy](https://clang.llvm.org/extra/clang-tidy/).
   */
   withClangTidy = false;

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -120,7 +120,7 @@ if host_machine.system() != 'windows'
   test_env += {'NIX_REMOTE' : meson.current_build_dir() / 'test-home' / 'store'}
 endif
 
-if 'fuzzer-no-link' in get_option('b_sanitize')
+if get_option('fuzzers')
   subdir('fuzz')
 endif
 

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -21,6 +21,7 @@
   version,
   filesetToSource,
   withBenchmarks ? false,
+  withFuzzTargets ? false,
 }:
 
 let
@@ -58,6 +59,7 @@ mkMesonExecutable (finalAttrs: {
 
   mesonFlags = [
     (lib.mesonBool "benchmarks" withBenchmarks)
+    (lib.mesonBool "fuzzers" withFuzzTargets)
   ];
 
   passthru = {
@@ -92,6 +94,10 @@ mkMesonExecutable (finalAttrs: {
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe' finalAttrs.finalPackage "nix-store-benchmarks"}
             ''
             + ''
+              for target in fuzz-parse-derivation fuzz-parse-derivation-experimental; do
+                ${if withFuzzTargets then "test -x" else "test ! -e"} \
+                  "${finalAttrs.finalPackage}/bin/$target${stdenv.hostPlatform.extensions.executable}"
+              done
               touch $out
             ''
           );

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -125,7 +125,7 @@ this_exe = executable(
   cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )
 
-if 'fuzzer-no-link' in get_option('b_sanitize')
+if get_option('fuzzers')
   subdir('fuzz')
 endif
 

--- a/src/libutil-tests/meson.options
+++ b/src/libutil-tests/meson.options
@@ -1,14 +1,6 @@
 # vim: filetype=meson
 
 option(
-  'benchmarks',
-  type : 'boolean',
-  value : false,
-  description : 'Build benchmarks (requires gbenchmark)',
-  yield : true,
-)
-
-option(
   'fuzzers',
   type : 'boolean',
   value : false,

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -17,6 +17,7 @@
   # Configuration Options
 
   version,
+  withFuzzTargets ? false,
 }:
 
 let
@@ -34,7 +35,7 @@ mkMesonExecutable (finalAttrs: {
     ./fuzz/harnesses
     ../../.version
     ./.version
-    # ./meson.options
+    ./meson.options
     (fileset.fileFilter (file: file.name == "meson.build") ./.)
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
@@ -53,6 +54,7 @@ mkMesonExecutable (finalAttrs: {
   ];
 
   mesonFlags = [
+    (lib.mesonBool "fuzzers" withFuzzTargets)
   ];
 
   passthru = {
@@ -70,6 +72,10 @@ mkMesonExecutable (finalAttrs: {
             + ''
               export _NIX_TEST_UNIT_DATA=${./data}
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
+              for target in fuzz-parse-dump fuzz-parse-dump-case-hacked; do
+                ${if withFuzzTargets then "test -x" else "test ! -e"} \
+                  "${finalAttrs.finalPackage}/bin/$target${stdenv.hostPlatform.extensions.executable}"
+              done
               touch $out
             ''
           );


### PR DESCRIPTION
## Motivation

Fuzz targets were previously enabled as a side effect of adding `fuzzer-no-link` to `b_sanitize`. This coupled target generation to instrumentation and hid target creation behind a sanitizer setting.

This change adds an explicit `fuzzers` option. `withFuzzer` continues to control instrumentation, while `withFuzzTargets` controls whether the fuzz executables are built.


## Context

The Meson test projects now use `fuzzers` to decide whether to build their fuzz targets. Configuration fails if targets are requested without `fuzzer-no-link` or while unit tests are disabled.

The component scope, development shell, sanitizer CI, packaging checks, and fuzzing documentation now set the two options separately. Package checks also verify whether the expected fuzz binaries are installed.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
