### PR TITLE
testing: only treat `_NIX_TEST_ACCEPT=1` as accept mode

### DIFF
--- a/tests/functional/characterisation-test-infra.sh
+++ b/tests/functional/characterisation-test-infra.sh
@@ -42,6 +42,15 @@ echo Bye! > "$TEST_ROOT/expected"
 )
 [[ "Bye!" == $(< "$TEST_ROOT/expected") ]]
 
+# _NIX_TEST_ACCEPT=0 means off: doesn't match, `badDiff=1` set, file unchanged
+echo Hi! > "$TEST_ROOT/got"
+echo Bye! > "$TEST_ROOT/expected"
+(
+  _NIX_TEST_ACCEPT=0 diffAndAcceptInner test "$TEST_ROOT/got" "$TEST_ROOT/expected"
+  (( "$badDiff" == 1 ))
+)
+[[ "Bye!" == $(< "$TEST_ROOT/expected") ]]
+
 # _NIX_TEST_ACCEPT=1 matches non-empty
 echo Hi! > "$TEST_ROOT/got"
 cp "$TEST_ROOT/got" "$TEST_ROOT/expected"

--- a/tests/functional/common/characterisation/framework.sh
+++ b/tests/functional/common/characterisation/framework.sh
@@ -5,7 +5,7 @@ badTestNames=()
 # Golden test support
 #
 # Test that the output of the given test matches what is expected. If
-# `_NIX_TEST_ACCEPT` is non-empty also update the expected output so
+# `_NIX_TEST_ACCEPT` is `1` also update the expected output so
 # that next time the test succeeds.
 function diffAndAcceptInner() {
     local -r testName=$1
@@ -27,8 +27,11 @@ function diffAndAcceptInner() {
         badTestNames+=("$testName")
     fi
 
-    # Update expected if `_NIX_TEST_ACCEPT` is non-empty.
-    if test -n "${_NIX_TEST_ACCEPT-}"; then
+    # Update expected if `_NIX_TEST_ACCEPT` is `1`. (Comparing against
+    # `1` exactly, rather than any non-empty value, matches the C++ unit
+    # tests' handling of this variable, and makes `_NIX_TEST_ACCEPT=0`
+    # mean "off" as one would expect.)
+    if [[ "${_NIX_TEST_ACCEPT-}" == 1 ]]; then
         cp "$got" "$expected"
         # Delete empty expected files to avoid bloating the repo with
         # empty files.
@@ -42,7 +45,7 @@ function characterisationTestExit() {
     # Make sure shellcheck knows all these will be defined by the caller
     : "${badDiff?} ${badExitCode?}"
 
-    if test -n "${_NIX_TEST_ACCEPT-}"; then
+    if [[ "${_NIX_TEST_ACCEPT-}" == 1 ]]; then
         if (( "$badDiff" )); then
             set +x
             echo >&2 'Output did mot match, but accepted output as the persisted expected output.'


### PR DESCRIPTION
Previously the shell characterisation-test framework treated any non-empty value of `_NIX_TEST_ACCEPT` — including `0` — as accept mode, silently regenerating the golden files. Compare against `1` exactly, matching what the C++ unit tests already do, and pin the new behavior in the framework's self-test.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
