### PR TITLE
Progress bar signal handling improvements

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -105,7 +105,7 @@ private:
     bool printBuildLogs = false;
     bool isTTY;
 
-    std::unique_ptr<InterruptCallback> interruptCallback;
+    std::unique_ptr<InterruptCallback> interruptCallback, stopCallback, contCallback, winchCallback;
 
     void hideCursorIfNeeded() const
     {
@@ -130,6 +130,30 @@ public:
     {
         hideCursorIfNeeded();
         state_.lock()->active = isTTY;
+
+        /* On Ctrl-Z, unhide the cursor before the process is
+           stopped. */
+        stopCallback = createSignalCallback(SignalType::Stop, [&]() {
+            auto state(state_.lock());
+            if (state->active && !state->isPaused())
+                unhideCursorIfNeeded();
+        });
+
+        /* Redraw the progress bar when the process is resumed or the
+           terminal size changes. */
+        auto redrawCallback = [&]() {
+            auto state(state_.lock());
+            if (state->active && !state->isPaused()) {
+                /* Force a redraw, since the new output may be
+                   identical to the one cached by redraw(). */
+                invalidateRedrawCache();
+                hideCursorIfNeeded();
+                update(*state);
+            }
+        };
+        contCallback = createSignalCallback(SignalType::Cont, redrawCallback);
+        winchCallback = createSignalCallback(SignalType::Winch, redrawCallback);
+
         updateThread = std::thread([&]() {
             auto state(state_.lock());
             auto nextWakeup = std::chrono::milliseconds::max();

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -197,6 +197,13 @@ void initNix(bool loadConfig)
     if (sigaction(SIGWINCH, &act, 0))
         throw SysError("handling SIGWINCH");
 
+    /* Same for SIGCONT and SIGTSTP, which are also handled by
+     * signalHandlerThread. */
+    if (sigaction(SIGCONT, &act, 0))
+        throw SysError("handling SIGCONT");
+    if (sigaction(SIGTSTP, &act, 0))
+        throw SysError("handling SIGTSTP");
+
     /* Disable SA_RESTART for interrupts, so that system calls on this thread
      * error with EINTR like they do on Linux.
      * Most signals on BSD systems default to SA_RESTART on, but Nix

--- a/src/libutil/include/nix/util/signals.hh
+++ b/src/libutil/include/nix/util/signals.hh
@@ -51,6 +51,37 @@ struct InterruptCallback
 };
 
 /**
+ * Portable identifiers for the signal events that callbacks can be
+ * registered for via `createSignalCallback()`.
+ */
+enum class SignalType {
+    /**
+     * SIGINT/SIGTERM/SIGHUP, or a programmatic `triggerInterrupt()`.
+     */
+    Int,
+    /**
+     * SIGTSTP, called just before the process stops itself.
+     */
+    Stop,
+    /**
+     * SIGCONT, i.e. the process was resumed after being stopped.
+     */
+    Cont,
+    /**
+     * SIGWINCH, i.e. the terminal size changed.
+     */
+    Winch,
+};
+
+/**
+ * Register a function that gets called from the signal handler thread
+ * (in a non-signal context) when the given signal type is received.
+ *
+ * @note Does nothing on Windows
+ */
+std::unique_ptr<InterruptCallback> createSignalCallback(SignalType type, fun<void()> callback);
+
+/**
  * Register a function that gets called on SIGINT (in a non-signal
  * context).
  *

--- a/src/libutil/unix/signals.cc
+++ b/src/libutil/unix/signals.cc
@@ -31,11 +31,11 @@ void unix::_interrupted()
 
 //////////////////////////////////////////////////////////////////////
 
-/* We keep track of interrupt callbacks using integer tokens, so we can iterate
+/* We keep track of signal callbacks using integer tokens, so we can iterate
    safely without having to lock the data structure while executing arbitrary
    functions.
  */
-struct InterruptCallbacks
+struct SignalCallbacks
 {
     typedef int64_t Token;
 
@@ -43,21 +43,47 @@ struct InterruptCallbacks
        handler because of an erroneous double delete. */
     Token nextToken = 0;
 
-    /* Used as a list, see InterruptCallbacks comment. */
-    std::map<Token, fun<void()>> callbacks;
+    /* Each per-signal map is used as a list, see SignalCallbacks comment. */
+    std::map<SignalType, std::map<Token, fun<void()>>> callbacks;
 };
 
 InterruptCallback::~InterruptCallback() {}
 
 /* Required to avoid static initialization order fiasco. This allows global
    objects to safely register callbacks. */
-static Sync<InterruptCallbacks> & getInterruptCallbacks()
+static Sync<SignalCallbacks> & getSignalCallbacks()
 {
     /* Intentionally leak, according to the Construct On First Use Idiom.
        An alternative is to use the Nifty Counter Idiom, but
-       InterruptCallbacks' destructor is not very important. */
-    static Sync<InterruptCallbacks> * _interruptCallbacks = new Sync<InterruptCallbacks>();
-    return *_interruptCallbacks;
+       SignalCallbacks' destructor is not very important. */
+    static Sync<SignalCallbacks> * _signalCallbacks = new Sync<SignalCallbacks>();
+    return *_signalCallbacks;
+}
+
+static void triggerSignalCallbacks(SignalType type)
+{
+    SignalCallbacks::Token i = 0;
+    while (true) {
+        std::function<void()> callback;
+        {
+            auto signalCallbacks(getSignalCallbacks().lock());
+            auto it = signalCallbacks->callbacks.find(type);
+            if (it == signalCallbacks->callbacks.end())
+                break;
+            auto lb = it->second.lower_bound(i);
+            if (lb == it->second.end())
+                break;
+
+            callback = lb->second;
+            i = lb->first + 1;
+        }
+
+        try {
+            callback();
+        } catch (...) {
+            ignoreExceptionInDestructor();
+        }
+    }
 }
 
 static void signalHandlerThread(sigset_t set)
@@ -72,7 +98,23 @@ static void signalHandlerThread(sigset_t set)
 
         else if (signal == SIGWINCH) {
             updateWindowSize();
+            triggerSignalCallbacks(SignalType::Winch);
         }
+
+        else if (signal == SIGCONT)
+            triggerSignalCallbacks(SignalType::Cont);
+
+#ifndef __FreeBSD__
+        else if (signal == SIGTSTP) {
+            triggerSignalCallbacks(SignalType::Stop);
+            /* Since we consumed SIGTSTP via sigwait(), its default
+               action (stopping the process) no longer happens, so stop
+               ourselves explicitly. SIGSTOP cannot be blocked. On
+               resumption, SIGCONT is delivered via sigwait() as
+               usual. */
+            kill(getpid(), SIGSTOP);
+        }
+#endif
     }
 }
 
@@ -80,27 +122,7 @@ void unix::triggerInterrupt()
 {
     _isInterrupted = true;
 
-    {
-        InterruptCallbacks::Token i = 0;
-        while (true) {
-            std::function<void()> callback;
-            {
-                auto interruptCallbacks(getInterruptCallbacks().lock());
-                auto lb = interruptCallbacks->callbacks.lower_bound(i);
-                if (lb == interruptCallbacks->callbacks.end())
-                    break;
-
-                callback = lb->second;
-                i = lb->first + 1;
-            }
-
-            try {
-                callback();
-            } catch (...) {
-                ignoreExceptionInDestructor();
-            }
-        }
-    }
+    triggerSignalCallbacks(SignalType::Int);
 }
 
 sigset_t unix::savedSignalMask;
@@ -127,6 +149,12 @@ void unix::startSignalHandlerThread()
     sigaddset(&set, SIGHUP);
     sigaddset(&set, SIGPIPE);
     sigaddset(&set, SIGWINCH);
+    sigaddset(&set, SIGCONT);
+#ifndef __FreeBSD__
+    /* Not on FreeBSD, where SIGTSTP doubles as NIX_SIG_MULTI_INT and is
+       delivered to specific threads using pthread_kill(). */
+    sigaddset(&set, SIGTSTP);
+#endif
     if (pthread_sigmask(SIG_BLOCK, &set, nullptr))
         throw SysError("blocking signals");
 
@@ -158,10 +186,12 @@ namespace {
 /* RAII helper to automatically deregister a callback. */
 struct InterruptCallbackImpl : InterruptCallback
 {
-    InterruptCallbacks::Token token;
+    SignalType type;
+    SignalCallbacks::Token token;
 
-    InterruptCallbackImpl(InterruptCallbacks::Token token)
-        : token(token)
+    InterruptCallbackImpl(SignalType type, SignalCallbacks::Token token)
+        : type(type)
+        , token(token)
     {
     }
 
@@ -172,19 +202,24 @@ struct InterruptCallbackImpl : InterruptCallback
 
     ~InterruptCallbackImpl() override
     {
-        auto interruptCallbacks(getInterruptCallbacks().lock());
-        interruptCallbacks->callbacks.erase(token);
+        auto signalCallbacks(getSignalCallbacks().lock());
+        signalCallbacks->callbacks[type].erase(token);
     }
 };
 
 } // namespace
 
+std::unique_ptr<InterruptCallback> createSignalCallback(SignalType type, fun<void()> callback)
+{
+    auto signalCallbacks(getSignalCallbacks().lock());
+    auto token = signalCallbacks->nextToken++;
+    signalCallbacks->callbacks[type].emplace(token, callback);
+    return std::make_unique<InterruptCallbackImpl>(type, token);
+}
+
 std::unique_ptr<InterruptCallback> createInterruptCallback(fun<void()> callback)
 {
-    auto interruptCallbacks(getInterruptCallbacks().lock());
-    auto token = interruptCallbacks->nextToken++;
-    interruptCallbacks->callbacks.emplace(token, callback);
-    return std::make_unique<InterruptCallbackImpl>(token);
+    return createSignalCallback(SignalType::Int, std::move(callback));
 }
 
 } // namespace nix

--- a/src/libutil/unix/signals.cc
+++ b/src/libutil/unix/signals.cc
@@ -101,8 +101,14 @@ static void signalHandlerThread(sigset_t set)
             triggerSignalCallbacks(SignalType::Winch);
         }
 
