### PR TITLE
libcmd: pass AutoCall explicitly to getCursors()

### DIFF
--- a/src/libcmd/include/nix/cmd/installable-flake.hh
+++ b/src/libcmd/include/nix/cmd/installable-flake.hh
@@ -66,7 +66,7 @@ struct InstallableFlake : InstallableValue
      * Get a cursor to every attrpath in getActualAttrPaths() that
      * exists. However if none exists, throw an exception.
      */
-    std::vector<ref<eval_cache::AttrCursor>> getCursors(EvalState & state) override;
+    std::vector<ref<eval_cache::AttrCursor>> getCursors(EvalState & state, AutoCall autoCall) override;
 
     ref<flake::LockedFlake> getLockedFlake() const;
 

--- a/src/libcmd/include/nix/cmd/installable-value.hh
+++ b/src/libcmd/include/nix/cmd/installable-value.hh
@@ -102,14 +102,18 @@ struct InstallableValue : Installable
      * However if none exists, throw exception instead of returning
      * empty vector.
      */
-    virtual std::vector<ref<eval_cache::AttrCursor>> getCursors(EvalState & state);
+    virtual std::vector<ref<eval_cache::AttrCursor>> getCursors(EvalState & state, AutoCall autoCall);
 
     /**
      * Get the first and most preferred cursor this Installable could
      * refer to, or throw an exception if none exists.
      */
-    virtual ref<eval_cache::AttrCursor> getCursor(EvalState & state);
+    virtual ref<eval_cache::AttrCursor> getCursor(EvalState & state, AutoCall autoCall);
 
+    /**
+     * Get the app this Installable refers to. Implies `AutoCall::Yes`,
+     * since an app has to be a package or an app definition.
+     */
     UnresolvedApp toApp(EvalState & state);
 
     static InstallableValue & require(Installable & installable);

--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -69,7 +69,7 @@ DerivedPathsWithInfo InstallableFlake::toDerivedPaths()
 {
     Activity act(*logger, lvlTalkative, actUnknown, fmt("evaluating derivation '%s'", what()));
 
-    auto attr = getCursor(*state);
+    auto attr = getCursor(*state, AutoCall::No);
 
     auto attrPath = attr->getAttrPathStr();
 
@@ -141,12 +141,12 @@ DerivedPathsWithInfo InstallableFlake::toDerivedPaths()
     }};
 }
 
-std::pair<Value *, PosIdx> InstallableFlake::toValue(EvalState & state, AutoCall)
+std::pair<Value *, PosIdx> InstallableFlake::toValue(EvalState & state, AutoCall autoCall)
 {
-    return {&getCursor(state)->forceValue(), noPos};
+    return {&getCursor(state, autoCall)->forceValue(), noPos};
 }
 
-std::vector<ref<eval_cache::AttrCursor>> InstallableFlake::getCursors(EvalState & state)
+std::vector<ref<eval_cache::AttrCursor>> InstallableFlake::getCursors(EvalState & state, AutoCall)
 {
     auto evalCache = openEvalCache(state, getLockedFlake());
 

--- a/src/libcmd/installable-value.cc
+++ b/src/libcmd/installable-value.cc
@@ -4,18 +4,18 @@
 
 namespace nix {
 
-std::vector<ref<eval_cache::AttrCursor>> InstallableValue::getCursors(EvalState & state)
+std::vector<ref<eval_cache::AttrCursor>> InstallableValue::getCursors(EvalState & state, AutoCall autoCall)
 {
     auto evalCache = std::make_shared<nix::eval_cache::EvalCache>(
-        std::nullopt, state, [&]() { return toValue(state, AutoCall::Yes).first; });
+        std::nullopt, state, [&, autoCall]() { return toValue(state, autoCall).first; });
     return {evalCache->getRoot()};
 }
 
-ref<eval_cache::AttrCursor> InstallableValue::getCursor(EvalState & state)
+ref<eval_cache::AttrCursor> InstallableValue::getCursor(EvalState & state, AutoCall autoCall)
 {
     /* Although getCursors should return at least one element, in case it doesn't,
        bound check to avoid an undefined behavior for vector[0] */
-    return getCursors(state).at(0);
+    return getCursors(state, autoCall).at(0);
 }
 
 static UsageError nonValueInstallable(Installable & installable)

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -53,7 +53,7 @@ resolveString(Store & store, const std::string & toResolve, const std::vector<Bu
 
 UnresolvedApp InstallableValue::toApp(EvalState & state)
 {
-    auto cursor = getCursor(state);
+    auto cursor = getCursor(state, AutoCall::Yes);
     auto attrPath = cursor->getAttrPath();
 
     auto type = cursor->getAttr("type")->getString();

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -921,7 +921,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
             defaultTemplateAttrPathsPrefixes,
             lockFlags);
 
-        auto cursor = installable.getCursor(*evalState);
+        auto cursor = installable.getCursor(*evalState, AutoCall::No);
 
         auto templateDirAttr = cursor->getAttr("path")->forceValue();
         NixStringContext context;

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -186,7 +186,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
             }
         };
 
-        for (auto & cursor : installable->getCursors(*state))
+        for (auto & cursor : installable->getCursors(*state, AutoCall::Yes))
             visit(*cursor, cursor->getAttrPath(), true);
 
         if (json)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

autocall becomes an explicit parameter of `toValue` in #15895.
this follow up PR adds the same for `getCursors`, so that autocall behavior can be specified by each cli tool independently.

## Context

<!-- Provide context. Reference open issues if available. -->

https://github.com/NixOS/nix/pull/15895#discussion_r3789575588

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Assisted-by: pi (claude-opus-5)

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
