### PR TITLE
libstore: check fixed-output derivation paths against their content address

### DIFF
--- a/doc/manual/source/development/testing.md
+++ b/doc/manual/source/development/testing.md
@@ -367,6 +367,29 @@ xdg-open cov-html/index.html
 
 If you have found a memory safety issue using fuzzing, consider reporting it [privately](https://github.com/NixOS/nix/security/) if you deem the issue to be security relevant.
 
+### Checks that defeat fuzzing
+
+Fuzzing is crucial for validating invariants, but a few invariants are ones a fuzzer can never satisfy.
+A check that a field equals a cryptographic hash of other fields is the usual case: passing it requires a hash preimage, so the code below the check becomes *unreachable* to the fuzzer rather than merely hard to reach.
+This is different from a check that is only awkward to satisfy --- sorted keys, balanced delimiters, no redundant escapes --- which a coverage-guided fuzzer will learn to get past on its own.
+Only the former should be gated.
+
+Such checks are compiled out under `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`, e.g.:
+
+```c++
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    if (path != computedPath)
+        throw FormatError(...);
+#endif
+```
+
+The macro name is a convention from [OSS-Fuzz](https://google.github.io/oss-fuzz/) and libFuzzer.
+`nix-meson-build-support/common/meson.build` defines it for every subproject when `fuzzer-no-link` is in `b_sanitize`, which is exactly when a fuzzer-instrumented build is being made.
+Builds using an external `fuzzing-engine` are expected to pass it themselves, as OSS-Fuzz does.
+
+Anything gated this way is no longer exercised by the fuzzer, so it must be covered by a unit test instead.
+For an example of both halves, see the fixed-output derivation path check in `parseOutput` (`src/libstore/derivation/aterm.cc`) and its test `CAFixedPathMismatch`.
+
 ## Installer tests
 
 GitHub Actions CI in the Nix repository also tests the installer on PRs. It does not require additional setup and utilises [GHA Artifacts](https://docs.github.com/en/actions/tutorials/store-and-share-data) and can be run in any Nix repository fork.

--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -94,6 +94,20 @@ if is_using_libstdcxx
   add_project_arguments('-D_GLIBCXX_USE_TBB_PAR_BACKEND=0', language : 'cpp')
 endif
 
+# See "Checks that defeat fuzzing" in
+# doc/manual/source/development/testing.md for what this gates and when
+# to use it.
+#
+# Keyed off `b_sanitize` rather than the `fuzzers` option because this
+# file is included by every subproject, and only the `-tests` ones
+# declare `fuzzers`.
+if 'fuzzer-no-link' in get_option('b_sanitize').split(',')
+  add_project_arguments(
+    '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1',
+    language : [ 'c', 'cpp' ],
+  )
+endif
+
 # Darwin ld doesn't like "X.Y.ZpreABCD+W"
 nix_soversion = meson.project_version().split('+')[0].split('pre')[0]
 

--- a/src/libstore-tests/data/derivation/bad-ca-fixed-path.drv
+++ b/src/libstore-tests/data/derivation/bad-ca-fixed-path.drv
@@ -1,0 +1,1 @@
+Derive([("out","/nix/store/c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-fixed","sha256","89451791163c896ec31a2adbd33c0681fd5f45b2c0ef0a264c92a03fb97f390f")],[],[],"x86_64-linux","/bin/sh",[],[("out","/nix/store/c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-fixed")])

--- a/src/libstore-tests/derivation/external-formats.cc
+++ b/src/libstore-tests/derivation/external-formats.cc
@@ -25,6 +25,24 @@ TEST_F(DerivationTest, UnterminatedString)
         FormatError);
 }
 
+/**
+ * A fixed-output derivation states its output path, but that path is a
+ * function of the content address, so a stated path that disagrees is
+ * rejected rather than silently kept.
+ *
+ * This is also the coverage for the check itself, which `parseOutput`
+ * compiles out under `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`.
+ */
+TEST_F(DerivationTest, CAFixedPathMismatch)
+{
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    GTEST_SKIP() << "Path check is compiled out of fuzzer-instrumented builds";
+#endif
+    ASSERT_THROW(
+        derivation::parse(*store, readFile(goldenMaster("bad-ca-fixed-path.drv")), "fixed", mockXpSettings),
+        FormatError);
+}
+
 TEST_F(DynDerivationTest, BadATerm_oldVersionDynDeps)
 {
     ASSERT_THROW(

--- a/src/libstore/derivation/aterm.cc
+++ b/src/libstore/derivation/aterm.cc
@@ -177,6 +177,8 @@ static StorePathSet parseStorePaths(const StoreDirConfig & store, StringViewStre
 
 static Output parseOutput(
     const StoreDirConfig & store,
+    std::string_view drvName,
+    OutputNameView outputName,
     std::string_view pathS,
     std::string_view hashAlgoStr,
     std::string_view hashS,
@@ -200,13 +202,31 @@ static Output parseOutput(
         } else if (!hashS.empty()) {
             [[maybe_unused]] auto path = store.parseStorePathCanonical(pathS);
             auto hash = Hash::parseNonSRIUnprefixed(hashS, hashAlgo);
-            return Output::CAFixed{
+            Output::CAFixed dof{
                 .ca =
                     ContentAddress{
                         .method = std::move(method),
                         .hash = std::move(hash),
                     },
             };
+            /* The stated path is redundant --- it is a function of the
+               content address --- but it must still agree, lest two
+               derivations that mean the same thing hash differently.
+
+               Skipped when fuzzing: the check makes the path a preimage
+               of a hash of the rest of the output, which a fuzzer has no
+               way to solve, so leaving it in would make this branch
+               unreachable to it. `CAFixedPathMismatch` covers the check
+               itself. See "Checks that defeat fuzzing" in
+               doc/manual/source/development/testing.md. */
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            if (path != dof.path(store, drvName, outputName))
+                throw FormatError(
+                    "derivation output '%s' has path '%s', which does not match its content address",
+                    outputName,
+                    pathS);
+#endif
+            return dof;
         } else {
             xpSettings.require(Xp::CaDerivations);
             if (!pathS.empty())
@@ -228,6 +248,8 @@ static Output parseOutput(
 
 static Output parseOutput(
     const StoreDirConfig & store,
+    std::string_view drvName,
+    OutputNameView outputName,
     StringViewStream & str,
     const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings)
 {
@@ -239,7 +261,7 @@ static Output parseOutput(
     const auto hash = parseString(str);
     expect(str, ')');
 
-    return parseOutput(store, *pathS, *hashAlgo, *hash, xpSettings);
+    return parseOutput(store, drvName, outputName, *pathS, *hashAlgo, *hash, xpSettings);
 }
 
 /**
@@ -347,7 +369,7 @@ Full parse(
     while (!endOfList(str)) {
         expect(str, '(');
         std::string id = parseString(str).toOwned();
-        auto output = parseOutput(store, str, xpSettings);
+        auto output = parseOutput(store, name, id, str, xpSettings);
         drv.outputs.emplace(std::move(id), std::move(output));
     }
 
@@ -984,13 +1006,13 @@ Hash hashModulo(Store & store, const Basic & drv)
    Wire protocol serialisation
    -------------------------------------------------------------------------- */
 
-static Output readOutput(Source & in, const StoreDirConfig & store)
+static Output readOutput(Source & in, const StoreDirConfig & store, std::string_view drvName, OutputNameView outputName)
 {
     const auto pathS = readString(in);
     const auto hashAlgo = readString(in);
     const auto hash = readString(in);
 
-    return parseOutput(store, pathS, hashAlgo, hash, experimentalFeatureSettings);
+    return parseOutput(store, drvName, outputName, pathS, hashAlgo, hash, experimentalFeatureSettings);
 }
 
 Source & read(Source & in, const StoreDirConfig & store, Basic & drv, std::string_view name)
@@ -1000,9 +1022,9 @@ Source & read(Source & in, const StoreDirConfig & store, Basic & drv, std::strin
     drv.outputs.clear();
     auto nr = readNum<size_t>(in);
     for (size_t n = 0; n < nr; n++) {
-        auto name = readString(in);
-        auto output = readOutput(in, store);
-        drv.outputs.emplace(std::move(name), std::move(output));
+        auto outputName = readString(in);
+        auto output = readOutput(in, store, name, outputName);
+        drv.outputs.emplace(std::move(outputName), std::move(output));
     }
 
     drv.inputs = CommonProto::Serialise<StorePathSet>::read(store, CommonProto::ReadConn{.from = in});


### PR DESCRIPTION
(description emitted by @Ericson2314)

## Motivation

The output path stated in the ATerm for a fixed-output derivation is redundant --- it is a function of the content address --- and we were simply discarding it while parsing. This meant bogus paths were not getting caught, and they would also cause a round-trip violation.

Now, we instead assert that the path is correct. We compute the path as the unparser does, and reject a mismatch.

## Context

This requires threading the derivation name and output name into `parseOutput`, and so also into `readOutput` for the wire protocol, which had the same gap.

### Fuzzing

The check is compiled out under `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`, which our fuzz builds define project-wide. (It is an OSS-Fuzz/libFuzzer convention passed by the build system; Clang does not define it itself.)

The other canonicality checks on this branch --- sorted keys, no redundant escapes --- are ones a fuzzer can learn to satisfy. This one is not: it asks for a hash preimage, so keeping it would make the fixed-output branch *unreachable* to the fuzzer rather than merely hard to reach. Compiling out checksum guards is the usual treatment for this.

The check itself is therefore covered by a unit test (`CAFixedPathMismatch`) rather than by the fuzzer.

Note that the fixed-output branch is thinly covered today regardless: no derivation in the seed corpus is fixed-output (`hello-ca.drv` is CA-*floating*, `("out","","r:sha256","")`), and `derivations.dict` has no hash tokens. A follow-up will seed the corpus accordingly.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).

