### PR TITLE
Use correct eval/fetchSettings in MixEvalArgs, prune unused programPath global

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -30,8 +30,7 @@ EvalSettings evalSettings{
                 /* Const is a lie here, because settings currently carry mutables caches. */
                 const auto & fetchSettings = state.fetchSettings;
                 experimentalFeatureSettings.require(Xp::Flakes);
-                // FIXME `parseFlakeRef` should take a `std::string_view`.
-                auto flakeRef = parseFlakeRef(fetchSettings, std::string{rest}, {}, true, false);
+                auto flakeRef = parseFlakeRef(fetchSettings, rest, {}, true, false);
                 debug("fetching flake search path element '%s''", rest);
                 auto [accessor, lockedRef] =
                     flakeRef.resolve(fetchSettings, *state.store).lazyFetch(fetchSettings, *state.store);

--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -27,6 +27,8 @@ EvalSettings evalSettings{
         {
             "flake",
             [](EvalState & state, std::string_view rest) {
+                /* Const is a lie here, because settings currently carry mutables caches. */
+                const auto & fetchSettings = state.fetchSettings;
                 experimentalFeatureSettings.require(Xp::Flakes);
                 // FIXME `parseFlakeRef` should take a `std::string_view`.
                 auto flakeRef = parseFlakeRef(fetchSettings, std::string{rest}, {}, true, false);
@@ -34,11 +36,7 @@ EvalSettings evalSettings{
                 auto [accessor, lockedRef] =
                     flakeRef.resolve(fetchSettings, *state.store).lazyFetch(fetchSettings, *state.store);
                 auto storePath = nix::fetchToStore(
-                    state.fetchSettings,
-                    *state.store,
-                    SourcePath(accessor),
-                    FetchMode::Copy,
-                    lockedRef.input.getName());
+                    fetchSettings, *state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
                 state.allowPath(storePath);
                 return state.storePath(storePath);
             },
@@ -177,9 +175,11 @@ const Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
 
 SourcePath lookupFileArg(EvalState & state, std::string_view s, const std::filesystem::path * baseDir)
 {
+    const auto & fetchSettings = state.fetchSettings;
+
     if (EvalSettings::isPseudoUrl(s)) {
-        auto accessor = fetchers::downloadTarball(*state.store, state.fetchSettings, EvalSettings::resolvePseudoUrl(s));
-        auto storePath = fetchToStore(state.fetchSettings, *state.store, SourcePath(accessor), FetchMode::Copy);
+        auto accessor = fetchers::downloadTarball(*state.store, fetchSettings, EvalSettings::resolvePseudoUrl(s));
+        auto storePath = fetchToStore(fetchSettings, *state.store, SourcePath(accessor), FetchMode::Copy);
         return state.storePath(storePath);
     }
 
@@ -189,7 +189,7 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s, const std::files
         auto [accessor, lockedRef] =
             flakeRef.resolve(fetchSettings, *state.store).lazyFetch(fetchSettings, *state.store);
         auto storePath = nix::fetchToStore(
-            state.fetchSettings, *state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
+            fetchSettings, *state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
         state.allowPath(storePath);
         return state.storePath(storePath);
     }

--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -12,8 +12,6 @@
 
 namespace nix {
 
-extern std::string programPath;
-
 extern char ** savedArgv;
 
 class EvalState;

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -723,8 +723,11 @@ void NixRepl::loadFlake(const std::string & flakeRefS)
         throw SystemError(e.code(), "cannot determine current working directory");
     }
 
+    const auto & fetchSettings = state->fetchSettings;
+    const bool isPureEval = state->settings.pureEval;
+
     auto flakeRef = parseFlakeRef(fetchSettings, flakeRefS, cwd.string(), true);
-    if (evalSettings.pureEval && !flakeRef.input.isLocked(fetchSettings))
+    if (isPureEval && !flakeRef.input.isLocked(fetchSettings))
         throw Error("cannot use ':load-flake' on unlocked flake reference '%s' (use --impure to override)", flakeRefS);
 
     Value v;
@@ -737,8 +740,8 @@ void NixRepl::loadFlake(const std::string & flakeRefS)
             flakeRef,
             flake::LockFlags{
                 .updateLockFile = false,
-                .useRegistries = !evalSettings.pureEval,
-                .allowUnlocked = !evalSettings.pureEval,
+                .useRegistries = !isPureEval,
+                .allowUnlocked = !isPureEval,
             }),
         v);
     addAttrsToScope(v);

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -73,7 +73,7 @@ FlakeRef::resolve(const fetchers::Settings & fetchSettings, Store & store, fetch
 
 FlakeRef parseFlakeRef(
     const fetchers::Settings & fetchSettings,
-    const std::string & url,
+    std::string_view url,
     const std::optional<std::filesystem::path> & baseDir,
     bool allowMissing,
     bool isFlake,
@@ -100,7 +100,7 @@ fromParsedURL(const fetchers::Settings & fetchSettings, ParsedURL && parsedURL, 
 
 std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
     const fetchers::Settings & fetchSettings,
-    const std::string & url,
+    std::string_view url,
     const std::optional<std::filesystem::path> & baseDir,
     bool allowMissing,
     bool isFlake,
@@ -108,8 +108,8 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
 {
     static std::regex pathFlakeRegex(R"(([^?#]*)(\?([^#]*))?(#(.*))?)", std::regex::ECMAScript);
 
-    std::smatch match;
-    auto succeeds = std::regex_match(url, match, pathFlakeRegex);
+    std::match_results<std::string_view::const_iterator> match;
+    auto succeeds = std::regex_match(url.begin(), url.end(), match, pathFlakeRegex);
     if (!succeeds)
         throw Error("invalid flakeref '%s'", url);
     std::filesystem::path path = match[1].str();
@@ -220,15 +220,16 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
  * `flake:<flake-id>?ref=<ref>&rev=<rev>`.
  */
 static std::optional<std::pair<FlakeRef, std::string>>
-parseFlakeIdRef(const fetchers::Settings & fetchSettings, const std::string & url, bool isFlake)
+parseFlakeIdRef(const fetchers::Settings & fetchSettings, std::string_view url, bool isFlake)
 {
-    std::smatch match;
+    /* https://lists.isocpp.org/std-proposals/att-0008/Dxxxx_string_view_support_for_regex.pdf */
+    std::match_results<std::string_view::const_iterator> match;
 
     static std::regex flakeRegex(
         "((" + flakeIdRegexS + ")(?:/(?:" + refAndOrRevRegex + "))?)" + "(?:#(" + fragmentRegex + "))?",
         std::regex::ECMAScript);
 
-    if (std::regex_match(url, match, flakeRegex)) {
+    if (std::regex_match(url.begin(), url.end(), match, flakeRegex)) {
         auto parsedURL = ParsedURL{
             .scheme = "flake",
             .authority = std::nullopt,
@@ -244,7 +245,7 @@ parseFlakeIdRef(const fetchers::Settings & fetchSettings, const std::string & ur
 
 std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
     const fetchers::Settings & fetchSettings,
-    const std::string & url,
+    std::string_view url,
     const std::optional<std::filesystem::path> & baseDir,
     bool isFlake)
 {
@@ -264,7 +265,7 @@ std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
 
 std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
     const fetchers::Settings & fetchSettings,
-    const std::string & url,
+    std::string_view url,
     const std::optional<std::filesystem::path> & baseDir,
     bool allowMissing,
     bool isFlake,
@@ -348,7 +349,7 @@ FlakeRef FlakeRef::canonicalize() const
 
 std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragmentAndExtendedOutputsSpec(
     const fetchers::Settings & fetchSettings,
-    const std::string & url,
+    std::string_view url,
     const std::optional<std::filesystem::path> & baseDir,
     bool allowMissing,
     bool isFlake)

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -96,7 +96,7 @@ std::ostream & operator<<(std::ostream & str, const FlakeRef & flakeRef);
  */
 FlakeRef parseFlakeRef(
     const fetchers::Settings & fetchSettings,
-    const std::string & url,
+    std::string_view url,
     const std::optional<std::filesystem::path> & baseDir = {},
     bool allowMissing = false,
     bool isFlake = true,
@@ -107,7 +107,7 @@ FlakeRef parseFlakeRef(
  */
 std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
     const fetchers::Settings & fetchSettings,
-    const std::string & url,
+    std::string_view url,
     const std::optional<std::filesystem::path> & baseDir = {},
     bool allowMissing = false,
     bool isFlake = true,
@@ -118,7 +118,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
  */
 std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragmentAndExtendedOutputsSpec(
     const fetchers::Settings & fetchSettings,
-    const std::string & url,
+    std::string_view url,
     const std::optional<std::filesystem::path> & baseDir = {},
     bool allowMissing = false,
     bool isFlake = true);

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -1,3 +1,4 @@
+#include "nix/util/json-utils.hh" // IWYU pragma: keep (partial specialization of adl_serialiser)
 #include "nix/cmd/common-eval-args.hh"
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/util/args/root.hh"
@@ -469,7 +470,7 @@ void mainWrapped(int argc, char ** argv)
             b["args"] = primOp->args;
             b["doc"] = trim(stripIndentation(*primOp->doc));
             if (primOp->experimentalFeature)
-                b["experimental-feature"] = primOp->experimentalFeature;
+                b["experimental-feature"] = *primOp->experimentalFeature;
             builtinsJson.emplace(state.symbols[builtin.name], std::move(b));
         }
         for (auto & [name, info] : state.constantInfos) {

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -86,8 +86,6 @@ static bool haveInternet()
 #endif
 }
 
-std::string programPath;
-
 struct NixArgs : virtual MultiCommand, virtual MixCommonArgs, virtual RootArgs
 {
     bool useNet = true;
@@ -408,8 +406,7 @@ void mainWrapped(int argc, char ** argv)
 
     Finally f([] { logger->stop(); });
 
-    programPath = argv[0];
-    auto programName = std::string(baseNameOf(programPath));
+    auto programName = std::string(baseNameOf(argv[0]));
     auto extensionPos = programName.find_last_of(".");
     if (extensionPos != std::string::npos)
         programName.erase(extensionPos);

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -1,3 +1,4 @@
+#include "nix/util/json-utils.hh"
 #include "nix/cmd/command.hh"
 #include "nix/cmd/installable-flake.hh"
 #include "nix/main/common-args.hh"
@@ -156,8 +157,8 @@ struct ProfileManifest
                 }
                 if (e.value(sUrl, "") != "") {
                     element.source = ProfileElementSource{
-                        parseFlakeRef(fetchSettings, e[sOriginalUrl]),
-                        parseFlakeRef(fetchSettings, e[sUrl]),
+                        parseFlakeRef(fetchSettings, getString(e[sOriginalUrl])),
+                        parseFlakeRef(fetchSettings, getString(e[sUrl])),
                         e["attrPath"],
                         e["outputs"].get<ExtendedOutputsSpec>()};
                 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

evalSettings lookupPath hooks and lookupFileArg were using the wrong fetchSettings (which is not the global one when the state is created through the C API). Same in NixRepl::loadFlake, but it's quite inconsequential because in practice it is always the global one.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
