### PR TITLE
libutil: Test and fix bugs in movePath, delete moveFile

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1335,7 +1335,22 @@ StorePath LocalStore::addToStoreFromDump(
                 }
             } else {
                 /* Move the temporary path we restored above. */
-                moveFile(tempPath, realPath);
+                try {
+                    renameFile(tempPath, realPath);
+                } catch (const SystemError & e) {
+                    if (!e.is(std::errc::cross_device_link))
+                        throw;
+
+                    /* Apparently this can happen even on the same filesystem (and the paths that are renamed above
+                       are on the same filesystem) with overlayfs https://github.com/NixOS/nix/issues/6262.
+                       Since we couldn't rename, this won't be atomic and we have to gradually copy to the realPath.
+                       Note that copyRecursive doesn't copy over permissions, but those will be canonicalised below. */
+                    warn("can't rename %s as %s, copying instead", PathFmt(tempPath), PathFmt(realPath));
+                    RestoreSink copySink{/*startFsync=*/false};
+                    copySink.dstPath = realPath;
+                    copyRecursive(*makeFSSourceAccessor(tempPath), CanonPath::root, copySink, CanonPath::root);
+                    delTempDir->deletePath();
+                }
             }
 
             /* For computing the nar hash. In recursive SHA-256 mode, this

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -253,24 +253,6 @@ SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()
     return builtOutputs;
 }
 
-/* Move/rename path 'src' to 'dst'. Temporarily make 'src' writable if
-   it's a directory and we're not root (to be able to update the
-   directory's parent link ".."). */
-static void movePath(const std::filesystem::path & src, const std::filesystem::path & dst)
-{
-    auto st = lstat(src);
-
-    bool changePerm = (geteuid() && S_ISDIR(st.st_mode) && !(st.st_mode & S_IWUSR));
-
-    if (changePerm)
-        chmod(src, st.st_mode | S_IWUSR);
-
-    std::filesystem::rename(src, dst);
-
-    if (changePerm)
-        chmod(dst, st.st_mode);
-}
-
 static void replaceValidPath(const std::filesystem::path & storePath, const std::filesystem::path & tmpPath)
 {
     /* We can't atomically replace storePath (the original) with

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -413,6 +413,28 @@ TEST_F(MovePathTest, nonWritableDirectories)
     ASSERT_EQ(lstat(dstDir).st_mode & 0777, 0500);
 }
 
+TEST_F(MovePathTest, symlinkReplacesSymlink)
+{
+    auto srcLink = tmpDir / "link";
+    auto dstLink = tmpDir / "dst";
+    createSymlink("dangling", srcLink);
+    createSymlink("other", dstLink);
+
+    movePath(srcLink, dstLink);
+    ASSERT_EQ(readLink(dstLink), "dangling");
+}
+
+TEST_F(MovePathTest, symlinkReplacesRegular)
+{
+    auto srcLink = tmpDir / "link";
+    auto dst = tmpDir / "dst";
+    createSymlink("hello", srcLink);
+    writeFile(dst, "test");
+
+    movePath(srcLink, dst);
+    ASSERT_EQ(readLink(dst), "hello");
+}
+
 #endif
 
 } // namespace nix

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -408,10 +408,9 @@ TEST_F(MovePathTest, nonWritableDirectories)
     ASSERT_FALSE(pathExists(srcDir));
     ASSERT_EQ(lstat(dstDir).st_mode & 0777, 0500);
 
-    // Buggy behavior. We don't restore permissions on rename errors.
     ASSERT_THROW(movePath(dstDir, tmpDir / "nonexistent" / "dir"), SysError);
-    // FIXME: Should be the old 0500 permissions and not remain writable.
-    ASSERT_EQ(lstat(dstDir).st_mode & 0777, 0700);
+    // Permissions are restored on rename errors.
+    ASSERT_EQ(lstat(dstDir).st_mode & 0777, 0500);
 }
 
 #endif

--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 #include <rapidcheck/gtest.h>
 
+#include <ranges>
+
 #ifdef _WIN32
 #  define FS_SEP L"\\"
 #  define FS_ROOT_NO_TRAILING_SLASH L"C:" // Need a mounted one, C drive is likely
@@ -346,5 +348,72 @@ TEST(createTempDir, works)
     nix::AutoDelete delTmpDir(tmpDir, /*recursive=*/true);
     ASSERT_TRUE(std::filesystem::is_directory(tmpDir));
 }
