### PR TITLE
libstore: Add fuzz harness for StorePath

### DIFF
--- a/src/libstore-tests/fuzz/meson.build
+++ b/src/libstore-tests/fuzz/meson.build
@@ -1,6 +1,7 @@
 fuzz_targets = [
   [ 'parse-derivation', files('parse-derivation.cc') ],
   [ 'parse-derivation-experimental', files('parse-derivation-experimental.cc') ],
+  [ 'store-path', files('store-path.cc') ],
 ]
 
 subdir('harnesses')

--- a/src/libstore-tests/fuzz/store-path.cc
+++ b/src/libstore-tests/fuzz/store-path.cc
@@ -1,0 +1,83 @@
+#include "nix/store/path.hh"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
+{
+    using namespace nix;
+
+    auto view = std::string_view(reinterpret_cast<const char *>(data), size);
+
+    std::optional<StorePath> parsed = [view]() -> std::optional<StorePath> {
+        try {
+            return StorePath(view);
+        } catch (const BadStorePath &) {
+            /* This is the only type of exception it can throw. */
+            return std::nullopt;
+        }
+    }();
+
+    if (!parsed)
+        /* Keep in the corpus. */
+        return 0;
+
+    auto parsedView = parsed->to_string();
+
+    /* Now actually check invariants. See nameRegexStr. MaxPathLen is actually
+       a misnomer - it's the maximum length of the store object name, not the
+       pathname. Pathname length includes the hash len + `-`.
+       Is the following checks a bit overkill? Maybe - but StorePath is also used
+       everywhere so we better get it right. */
+    assert(parsedView.size() <= StorePath::MaxPathLen + StorePath::HashLen + 1);
+
+    /* Name can't be empty, so strict comparison. */
+    assert(parsedView.size() > StorePath::HashLen + 1);
+
+    /* Some trivial things to check. */
+    assert(parsed->hashPart().data() == parsedView.data());
+    assert(parsed->hashPart().size() == StorePath::HashLen);
+
+    /* Check that the hash part is valid nix32. */
+    for (char c : parsed->hashPart()) {
+        switch (c) {
+        case 'a' ... 'z':
+            if (c == 'e' || c == 'o' || c == 'u' || c == 't')
+                __builtin_trap();
+            break;
+        case '0' ... '9':
+            break;
+        default:
+            __builtin_trap();
+        }
+    }
+
+    /* Must be followed by a dash *always*. Duh. */
+    assert(parsedView[StorePath::HashLen] == '-');
+
+    auto name = parsed->name();
+
+    assert(name.data() == parsedView.data() + StorePath::HashLen + 1);
+    assert(name.size() == parsedView.size() - (StorePath::HashLen + 1));
+
+    assert(name != ".");
+    assert(name != "..");
+    assert(!name.starts_with(".-"));
+    assert(!name.starts_with("..-"));
+
+    for (char c : name) {
+        switch (c) {
+        case 'a' ... 'z':
+        case 'A' ... 'Z':
+        case '0' ... '9':
+        case '+':
+        case '-':
+        case '.':
+        case '_':
+        case '?':
+        case '=':
+            break;
+        default:
+            __builtin_trap();
+        }
+    }
+
+    return 0;
+}

--- a/src/libstore/include/nix/store/path.hh
+++ b/src/libstore/include/nix/store/path.hh
@@ -11,6 +11,9 @@ namespace nix {
 
 struct Hash;
 
+MakeError(BadStorePath, Error);
+MakeError(BadStorePathName, BadStorePath);
+
 /**
  * Check whether a name is a valid store path name.
  *

--- a/src/libstore/include/nix/store/store-dir-config.hh
+++ b/src/libstore/include/nix/store/store-dir-config.hh
@@ -14,9 +14,6 @@ namespace nix {
 
 struct SourcePath;
 
-MakeError(BadStorePath, Error);
-MakeError(BadStorePathName, BadStorePath);
-
 /**
  * @todo This should just be inherited by `StoreConfig`. However, it
  * would be a huge amount of churn if `Store` didn't have these methods


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This might be a bit overkill, but we did get it wrong (see 089ac360af56c8812546de6b93af687ab723d8a6).

I specifically tried defining all the invariants we have documented from the ground-up instead of reusing other helpers.

Also moves exception definitions to the right file.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
