### PR TITLE
Add traces for all operators

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1208,8 +1208,9 @@ void EvalState::eval(Expr * e, Value & v)
     e->eval(*this, baseEnv, v);
 }
 
-inline bool EvalState::evalBool(Env & env, Expr * e, const PosIdx pos, std::string_view errorCtx)
+inline bool EvalState::evalBool(Env & env, Expr * e, std::string_view errorCtx)
 {
+    PosIdx pos = e->getPos();
     try {
         Value v;
         e->eval(*this, env, v);
@@ -1226,8 +1227,9 @@ inline bool EvalState::evalBool(Env & env, Expr * e, const PosIdx pos, std::stri
     }
 }
 
-inline void EvalState::evalAttrs(Env & env, Expr * e, Value & v, const PosIdx pos, std::string_view errorCtx)
+inline void EvalState::evalAttrs(Env & env, Expr * e, Value & v, std::string_view errorCtx)
 {
+    PosIdx pos = e->getPos();
     try {
         e->eval(*this, env, v);
         if (v.type() != nAttrs)
@@ -1237,6 +1239,16 @@ inline void EvalState::evalAttrs(Env & env, Expr * e, Value & v, const PosIdx po
                 .debugThrow();
     } catch (Error & e) {
         e.addTrace(positions[pos], errorCtx);
+        throw;
+    }
+}
+
+void Expr::eval(EvalState & state, Env & env, Value & v, std::string_view errorCtx)
+{
+    try {
+        eval(state, env, v);
+    } catch (Error & e) {
+        e.addTrace(state.positions[getPos()], errorCtx);
         throw;
     }
 }
@@ -1456,7 +1468,7 @@ void ExprSelect::eval(EvalState & state, Env & env, Value & v)
     // cursor, result if successful
     Value * vAttrs = &vTmp;
 
-    e->eval(state, env, vTmp);
+    e->eval(state, env, vTmp, "while selecting an attribute");
 
     try {
         auto dts = state.debugRepl ? makeDebugTraceStacker(
@@ -1541,7 +1553,7 @@ void ExprOpHasAttr::eval(EvalState & state, Env & env, Value & v)
     Value vTmp;
     Value * vAttrs = &vTmp;
 
-    e->eval(state, env, vTmp);
+    e->eval(state, env, vTmp, "in the argument of '?'");
 
     for (auto & i : attrPath) {
         state.forceValue(*vAttrs, getPos());
@@ -1896,12 +1908,12 @@ void ExprWith::eval(EvalState & state, Env & env, Value & v)
 void ExprIf::eval(EvalState & state, Env & env, Value & v)
 {
     // We cheat in the parser, and pass the position of the condition as the position of the if itself.
-    (state.evalBool(env, cond, pos, "while evaluating a branch condition") ? then : else_)->eval(state, env, v);
+    (state.evalBool(env, cond, "while evaluating a branch condition") ? then : else_)->eval(state, env, v);
 }
 
 void ExprAssert::eval(EvalState & state, Env & env, Value & v)
 {
-    if (!state.evalBool(env, cond, pos, "in the condition of the assert statement")) {
+    if (!state.evalBool(env, cond, "in the condition of the assert statement")) {
         std::ostringstream out;
         cond->show(state.symbols, out);
         auto exprStr = out.view();
@@ -1926,46 +1938,46 @@ void ExprAssert::eval(EvalState & state, Env & env, Value & v)
 
 void ExprOpNot::eval(EvalState & state, Env & env, Value & v)
 {
-    v.mkBool(!state.evalBool(env, e, getPos(), "in the argument of '!'"));
+    v.mkBool(!state.evalBool(env, e, "in the argument of '!'"));
 }
 
 void ExprOpEq::eval(EvalState & state, Env & env, Value & v)
 {
     Value v1;
-    e1->eval(state, env, v1);
+    e1->eval(state, env, v1, "in the left operand of '=='");
     Value v2;
-    e2->eval(state, env, v2);
+    e2->eval(state, env, v2, "in the right operand of '=='");
     v.mkBool(state.eqValues(v1, v2, pos, "while testing two values for equality"));
 }
 
 void ExprOpNEq::eval(EvalState & state, Env & env, Value & v)
 {
     Value v1;
-    e1->eval(state, env, v1);
+    e1->eval(state, env, v1, "in the left operand of '!='");
     Value v2;
-    e2->eval(state, env, v2);
+    e2->eval(state, env, v2, "in the right operand of '!='");
     v.mkBool(!state.eqValues(v1, v2, pos, "while testing two values for inequality"));
 }
 
 void ExprOpAnd::eval(EvalState & state, Env & env, Value & v)
 {
     v.mkBool(
-        state.evalBool(env, e1, pos, "in the left operand of '&&'")
-        && state.evalBool(env, e2, pos, "in the right operand of '&&'"));
+        state.evalBool(env, e1, "in the left operand of '&&'")
+        && state.evalBool(env, e2, "in the right operand of '&&'"));
 }
 
 void ExprOpOr::eval(EvalState & state, Env & env, Value & v)
 {
     v.mkBool(
-        state.evalBool(env, e1, pos, "in the left operand of '||'")
-        || state.evalBool(env, e2, pos, "in the right operand of '||'"));
+        state.evalBool(env, e1, "in the left operand of '||'")
+        || state.evalBool(env, e2, "in the right operand of '||'"));
 }
 
 void ExprOpImpl::eval(EvalState & state, Env & env, Value & v)
 {
     v.mkBool(
-        !state.evalBool(env, e1, pos, "in the left operand of '->'")
-        || state.evalBool(env, e2, pos, "in the right operand of '->'"));
+        !state.evalBool(env, e1, "in the left operand of '->'")
+        || state.evalBool(env, e2, "in the right operand of '->'"));
 }
 
 void ExprOpUpdate::eval(EvalState & state, Value & v, Value & v1, Value & v2)
@@ -2062,7 +2074,7 @@ void ExprOpUpdate::eval(EvalState & state, Env & env, Value & v)
 void Expr::evalForUpdate(EvalState & state, Env & env, UpdateQueue & q, std::string_view errorCtx)
 {
     Value v;
-    state.evalAttrs(env, this, v, getPos(), errorCtx);
+    state.evalAttrs(env, this, v, errorCtx);
     q.push_back(v);
 }
 
@@ -2082,9 +2094,9 @@ void ExprOpUpdate::evalForUpdate(EvalState & state, Env & env, UpdateQueue & q, 
 void ExprOpConcatLists::eval(EvalState & state, Env & env, Value & v)
 {
     Value v1;
-    e1->eval(state, env, v1);
+    e1->eval(state, env, v1, "in the left operand of '++'");
     Value v2;
-    e2->eval(state, env, v2);
+    e2->eval(state, env, v2, "in the right operand of '++'");
     Value * lists[2] = {&v1, &v2};
     state.concatLists(v, lists, pos, "while evaluating one of the elements to concatenate");
 }
@@ -2138,7 +2150,7 @@ void ExprConcatStrings::eval(EvalState & state, Env & env, Value & v)
 
     for (auto & [i_pos, i] : es) {
         Value & vTmp = *vTmpP++;
-        i->eval(state, env, vTmp);
+        i->eval(state, env, vTmp, "in an operand of '+'");
 
         /* If the first element is a path, then the result will also
            be a path, we don't copy anything (yet - that's done later,

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1926,7 +1926,7 @@ void ExprAssert::eval(EvalState & state, Env & env, Value & v)
 
 void ExprOpNot::eval(EvalState & state, Env & env, Value & v)
 {
-    v.mkBool(!state.evalBool(env, e, getPos(), "in the argument of the not operator")); // XXX: FIXME: !
+    v.mkBool(!state.evalBool(env, e, getPos(), "in the argument of '!'"));
 }
 
 void ExprOpEq::eval(EvalState & state, Env & env, Value & v)
@@ -1950,22 +1950,22 @@ void ExprOpNEq::eval(EvalState & state, Env & env, Value & v)
 void ExprOpAnd::eval(EvalState & state, Env & env, Value & v)
 {
     v.mkBool(
-        state.evalBool(env, e1, pos, "in the left operand of the AND (&&) operator")
-        && state.evalBool(env, e2, pos, "in the right operand of the AND (&&) operator"));
+        state.evalBool(env, e1, pos, "in the left operand of '&&'")
+        && state.evalBool(env, e2, pos, "in the right operand of '&&'"));
 }
 
 void ExprOpOr::eval(EvalState & state, Env & env, Value & v)
 {
     v.mkBool(
-        state.evalBool(env, e1, pos, "in the left operand of the OR (||) operator")
-        || state.evalBool(env, e2, pos, "in the right operand of the OR (||) operator"));
+        state.evalBool(env, e1, pos, "in the left operand of '||'")
+        || state.evalBool(env, e2, pos, "in the right operand of '||'"));
 }
 
 void ExprOpImpl::eval(EvalState & state, Env & env, Value & v)
 {
     v.mkBool(
-        !state.evalBool(env, e1, pos, "in the left operand of the IMPL (->) operator")
-        || state.evalBool(env, e2, pos, "in the right operand of the IMPL (->) operator"));
+        !state.evalBool(env, e1, pos, "in the left operand of '->'")
+        || state.evalBool(env, e2, pos, "in the right operand of '->'"));
 }
 
 void ExprOpUpdate::eval(EvalState & state, Value & v, Value & v1, Value & v2)
@@ -2070,8 +2070,8 @@ void ExprOpUpdate::evalForUpdate(EvalState & state, Env & env, UpdateQueue & q)
 {
     /* Output rightmost attrset first to the merge queue as the one
        with the most priority. */
-    e2->evalForUpdate(state, env, q, "in the right operand of the update (//) operator");
-    e1->evalForUpdate(state, env, q, "in the left operand of the update (//) operator");
+    e2->evalForUpdate(state, env, q, "in the right operand of '//'");
+    e1->evalForUpdate(state, env, q, "in the left operand of '//'");
 }
 
 void ExprOpUpdate::evalForUpdate(EvalState & state, Env & env, UpdateQueue & q, std::string_view errorCtx)

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -685,8 +685,8 @@ public:
      * type.
      */
     inline bool evalBool(Env & env, Expr * e);
-    inline bool evalBool(Env & env, Expr * e, const PosIdx pos, std::string_view errorCtx);
-    inline void evalAttrs(Env & env, Expr * e, Value & v, const PosIdx pos, std::string_view errorCtx);
+    inline bool evalBool(Env & env, Expr * e, std::string_view errorCtx);
+    inline void evalAttrs(Env & env, Expr * e, Value & v, std::string_view errorCtx);
 
     /**
      * If `v` is a thunk, enter it and overwrite `v` with the result

--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -117,6 +117,9 @@ struct Expr
     /** Normal evaluation, implemented directly by all subclasses. */
     virtual void eval(EvalState & state, Env & env, Value & v);
 
+    /** Wrapper around the above that adds errorCtx to any thrown errors. */
+    void eval(EvalState & state, Env & env, Value & v, std::string_view errorCtx);
+
     /**
      * Create a thunk for the delayed computation of the given expression
      * in the given environment. But if the expression is a variable,

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -297,8 +297,8 @@ expr_pipe_into
 expr_op
   : '!' expr_op %prec NOT { $$ = state->exprs.add<ExprOpNot>($2); }
   | '-' expr_op %prec NEGATE { $$ = state->exprs.add<ExprCall>(CUR_POS, state->exprs.add<ExprVar>(state->s.sub), {state->exprs.add<ExprInt>(0), $2}); }
-  | expr_op EQ expr_op { $$ = state->exprs.add<ExprOpEq>($1, $3); }
-  | expr_op NEQ expr_op { $$ = state->exprs.add<ExprOpNEq>($1, $3); }
+  | expr_op EQ expr_op { $$ = state->exprs.add<ExprOpEq>(state->at(@2), $1, $3); }
+  | expr_op NEQ expr_op { $$ = state->exprs.add<ExprOpNEq>(state->at(@2), $1, $3); }
   | expr_op '<' expr_op { $$ = state->exprs.add<ExprCall>(state->at(@2), state->exprs.add<ExprVar>(state->s.lessThan), {$1, $3}); }
   | expr_op LEQ expr_op { $$ = state->exprs.add<ExprOpNot>(state->exprs.add<ExprCall>(state->at(@2), state->exprs.add<ExprVar>(state->s.lessThan), {$3, $1})); }
   | expr_op '>' expr_op { $$ = state->exprs.add<ExprCall>(state->at(@2), state->exprs.add<ExprVar>(state->s.lessThan), {$3, $1}); }

--- a/tests/functional/lang/eval-fail-addErrorContext-example.err.exp
+++ b/tests/functional/lang/eval-fail-addErrorContext-example.err.exp
@@ -1,6 +1,13 @@
 error:
        … while counting down; n = 10
 
+       … in an operand of '+'
+         at /pwd/lang/eval-fail-addErrorContext-example.nix:7:80:
+            6|     else
+            7|       builtins.addErrorContext "while counting down; n = ${toString n}" ("x" + countDown (n - 1));
+             |                                                                                ^
+            8| in
+
        … while counting down; n = 9
 
        … while counting down; n = 8

--- a/tests/functional/lang/eval-fail-assert-equal-derivations-extra.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-derivations-extra.err.exp
@@ -6,6 +6,11 @@ error:
             2|   {
 
        … while comparing attribute 'foo'
+         at /pwd/lang/eval-fail-assert-equal-derivations-extra.nix:7:5:
+            6|     };
+            7|   } == {
+             |     ^
+            8|     foo = {
 
        … where left hand side is
          at /pwd/lang/eval-fail-assert-equal-derivations-extra.nix:3:5:
@@ -22,5 +27,10 @@ error:
             9|       type = "derivation";
 
        … while comparing a derivation by its 'outPath' attribute
+         at /pwd/lang/eval-fail-assert-equal-derivations-extra.nix:7:5:
+            6|     };
+            7|   } == {
+             |     ^
+            8|     foo = {
 
        error: string '"/nix/store/0"' is not equal to string '"/nix/store/1"'

--- a/tests/functional/lang/eval-fail-assert-equal-derivations.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-derivations.err.exp
@@ -6,6 +6,11 @@ error:
             2|   {
 
        … while comparing attribute 'foo'
+         at /pwd/lang/eval-fail-assert-equal-derivations.nix:8:5:
+            7|     };
+            8|   } == {
+             |     ^
+            9|     foo = {
 
        … where left hand side is
          at /pwd/lang/eval-fail-assert-equal-derivations.nix:3:5:
@@ -22,5 +27,10 @@ error:
            10|       type = "derivation";
 
        … while comparing a derivation by its 'outPath' attribute
+         at /pwd/lang/eval-fail-assert-equal-derivations.nix:8:5:
+            7|     };
+            8|   } == {
+             |     ^
+            9|     foo = {
 
        error: string '"/nix/store/0"' is not equal to string '"/nix/store/1"'

--- a/tests/functional/lang/eval-fail-assert-equal-floats.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-floats.err.exp
@@ -6,6 +6,10 @@ error:
             2| abort "unreachable"
 
        … while comparing attribute 'b'
+         at /pwd/lang/eval-fail-assert-equal-floats.nix:1:21:
+            1| assert { b = 1.0; } == { b = 1.01; };
+             |                     ^
+            2| abort "unreachable"
 
        … where left hand side is
          at /pwd/lang/eval-fail-assert-equal-floats.nix:1:10:

--- a/tests/functional/lang/eval-fail-assert-equal-ints.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-ints.err.exp
@@ -6,6 +6,10 @@ error:
             2| abort "unreachable"
 
        … while comparing attribute 'b'
+         at /pwd/lang/eval-fail-assert-equal-ints.nix:1:19:
+            1| assert { b = 1; } == { b = 2; };
+             |                   ^
+            2| abort "unreachable"
 
        … where left hand side is
          at /pwd/lang/eval-fail-assert-equal-ints.nix:1:10:

--- a/tests/functional/lang/eval-fail-assert-equal-type-nested.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-type-nested.err.exp
@@ -6,6 +6,10 @@ error:
             2| abort "unreachable"
 
        … while comparing attribute 'ding'
+         at /pwd/lang/eval-fail-assert-equal-type-nested.nix:1:26:
+            1| assert { ding = false; } == { ding = null; };
+             |                          ^
+            2| abort "unreachable"
 
        … where left hand side is
          at /pwd/lang/eval-fail-assert-equal-type-nested.nix:1:10:

--- a/tests/functional/lang/eval-fail-assert-nested-bool.err.exp
+++ b/tests/functional/lang/eval-fail-assert-nested-bool.err.exp
@@ -6,6 +6,10 @@ error:
             2|
 
        … while comparing attribute 'a'
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:1:39:
+            1| assert { a.b = [ { c.d = true; } ]; } == { a.b = [ { c.d = false; } ]; };
+             |                                       ^
+            2|
 
        … where left hand side is
          at /pwd/lang/eval-fail-assert-nested-bool.nix:1:10:
@@ -20,6 +24,10 @@ error:
             2|
 
        … while comparing attribute 'b'
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:1:39:
+            1| assert { a.b = [ { c.d = true; } ]; } == { a.b = [ { c.d = false; } ]; };
+             |                                       ^
+            2|
 
        … where left hand side is
          at /pwd/lang/eval-fail-assert-nested-bool.nix:1:10:
@@ -34,8 +42,16 @@ error:
             2|
 
        … while comparing list element 0
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:1:39:
+            1| assert { a.b = [ { c.d = true; } ]; } == { a.b = [ { c.d = false; } ]; };
+             |                                       ^
+            2|
 
        … while comparing attribute 'c'
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:1:39:
+            1| assert { a.b = [ { c.d = true; } ]; } == { a.b = [ { c.d = false; } ]; };
+             |                                       ^
+            2|
 
        … where left hand side is
          at /pwd/lang/eval-fail-assert-nested-bool.nix:1:20:
@@ -50,6 +66,10 @@ error:
             2|
 
        … while comparing attribute 'd'
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:1:39:
+            1| assert { a.b = [ { c.d = true; } ]; } == { a.b = [ { c.d = false; } ]; };
+             |                                       ^
+            2|
 
        … where left hand side is
          at /pwd/lang/eval-fail-assert-nested-bool.nix:1:20:

--- a/tests/functional/lang/eval-fail-derivation-name.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-name.err.exp
@@ -6,6 +6,13 @@ error:
              |       ^
      <number>|       drvPath = strict.drvPath;
 
+       … while selecting an attribute
+         at «nix-internal»/derivation-internal.nix:<number>:<number>:
+     <number>|     value = commonAttrs // {
+     <number>|       outPath = strict.${outputName};
+             |                 ^
+     <number>|       drvPath = strict.drvPath;
+
        … while calling the 'derivationStrict' builtin
          at «nix-internal»/derivation-internal.nix:<number>:<number>:
      <number>|

--- a/tests/functional/lang/eval-fail-derivation-stack-trace.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-stack-trace.err.exp
@@ -6,12 +6,12 @@ error:
              |       ^
            50|       drvPath = strict.drvPath;
 
-       … while calling the 'derivationStrict' builtin
-         at «nix-internal»/derivation-internal.nix:36:12:
-           35|
-           36|   strict = derivationStrict drvAttrs;
-             |            ^
-           37|
+       … while selecting an attribute
+         at «nix-internal»/derivation-internal.nix:49:17:
+           48|     value = commonAttrs // {
+           49|       outPath = strict.${outputName};
+             |                 ^
+           50|       drvPath = strict.drvPath;
 
        … while evaluating derivation 'test-5'
          whose name attribute is located at /pwd/lang/eval-fail-derivation-stack-trace.nix:12:9

--- a/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
@@ -6,6 +6,13 @@ error:
              |       ^
            50|       drvPath = strict.drvPath;
 
+       … while selecting an attribute
+         at «nix-internal»/derivation-internal.nix:49:17:
+           48|     value = commonAttrs // {
+           49|       outPath = strict.${outputName};
+             |                 ^
+           50|       drvPath = strict.drvPath;
+
        … while calling the 'derivationStrict' builtin
          at «nix-internal»/derivation-internal.nix:36:12:
            35|

--- a/tests/functional/lang/eval-fail-foldlPrime-4.err.exp
+++ b/tests/functional/lang/eval-fail-foldlPrime-4.err.exp
@@ -11,7 +11,7 @@ error:
              |                     ^
             2|
 
-       … in the left operand of the AND (&&) operator
+       … in the left operand of '&&'
          at /pwd/lang/eval-fail-foldlPrime-4.nix:1:26:
             1| builtins.foldl' (a: b: a && b) "foo" [ true ]
              |                          ^

--- a/tests/functional/lang/eval-fail-foldlPrime-4.err.exp
+++ b/tests/functional/lang/eval-fail-foldlPrime-4.err.exp
@@ -12,13 +12,13 @@ error:
             2|
 
        … in the left operand of '&&'
-         at /pwd/lang/eval-fail-foldlPrime-4.nix:1:26:
+         at /pwd/lang/eval-fail-foldlPrime-4.nix:1:24:
             1| builtins.foldl' (a: b: a && b) "foo" [ true ]
-             |                          ^
+             |                        ^
             2|
 
        error: expected a Boolean but found a string: "foo"
-       at /pwd/lang/eval-fail-foldlPrime-4.nix:1:26:
+       at /pwd/lang/eval-fail-foldlPrime-4.nix:1:24:
             1| builtins.foldl' (a: b: a && b) "foo" [ true ]
-             |                          ^
+             |                        ^
             2|

--- a/tests/functional/lang/eval-fail-not-throws.err.exp
+++ b/tests/functional/lang/eval-fail-not-throws.err.exp
@@ -1,5 +1,5 @@
 error:
-       … in the argument of the not operator
+       … in the argument of '!'
          at /pwd/lang/eval-fail-not-throws.nix:1:3:
             1| !(throw "uh oh!")
              |   ^

--- a/tests/functional/lang/eval-fail-operator-trace.err.exp
+++ b/tests/functional/lang/eval-fail-operator-trace.err.exp
@@ -1,0 +1,156 @@
+error:
+       … in the left operand of '->'
+         at /pwd/lang/eval-fail-operator-trace.nix:23:7:
+           22|   s = r || a;
+           23|   t = s -> a;
+             |       ^
+           24| in
+
+       … in the left operand of '||'
+         at /pwd/lang/eval-fail-operator-trace.nix:22:7:
+           21|   r = q && a;
+           22|   s = r || a;
+             |       ^
+           23|   t = s -> a;
+
+       … in the left operand of '&&'
+         at /pwd/lang/eval-fail-operator-trace.nix:21:7:
+           20|   q = p != 1;
+           21|   r = q && a;
+             |       ^
+           22|   s = r || a;
+
+       … in the left operand of '!='
+         at /pwd/lang/eval-fail-operator-trace.nix:20:7:
+           19|   p = o == 1;
+           20|   q = p != 1;
+             |       ^
+           21|   r = q && a;
+
+       … in the left operand of '=='
+         at /pwd/lang/eval-fail-operator-trace.nix:19:7:
+           18|   o = n >= 1;
+           19|   p = o == 1;
+             |       ^
+           20|   q = p != 1;
+
+       … in the argument of '!'
+         at /pwd/lang/eval-fail-operator-trace.nix:18:9:
+           17|   n = m > 1;
+           18|   o = n >= 1;
+             |         ^
+           19|   p = o == 1;
+
+       … while calling the 'lessThan' builtin
+         at /pwd/lang/eval-fail-operator-trace.nix:18:9:
+           17|   n = m > 1;
+           18|   o = n >= 1;
+             |         ^
+           19|   p = o == 1;
+
+       … while calling the 'lessThan' builtin
+         at /pwd/lang/eval-fail-operator-trace.nix:17:9:
+           16|   m = l <= 1;
+           17|   n = m > 1;
+             |         ^
+           18|   o = n >= 1;
+
+       … in the argument of '!'
+         at /pwd/lang/eval-fail-operator-trace.nix:16:9:
+           15|   l = k < 1;
+           16|   m = l <= 1;
+             |         ^
+           17|   n = m > 1;
+
+       … while calling the 'lessThan' builtin
+         at /pwd/lang/eval-fail-operator-trace.nix:16:9:
+           15|   l = k < 1;
+           16|   m = l <= 1;
+             |         ^
+           17|   n = m > 1;
+
+       … while calling the 'lessThan' builtin
+         at /pwd/lang/eval-fail-operator-trace.nix:15:9:
+           14|   k = j // { };
+           15|   l = k < 1;
+             |         ^
+           16|   m = l <= 1;
+
+       … in the left operand of '//'
+         at /pwd/lang/eval-fail-operator-trace.nix:14:7:
+           13|   j = !i;
+           14|   k = j // { };
+             |       ^
+           15|   l = k < 1;
+
+       … in the argument of '!'
+         at /pwd/lang/eval-fail-operator-trace.nix:13:8:
+           12|   i = h + 1;
+           13|   j = !i;
+             |        ^
+           14|   k = j // { };
+
+       … in an operand of '+'
+         at /pwd/lang/eval-fail-operator-trace.nix:12:7:
+           11|   h = g - 1;
+           12|   i = h + 1;
+             |       ^
+           13|   j = !i;
+
+       … while calling the 'sub' builtin
+         at /pwd/lang/eval-fail-operator-trace.nix:11:9:
+           10|   g = f / 1;
+           11|   h = g - 1;
+             |         ^
+           12|   i = h + 1;
+
+       … while calling the 'div' builtin
+         at /pwd/lang/eval-fail-operator-trace.nix:10:9:
+            9|   f = e * 1;
+           10|   g = f / 1;
+             |         ^
+           11|   h = g - 1;
+
+       … while calling the 'mul' builtin
+         at /pwd/lang/eval-fail-operator-trace.nix:9:9:
+            8|   e = d ++ [ ];
+            9|   f = e * 1;
+             |         ^
+           10|   g = f / 1;
+
+       … in the left operand of '++'
+         at /pwd/lang/eval-fail-operator-trace.nix:8:7:
+            7|   d = c ? y;
+            8|   e = d ++ [ ];
+             |       ^
+            9|   f = e * 1;
+
+       … in the argument of '?'
+         at /pwd/lang/eval-fail-operator-trace.nix:7:7:
+            6|   c = -b;
+            7|   d = c ? y;
+             |       ^
+            8|   e = d ++ [ ];
+
+       … while calling the 'sub' builtin
+         at /pwd/lang/eval-fail-operator-trace.nix:6:7:
+            5|   b = a.x;
+            6|   c = -b;
+             |       ^
+            7|   d = c ? y;
+
+       … while selecting an attribute
+         at /pwd/lang/eval-fail-operator-trace.nix:5:7:
+            4|   a = throw "kaboom";
+            5|   b = a.x;
+             |       ^
+            6|   c = -b;
+
+       … while calling the 'throw' builtin
+         at /pwd/lang/eval-fail-operator-trace.nix:4:7:
+            3| let
+            4|   a = throw "kaboom";
+             |       ^
+            5|   b = a.x;
+
+       error: kaboom

--- a/tests/functional/lang/eval-fail-operator-trace.nix
+++ b/tests/functional/lang/eval-fail-operator-trace.nix
@@ -1,0 +1,25 @@
+# Test that every operator gets a stack frame, even if it's been mangled to a
+# builtins call.
+let
+  a = throw "kaboom";
+  b = a.x;
+  c = -b;
+  d = c ? y;
+  e = d ++ [ ];
+  f = e * 1;
+  g = f / 1;
+  h = g - 1;
+  i = h + 1;
+  j = !i;
+  k = j // { };
+  l = k < 1;
+  m = l <= 1;
+  n = m > 1;
+  o = n >= 1;
+  p = o == 1;
+  q = p != 1;
+  r = q && a;
+  s = r || a;
+  t = s -> a;
+in
+t

--- a/tests/functional/lang/eval-fail-recursion.err.exp
+++ b/tests/functional/lang/eval-fail-recursion.err.exp
@@ -1,7 +1,7 @@
 error:
        … entering the infinite recursion
 
-       … in the right operand of the update (//) operator
+       … in the right operand of '//'
          at /pwd/lang/eval-fail-recursion.nix:2:14:
             1| let
             2|   a = { } // a;

--- a/tests/functional/lang/eval-fail-recursion.err.exp
+++ b/tests/functional/lang/eval-fail-recursion.err.exp
@@ -1,4 +1,11 @@
 error:
+       … while selecting an attribute
+         at /pwd/lang/eval-fail-recursion.nix:4:1:
+            3| in
+            4| a.foo
+             | ^
+            5|
+
        … entering the infinite recursion
 
        … in the right operand of '//'

--- a/tests/functional/lang/eval-fail-scope-5.err.exp
+++ b/tests/functional/lang/eval-fail-scope-5.err.exp
@@ -26,6 +26,13 @@ error:
              |     ^
             8|       x ? y,
 
+       … in an operand of '+'
+         at /pwd/lang/eval-fail-scope-5.nix:11:5:
+           10|     }:
+           11|     x + y;
+             |     ^
+           12|
+
        … entering the infinite recursion
 
        error: infinite recursion encountered

--- a/tests/functional/lang/eval-fail-sort-5.err.exp
+++ b/tests/functional/lang/eval-fail-sort-5.err.exp
@@ -11,7 +11,7 @@ error:
              |                   ^
             2|   "foo"
 
-       … in the argument of the not operator
+       … in the argument of '!'
          at /pwd/lang/eval-fail-sort-5.nix:1:24:
             1| builtins.sort (a: b: a <= b) [
              |                        ^

--- a/tests/functional/lang/eval-fail-sort-6.err.exp
+++ b/tests/functional/lang/eval-fail-sort-6.err.exp
@@ -11,7 +11,7 @@ error:
              |                   ^
             2|   { }
 
-       … in the argument of the not operator
+       … in the argument of '!'
          at /pwd/lang/eval-fail-sort-6.nix:1:24:
             1| builtins.sort (a: b: a <= b) [
              |                        ^


### PR DESCRIPTION
Ensure that every operator in the language (except for the ones that desugar to builtins) gets a stack trace entry that correctly points to the operand with the evaluation error.

## Motivation

Here is the change as illustrated by the [new test](https://github.com/NixOS/nix/compare/master...rhendric:rhendric/trace-operators?expand=1#diff-05e67e8c0b6130d941dd6b6bc234e6d04ebbe34a5cc6ae89d5dcf058525b23e0).

```diff
@@ -1,25 +1,39 @@
 error:
        … in the left operand of the IMPL (->) operator
-         at /pwd/lang/eval-fail-operator-trace.nix:23:9:
+         at /pwd/lang/eval-fail-operator-trace.nix:23:7:
            22|   s = r || a;
            23|   t = s -> a;
-             |         ^
+             |       ^
            24| in
 
        … in the left operand of the OR (||) operator
-         at /pwd/lang/eval-fail-operator-trace.nix:22:9:
+         at /pwd/lang/eval-fail-operator-trace.nix:22:7:
            21|   r = q && a;
            22|   s = r || a;
-             |         ^
+             |       ^
            23|   t = s -> a;
 
        … in the left operand of the AND (&&) operator
-         at /pwd/lang/eval-fail-operator-trace.nix:21:9:
+         at /pwd/lang/eval-fail-operator-trace.nix:21:7:
            20|   q = p != 1;
            21|   r = q && a;
-             |         ^
+             |       ^
            22|   s = r || a;
 
+       … in the left operand of the NEQ (!=) operator
+         at /pwd/lang/eval-fail-operator-trace.nix:20:7:
+           19|   p = o == 1;
+           20|   q = p != 1;
+             |       ^
+           21|   r = q && a;
+
+       … in the left operand of the EQ (==) operator
+         at /pwd/lang/eval-fail-operator-trace.nix:19:7:
+           18|   o = n >= 1;
+           19|   p = o == 1;
+             |       ^
+           20|   q = p != 1;
+
        … in the argument of the not operator
          at /pwd/lang/eval-fail-operator-trace.nix:18:9:
            17|   n = m > 1;
@@ -76,6 +90,13 @@
              |        ^
            14|   k = j // { };
 
+       … in an operand of the add/concat (+) operator
+         at /pwd/lang/eval-fail-operator-trace.nix:12:7:
+           11|   h = g - 1;
+           12|   i = h + 1;
+             |       ^
+           13|   j = !i;
+
        … while calling the 'sub' builtin
          at /pwd/lang/eval-fail-operator-trace.nix:11:9:
            10|   g = f / 1;
@@ -97,6 +118,20 @@
              |         ^
            10|   g = f / 1;
 
+       … in the left operand of the list concat (++) operator
+         at /pwd/lang/eval-fail-operator-trace.nix:8:7:
+            7|   d = c ? y;
+            8|   e = d ++ [ ];
+             |       ^
+            9|   f = e * 1;
+
+       … in the argument of the has-attribute (?) operator
+         at /pwd/lang/eval-fail-operator-trace.nix:7:7:
+            6|   c = -b;
+            7|   d = c ? y;
+             |       ^
+            8|   e = d ++ [ ];
+
        … while calling the 'sub' builtin
          at /pwd/lang/eval-fail-operator-trace.nix:6:7:
             5|   b = a.x;
@@ -104,6 +139,13 @@
              |       ^
             7|   d = c ? y;
 
+       … while selecting an attribute
+         at /pwd/lang/eval-fail-operator-trace.nix:5:7:
+            4|   a = throw "kaboom";
+            5|   b = a.x;
+             |       ^
+            6|   c = -b;
+
        … while calling the 'throw' builtin
          at /pwd/lang/eval-fail-operator-trace.nix:4:7:
             3| let

```

## Context

The only moderately invasive change here is removing the `PosIdx` argument from `evalBool` and `evalAttrs`; it was generally being filled with the position of the enclosing expression, which is not as useful as the position of the operand being evaluated — provided, of course, that said expression has a non-`noPos` position. It's possible that this regresses the trace for some edge case, if an operand expression might have `noPos` as its position. I don't know how concerned I should be about this; if we really want, I could restore the argument and use `(pos2 = getPos()) == noPos ? pos : pos2` as the position, to get the best of both worlds.

Somewhat suboptimal: the `add/concat (+) operator` language also applies to string interpolation.

```
$ nix-instantiate --eval --expr '"string ${throw "kaboom"} interpolation"'
error:
       … in an operand of the add/concat (+) operator
         at «string»:1:11:
            1| "string ${throw "kaboom"} interpolation"
             |           ^

       … while calling the 'throw' builtin
         at «string»:1:11:
            1| "string ${throw "kaboom"} interpolation"
             |           ^

       error: kaboom
```

This could be fixed with a flag on `ExprConcatStrings` (or by adapting the existing `forceStrings` flag from a `bool` to an enum) if we care.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