+
+/* ----------------------------------------------------------------------------
+ * movePath
+ * --------------------------------------------------------------------------*/
+
+class MovePathTest : public ::testing::Test
+{
+protected:
+    std::filesystem::path tmpDir;
+    nix::AutoDelete delTmpDir;
+
+private:
+    void SetUp() override
+    {
+        tmpDir = createTempDir();
+        delTmpDir = {tmpDir, /*recursive=*/true};
+    }
+
+    void TearDown() override
+    {
+        delTmpDir.deletePath();
+    }
+};
+
+TEST_F(MovePathTest, works)
+{
+    auto regSrc = tmpDir / OS_STR("reg1");
+    auto regAnother = tmpDir / OS_STR("reg2");
+    writeFile(regSrc, "hello1");
+    writeFile(regAnother, "hello2");
+    // Overwrite existing.
+    movePath(regAnother, regSrc);
+
+    auto dirSrc = tmpDir / OS_STR("dir");
+    createDir(dirSrc);
+    writeFile(dirSrc / OS_STR("reg"), "hello3");
+    auto dst = tmpDir / OS_STR("renamed");
+    movePath(regSrc, dst);
+    ASSERT_FALSE(pathExists(regSrc));
+    ASSERT_EQ(readFile(dst), "hello2");
+
+    // Non-empty directory can't replace a regular file.
+    unlink(dst);
+    movePath(dirSrc, dst);
+    auto files = std::ranges::to<std::vector<std::filesystem::path>>(DirectoryIterator{dst});
+    ASSERT_EQ(files, std::vector{dst / OS_STR("reg")});
+}
+
+#ifndef _WIN32
+
+TEST_F(MovePathTest, nonWritableDirectories)
+{
+    // Non-writable source directory.
+    auto srcDir = tmpDir / "src";
+    auto dstDir = tmpDir / "dst";
+    createDir(srcDir, 0500);
+    movePath(srcDir, dstDir);
+    ASSERT_FALSE(pathExists(srcDir));
+    ASSERT_EQ(lstat(dstDir).st_mode & 0777, 0500);
+
+    // Buggy behavior. We don't restore permissions on rename errors.
+    ASSERT_THROW(movePath(dstDir, tmpDir / "nonexistent" / "dir"), SysError);
+    // FIXME: Should be the old 0500 permissions and not remain writable.
+    ASSERT_EQ(lstat(dstDir).st_mode & 0777, 0700);
+}
+
+#endif
 
 } // namespace nix

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -378,19 +378,6 @@ void recursiveSync(const std::filesystem::path & path)
     }
 }
 
