### PR TITLE
Fixes #4328: XML serialization of meta attributes

### DIFF
--- a/src/libexpr/include/nix/expr/value-to-xml.hh
+++ b/src/libexpr/include/nix/expr/value-to-xml.hh
@@ -18,4 +18,12 @@ void printValueAsXML(
     NixStringContext & context,
     const PosIdx pos);
 
-}
+void printValueAsXML(
+    EvalState & state,
+    bool strict,
+    bool location,
+    Value & v,
+    XMLWriter & doc,
+    NixStringContext & context,
+    const PosIdx pos);
+} // namespace nix

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -206,4 +206,17 @@ void printValueAsXML(
     printValueAsXML(state, strict, location, v, doc, context, drvsSeen, pos);
 }
 
+void printValueAsXML(
+    EvalState & state,
+    bool strict,
+    bool location,
+    Value & v,
+    XMLWriter & doc,
+    NixStringContext & context,
+    const PosIdx pos)
+{
+    StringSet drvsSeen;
+    printValueAsXML(state, strict, location, v, doc, context, drvsSeen, pos);
+}
+
 } // namespace nix

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -16,6 +16,7 @@
 #include "nix/store/local-fs-store.hh"
 #include "user-env.hh"
 #include "nix/expr/value-to-json.hh"
+#include "nix/expr/value-to-xml.hh"
 #include "nix/util/xml-writer.hh"
 #include "nix/cmd/legacy.hh"
 #include "nix/expr/eval-settings.hh" // for defexpr
@@ -1223,6 +1224,11 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                 }
                 if (printMeta) {
                     StringSet metaNames = i.queryMetaNames();
+                    auto printMetaAsXML = [&](XMLAttrs & attrs, Value * v) {
+                        XMLOpenElement m(xml, "meta", attrs);
+                        NixStringContext context;
+                        printValueAsXML(*globals.state, true, false, *v, xml, context, noPos);
+                    };
                     for (auto & j : metaNames) {
                         XMLAttrs attrs2;
                         attrs2["name"] = j;
@@ -1247,26 +1253,26 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                                 attrs2["value"] = v->boolean() ? "true" : "false";
                                 xml.writeEmptyElement("meta", attrs2);
                             } else if (v->type() == nList) {
-                                attrs2["type"] = "strings";
-                                XMLOpenElement m(xml, "meta", attrs2);
+                                bool isListOfOnlyStrings = true;
                                 for (auto elem : v->listView()) {
-                                    if (elem->type() != nString)
-                                        continue;
-                                    XMLAttrs attrs3;
-                                    attrs3["value"] = elem->string_view();
-                                    xml.writeEmptyElement("string", attrs3);
+                                    if (elem->type() != nString) {
+                                        isListOfOnlyStrings = false;
+                                        break;
+                                    }
+                                }
+                                if (isListOfOnlyStrings) {
+                                    attrs2["type"] = "strings";
+                                    XMLOpenElement m(xml, "meta", attrs2);
+                                    for (auto elem : v->listView()) {
+                                        XMLAttrs attrs3;
+                                        attrs3["value"] = elem->string_view();
+                                        xml.writeEmptyElement("string", attrs3);
+                                    }
+                                } else {
+                                    printMetaAsXML(attrs2, v);
                                 }
                             } else if (v->type() == nAttrs) {
-                                attrs2["type"] = "strings";
-                                XMLOpenElement m(xml, "meta", attrs2);
-                                for (auto & i : *v->attrs()) {
-                                    if (i.value->type() != nString)
-                                        continue;
-                                    XMLAttrs attrs3;
-                                    attrs3["type"] = globals.state->symbols[i.name];
-                                    attrs3["value"] = i.value->string_view();
-                                    xml.writeEmptyElement("string", attrs3);
-                                }
+                                printMetaAsXML(attrs2, v);
                             }
                         }
                     }

--- a/tests/functional/cli-characterisation/nix-env-qa-xml-maintainers.cmd
+++ b/tests/functional/cli-characterisation/nix-env-qa-xml-maintainers.cmd
@@ -1,0 +1,1 @@
+0 nix-env -f ./cli-characterisation/xml-maintainers.nix -qa --meta --xml

