### PR TITLE
Configure case-hack once in the NAR fuzzer

### DIFF
--- a/src/libutil-tests/fuzz/parse-dump-case-hacked.cc
+++ b/src/libutil-tests/fuzz/parse-dump-case-hacked.cc
@@ -5,6 +5,8 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
 {
     using namespace nix;
-    assert(globalConfig.set("use-case-hack", "true"));
+    static const bool caseHackConfigured = globalConfig.set("use-case-hack", "true");
+    if (!caseHackConfigured)
+        __builtin_trap();
     return fuzzParseDumpCommon(std::string_view(reinterpret_cast<const char *>(data), size), /*acceptInvalid=*/true);
 }


### PR DESCRIPTION
## Motivation

The case-hacked NAR fuzzer sets `use-case-hack` inside an `assert` for every input, even though the setting only needs to be applied once.

## Context

Move the setup to a checked function-local static. It runs once, and the harness traps if the setting cannot be applied.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
