### PR TITLE
Decouple fuzzers from unit tests

### DIFF
--- a/ci/gha/tests/default.nix
+++ b/ci/gha/tests/default.nix
@@ -64,6 +64,17 @@ rec {
     }
   );
 
+  nixComponentsFuzzerOnly = nixComponents.overrideScope (
+    _: _: {
+      withUnitTests = false;
+      withASan = withSanitizers;
+      withUBSan = withSanitizers;
+      withFuzzer = withSanitizers;
+      withFuzzTargets = withSanitizers;
+      mesonComponentOverrides = lib.composeManyExtensions componentOverrides;
+    }
+  );
+
   # Import NixOS tests using the instrumented components
   nixosTests = import ../../../tests/nixos {
     inherit lib pkgs;
@@ -95,11 +106,11 @@ rec {
       let
         nix = packages'.nix;
         checkFuzzConfiguration =
-          withFuzzer: withFuzzTargets:
+          withUnitTests: withFuzzer: withFuzzTargets:
           let
             components = nixComponents.overrideScope (
               _: _: {
-                inherit withFuzzer withFuzzTargets;
+                inherit withUnitTests withFuzzer withFuzzTargets;
               }
             );
           in
@@ -109,7 +120,9 @@ rec {
               let
                 flags = components.${name}.mesonFlags;
               in
-              ((lib.elem (lib.mesonOption "b_sanitize" "fuzzer-no-link") flags) == withFuzzer)
+              lib.elem (lib.mesonBool "unit-tests" withUnitTests) flags
+              && !(lib.elem (lib.mesonBool "unit-tests" (!withUnitTests)) flags)
+              && ((lib.elem (lib.mesonOption "b_sanitize" "fuzzer-no-link") flags) == withFuzzer)
               && lib.elem (lib.mesonBool "fuzzers" withFuzzTargets) flags
               && !(lib.elem (lib.mesonBool "fuzzers" (!withFuzzTargets)) flags)
             )
@@ -117,12 +130,44 @@ rec {
               "nix-util-tests"
               "nix-store-tests"
             ];
+        fuzzerOnlyComponents = nixComponents.overrideScope (
+          _: _: {
+            withUnitTests = false;
+            withFuzzTargets = true;
+          }
+        );
+        emptyTestComponents = nixComponents.overrideScope (
+          _: _: {
+            withUnitTests = false;
+            withFuzzTargets = false;
+          }
+        );
+        emptyInstrumentedTestComponents = nixComponents.overrideScope (
+          _: _: {
+            withUnitTests = false;
+            withFuzzer = true;
+            withFuzzTargets = false;
+          }
+        );
+        utilFuzzerOnly = fuzzerOnlyComponents.nix-util-tests;
+        storeFuzzerOnly = fuzzerOnlyComponents.nix-store-tests;
       in
       assert (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src.patches == [ pkgs.emptyFile ];
-      assert checkFuzzConfiguration false false;
-      assert checkFuzzConfiguration false true;
-      assert checkFuzzConfiguration true false;
-      assert checkFuzzConfiguration true true;
+      assert checkFuzzConfiguration false false true;
+      assert checkFuzzConfiguration false true true;
+      assert checkFuzzConfiguration true false false;
+      assert checkFuzzConfiguration true false true;
+      assert checkFuzzConfiguration true true false;
+      assert checkFuzzConfiguration true true true;
+      assert utilFuzzerOnly.buildInputs == [ (lib.getDev fuzzerOnlyComponents.nix-util) ];
+      assert storeFuzzerOnly.buildInputs == [ (lib.getDev fuzzerOnlyComponents.nix-store) ];
+      assert !(utilFuzzerOnly.tests ? run-without-new-syscalls);
+      assert !(utilFuzzerOnly.meta ? mainProgram);
+      assert !(storeFuzzerOnly.meta ? mainProgram);
+      assert !(builtins.tryEval emptyTestComponents.nix-util-tests.drvPath).success;
+      assert !(builtins.tryEval emptyTestComponents.nix-store-tests.drvPath).success;
+      assert !(builtins.tryEval emptyInstrumentedTestComponents.nix-util-tests.drvPath).success;
+      assert !(builtins.tryEval emptyInstrumentedTestComponents.nix-store-tests.drvPath).success;
       if pkgs.stdenv.buildPlatform.isDarwin then
         lib.warn "packaging-overriding check currently disabled because of a permissions issue on macOS" pkgs.emptyFile
       else
@@ -161,6 +206,12 @@ rec {
         }
       ) (pkg.tests or { })
     ) nixComponentsInstrumented)
