### PR TITLE
Support external fuzzing engines

### DIFF
--- a/doc/manual/source/development/testing.md
+++ b/doc/manual/source/development/testing.md
@@ -305,10 +305,12 @@ You can run them manually with `nix build .#hydraJobs.tests.{testName}` or `nix-
 
 ## Fuzzing
 
-The project utilises [`libFuzzer`](https://llvm.org/docs/LibFuzzer.html) and LLVM coverage instrumentation to fuzz sensitive pieces of code.
+The project uses [`libFuzzer`](https://llvm.org/docs/LibFuzzer.html) and LLVM coverage instrumentation to fuzz sensitive pieces of code.
 The harnesses reside in corresponding `-tests` subprojects (e.g. `src/libutil-tests/fuzz`).
-The `fuzzers` option builds the harnesses, while `fuzzer-no-link` instruments the whole project.
-Meson rejects `fuzzers=true` unless `unit-tests=true` and `b_sanitize` includes `fuzzer-no-link`.
+The `fuzzers` option builds the harnesses. The `fuzzing-engine` option accepts one compiler-driver argument for linking an external fuzzing engine.
+Meson rejects `fuzzers=true` unless `unit-tests=true`.
+If `fuzzing-engine` is empty, Meson requires Clang and `fuzzer-no-link` in `b_sanitize`.
+The compiler driver then links the harnesses with libFuzzer and libstdc++.
 
 ```shell
 nix develop .#native-clangStdenv
