### PR TITLE
Show derivations in truncated traces

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1444,21 +1444,27 @@ static void prim_derivationStrict(EvalState & state, CallSite callSite, Value * 
     } catch (Error & e) {
         Pos pos = state.positions[nameAttr->pos];
         /*
-         * Here we make two abuses of the error system
+         * Here we call addTrace in a slightly unusual way:
          *
-         * 1. We print the location as a string to avoid a code snippet being
-         * printed. While the location of the name attribute is a good hint, the
-         * exact code there is irrelevant.
-         *
-         * 2. We mark this trace as a frame trace, meaning that we stop printing
-         * less important traces from now on. In particular, this prevents the
-         * display of the automatic "while calling builtins.derivationStrict"
-         * trace, which is of little use for the public we target here.
+         * 1. We print the location as a string (instead of passing it via the
+         * first argument to addTrace) to avoid a code snippet being printed.
+         * While the location of the name attribute is a good hint, the exact
+         * code there is irrelevant.
          *
          * Please keep in mind that error reporting is done on a best-effort
-         * basis in nix. There is no accurate location for a derivation, as it
-         * often results from the composition of several functions
+         * basis in nix. There is no single accurate location for a derivation,
+         * as it often results from the composition of several functions
          * (derivationStrict, derivation, mkDerivation, mkPythonModule, etc.)
+         *
+         * 2. We use TracePrint::Always so that users who have not enabled
+         * --show-trace will still get a full trace of the derivation
+         * dependency chain that led to an evaluation error. The user may be
+         * interested in the last item in the chain (the derivation with an
+         * eval issue), an item near the top of the chain (a package they added
+         * to their configuration), or an item in the middle of the chain (an
+         * optional dependency they can remove with an override somewhere
+         * because they don't need the corresponding functionality), so
+         * displaying the entire chain is worth the space.
          */
         e.addTrace(
             nullptr,
@@ -1466,7 +1472,8 @@ static void prim_derivationStrict(EvalState & state, CallSite callSite, Value * 
                 "while evaluating derivation '%s'\n"
                 "  whose name attribute is located at %s",
                 drvName,
-                pos));
+                pos),
+            TracePrint::Always);
         throw;
     }
 }

--- a/tests/functional/lang/eval-fail-derivation-stack-trace.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-stack-trace.err.exp
@@ -1,0 +1,33 @@
+error:
+       … while evaluating the attribute 'outPath'
+         at «nix-internal»/derivation-internal.nix:49:7:
+           48|     value = commonAttrs // {
+           49|       outPath = strict.${outputName};
+             |       ^
+           50|       drvPath = strict.drvPath;
+
+       … while calling the 'derivationStrict' builtin
+         at «nix-internal»/derivation-internal.nix:36:12:
+           35|
+           36|   strict = derivationStrict drvAttrs;
+             |            ^
+           37|
+
+       … while evaluating derivation 'test-5'
+         whose name attribute is located at /pwd/lang/eval-fail-derivation-stack-trace.nix:12:9
+
+       … while evaluating derivation 'test-4'
+         whose name attribute is located at /pwd/lang/eval-fail-derivation-stack-trace.nix:12:9
+
+       … while evaluating derivation 'test-3'
+         whose name attribute is located at /pwd/lang/eval-fail-derivation-stack-trace.nix:12:9
+
+       … while evaluating derivation 'test-2'
+         whose name attribute is located at /pwd/lang/eval-fail-derivation-stack-trace.nix:12:9
+
+       … while evaluating derivation 'test-1'
+         whose name attribute is located at /pwd/lang/eval-fail-derivation-stack-trace.nix:12:9
+
+       (stack trace truncated; use '--show-trace' to show the full, detailed trace)
+
+       error: kaboom

--- a/tests/functional/lang/eval-fail-derivation-stack-trace.flags
+++ b/tests/functional/lang/eval-fail-derivation-stack-trace.flags
@@ -1,0 +1,1 @@
+--eval --strict --no-show-trace

--- a/tests/functional/lang/eval-fail-derivation-stack-trace.nix
+++ b/tests/functional/lang/eval-fail-derivation-stack-trace.nix
@@ -1,0 +1,18 @@
+# The "while evaluating derivation %s" messages should always appear in the
+# stack trace, even when the trace is truncated, so that users can see how to
+# remove problem packages from their configurations.
+
+let
+  countDown =
+    i:
+    if i == 0 then
+      throw "kaboom"
+    else
+      derivation {
+        name = "test-${toString i}";
+        system = "x86_64-linux";
+        builder = "/bin/sh";
+        buildInputs = [ (countDown (i - 1)) ];
+      };
+in
+countDown 5


### PR DESCRIPTION
## Motivation

I'm sick of seeing people dunk on Nix because of #10061. This is an extremely cheap quality of life improvement for that issue.

Are there better ways to present these error trace lines, or improve traces more generally? Of course there are, and I'd be excited to help with that solution if you want, after this +2/−1 (ex comments and tests) patch lands.

## Context

Closes #10061. Could have interactions with #15832, but that PR doesn't seem to be moving.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