+    // lib.optionalAttrs withSanitizers {
+      "${componentTestsPrefix}nix-util-tests-fuzzer-only" =
+        nixComponentsFuzzerOnly.nix-util-tests.tests.run;
+      "${componentTestsPrefix}nix-store-tests-fuzzer-only" =
+        nixComponentsFuzzerOnly.nix-store-tests.tests.run;
+    }
     // lib.optionalAttrs (pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform) {
       "${componentTestsPrefix}nix-functional-tests" = nixComponentsInstrumented.nix-functional-tests;
       "${componentTestsPrefix}nix-json-schema-checks" = nixComponentsInstrumented.nix-json-schema-checks;

--- a/doc/manual/source/development/testing.md
+++ b/doc/manual/source/development/testing.md
@@ -307,13 +307,14 @@ You can run them manually with `nix build .#hydraJobs.tests.{testName}` or `nix-
 
 The project uses [`libFuzzer`](https://llvm.org/docs/LibFuzzer.html) and LLVM coverage instrumentation to fuzz sensitive pieces of code.
 The harnesses reside in corresponding `-tests` subprojects (e.g. `src/libutil-tests/fuzz`).
-The `fuzzers` option builds the harnesses. The `fuzzing-engine` option accepts one compiler-driver argument for linking an external fuzzing engine.
-Meson rejects `fuzzers=true` unless `unit-tests=true`.
+The `fuzzers` option builds the harnesses independently of `unit-tests`; set `unit-tests=false` for a fuzzer-only build.
+The `fuzzing-engine` option accepts one compiler-driver argument for linking an external fuzzing engine.
 If `fuzzing-engine` is empty, Meson requires Clang and `fuzzer-no-link` in `b_sanitize`.
 The compiler driver then links the harnesses with libFuzzer and libstdc++.
 
 ```shell
 nix develop .#native-clangStdenv
+appendToVar mesonFlags "-Dunit-tests=false"
 appendToVar mesonFlags "-Dfuzzers=true"
 appendToVar mesonFlags "-Db_sanitize=address,undefined,fuzzer-no-link"
 # Clang sanitizer/shared-library workaround: https://github.com/mesonbuild/meson/issues/764
