### PR TITLE
Improve 'sandbox-fallback' diagnostics, disallow fallback with reloca…

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1857,7 +1857,9 @@ std::unique_ptr<DerivationBuilder, DerivationBuilderDeleter> makeDerivationBuild
             useSandbox = type(params.drv).isSandboxed() && !params.drvOptions.noChroot;
     }
 
-    if (store.storeDir != store.config->realStoreDir.get()) {
+    const bool isRelocatedStore = store.storeDir != store.config->realStoreDir.get();
+
+    if (isRelocatedStore) {
 #if defined(__linux__) || defined(__FreeBSD__)
         useSandbox = true;
 #else
@@ -1870,10 +1872,19 @@ std::unique_ptr<DerivationBuilder, DerivationBuilderDeleter> makeDerivationBuild
         if (!localSettings.sandboxFallback)
             throw Error(
                 "this system does not support the kernel namespaces that are required for sandboxing; use '--no-sandbox' to disable sandboxing");
-        debug("auto-disabling sandboxing because the prerequisite namespaces are not available");
+
+        if (isRelocatedStore)
+            throw Error(
+                "this system does not support the kernel namespaces that are required for sandboxing, which is required for building in a diverted store");
+
+        static std::atomic<bool> warned = false;
+        warnOnce(
+            warned,
+            "auto-disabling sandboxing because the prerequisite namespaces are not available and '%1%' is enabled; use '--no-sandbox' or specify 'sandbox = false' setting to silence this warning",
+            localSettings.sandboxFallback.name);
+
         useSandbox = false;
     }
-
 #endif
 
     if (!useSandbox && params.drvOptions.useUidRange(params.drv))


### PR DESCRIPTION
…ted store

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Adds a warn-once warning for sandbox-fallback instead of a debug message and makes unsupported sandboxed builds an error for relocated stores (which accidentally went through the same fallback path, even though it really shouldn't).

Fixes https://github.com/NixOS/nix/issues/16291
Fixes https://github.com/NixOS/nix/issues/16207
Fixes https://github.com/NixOS/nix/issues/13928

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
