### PR TITLE
chore(libexpr): make no-show-trace say "stack trace filtered"

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -414,7 +414,7 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
         if (truncate) {
             oss << "\n"
                 << ANSI_WARNING
-                "(stack trace truncated; use '--show-trace' to show the full, detailed trace)" ANSI_NORMAL
+                "(stack trace filtered; use '--show-trace' to show the full, detailed trace)" ANSI_NORMAL
                 << "\n";
         }
 

--- a/tests/functional/lang/eval-fail-addErrorContext-example.err.exp
+++ b/tests/functional/lang/eval-fail-addErrorContext-example.err.exp
@@ -19,6 +19,6 @@ error:
 
        … while counting down; n = 1
 
-       (stack trace truncated; use '--show-trace' to show the full, detailed trace)
+       (stack trace filtered; use '--show-trace' to show the full, detailed trace)
 
        error: kaboom

--- a/tests/functional/lang/eval-fail-derivation-stack-trace.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-stack-trace.err.exp
@@ -28,6 +28,6 @@ error:
        … while evaluating derivation 'test-1'
          whose name attribute is located at /pwd/lang/eval-fail-derivation-stack-trace.nix:12:9
 
-       (stack trace truncated; use '--show-trace' to show the full, detailed trace)
+       (stack trace filtered; use '--show-trace' to show the full, detailed trace)
 
        error: kaboom


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

It's not truncation since we've been adding Always frames. When that was just addErrorContext, we got away with the lie, but now that derivations are kept too, we really need to describe it accurately.

## Context

- First non-truncation https://github.com/NixOS/nix/pull/10305
- Significant increase https://github.com/NixOS/nix/pull/16282
- Discovered by diagnosing my initial confusion checking https://github.com/NixOS/nix/pull/16301#discussion_r3791253888

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