@@ -327,6 +328,7 @@ To use an external fuzzing engine, set `fuzzing-engine`:
 
 ```shell
 mesonFlagsArray+=(
+  "-Dunit-tests=false"
   "-Dfuzzers=true"
   "-Dfuzzing-engine=$LIB_FUZZING_ENGINE"
 )

--- a/meson.build
+++ b/meson.build
@@ -43,15 +43,26 @@ if get_option('doc-gen')
 endif
 
 # Testing
-if get_option('fuzzers') and not get_option('unit-tests')
-  error('fuzzers=true requires unit-tests=true')
+unit_tests = get_option('unit-tests')
+fuzzers = get_option('fuzzers')
+
+if unit_tests
+  subproject('libutil-test-support')
 endif
 
-if get_option('unit-tests')
-  subproject('libutil-test-support')
+if unit_tests or fuzzers
   subproject('libutil-tests')
+endif
+
+if unit_tests
   subproject('libstore-test-support')
+endif
+
+if unit_tests or fuzzers
   subproject('libstore-tests')
+endif
+
+if unit_tests
   subproject('libfetchers-tests')
   subproject('libexpr-test-support')
   subproject('libexpr-tests')

--- a/nix-meson-build-support/fuzz/meson.build
+++ b/nix-meson-build-support/fuzz/meson.build
@@ -39,7 +39,7 @@ foreach t : fuzz_targets
   executable(
     'fuzz-' + t[0],
     t[1],
-    dependencies : deps_private_subproject + deps_private + deps_other,
+    dependencies : fuzz_dependencies,
     link_args : fuzz_link_args,
     install : true,
   )

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -326,6 +326,11 @@ in
   withFuzzer = false;
 
   /**
+    Whether to build unit-test executables in Meson test components.
+  */
+  withUnitTests = true;
+
+  /**
     Whether to build the libFuzzer targets in Meson test components.
   */
   withFuzzTargets = false;

--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -130,7 +130,12 @@ stdenv.mkDerivation (finalAttrs: {
     nix-functional-tests
   ]
   ++
-    lib.optionals (stdenv.hostPlatform.isLinux && stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+    lib.optionals
+      (
+        stdenv.hostPlatform.isLinux
+        && stdenv.buildPlatform.canExecute stdenv.hostPlatform
+        && nix-util-tests.tests ? run-without-new-syscalls
+      )
       [
         nix-util-tests.tests.run-without-new-syscalls
       ];

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -13,6 +13,7 @@ project(
 )
 
 cxx = meson.get_compiler('cpp')
+build_unit_tests = get_option('unit-tests')
 
 subdir('nix-meson-build-support/deps-lists')
 
@@ -20,8 +21,6 @@ nix_store = dependency('nix-store')
 
 deps_private_maybe_subproject = [
   nix_store,
-  dependency('nix-store-c'),
-  dependency('nix-store-test-support'),
 ]
 deps_public_maybe_subproject = []
 subdir('nix-meson-build-support/subprojects')
@@ -29,29 +28,9 @@ subdir('nix-meson-build-support/subprojects')
 subdir('nix-meson-build-support/export-all-symbols')
 subdir('nix-meson-build-support/windows-version')
 
-sqlite = dependency('sqlite3', 'sqlite', version : '>=3.6.19')
-deps_private += sqlite
-
-rapidcheck = dependency('rapidcheck')
-deps_private += rapidcheck
-
-gtest = dependency('gtest', main : true)
-deps_private += gtest
-
-configdata = configuration_data()
-configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
-
-configdata.set_quoted('NIX_STORE_DIR', nix_store.get_variable('storedir'))
-
-config_priv_h = configure_file(
-  configuration : configdata,
-  output : 'store-tests-config.hh',
-)
-
-gtest = dependency('gmock')
-deps_private += gtest
-
 subdir('nix-meson-build-support/common')
+
+fuzz_dependencies = deps_private + deps_other
 
 sources = files(
   'build-result.cc',
@@ -98,69 +77,90 @@ sources = files(
 
 include_dirs = [ include_directories('.') ]
 
+if build_unit_tests
+  unit_dependencies = fuzz_dependencies + [
+    dependency('nix-store-c'),
+    dependency('nix-store-test-support'),
+    dependency('sqlite3', 'sqlite', version : '>=3.6.19'),
+    dependency('rapidcheck'),
+    dependency('gtest', main : true),
+    dependency('gmock'),
+  ]
 
-this_exe = executable(
-  meson.project_name(),
-  sources,
-  config_priv_h,
-  dependencies : deps_private_subproject + deps_private + deps_other,
-  include_directories : include_dirs,
-  # TODO: -lrapidcheck, see ../libutil-support/build.meson
-  link_args : linker_export_flags + [ '-lrapidcheck' ],
-  # get main from gtest
-  install : true,
-  cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
-)
+  configdata = configuration_data()
+  configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+  configdata.set_quoted('NIX_STORE_DIR', nix_store.get_variable('storedir'))
 
-test_env = {
-  '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
-  'HOME' : meson.current_build_dir() / 'test-home',
-}
-
-if host_machine.system() != 'windows'
-  test_env += {'NIX_REMOTE' : meson.current_build_dir() / 'test-home' / 'store'}
-endif
-
-if get_option('fuzzers')
-  subdir('fuzz')
-endif
-
-test(
-  meson.project_name(),
-  this_exe,
-  env : test_env,
-  protocol : 'gtest',
-)
-
-# Build benchmarks if enabled
-if get_option('benchmarks')
-  gbenchmark = dependency('benchmark', required : true)
-
-  benchmark_sources = files(
-    'bench-main.cc',
-    'derivation-parser-bench.cc',
-    'ref-scan-bench.cc',
-    'register-valid-paths-bench.cc',
+  config_priv_h = configure_file(
+    configuration : configdata,
+    output : 'store-tests-config.hh',
   )
 
-  benchmark_exe = executable(
-    'nix-store-benchmarks',
-    benchmark_sources,
+  this_exe = executable(
+    meson.project_name(),
+    sources,
     config_priv_h,
-    dependencies : deps_private_subproject + deps_private + deps_other + [
-      gbenchmark,
-    ],
+    dependencies : unit_dependencies,
     include_directories : include_dirs,
-    link_args : linker_export_flags,
+    # TODO: -lrapidcheck, see ../libutil-support/build.meson
+    link_args : linker_export_flags + [ '-lrapidcheck' ],
+    # get main from gtest
     install : true,
     cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
   )
 
-  benchmark(
-    'nix-store-benchmarks',
-    benchmark_exe,
-    env : {
-      '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
-    },
+  test_env = {
+    '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
+    'HOME' : meson.current_build_dir() / 'test-home',
+  }
+
+  if host_machine.system() != 'windows'
+    test_env += {
+      'NIX_REMOTE' : meson.current_build_dir() / 'test-home' / 'store',
+    }
+  endif
+
+  test(
+    meson.project_name(),
+    this_exe,
+    env : test_env,
+    protocol : 'gtest',
   )
+
+  # Build benchmarks if enabled
+  if get_option('benchmarks')
+    gbenchmark = dependency('benchmark', required : true)
+
+    benchmark_sources = files(
+      'bench-main.cc',
+      'derivation-parser-bench.cc',
+      'ref-scan-bench.cc',
+      'register-valid-paths-bench.cc',
+    )
+
+    benchmark_exe = executable(
+      'nix-store-benchmarks',
+      benchmark_sources,
+      config_priv_h,
+      dependencies : unit_dependencies + [
+        gbenchmark,
+      ],
+      include_directories : include_dirs,
+      link_args : linker_export_flags,
+      install : true,
+      cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
+    )
+
+    benchmark(
+      'nix-store-benchmarks',
+      benchmark_exe,
+      env : {
+        '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
+      },
+    )
+  endif
+endif
+
+if get_option('fuzzers')
+  subdir('fuzz')
 endif

--- a/src/libstore-tests/meson.options
+++ b/src/libstore-tests/meson.options
@@ -1,6 +1,14 @@
 # vim: filetype=meson
 
 option(
+  'unit-tests',
+  type : 'boolean',
+  value : true,
+  description : 'Build unit tests',
+  yield : true,
+)
+
+option(
   'benchmarks',
   type : 'boolean',
   value : false,

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -21,12 +21,18 @@
   version,
   filesetToSource,
   withBenchmarks ? false,
+  withUnitTests ? true,
   withFuzzTargets ? false,
 }:
 
 let
   inherit (lib) fileset;
+  doBenchmarks = withUnitTests && withBenchmarks;
 in
+
+assert lib.assertMsg (
+  withUnitTests || withFuzzTargets
+) "nix-store-tests requires unit tests or fuzz targets";
 
 mkMesonExecutable (finalAttrs: {
   pname = "nix-store-tests";
@@ -46,19 +52,22 @@ mkMesonExecutable (finalAttrs: {
   ];
 
   buildInputs = [
+    nix-store
+  ]
+  ++ lib.optionals withUnitTests [
     sqlite
     rapidcheck
     gtest
-    nix-store
     nix-store-c
     nix-store-test-support
   ]
-  ++ lib.optionals withBenchmarks [
+  ++ lib.optionals doBenchmarks [
     gbenchmark
   ];
 
   mesonFlags = [
-    (lib.mesonBool "benchmarks" withBenchmarks)
+    (lib.mesonBool "unit-tests" withUnitTests)
+    (lib.mesonBool "benchmarks" doBenchmarks)
     (lib.mesonBool "fuzzers" withFuzzTargets)
   ];
 
@@ -78,22 +87,24 @@ mkMesonExecutable (finalAttrs: {
         in
         runCommand "${finalAttrs.pname}-run"
           {
-            meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
-            nativeBuildInputs = [
+            meta.broken = withUnitTests && !stdenv.hostPlatform.emulatorAvailable buildPackages;
+            nativeBuildInputs = lib.optionals withUnitTests [
               writableTmpDirAsHomeHook
               openssl
             ];
           }
           (
-            ''
+            lib.optionalString withUnitTests ''
               export _NIX_TEST_UNIT_DATA=${data + "/src/libstore-tests/data"}
               export NIX_REMOTE=$HOME/store
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
             ''
-            + lib.optionalString withBenchmarks ''
+            + lib.optionalString doBenchmarks ''
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe' finalAttrs.finalPackage "nix-store-benchmarks"}
             ''
             + ''
+              ${if withUnitTests then "test -x" else "test ! -e"} \
+                "${finalAttrs.finalPackage}/bin/${finalAttrs.pname}${stdenv.hostPlatform.extensions.executable}"
               for target in fuzz-parse-derivation fuzz-parse-derivation-experimental; do
                 ${if withFuzzTargets then "test -x" else "test ! -e"} \
                   "${finalAttrs.finalPackage}/bin/$target${stdenv.hostPlatform.extensions.executable}"
@@ -106,6 +117,8 @@ mkMesonExecutable (finalAttrs: {
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;
+  }
+  // lib.optionalAttrs withUnitTests {
     mainProgram = finalAttrs.pname + stdenv.hostPlatform.extensions.executable;
   };
 

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -13,13 +13,12 @@ project(
 )
 
 cxx = meson.get_compiler('cpp')
+build_unit_tests = get_option('unit-tests')
 
 subdir('nix-meson-build-support/deps-lists')
 
 deps_private_maybe_subproject = [
   dependency('nix-util'),
-  dependency('nix-util-c'),
-  dependency('nix-util-test-support'),
 ]
 deps_public_maybe_subproject = []
 subdir('nix-meson-build-support/subprojects')
@@ -27,33 +26,15 @@ subdir('nix-meson-build-support/subprojects')
 subdir('nix-meson-build-support/export-all-symbols')
 subdir('nix-meson-build-support/windows-version')
 
-rapidcheck = dependency('rapidcheck')
-deps_private += rapidcheck
-
-gtest = dependency('gtest', main : false)
-deps_private += gtest
-
-gmock = dependency('gmock')
-deps_private += gmock
-
-zstd = dependency('libzstd', version : '>= 1.4.0')
-deps_private += zstd
-
 if host_machine.system() == 'windows'
   # Boost.ASIO needs this unconditionally.
   socket = cxx.find_library('ws2_32')
   deps_other += socket
 endif
 
-configdata = configuration_data()
-configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
-
-config_priv_h = configure_file(
-  configuration : configdata,
-  output : 'util-tests-config.hh',
-)
-
 subdir('nix-meson-build-support/common')
+
+fuzz_dependencies = deps_private + deps_other
 
 sources = files(
   'alignment.cc',
@@ -111,54 +92,74 @@ endif
 
 include_dirs = [ include_directories('.') ]
 
+if build_unit_tests
+  unit_dependencies = fuzz_dependencies + [
+    dependency('nix-util-c'),
+    dependency('nix-util-test-support'),
+    dependency('rapidcheck'),
+    dependency('gtest', main : false),
+    dependency('gmock'),
+    dependency('libzstd', version : '>= 1.4.0'),
+  ]
 
-this_exe = executable(
-  meson.project_name(),
-  sources,
-  config_priv_h,
-  dependencies : deps_private_subproject + deps_private + deps_other,
-  include_directories : include_dirs,
-  # TODO: -lrapidcheck, see ../libutil-support/build.meson
-  link_args : linker_export_flags + [ '-lrapidcheck' ],
-  # get main from gtest
-  install : true,
-  cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
-)
+  configdata = configuration_data()
+  configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+
+  config_priv_h = configure_file(
+    configuration : configdata,
+    output : 'util-tests-config.hh',
+  )
+
+  this_exe = executable(
+    meson.project_name(),
+    sources,
+    config_priv_h,
+    dependencies : unit_dependencies,
+    include_directories : include_dirs,
+    # TODO: -lrapidcheck, see ../libutil-support/build.meson
+    link_args : linker_export_flags + [ '-lrapidcheck' ],
+    # get main from gtest
+    install : true,
+    cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
+  )
+endif
 
 if get_option('fuzzers')
   subdir('fuzz')
 endif
 
-test(
-  meson.project_name(),
-  this_exe,
-  env : {
-    '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
-  },
-  protocol : 'gtest',
-)
+if build_unit_tests
+  test(
+    meson.project_name(),
+    this_exe,
+    env : {
+      '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
+    },
+    protocol : 'gtest',
+  )
 
-# Run the same tests again under `enosys -d openat2` to exercise the
-# iterative (non-openat2) fallback path on Linux.  `enosys` uses
-# seccomp to make `openat2` return `ENOSYS`, which the wrapper in
-# file-system-at.cc caches and falls back to the iterative impl.
-if host_machine.system() == 'linux'
-  enosys = find_program('enosys', required : false)
-  if enosys.found()
-    test(
-      meson.project_name() + '-without-new-syscalls',
-      enosys,
-      args : [
-        '--syscall', 'openat2',
-        '--syscall', 'fchmodat2',
-        '--syscall', 'close_range',
-        '--',
-        this_exe,
-      ],
-      env : {
-        '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
-      },
-      protocol : 'gtest',
-    )
+  # Run the same tests again under `enosys -d openat2` to exercise the
+  # iterative (non-openat2) fallback path on Linux.  `enosys` uses
+  # seccomp to make `openat2` return `ENOSYS`, which the wrapper in
+  # file-system-at.cc caches and falls back to the iterative impl.
+  if host_machine.system() == 'linux'
+    enosys = find_program('enosys', required : false)
+    if enosys.found()
+      test(
+        meson.project_name() + '-without-new-syscalls',
+        enosys,
+        args : [
+          '--syscall', 'openat2',
+          '--syscall', 'fchmodat2',
+          '--syscall', 'close_range',
+          '--',
+          this_exe,
+        ],
+        env : {
+          '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
+        },
+        protocol : 'gtest',
+      )
+    endif
   endif
 endif

--- a/src/libutil-tests/meson.options
+++ b/src/libutil-tests/meson.options
@@ -1,6 +1,14 @@
 # vim: filetype=meson
 
 option(
+  'unit-tests',
+  type : 'boolean',
+  value : true,
+  description : 'Build unit tests',
+  yield : true,
+)
+
+option(
   'fuzzers',
   type : 'boolean',
   value : false,

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -17,12 +17,17 @@
   # Configuration Options
 
   version,
+  withUnitTests ? true,
   withFuzzTargets ? false,
 }:
 
 let
   inherit (lib) fileset;
 in
+
+assert lib.assertMsg (
+  withUnitTests || withFuzzTargets
+) "nix-util-tests requires unit tests or fuzz targets";
 
 mkMesonExecutable (finalAttrs: {
   pname = "nix-util-tests";
@@ -43,17 +48,20 @@ mkMesonExecutable (finalAttrs: {
 
   buildInputs = [
     nix-util
+  ]
+  ++ lib.optionals withUnitTests [
     nix-util-c
     nix-util-test-support
     rapidcheck
     gtest
     zstd
   ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
+  ++ lib.optionals (withUnitTests && stdenv.hostPlatform.isLinux) [
     util-linux
   ];
 
   mesonFlags = [
+    (lib.mesonBool "unit-tests" withUnitTests)
     (lib.mesonBool "fuzzers" withFuzzTargets)
   ];
 
@@ -62,16 +70,20 @@ mkMesonExecutable (finalAttrs: {
       run =
         runCommand "${finalAttrs.pname}-run"
           {
-            meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
+            meta.broken = withUnitTests && !stdenv.hostPlatform.emulatorAvailable buildPackages;
           }
           (
-            lib.optionalString stdenv.hostPlatform.isWindows ''
+            lib.optionalString (withUnitTests && stdenv.hostPlatform.isWindows) ''
               export HOME="$PWD/home-dir"
               mkdir -p "$HOME"
             ''
-            + ''
+            + lib.optionalString withUnitTests ''
               export _NIX_TEST_UNIT_DATA=${./data}
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
+            ''
+            + ''
+              ${if withUnitTests then "test -x" else "test ! -e"} \
+                "${finalAttrs.finalPackage}/bin/${finalAttrs.pname}${stdenv.hostPlatform.extensions.executable}"
               for target in fuzz-parse-dump fuzz-parse-dump-case-hacked; do
                 ${if withFuzzTargets then "test -x" else "test ! -e"} \
                   "${finalAttrs.finalPackage}/bin/$target${stdenv.hostPlatform.extensions.executable}"
@@ -82,7 +94,9 @@ mkMesonExecutable (finalAttrs: {
     }
     //
       lib.optionalAttrs
-        (stdenv.hostPlatform.isLinux && stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+        (
+          withUnitTests && stdenv.hostPlatform.isLinux && stdenv.buildPlatform.canExecute stdenv.hostPlatform
+        )
         {
           # Run the same tests with newer syscalls disabled via seccomp,
           # to exercise fallback paths (iterative openat for openat2,
@@ -107,6 +121,8 @@ mkMesonExecutable (finalAttrs: {
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;
+  }
+  // lib.optionalAttrs withUnitTests {
     mainProgram = finalAttrs.pname + stdenv.hostPlatform.extensions.executable;
   };
 

--- a/tests/fuzzing-engine/default.nix
+++ b/tests/fuzzing-engine/default.nix
@@ -22,9 +22,9 @@ let
       project('fuzzing-engine-${name}', 'cpp', meson_version : '>= 1.8')
 
       cxx = meson.get_compiler('cpp')
-      deps_private_subproject = []
-      deps_private = []
-      deps_other = []
+      fuzz_dependencies = []
+
+      assert(not get_option('unit-tests'))
 
       if get_option('fuzzers')
         fuzz_targets = [
@@ -143,6 +143,7 @@ let
       buildPhase =
         let
           mesonFlags = [
+            (lib.mesonBool "unit-tests" false)
             (lib.mesonBool "fuzzers" true)
           ]
           ++ lib.optional (fuzzingEngine != null) (lib.mesonOption "fuzzing-engine" fuzzingEngine)


### PR DESCRIPTION
## Motivation

The fuzz targets currently inherit the full unit-test dependency stack, including test frameworks, C wrappers, and test-support libraries. This makes standalone fuzz builds larger and harder to integrate.

## Context

The util and store test projects now separate their fuzz dependencies from their unit-test dependencies. Setting `unit-tests=false` skips unit executables, test frameworks, support libraries, generated test configuration, and benchmarks while keeping the fuzz targets available.

The Nix test packages expose the same split through `withUnitTests`. Their default behaviour is unchanged, and empty packages with neither units nor fuzzers are rejected.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
