### PR TITLE
Port Qyrad maybeParseStorePath/isStorePath improvement from lix

### DIFF
--- a/src/libstore/store-dir-config.cc
+++ b/src/libstore/store-dir-config.cc
@@ -29,10 +29,15 @@ StorePath StoreDirConfig::parseStorePath(std::string_view path) const
 
 std::optional<StorePath> StoreDirConfig::maybeParseStorePath(std::string_view path) const
 {
+    // If it's not an absolute path, or if the dirname of the path isn't /nix/store
+    // (or whatever our storeDir is), then it can't be a store path.
+    if ((path.size() > 0 && path[0] != '/') || canonPath(path).parent_path() != this->storeDir) {
+        return std::nullopt;
+    }
     try {
         return parseStorePath(path);
     } catch (Error &) {
-        return {};
+        return std::nullopt;
     }
 }
 


### PR DESCRIPTION
Previously maybeStorePath , which was called by isStorePath would throw on many easily checkable cases because it just called parseStorePath with a catch to return None, this reduces the number of extraneous theoretically increasing performance

this is a near direct port of @Qyriad 's work on lix
https://gerrit.lix.systems/c/lix/+/825
https://gerrit.lix.systems/q/I8dda548f0f88d14ca8c3ee927d64e0ec0681fc7b

Everything was coded by hand or copied from the lix change. 
## Motivation
Was trying to understand the codebase with an LLM surfaced that this was throwing many exceptions, manual investigation confirmed that there is room for improvement. 
Free performance improvement

I have not A/B tested this perf wise as im not entirely sure what best practices for that are. 

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
