### PR TITLE
libutil: link `ntdll` on Windows

### DIFF
--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -64,7 +64,10 @@ subdir('nix-meson-build-support/libatomic')
 
 if host_machine.system() == 'windows'
   socket = cxx.find_library('ws2_32')
-  deps_other += socket
+  # `NtCreateFile` and `RtlNtStatusToDosError`, used by the `*at`-style file
+  # system functions in `windows/file-system-at.cc`, live here.
+  nt = cxx.find_library('ntdll')
+  deps_other += [ socket, nt ]
 elif host_machine.system() == 'sunos'
   socket = cxx.find_library('socket')
   network_service_library = cxx.find_library('nsl')
@@ -251,7 +254,7 @@ libraries_private = []
 if host_machine.system() == 'windows'
   # `libraries_private` cannot contain ad-hoc dependencies (from
   # `find_library), so we need to do this manually
-  libraries_private += [ '-lws2_32' ]
+  libraries_private += [ '-lws2_32', '-lntdll' ]
 endif
 
 subdir('nix-meson-build-support/export')


### PR DESCRIPTION
`windows/file-system-at.cc` calls `NtCreateFile` and `RtlNtStatusToDosError`, which live in `ntdll`, but nothing asked for that library.

It only happened to link anyway with the GCC from Nixpkgs, because that one was configured with `--enable-threads=mcf`, whose spec appends `-lmcfgthread -lkernel32 -lntdll` for the sake of mcfgthreads. A toolchain that does not do that fails with undefined references to both symbols.

Now we make sure to link it, and put it in the *.pc files. This follows the precedent set with `ws2_32`.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
