### PR TITLE
docs: specify that left argument to `?` can be any expr

### DIFF
--- a/doc/manual/source/language/operators.md
+++ b/doc/manual/source/language/operators.md
@@ -5,7 +5,7 @@
 | [Attribute selection]                  | *attrset* `.` *attrpath* \[ `or` *expr* \] | none          | 1          |
 | [Function application]                 | *func* *expr*                              | left          | 2          |
 | [Arithmetic negation][arithmetic]      | `-` *number*                               | none          | 3          |
-| [Has attribute]                        | *attrset* `?` *attrpath*                   | none          | 4          |
+| [Has attribute]                        | *expr* `?` *attrpath*                      | none          | 4          |
 | List concatenation                     | *list* `++` *list*                         | right         | 5          |
 | [Multiplication][arithmetic]           | *number* `*` *number*                      | left          | 6          |
 | [Division][arithmetic]                 | *number* `/` *number*                      | left          | 6          |
@@ -68,18 +68,21 @@ A callable value is either:
 
 > **Syntax**
 >
-> *attrset* `?` *attrpath*
+> *expr* `?` *attrpath*
 
-Test whether [attribute set] *attrset* contains the attribute denoted by *attrpath*.
+Test whether *expr* is an [attribute set] containing the attribute denoted by *[attrpath]*.
+If *attrpath* contains multiple components, and any of its components (other than the last) do not correspond to an attribute set in *expr*, the result is false.
 The result is a [Boolean] value.
 
 See also: [`builtins.hasAttr`](@docroot@/language/builtins.md#builtins-hasAttr)
+
+[attrpath]: ./syntax.md#attrpath-literal
 
 [Boolean]: ./types.md#type-bool
 
 [Has attribute]: #has-attribute
 
-After evaluating *attrset* and *attrpath*, the computational complexity is O(log(*n*)) for *n* attributes in the *attrset*
+After evaluating *attrset* and *attrpath*, the computational complexity is O(log(*n*)) for *n* attributes in the *attrset*.
 
 ## Arithmetic
 

--- a/doc/manual/source/language/syntax.md
+++ b/doc/manual/source/language/syntax.md
@@ -125,6 +125,7 @@ Attributes in nested attribute sets can be written using *attribute paths*.
 >
 > *attrset* → `{` { *attrpath* `=` *expr* `;` } `}`
 
+<div id="attrpath-literal"></div>
 An attribute path is a dot-separated list of [names][name].
 
 > **Syntax**

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3281,9 +3281,11 @@ static RegisterPrimOp primop_hasAttr({
     .name = "__hasAttr",
     .args = {"s", "set"},
     .doc = R"(
-      `hasAttr` returns `true` if *set* has an attribute named *s*, and
-      `false` otherwise. This is a dynamic version of the `?` operator,
-      since *s* is an expression rather than an identifier.
+      `hasAttr` returns `true` if *set* has an attribute named *s*, and `false` if it does not.
+      This is a dynamic version of the `?` operator, since *s* is an expression rather than an identifier.
+
+      Unlike the `?` operator, however, *s* cannot refer to a nested attribute set.
+      Also unlike the `?` operator, if *s* is not a string or *set* is not an attribute set, evaluation is aborted.
 
       Has `O(log n)` time complexity, where `n` is number of attributes in the *set*.
     )",


### PR DESCRIPTION
This matches existing behavior (as far as I'm aware).

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes: #15768
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
