### PR TITLE
doc: make ignored local registry on flake inputs more obvious

### DIFF
--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -181,6 +181,11 @@ Currently the `type` attribute can be one of the following:
   entry in the registry; see [nix registry](./nix3-registry.md) for
   details.
 
+  > **Note**
+  >
+  > When used as inputs in a `flake.nix`, only the global registry is consulted.
+  > Read the note in [nix registry](./nix3-registry.md) for more details.
+
   For example, these are valid indirect flake references:
 
   * `nixpkgs`

--- a/src/nix/registry.md
+++ b/src/nix/registry.md
@@ -34,7 +34,15 @@ highest precedence:
 * Overrides specified on the command line using the option
   `--override-flake`.
 
-Note that the system and user registries are not used to resolve flake references in `flake.nix`. They are only used to resolve flake references on the command line.
+> **Note**
+>
+> The system and user registries are not used to resolve flake references in `flake.nix` for generating the `flake.lock` file.
+> They are only used to resolve flake references on the command line.
+>
+> This limitation is in place to avoid accidents
+> where users have local registry overrides that map `nixpkgs` to a `path:` flake in the local file system,
+> which is default for most NixOS flake configurations,
+> which then may unexpectedly end up in committed lock files pushed to other users.
 
 # Registry format
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The basic behavior was already documented in nix3-registry, through the note there was "hidden" as simple plain text, despite starting with a "Note that".

The behavior was never mentioned in nix3-flake where the note types are introduced. So this is now documented there as part of of the `indirect` type as well.

## Context

An improved documentation of this behavior seems needed as issues like https://github.com/NixOS/nix/issues/13156 &
https://github.com/NixOS/nix/issues/15441 are opened despite the behavior was documented since its introduction in
https://github.com/NixOS/nix/pull/12019.

Spoken from my own experience, this behavior seems unreasonable at first, even when having experience with flakes & nix in general, because the "registry" is often only introduced as being a single thing which consists of data from 3 different sources (global, system, local). And because the CLI does not have a problem reading from all 3 sources as expected, I expected my error to be in the way how to correctly specify `indirect` flake references in an input file (which is seen rarely, ironically because of its possible, unforeseen consequences). Thats why I think a note in nix3-flake is also needed.

Further, I took the liberty to copy an adapted version from edolstra’s reasoning from https://github.com/NixOS/nix/pull/12019, which is valid but non-obvious to me, into my change here as well.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
