### PR TITLE
libstore: use canonical store path parsing for derivations

### DIFF
--- a/src/libstore-tests/path.cc
+++ b/src/libstore-tests/path.cc
@@ -30,16 +30,17 @@ public:
 
 static std::regex nameRegex{std::string{nameRegexStr}};
 
-#define TEST_DONT_PARSE(NAME, STR)                                           \
-    TEST_F(StorePathTest, bad_##NAME)                                        \
-    {                                                                        \
-        std::string_view str = STORE_DIR HASH_PART "-" STR;                  \
-        /* ASSERT_THROW generates a duplicate goto label */                  \
-        /* A lambda isolates those labels. */                                \
-        [&]() { ASSERT_THROW(store->parseStorePath(str), BadStorePath); }(); \
-        std::string name{STR};                                               \
-        [&]() { ASSERT_THROW(nix::checkName(name), BadStorePathName); }();   \
-        EXPECT_FALSE(std::regex_match(name, nameRegex));                     \
+#define TEST_DONT_PARSE(NAME, STR)                                                    \
+    TEST_F(StorePathTest, bad_##NAME)                                                 \
+    {                                                                                 \
+        std::string_view str = STORE_DIR HASH_PART "-" STR;                           \
+        /* ASSERT_THROW generates a duplicate goto label */                           \
+        /* A lambda isolates those labels. */                                         \
+        [&]() { ASSERT_THROW(store->parseStorePath(str), BadStorePath); }();          \
+        [&]() { ASSERT_THROW(store->parseStorePathCanonical(str), BadStorePath); }(); \
+        std::string name{STR};                                                        \
+        [&]() { ASSERT_THROW(nix::checkName(name), BadStorePathName); }();            \
+        EXPECT_FALSE(std::regex_match(name, nameRegex));                              \
     }
 
 TEST_DONT_PARSE(empty, "")
@@ -64,6 +65,7 @@ TEST_DONT_PARSE(dot_dash_a, ".-a")
         auto p = store->parseStorePath(str);                \
         std::string name{p.name()};                         \
         EXPECT_EQ(p.name(), STR);                           \
+        EXPECT_EQ(store->parseStorePathCanonical(str), p);  \
         EXPECT_TRUE(std::regex_match(name, nameRegex));     \
     }
 
@@ -85,6 +87,48 @@ TEST_DO_PARSE(triple_dot_dash, "...-")
 TEST_DO_PARSE(triple_dot, "...")
 
 #undef TEST_DO_PARSE
+
+/* Non-canonical spellings of an otherwise-valid store path:
+   `parseStorePath` normalises them away, `parseStorePathCanonical`
+   rejects them. */
+#define TEST_ONLY_PARSE_NON_CANONICAL(NAME, STR)                                      \
+    TEST_F(StorePathTest, only_non_canonical_##NAME)                                  \
+    {                                                                                 \
+        std::string_view str = STR;                                                   \
+        EXPECT_EQ(store->parseStorePath(str), StorePath{HASH_PART "-foo"});           \
+        [&]() { ASSERT_THROW(store->parseStorePathCanonical(str), BadStorePath); }(); \
+    }
+
+TEST_ONLY_PARSE_NON_CANONICAL(trailing_slash, STORE_DIR HASH_PART "-foo/")
+TEST_ONLY_PARSE_NON_CANONICAL(double_slash, "/nix/store//" HASH_PART "-foo")
+TEST_ONLY_PARSE_NON_CANONICAL(dot, STORE_DIR "./" HASH_PART "-foo")
+TEST_ONLY_PARSE_NON_CANONICAL(dot_dot, STORE_DIR "bar/../" HASH_PART "-foo")
+
+#undef TEST_ONLY_PARSE_NON_CANONICAL
+
+/* Neither function accepts these. */
+#define TEST_PARSE_NEITHER(NAME, STR)                                                 \
+    TEST_F(StorePathTest, neither_##NAME)                                             \
+    {                                                                                 \
+        std::string_view str = STR;                                                   \
+        [&]() { ASSERT_THROW(store->parseStorePath(str), Error); }();                 \
+        [&]() { ASSERT_THROW(store->parseStorePathCanonical(str), BadStorePath); }(); \
+    }
+
+TEST_PARSE_NEITHER(empty, "")
+TEST_PARSE_NEITHER(relative, HASH_PART "-foo")
+TEST_PARSE_NEITHER(outside_store, "/foo/" HASH_PART "-foo")
+TEST_PARSE_NEITHER(store_dir_itself, "/nix/store")
+TEST_PARSE_NEITHER(store_dir_slash, STORE_DIR)
+TEST_PARSE_NEITHER(subdirectory, STORE_DIR HASH_PART "-foo/bin/sh")
+TEST_PARSE_NEITHER(prefix_only, "/nix/store" HASH_PART "-foo")
+
+#undef TEST_PARSE_NEITHER
+
+RC_GTEST_FIXTURE_PROP(StorePathTest, prop_canonical_round_trip, (const StorePath & p))
+{
+    RC_ASSERT(p == store->parseStorePathCanonical(store->printStorePath(p)));
+}
 
 RC_GTEST_FIXTURE_PROP(StorePathTest, prop_regex_accept, (const StorePath & p))
 {

--- a/src/libstore/derivation/aterm.cc
+++ b/src/libstore/derivation/aterm.cc
@@ -138,17 +138,10 @@ static BackedStringView parseString(StringViewStream & str)
     return res;
 }
 
-static void validatePath(std::string_view s)
+/* Store paths in derivations must be written in their canonical form. */
+static StorePath parseStorePath(const StoreDirConfig & store, StringViewStream & str)
 {
-    if (s.size() == 0 || s[0] != '/')
-        throw FormatError("bad path '%1%' in derivation", s);
-}
-
-static BackedStringView parsePath(StringViewStream & str)
-{
-    auto s = parseString(str);
-    validatePath(*s);
-    return s;
+    return store.parseStorePathCanonical(*parseString(str));
 }
 
 static bool endOfList(StringViewStream & str)
@@ -164,12 +157,21 @@ static bool endOfList(StringViewStream & str)
     return false;
 }
 
-static StringSet parseStrings(StringViewStream & str, bool arePaths)
+static StringSet parseStrings(StringViewStream & str)
 {
     StringSet res;
     expect(str, '[');
     while (!endOfList(str))
-        res.insert((arePaths ? parsePath(str) : parseString(str)).toOwned());
+        res.insert(parseString(str).toOwned());
+    return res;
+}
+
+static StorePathSet parseStorePaths(const StoreDirConfig & store, StringViewStream & str)
+{
+    StorePathSet res;
+    expect(str, '[');
+    while (!endOfList(str))
+        res.insert(parseStorePath(store, str));
     return res;
 }
 
@@ -196,7 +198,7 @@ static Output parseOutput(
                 .hashAlgo = std::move(hashAlgo),
             };
         } else if (!hashS.empty()) {
-            validatePath(pathS);
+            [[maybe_unused]] auto path = store.parseStorePathCanonical(pathS);
             auto hash = Hash::parseNonSRIUnprefixed(hashS, hashAlgo);
             return Output::CAFixed{
                 .ca =
@@ -218,9 +220,8 @@ static Output parseOutput(
         if (pathS.empty()) {
             return Output::Deferred{};
         }
-        validatePath(pathS);
         return Output::InputAddressed{
-            .path = store.parseStorePath(pathS),
+            .path = store.parseStorePathCanonical(pathS),
         };
     }
 }
@@ -265,7 +266,7 @@ parseDerivedPathMapNode(const StoreDirConfig & store, StringViewStream & str, AT
 
     DerivedPathMap<StringSet>::ChildNode node;
 
-    auto parseNonDynamic = [&]() { node.value = parseStrings(str, false); };
+    auto parseNonDynamic = [&]() { node.value = parseStrings(str); };
 
     // Older derivation should never use new form, but newer
     // derivation can use old form.
@@ -280,7 +281,7 @@ parseDerivedPathMapNode(const StoreDirConfig & store, StringViewStream & str, AT
             break;
         case '(':
             expect(str, '(');
-            node.value = parseStrings(str, false);
+            node.value = parseStrings(str);
             expect(str, ",["sv);
             while (!endOfList(str)) {
                 expect(str, '(');
@@ -355,20 +356,20 @@ Full parse(
     expect(str, ",["sv);
     while (!endOfList(str)) {
         expect(str, '(');
-        auto drvPath = parsePath(str);
+        auto drvPath = parseStorePath(store, str);
         expect(str, ',');
         auto node = parseDerivedPathMapNode(store, str, version);
         /* Such an entry cannot be represented in the flat inputs set,
            and would thus be silently dropped rather than round-tripped.
            Nix itself never produces one. */
         if (node.value.empty() && node.childMap.empty())
-            throw FormatError("inputDrvs entry for '%s' specifies no outputs", *drvPath);
-        fullInputs.drvs.map.insert_or_assign(store.parseStorePath(*drvPath), std::move(node));
+            throw FormatError("inputDrvs entry for '%s' specifies no outputs", store.printStorePath(drvPath));
+        fullInputs.drvs.map.insert_or_assign(std::move(drvPath), std::move(node));
         expect(str, ')');
     }
 
     expect(str, ',');
-    fullInputs.srcs = store.parseStorePathSet(parseStrings(str, true));
+    fullInputs.srcs = parseStorePaths(store, str);
     drv.inputs = fullInputs.toSet();
     expect(str, ',');
     drv.platform = parseString(str).toOwned();

--- a/src/libstore/include/nix/store/store-dir-config.hh
+++ b/src/libstore/include/nix/store/store-dir-config.hh
@@ -33,16 +33,18 @@ struct StoreDirConfig
 
     StorePath parseStorePath(std::string_view path) const;
 
+    /**
+     * Parse a store path, requiring canonical form.
+     * Rejects paths with trailing or excess path separators
+     *
+     * @todo Try to use this as much as possible, and then rename so we
+     * have `parseStorePath` and `parseStorePathNonCanonical`.
+     */
+    StorePath parseStorePathCanonical(std::string_view path) const;
+
     std::optional<StorePath> maybeParseStorePath(std::string_view path) const;
 
     std::string printStorePath(const StorePath & path) const;
-
-    /**
-     * Deprecated
-     *
-     * \todo remove
-     */
-    StorePathSet parseStorePathSet(const StringSet & paths) const;
 
     StringSet printStorePathSet(const StorePathSet & path) const;
 

--- a/src/libstore/store-dir-config.cc
+++ b/src/libstore/store-dir-config.cc
@@ -27,6 +27,18 @@ StorePath StoreDirConfig::parseStorePath(std::string_view path) const
     return StorePath(p.filename().string());
 }
 
+StorePath StoreDirConfig::parseStorePathCanonical(std::string_view path) const
+{
+    if (!path.starts_with(storeDir))
+        throw BadStorePath("path '%s' is not in the Nix store", path);
+    path.remove_prefix(storeDir.length());
+
+    if (!path.starts_with('/'))
+        throw BadStorePath("path '%s' is not in the Nix store", path);
+
+    return StorePath(path.substr(1));
+}
+
 std::optional<StorePath> StoreDirConfig::maybeParseStorePath(std::string_view path) const
 {
     try {
@@ -39,14 +51,6 @@ std::optional<StorePath> StoreDirConfig::maybeParseStorePath(std::string_view pa
 bool StoreDirConfig::isStorePath(std::string_view path) const
 {
     return (bool) maybeParseStorePath(path);
-}
-
-StorePathSet StoreDirConfig::parseStorePathSet(const StringSet & paths) const
-{
-    StorePathSet res;
-    for (auto & i : paths)
-        res.insert(parseStorePath(i));
-    return res;
 }
 
 std::string StoreDirConfig::printStorePath(const StorePath & path) const

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -272,7 +272,15 @@ static int main_build_remote(int argc, char ** argv)
 
         std::cerr << "# accept\n" << storeUri << "\n";
 
-        auto inputs = readStrings<StringSet>(source);
+        /* The other side of the build hook protocol is Nix itself, so
+           these are always printed in canonical form. */
+        auto inputs = [&] {
+            StorePathSet res;
+            for (auto & i : readStrings<StringSet>(source))
+                res.insert(store->parseStorePathCanonical(i));
+            return res;
+        }();
+
         auto wantedOutputs = readStrings<StringSet>(source);
 
         AutoCloseFD uploadLock;
@@ -306,7 +314,7 @@ static int main_build_remote(int argc, char ** argv)
 
         {
             Activity act(*logger, lvlTalkative, actUnknown, fmt("copying dependencies to '%s'", storeUri));
-            copyPaths(*store, *sshStore, store->parseStorePathSet(inputs), NoRepair, NoCheckSigs, substitute);
+            copyPaths(*store, *sshStore, inputs, NoRepair, NoCheckSigs, substitute);
         }
 
         uploadLock = -1;
@@ -346,7 +354,7 @@ static int main_build_remote(int argc, char ** argv)
                 // 2. Changing the `inputSrcs` set changes the
                 //    associated output ids, which break CA derivations
                 .inputs =
-                    hasInputDrvs ? store->parseStorePathSet(inputs) : [&] {
+                    hasInputDrvs ? inputs : [&] {
                         StorePathSet srcs;
                         for (auto & input : drv.inputs)
                             if (auto * op = std::get_if<SingleDerivedPath::Opaque>(&input.raw()))


### PR DESCRIPTION
(description emitted by @Ericson2314)

## Motivation

The derivation parser previously accepted non-canonical store paths that resolve to the same file system location, e.g. `/nix/store//<hash>-foo` or `/nix/store/./<hash>-foo`. There are many contexts where we do not want this sort of non-injectivity, such as derivation parsing.

## Context

Add `StoreDirConfig::parseStorePathCanonical`, which accepts only the canonical `<store-dir>/<hash>-<name>` form, and use it throughout the ATerm derivation parser. Nix itself has only ever written canonical paths, so nothing should be relying on the old leniency.

The code in the ATerm parser was less type-directed before simply because it dated back before we even had a separate `StorePath` data type so we couldn't do "parse, not validate". Now we do, so we can make everything more structured accordingly. The parser goes straight from the stream to `StorePath`, and two helpers that only existed to prop up the stringly-typed version fall away:

- `validatePath` merely checked for a leading `/`; `parseStorePathCanonical` subsumes it for anything that becomes a `StorePath`. Its sole remaining caller was the path stated for a fixed-output derivation, which is redundant with the content address and so is discarded rather than parsed; a proper check that the two agree is left for a follow-up. `validatePath` is therefore deleted outright.

- `parseStorePathSet` is unnecessary now that the parser builds a `StorePathSet` directly rather than an intermediate `StringSet`. That left it with a single caller in `build-remote`, where it is replaced in the definition of the local variable, so the deprecated method is removed too.

Unit tests in `src/libstore-tests/path.cc` cover the error paths: the existing `TEST_DONT_PARSE`/`TEST_DO_PARSE` macros now exercise `parseStorePathCanonical` as well, plus new cases for paths that only the non-canonical parser accepts (trailing slash, double slash, `./`, `bar/../`) and paths that neither accepts.

This is split out from #16284.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