-void createDir(const std::filesystem::path & path, mode_t mode)
-{
-    if (mkdir(
-            path.string().c_str()
-#ifndef _WIN32
-                ,
-            mode
-#endif
-            )
-        == -1)
-        throw SysError("creating directory %s", PathFmt(path));
-}
-
 void createDirs(const std::filesystem::path & path)
 {
     try {

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -613,28 +613,6 @@ void copyFile(const std::filesystem::path & from, const std::filesystem::path & 
     }
 }
 
-void moveFile(const std::filesystem::path & oldName, const std::filesystem::path & newName)
-{
-    try {
-        std::filesystem::rename(oldName, newName);
-    } catch (std::filesystem::filesystem_error & e) {
-        auto oldPath = oldName;
-        auto newPath = newName;
-        // For the move to be as atomic as possible, copy to a temporary
-        // directory
-        std::filesystem::path temp = createTempDir(os_string_to_string(PathView{newPath.parent_path()}), "rename-tmp");
-        Finally removeTemp = [&]() { std::filesystem::remove(temp); };
-        auto tempCopyTarget = temp / "copy-target";
-        if (e.code().value() == EXDEV) {
-            std::filesystem::remove(newPath);
-            warn("can’t rename %s as %s, copying instead", PathFmt(oldName), PathFmt(newName));
-            copyFile(oldPath, tempCopyTarget, true);
-            std::filesystem::rename(
-                os_string_to_string(PathView{tempCopyTarget}), os_string_to_string(PathView{newPath}));
-        }
-    }
-}
-
 //////////////////////////////////////////////////////////////////////
 
 bool isExecutableFileAmbient(const std::filesystem::path & exe)

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -328,19 +328,11 @@ void createSymlink(const std::filesystem::path & target, const std::filesystem::
 void replaceSymlink(const std::filesystem::path & target, const std::filesystem::path & link);
 
 /**
- * Similar to 'renameFile', but fallback to a copy+remove if `src` and `dst`
- * are on a different filesystem.
- *
- * Beware that this might not be atomic because of the copy that happens behind
- * the scenes
- */
-void moveFile(const std::filesystem::path & src, const std::filesystem::path & dst);
-
-/**
  * Recursively copy the content of `oldPath` to `newPath`. If `andDelete` is
- * `true`, then also remove `oldPath` (making this equivalent to `moveFile`, but
- * with the guaranty that the destination will be “fresh”, with no stale inode
- * or file descriptor pointing to it).
+ * `true`, then also remove `oldPath`.
+ *
+ * @todo Delete this. This function is prone to TOCTOU races and follows
+ * symlinks in the destination.
  *
  * If contents is set, always create a regular file, even if the source is a
  * link.
@@ -544,6 +536,14 @@ void tryUnlink(const std::filesystem::path & path);
  * dst is a symlink.
  */
 void movePath(const std::filesystem::path & src, const std::filesystem::path & dst);
+
+/**
+ * @brief Thin wrapper around ::rename that throws SystemError on errors.
+ *
+ * Unlike @ref nix::movePath(), doesn't attempt to make the source writable if
+ * it's a directory.
+ */
+void renameFile(const std::filesystem::path & src, const std::filesystem::path & dst);
 
 /**
  * @brief A directory iterator that can be used to iterate over the

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -535,6 +535,17 @@ void unlinkIfExists(const std::filesystem::path & path);
 void tryUnlink(const std::filesystem::path & path);
 
 /**
+ * @brief Move/rename path 'src' to 'dst'.
+ *
+ * Temporarily makes 'src' writable if it's a directory and we're not root (to
+ * be able to update the directory's parent link "..").
+ *
+ * Atomically replaces the destination if it exists. Does not follow symlinks if
+ * dst is a symlink.
+ */
+void movePath(const std::filesystem::path & src, const std::filesystem::path & dst);
+
+/**
  * @brief A directory iterator that can be used to iterate over the
  * contents of a directory. It is similar to std::filesystem::directory_iterator
  * but throws NixError on failure instead of std::filesystem::filesystem_error.

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -297,4 +297,21 @@ void chown(const std::filesystem::path & path, uid_t owner, gid_t group)
         throw SysError("changing ownership of %s", PathFmt(path));
 }
 
+void movePath(const std::filesystem::path & src, const std::filesystem::path & dst)
+{
+    const PosixStat st = nix::lstat(src);
+
+    bool changePerm = (::geteuid() && S_ISDIR(st.st_mode) && !(st.st_mode & S_IWUSR));
+    if (changePerm)
+        /* TODO: Can we do this fchmod to avoid TOCTOU? */
+        nix::chmod(src, st.st_mode | S_IWUSR);
+
+    if (::rename(src.c_str(), dst.c_str()) == -1)
+        /* FIXME: Revert write permissions on error path if changePerm. */
+        throw SysError("renaming %1% to %2%", PathFmt(src), PathFmt(dst));
+
+    if (changePerm)
+        nix::chmod(dst, st.st_mode);
+}
+
 } // namespace nix

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -363,6 +363,12 @@ void movePath(const std::filesystem::path & src, const std::filesystem::path & d
     }
 }
 