--- a/tests/functional/cli-characterisation/nix-env-qa-xml-maintainers.out.exp
+++ b/tests/functional/cli-characterisation/nix-env-qa-xml-maintainers.out.exp
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='utf-8'?>
+<items>
+  <item attrPath="" name="xml-maintainers" outputName="out" pname="xml-maintainers" system="SYSTEM" version="">
+    <output name="out" />
+    <meta name="license">
+      <list>
+        <attrs>
+          <attr name="fullName">
+            <string value="MIT License" />
+          </attr>
+          <attr name="spdxId">
+            <string value="MIT" />
+          </attr>
+        </attrs>
+        <attrs>
+          <attr name="fullName">
+            <string value="GNU General Public License v2.0 only" />
+          </attr>
+          <attr name="shortName">
+            <string value="gpl2Only" />
+          </attr>
+          <attr name="spdxId">
+            <string value="GPL-2.0-only" />
+          </attr>
+          <attr name="url">
+            <string value="https://spdx.org/licenses/GPL-2.0-only.html" />
+          </attr>
+        </attrs>
+      </list>
+    </meta>
+    <meta name="maintainers">
+      <list>
+        <attrs>
+          <attr name="email">
+            <string value="alice@example.org" />
+          </attr>
+          <attr name="name">
+            <string value="Alice" />
+          </attr>
+        </attrs>
+        <attrs>
+          <attr name="email">
+            <string value="bob@example.org" />
+          </attr>
+          <attr name="name">
+            <string value="Bob" />
+          </attr>
+        </attrs>
+      </list>
+    </meta>
+  </item>
+</items>

--- a/tests/functional/cli-characterisation/xml-maintainers.nix
+++ b/tests/functional/cli-characterisation/xml-maintainers.nix
@@ -1,0 +1,28 @@
+with import ../config.nix;
+mkDerivation {
+  name = "xml-maintainers";
+  buildCommand = "mkdir -p $out";
+  meta.maintainers = [
+    {
+      name = "Alice";
+      email = "alice@example.org";
+    }
+    {
+      name = "Bob";
+      email = "bob@example.org";
+    }
+  ];
+  meta.license = [
+    {
+      spdxId = "MIT";
+      fullName = "MIT License";
+    }
+
+    {
+      fullName = "GNU General Public License v2.0 only";
+      shortName = "gpl2Only";
+      spdxId = "GPL-2.0-only";
+      url = "https://spdx.org/licenses/GPL-2.0-only.html";
+    }
+  ];
+}


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Historically meta attributes were strings or lists of strings. 
Modern derivations use lists of attrsets, for example for license and maintainers.
Before `nix-env --query --meta --xml` silently discarded non-string values in `meta`.
I want the the xml to be correctly serialized.
This came to mind after using: https://github.com/NixOS/nixpkgs/blob/master/maintainers/scripts/nixpkgs-lint.pl
It gave problems even on packages which I was kinda sure were correct: firefox.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

I fixed the problem by grepping for xml in the codebase and reading the code. Since I'm not familiar with the repo I searched if there were related issues/prs:

<details close>
<summary>gh list "nix-env meta xml" results</summary>

```bash
$ gh issue list --repo NixOS/nix --state all --search "nix-env meta xml"
#4328   license meta attribute gets incorrectly serialized when using XML ...  bug, stale      about 4 years ago
#635    nix-env query options inconsistent behaviors                           UX, cli, stale  about 3 hours ago
...
#288    stdenv.lib.licenses is not shown in a query with --meta --xml options                  about 10 years ago

$ gh pr list --repo NixOS/nix --state all --search "nix-env meta xml"
...
#712    Print license information on '--xml --meta'     pSub:print-meta-license                  about 10 years ago
```

</details>

It seems to me that I'm fixing #4328 and this might also be related to #635 (which is already closed).
I'm doing a much needed refresh of the #712 pr. 10 years have passed things have changed :)

I'm tagging @poscat0x04 since he opened the @4328 issue, hope I'm not disturbing.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

## Implementation

It used to iterate over list items and just skip them if they were not strings. So attrsets got discarded.

I kept the original code for "strings of lists", but guarded behind a check to see if the list contains only strings.

If it contains something else I treat it the same as if it was a attrset to begin with.

### Overload printvalueasxml
I got some problems since `printValueAsXML` didn't have the correct overload I wanted.

I initially used:
```diff
- printValueAsXML(*globals.state, true, false, *v, std::cout, context, noPos);
+ printValueAsXML(*globals.state, true, false, *v, xml, context, noPos);
```
But this created nested xml.

I **considered** removing `static` from 
https://github.com/lnk3/nix/blob/0cf9fa798cf71d9e8445d8256c457d818f5599b9/src/libexpr/value-to-xml.cc#L17

But then just added a new overload. Seemed cleaner not increasing the api.

## Checklist
- [x] Write test (I might need help)
- [x] Update nixpkgs-lint.pl in nixkgs repo. https://github.com/NixOS/nixpkgs/pull/552249
- [ ] Update docs/release notes, **I'm not sure how / where** 
- [ ] Rebase ?
---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
