### PR TITLE
flake: Use crossIndex helper functions from nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -134,85 +134,17 @@
         a given `pkgs` and `getStdenv`.
       */
       packageSetsFor =
-        let
-          /**
-            Removes a prefix from the attribute names of a set of splices.
-            This is a completely uninteresting and exists for compatibility only.
-
-            Example:
-            ```nix
-            renameSplicesFrom "pkgs" { pkgsBuildBuild = ...; ... }
-            => { buildBuild = ...; ... }
-            ```
-          */
-          renameSplicesFrom = prefix: x: {
-            buildBuild = x."${prefix}BuildBuild";
-            buildHost = x."${prefix}BuildHost";
-            buildTarget = x."${prefix}BuildTarget";
-            hostHost = x."${prefix}HostHost";
-            hostTarget = x."${prefix}HostTarget";
-            targetTarget = x."${prefix}TargetTarget";
-          };
-
-          /**
-            Adds a prefix to the attribute names of a set of splices.
-            This is a completely uninteresting and exists for compatibility only.
-
-            Example:
-            ```nix
-            renameSplicesTo "self" { buildBuild = ...; ... }
-            => { selfBuildBuild = ...; ... }
-            ```
-          */
-          renameSplicesTo = prefix: x: {
-            "${prefix}BuildBuild" = x.buildBuild;
-            "${prefix}BuildHost" = x.buildHost;
-            "${prefix}BuildTarget" = x.buildTarget;
-            "${prefix}HostHost" = x.hostHost;
-            "${prefix}HostTarget" = x.hostTarget;
-            "${prefix}TargetTarget" = x.targetTarget;
-          };
-
-          /**
-            Takes a function `f` and returns a function that applies `f` pointwise to each splice.
-
-            Example:
-            ```nix
-            mapSplices (x: x * 10) { buildBuild = 1; buildHost = 2; ... }
-            => { buildBuild = 10; buildHost = 20; ... }
-            ```
-          */
-          mapSplices =
-            f:
-            {
-              buildBuild,
-              buildHost,
-              buildTarget,
-              hostHost,
-              hostTarget,
-              targetTarget,
-            }:
-            {
-              buildBuild = f buildBuild;
-              buildHost = f buildHost;
-              buildTarget = f buildTarget;
-              hostHost = f hostHost;
-              hostTarget = f hostTarget;
-              targetTarget = f targetTarget;
-            };
-
-        in
         args@{
           pkgs,
           getStdenv ? pkgs: pkgs.stdenv,
         }:
         let
-          nixComponentsSplices = mapSplices (
+          nixComponentsSplices = lib.mapCrossIndex (
             pkgs': (packageSetsFor (args // { pkgs = pkgs'; })).nixComponents
-          ) (renameSplicesFrom "pkgs" pkgs);
-          nixDependenciesSplices = mapSplices (
+          ) (lib.renameCrossIndexFrom "pkgs" pkgs);
+          nixDependenciesSplices = lib.mapCrossIndex (
             pkgs': (packageSetsFor (args // { pkgs = pkgs'; })).nixDependencies
-          ) (renameSplicesFrom "pkgs" pkgs);
+          ) (lib.renameCrossIndexFrom "pkgs" pkgs);
 
           # A new scope, so that we can use `callPackage` to inject our own interdependencies
           # without "polluting" the top level "`pkgs`" attrset.
@@ -225,7 +157,7 @@
                 inherit (nixDependencies) newScope;
               }
               {
-                otherSplices = renameSplicesTo "self" nixComponentsSplices;
+                otherSplices = lib.renameCrossIndexTo "self" nixComponentsSplices;
                 f = import ./packaging/components.nix {
                   inherit (pkgs) lib;
                   inherit officialRelease;
@@ -244,7 +176,7 @@
                 inherit (pkgs) newScope; # layered directly on pkgs, unlike nixComponents2 above
               }
               {
-                otherSplices = renameSplicesTo "self" nixDependenciesSplices;
+                otherSplices = lib.renameCrossIndexTo "self" nixDependenciesSplices;
                 f = import ./packaging/dependencies.nix {
                   inherit inputs pkgs;
                   stdenv = getStdenv pkgs;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Thanks to Robert Hensing these helpers have been merged to nixpkgs. Use those now to make our code less arcane and more idiomatic.

Noticed while exploring the whole "making cross work with scopes" machinery.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