@@ -320,6 +322,18 @@ appendToVar mesonFlags "-Dlibexpr:gc=disabled" # Because Boehm doesn't play well
 configurePhase
 buildPhase
 ```
+
+To use an external fuzzing engine, set `fuzzing-engine`:
+
+```shell
+mesonFlagsArray+=(
+  "-Dfuzzers=true"
+  "-Dfuzzing-engine=$LIB_FUZZING_ENGINE"
+)
+```
+
+Nix passes this value as one compiler-driver argument.
+The caller must also choose a compatible compiler and C++ runtime and provide any required instrumentation and sanitizer flags.
 
 If you want to collect coverage metrics you also need to specify the following compiler flags before running the `configurePhase`:
 

--- a/flake.nix
+++ b/flake.nix
@@ -259,6 +259,9 @@
         // (lib.optionalAttrs (builtins.elem system linux64BitSystems)) {
           dockerImage = self.hydraJobs.dockerImage.${system};
         }
+        // (lib.optionalAttrs (system == "x86_64-linux")) {
+          fuzzing-engine = nixpkgsFor.${system}.native.callPackage ./tests/fuzzing-engine { };
+        }
         # Add "passthru" tests
         //
           flatMapAttrs

--- a/meson.options
+++ b/meson.options
@@ -18,7 +18,14 @@ option(
   'fuzzers',
   type : 'boolean',
   value : false,
-  description : 'Build libFuzzer targets',
+  description : 'Build fuzz targets',
+)
+
+option(
+  'fuzzing-engine',
+  type : 'string',
+  value : '',
+  description : 'One compiler-driver argument for linking an external fuzzing engine',
 )
 
 option(

--- a/nix-meson-build-support/fuzz/meson.build
+++ b/nix-meson-build-support/fuzz/meson.build
@@ -1,17 +1,19 @@
 # To deduplicate the boilerplate of compiling fuzz harnesses, this file provides
 # the shared definitions for that.
 
-sanitizers_for_project = get_option('b_sanitize').split(',')
-if 'fuzzer-no-link' not in sanitizers_for_project
-  error('fuzzers=true requires fuzzer-no-link in b_sanitize')
-endif
+fuzzing_engine = get_option('fuzzing-engine')
 
-if cxx.get_id() != 'clang'
-  # Because we use libFuzzer.
-  error('fuzzing requires an LLVM toolchain')
-endif
+if fuzzing_engine == ''
+  sanitizers_for_project = get_option('b_sanitize').split(',')
+  if 'fuzzer-no-link' not in sanitizers_for_project
+    error('fuzzers=true requires fuzzer-no-link in b_sanitize')
+  endif
 
-foreach t : fuzz_targets
+  if cxx.get_id() != 'clang'
+    # Because we use libFuzzer.
+    error('fuzzing requires an LLVM toolchain')
+  endif
+
   sanitizers = []
   foreach i : sanitizers_for_project
     if i != 'fuzzer-no-link'
@@ -20,19 +22,25 @@ foreach t : fuzz_targets
   endforeach
   sanitizers += 'fuzzer'
 
+  fuzz_link_args = [
+    '-fsanitize=' + ','.join(sanitizers),
+    # Linking order shenanigans. For whatever reason libstdc++ gets linked
+    # first before libasan when also building with fuzzer sanitizer?
+    # LD_PRELOAD is annoying, so it would be nice if this worked out-of-the box.
+    # TODO: Make this work with libc++ too.
+    '-nostdlib++',
+    '-lstdc++',
+  ]
+else
+  fuzz_link_args = [ fuzzing_engine ]
+endif
+
+foreach t : fuzz_targets
   executable(
     'fuzz-' + t[0],
     t[1],
     dependencies : deps_private_subproject + deps_private + deps_other,
-    link_args : [
-      '-fsanitize=' + ','.join(sanitizers),
-      # Linking order shenanigans. For whatever reason libstdc++ gets linked
-      # first before libasan when also building with fuzzer sanitizer?
-      # LD_PRELOAD is annoying, so it would be nice if this worked out-of-the box.
-      # TODO: Make this work with libc++ too.
-      '-nostdlib++',
-      '-lstdc++',
-    ],
+    link_args : fuzz_link_args,
     install : true,
   )
 endforeach

--- a/src/libstore-tests/meson.options
+++ b/src/libstore-tests/meson.options
@@ -12,6 +12,14 @@ option(
   'fuzzers',
   type : 'boolean',
   value : false,
-  description : 'Build libFuzzer targets',
+  description : 'Build fuzz targets',
+  yield : true,
+)
+
+option(
+  'fuzzing-engine',
+  type : 'string',
+  value : '',
+  description : 'One compiler-driver argument for linking an external fuzzing engine',
   yield : true,
 )

--- a/src/libutil-tests/meson.options
+++ b/src/libutil-tests/meson.options
@@ -4,6 +4,14 @@ option(
   'fuzzers',
   type : 'boolean',
   value : false,
-  description : 'Build libFuzzer targets',
+  description : 'Build fuzz targets',
+  yield : true,
+)
+
+option(
+  'fuzzing-engine',
+  type : 'string',
+  value : '',
+  description : 'One compiler-driver argument for linking an external fuzzing engine',
   yield : true,
 )

--- a/tests/fuzzing-engine/default.nix
+++ b/tests/fuzzing-engine/default.nix
@@ -1,0 +1,217 @@
+{
+  clangStdenv,
+  gccStdenv,
+  lib,
+  linkFarm,
+  meson,
+  ninja,
+  writeText,
+}:
+
+let
+  parentMeson = writeText "meson.build" ''
+    project('fuzzing-engine-parent', 'cpp', meson_version : '>= 1.8')
+
+    subproject('util')
+    subproject('store')
+  '';
+
+  mkChildMeson =
+    name:
+    writeText "meson.build" ''
+      project('fuzzing-engine-${name}', 'cpp', meson_version : '>= 1.8')
+
+      cxx = meson.get_compiler('cpp')
+      deps_private_subproject = []
+      deps_private = []
+      deps_other = []
+
+      if get_option('fuzzers')
+        fuzz_targets = [
+          [ '${name}', files('fuzz.cc') ],
+        ]
+        subdir('fuzz/harnesses')
+      endif
+    '';
+
+  harness = writeText "fuzz.cc" ''
+    #include <cstddef>
+    #include <cstdint>
+
+    extern "C" int LLVMFuzzerTestOneInput(
+        const std::uint8_t *,
+        std::size_t)
+    {
+        return 0;
+    }
+  '';
+
+  engineMain = writeText "engine.c" ''
+    #include <stddef.h>
+
+    extern int LLVMFuzzerTestOneInput(const unsigned char *, size_t);
+
+    int main(void)
+    {
+        static const unsigned char input = 0;
+        return LLVMFuzzerTestOneInput(&input, 1);
+    }
+  '';
+
+  gccEngine = gccStdenv.mkDerivation {
+    name = "gcc-fuzzing-engine";
+    dontUnpack = true;
+
+    buildPhase = ''
+      runHook preBuild
+      $CC -c ${engineMain} -o engine.o
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/lib"
+      ar rcs "$out/lib/GCC engine with spaces.a" engine.o
+      runHook postInstall
+    '';
+  };
+
+  fixture = linkFarm "fuzzing-engine-fixture" [
+    {
+      name = "meson.build";
+      path = parentMeson;
+    }
+    {
+      name = "meson.options";
+      path = ../../meson.options;
+    }
+    {
+      name = "subprojects/util/meson.build";
+      path = mkChildMeson "util";
+    }
+    {
+      name = "subprojects/util/meson.options";
+      path = ../../src/libutil-tests/meson.options;
+    }
+    {
+      name = "subprojects/util/fuzz.cc";
+      path = harness;
+    }
+    {
+      name = "subprojects/util/fuzz/harnesses/meson.build";
+      path = ../../nix-meson-build-support/fuzz/meson.build;
+    }
+    {
+      name = "subprojects/store/meson.build";
+      path = mkChildMeson "store";
+    }
+    {
+      name = "subprojects/store/meson.options";
+      path = ../../src/libstore-tests/meson.options;
+    }
+    {
+      name = "subprojects/store/fuzz.cc";
+      path = harness;
+    }
+    {
+      name = "subprojects/store/fuzz/harnesses/meson.build";
+      path = ../../nix-meson-build-support/fuzz/meson.build;
+    }
+  ];
+
+  mkFixture =
+    {
+      name,
+      stdenv,
+      src,
+      executables,
+      fuzzingEngine ? null,
+      localFallback ? false,
+      runArgs ? "",
+    }:
+    stdenv.mkDerivation {
+      inherit name src;
+      strictDeps = true;
+      dontUnpack = true;
+      dontConfigure = true;
+
+      nativeBuildInputs = [
+        meson
+        ninja
+      ];
+
+      buildPhase =
+        let
+          mesonFlags = [
+            (lib.mesonBool "fuzzers" true)
+          ]
+          ++ lib.optional (fuzzingEngine != null) (lib.mesonOption "fuzzing-engine" fuzzingEngine)
+          ++ lib.optionals localFallback [
+            (lib.mesonOption "b_sanitize" "fuzzer-no-link")
+            (lib.mesonBool "b_lundef" false)
+          ];
+        in
+        ''
+          runHook preBuild
+          meson setup build "$src" \
+            --prefix="$out" \
+            ${lib.escapeShellArgs mesonFlags}
+          meson compile -C build
+          runHook postBuild
+        '';
+
+      installPhase = ''
+        runHook preInstall
+        meson install -C build
+        ${lib.concatMapStringsSep "\n" (executable: ''
+          test -x "$out/bin/fuzz-${executable}"
+          "$out/bin/fuzz-${executable}" ${runArgs}
+        '') executables}
+        runHook postInstall
+      '';
+    };
+
+  externalSanitizer = mkFixture {
+    name = "fuzzing-engine-external-sanitizer";
+    stdenv = clangStdenv;
+    src = "${fixture}/subprojects/util";
+    executables = [ "util" ];
+    fuzzingEngine = "-fsanitize=fuzzer";
+    runArgs = "-runs=1";
+  };
+
+  parentYield = mkFixture {
+    name = "fuzzing-engine-parent-yield";
+    stdenv = gccStdenv;
+    src = fixture;
+    executables = [
+      "util"
+      "store"
+    ];
+    fuzzingEngine = "${gccEngine}/lib/GCC engine with spaces.a";
+  };
+
+  localFallback = mkFixture {
+    name = "fuzzing-engine-local-fallback";
+    stdenv = clangStdenv;
+    src = "${fixture}/subprojects/util";
+    executables = [ "util" ];
+    localFallback = true;
+    runArgs = "-runs=1";
+  };
+in
+
+linkFarm "fuzzing-engine" [
+  {
+    name = "external-sanitize-fuzzer";
+    path = externalSanitizer;
+  }
+  {
+    name = "gcc-archive-parent-yield";
+    path = parentYield;
+  }
+  {
+    name = "local-fallback";
+    path = localFallback;
+  }
+]


### PR DESCRIPTION
## Motivation

The shared fuzz helper currently assumes Nix's local Clang and libFuzzer setup. It requires `fuzzer-no-link`, builds its own sanitizer link argument, and selects libstdc++.

External fuzzing systems already choose their compiler, instrumentation, C++ runtime, and engine. They need a way to supply the final engine link argument without inheriting Nix's local assumptions.

## Context

This adds a `fuzzing-engine` Meson string option. The empty default preserves the current local libFuzzer behaviour. A non-empty value is passed through unchanged as one compiler-driver link argument.

The option is available from the top-level project and both fuzzing test subprojects.

This is the external-engine follow-up from #15864, built on the fuzzing infrastructure added in #15865 and #16262.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
