### PR TITLE
Drop unnecessary fetchSettings from Input methods

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -30,7 +30,7 @@ EvalSettings evalSettings{
                 /* Const is a lie here, because settings currently carry mutables caches. */
                 const auto & fetchSettings = state.fetchSettings;
                 experimentalFeatureSettings.require(Xp::Flakes);
-                auto flakeRef = parseFlakeRef(fetchSettings, rest, {}, true, false);
+                auto flakeRef = parseFlakeRef(rest, {}, true, false);
                 debug("fetching flake search path element '%s''", rest);
                 auto [accessor, lockedRef] =
                     flakeRef.resolve(fetchSettings, *state.store).lazyFetch(fetchSettings, *state.store);
@@ -122,8 +122,8 @@ MixEvalArgs::MixEvalArgs()
         .category = category,
         .labels = {"original-ref", "resolved-ref"},
         .handler = {[&](std::string _from, std::string _to) {
-            auto from = parseFlakeRef(fetchSettings, _from, std::filesystem::current_path().string());
-            auto to = parseFlakeRef(fetchSettings, _to, std::filesystem::current_path().string());
+            auto from = parseFlakeRef(_from, std::filesystem::current_path().string());
+            auto to = parseFlakeRef(_to, std::filesystem::current_path().string());
             fetchers::Attrs extraAttrs;
             if (to.subdir != "")
                 extraAttrs["dir"] = to.subdir;
@@ -184,9 +184,9 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s, const std::files
 
     else if (hasPrefix(s, "flake:")) {
         experimentalFeatureSettings.require(Xp::Flakes);
-        auto flakeRef = parseFlakeRef(fetchSettings, std::string(s.substr(6)), {}, true, false);
+        auto flakeRef = parseFlakeRef(std::string(s.substr(6)), {}, true, false);
         auto [accessor, lockedRef] =
-            flakeRef.resolve(fetchSettings, *state.store).lazyFetch(fetchSettings, *state.store);
+            flakeRef.resolve(state.fetchSettings, *state.store).lazyFetch(state.fetchSettings, *state.store);
         auto storePath = nix::fetchToStore(
             fetchSettings, *state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
         state.allowPath(storePath);

--- a/src/libcmd/include/nix/cmd/installable-flake.hh
+++ b/src/libcmd/include/nix/cmd/installable-flake.hh
@@ -1,7 +1,6 @@
 #pragma once
 ///@file
 
-#include "nix/cmd/common-eval-args.hh"
 #include "nix/cmd/installable-value.hh"
 
 namespace nix {
@@ -84,7 +83,7 @@ struct InstallableFlake : InstallableValue
  */
 static inline FlakeRef defaultNixpkgsFlakeRef()
 {
-    return FlakeRef::fromAttrs(fetchSettings, {{"type", "indirect"}, {"id", "nixpkgs"}});
+    return FlakeRef::fromAttrs({{"type", "indirect"}, {"id", "nixpkgs"}});
 }
 
 } // namespace nix

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -137,7 +137,7 @@ MixFlakeOptions::MixFlakeOptions()
                 throw UsageError(
                     "--override-input was passed a zero-length input path, which would refer to the flake itself, not an input");
             lockFlags.inputOverrides.insert_or_assign(
-                std::move(*path), parseFlakeRef(fetchSettings, flakeRef, absPath(getCommandBaseDir()).string(), true));
+                std::move(*path), parseFlakeRef(flakeRef, absPath(getCommandBaseDir()).string(), true));
         }},
         .completer = {[&](AddCompletions & completions, size_t n, std::string_view prefix) {
             if (n == 0) {
@@ -178,7 +178,7 @@ MixFlakeOptions::MixFlakeOptions()
             auto flake = flake::lockFlake(
                 flakeSettings,
                 *evalState,
-                parseFlakeRef(fetchSettings, flakeRef, absPath(getCommandBaseDir()).string()),
+                parseFlakeRef(flakeRef, absPath(getCommandBaseDir()).string()),
                 {.writeLockFile = false});
             for (auto & [inputName, input] : flake.lockFile.root->inputs) {
                 auto input2 = flake.lockFile.findInput({inputName}); // resolve 'follows' nodes
@@ -190,7 +190,7 @@ MixFlakeOptions::MixFlakeOptions()
                     }
 
                     overrideRegistry(
-                        fetchers::Input::fromAttrs(fetchSettings, {{"type", "indirect"}, {"id", inputName}}),
+                        fetchers::Input::fromAttrs({{"type", "indirect"}, {"id", inputName}}),
                         input3->lockedRef.input,
                         extraAttrs);
                 }
@@ -343,8 +343,7 @@ void completeFlakeRefWithFragment(
             auto flakeRefS = std::string(prefix.substr(0, hash));
 
             // TODO: ideally this would use the command base directory instead of assuming ".".
-            auto flakeRef =
-                parseFlakeRef(fetchSettings, expandTilde(flakeRefS), std::filesystem::current_path().string());
+            auto flakeRef = parseFlakeRef(expandTilde(flakeRefS), std::filesystem::current_path().string());
 
             auto evalCache = openEvalCache(
                 *evalState, make_ref<flake::LockedFlake>(lockFlake(flakeSettings, *evalState, flakeRef, lockFlags)));
@@ -507,7 +506,7 @@ Installables SourceExprCommand::parseInstallables(ref<Store> store, std::vector<
 
             try {
                 auto [flakeRef, fragment] =
-                    parseFlakeRefWithFragment(fetchSettings, std::string{prefix}, absPath(getCommandBaseDir()));
+                    parseFlakeRefWithFragment(std::string{prefix}, absPath(getCommandBaseDir()));
                 result.push_back(
                     make_ref<InstallableFlake>(
                         this,
@@ -760,8 +759,7 @@ std::vector<FlakeRef> RawInstallablesCommand::getFlakeRefsForCompletion()
     std::vector<FlakeRef> res;
     res.reserve(rawInstallables.size());
     for (const auto & i : rawInstallables)
-        res.push_back(
-            parseFlakeRefWithFragment(fetchSettings, expandTilde(i), absPath(getCommandBaseDir()).string()).first);
+        res.push_back(parseFlakeRefWithFragment(expandTilde(i), absPath(getCommandBaseDir()).string()).first);
     return res;
 }
 
@@ -780,8 +778,7 @@ void RawInstallablesCommand::run(ref<Store> store)
 
 std::vector<FlakeRef> InstallableCommand::getFlakeRefsForCompletion()
 {
-    return {parseFlakeRefWithFragment(fetchSettings, expandTilde(_installable), absPath(getCommandBaseDir()).string())
-                .first};
+    return {parseFlakeRefWithFragment(expandTilde(_installable), absPath(getCommandBaseDir()).string()).first};
 }
 
 void InstallablesCommand::run(ref<Store> store, std::vector<std::string> && rawInstallables)

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -726,7 +726,7 @@ void NixRepl::loadFlake(const std::string & flakeRefS)
     const auto & fetchSettings = state->fetchSettings;
     const bool isPureEval = state->settings.pureEval;
 
-    auto flakeRef = parseFlakeRef(fetchSettings, flakeRefS, cwd.string(), true);
+    auto flakeRef = parseFlakeRef(flakeRefS, cwd.string(), true);
     if (isPureEval && !flakeRef.input.isLocked(fetchSettings))
         throw Error("cannot use ':load-flake' on unlocked flake reference '%s' (use --impure to override)", flakeRefS);
 

--- a/src/libexpr/primops/fetchMercurial.cc
+++ b/src/libexpr/primops/fetchMercurial.cc
@@ -77,7 +77,7 @@ static void prim_fetchMercurial(EvalState & state, CallSite callSite, Value * co
         attrs.insert_or_assign("ref", *ref);
     if (rev)
         attrs.insert_or_assign("rev", rev->gitRev());
-    auto input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
+    auto input = fetchers::Input::fromAttrs(std::move(attrs));
 
     auto [storePath, input2] = input.fetchToStore(state.fetchSettings, *state.store);
 

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -268,7 +268,7 @@ static void fetchTree(
                     .atPos(noPos)
                     .debugThrow();
 
-        input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
+        input = fetchers::Input::fromAttrs(std::move(attrs));
     } else {
         auto url = state
                        .coerceToString(
@@ -288,7 +288,7 @@ static void fetchTree(
                 && (!attrs.contains("submodules") || !*fetchers::maybeGetBoolAttr(attrs, "submodules"))) {
                 attrs.emplace("exportIgnore", Explicit<bool>{true});
             }
-            input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
+            input = fetchers::Input::fromAttrs(std::move(attrs));
         } else {
             if (!experimentalFeatureSettings.isEnabled(Xp::Flakes))
                 state
@@ -296,7 +296,7 @@ static void fetchTree(
                         "passing a string argument to '%s' requires the 'flakes' experimental feature", fetcher)
                     .atPos(noPos)
                     .debugThrow();
-            input = fetchers::Input::fromURL(state.fetchSettings, url);
+            input = fetchers::Input::fromURL(url);
         }
     }
 
@@ -585,7 +585,7 @@ fetch(EvalState & state, Value * const * args, Value & v, const std::string & wh
         };
         if (expectedHash)
             attrs.emplace("narHash", expectedHash->to_string(HashFormat::SRI, true));
-        auto input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
+        auto input = fetchers::Input::fromAttrs(std::move(attrs));
         auto cachedInput =
             state.inputCache->getAccessor(state.fetchSettings, *state.store, input, fetchers::UseRegistries::No);
         auto storePath = state.mountInput(cachedInput.lockedInput, input, cachedInput.accessor);

--- a/src/libfetchers-tests/access-tokens.cc
+++ b/src/libfetchers-tests/access-tokens.cc
@@ -25,7 +25,7 @@ TEST_F(AccessKeysTest, singleOrgGitHub)
 {
     fetchers::Settings fetchSettings = fetchers::Settings{};
     fetchSettings.accessTokens.get().insert({"github.com/a", "token"});
-    auto i = Input::fromURL(fetchSettings, "github:a/b");
+    auto i = Input::fromURL("github:a/b");
 
     auto token = i.scheme->getAccessToken(fetchSettings, "github.com", "github.com/a/b");
     ASSERT_EQ(token, "token");
@@ -35,7 +35,7 @@ TEST_F(AccessKeysTest, nonMatches)
 {
     fetchers::Settings fetchSettings = fetchers::Settings{};
     fetchSettings.accessTokens.get().insert({"github.com", "token"});
-    auto i = Input::fromURL(fetchSettings, "gitlab:github.com/evil");
+    auto i = Input::fromURL("gitlab:github.com/evil");
 
     auto token = i.scheme->getAccessToken(fetchSettings, "gitlab.com", "gitlab.com/github.com/evil");
     ASSERT_EQ(token, std::nullopt);
@@ -45,7 +45,7 @@ TEST_F(AccessKeysTest, noPartialMatches)
 {
     fetchers::Settings fetchSettings = fetchers::Settings{};
     fetchSettings.accessTokens.get().insert({"github.com/partial", "token"});
-    auto i = Input::fromURL(fetchSettings, "github:partial-match/repo");
+    auto i = Input::fromURL("github:partial-match/repo");
 
     auto token = i.scheme->getAccessToken(fetchSettings, "github.com", "github.com/partial-match");
     ASSERT_EQ(token, std::nullopt);
@@ -57,7 +57,7 @@ TEST_F(AccessKeysTest, repoGitHub)
     fetchSettings.accessTokens.get().insert({"github.com", "token"});
     fetchSettings.accessTokens.get().insert({"github.com/a/b", "another_token"});
     fetchSettings.accessTokens.get().insert({"github.com/a/c", "yet_another_token"});
-    auto i = Input::fromURL(fetchSettings, "github:a/a");
+    auto i = Input::fromURL("github:a/a");
 
     auto token = i.scheme->getAccessToken(fetchSettings, "github.com", "github.com/a/a");
     ASSERT_EQ(token, "token");
@@ -74,7 +74,7 @@ TEST_F(AccessKeysTest, multipleGitLab)
     fetchers::Settings fetchSettings = fetchers::Settings{};
     fetchSettings.accessTokens.get().insert({"gitlab.com", "token"});
     fetchSettings.accessTokens.get().insert({"gitlab.com/a/b", "another_token"});
-    auto i = Input::fromURL(fetchSettings, "gitlab:a/b");
+    auto i = Input::fromURL("gitlab:a/b");
 
     auto token = i.scheme->getAccessToken(fetchSettings, "gitlab.com", "gitlab.com/a/b");
     ASSERT_EQ(token, "another_token");
@@ -88,7 +88,7 @@ TEST_F(AccessKeysTest, multipleSourceHut)
     fetchers::Settings fetchSettings = fetchers::Settings{};
     fetchSettings.accessTokens.get().insert({"git.sr.ht", "token"});
     fetchSettings.accessTokens.get().insert({"git.sr.ht/~a/b", "another_token"});
-    auto i = Input::fromURL(fetchSettings, "sourcehut:a/b");
+    auto i = Input::fromURL("sourcehut:a/b");
 
     auto token = i.scheme->getAccessToken(fetchSettings, "git.sr.ht", "git.sr.ht/~a/b");
     ASSERT_EQ(token, "another_token");

--- a/src/libfetchers-tests/git.cc
+++ b/src/libfetchers-tests/git.cc
@@ -187,14 +187,12 @@ TEST_F(GitTest, submodulePeriodSupport)
     }();
 
     auto settings = fetchers::Settings{};
-    auto input = fetchers::Input::fromAttrs(
-        settings,
-        {
-            {"url", "file://" + encodeUrlPath(pathToUrlPath(repoPath))},
-            {"submodules", Explicit{true}},
-            {"type", "git"},
-            {"ref", "main"},
-        });
+    auto input = fetchers::Input::fromAttrs({
+        {"url", "file://" + encodeUrlPath(pathToUrlPath(repoPath))},
+        {"submodules", Explicit{true}},
+        {"type", "git"},
+        {"ref", "main"},
+    });
 
     auto [accessor, i] = input.getAccessor(settings, *store);
 

--- a/src/libfetchers-tests/input.cc
+++ b/src/libfetchers-tests/input.cc
@@ -27,16 +27,14 @@ class InputFromAttrsTest : public ::testing::WithParamInterface<InputFromAttrsTe
 
 TEST_P(InputFromAttrsTest, attrsAreCorrectAndRoundTrips)
 {
-    fetchers::Settings fetchSettings;
-
     const auto & testCase = GetParam();
 
-    auto input = fetchers::Input::fromAttrs(fetchSettings, fetchers::Attrs(testCase.attrs));
+    auto input = fetchers::Input::fromAttrs(fetchers::Attrs(testCase.attrs));
 
     EXPECT_EQ(input.toAttrs(), testCase.expectedAttrs);
     EXPECT_EQ(input.toURLString(), testCase.expectedUrl);
 
-    auto input2 = fetchers::Input::fromAttrs(fetchSettings, input.toAttrs());
+    auto input2 = fetchers::Input::fromAttrs(input.toAttrs());
     EXPECT_EQ(input, input2);
     EXPECT_EQ(input.toAttrs(), input2.toAttrs());
 }
@@ -70,7 +68,7 @@ class GitHubInputTest : public ::testing::Test
 TEST_F(GitHubInputTest, throwOnInvalidURLParam)
 {
     EXPECT_THAT(
-        []() { Input::fromURL(fetchers::Settings{}, "github:a/b?tag=foo"); },
+        []() { Input::fromURL("github:a/b?tag=foo"); },
         ::testing::ThrowsMessage<BadURL>(testing::HasSubstrIgnoreANSIMatcher("tag")));
 }
 

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -37,9 +37,9 @@ const InputSchemeMap & getAllInputSchemes()
     return inputSchemes();
 }
 
-Input Input::fromURL(const Settings & settings, const std::string & url, bool requireTree)
+Input Input::fromURL(const std::string & url, bool requireTree)
 {
-    return fromURL(settings, parseURL(url), requireTree);
+    return fromURL(parseURL(url), requireTree);
 }
 
 static void fixupInput(Input & input)
@@ -51,10 +51,10 @@ static void fixupInput(Input & input)
     input.getLastModified();
 }
 
-Input Input::fromURL(const Settings & settings, const ParsedURL & url, bool requireTree)
+Input Input::fromURL(const ParsedURL & url, bool requireTree)
 {
     for (auto & [_, inputScheme] : inputSchemes()) {
-        auto res = inputScheme->inputFromURL(settings, url, requireTree);
+        auto res = inputScheme->inputFromURL(url, requireTree);
         if (res) {
             experimentalFeatureSettings.require(inputScheme->experimentalFeature());
             res->scheme = inputScheme;
@@ -72,7 +72,7 @@ Input Input::fromURL(const Settings & settings, const ParsedURL & url, bool requ
     throw Error("input '%s' is unsupported", url);
 }
 
-Input Input::fromAttrs(const Settings & settings, Attrs && attrs)
+Input Input::fromAttrs(Attrs && attrs)
 {
     auto schemeName = ({
         auto schemeNameOpt = maybeGetStrAttr(attrs, "type");
@@ -108,7 +108,7 @@ Input Input::fromAttrs(const Settings & settings, Attrs && attrs)
         if (name != "type" && name != "__final" && allowedAttrs.count(name) == 0)
             throw Error("input attribute '%s' not supported by scheme '%s'", name, schemeName);
 
-    auto res = inputScheme->inputFromAttrs(settings, attrs);
+    auto res = inputScheme->inputFromAttrs(attrs);
     if (!res)
         return raw();
     res->scheme = inputScheme;

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -171,7 +171,7 @@ static LazyAttr makeLazyAttr(fun<ResolvedAttr()> compute)
 
 struct GitInputScheme : InputScheme
 {
-    std::optional<Input> inputFromURL(const Settings & settings, const ParsedURL & url, bool requireTree) const override
+    std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const override
     {
         if (url.scheme != "git" && parseUrlScheme(url.scheme).application != "git")
             return {};
@@ -195,7 +195,7 @@ struct GitInputScheme : InputScheme
 
         attrs.emplace("url", url2.to_string());
 
-        return inputFromAttrs(settings, attrs);
+        return inputFromAttrs(attrs);
     }
 
     std::string_view schemeName() const override
@@ -382,7 +382,7 @@ struct GitInputScheme : InputScheme
         return attrs;
     }
 
-    std::optional<Input> inputFromAttrs(const Settings & settings, const Attrs & attrs) const override
+    std::optional<Input> inputFromAttrs(const Attrs & attrs) const override
     {
         for (auto & [name, _] : attrs)
             if (name == "verifyCommit" || name == "keytype" || name == "publicKey" || name == "publicKeys")
@@ -965,7 +965,7 @@ struct GitInputScheme : InputScheme
                 attrs.insert_or_assign("submodules", Explicit<bool>{true});
                 attrs.insert_or_assign("lfs", Explicit<bool>{smudgeLfs});
                 attrs.insert_or_assign("allRefs", Explicit<bool>{true});
-                auto submoduleInput = fetchers::Input::fromAttrs(settings, std::move(attrs));
+                auto submoduleInput = fetchers::Input::fromAttrs(std::move(attrs));
                 auto [submoduleAccessor, submoduleInput2] = submoduleInput.getAccessor(settings, store);
                 submoduleAccessor->setPathDisplay("«" + submoduleInput.to_string() + "»");
                 mounts.insert_or_assign(submodule.path, submoduleAccessor);
@@ -1015,7 +1015,7 @@ struct GitInputScheme : InputScheme
                 // TODO: fall back to getAccessorFromCommit-like fetch when submodules aren't checked out
                 // attrs.insert_or_assign("allRefs", Explicit<bool>{ true });
 
-                auto submoduleInput = fetchers::Input::fromAttrs(settings, std::move(attrs));
+                auto submoduleInput = fetchers::Input::fromAttrs(std::move(attrs));
                 auto [submoduleAccessor, submoduleInput2] = submoduleInput.getAccessor(settings, store);
                 submoduleAccessor->setPathDisplay("«" + submoduleInput.to_string() + "»");
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -30,8 +30,7 @@ struct GitArchiveInputScheme : InputScheme
     virtual std::optional<std::pair<std::string, std::string>>
     accessHeaderFromToken(const std::string & token) const = 0;
 
-    std::optional<Input>
-    inputFromURL(const fetchers::Settings & settings, const ParsedURL & url, bool requireTree) const override
+    std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const override
     {
         if (url.scheme != schemeName())
             return {};
@@ -80,7 +79,7 @@ struct GitArchiveInputScheme : InputScheme
         attrs.insert_or_assign("owner", path[0]);
         attrs.insert_or_assign("repo", path[1]);
 
-        return inputFromAttrs(settings, attrs);
+        return inputFromAttrs(attrs);
     }
 
     const std::map<std::string, AttributeInfo> & allowedAttrs() const override
@@ -122,7 +121,7 @@ struct GitArchiveInputScheme : InputScheme
         return attrs;
     }
 
-    std::optional<Input> inputFromAttrs(const fetchers::Settings & settings, const Attrs & attrs) const override
+    std::optional<Input> inputFromAttrs(const Attrs & attrs) const override
     {
         getStrAttr(attrs, "owner");
         getStrAttr(attrs, "repo");
@@ -452,7 +451,7 @@ struct GitHubInputScheme : GitArchiveInputScheme
         const override
     {
         auto host = getHost(input);
-        Input::fromURL(settings, fmt("git+https://%s/%s/%s.git", host, getOwner(input), getRepo(input)))
+        Input::fromURL(fmt("git+https://%s/%s/%s.git", host, getOwner(input), getRepo(input)))
             .applyOverrides(input.getRef(), input.getRev())
             .clone(settings, store, destDir);
     }
@@ -542,7 +541,6 @@ struct GitLabInputScheme : GitArchiveInputScheme
         auto host = maybeGetStrAttr(input.attrs, "host").value_or("gitlab.com");
         // FIXME: get username somewhere
         Input::fromURL(
-            settings,
             fmt("git+https://%s/%s/%s.git", host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo")))
             .applyOverrides(input.getRef(), input.getRev())
             .clone(settings, store, destDir);
@@ -637,7 +635,6 @@ struct SourceHutInputScheme : GitArchiveInputScheme
     {
         auto host = maybeGetStrAttr(input.attrs, "host").value_or("git.sr.ht");
         Input::fromURL(
-            settings,
             fmt("git+https://%s/%s/%s", host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo")))
             .applyOverrides(input.getRef(), input.getRev())
             .clone(settings, store, destDir);

--- a/src/libfetchers/include/nix/fetchers/fetchers.hh
+++ b/src/libfetchers/include/nix/fetchers/fetchers.hh
@@ -50,16 +50,16 @@ public:
      *
      * The URL indicate which sort of fetcher, and provides information to that fetcher.
      */
-    static Input fromURL(const Settings & settings, const std::string & url, bool requireTree = true);
+    static Input fromURL(const std::string & url, bool requireTree = true);
 
-    static Input fromURL(const Settings & settings, const ParsedURL & url, bool requireTree = true);
+    static Input fromURL(const ParsedURL & url, bool requireTree = true);
 
     /**
      * Create an `Input` from a an `Attrs`.
      *
      * The URL indicate which sort of fetcher, and provides information to that fetcher.
      */
-    static Input fromAttrs(const Settings & settings, Attrs && attrs);
+    static Input fromAttrs(Attrs && attrs);
 
     ParsedURL toURL() const;
 
@@ -189,10 +189,9 @@ struct InputScheme
 {
     virtual ~InputScheme() {}
 
-    virtual std::optional<Input>
-    inputFromURL(const Settings & settings, const ParsedURL & url, bool requireTree) const = 0;
+    virtual std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const = 0;
 
-    virtual std::optional<Input> inputFromAttrs(const Settings & settings, const Attrs & attrs) const = 0;
+    virtual std::optional<Input> inputFromAttrs(const Attrs & attrs) const = 0;
 
     /**
      * What is the name of the scheme?

--- a/src/libfetchers/indirect.cc
+++ b/src/libfetchers/indirect.cc
@@ -9,7 +9,7 @@ std::regex flakeRegex("[a-zA-Z][a-zA-Z0-9_-]*", std::regex::ECMAScript);
 
 struct IndirectInputScheme : InputScheme
 {
-    std::optional<Input> inputFromURL(const Settings & settings, const ParsedURL & url, bool requireTree) const override
+    std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const override
     {
         if (url.scheme != "flake")
             return {};
@@ -89,7 +89,7 @@ struct IndirectInputScheme : InputScheme
         return attrs;
     }
 
-    std::optional<Input> inputFromAttrs(const Settings & settings, const Attrs & attrs) const override
+    std::optional<Input> inputFromAttrs(const Attrs & attrs) const override
     {
         auto id = getStrAttr(attrs, "id");
         if (!std::regex_match(id, flakeRegex))

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -40,7 +40,7 @@ static std::string runHg(OsStrings args)
 
 struct MercurialInputScheme : InputScheme
 {
-    std::optional<Input> inputFromURL(const Settings & settings, const ParsedURL & url, bool requireTree) const override
+    std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const override
     {
         if (url.scheme != "hg+http" && url.scheme != "hg+https" && url.scheme != "hg+ssh" && url.scheme != "hg+file")
             return {};
@@ -61,7 +61,7 @@ struct MercurialInputScheme : InputScheme
 
         attrs.emplace("url", url2.to_string());
 
-        return inputFromAttrs(settings, attrs);
+        return inputFromAttrs(attrs);
     }
 
     std::string_view schemeName() const override
@@ -106,7 +106,7 @@ struct MercurialInputScheme : InputScheme
         return attrs;
     }
 
-    std::optional<Input> inputFromAttrs(const Settings & settings, const Attrs & attrs) const override
+    std::optional<Input> inputFromAttrs(const Attrs & attrs) const override
     {
         parseURL(getStrAttr(attrs, "url"));
 

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -9,7 +9,7 @@ namespace nix::fetchers {
 
 struct PathInputScheme : InputScheme
 {
-    std::optional<Input> inputFromURL(const Settings & settings, const ParsedURL & url, bool requireTree) const override
+    std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const override
     {
         if (url.scheme != "path")
             return {};
@@ -78,7 +78,7 @@ struct PathInputScheme : InputScheme
         return attrs;
     }
 
-    std::optional<Input> inputFromAttrs(const Settings & settings, const Attrs & attrs) const override
+    std::optional<Input> inputFromAttrs(const Attrs & attrs) const override
     {
         getStrAttr(attrs, "path");
 

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -37,8 +37,8 @@ std::shared_ptr<Registry> Registry::read(const Settings & settings, const Source
                 auto exact = i.find("exact");
                 registry->entries.push_back(
                     Entry{
-                        .from = Input::fromAttrs(settings, jsonToAttrs(i["from"])),
-                        .to = Input::fromAttrs(settings, std::move(toAttrs)),
+                        .from = Input::fromAttrs(jsonToAttrs(i["from"])),
+                        .to = Input::fromAttrs(std::move(toAttrs)),
                         .extraAttrs = extraAttrs,
                         .exact = exact != i.end() && exact.value()});
             }

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -230,7 +230,7 @@ ref<SourceAccessor> downloadTarball(Store & store, const Settings & settings, co
     attrs.insert_or_assign("type", "tarball");
     attrs.insert_or_assign("url", url);
 
-    auto input = Input::fromAttrs(settings, std::move(attrs));
+    auto input = Input::fromAttrs(std::move(attrs));
 
     return input.getAccessor(settings, store).first;
 }
@@ -254,8 +254,7 @@ struct CurlInputScheme : InputScheme
 
     static const StringSet specialParams;
 
-    std::optional<Input>
-    inputFromURL(const Settings & settings, const ParsedURL & _url, bool requireTree) const override
+    std::optional<Input> inputFromURL(const ParsedURL & _url, bool requireTree) const override
     {
         if (!isValidURL(_url, requireTree))
             return std::nullopt;
@@ -373,7 +372,7 @@ struct CurlInputScheme : InputScheme
         return allowedAttrsImpl();
     }
 
-    std::optional<Input> inputFromAttrs(const Settings & settings, const Attrs & attrs) const override
+    std::optional<Input> inputFromAttrs(const Attrs & attrs) const override
     {
         Input input{};
         input.attrs = attrs;
@@ -495,7 +494,7 @@ struct TarballInputScheme : CurlInputScheme
         auto result = downloadTarball_(settings, getStrAttr(input.attrs, "url"), {}, "«" + input.to_string() + "»");
 
         if (result.immutableUrl) {
-            auto immutableInput = Input::fromURL(settings, *result.immutableUrl);
+            auto immutableInput = Input::fromURL(*result.immutableUrl);
             // FIXME: would be nice to support arbitrary flakerefs
             // here, e.g. git flakes.
             if (immutableInput.getType() != "tarball")

--- a/src/libflake-c/nix_api_flake.cc
+++ b/src/libflake-c/nix_api_flake.cc
@@ -70,7 +70,7 @@ nix_err nix_flake_reference_parse_flags_set_base_directory(
 
 nix_err nix_flake_reference_and_fragment_from_string(
     nix_c_context * context,
-    nix_fetchers_settings * fetchSettings,
+    [[maybe_unused]] nix_fetchers_settings * fetchSettings,
     nix_flake_settings * flakeSettings,
     nix_flake_reference_parse_flags * parseFlags,
     const char * strData,
@@ -84,8 +84,7 @@ nix_err nix_flake_reference_and_fragment_from_string(
     try {
         std::string str(strData, strSize);
 
-        auto [flakeRef, fragment] =
-            nix::parseFlakeRefWithFragment(*fetchSettings->settings, str, parseFlags->baseDirectory, true);
+        auto [flakeRef, fragment] = nix::parseFlakeRefWithFragment(str, parseFlags->baseDirectory, true);
         *flakeReferenceOut = new nix_flake_reference{nix::make_ref<nix::FlakeRef>(flakeRef)};
         return call_nix_get_string_callback(fragment, fragmentCallback, fragmentCallbackUserData);
     }

--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -7,6 +7,7 @@
 #include "nix/flake/flakeref.hh"
 #include "nix/fetchers/attrs.hh"
 #include "nix/fetchers/fetchers.hh"
+#include "nix/store/tests/libstore.hh"
 #include "nix/util/configuration.hh"
 #include "nix/util/error.hh"
 #include "nix/util/experimental-features.hh"
@@ -17,49 +18,49 @@ namespace nix {
 
 TEST(parseFlakeRef, path)
 {
-    experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
+    EnableExperimentalFeature enableFlakes("flakes");
 
     fetchers::Settings fetchSettings;
 
     {
         auto s = "/foo/bar";
-        auto flakeref = parseFlakeRef(fetchSettings, s);
+        auto flakeref = parseFlakeRef(s);
         ASSERT_EQ(flakeref.to_string(), "path:/foo/bar");
     }
 
     {
         auto s = "/foo/bar?revCount=123&rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        auto flakeref = parseFlakeRef(fetchSettings, s);
+        auto flakeref = parseFlakeRef(s);
         ASSERT_EQ(flakeref.to_string(), "path:/foo/bar?rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&revCount=123");
     }
 
     {
         auto s = "/foo/bar?xyzzy=123";
-        EXPECT_THROW(parseFlakeRef(fetchSettings, s), Error);
+        EXPECT_THROW(parseFlakeRef(s), Error);
     }
 
     {
         auto s = "/foo/bar#bla";
-        EXPECT_THROW(parseFlakeRef(fetchSettings, s), Error);
+        EXPECT_THROW(parseFlakeRef(s), Error);
     }
 
     {
         auto s = "/foo/bar#bla";
-        auto [flakeref, fragment] = parseFlakeRefWithFragment(fetchSettings, s);
+        auto [flakeref, fragment] = parseFlakeRefWithFragment(s);
         ASSERT_EQ(flakeref.to_string(), "path:/foo/bar");
         ASSERT_EQ(fragment, "bla");
     }
 
     {
         auto s = "/foo/bar?revCount=123#bla";
-        auto [flakeref, fragment] = parseFlakeRefWithFragment(fetchSettings, s);
+        auto [flakeref, fragment] = parseFlakeRefWithFragment(s);
         ASSERT_EQ(flakeref.to_string(), "path:/foo/bar?revCount=123");
         ASSERT_EQ(fragment, "bla");
     }
 
     {
         auto s = "/foo bar/baz?dir=bla space";
-        auto flakeref = parseFlakeRef(fetchSettings, s);
+        auto flakeref = parseFlakeRef(s);
         ASSERT_EQ(flakeref.to_string(), "path:/foo%20bar/baz?dir=bla%20space");
         ASSERT_EQ(flakeref.toAttrs().at("dir"), fetchers::Attr("bla space"));
     }
@@ -67,32 +68,32 @@ TEST(parseFlakeRef, path)
 
 TEST(parseFlakeRef, GitArchiveInput)
 {
-    experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
+    EnableExperimentalFeature enableFlakes("flakes");
 
     fetchers::Settings fetchSettings;
 
     {
         auto s = "github:foo/bar/branch%23"; // branch name with `#`
-        auto flakeref = parseFlakeRef(fetchSettings, s);
+        auto flakeref = parseFlakeRef(s);
         ASSERT_EQ(flakeref.to_string(), "github:foo/bar/branch%23");
     }
 
     {
         auto s = "github:foo/bar?ref=branch%23"; // branch name with `#`
-        auto flakeref = parseFlakeRef(fetchSettings, s);
+        auto flakeref = parseFlakeRef(s);
         ASSERT_EQ(flakeref.to_string(), "github:foo/bar/branch%23");
     }
 
     {
         auto s = "github:foo/bar?ref=branch#\"name.with.dot\""; // unescaped quotes `"`
-        auto [flakeref, fragment] = parseFlakeRefWithFragment(fetchSettings, s);
+        auto [flakeref, fragment] = parseFlakeRefWithFragment(s);
         ASSERT_EQ(fragment, "\"name.with.dot\"");
         ASSERT_EQ(flakeref.to_string(), "github:foo/bar/branch");
     }
 
     {
         auto s = "github:foo/bar#\"name.with.dot\""; // unescaped quotes `"`
-        auto [flakeref, fragment] = parseFlakeRefWithFragment(fetchSettings, s);
+        auto [flakeref, fragment] = parseFlakeRefWithFragment(s);
         ASSERT_EQ(fragment, "\"name.with.dot\"");
         ASSERT_EQ(flakeref.to_string(), "github:foo/bar");
     }
@@ -111,23 +112,22 @@ class InputFromURLTest : public ::testing::WithParamInterface<InputFromURLTestCa
 
 TEST_P(InputFromURLTest, attrsAreCorrectAndRoundTrips)
 {
-    experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
-    fetchers::Settings fetchSettings;
+    EnableExperimentalFeature enableFlakes("flakes");
 
     const auto & testCase = GetParam();
 
-    auto flakeref = parseFlakeRef(fetchSettings, testCase.url);
+    auto flakeref = parseFlakeRef(testCase.url);
 
     EXPECT_EQ(flakeref.toAttrs(), testCase.attrs);
     EXPECT_EQ(flakeref.to_string(), testCase.expectedUrl);
 
-    auto input = fetchers::Input::fromURL(fetchSettings, flakeref.to_string());
+    auto input = fetchers::Input::fromURL(flakeref.to_string());
 
     EXPECT_EQ(input.toURLString(), testCase.expectedUrl);
     EXPECT_EQ(input.toAttrs(), testCase.attrs);
 
     // Round-trip check.
-    auto input2 = fetchers::Input::fromURL(fetchSettings, input.toURLString());
+    auto input2 = fetchers::Input::fromURL(input.toURLString());
     EXPECT_EQ(input, input2);
     EXPECT_EQ(input.toURLString(), input2.toURLString());
 }
@@ -274,9 +274,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(to_string, doesntReencodeUrl)
 {
-    fetchers::Settings fetchSettings;
     auto s = "http://localhost:8181/test/+3d.tar.gz";
-    auto flakeref = parseFlakeRef(fetchSettings, s);
+    auto flakeref = parseFlakeRef(s);
     auto unparsed = flakeref.to_string();
     auto expected = "http://localhost:8181/test/%2B3d.tar.gz";
 
@@ -285,16 +284,14 @@ TEST(to_string, doesntReencodeUrl)
 
 TEST(parseFlakeRef, malformedGithubUrlDoesNotCrash)
 {
-    experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
+    EnableExperimentalFeature enableFlakes("flakes");
 
     fetchers::Settings fetchSettings;
 
     // Using ref= instead of rev= with a github: URL should produce an
     // error, not an assertion failure in renderAuthorityAndPath
     // (https://github.com/NixOS/nix/issues/15196).
-    EXPECT_THROW(
-        parseFlakeRef(fetchSettings, "github:nixos/nixpkgs/nixpkgs.git?ref=aead170c1a49253ebfa5027010dfd89a77b73ca4"),
-        Error);
+    EXPECT_THROW(parseFlakeRef("github:nixos/nixpkgs/nixpkgs.git?ref=aead170c1a49253ebfa5027010dfd89a77b73ca4"), Error);
 }
 
 } // namespace nix

--- a/src/libflake/flake-primops.cc
+++ b/src/libflake/flake-primops.cc
@@ -47,7 +47,7 @@ PrimOp getFlake(const Settings & settings)
             std::string flakeRefS(
                 state.forceStringNoCtx(*args[0], noPos, "while evaluating the argument passed to builtins.getFlake"));
 
-            auto flakeRef = nix::parseFlakeRef(state.fetchSettings, flakeRefS, {}, true);
+            auto flakeRef = nix::parseFlakeRef(flakeRefS, {}, true);
             if (state.settings.pureEval && !flakeRef.input.isLocked(state.fetchSettings))
                 throw Error(
                     "cannot call 'getFlake' on unlocked flake reference '%s', at %s (use --impure to override)",
@@ -100,7 +100,7 @@ static void prim_parseFlakeRef(EvalState & state, CallSite callSite, Value * con
 {
     std::string flakeRefS(
         state.forceStringNoCtx(*args[0], noPos, "while evaluating the argument passed to builtins.parseFlakeRef"));
-    auto attrs = nix::parseFlakeRef(state.fetchSettings, flakeRefS, {}, true).toAttrs();
+    auto attrs = nix::parseFlakeRef(flakeRefS, {}, true).toAttrs();
     auto binds = state.buildBindings(attrs.size());
     for (const auto & [key, value] : attrs) {
         auto s = state.symbols.create(key);
@@ -171,7 +171,7 @@ static void prim_flakeRefToString(EvalState & state, CallSite callSite, Value * 
                 .debugThrow();
         }
     }
-    auto flakeRef = FlakeRef::fromAttrs(state.fetchSettings, attrs);
+    auto flakeRef = FlakeRef::fromAttrs(attrs);
     v.mkString(flakeRef.to_string(), state.mem);
 }
 

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -188,7 +188,7 @@ static FlakeInput parseFlakeInput(
 
     if (attrs.count("type"))
         try {
-            input.ref = FlakeRef::fromAttrs(state.fetchSettings, attrs);
+            input.ref = FlakeRef::fromAttrs(attrs);
         } catch (Error & e) {
             e.addTrace(state.positions[pos], HintFmt("while evaluating flake input"));
             throw;
@@ -198,7 +198,7 @@ static FlakeInput parseFlakeInput(
         if (!attrs.empty())
             throw Error("unexpected flake input attribute '%s', at %s", attrs.begin()->first, state.positions[pos]);
         if (url)
-            input.ref = parseFlakeRef(state.fetchSettings, *url, {}, true, input.isFlake, true);
+            input.ref = parseFlakeRef(*url, {}, true, input.isFlake, true);
     }
 
     if (input.ref && input.follows)
@@ -284,8 +284,7 @@ static Flake readFlake(
                     if (formal.name != state.s.self)
                         flake.inputs.emplace(
                             state.symbols[formal.name],
-                            FlakeInput{
-                                .ref = parseFlakeRef(state.fetchSettings, std::string(state.symbols[formal.name]))});
+                            FlakeInput{.ref = parseFlakeRef(std::string(state.symbols[formal.name]))});
                 }
             }
         }
@@ -571,8 +570,10 @@ LockedFlake lockFlake(
                     }
 
                     if (!input.ref)
-                        input.ref =
-                            FlakeRef::fromAttrs(state.fetchSettings, {{"type", "indirect"}, {"id", std::string(id)}});
+                        input.ref = FlakeRef::fromAttrs({
+                            {"type", "indirect"},
+                            {"id", std::string(id)},
+                        });
 
                     auto overriddenParentPath =
                         input.ref->input.isRelative()
@@ -906,7 +907,7 @@ LockedFlake
 lockFlake(const Settings & settings, EvalState & state, const SourcePath & flakeDir, const LockFlags & lockFlags)
 {
     /* We need a fake flakeref to put in the `Flake` struct, but it's not used for anything. */
-    auto fakeRef = parseFlakeRef(state.fetchSettings, "flake:get-flake");
+    auto fakeRef = parseFlakeRef("flake:get-flake");
     return lockFlake(settings, state, fakeRef, lockFlags, readFlake(state, fakeRef, fakeRef, fakeRef, flakeDir, {}));
 }
 

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -72,22 +72,19 @@ FlakeRef::resolve(const fetchers::Settings & fetchSettings, Store & store, fetch
 }
 
 FlakeRef parseFlakeRef(
-    const fetchers::Settings & fetchSettings,
     std::string_view url,
     const std::optional<std::filesystem::path> & baseDir,
     bool allowMissing,
     bool isFlake,
     bool preserveRelativePaths)
 {
-    auto [flakeRef, fragment] =
-        parseFlakeRefWithFragment(fetchSettings, url, baseDir, allowMissing, isFlake, preserveRelativePaths);
+    auto [flakeRef, fragment] = parseFlakeRefWithFragment(url, baseDir, allowMissing, isFlake, preserveRelativePaths);
     if (fragment != "")
         throw Error("unexpected fragment '%s' in flake reference '%s'", fragment, url);
     return flakeRef;
 }
 
-static std::pair<FlakeRef, std::string>
-fromParsedURL(const fetchers::Settings & fetchSettings, ParsedURL && parsedURL, bool isFlake)
+static std::pair<FlakeRef, std::string> fromParsedURL(ParsedURL && parsedURL, bool isFlake)
 {
     auto dir = getOr(parsedURL.query, "dir", "");
     parsedURL.query.erase("dir");
@@ -95,11 +92,10 @@ fromParsedURL(const fetchers::Settings & fetchSettings, ParsedURL && parsedURL, 
     std::string fragment;
     std::swap(fragment, parsedURL.fragment);
 
-    return {FlakeRef(fetchers::Input::fromURL(fetchSettings, parsedURL, isFlake), dir), fragment};
+    return {FlakeRef(fetchers::Input::fromURL(parsedURL, isFlake), dir), fragment};
 }
 
 std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
-    const fetchers::Settings & fetchSettings,
     std::string_view url,
     const std::optional<std::filesystem::path> & baseDir,
     bool allowMissing,
@@ -190,7 +186,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
                     if (pathExists(flakeRoot / ".git" / "shallow"))
                         parsedURL.query.insert_or_assign("shallow", "1");
 
-                    return fromParsedURL(fetchSettings, std::move(parsedURL), isFlake);
+                    return fromParsedURL(std::move(parsedURL), isFlake);
                 }
 
                 subdir = flakeRoot.filename().string() + (subdir.empty() ? "" : "/" + subdir);
@@ -204,7 +200,6 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
     }
 
     return fromParsedURL(
-        fetchSettings,
         {
             .scheme = "path",
             .authority = path.is_absolute() ? std::optional{ParsedURL::Authority{}} : std::nullopt,
@@ -219,8 +214,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
  * Check if `url` is a flake ID. This is an abbreviated syntax for
  * `flake:<flake-id>?ref=<ref>&rev=<rev>`.
  */
-static std::optional<std::pair<FlakeRef, std::string>>
-parseFlakeIdRef(const fetchers::Settings & fetchSettings, std::string_view url, bool isFlake)
+static std::optional<std::pair<FlakeRef, std::string>> parseFlakeIdRef(std::string_view url, bool isFlake)
 {
     /* https://lists.isocpp.org/std-proposals/att-0008/Dxxxx_string_view_support_for_regex.pdf */
     std::match_results<std::string_view::const_iterator> match;
@@ -236,18 +230,14 @@ parseFlakeIdRef(const fetchers::Settings & fetchSettings, std::string_view url, 
             .path = splitString<std::vector<std::string>>(match[1].str(), "/"),
         };
 
-        return std::make_pair(
-            FlakeRef(fetchers::Input::fromURL(fetchSettings, parsedURL, isFlake), ""), percentDecode(match.str(6)));
+        return std::make_pair(FlakeRef(fetchers::Input::fromURL(parsedURL, isFlake), ""), percentDecode(match.str(6)));
     }
 
     return {};
 }
 
-std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
-    const fetchers::Settings & fetchSettings,
-    std::string_view url,
-    const std::optional<std::filesystem::path> & baseDir,
-    bool isFlake)
+std::optional<std::pair<FlakeRef, std::string>>
+parseURLFlakeRef(std::string_view url, const std::optional<std::filesystem::path> & baseDir, bool isFlake)
 {
     try {
         auto parsed = parseURL(url, /*lenient=*/true);
@@ -257,14 +247,13 @@ std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
             if (!path.is_absolute())
                 parsed.path = pathToUrlPath(absPath(path, get(baseDir)));
         }
-        return fromParsedURL(fetchSettings, std::move(parsed), isFlake);
+        return fromParsedURL(std::move(parsed), isFlake);
     } catch (BadURL &) {
         return std::nullopt;
     }
 }
 
 std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
-    const fetchers::Settings & fetchSettings,
     std::string_view url,
     const std::optional<std::filesystem::path> & baseDir,
     bool allowMissing,
@@ -273,22 +262,21 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
 {
     using namespace nix::fetchers;
 
-    if (auto res = parseFlakeIdRef(fetchSettings, url, isFlake)) {
+    if (auto res = parseFlakeIdRef(url, isFlake)) {
         return *res;
-    } else if (auto res = parseURLFlakeRef(fetchSettings, url, baseDir, isFlake)) {
+    } else if (auto res = parseURLFlakeRef(url, baseDir, isFlake)) {
         return *res;
     } else {
-        return parsePathFlakeRefWithFragment(fetchSettings, url, baseDir, allowMissing, isFlake, preserveRelativePaths);
+        return parsePathFlakeRefWithFragment(url, baseDir, allowMissing, isFlake, preserveRelativePaths);
     }
 }
 
-FlakeRef FlakeRef::fromAttrs(const fetchers::Settings & fetchSettings, const fetchers::Attrs & attrs)
+FlakeRef FlakeRef::fromAttrs(const fetchers::Attrs & attrs)
 {
     auto attrs2(attrs);
     attrs2.erase("dir");
     return FlakeRef(
-        fetchers::Input::fromAttrs(fetchSettings, std::move(attrs2)),
-        fetchers::maybeGetStrAttr(attrs, "dir").value_or(""));
+        fetchers::Input::fromAttrs(std::move(attrs2)), fetchers::maybeGetStrAttr(attrs, "dir").value_or(""));
 }
 
 std::pair<ref<SourceAccessor>, FlakeRef>
@@ -348,15 +336,10 @@ FlakeRef FlakeRef::canonicalize() const
 }
 
 std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragmentAndExtendedOutputsSpec(
-    const fetchers::Settings & fetchSettings,
-    std::string_view url,
-    const std::optional<std::filesystem::path> & baseDir,
-    bool allowMissing,
-    bool isFlake)
+    std::string_view url, const std::optional<std::filesystem::path> & baseDir, bool allowMissing, bool isFlake)
 {
     auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse(url);
-    auto [flakeRef, fragment] =
-        parseFlakeRefWithFragment(fetchSettings, std::string{prefix}, baseDir, allowMissing, isFlake);
+    auto [flakeRef, fragment] = parseFlakeRefWithFragment(std::string{prefix}, baseDir, allowMissing, isFlake);
     return {std::move(flakeRef), fragment, std::move(extendedOutputsSpec)};
 }
 

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -78,7 +78,7 @@ struct FlakeRef
         Store & store,
         fetchers::UseRegistries useRegistries = fetchers::UseRegistries::All) const;
 
-    static FlakeRef fromAttrs(const fetchers::Settings & fetchSettings, const fetchers::Attrs & attrs);
+    static FlakeRef fromAttrs(const fetchers::Attrs & attrs);
 
     std::pair<ref<SourceAccessor>, FlakeRef> lazyFetch(const fetchers::Settings & fetchSettings, Store & store) const;
 
@@ -95,7 +95,6 @@ std::ostream & operator<<(std::ostream & str, const FlakeRef & flakeRef);
  * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory)
  */
 FlakeRef parseFlakeRef(
-    const fetchers::Settings & fetchSettings,
     std::string_view url,
     const std::optional<std::filesystem::path> & baseDir = {},
     bool allowMissing = false,
@@ -106,7 +105,6 @@ FlakeRef parseFlakeRef(
  * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory)
  */
 std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
-    const fetchers::Settings & fetchSettings,
     std::string_view url,
     const std::optional<std::filesystem::path> & baseDir = {},
     bool allowMissing = false,
@@ -117,7 +115,6 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
  * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory)
  */
 std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragmentAndExtendedOutputsSpec(
-    const fetchers::Settings & fetchSettings,
     std::string_view url,
     const std::optional<std::filesystem::path> & baseDir = {},
     bool allowMissing = false,

--- a/src/libflake/lockfile.cc
+++ b/src/libflake/lockfile.cc
@@ -56,7 +56,7 @@ getFlakeRef(const fetchers::Settings & fetchSettings, const nlohmann::json & jso
                     attrs.insert_or_assign(k.first, k.second);
             }
         }
-        return FlakeRef::fromAttrs(fetchSettings, attrs);
+        return FlakeRef::fromAttrs(attrs);
     }
 
     throw Error("attribute '%s' missing in lock file", attr);

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -78,8 +78,8 @@ struct CmdBundle : InstallableValueCommand
 
         auto val = installable->toValue(*evalState).first;
 
-        auto [bundlerFlakeRef, bundlerName, extendedOutputsSpec] = parseFlakeRefWithFragmentAndExtendedOutputsSpec(
-            fetchSettings, bundler, std::filesystem::current_path().string());
+        auto [bundlerFlakeRef, bundlerName, extendedOutputsSpec] =
+            parseFlakeRefWithFragmentAndExtendedOutputsSpec(bundler, std::filesystem::current_path().string());
         const flake::LockFlags lockFlags{.writeLockFile = false};
         InstallableFlake bundler{
             this,

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -51,7 +51,7 @@ FlakeCommand::FlakeCommand()
 
 FlakeRef FlakeCommand::getFlakeRef()
 {
-    return parseFlakeRef(fetchSettings, flakeUrl, std::filesystem::current_path().string()); // FIXME
+    return parseFlakeRef(flakeUrl, std::filesystem::current_path().string()); // FIXME
 }
 
 flake::LockedFlake FlakeCommand::lockFlake()
@@ -62,7 +62,7 @@ flake::LockedFlake FlakeCommand::lockFlake()
 std::vector<FlakeRef> FlakeCommand::getFlakeRefsForCompletion()
 {
     return {// Like getFlakeRef but with expandTilde called first
-            parseFlakeRef(fetchSettings, expandTilde(flakeUrl), std::filesystem::current_path().string())};
+            parseFlakeRef(expandTilde(flakeUrl), std::filesystem::current_path().string())};
 }
 
 struct CmdFlakeUpdate : FlakeCommand
@@ -907,7 +907,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
         auto evalState = getEvalState();
 
         auto [templateFlakeRef, templateName] =
-            parseFlakeRefWithFragment(fetchSettings, templateUrl, std::filesystem::current_path().string());
+            parseFlakeRefWithFragment(templateUrl, std::filesystem::current_path().string());
 
         auto installable = InstallableFlake(
             nullptr,

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -157,8 +157,8 @@ struct ProfileManifest
                 }
                 if (e.value(sUrl, "") != "") {
                     element.source = ProfileElementSource{
-                        parseFlakeRef(fetchSettings, getString(e[sOriginalUrl])),
-                        parseFlakeRef(fetchSettings, getString(e[sUrl])),
+                        parseFlakeRef(getString(e[sOriginalUrl])),
+                        parseFlakeRef(getString(e[sUrl])),
                         e["attrPath"],
                         e["outputs"].get<ExtendedOutputsSpec>()};
                 }

--- a/src/nix/registry.cc
+++ b/src/nix/registry.cc
@@ -107,8 +107,8 @@ struct CmdRegistryAdd : MixEvalArgs, Command, RegistryCommand
 
     void run() override
     {
-        auto fromRef = parseFlakeRef(fetchSettings, fromUrl);
-        auto toRef = parseFlakeRef(fetchSettings, toUrl);
+        auto fromRef = parseFlakeRef(fromUrl);
+        auto toRef = parseFlakeRef(toUrl);
         auto registry = getRegistry();
         fetchers::Attrs extraAttrs;
         if (toRef.subdir != "")
@@ -143,7 +143,7 @@ struct CmdRegistryRemove : RegistryCommand, Command
     void run() override
     {
         auto registry = getRegistry();
-        registry->remove(parseFlakeRef(fetchSettings, url).input);
+        registry->remove(parseFlakeRef(url).input);
         registry->write(getRegistryPath().string());
     }
 };
@@ -184,8 +184,8 @@ struct CmdRegistryPin : RegistryCommand, EvalCommand
         if (locked.empty())
             locked = url;
         auto registry = getRegistry();
-        auto ref = parseFlakeRef(fetchSettings, url);
-        auto lockedRef = parseFlakeRef(fetchSettings, locked);
+        auto ref = parseFlakeRef(url);
+        auto lockedRef = parseFlakeRef(locked);
         auto resolvedInput = lockedRef.resolve(fetchSettings, *store).input;
         auto resolved = resolvedInput.getAccessor(fetchSettings, *store).second;
         if (!resolved.isLocked(fetchSettings))
@@ -226,7 +226,7 @@ struct CmdRegistryResolve : StoreCommand
     void run(nix::ref<nix::Store> store) override
     {
         for (auto & url : urls) {
-            auto ref = parseFlakeRef(fetchSettings, url);
+            auto ref = parseFlakeRef(url);
             auto resolved = ref.resolve(fetchSettings, *store);
             logger->cout("%s", resolved.to_string());
         }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Now that Input no longer holds a reference to fetchSettings there's no need to pass this around. Also it turns out that we have a useless parameter is the C API :)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