+void renameFile(const std::filesystem::path & src, const std::filesystem::path & dst)
+{
+    if (::rename(src.c_str(), dst.c_str()) == -1)
+        throw SysError("renaming %1% to %2%", PathFmt(src), PathFmt(dst));
+}
+
 void createDir(const std::filesystem::path & path, mode_t mode)
 {
     if (::mkdir(path.c_str(), mode) == -1)

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -314,4 +314,10 @@ void movePath(const std::filesystem::path & src, const std::filesystem::path & d
         nix::chmod(dst, st.st_mode);
 }
 
+void createDir(const std::filesystem::path & path, mode_t mode)
+{
+    if (::mkdir(path.c_str(), mode) == -1)
+        throw SysError("creating directory %s", PathFmt(path));
+}
+
 } // namespace nix

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -306,9 +306,14 @@ void movePath(const std::filesystem::path & src, const std::filesystem::path & d
         /* TODO: Can we do this fchmod to avoid TOCTOU? */
         nix::chmod(src, st.st_mode | S_IWUSR);
 
-    if (::rename(src.c_str(), dst.c_str()) == -1)
-        /* FIXME: Revert write permissions on error path if changePerm. */
-        throw SysError("renaming %1% to %2%", PathFmt(src), PathFmt(dst));
+    if (::rename(src.c_str(), dst.c_str()) == -1) {
+        const int savedErrno = errno;
+        if (changePerm)
+            /* Ignore all errors on restoring permissions. We want to throw the
+               original error originating from ::rename. */
+            ::chmod(src.c_str(), st.st_mode);
+        throw SysError(savedErrno, "renaming %1% to %2%", PathFmt(src), PathFmt(dst));
+    }
 
     if (changePerm)
         nix::chmod(dst, st.st_mode);

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -299,24 +299,68 @@ void chown(const std::filesystem::path & path, uid_t owner, gid_t group)
 
 void movePath(const std::filesystem::path & src, const std::filesystem::path & dst)
 {
+    /* If we have O_PATH (Linux, FreeBSD), then we can open the to-be-renamed
+       file without requiring any permissions and "pin" the inode that we'll
+       fchmod. This avoids operating on paths, which is prone to TOCTOU. */
+#ifdef O_PATH
+    AutoCloseFD fd = ::open(src.c_str(), O_NOFOLLOW | O_CLOEXEC | O_PATH);
+    if (!fd)
+        throw SysError("failed to open file %1%", PathFmt(src));
+
+    auto changePermsOnFile = [&](mode_t newMode) -> int {
+        /* AT_EMPTY_PATH here is supported since 6.6, but reports EINVAL without fchmodat2. */
+        if (::fchmodat(fd.get(), "", newMode, AT_EMPTY_PATH) == 0)
+            return 0;
+
+#  ifdef __linux__
+        if (errno == EINVAL) {
+            auto path = fmt("/proc/self/fd/%d", fd.get());
+            if (::chmod(path.c_str(), newMode) == 0)
+                return 0;
+        }
+#  endif
+
+        return -1;
+    };
+
+    const PosixStat st = nix::fstat(fd.get());
+#else
     const PosixStat st = nix::lstat(src);
+#endif
 
     bool changePerm = (::geteuid() && S_ISDIR(st.st_mode) && !(st.st_mode & S_IWUSR));
-    if (changePerm)
-        /* TODO: Can we do this fchmod to avoid TOCTOU? */
-        nix::chmod(src, st.st_mode | S_IWUSR);
+    if (changePerm) {
+        const mode_t newMode = st.st_mode | S_IWUSR;
+#ifdef O_PATH
+        if (changePermsOnFile(newMode) == -1)
+            throw SysError("making %s writable for renaming", PathFmt(src));
+#else
+        nix::chmod(src, newMode);
+#endif
+    }
 
     if (::rename(src.c_str(), dst.c_str()) == -1) {
         const int savedErrno = errno;
-        if (changePerm)
+        if (changePerm) {
             /* Ignore all errors on restoring permissions. We want to throw the
                original error originating from ::rename. */
+#ifdef O_PATH
+            changePermsOnFile(st.st_mode);
+#else
             ::chmod(src.c_str(), st.st_mode);
+#endif
+        }
         throw SysError(savedErrno, "renaming %1% to %2%", PathFmt(src), PathFmt(dst));
     }
 
-    if (changePerm)
+    if (changePerm) {
+#ifdef O_PATH
+        if (changePermsOnFile(st.st_mode) == -1)
+            throw SysError("restoring permissions on %s", PathFmt(dst));
+#else
         nix::chmod(dst, st.st_mode);
+#endif
+    }
 }
 
 void createDir(const std::filesystem::path & path, mode_t mode)

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -195,6 +195,11 @@ std::optional<PosixStat> maybeLstat(const std::filesystem::path & path)
 
 void movePath(const std::filesystem::path & src, const std::filesystem::path & dst)
 {
+    renameFile(src, dst);
+}
+
+void renameFile(const std::filesystem::path & src, const std::filesystem::path & dst)
+{
     /* TODO: FileRenameInformationEx with FILE_RENAME_POSIX_SEMANTICS? */
     if (!::MoveFileExW(src.c_str(), dst.c_str(), MOVEFILE_REPLACE_EXISTING))
         throw windows::WinError("renaming %1% to %2%", PathFmt(src), PathFmt(dst));

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -200,4 +200,10 @@ void movePath(const std::filesystem::path & src, const std::filesystem::path & d
         throw windows::WinError("renaming %1% to %2%", PathFmt(src), PathFmt(dst));
 }
 
+void createDir(const std::filesystem::path & path, [[maybe_unused]] mode_t mode)
+{
+    if (!::CreateDirectoryW(path.c_str(), nullptr))
+        throw windows::WinError("creating directory %s", PathFmt(path));
+}
+
 } // namespace nix

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -193,4 +193,11 @@ std::optional<PosixStat> maybeLstat(const std::filesystem::path & path)
     return statFromFileInfo(attrData);
 }
 
+void movePath(const std::filesystem::path & src, const std::filesystem::path & dst)
+{
+    /* TODO: FileRenameInformationEx with FILE_RENAME_POSIX_SEMANTICS? */
+    if (!::MoveFileExW(src.c_str(), dst.c_str(), MOVEFILE_REPLACE_EXISTING))
+        throw windows::WinError("renaming %1% to %2%", PathFmt(src), PathFmt(dst));
+}
+
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I suggest going through commit-by-commit.

Overarching goals:

- Move towards deleting copyFile for good. So that we don't have accidental symlink following and TOCTOU issues.
- Split out windows/posix cases fully so that we don't do pointless conversions std::fs::path -> string when not needed.
- Test more things and surface more bugs.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
