### PR TITLE
feat(libexpr): mark start of infinite recursion in error traces

### DIFF
--- a/doc/manual/rl-next/infinite-recursion-start.md
+++ b/doc/manual/rl-next/infinite-recursion-start.md
@@ -1,0 +1,28 @@
+---
+synopsis: Start of infinite recursion is now visible
+issues: []
+prs: [16296]
+---
+
+When Nix reports a trace for an infinitely recursive evaluation,
+it will now let you discern the cycle from the code that leads up to the cycle.
+
+Example:
+
+`nix eval --expr 'let f = builtins.add f 1; in toString f' --show-trace`
+```
+error:
+       … while calling the 'toString' builtin
+         at «string»:1:30:
+            1| let f = builtins.add f 1; in toString f
+             |                              ^
+
+       … entering the infinite recursion
+
+       … while calling the 'add' builtin
+         at «string»:1:9:
+            1| let f = builtins.add f 1; in toString f
+             |         ^
+
+       error: infinite recursion encountered
+```

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2233,7 +2233,7 @@ void ExprBlackHole::eval(EvalState & state, [[maybe_unused]] Env & env, Value & 
 
 [[gnu::noinline]] [[noreturn]] void ExprBlackHole::throwInfiniteRecursionError(EvalState & state, Value & v)
 {
-    state.error<InfiniteRecursionError>("infinite recursion encountered").atPos(v.determinePos(noPos)).debugThrow();
+    state.error<InfiniteRecursionError>(&v, "infinite recursion encountered").atPos(v.determinePos(noPos)).debugThrow();
 }
 
 // always force this to be separate, otherwise forceValue may inline it and take
@@ -2250,6 +2250,17 @@ void EvalState::handleEvalExceptionForThunk(Env * env, Expr * expr, Value & v, c
         std::rethrow_exception(e);
     } catch (const Interrupted & e) {
         recovery = allocValue();
+    } catch (InfiniteRecursionError & ir) {
+        // Mark where evaluation enters the infinite recursion, so the trace
+        // distinguishes the cycle from the code leading up to it.
+        //
+        // The blackholed value is forced at two frames:
+        // 1. re-forcing of the thunk at stack tip (`env` is null)
+        // 2. initial forcing of the thunk, which is where the cycle starts
+        // Only the first force has an `env`, so we expect this entry to be added once.
+        if (env && ir.v == &v)
+            ir.addTrace(
+                nullptr, HintFmt(ANSI_WARNING "entering the infinite recursion" ANSI_NORMAL), TracePrint::Always);
     } catch (const RecoverableEvalError & e) {
         recovery = allocValue();
     } catch (...) {

--- a/src/libexpr/include/nix/expr/eval-error.hh
+++ b/src/libexpr/include/nix/expr/eval-error.hh
@@ -57,7 +57,27 @@ MakeError(Abort, EvalError);
 MakeError(TypeError, EvalError);
 MakeError(UndefinedVarError, EvalError);
 MakeError(MissingArgumentError, EvalError);
-MakeError(InfiniteRecursionError, EvalError);
+
+class InfiniteRecursionError : public CloneableError<InfiniteRecursionError, EvalError>
+{
+    void anchor() override;
+
+public:
+
+    /**
+     * Memory location of the Value that was found to be a blackhole, used to
+     * mark where the recursion starts in the printed trace. Only pointer
+     * identity is of interest.
+     */
+    const Value * const v;
+
+    template<typename... Args>
+    explicit InfiniteRecursionError(EvalState & state, const Value * v, const Args &... args)
+        : CloneableError(state, args...)
+        , v(v)
+    {
+    }
+};
 
 /**
  * Resource exhaustion error when evaluation exceeds max-call-depth.

--- a/tests/functional/lang/eval-fail-blackhole.err.exp
+++ b/tests/functional/lang/eval-fail-blackhole.err.exp
@@ -12,6 +12,8 @@ error:
              |   ^
             3|   x = y;
 
+       … entering the infinite recursion
+
        error: infinite recursion encountered
        at /pwd/lang/eval-fail-blackhole.nix:3:7:
             2|   body = x;

--- a/tests/functional/lang/eval-fail-infinite-recursion-builtin.err.exp
+++ b/tests/functional/lang/eval-fail-infinite-recursion-builtin.err.exp
@@ -1,0 +1,18 @@
+error:
+       … while calling the 'toString' builtin
+         at /pwd/lang/eval-fail-infinite-recursion-builtin.nix:5:1:
+            4| in
+            5| toString f
+             | ^
+            6|
+
+       … entering the infinite recursion
+
+       … while calling the 'add' builtin
+         at /pwd/lang/eval-fail-infinite-recursion-builtin.nix:3:7:
+            2| let
+            3|   f = builtins.add f 1;
+             |       ^
+            4| in
+
+       error: infinite recursion encountered

--- a/tests/functional/lang/eval-fail-infinite-recursion-builtin.nix
+++ b/tests/functional/lang/eval-fail-infinite-recursion-builtin.nix
@@ -1,0 +1,5 @@
+# An infinite recursion that occurs in the context of another call that isn't part of the cycle
+let
+  f = builtins.add f 1;
+in
+toString f

--- a/tests/functional/lang/eval-fail-recursion.err.exp
+++ b/tests/functional/lang/eval-fail-recursion.err.exp
@@ -1,4 +1,6 @@
 error:
+       … entering the infinite recursion
+
        … in the right operand of the update (//) operator
          at /pwd/lang/eval-fail-recursion.nix:2:14:
             1| let

--- a/tests/functional/lang/eval-fail-scope-5.err.exp
+++ b/tests/functional/lang/eval-fail-scope-5.err.exp
@@ -26,6 +26,8 @@ error:
              |     ^
             8|       x ? y,
 
+       … entering the infinite recursion
+
        error: infinite recursion encountered
        at /pwd/lang/eval-fail-scope-5.nix:8:11:
             7|     {


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Trace useful. Found a need for this again when debugging the tracing cache (STF)

> When Nix reports a trace for cyclic expression, it will now let you discern the cycle from the code that leads up to the cycle.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Improved after taking from https://github.com/NixOS/nix/pull/8623

Assisted-By: Claude Code (Claude Opus 4.7)
Assisted-By: Claude Code (Claude Opus 5)

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