-        else if (signal == SIGCONT)
+        else if (signal == SIGCONT) {
+            /* The terminal may have been resized while we were
+               stopped, and we won't have received SIGWINCH for it,
+               since the kernel only sends it to the foreground process
+               group. */
+            updateWindowSize();
             triggerSignalCallbacks(SignalType::Cont);
+        }
 
 #ifndef __FreeBSD__
         else if (signal == SIGTSTP) {

--- a/src/libutil/windows/include/nix/util/signals-impl.hh
+++ b/src/libutil/windows/include/nix/util/signals-impl.hh
@@ -44,6 +44,11 @@ struct ReceiveInterrupts
     ~ReceiveInterrupts() {}
 };
 
+inline std::unique_ptr<InterruptCallback> createSignalCallback(SignalType type, fun<void()> callback)
+{
+    return {};
+}
+
 inline std::unique_ptr<InterruptCallback> createInterruptCallback(fun<void()> callback)
 {
     return {};


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

* Unhide the cursor when the user hits Ctrl-Z (SIGTSTP).
* Redraw the progress bar when Nix is resumed (SIGCONT).
* Redraw the progress bar immediately when the window size changes (SIGWINCH).

This is implemented by generalizing the `InterruptCallback` mechanism to support other signals.

Taken from https://github.com/DeterminateSystems/nix-src/pull/586.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
