### PR TITLE
Fix randomly failing build.sh test

### DIFF
--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -229,7 +229,8 @@ if isDaemonNewer "2.34pre" && canUseSandbox; then
     if ! isTestOnNixOS; then
         sandboxPathsArg=(--option sandbox-paths "/nix/store")
     fi
-    out="$(nix flake check ./cancelled-builds --impure -L -j2 \
+    cat /proc/sys/user/max_user_namespaces /proc/sys/user/max_pid_namespaces >&2 || true
+    out="$(nix flake check ./cancelled-builds --no-sandbox-fallback --impure -L -j2 \
         --option sandbox true \
         "${sandboxPathsArg[@]}" \
         --option sandbox-build-dir /build-tmp \
@@ -255,7 +256,7 @@ if isDaemonNewer "2.34pre" && canUseSandbox; then
         sandboxPathsArg=(--option sandbox-paths "/nix/store")
     fi
     system=$(nix eval --raw --impure --expr builtins.currentSystem)
-    out="$(nix build --impure -L -j2 \
+    out="$(nix build --no-sandbox-fallback --impure -L -j2 \
         --option sandbox true \
         "${sandboxPathsArg[@]}" \
         --option sandbox-build-dir /build-tmp \

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -216,7 +216,7 @@ fi
 # Only fast-fail should be reported as a failure.
 # Uses fifo for synchronization to ensure deterministic behavior.
 # Requires -j2 so slow and fast-fail run concurrently (fifo deadlocks if serialized).
-if isDaemonNewer "2.34pre" && canUseSandbox; then
+if isDaemonNewer "2.34pre" && canUseSandbox && unprivilegedUserNamespacesSupported; then
     fifoDir="$TEST_ROOT/cancelled-builds-fifo"
     mkdir -p "$fifoDir"
     mkfifo "$fifoDir/fifo"
@@ -229,7 +229,6 @@ if isDaemonNewer "2.34pre" && canUseSandbox; then
     if ! isTestOnNixOS; then
         sandboxPathsArg=(--option sandbox-paths "/nix/store")
     fi
-    cat /proc/sys/user/max_user_namespaces /proc/sys/user/max_pid_namespaces >&2 || true
     out="$(nix flake check ./cancelled-builds --no-sandbox-fallback --impure -L -j2 \
         --option sandbox true \
         "${sandboxPathsArg[@]}" \

--- a/tests/functional/common/functions.sh
+++ b/tests/functional/common/functions.sh
@@ -352,8 +352,14 @@ count() {
 
 trap onError ERR
 
+# Note: with newer AppArmor stacks, this restriction doesn't prevent *creating*
+# a user namespace, but denies mounting inside it, which Nix's sandbox needs.
+unprivilegedUserNamespacesSupported() {
+  ! { [[ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]] && [[ $(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns) -eq 1 ]]; }
+}
+
 requiresUnprivilegedUserNamespaces() {
-  if [[ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]] && [[ $(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns) -eq 1 ]]; then
+  if ! unprivilegedUserNamespacesSupported; then
     skipTest "Unprivileged user namespaces are disabled. Run 'sudo sysctl -w /proc/sys/kernel/apparmor_restrict_unprivileged_userns=0' to allow, and run these tests."
   fi
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fix random failures in `build.sh` in GHA, e.g. https://github.com/DeterminateSystems/nix-src/actions/runs/30926645783/job/92052907077. Sometimes on GHA builders, `canUseSandbox` returns true but `mountAndPidNamespacesSupported()` fails.

Taken from https://github.com/DeterminateSystems/nix-src/pull/587.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
