### PR TITLE
refactor: perfect-forward remaining error ctors

### DIFF
--- a/src/libexpr/include/nix/expr/value/context.hh
+++ b/src/libexpr/include/nix/expr/value/context.hh
@@ -17,11 +17,11 @@ public:
     std::string_view raw;
 
     template<typename... Args>
-    BadNixStringContextElem(std::string_view raw_, const Args &... args)
+    BadNixStringContextElem(std::string_view raw_, Args &&... args)
         : CloneableError("")
     {
         raw = raw_;
-        auto hf = HintFmt(args...);
+        auto hf = HintFmt(std::forward<Args>(args)...);
         err.msg = HintFmt("Bad String Context element: %1%: %2%", Uncolored(hf.str()), raw);
     }
 };

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -1446,20 +1446,16 @@ void FileTransfer::download(
 void FileTransferError::anchor() {}
 
 template<typename... Args>
-FileTransferError::FileTransferError(
-    FileTransfer::Error error, std::optional<std::string> response, const Args &... args)
-    : CloneableError(args...)
+FileTransferError::FileTransferError(FileTransfer::Error error, std::optional<std::string> response, Args &&... args)
+    : CloneableError(HintFmt(std::forward<Args>(args)...))
     , error(error)
     , response(response)
 {
-    const auto hf = HintFmt(args...);
     // FIXME: Due to https://github.com/NixOS/nix/issues/3841 we don't know how
     // to print different messages for different verbosity levels. For now
     // we add some heuristics for detecting when we want to show the response.
     if (response && (response->size() < 1024 || response->find("<html>") != std::string::npos))
-        err.msg = HintFmt("%1%\n\nresponse body:\n\n%2%", Uncolored(hf.str()), chomp(*response));
-    else
-        err.msg = hf;
+        err.msg = HintFmt("%1%\n\nresponse body:\n\n%2%", Uncolored(err.msg.str()), chomp(*response));
 }
 
 } // namespace nix

--- a/src/libstore/include/nix/store/build-result.hh
+++ b/src/libstore/include/nix/store/build-result.hh
@@ -82,8 +82,8 @@ public:
      * Delegates to the string constructor after formatting.
      */
     template<typename... Args>
-    BuildError(Status status, const Args &... args)
-        : CloneableError(args...)
+    BuildError(Status status, Args &&... args)
+        : CloneableError(std::forward<Args>(args)...)
         , status{status}
     {
     }

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -499,7 +499,7 @@ public:
     std::optional<std::string> response;
 
     template<typename... Args>
-    FileTransferError(FileTransfer::Error error, std::optional<std::string> response, const Args &... args);
+    FileTransferError(FileTransfer::Error error, std::optional<std::string> response, Args &&... args);
 };
 
 } // namespace nix

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -176,9 +176,9 @@ class SQLiteError : public CloneableError<SQLiteError, Error>
 
 public:
     template<typename... Args>
-    [[noreturn]] static void throw_(sqlite3 * db, const std::string & fs, const Args &... args)
+    [[noreturn]] static void throw_(sqlite3 * db, const std::string & fs, Args &&... args)
     {
-        throw_(db, HintFmt(fs, args...));
+        throw_(db, HintFmt(fs, std::forward<Args>(args)...));
     }
 
     SQLiteError(const char * path, const char * errMsg, int errNo, int extendedErrNo, int offset, HintFmt && hf);
@@ -193,8 +193,8 @@ protected:
         int extendedErrNo,
         int offset,
         const std::string & fs,
-        const Args &... args)
-        : SQLiteError(path, errMsg, errNo, extendedErrNo, offset, HintFmt(fs, args...))
+        Args &&... args)
+        : SQLiteError(path, errMsg, errNo, extendedErrNo, offset, HintFmt(fs, std::forward<Args>(args)...))
     {
     }
 

--- a/src/libstore/windows/pathlocks.cc
+++ b/src/libstore/windows/pathlocks.cc
@@ -55,14 +55,14 @@ AutoCloseFD openLockFile(const std::filesystem::path & path, bool create)
  * Wine has incomplete file locking support, so we degrade gracefully.
  */
 template<typename... Args>
-static bool warnOrThrowWine(DWORD lastError, const std::string & fs, const Args &... args)
+static bool warnOrThrowWine(DWORD lastError, const std::string & fs, Args &&... args)
 {
     using namespace nix::windows;
     if (isWine()) {
         warn(fs + ": %s (ignored under Wine)", args..., lastError);
         return true;
     }
-    throw WinError(lastError, fs, args...);
+    throw WinError(lastError, fs, std::forward<Args>(args)...);
 }
 
 bool lockFile(Descriptor desc, LockType lockType, bool wait)

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -139,9 +139,9 @@ void dumpString(std::string_view s, Sink & sink)
 }
 
 template<typename... Args>
-static SerialisationError badArchive(std::string_view s, const Args &... args)
+static SerialisationError badArchive(std::string_view s, Args &&... args)
 {
-    return SerialisationError("bad archive: " + s, args...);
+    return SerialisationError("bad archive: " + s, std::forward<Args>(args)...);
 }
 
 static void parseContents(CreateRegularFileSink & sink, Source & source)

--- a/src/libutil/include/nix/util/processes.hh
+++ b/src/libutil/include/nix/util/processes.hh
@@ -147,8 +147,8 @@ public:
     int status;
 
     template<typename... Args>
-    ExecError(int status, const Args &... args)
-        : CloneableError(args...)
+    ExecError(int status, Args &&... args)
+        : CloneableError(std::forward<Args>(args)...)
         , status(status)
     {
     }


### PR DESCRIPTION
Follow-up on https://github.com/NixOS/nix/pull/16296#discussion_r3789219350 that I had already started.

Uneventful, except `FileTransferError` used `args` twice: once for the base class, once for a second `HintFmt` that overwrote the first result. Can't forward twice, so now it formats once and mutates in place.

Assisted-by: Claude Code (Claude Opus 5)

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
cleanup
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- https://github.com/NixOS/nix/pull/16296#discussion_r3789219350

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
