### PR TITLE
nix-shell: copy source inputs from the eval store to the build store

### DIFF
--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -523,6 +523,20 @@ static void main_nix_build(int argc, char ** argv)
                 pathsToBuild.push_back(DerivedPath::fromSingle(input));
         }
 
+        /* The derivation's source inputs are realised below on the build store
+           as bare Opaque paths, which buildPaths() won't copy from the eval
+           store (it only copies a derivation's sources when it builds that
+           derivation). Copy any that exist only in the eval store, e.g. a dirty
+           working tree, or realisation fails with no substituter. */
+        if (store != evalStore) {
+            RealisedPath::Set inputSrcs;
+            for (const auto & input : drv.inputs)
+                if (const auto * op = std::get_if<SingleDerivedPath::Opaque>(&input.raw()))
+                    if (evalStore->isValidPath(op->path))
+                        inputSrcs.insert(op->path);
+            copyClosure(*evalStore, *store, inputSrcs);
+        }
+
         buildPaths(pathsToBuild);
 
         if (dryRun)

--- a/tests/functional/eval-store.sh
+++ b/tests/functional/eval-store.sh
@@ -54,3 +54,11 @@ ls "$NIX_STORE_DIR"/*dependencies-top/foobar
 # Can't write .drv by default
 (! nix-instantiate dependencies.nix --eval-store "dummy://")
 nix-instantiate dependencies.nix --eval-store "dummy://?read-only=false"
+
+clearStore
+rm -rf "$eval_store"
+
+# Regression: `src` is ingested into the eval store during evaluation, so
+# nix-shell must copy it to the build store before it can realise it.
+NIX_BUILD_SHELL="$BASH" nix-shell --eval-store "$eval_store" --run true \
+    -E 'with import ./config.nix; mkDerivation { name = "eval-store-shell-src"; src = ./config.nix; buildCommand = ":"; }'


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

buildPaths() copies a derivation's sources from the eval store only when it builds that derivation, but nix-shell realises them directly as Opaque paths, which it never copies. So a source that lives only in the eval store (e.g. a dirty tree) fails to realise.

Restores the copy dropped for this path in eb6db4fd3 (#5025).

## Context


Closes: https://github.com/NixOS/nix/issues/16297

More context: https://github.com/NixOS/nix/issues/5025

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
