### PR TITLE
Drop lexically redundant traces

### DIFF
--- a/src/libexpr-tests/error_traces.cc
+++ b/src/libexpr-tests/error_traces.cc
@@ -22,7 +22,7 @@ TEST_F(ErrorTraceTest, TraceBuilder)
             try {
                 state.error<EvalError>("puppy").withTrace(noPos, "doggy").debugThrow();
             } catch (Error & e) {
-                e.addTrace(state.positions[noPos], "beans");
+                e.addTrace(state.positions.getEntry(noPos), "beans");
                 throw;
             }
         } catch (BaseError & e) {
@@ -45,8 +45,8 @@ TEST_F(ErrorTraceTest, NestedThrows)
         try {
             state.error<EvalError>("beans").debugThrow();
         } catch (Error & e2) {
-            e.addTrace(state.positions[noPos], "beans2");
-            // e2.addTrace(state.positions[noPos], "Something", "");
+            e.addTrace(state.positions.getEntry(noPos), "beans2");
+            // e2.addTrace(state.positions.getEntry(noPos), "Something", "");
             ASSERT_TRUE(e.info().traces.size() == 2u);
             ASSERT_TRUE(e2.info().traces.size() == 0u);
             ASSERT_FALSE(&e.info() == &e2.info());

--- a/src/libexpr/eval-error.cc
+++ b/src/libexpr/eval-error.cc
@@ -21,6 +21,7 @@ EvalErrorBuilder<T> & EvalErrorBuilder<T>::withExitStatus(unsigned int exitStatu
 template<class T>
 EvalErrorBuilder<T> & EvalErrorBuilder<T>::atPos(PosIdx pos)
 {
+    error.err.lastTracePos = pos;
     error.err.pos = error.state.positions[pos];
     return *this;
 }
@@ -34,7 +35,7 @@ EvalErrorBuilder<T> & EvalErrorBuilder<T>::atPos(Value & value, PosIdx fallback)
 template<class T>
 EvalErrorBuilder<T> & EvalErrorBuilder<T>::withTrace(PosIdx pos, const std::string_view text)
 {
-    error.addTrace(error.state.positions[pos], text);
+    error.addTrace(error.state.positions.getEntry(pos), text);
     return *this;
 }
 
@@ -64,7 +65,7 @@ EvalErrorBuilder<T> & EvalErrorBuilder<T>::withFrame(const Env & env, const Expr
 template<class T>
 EvalErrorBuilder<T> & EvalErrorBuilder<T>::addTrace(PosIdx pos, HintFmt hint)
 {
-    error.addTrace(error.state.positions[pos], hint);
+    error.addTrace(error.state.positions.getEntry(pos), hint);
     return *this;
 }
 
@@ -74,7 +75,7 @@ EvalErrorBuilder<T> &
 EvalErrorBuilder<T>::addTrace(PosIdx pos, std::string_view formatString, const Args &... formatArgs)
 {
 
-    addTrace(error.state.positions[pos], HintFmt(std::string(formatString), formatArgs...));
+    addTrace(error.state.positions.getEntry(pos), HintFmt(std::string(formatString), formatArgs...));
     return *this;
 }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -671,7 +671,7 @@ std::optional<EvalState::Doc> EvalState::getDoc(Value & v)
             auto _level = addCallDepth(noPos);
             return getDoc(partiallyApplied);
         } catch (Error & e) {
-            e.addTrace(nullptr, "while partially calling '%1%' to retrieve documentation", "__functor");
+            e.addTrace({}, "while partially calling '%1%' to retrieve documentation", "__functor");
             throw;
         }
     }
@@ -871,13 +871,13 @@ void EvalState::runDebugRepl(const Error * error, const Env & env, const Expr & 
 template<typename... Args>
 void EvalState::addErrorTrace(Error & e, const Args &... formatArgs) const
 {
-    e.addTrace(nullptr, HintFmt(formatArgs...));
+    e.addTrace({}, HintFmt(formatArgs...));
 }
 
 template<typename... Args>
 void EvalState::addErrorTrace(Error & e, const PosIdx pos, const Args &... formatArgs) const
 {
-    e.addTrace(positions[pos], HintFmt(formatArgs...));
+    e.addTrace(positions.getEntry(pos), HintFmt(formatArgs...));
 }
 
 template<typename... Args>
@@ -1222,7 +1222,7 @@ inline bool EvalState::evalBool(Env & env, Expr * e, std::string_view errorCtx)
                 .debugThrow();
         return v.boolean();
     } catch (Error & e) {
-        e.addTrace(positions[pos], errorCtx);
+        e.addTrace(positions.getEntry(pos), errorCtx);
         throw;
     }
 }
@@ -1238,7 +1238,7 @@ inline void EvalState::evalAttrs(Env & env, Expr * e, Value & v, std::string_vie
                 .withFrame(env, *e)
                 .debugThrow();
     } catch (Error & e) {
-        e.addTrace(positions[pos], errorCtx);
+        e.addTrace(positions.getEntry(pos), errorCtx);
         throw;
     }
 }
@@ -1248,7 +1248,7 @@ void Expr::eval(EvalState & state, Env & env, Value & v, std::string_view errorC
     try {
         eval(state, env, v);
     } catch (Error & e) {
-        e.addTrace(state.positions[getPos()], errorCtx);
+        e.addTrace(state.positions.getEntry(getPos()), errorCtx);
         throw;
     }
 }
@@ -1620,7 +1620,7 @@ void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value &
                     forceAttrs(*args[0], lambda.pos, "while evaluating the value passed for the lambda argument");
                 } catch (Error & e) {
                     if (pos)
-                        e.addTrace(positions[pos], "from call site");
+                        e.addTrace(positions.getEntry(pos), "from call site");
                     throw;
                 }
 
@@ -1796,7 +1796,8 @@ void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value &
             try {
                 callFunction(*functor->value, std::to_array({&(*allocValue() = vCur), args[0]}), vCur, functor->pos);
             } catch (Error & e) {
-                e.addTrace(positions[pos], "while calling a functor (an attribute set with a '__functor' attribute)");
+                e.addTrace(
+                    positions.getEntry(pos), "while calling a functor (an attribute set with a '__functor' attribute)");
                 throw;
             }
             args = args.subspan(1);
@@ -1926,7 +1927,8 @@ void ExprAssert::eval(EvalState & state, Env & env, Value & v)
                 eq->e2->eval(state, env, v2);
                 state.assertEqValues(v1, v2, eq->pos, "in an equality assertion");
             } catch (AssertionError & e) {
-                e.addTrace(state.positions[pos], "while evaluating the condition of the assertion '%s'", exprStr);
+                e.addTrace(
+                    state.positions.getEntry(pos), "while evaluating the condition of the assertion '%s'", exprStr);
                 throw;
             }
         }
@@ -2271,8 +2273,7 @@ void EvalState::handleEvalExceptionForThunk(Env * env, Expr * expr, Value & v, c
         // 2. initial forcing of the thunk, which is where the cycle starts
         // Only the first force has an `env`, so we expect this entry to be added once.
         if (env && ir.v == &v)
-            ir.addTrace(
-                nullptr, HintFmt(ANSI_WARNING "entering the infinite recursion" ANSI_NORMAL), TracePrint::Always);
+            ir.addTrace({}, HintFmt(ANSI_WARNING "entering the infinite recursion" ANSI_NORMAL), TracePrint::Always);
     } catch (const RecoverableEvalError & e) {
         recovery = allocValue();
     } catch (...) {
@@ -2323,7 +2324,7 @@ void EvalState::tryFixupBlackHolePos(Value & v, PosIdx pos)
         std::rethrow_exception(e);
     } catch (InfiniteRecursionError & e) {
         if (!e.hasPos())
-            e.atPos(positions[pos]);
+            e.atPos(positions.getEntry(pos));
     } catch (...) {
     }
 }
@@ -2385,7 +2386,7 @@ NixInt EvalState::forceInt(Value & v, const PosIdx pos, std::string_view errorCt
                 .debugThrow();
         return v.integer();
     } catch (Error & e) {
-        e.addTrace(positions[pos], errorCtx);
+        e.addTrace(positions.getEntry(pos), errorCtx);
         throw;
     }
 
@@ -2405,7 +2406,7 @@ NixFloat EvalState::forceFloat(Value & v, const PosIdx pos, std::string_view err
                 .debugThrow();
         return v.fpoint();
     } catch (Error & e) {
-        e.addTrace(positions[pos], errorCtx);
+        e.addTrace(positions.getEntry(pos), errorCtx);
         throw;
     }
 }
@@ -2421,7 +2422,7 @@ bool EvalState::forceBool(Value & v, const PosIdx pos, std::string_view errorCtx
                 .debugThrow();
         return v.boolean();
     } catch (Error & e) {
-        e.addTrace(positions[pos], errorCtx);
+        e.addTrace(positions.getEntry(pos), errorCtx);
         throw;
     }
 
@@ -2452,7 +2453,7 @@ void EvalState::forceFunction(Value & v, const PosIdx pos, std::string_view erro
                 .atPos(pos)
                 .debugThrow();
     } catch (Error & e) {
-        e.addTrace(positions[pos], errorCtx);
+        e.addTrace(positions.getEntry(pos), errorCtx);
         throw;
     }
 }
@@ -2468,7 +2469,7 @@ std::string_view EvalState::forceString(Value & v, const PosIdx pos, std::string
                 .debugThrow();
         return v.string_view();
     } catch (Error & e) {
-        e.addTrace(positions[pos], errorCtx);
+        e.addTrace(positions.getEntry(pos), errorCtx);
         throw;
     }
 }
@@ -2582,7 +2583,7 @@ BackedStringView EvalState::coerceToString(
         try {
             return v.external()->coerceToString(*this, pos, context, coerceMore, copyToStore);
         } catch (Error & e) {
-            e.addTrace(nullptr, errorCtx);
+            e.addTrace({}, errorCtx);
             throw;
         }
     }
@@ -2615,7 +2616,7 @@ BackedStringView EvalState::coerceToString(
                         copyToStore,
                         canonicalizePath);
                 } catch (Error & e) {
-                    e.addTrace(positions[pos], errorCtx);
+                    e.addTrace(positions.getEntry(pos), errorCtx);
                     throw;
                 }
                 if (n < v.listSize() - 1
@@ -2839,7 +2840,7 @@ void EvalState::assertEqValues(Value & v1, Value & v2, const PosIdx pos, std::st
             try {
                 assertEqValues(*v1.listView()[n], *v2.listView()[n], pos, errorCtx);
             } catch (Error & e) {
-                e.addTrace(positions[pos], "while comparing list element %d", n);
+                e.addTrace(positions.getEntry(pos), "while comparing list element %d", n);
                 throw;
             }
         }
@@ -2854,7 +2855,8 @@ void EvalState::assertEqValues(Value & v1, Value & v2, const PosIdx pos, std::st
                     assertEqValues(*i->value, *j->value, pos, errorCtx);
                     return;
                 } catch (Error & e) {
-                    e.addTrace(positions[pos], "while comparing a derivation by its '%s' attribute", "outPath");
+                    e.addTrace(
+                        positions.getEntry(pos), "while comparing a derivation by its '%s' attribute", "outPath");
                     throw;
                 }
                 assert(false);
@@ -2906,10 +2908,10 @@ void EvalState::assertEqValues(Value & v1, Value & v2, const PosIdx pos, std::st
                 //    at <pos>
                 //  while comparing attribute '<name>'
                 if (j->pos != noPos)
-                    e.addTrace(positions[j->pos], "where right hand side is");
+                    e.addTrace(positions.getEntry(j->pos), "where right hand side is");
                 if (i->pos != noPos)
-                    e.addTrace(positions[i->pos], "where left hand side is");
-                e.addTrace(positions[pos], "while comparing attribute '%s'", symbols[i->name]);
+                    e.addTrace(positions.getEntry(i->pos), "where left hand side is");
+                e.addTrace(positions.getEntry(pos), "while comparing attribute '%s'", symbols[i->name]);
                 throw;
             }
         }
@@ -3505,7 +3507,7 @@ void forceNoNullByte(std::string_view s, std::function<Pos()> pos)
         auto str = replaceStrings(std::string(s), "\0"sv, "␀"sv);
         Error error("input string '%s' cannot be represented as Nix string because it contains null bytes", str);
         if (pos) {
-            error.atPos(pos());
+            error.atPos({noPos, pos()});
         }
         throw std::move(error);
     }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1221,8 +1221,9 @@ inline bool EvalState::evalBool(Env & env, Expr * e, std::string_view errorCtx)
                 .withFrame(env, *e)
                 .debugThrow();
         return v.boolean();
-    } catch (Error & e) {
-        e.addTrace(positions.getEntry(pos), errorCtx);
+    } catch (Error & err) {
+        if (e->hasNewPos(err))
+            err.addTrace(positions.getEntry(pos), errorCtx);
         throw;
     }
 }
@@ -1237,8 +1238,9 @@ inline void EvalState::evalAttrs(Env & env, Expr * e, Value & v, std::string_vie
                 "expected a set but found %1%: %2%", showType(v), ValuePrinter(*this, v, errorPrintOptions))
                 .withFrame(env, *e)
                 .debugThrow();
-    } catch (Error & e) {
-        e.addTrace(positions.getEntry(pos), errorCtx);
+    } catch (Error & err) {
+        if (e->hasNewPos(err))
+            err.addTrace(positions.getEntry(pos), errorCtx);
         throw;
     }
 }
@@ -1248,7 +1250,8 @@ void Expr::eval(EvalState & state, Env & env, Value & v, std::string_view errorC
     try {
         eval(state, env, v);
     } catch (Error & e) {
-        e.addTrace(state.positions.getEntry(getPos()), errorCtx);
+        if (hasNewPos(e))
+            e.addTrace(state.positions.getEntry(getPos()), errorCtx);
         throw;
     }
 }
@@ -1467,6 +1470,7 @@ void ExprSelect::eval(EvalState & state, Env & env, Value & v)
     const AttrName * unresolvedOrEnd = attrPathStart;
     // cursor, result if successful
     Value * vAttrs = &vTmp;
+    Expr * thunkExpr = nullptr;
 
     e->eval(state, env, vTmp, "while selecting an attribute");
 
@@ -1510,11 +1514,12 @@ void ExprSelect::eval(EvalState & state, Env & env, Value & v)
                 state.attrSelects->try_emplace_or_visit(attrPos, 1, [](auto & i) { i.second++; });
         }
 
+        thunkExpr = vAttrs->maybeGetThunkExpr();
         state.forceValue(*vAttrs, (attrPos ? attrPos : this->pos));
 
     } catch (Error & e) {
         // Traces are printed in reverse, so we add context before the main item.
-        if (attrPos) {
+        if (attrPos && (thunkExpr == nullptr || thunkExpr->hasNewPos(e))) {
             auto attrPosR = state.positions[attrPos];
             auto origin = std::get_if<SourcePath>(&attrPosR.origin);
             if (!(origin && *origin == state.derivationInternal)) {
@@ -1524,8 +1529,10 @@ void ExprSelect::eval(EvalState & state, Env & env, Value & v)
             }
         }
         // Add main item: the selection site itself (`a.b`), ie the actual access
-        state.addErrorTrace(
-            e, getPos(), "while evaluating the attribute '%1%'", showAttrSelectionPath(state, env, getAttrPath()));
+        if (hasNewPos(e)) {
+            state.addErrorTrace(
+                e, getPos(), "while evaluating the attribute '%1%'", showAttrSelectionPath(state, env, getAttrPath()));
+        }
         throw;
     }
 
@@ -1575,7 +1582,8 @@ void ExprLambda::eval(EvalState & state, Env & env, Value & v)
     v.mkLambda(&env, this);
 }
 
-void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value & vRes, const PosIdx pos)
+void EvalState::callFunction(
+    Value & fun, std::span<Value * const> args, Value & vRes, const PosIdx pos, const Expr * expr)
 {
     auto _level = addCallDepth(pos);
 
@@ -1619,7 +1627,9 @@ void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value &
                 try {
                     forceAttrs(*args[0], lambda.pos, "while evaluating the value passed for the lambda argument");
                 } catch (Error & e) {
-                    if (pos)
+                    // Do not trace the call site if it encloses the lambda
+                    // being called; the lambda already has a trace.
+                    if (pos && pos != lambda.pos && (expr == nullptr || expr->comparePos(lambda.pos) != 0))
                         e.addTrace(positions.getEntry(pos), "from call site");
                     throw;
                 }
@@ -1697,12 +1707,16 @@ void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value &
                 lambda.body->eval(*this, env2, vCur);
             } catch (Error & e) {
                 if (loggerSettings.showTrace.get()) {
-                    addErrorTrace(
-                        e,
-                        lambda.pos,
-                        "while calling %s",
-                        lambda.name ? concatStrings("'", symbols[lambda.name], "'") : "anonymous lambda");
-                    if (pos)
+                    if (lambda.hasNewPos(e)) {
+                        addErrorTrace(
+                            e,
+                            lambda.pos,
+                            "while calling %s",
+                            lambda.name ? concatStrings("'", symbols[lambda.name], "'") : "anonymous lambda");
+                    }
+                    // Do not trace the call site if it encloses the lambda
+                    // being called; the lambda already has a trace.
+                    if (pos && pos != lambda.pos && (expr == nullptr || expr->comparePos(lambda.pos) != 0))
                         addErrorTrace(e, pos, "from call site");
                 }
                 throw;
@@ -1730,7 +1744,7 @@ void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value &
                 try {
                     fn->impl(*this, CallSite{pos}, args.data(), vCur);
                 } catch (Error & e) {
-                    if (fn->addTrace)
+                    if (fn->addTrace && (expr == nullptr || expr->hasNewPos(e)))
                         addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);
                     throw;
                 }
@@ -1780,7 +1794,7 @@ void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value &
                     //    so the debugger allows to inspect the wrong parameters passed to the builtin.
                     fn->impl(*this, CallSite{pos}, vArgs, vCur);
                 } catch (Error & e) {
-                    if (fn->addTrace)
+                    if (fn->addTrace && (expr == nullptr || expr->hasNewPos(e)))
                         addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);
                     throw;
                 }
@@ -1793,11 +1807,15 @@ void EvalState::callFunction(Value & fun, std::span<Value * const> args, Value &
             /* 'vCur' may be allocated on the stack of the calling
                function, but for functors we may keep a reference, so
                heap-allocate a copy and use that instead. */
+            auto thunkExpr = functor->value->maybeGetThunkExpr();
             try {
                 callFunction(*functor->value, std::to_array({&(*allocValue() = vCur), args[0]}), vCur, functor->pos);
             } catch (Error & e) {
-                e.addTrace(
-                    positions.getEntry(pos), "while calling a functor (an attribute set with a '__functor' attribute)");
+                if (thunkExpr == nullptr || thunkExpr->hasNewPos(e)) {
+                    e.addTrace(
+                        positions.getEntry(pos),
+                        "while calling a functor (an attribute set with a '__functor' attribute)");
+                }
                 throw;
             }
             args = args.subspan(1);
@@ -1833,7 +1851,7 @@ void ExprCall::eval(EvalState & state, Env & env, Value & v)
     for (size_t i = 0; i < args->size(); ++i)
         vArgs[i] = (*args)[i]->maybeThunk(state, env);
 
-    state.callFunction(vFun, vArgs, v, pos);
+    state.callFunction(vFun, vArgs, v, pos, this);
 }
 
 // Lifted out of callFunction() because it creates a temporary that
@@ -1927,8 +1945,10 @@ void ExprAssert::eval(EvalState & state, Env & env, Value & v)
                 eq->e2->eval(state, env, v2);
                 state.assertEqValues(v1, v2, eq->pos, "in an equality assertion");
             } catch (AssertionError & e) {
-                e.addTrace(
-                    state.positions.getEntry(pos), "while evaluating the condition of the assertion '%s'", exprStr);
+                if (hasNewPos(e)) {
+                    e.addTrace(
+                        state.positions.getEntry(pos), "while evaluating the condition of the assertion '%s'", exprStr);
+                }
                 throw;
             }
         }
@@ -2342,7 +2362,8 @@ void EvalState::forceValueDeep(Value & v)
         state.forceValue(v, v.determinePos(noPos));
 
         if (v.type() == nAttrs) {
-            for (auto & i : *v.attrs())
+            for (auto & i : *v.attrs()) {
+                auto thunkExpr = i.value->maybeGetThunkExpr();
                 try {
                     // If the value is a thunk, we're evaling. Otherwise no trace necessary.
                     auto dts = state.debugRepl && i.value->isThunk() ? makeDebugTraceStacker(
@@ -2356,9 +2377,11 @@ void EvalState::forceValueDeep(Value & v)
 
                     recurse(*i.value);
                 } catch (Error & e) {
-                    state.addErrorTrace(e, i.pos, "while evaluating the attribute '%1%'", state.symbols[i.name]);
+                    if (thunkExpr == nullptr || thunkExpr->hasNewPos(e))
+                        state.addErrorTrace(e, i.pos, "while evaluating the attribute '%1%'", state.symbols[i.name]);
                     throw;
                 }
+            }
         }
 
         else if (v.isList()) {

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -73,7 +73,8 @@ std::optional<StorePath> PackageInfo::queryDrvPath() const
             try {
                 found.requireDerivation();
             } catch (Error & e) {
-                e.addTrace(state->positions[i->pos], "while evaluating the 'drvPath' attribute of a derivation");
+                e.addTrace(
+                    state->positions.getEntry(i->pos), "while evaluating the 'drvPath' attribute of a derivation");
                 throw;
             }
             drvPath = {std::move(found)};
@@ -441,7 +442,7 @@ static void getDerivations(
                     }
                 }
             } catch (Error & e) {
-                e.addTrace(state.positions[i->pos], "while evaluating the attribute '%s'", symbol);
+                e.addTrace(state.positions.getEntry(i->pos), "while evaluating the attribute '%s'", symbol);
                 throw;
             }
         }

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -421,6 +421,7 @@ static void getDerivations(
            precedence). */
         for (auto & i : v.attrs()->lexicographicOrder(state.symbols)) {
             std::string_view symbol{state.symbols[i->name]};
+            Expr * thunkExpr = i->value->maybeGetThunkExpr();
             try {
                 debug("evaluating attribute '%1%'", symbol);
                 if (!isAttrPathComponent(symbol))
@@ -442,7 +443,8 @@ static void getDerivations(
                     }
                 }
             } catch (Error & e) {
-                e.addTrace(state.positions.getEntry(i->pos), "while evaluating the attribute '%s'", symbol);
+                if (thunkExpr == nullptr || thunkExpr->hasNewPos(e))
+                    e.addTrace(state.positions.getEntry(i->pos), "while evaluating the attribute '%s'", symbol);
                 throw;
             }
         }

--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -195,7 +195,7 @@ EvalState::peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringRe
             try {
                 state.callFunction(*i->value, v, v1, i->pos);
             } catch (Error & e) {
-                e.addTrace(state.positions[i->pos], "while calling the `__toString` attribute");
+                e.addTrace(state.positions.getEntry(i->pos), "while calling the `__toString` attribute");
                 throw;
             }
             cameThroughToString = true;
@@ -204,7 +204,9 @@ EvalState::peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringRe
                 return peel(i->pos, v1);
             } catch (Error & e) {
                 e.addTrace(
-                    state.positions[i->pos], "while %s the result of the `__toString` attribute", WhileTryingToUse{v1});
+                    state.positions.getEntry(i->pos),
+                    "while %s the result of the `__toString` attribute",
+                    WhileTryingToUse{v1});
                 throw;
             }
         }
@@ -214,7 +216,8 @@ EvalState::peelToStringOutPath(const PosIdx pos, Value & v, bool checkToStringRe
                 auto _level = state.addCallDepth(pos);
                 return peel(i->pos, *i->value);
             } catch (Error & e) {
-                e.addTrace(state.positions[i->pos], "while %s the `outPath` attribute", WhileTryingToUse{*i->value});
+                e.addTrace(
+                    state.positions.getEntry(i->pos), "while %s the `outPath` attribute", WhileTryingToUse{*i->value});
                 throw;
             }
         }

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -1015,11 +1015,12 @@ public:
 
     bool isFunctor(const Value & fun) const;
 
-    void callFunction(Value & fun, std::span<Value * const> args, Value & vRes, const PosIdx pos);
+    void callFunction(
+        Value & fun, std::span<Value * const> args, Value & vRes, const PosIdx pos, const Expr * expr = nullptr);
 
-    void callFunction(Value & fun, Value & arg, Value & vRes, const PosIdx pos)
+    void callFunction(Value & fun, Value & arg, Value & vRes, const PosIdx pos, const Expr * expr = nullptr)
     {
-        callFunction(fun, std::to_array({&arg}), vRes, pos);
+        callFunction(fun, std::to_array({&arg}), vRes, pos, expr);
     }
 
     /**

--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -562,7 +562,7 @@ public:
                 "too many formal arguments, implementation supports at most %1%",
                 std::numeric_limits<decltype(nFormals)>::max());
             if (pos)
-                err.atPos(positions[pos]);
+                err.atPos(positions.getEntry(pos));
             throw std::move(err);
         }
         std::uninitialized_copy_n(formals.formals.begin(), nFormals, formalsStart);

--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -143,9 +143,62 @@ struct Expr
         return noPos;
     }
 
+    /**
+     * Return equivalent if this expression includes a subexpression positioned
+     * at `otherPos`, unordered if this is unpositioned or `otherPos` is
+     * `noPos`, and less or greater if `otherPos` occurs after or before every
+     * marked position in this expression.
+     *
+     * Note that positions that don't correspond to positioned subexpressions
+     * may not pass this test, even if that position is contained in the
+     * interval spanned by the parsed expression. For example: `foo 0`, as an
+     * expression, contains the subexpression `0`, but since integer literals
+     * don't get their own position information, calling `comparePos` on the
+     * `ExprCall` with the position of the `0` literal is not guaranteed to
+     * return equivalent. Another example: `foo bar` spans the position of the `a`
+     * character, but calling `comparePos` on the `ExprCall` with the position
+     * of the `a` is not guaranteed to return equivalent either, because `ExprVar`s
+     * don't know how long they are.
+     *
+     * This is fine for two reasons:
+     * 1. We don't really care about incorrect misses; this function is only
+     * used to filter traces, and an incorrect non-equivalent just means that a
+     * trace slips through.
+     * 2. This should only ever be called with positions that came from
+     * subexpressions in the first place -- so nothing from unpositioned
+     * expressions like integer literals, and nothing that comes from the
+     * middle of a token.
+     */
+    virtual std::partial_ordering comparePos(PosIdx otherPos) const noexcept
+    {
+        return getPos().partialCompare(otherPos);
+    }
+
+    /**
+     * Return true if this expression does not contain the position of the
+     * last-added trace in the argument.
+     *
+     * Use this method to drop traces that would be redundant. In an expression
+     * like `throw "oops" * 5 + 1`, we don't need a trace entry for `throw`
+     * *and* for the multiplication *and* for the addition. Once the `throw`
+     * has been indicated, the other two traces would be redundant; the user
+     * already knows where to look from the `throw` trace. If the expression
+     * for the current stack frame is known when an error `e` is caught, we can
+     * remove these redundant frames by only adding a trace if `hasNewPos(e)`
+     * is true.
+     */
+    bool hasNewPos(const Error & e) const
+    {
+        return comparePos(e.getLastTracePosIdx()) != 0;
+    }
+
     // These are temporary methods to be used only in parser.y
     virtual void resetCursedOr() {};
     virtual void warnIfCursedOr(const SymbolTable & symbols, const PosTable & positions) {};
+
+protected:
+    /** The shared logic for implementing comparePos for binary operators. */
+    static std::partial_ordering binOpComparePos(const Expr *, PosIdx, const Expr *, PosIdx);
 };
 
 #define COMMON_METHODS                                                         \
@@ -319,6 +372,8 @@ struct ExprSelect : Expr
         return pos;
     }
 
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
+
     /**
      * @return `std::span<const AttrName>` starting at `attrPathStart`
      */
@@ -357,6 +412,8 @@ struct ExprOpHasAttr : Expr
     {
         return e->getPos();
     }
+
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
 
     COMMON_METHODS
 };
@@ -440,6 +497,8 @@ struct ExprAttrs : Expr
         return pos;
     }
 
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
+
     COMMON_METHODS
 
     std::shared_ptr<const StaticEnv> bindInheritSources(EvalState & es, const std::shared_ptr<const StaticEnv> & env);
@@ -465,6 +524,8 @@ struct ExprList : Expr
     {
         return elems.empty() ? noPos : elems.front()->getPos();
     }
+
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
 };
 
 struct Formal
@@ -593,6 +654,8 @@ public:
         return pos;
     }
 
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
+
     virtual void setDocComment(DocComment docComment) override;
     COMMON_METHODS
 };
@@ -628,6 +691,8 @@ struct ExprCall : Expr
         return pos;
     }
 
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
+
     virtual void resetCursedOr() override;
     virtual void warnIfCursedOr(const SymbolTable & symbols, const PosTable & positions) override;
     void moveDataToAllocator(std::pmr::polymorphic_allocator<char> & alloc);
@@ -641,6 +706,9 @@ struct ExprLet : Expr
     ExprLet(ExprAttrs * attrs, Expr * body)
         : attrs(attrs)
         , body(body) {};
+
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
+
     COMMON_METHODS
 };
 
@@ -660,6 +728,8 @@ struct ExprWith : Expr
         return pos;
     }
 
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
+
     COMMON_METHODS
 };
 
@@ -678,6 +748,8 @@ struct ExprIf : Expr
         return pos;
     }
 
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
+
     COMMON_METHODS
 };
 
@@ -695,6 +767,8 @@ struct ExprAssert : Expr
         return pos;
     }
 
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
+
     COMMON_METHODS
 };
 
@@ -708,6 +782,8 @@ struct ExprOpNot : Expr
     {
         return e->getPos();
     }
+
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
 
     COMMON_METHODS
 };
@@ -739,6 +815,10 @@ struct ExprOpNot : Expr
     PosIdx getPos() const override                                                       \
     {                                                                                    \
         return pos;                                                                      \
+    }                                                                                    \
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override            \
+    {                                                                                    \
+        return binOpComparePos(e1, pos, e2, otherPos);                                   \
     }
 
 #define MakeBinOp(name, s)        \
@@ -800,6 +880,8 @@ struct ExprConcatStrings : Expr
     {
         return pos;
     }
+
+    std::partial_ordering comparePos(PosIdx otherPos) const noexcept override;
 
     COMMON_METHODS
 };

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -1554,6 +1554,11 @@ public:
         return getStorage<ClosureThunk>();
     }
 
+    Expr * maybeGetThunkExpr() const noexcept
+    {
+        return isThunk() ? thunk().expr : nullptr;
+    }
+
     PrimOpApplicationThunk primOpApp() const noexcept
     {
         return getStorage<PrimOpApplicationThunk>();

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -595,6 +595,278 @@ void ExprPos::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & 
         es.exprEnvs.insert(std::make_pair(this, env));
 }
 
+/* Finding positions in expressions for error traces. */
+
+std::partial_ordering ExprOpHasAttr::comparePos(PosIdx otherPos) const noexcept
+{
+    return e->comparePos(otherPos);
+}
+
+std::partial_ordering ExprOpNot::comparePos(PosIdx otherPos) const noexcept
+{
+    return e->comparePos(otherPos);
+}
+
+/**
+ * Utility for aggregating invididual comparisons between points in an interval
+ * and a point into an overall comparison between the entire interval and the
+ * point.
+ *
+ * comparePos methods, if implemented naively, would walk the entire expression
+ * tree. To try to make them a little less expensive, we exploit the (mostly)
+ * ordered nature of the tree and perform the comparison in two directions:
+ * first from the left, until we find a value that is less than the position in
+ * question; at which point we pivot to searching from the right. If we also
+ * find a value that is greater than the position in question, we can terminate
+ * the search. (Of course, if when searching from the left, we find a value
+ * that is *greater* than the position in question, we can also terminate
+ * early; same for the other side.)
+ */
+struct PartialOrderingAccumulator
+{
+    /**
+     * The result of the comparison. Is kept updated throughout, and is used to
+     * record whether a value less than or greater than the needle has been
+     * found yet.
+     */
+    std::partial_ordering result = std::partial_ordering::unordered;
+
+    /**
+     * Accumulate `po` into `result`. Return true if the result is known after
+     * the update.
+     */
+    bool updateAgnostic(std::partial_ordering po)
+    {
+        if (po == std::partial_ordering::unordered) {
+            return false;
+        }
+        if (po < 0) {
+            if (!(result > 0)) {
+                result = std::partial_ordering::less;
+                return false;
+            }
+        } else if (po > 0) {
+            if (!(result < 0)) {
+                result = std::partial_ordering::greater;
+                return false;
+            }
+        }
+        result = std::partial_ordering::equivalent;
+        return true;
+    }
+
+    /**
+     * As `updateAgnostic`, but optimized for when every comparison to the left
+     * of this one has already been checked.
+     */
+    bool updateLeft(std::partial_ordering po)
+    {
+        if (po == std::partial_ordering::unordered) {
+            return false;
+        }
+        if (po < 0 && !(result > 0)) {
+            result = std::partial_ordering::less;
+            return false;
+        }
+        result = po <= 0 || (po > 0 && result < 0) ? std::partial_ordering::equivalent : std::partial_ordering::greater;
+        return true;
+    }
+
+    /**
+     * As `updateAgnostic`, but optimized for when every comparison to the
+     * right of this one has already been checked. Prefer searching from the
+     * right with this method when `result < 0` (meaning that the interval is
+     * already known to contain a value less than the needle).
+     */
+    bool updateRight(std::partial_ordering po)
+    {
+        if (po == std::partial_ordering::unordered) {
+            return false;
+        }
+        if (po > 0 && !(result < 0)) {
+            result = std::partial_ordering::greater;
+            return false;
+        }
+        result = po >= 0 || (po < 0 && result > 0) ? std::partial_ordering::equivalent : std::partial_ordering::less;
+        return true;
+    }
+};
+
+/**
+ * Search a sequence of expressions, known to be in order of their positions
+ * and found to the right of all other positions (which must have already been
+ * checked) in the subexpression.
+ */
+static std::partial_ordering
+updateAndEndWithExprs(PartialOrderingAccumulator & poa, const std::span<Expr * const> elems, PosIdx otherPos)
+{
+    Expr * const * lastChecked = nullptr;
+    if (!(poa.result < 0)) {
+        for (auto & elem : elems) {
+            if (poa.updateLeft(elem->comparePos(otherPos)) || &elem == &elems.back())
+                return poa.result;
+
+            if (poa.result < 0) {
+                lastChecked = &elem;
+                break;
+            }
+        }
+    }
+    for (auto & elem : std::views::reverse(elems)) {
+        if (&elem == lastChecked || poa.updateRight(elem->comparePos(otherPos)))
+            break;
+    }
+    return poa.result;
+}
+
+std::partial_ordering ExprList::comparePos(PosIdx otherPos) const noexcept
+{
+    if (otherPos == noPos)
+        return std::partial_ordering::unordered;
+
+    PartialOrderingAccumulator poa{};
+    return updateAndEndWithExprs(poa, elems, otherPos);
+}
+
+std::partial_ordering ExprCall::comparePos(PosIdx otherPos) const noexcept
+{
+    if (otherPos == noPos)
+        return std::partial_ordering::unordered;
+
+    PartialOrderingAccumulator poa{};
+
+    // Only check pos if we know this is not a desugared infix operator. In
+    // those cases, pos points to a location between the first and second
+    // arguments. So comparing with the argument positions only is sufficient,
+    // and comparing with pos would lead to an incorrect result if otherPos is
+    // contained in the first operand.
+    PosIdx p;
+    if (args->empty() || (p = args->front()->getPos()) == noPos || p >= pos) {
+        if (poa.updateLeft(pos.partialCompare(otherPos)))
+            return poa.result;
+    }
+
+    return updateAndEndWithExprs(poa, std::span(*args), otherPos);
+}
+
+std::partial_ordering ExprConcatStrings::comparePos(PosIdx otherPos) const noexcept
+{
+    if (otherPos == noPos)
+        return std::partial_ordering::unordered;
+
+    PartialOrderingAccumulator poa{};
+
+    // We ignore pos, since as in the ExprCall case, it might be an infix
+    // operator. Unlike in the ExprCall case, we never need to check the
+    // position of the outer string, since it can't be the position of a
+    // subexpression. Checking only the operands/interpolated values is
+    // sufficient.
+    std::pair<PosIdx, Expr *> * lastChecked = nullptr;
+    for (auto & e : es) {
+        if (poa.updateLeft(e.first.partialCompare(otherPos)))
+            return poa.result;
+
+        if (poa.result < 0) {
+            lastChecked = &e;
+            break;
+        }
+    }
+
+    for (auto & e : std::views::reverse(es)) {
+        if (&e == lastChecked || poa.updateRight(e.second->comparePos(otherPos))
+            || poa.updateRight(e.first.partialCompare(otherPos)))
+            return poa.result;
+    }
+
+    return poa.result;
+}
+
+std::partial_ordering ExprAttrs::comparePos(PosIdx otherPos) const noexcept
+{
+    if (otherPos == noPos)
+        return std::partial_ordering::unordered;
+
+    PartialOrderingAccumulator poa{};
+
+    if (poa.updateLeft(pos.partialCompare(otherPos)))
+        return poa.result;
+
+    // Attributes aren't position-ordered, so this can't use the smart
+    // reversing search we use for lists.
+    for (auto & [_, attr] : *attrs) {
+        if (poa.updateAgnostic(attr.pos.partialCompare(otherPos)) || poa.updateAgnostic(attr.e->comparePos(otherPos)))
+            return poa.result;
+    }
+    for (auto & attr : *dynamicAttrs) {
+        if (poa.updateAgnostic(attr.pos.partialCompare(otherPos))
+            || poa.updateAgnostic(attr.nameExpr->comparePos(otherPos))
+            || poa.updateAgnostic(attr.valueExpr->comparePos(otherPos)))
+            return poa.result;
+    }
+
+    return poa.result;
+}
+
+// This macro assumes a free PosIdx otherPos.
+#define COMPARE_POS_BODY_TEMPLATE(updates)       \
+    if (otherPos == noPos)                       \
+        return std::partial_ordering::unordered; \
+    PartialOrderingAccumulator poa{};            \
+    updates;                                     \
+    return poa.result;
+
+#define COMPARE_POS_TEMPLATE(Cls, updates)                                \
+    std::partial_ordering Cls::comparePos(PosIdx otherPos) const noexcept \
+    {                                                                     \
+        COMPARE_POS_BODY_TEMPLATE(updates)                                \
+    }
+
+// These macros assume a free PartialOrderingAccumulator poa.
+#define UPDATE_L2(e1, e2) (poa.updateLeft(e1) || poa.updateLeft(e2))
+#define UPDATE_L3(e1, e2, e3) (poa.updateLeft(e1) || (poa.result < 0 ? UPDATE_R2(e2, e3) : UPDATE_L2(e2, e3)))
+#define UPDATE_L4(e1, e2, e3, e4) \
+    (poa.updateLeft(e1) || (poa.result < 0 ? UPDATE_R3(e2, e3, e4) : UPDATE_L3(e2, e3, e4)))
+#define UPDATE_R2(e1, e2) (poa.updateRight(e2) || poa.updateRight(e1))
+#define UPDATE_R3(e1, e2, e3) (poa.updateRight(e3) || UPDATE_R2(e1, e2))
+
+COMPARE_POS_TEMPLATE(ExprLambda, UPDATE_L2(pos.partialCompare(otherPos), body->comparePos(otherPos)));
+COMPARE_POS_TEMPLATE(ExprLet, UPDATE_L2(attrs->comparePos(otherPos), body->comparePos(otherPos)));
+
+COMPARE_POS_TEMPLATE(
+    ExprAssert, UPDATE_L3(pos.partialCompare(otherPos), cond->comparePos(otherPos), body->comparePos(otherPos)));
+
+COMPARE_POS_TEMPLATE(
+    ExprSelect,
+    UPDATE_L3(
+        pos.partialCompare(otherPos),
+        e->comparePos(otherPos),
+        def ? def->comparePos(otherPos) : std::partial_ordering::unordered));
+
+COMPARE_POS_TEMPLATE(
+    ExprWith, UPDATE_L3(pos.partialCompare(otherPos), attrs->comparePos(otherPos), body->comparePos(otherPos)));
+
+std::partial_ordering Expr::binOpComparePos(const Expr * e1, PosIdx pos, const Expr * e2, PosIdx otherPos)
+{
+    COMPARE_POS_BODY_TEMPLATE(
+        UPDATE_L3(e1->comparePos(otherPos), pos.partialCompare(otherPos), e2->comparePos(otherPos)));
+}
+
+COMPARE_POS_TEMPLATE(
+    ExprIf,
+    UPDATE_L4(
+        pos.partialCompare(otherPos),
+        cond->comparePos(otherPos),
+        then->comparePos(otherPos),
+        else_->comparePos(otherPos)));
+
+#undef COMPARE_POS_BODY_TEMPLATE
+#undef COMPARE_POS_TEMPLATE
+#undef UPDATE_L2
+#undef UPDATE_L3
+#undef UPDATE_L4
+#undef UPDATE_R2
+#undef UPDATE_R3
+
 /* Storing function names. */
 
 void Expr::setName(Symbol name) {}

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -183,7 +183,7 @@ SourcePath EvalState::realisePath(
         }
         return resolveSymlinks ? path.resolveSymlinks(*resolveSymlinks) : path;
     } catch (Error & e) {
-        e.addTrace(nullptr, "while realising the context of path '%s'", path);
+        e.addTrace({}, "while realising the context of path '%s'", path);
         throw;
     }
 }
@@ -519,13 +519,13 @@ void prim_exec(EvalState & state, CallSite callSite, Value * const * args, Value
     try {
         parsed = state.parseExprFromString(std::move(output), state.rootPath(CanonPath::root));
     } catch (Error & e) {
-        e.addTrace(nullptr, "while parsing the output from '%1%'", program);
+        e.addTrace({}, "while parsing the output from '%1%'", program);
         throw;
     }
     try {
         state.eval(parsed, v);
     } catch (Error & e) {
-        e.addTrace(nullptr, "while evaluating the output from '%1%'", program);
+        e.addTrace({}, "while evaluating the output from '%1%'", program);
         throw;
     }
 }
@@ -780,7 +780,7 @@ struct CompareValues
             }
         } catch (Error & e) {
             if (!errorCtx.empty())
-                e.addTrace(nullptr, errorCtx);
+                e.addTrace({}, errorCtx);
             throw;
         }
     }
@@ -830,7 +830,7 @@ static void prim_genericClosure(EvalState & state, CallSite callSite, Value * co
         try {
             state.forceAttrs(*e, noPos, "");
         } catch (Error & err) {
-            err.addTrace(nullptr, "in genericClosure element %s", ValuePrinter(state, *e, errorPrintOptions));
+            err.addTrace({}, "in genericClosure element %s", ValuePrinter(state, *e, errorPrintOptions));
             throw;
         }
 
@@ -838,7 +838,7 @@ static void prim_genericClosure(EvalState & state, CallSite callSite, Value * co
         try {
             key = state.getAttr(state.s.key, e->attrs(), "");
         } catch (Error & err) {
-            err.addTrace(nullptr, "in genericClosure element %s", ValuePrinter(state, *e, errorPrintOptions));
+            err.addTrace({}, "in genericClosure element %s", ValuePrinter(state, *e, errorPrintOptions));
             throw;
         }
         state.forceValue(*key->value, noPos);
@@ -861,11 +861,11 @@ static void prim_genericClosure(EvalState & state, CallSite callSite, Value * co
             }
             if (otherElem) {
                 // Traces are printed in reverse order; pre-swap them.
-                err.addTrace(nullptr, "with element %s", ValuePrinter(state, *otherElem, errorPrintOptions));
-                err.addTrace(nullptr, "while comparing element %s", ValuePrinter(state, *e, errorPrintOptions));
+                err.addTrace({}, "with element %s", ValuePrinter(state, *otherElem, errorPrintOptions));
+                err.addTrace({}, "while comparing element %s", ValuePrinter(state, *e, errorPrintOptions));
             } else {
                 // Couldn't find the specific element, just show current
-                err.addTrace(nullptr, "while checking key of element %s", ValuePrinter(state, *e, errorPrintOptions));
+                err.addTrace({}, "while checking key of element %s", ValuePrinter(state, *e, errorPrintOptions));
             }
             throw;
         }
@@ -888,7 +888,7 @@ static void prim_genericClosure(EvalState & state, CallSite callSite, Value * co
             }
         } catch (Error & err) {
             err.addTrace(
-                nullptr,
+                {},
                 "while calling %s on genericClosure element %s",
                 state.symbols[state.s.operator_],
                 ValuePrinter(state, *e, errorPrintOptions));
@@ -1041,7 +1041,7 @@ static void prim_addErrorContext(EvalState & state, CallSite callSite, Value * c
                                false,
                                false)
                            .toOwned();
-        e.addTrace(nullptr, HintFmt(message), TracePrint::Always);
+        e.addTrace({}, HintFmt(message), TracePrint::Always);
         throw;
     }
 }
@@ -1437,7 +1437,7 @@ static void prim_derivationStrict(EvalState & state, CallSite callSite, Value * 
         drvName = state.forceStringNoCtx(
             *nameAttr->value, noPos, "while evaluating the `name` attribute passed to builtins.derivationStrict");
     } catch (Error & e) {
-        e.addTrace(state.positions[nameAttr->pos], "while evaluating the derivation attribute 'name'");
+        e.addTrace(state.positions.getEntry(nameAttr->pos), "while evaluating the derivation attribute 'name'");
         throw;
     }
 
@@ -1469,7 +1469,7 @@ static void prim_derivationStrict(EvalState & state, CallSite callSite, Value * 
          * displaying the entire chain is worth the space.
          */
         e.addTrace(
-            nullptr,
+            {},
             HintFmt(
                 "while evaluating derivation '%s'\n"
                 "  whose name attribute is located at %s",
@@ -1768,7 +1768,8 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
 
         } catch (Error & e) {
             e.addTrace(
-                state.positions[i->pos], HintFmt("while evaluating attribute '%1%' of derivation '%2%'", key, drvName));
+                state.positions.getEntry(i->pos),
+                HintFmt("while evaluating attribute '%1%' of derivation '%2%'", key, drvName));
             throw;
         }
     }
@@ -2733,7 +2734,7 @@ static void prim_fromJSON(EvalState & state, CallSite callSite, Value * const * 
     try {
         parseJSON(state, s, v);
     } catch (JSONParseError & e) {
-        e.addTrace(nullptr, "while decoding a JSON string");
+        e.addTrace({}, "while decoding a JSON string");
         throw;
     }
 }
@@ -2963,7 +2964,7 @@ static void addPath(
         } else
             state.allowAndSetStorePathString(*expectedStorePath, v);
     } catch (Error & e) {
-        e.addTrace(nullptr, "while adding path '%s'", path);
+        e.addTrace({}, "while adding path '%s'", path);
         throw;
     }
 }

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -63,14 +63,17 @@ json printValueAsJSON(
                 // All that remains is to return a JSON object.
                 json obj = json::object();
                 for (auto & a : peeled->attrs()->lexicographicOrder(state.symbols)) {
+                    auto thunkExpr = a->value->maybeGetThunkExpr();
                     try {
                         obj.emplace(
                             state.symbols[a->name],
                             printValueAsJSON(state, strict, *a->value, a->pos, context, copyToStore));
                     } catch (Error & e) {
-                        e.addTrace(
-                            state.positions.getEntry(a->pos),
-                            HintFmt("while evaluating attribute '%1%'", state.symbols[a->name]));
+                        if (thunkExpr == nullptr || thunkExpr->hasNewPos(e)) {
+                            e.addTrace(
+                                state.positions.getEntry(a->pos),
+                                HintFmt("while evaluating attribute '%1%'", state.symbols[a->name]));
+                        }
                         throw;
                     }
                 }
@@ -83,10 +86,12 @@ json printValueAsJSON(
         out = json::array();
         int i = 0;
         for (auto elem : v.listView()) {
+            auto thunkExpr = elem->maybeGetThunkExpr();
             try {
                 out.push_back(printValueAsJSON(state, strict, *elem, pos, context, copyToStore));
             } catch (Error & e) {
-                e.addTrace(state.positions.getEntry(pos), HintFmt("while evaluating list element at index %1%", i));
+                if (thunkExpr == nullptr || thunkExpr->hasNewPos(e))
+                    e.addTrace(state.positions.getEntry(pos), HintFmt("while evaluating list element at index %1%", i));
                 throw;
             }
             i++;

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -69,7 +69,7 @@ json printValueAsJSON(
                             printValueAsJSON(state, strict, *a->value, a->pos, context, copyToStore));
                     } catch (Error & e) {
                         e.addTrace(
-                            state.positions[a->pos],
+                            state.positions.getEntry(a->pos),
                             HintFmt("while evaluating attribute '%1%'", state.symbols[a->name]));
                         throw;
                     }
@@ -86,7 +86,7 @@ json printValueAsJSON(
             try {
                 out.push_back(printValueAsJSON(state, strict, *elem, pos, context, copyToStore));
             } catch (Error & e) {
-                e.addTrace(state.positions[pos], HintFmt("while evaluating list element at index %1%", i));
+                e.addTrace(state.positions.getEntry(pos), HintFmt("while evaluating list element at index %1%", i));
                 throw;
             }
             i++;

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1469,7 +1469,7 @@ struct GitFileSystemObjectSinkImpl final : GitFileSystemObjectSink
                         throw Error("cannot create a hard link to a directory");
                     addNode(path, {child.mode, child.getOid()});
                 } catch (Error & e) {
-                    e.addTrace(nullptr, "while creating a hard link from '%s' to '%s'", path, target);
+                    e.addTrace({}, "while creating a hard link from '%s' to '%s'", path, target);
                     throw;
                 }
             }

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -181,7 +181,8 @@ static FlakeInput parseFlakeInput(
                 parseFlakeInputAttr(state, attr, attrs);
         } catch (Error & e) {
             e.addTrace(
-                state.positions[attr.pos], HintFmt("while evaluating flake attribute '%s'", state.symbols[attr.name]));
+                state.positions.getEntry(attr.pos),
+                HintFmt("while evaluating flake attribute '%s'", state.symbols[attr.name]));
             throw;
         }
     }
@@ -190,7 +191,7 @@ static FlakeInput parseFlakeInput(
         try {
             input.ref = FlakeRef::fromAttrs(attrs);
         } catch (Error & e) {
-            e.addTrace(state.positions[pos], HintFmt("while evaluating flake input"));
+            e.addTrace(state.positions.getEntry(pos), HintFmt("while evaluating flake input"));
             throw;
         }
     else {

--- a/src/libstore/unix/build/hook-instance.cc
+++ b/src/libstore/unix/build/hook-instance.cc
@@ -22,7 +22,7 @@ HookInstance::HookInstance(const Strings & _buildHook, std::chrono::milliseconds
     try {
         buildHook = ExecutablePath::load().findPath(buildHook);
     } catch (ExecutableLookupError & e) {
-        e.addTrace(nullptr, "while resolving the 'build-hook' setting'");
+        e.addTrace({}, "while resolving the 'build-hook' setting'");
         throw;
     }
 

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -26,9 +26,10 @@ void SystemError::anchor() {}
 
 void SysError::anchor() {}
 
-void BaseError::addTrace(std::shared_ptr<const Pos> && e, HintFmt hint, TracePrint print)
+void BaseError::addTrace(std::pair<PosIdx, std::shared_ptr<const Pos>> && e, HintFmt hint, TracePrint print)
 {
-    err.traces.push_front(Trace{.pos = std::move(e), .hint = hint, .print = print});
+    err.lastTracePos = e.first;
+    err.traces.push_front(Trace{.pos = std::move(e.second), .hint = hint, .print = print});
 }
 
 void throwExceptionSelfCheck()
@@ -57,6 +58,11 @@ const std::string & BaseError::calcWhat() const
 bool BaseError::hasPos() const
 {
     return err.pos.get() && *err.pos.get();
+}
+
+PosIdx BaseError::getLastTracePosIdx() const
+{
+    return err.lastTracePos;
 }
 
 std::optional<std::string> ErrorInfo::programName = std::nullopt;

--- a/src/libutil/include/nix/util/error.hh
+++ b/src/libutil/include/nix/util/error.hh
@@ -19,6 +19,7 @@
 #include "nix/util/fmt.hh"
 #include "nix/util/fun.hh"
 #include "nix/util/config.hh"
+#include "nix/util/pos-idx.hh"
 
 #include <concepts>
 #include <cstring>
@@ -102,6 +103,8 @@ struct ErrorInfo
     Suggestions suggestions;
 
     static std::optional<std::string> programName;
+
+    PosIdx lastTracePos = noPos;
 };
 
 std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool showTrace);
@@ -193,12 +196,15 @@ public:
         err.status = status;
     }
 
-    void atPos(std::shared_ptr<const Pos> pos)
+    void atPos(std::pair<PosIdx, std::shared_ptr<const Pos>> pos)
     {
-        err.pos = pos;
+        err.lastTracePos = pos.first;
+        err.pos = pos.second;
     }
 
     bool hasPos() const;
+
+    PosIdx getLastTracePosIdx() const;
 
     void pushTrace(Trace trace)
     {
@@ -213,7 +219,7 @@ public:
      * @param args Format string arguments.
      */
     template<typename... Args>
-    void addTrace(std::shared_ptr<const Pos> && pos, std::string_view fs, Args &&... args)
+    void addTrace(std::pair<PosIdx, std::shared_ptr<const Pos>> && pos, std::string_view fs, Args &&... args)
     {
         addTrace(std::move(pos), HintFmt(std::string(fs), std::forward<Args>(args)...));
     }
@@ -225,7 +231,8 @@ public:
      * @param hint Formatted error message
      * @param print Optional, whether to always print (used by `addErrorContext`)
      */
-    void addTrace(std::shared_ptr<const Pos> && pos, HintFmt hint, TracePrint print = TracePrint::Default);
+    void addTrace(
+        std::pair<PosIdx, std::shared_ptr<const Pos>> && pos, HintFmt hint, TracePrint print = TracePrint::Default);
 
     bool hasTrace() const
     {

--- a/src/libutil/include/nix/util/pos-idx.hh
+++ b/src/libutil/include/nix/util/pos-idx.hh
@@ -36,6 +36,11 @@ public:
         return id <=> other.id;
     }
 
+    std::partial_ordering partialCompare(const PosIdx other) const
+    {
+        return id == 0 || other.id == 0 ? std::partial_ordering::unordered : id <=> other.id;
+    }
+
     bool operator==(const PosIdx other) const
     {
         return id == other.id;

--- a/src/libutil/include/nix/util/pos-table.hh
+++ b/src/libutil/include/nix/util/pos-table.hh
@@ -107,6 +107,11 @@ public:
      */
     Pos operator[](PosIdx p) const;
 
+    std::pair<PosIdx, std::shared_ptr<const Pos>> getEntry(PosIdx p) const
+    {
+        return {p, std::move((*this)[p])};
+    }
+
     Pos::Origin originOf(PosIdx p) const
     {
         if (auto o = resolve(p))

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -98,7 +98,8 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
                             recurse(*attr.value, attr.pos, path / name);
                         } catch (Error & e) {
                             e.addTrace(
-                                state->positions[attr.pos], HintFmt("while evaluating the attribute '%s'", name));
+                                state->positions.getEntry(attr.pos),
+                                HintFmt("while evaluating the attribute '%s'", name));
                             throw;
                         }
                     }

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -387,7 +387,7 @@ struct CmdFlakeCheck : FlakeCommand, MixPrintOutPaths, MixOutLinkBase
 
         // FIXME: rewrite to use EvalCache.
 
-        auto resolve = [&](PosIdx p) { return state->positions[p]; };
+        auto resolve = [&](PosIdx p) { return state->positions.getEntry(p); };
 
         auto argHasName = [&](Symbol arg, std::string_view expected) {
             std::string_view name = state->symbols[arg];
@@ -397,7 +397,7 @@ struct CmdFlakeCheck : FlakeCommand, MixPrintOutPaths, MixOutLinkBase
         auto checkSystemName = [&](std::string_view system, const PosIdx pos) {
             // FIXME: what's the format of "system"?
             if (system.find('-') == std::string::npos)
-                reportError(Error("'%s' is not a valid system type, at %s", system, resolve(pos)));
+                reportError(Error("'%s' is not a valid system type, at %s", system, resolve(pos).second));
         };
 
         auto checkSystemType = [&](std::string_view system, const PosIdx pos) {

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -682,7 +682,7 @@ static void upgradeDerivations(Globals & globals, const Strings & args, UpgradeT
                     newElems.push_back(i);
 
             } catch (Error & e) {
-                e.addTrace(nullptr, "while trying to find an upgrade for '%s'", i.queryName());
+                e.addTrace({}, "while trying to find an upgrade for '%s'", i.queryName());
                 throw;
             }
         }
@@ -951,7 +951,7 @@ queryJSON(Globals & globals, std::vector<PackageInfo> & elems, bool printOutPath
         } catch (AssertionError & e) {
             printMsg(lvlTalkative, "skipping derivation named '%1%' which gives an assertion failure", i.queryName());
         } catch (Error & e) {
-            e.addTrace(nullptr, "while querying the derivation named '%1%'", i.queryName());
+            e.addTrace({}, "while querying the derivation named '%1%'", i.queryName());
             throw;
         }
     }
@@ -1279,7 +1279,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
         } catch (AssertionError & e) {
             printMsg(lvlTalkative, "skipping derivation named '%1%' which gives an assertion failure", i.queryName());
         } catch (Error & e) {
-            e.addTrace(nullptr, "while querying the derivation named '%1%'", i.queryName());
+            e.addTrace({}, "while querying the derivation named '%1%'", i.queryName());
             throw;
         }
     }

--- a/tests/functional/lang/eval-fail-assert-equal-derivations-extra.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-derivations-extra.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while evaluating the condition of the assertion '({ foo = { outPath = "/nix/store/0"; type = "derivation"; }; } == { foo = { devious = true; outPath = "/nix/store/1"; type = "derivation"; }; })'
-         at /pwd/lang/eval-fail-assert-equal-derivations-extra.nix:1:1:
-            1| assert
-             | ^
-            2|   {
-
        … while comparing attribute 'foo'
          at /pwd/lang/eval-fail-assert-equal-derivations-extra.nix:7:5:
             6|     };

--- a/tests/functional/lang/eval-fail-assert-equal-derivations.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-derivations.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while evaluating the condition of the assertion '({ foo = { ignored = (abort "not ignored"); outPath = "/nix/store/0"; type = "derivation"; }; } == { foo = { ignored = (abort "not ignored"); outPath = "/nix/store/1"; type = "derivation"; }; })'
-         at /pwd/lang/eval-fail-assert-equal-derivations.nix:1:1:
-            1| assert
-             | ^
-            2|   {
-
        … while comparing attribute 'foo'
          at /pwd/lang/eval-fail-assert-equal-derivations.nix:8:5:
             7|     };

--- a/tests/functional/lang/eval-fail-assert-equal-floats.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-floats.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while evaluating the condition of the assertion '({ b = 1; } == { b = 1.01; })'
-         at /pwd/lang/eval-fail-assert-equal-floats.nix:1:1:
-            1| assert { b = 1.0; } == { b = 1.01; };
-             | ^
-            2| abort "unreachable"
-
        … while comparing attribute 'b'
          at /pwd/lang/eval-fail-assert-equal-floats.nix:1:21:
             1| assert { b = 1.0; } == { b = 1.01; };

--- a/tests/functional/lang/eval-fail-assert-equal-ints.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-ints.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while evaluating the condition of the assertion '({ b = 1; } == { b = 2; })'
-         at /pwd/lang/eval-fail-assert-equal-ints.nix:1:1:
-            1| assert { b = 1; } == { b = 2; };
-             | ^
-            2| abort "unreachable"
-
        … while comparing attribute 'b'
          at /pwd/lang/eval-fail-assert-equal-ints.nix:1:19:
             1| assert { b = 1; } == { b = 2; };

--- a/tests/functional/lang/eval-fail-assert-equal-type-nested.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-type-nested.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while evaluating the condition of the assertion '({ ding = false; } == { ding = null; })'
-         at /pwd/lang/eval-fail-assert-equal-type-nested.nix:1:1:
-            1| assert { ding = false; } == { ding = null; };
-             | ^
-            2| abort "unreachable"
-
        … while comparing attribute 'ding'
          at /pwd/lang/eval-fail-assert-equal-type-nested.nix:1:26:
             1| assert { ding = false; } == { ding = null; };

--- a/tests/functional/lang/eval-fail-assert-nested-bool.err.exp
+++ b/tests/functional/lang/eval-fail-assert-nested-bool.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while evaluating the condition of the assertion '({ a = { b = [ ({ c = { d = true; }; }) ]; }; } == { a = { b = [ ({ c = { d = false; }; }) ]; }; })'
-         at /pwd/lang/eval-fail-assert-nested-bool.nix:1:1:
-            1| assert { a.b = [ { c.d = true; } ]; } == { a.b = [ { c.d = false; } ]; };
-             | ^
-            2|
-
        … while comparing attribute 'a'
          at /pwd/lang/eval-fail-assert-nested-bool.nix:1:39:
             1| assert { a.b = [ { c.d = true; } ]; } == { a.b = [ { c.d = false; } ]; };

--- a/tests/functional/lang/eval-fail-assert.err.exp
+++ b/tests/functional/lang/eval-fail-assert.err.exp
@@ -1,30 +1,10 @@
 error:
-       … while evaluating the attribute 'body'
-         at /pwd/lang/eval-fail-assert.nix:1:1:
-            1| let {
-             | ^
-            2|   x =
-
-       … from the definition of 'body'
-         at /pwd/lang/eval-fail-assert.nix:7:3:
-            6|
-            7|   body = x "x";
-             |   ^
-            8| }
-
        … from call site
          at /pwd/lang/eval-fail-assert.nix:7:10:
             6|
             7|   body = x "x";
              |          ^
             8| }
-
-       … while calling 'x'
-         at /pwd/lang/eval-fail-assert.nix:3:5:
-            2|   x =
-            3|     arg:
-             |     ^
-            4|     assert arg == "y";
 
        … while evaluating the condition of the assertion '(arg == "y")'
          at /pwd/lang/eval-fail-assert.nix:4:5:

--- a/tests/functional/lang/eval-fail-blackhole.err.exp
+++ b/tests/functional/lang/eval-fail-blackhole.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while evaluating the attribute 'body'
-         at /pwd/lang/eval-fail-blackhole.nix:1:1:
-            1| let {
-             | ^
-            2|   body = x;
-
        … from the definition of 'body'
          at /pwd/lang/eval-fail-blackhole.nix:2:3:
             1| let {

--- a/tests/functional/lang/eval-fail-concatMap-3.err.exp
+++ b/tests/functional/lang/eval-fail-concatMap-3.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while calling the 'concatMap' builtin
-         at /pwd/lang/eval-fail-concatMap-3.nix:1:1:
-            1| builtins.concatMap (x: 1) [ "foo" ]
-             | ^
-            2|
-
        … while evaluating the return value of the function passed to builtins.concatMap
          at /pwd/lang/eval-fail-concatMap-3.nix:1:21:
             1| builtins.concatMap (x: 1) [ "foo" ]

--- a/tests/functional/lang/eval-fail-concatMap-4.err.exp
+++ b/tests/functional/lang/eval-fail-concatMap-4.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while calling the 'concatMap' builtin
-         at /pwd/lang/eval-fail-concatMap-4.nix:1:1:
-            1| builtins.concatMap (x: "foo") [
-             | ^
-            2|   1
-
        … while evaluating the return value of the function passed to builtins.concatMap
          at /pwd/lang/eval-fail-concatMap-4.nix:1:21:
             1| builtins.concatMap (x: "foo") [

--- a/tests/functional/lang/eval-fail-deepseq-list-attr.err.exp
+++ b/tests/functional/lang/eval-fail-deepseq-list-attr.err.exp
@@ -8,13 +8,6 @@ error:
 
        … while evaluating list element at index 1
 
-       … while evaluating the attribute 'b'
-         at /pwd/lang/eval-fail-deepseq-list-attr.nix:7:5:
-            6|     a = 2;
-            7|     b = throw "error in attr in list element";
-             |     ^
-            8|   }
-
        … while calling the 'throw' builtin
          at /pwd/lang/eval-fail-deepseq-list-attr.nix:7:9:
             6|     a = 2;

--- a/tests/functional/lang/eval-fail-deepseq.err.exp
+++ b/tests/functional/lang/eval-fail-deepseq.err.exp
@@ -1,16 +1,4 @@
 error:
-       … while calling the 'deepSeq' builtin
-         at /pwd/lang/eval-fail-deepseq.nix:1:1:
-            1| builtins.deepSeq { x = abort "foo"; } 456
-             | ^
-            2|
-
-       … while evaluating the attribute 'x'
-         at /pwd/lang/eval-fail-deepseq.nix:1:20:
-            1| builtins.deepSeq { x = abort "foo"; } 456
-             |                    ^
-            2|
-
        … while calling the 'abort' builtin
          at /pwd/lang/eval-fail-deepseq.nix:1:24:
             1| builtins.deepSeq { x = abort "foo"; } 456

--- a/tests/functional/lang/eval-fail-derivation-name.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-name.err.exp
@@ -1,11 +1,4 @@
 error:
-       … while evaluating the attribute 'outPath'
-         at «nix-internal»/derivation-internal.nix:<number>:<number>:
-     <number>|     value = commonAttrs // {
-     <number>|       outPath = strict.${outputName};
-             |       ^
-     <number>|       drvPath = strict.drvPath;
-
        … while selecting an attribute
          at «nix-internal»/derivation-internal.nix:<number>:<number>:
      <number>|     value = commonAttrs // {

--- a/tests/functional/lang/eval-fail-derivation-stack-trace.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-stack-trace.err.exp
@@ -1,17 +1,17 @@
 error:
-       … while evaluating the attribute 'outPath'
-         at «nix-internal»/derivation-internal.nix:49:7:
-           48|     value = commonAttrs // {
-           49|       outPath = strict.${outputName};
-             |       ^
-           50|       drvPath = strict.drvPath;
-
        … while selecting an attribute
          at «nix-internal»/derivation-internal.nix:49:17:
            48|     value = commonAttrs // {
            49|       outPath = strict.${outputName};
              |                 ^
            50|       drvPath = strict.drvPath;
+
+       … while calling the 'derivationStrict' builtin
+         at «nix-internal»/derivation-internal.nix:36:12:
+           35|
+           36|   strict = derivationStrict drvAttrs;
+             |            ^
+           37|
 
        … while evaluating derivation 'test-5'
          whose name attribute is located at /pwd/lang/eval-fail-derivation-stack-trace.nix:12:9

--- a/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-structuredAttrs-stack-overflow.err.exp
@@ -1,11 +1,4 @@
 error:
-       … while evaluating the attribute 'outPath'
-         at «nix-internal»/derivation-internal.nix:49:7:
-           48|     value = commonAttrs // {
-           49|       outPath = strict.${outputName};
-             |       ^
-           50|       drvPath = strict.drvPath;
-
        … while selecting an attribute
          at «nix-internal»/derivation-internal.nix:49:17:
            48|     value = commonAttrs // {

--- a/tests/functional/lang/eval-fail-derivationStrict-3.err.exp
+++ b/tests/functional/lang/eval-fail-derivationStrict-3.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while calling the 'derivationStrict' builtin
-         at /pwd/lang/eval-fail-derivationStrict-3.nix:1:1:
-            1| builtins.derivationStrict { name = 1; }
-             | ^
-            2|
-
        … while evaluating the derivation attribute 'name'
          at /pwd/lang/eval-fail-derivationStrict-3.nix:1:29:
             1| builtins.derivationStrict { name = 1; }

--- a/tests/functional/lang/eval-fail-dup-dynamic-attrs.err.exp
+++ b/tests/functional/lang/eval-fail-dup-dynamic-attrs.err.exp
@@ -1,12 +1,4 @@
-error:
-       … while evaluating the attribute 'set'
-         at /pwd/lang/eval-fail-dup-dynamic-attrs.nix:2:3:
-            1| {
-            2|   set = {
-             |   ^
-            3|     "${"" + "b"}" = 1;
-
-       error: dynamic attribute 'b' already defined at /pwd/lang/eval-fail-dup-dynamic-attrs.nix:3:5
+error: dynamic attribute 'b' already defined at /pwd/lang/eval-fail-dup-dynamic-attrs.nix:3:5
        at /pwd/lang/eval-fail-dup-dynamic-attrs.nix:6:5:
             5|   set = {
             6|     "${"b" + ""}" = 2;

--- a/tests/functional/lang/eval-fail-duplicate-traces.err.exp
+++ b/tests/functional/lang/eval-fail-duplicate-traces.err.exp
@@ -6,13 +6,6 @@ error:
              | ^
             7|
 
-       … while calling 'throwAfter'
-         at /pwd/lang/eval-fail-duplicate-traces.nix:4:16:
-            3| let
-            4|   throwAfter = n: if n > 0 then throwAfter (n - 1) else throw "Uh oh!";
-             |                ^
-            5| in
-
        … from call site
          at /pwd/lang/eval-fail-duplicate-traces.nix:4:33:
             3| let
@@ -20,25 +13,11 @@ error:
              |                                 ^
             5| in
 
-       … while calling 'throwAfter'
-         at /pwd/lang/eval-fail-duplicate-traces.nix:4:16:
-            3| let
-            4|   throwAfter = n: if n > 0 then throwAfter (n - 1) else throw "Uh oh!";
-             |                ^
-            5| in
-
        … from call site
          at /pwd/lang/eval-fail-duplicate-traces.nix:4:33:
             3| let
             4|   throwAfter = n: if n > 0 then throwAfter (n - 1) else throw "Uh oh!";
              |                                 ^
-            5| in
-
-       … while calling 'throwAfter'
-         at /pwd/lang/eval-fail-duplicate-traces.nix:4:16:
-            3| let
-            4|   throwAfter = n: if n > 0 then throwAfter (n - 1) else throw "Uh oh!";
-             |                ^
             5| in
 
        … while calling the 'throw' builtin

--- a/tests/functional/lang/eval-fail-flake-ref-to-string-negative-integer.err.exp
+++ b/tests/functional/lang/eval-fail-flake-ref-to-string-negative-integer.err.exp
@@ -1,11 +1,4 @@
 error:
-       … while calling the 'seq' builtin
-         at /pwd/lang/eval-fail-flake-ref-to-string-negative-integer.nix:4:1:
-            3| in
-            4| builtins.seq n (
-             | ^
-            5|   builtins.flakeRefToString {
-
        … while calling the 'flakeRefToString' builtin
          at /pwd/lang/eval-fail-flake-ref-to-string-negative-integer.nix:5:3:
             4| builtins.seq n (

--- a/tests/functional/lang/eval-fail-foldlPrime-4.err.exp
+++ b/tests/functional/lang/eval-fail-foldlPrime-4.err.exp
@@ -1,23 +1,4 @@
-error:
-       … while calling the 'foldl'' builtin
-         at /pwd/lang/eval-fail-foldlPrime-4.nix:1:1:
-            1| builtins.foldl' (a: b: a && b) "foo" [ true ]
-             | ^
-            2|
-
-       … while calling anonymous lambda
-         at /pwd/lang/eval-fail-foldlPrime-4.nix:1:21:
-            1| builtins.foldl' (a: b: a && b) "foo" [ true ]
-             |                     ^
-            2|
-
-       … in the left operand of '&&'
-         at /pwd/lang/eval-fail-foldlPrime-4.nix:1:24:
-            1| builtins.foldl' (a: b: a && b) "foo" [ true ]
-             |                        ^
-            2|
-
-       error: expected a Boolean but found a string: "foo"
+error: expected a Boolean but found a string: "foo"
        at /pwd/lang/eval-fail-foldlPrime-4.nix:1:24:
             1| builtins.foldl' (a: b: a && b) "foo" [ true ]
              |                        ^

--- a/tests/functional/lang/eval-fail-foldlStrict-strict-op-application.err.exp
+++ b/tests/functional/lang/eval-fail-foldlStrict-strict-op-application.err.exp
@@ -1,31 +1,10 @@
 error:
-       … while calling the 'foldl'' builtin
-         at /pwd/lang/eval-fail-foldlStrict-strict-op-application.nix:2:1:
-            1| # Tests that the result of applying op is forced even if the value is never used
-            2| builtins.foldl' (_: f: f null) null [
-             | ^
-            3|   (_: throw "Not the final value, but is still forced!")
-
-       … while calling anonymous lambda
-         at /pwd/lang/eval-fail-foldlStrict-strict-op-application.nix:2:21:
-            1| # Tests that the result of applying op is forced even if the value is never used
-            2| builtins.foldl' (_: f: f null) null [
-             |                     ^
-            3|   (_: throw "Not the final value, but is still forced!")
-
        … from call site
          at /pwd/lang/eval-fail-foldlStrict-strict-op-application.nix:2:24:
             1| # Tests that the result of applying op is forced even if the value is never used
             2| builtins.foldl' (_: f: f null) null [
              |                        ^
             3|   (_: throw "Not the final value, but is still forced!")
-
-       … while calling anonymous lambda
-         at /pwd/lang/eval-fail-foldlStrict-strict-op-application.nix:3:4:
-            2| builtins.foldl' (_: f: f null) null [
-            3|   (_: throw "Not the final value, but is still forced!")
-             |    ^
-            4|   (_: 23)
 
        … while calling the 'throw' builtin
          at /pwd/lang/eval-fail-foldlStrict-strict-op-application.nix:3:7:

--- a/tests/functional/lang/eval-fail-genList-3.err.exp
+++ b/tests/functional/lang/eval-fail-genList-3.err.exp
@@ -1,18 +1,6 @@
 error:
        … while evaluating list element at index 0
 
-       … from call site
-         at /pwd/lang/eval-fail-genList-3.nix:1:19:
-            1| builtins.genList (x: x + "foo") 2
-             |                   ^
-            2|
-
-       … while calling anonymous lambda
-         at /pwd/lang/eval-fail-genList-3.nix:1:19:
-            1| builtins.genList (x: x + "foo") 2
-             |                   ^
-            2|
-
        error: cannot add a string to an integer
        at /pwd/lang/eval-fail-genList-3.nix:1:26:
             1| builtins.genList (x: x + "foo") 2

--- a/tests/functional/lang/eval-fail-genericClosure-deeply-nested-element.err.exp
+++ b/tests/functional/lang/eval-fail-genericClosure-deeply-nested-element.err.exp
@@ -1,11 +1,4 @@
 error:
-       … while calling the 'seq' builtin
-         at /pwd/lang/eval-fail-genericClosure-deeply-nested-element.nix:25:1:
-           24| in
-           25| builtins.seq finiteVal (
-             | ^
-           26|   builtins.genericClosure {
-
        … while calling the 'genericClosure' builtin
          at /pwd/lang/eval-fail-genericClosure-deeply-nested-element.nix:26:3:
            25| builtins.seq finiteVal (

--- a/tests/functional/lang/eval-fail-infinite-recursion-lambda.err.exp
+++ b/tests/functional/lang/eval-fail-infinite-recursion-lambda.err.exp
@@ -1,26 +1,8 @@
 error:
        … from call site
-         at /pwd/lang/eval-fail-infinite-recursion-lambda.nix:1:1:
-            1| (x: x x) (x: x x)
-             | ^
-            2|
-
-       … while calling anonymous lambda
-         at /pwd/lang/eval-fail-infinite-recursion-lambda.nix:1:2:
-            1| (x: x x) (x: x x)
-             |  ^
-            2|
-
-       … from call site
          at /pwd/lang/eval-fail-infinite-recursion-lambda.nix:1:5:
             1| (x: x x) (x: x x)
              |     ^
-            2|
-
-       … while calling anonymous lambda
-         at /pwd/lang/eval-fail-infinite-recursion-lambda.nix:1:11:
-            1| (x: x x) (x: x x)
-             |           ^
             2|
 
        … from call site
@@ -29,7 +11,7 @@ error:
              |              ^
             2|
 
-       (197 duplicate frames omitted)
+       (98 duplicate frames omitted)
 
        error: stack overflow; max-call-depth exceeded
        at /pwd/lang/eval-fail-infinite-recursion-lambda.nix:1:14:

--- a/tests/functional/lang/eval-fail-listToAttrs-4.err.exp
+++ b/tests/functional/lang/eval-fail-listToAttrs-4.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while calling the 'listToAttrs' builtin
-         at /pwd/lang/eval-fail-listToAttrs-4.nix:1:1:
-            1| builtins.listToAttrs [ { name = 1; } ]
-             | ^
-            2|
-
        … while evaluating the `name` attribute of an element of the list passed to builtins.listToAttrs
          at /pwd/lang/eval-fail-listToAttrs-4.nix:1:26:
             1| builtins.listToAttrs [ { name = 1; } ]

--- a/tests/functional/lang/eval-fail-mapAttrs-4.err.exp
+++ b/tests/functional/lang/eval-fail-mapAttrs-4.err.exp
@@ -1,12 +1,6 @@
 error:
        … while evaluating the attribute 'foo'
 
-       … while calling anonymous lambda
-         at /pwd/lang/eval-fail-mapAttrs-4.nix:1:23:
-            1| builtins.mapAttrs (x: y: x + 1) { foo.bar = 1; }
-             |                       ^
-            2|
-
        … while evaluating a path segment
          at /pwd/lang/eval-fail-mapAttrs-4.nix:1:30:
             1| builtins.mapAttrs (x: y: x + 1) { foo.bar = 1; }

--- a/tests/functional/lang/eval-fail-memoised-error-trace-not-mutated.err.exp
+++ b/tests/functional/lang/eval-fail-memoised-error-trace-not-mutated.err.exp
@@ -1,12 +1,5 @@
 error:
        … while calling the 'seq' builtin
-         at /pwd/lang/eval-fail-memoised-error-trace-not-mutated.nix:10:1:
-            9| # a fresh instance of the exceptions to avoid trace mutation.
-           10| builtins.seq (builtins.tryEval b) (builtins.seq (builtins.tryEval c) d)
-             | ^
-           11|
-
-       … while calling the 'seq' builtin
          at /pwd/lang/eval-fail-memoised-error-trace-not-mutated.nix:10:36:
             9| # a fresh instance of the exceptions to avoid trace mutation.
            10| builtins.seq (builtins.tryEval b) (builtins.seq (builtins.tryEval c) d)

--- a/tests/functional/lang/eval-fail-mutual-recursion.err.exp
+++ b/tests/functional/lang/eval-fail-mutual-recursion.err.exp
@@ -6,13 +6,6 @@ error:
              | ^
            41|
 
-       … while calling 'throwAfterA'
-         at /pwd/lang/eval-fail-mutual-recursion.nix:32:14:
-           31|   throwAfterA =
-           32|     recurse: n:
-             |              ^
-           33|     if n > 0 then
-
        … from call site
          at /pwd/lang/eval-fail-mutual-recursion.nix:34:7:
            33|     if n > 0 then
@@ -20,7 +13,7 @@ error:
              |       ^
            35|     else if recurse then
 
-       (19 duplicate frames omitted)
+       (9 duplicate frames omitted)
 
        … from call site
          at /pwd/lang/eval-fail-mutual-recursion.nix:36:7:
@@ -29,13 +22,6 @@ error:
              |       ^
            37|     else
 
-       … while calling 'throwAfterB'
-         at /pwd/lang/eval-fail-mutual-recursion.nix:23:14:
-           22|   throwAfterB =
-           23|     recurse: n:
-             |              ^
-           24|     if n > 0 then
-
        … from call site
          at /pwd/lang/eval-fail-mutual-recursion.nix:25:7:
            24|     if n > 0 then
@@ -43,7 +29,7 @@ error:
              |       ^
            26|     else if recurse then
 
-       (19 duplicate frames omitted)
+       (9 duplicate frames omitted)
 
        … from call site
          at /pwd/lang/eval-fail-mutual-recursion.nix:27:7:
@@ -52,7 +38,7 @@ error:
              |       ^
            28|     else
 
-       (21 duplicate frames omitted)
+       (10 duplicate frames omitted)
 
        … while calling the 'throw' builtin
          at /pwd/lang/eval-fail-mutual-recursion.nix:38:7:

--- a/tests/functional/lang/eval-fail-not-throws.err.exp
+++ b/tests/functional/lang/eval-fail-not-throws.err.exp
@@ -1,10 +1,4 @@
 error:
-       … in the argument of '!'
-         at /pwd/lang/eval-fail-not-throws.nix:1:3:
-            1| !(throw "uh oh!")
-             |   ^
-            2|
-
        … while calling the 'throw' builtin
          at /pwd/lang/eval-fail-not-throws.nix:1:3:
             1| !(throw "uh oh!")

--- a/tests/functional/lang/eval-fail-operator-trace.err.exp
+++ b/tests/functional/lang/eval-fail-operator-trace.err.exp
@@ -55,13 +55,6 @@ error:
              |         ^
            18|   o = n >= 1;
 
-       … in the argument of '!'
-         at /pwd/lang/eval-fail-operator-trace.nix:16:9:
-           15|   l = k < 1;
-           16|   m = l <= 1;
-             |         ^
-           17|   n = m > 1;
-
        … while calling the 'lessThan' builtin
          at /pwd/lang/eval-fail-operator-trace.nix:16:9:
            15|   l = k < 1;

--- a/tests/functional/lang/eval-fail-overflowing-div.err.exp
+++ b/tests/functional/lang/eval-fail-overflowing-div.err.exp
@@ -1,18 +1,4 @@
 error:
-       … while calling the 'seq' builtin
-         at /pwd/lang/eval-fail-overflowing-div.nix:8:1:
-            7| in
-            8| builtins.seq intMin (builtins.seq b (intMin / b))
-             | ^
-            9|
-
-       … while calling the 'seq' builtin
-         at /pwd/lang/eval-fail-overflowing-div.nix:8:22:
-            7| in
-            8| builtins.seq intMin (builtins.seq b (intMin / b))
-             |                      ^
-            9|
-
        … while calling the 'div' builtin
          at /pwd/lang/eval-fail-overflowing-div.nix:8:45:
             7| in

--- a/tests/functional/lang/eval-fail-overflowing-mul.err.exp
+++ b/tests/functional/lang/eval-fail-overflowing-mul.err.exp
@@ -1,12 +1,5 @@
 error:
        … while calling the 'mul' builtin
-         at /pwd/lang/eval-fail-overflowing-mul.nix:4:7:
-            3| in
-            4| a * a * a
-             |       ^
-            5|
-
-       … while calling the 'mul' builtin
          at /pwd/lang/eval-fail-overflowing-mul.nix:4:3:
             3| in
             4| a * a * a

--- a/tests/functional/lang/eval-fail-readDir-nonexistent-1.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-nonexistent-1.err.exp
@@ -1,11 +1,4 @@
 error:
-       … while evaluating the attribute 'absolutePath'
-         at /pwd/lang/eval-fail-readDir-nonexistent-1.nix:2:3:
-            1| {
-            2|   absolutePath = builtins.readDir /this/path/really/should/not/exist;
-             |   ^
-            3| }
-
        … while calling the 'readDir' builtin
          at /pwd/lang/eval-fail-readDir-nonexistent-1.nix:2:18:
             1| {

--- a/tests/functional/lang/eval-fail-readDir-nonexistent-2.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-nonexistent-2.err.exp
@@ -1,11 +1,4 @@
 error:
-       … while evaluating the attribute 'relativePath'
-         at /pwd/lang/eval-fail-readDir-nonexistent-2.nix:2:3:
-            1| {
-            2|   relativePath = builtins.readDir ./this/path/really/should/not/exist;
-             |   ^
-            3| }
-
        … while calling the 'readDir' builtin
          at /pwd/lang/eval-fail-readDir-nonexistent-2.nix:2:18:
             1| {

--- a/tests/functional/lang/eval-fail-readDir-not-a-directory-1.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-not-a-directory-1.err.exp
@@ -1,11 +1,4 @@
 error:
-       … while evaluating the attribute 'regularFile'
-         at /pwd/lang/eval-fail-readDir-not-a-directory-1.nix:2:3:
-            1| {
-            2|   regularFile = builtins.readDir ./readDir/bar;
-             |   ^
-            3| }
-
        … while calling the 'readDir' builtin
          at /pwd/lang/eval-fail-readDir-not-a-directory-1.nix:2:17:
             1| {

--- a/tests/functional/lang/eval-fail-readDir-not-a-directory-2.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-not-a-directory-2.err.exp
@@ -1,11 +1,4 @@
 error:
-       … while evaluating the attribute 'symlinkedRegularFile'
-         at /pwd/lang/eval-fail-readDir-not-a-directory-2.nix:2:3:
-            1| {
-            2|   symlinkedRegularFile = builtins.readDir ./readDir/linked;
-             |   ^
-            3| }
-
        … while calling the 'readDir' builtin
          at /pwd/lang/eval-fail-readDir-not-a-directory-2.nix:2:26:
             1| {

--- a/tests/functional/lang/eval-fail-readFileType-outPath-abort.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-outPath-abort.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while calling the 'readFileType' builtin
-         at /pwd/lang/eval-fail-readFileType-outPath-abort.nix:1:1:
-            1| builtins.readFileType { outPath = abort "some failure"; }
-             | ^
-            2|
-
        … while evaluating the `outPath` attribute
          at /pwd/lang/eval-fail-readFileType-outPath-abort.nix:1:25:
             1| builtins.readFileType { outPath = abort "some failure"; }

--- a/tests/functional/lang/eval-fail-readFileType-outPath-non-absolute.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-outPath-non-absolute.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while calling the 'readFileType' builtin
-         at /pwd/lang/eval-fail-readFileType-outPath-non-absolute.nix:1:1:
-            1| builtins.readFileType { outPath = "not-absolute"; }
-             | ^
-            2|
-
        … while using the `outPath` attribute
          at /pwd/lang/eval-fail-readFileType-outPath-non-absolute.nix:1:25:
             1| builtins.readFileType { outPath = "not-absolute"; }

--- a/tests/functional/lang/eval-fail-readFileType-toString-non-absolute.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-toString-non-absolute.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while calling the 'readFileType' builtin
-         at /pwd/lang/eval-fail-readFileType-toString-non-absolute.nix:1:1:
-            1| builtins.readFileType { __toString = self: "not-absolute"; }
-             | ^
-            2|
-
        … while using the result of the `__toString` attribute
          at /pwd/lang/eval-fail-readFileType-toString-non-absolute.nix:1:25:
             1| builtins.readFileType { __toString = self: "not-absolute"; }

--- a/tests/functional/lang/eval-fail-readFileType-toString-not-function.err.exp
+++ b/tests/functional/lang/eval-fail-readFileType-toString-not-function.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while calling the 'readFileType' builtin
-         at /pwd/lang/eval-fail-readFileType-toString-not-function.nix:1:1:
-            1| builtins.readFileType { __toString = "not a function"; }
-             | ^
-            2|
-
        … while calling the `__toString` attribute
          at /pwd/lang/eval-fail-readFileType-toString-not-function.nix:1:25:
             1| builtins.readFileType { __toString = "not a function"; }

--- a/tests/functional/lang/eval-fail-recursion.err.exp
+++ b/tests/functional/lang/eval-fail-recursion.err.exp
@@ -8,13 +8,6 @@ error:
 
        … entering the infinite recursion
 
-       … in the right operand of '//'
-         at /pwd/lang/eval-fail-recursion.nix:2:14:
-            1| let
-            2|   a = { } // a;
-             |              ^
-            3| in
-
        error: infinite recursion encountered
        at /pwd/lang/eval-fail-recursion.nix:2:14:
             1| let

--- a/tests/functional/lang/eval-fail-remove.err.exp
+++ b/tests/functional/lang/eval-fail-remove.err.exp
@@ -1,17 +1,4 @@
 error:
-       … while evaluating the attribute 'body'
-         at /pwd/lang/eval-fail-remove.nix:1:1:
-            1| let {
-             | ^
-            2|   attrs = {
-
-       … from the definition of 'body'
-         at /pwd/lang/eval-fail-remove.nix:7:3:
-            6|
-            7|   body = (removeAttrs attrs [ "x" ]).x;
-             |   ^
-            8| }
-
        … while evaluating the attribute 'x'
          at /pwd/lang/eval-fail-remove.nix:7:10:
             6|

--- a/tests/functional/lang/eval-fail-scope-5.err.exp
+++ b/tests/functional/lang/eval-fail-scope-5.err.exp
@@ -1,30 +1,10 @@
 error:
-       … while evaluating the attribute 'body'
-         at /pwd/lang/eval-fail-scope-5.nix:1:1:
-            1| let {
-             | ^
-            2|
-
-       … from the definition of 'body'
-         at /pwd/lang/eval-fail-scope-5.nix:13:3:
-           12|
-           13|   body = f { };
-             |   ^
-           14|
-
        … from call site
          at /pwd/lang/eval-fail-scope-5.nix:13:10:
            12|
            13|   body = f { };
              |          ^
            14|
-
-       … while calling 'f'
-         at /pwd/lang/eval-fail-scope-5.nix:7:5:
-            6|   f =
-            7|     {
-             |     ^
-            8|       x ? y,
 
        … in an operand of '+'
          at /pwd/lang/eval-fail-scope-5.nix:11:5:

--- a/tests/functional/lang/eval-fail-seq.err.exp
+++ b/tests/functional/lang/eval-fail-seq.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while calling the 'seq' builtin
-         at /pwd/lang/eval-fail-seq.nix:1:1:
-            1| builtins.seq (abort "foo") 2
-             | ^
-            2|
-
        … while calling the 'abort' builtin
          at /pwd/lang/eval-fail-seq.nix:1:15:
             1| builtins.seq (abort "foo") 2

--- a/tests/functional/lang/eval-fail-sort-5.err.exp
+++ b/tests/functional/lang/eval-fail-sort-5.err.exp
@@ -1,22 +1,4 @@
 error:
-       … while calling the 'sort' builtin
-         at /pwd/lang/eval-fail-sort-5.nix:1:1:
-            1| builtins.sort (a: b: a <= b) [
-             | ^
-            2|   "foo"
-
-       … while calling anonymous lambda
-         at /pwd/lang/eval-fail-sort-5.nix:1:19:
-            1| builtins.sort (a: b: a <= b) [
-             |                   ^
-            2|   "foo"
-
-       … in the argument of '!'
-         at /pwd/lang/eval-fail-sort-5.nix:1:24:
-            1| builtins.sort (a: b: a <= b) [
-             |                        ^
-            2|   "foo"
-
        … while calling the 'lessThan' builtin
          at /pwd/lang/eval-fail-sort-5.nix:1:24:
             1| builtins.sort (a: b: a <= b) [

--- a/tests/functional/lang/eval-fail-sort-6.err.exp
+++ b/tests/functional/lang/eval-fail-sort-6.err.exp
@@ -1,22 +1,4 @@
 error:
-       … while calling the 'sort' builtin
-         at /pwd/lang/eval-fail-sort-6.nix:1:1:
-            1| builtins.sort (a: b: a <= b) [
-             | ^
-            2|   { }
-
-       … while calling anonymous lambda
-         at /pwd/lang/eval-fail-sort-6.nix:1:19:
-            1| builtins.sort (a: b: a <= b) [
-             |                   ^
-            2|   { }
-
-       … in the argument of '!'
-         at /pwd/lang/eval-fail-sort-6.nix:1:24:
-            1| builtins.sort (a: b: a <= b) [
-             |                        ^
-            2|   { }
-
        … while calling the 'lessThan' builtin
          at /pwd/lang/eval-fail-sort-6.nix:1:24:
             1| builtins.sort (a: b: a <= b) [

--- a/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-outPath-through-toString.err.exp
@@ -1,11 +1,4 @@
 error:
-       … while calling the 'toJSON' builtin
-         at /pwd/lang/eval-fail-toJSON-outPath-through-toString.nix:4:1:
-            3| # fails, even though the outer `outPath` traversal could otherwise succeed.
-            4| builtins.toJSON {
-             | ^
-            5|   outPath = {
-
        … while using the `outPath` attribute
          at /pwd/lang/eval-fail-toJSON-outPath-through-toString.nix:5:3:
             4| builtins.toJSON {

--- a/tests/functional/lang/eval-fail-toJSON-toString-not-string.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-toString-not-string.err.exp
@@ -1,10 +1,4 @@
 error:
-       … while calling the 'toJSON' builtin
-         at /pwd/lang/eval-fail-toJSON-toString-not-string.nix:1:1:
-            1| builtins.toJSON { __toString = self: 42; }
-             | ^
-            2|
-
        … while using the result of the `__toString` attribute
          at /pwd/lang/eval-fail-toJSON-toString-not-string.nix:1:19:
             1| builtins.toJSON { __toString = self: 42; }

--- a/tests/functional/lang/eval-fail-toJSON-toString-returns-attrs.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-toString-returns-attrs.err.exp
@@ -1,11 +1,4 @@
 error:
-       … while calling the 'toJSON' builtin
-         at /pwd/lang/eval-fail-toJSON-toString-returns-attrs.nix:2:1:
-            1| # toJSON checks the return type of __toString
-            2| builtins.toJSON { __toString = self: { a = 1; }; }
-             | ^
-            3|
-
        … while using the result of the `__toString` attribute
          at /pwd/lang/eval-fail-toJSON-toString-returns-attrs.nix:2:19:
             1| # toJSON checks the return type of __toString

--- a/tests/functional/lang/eval-fail-toJSON.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON.err.exp
@@ -1,45 +1,4 @@
 error:
-       … while calling the 'toJSON' builtin
-         at /pwd/lang/eval-fail-toJSON.nix:1:1:
-            1| builtins.toJSON {
-             | ^
-            2|   a.b = [
-
-       … while evaluating attribute 'a'
-         at /pwd/lang/eval-fail-toJSON.nix:2:3:
-            1| builtins.toJSON {
-            2|   a.b = [
-             |   ^
-            3|     true
-
-       … while evaluating attribute 'b'
-         at /pwd/lang/eval-fail-toJSON.nix:2:3:
-            1| builtins.toJSON {
-            2|   a.b = [
-             |   ^
-            3|     true
-
-       … while evaluating list element at index 3
-         at /pwd/lang/eval-fail-toJSON.nix:2:3:
-            1| builtins.toJSON {
-            2|   a.b = [
-             |   ^
-            3|     true
-
-       … while evaluating attribute 'c'
-         at /pwd/lang/eval-fail-toJSON.nix:7:7:
-            6|     {
-            7|       c.d = throw "hah no";
-             |       ^
-            8|     }
-
-       … while evaluating attribute 'd'
-         at /pwd/lang/eval-fail-toJSON.nix:7:7:
-            6|     {
-            7|       c.d = throw "hah no";
-             |       ^
-            8|     }
-
        … while calling the 'throw' builtin
          at /pwd/lang/eval-fail-toJSON.nix:7:13:
             6|     {

--- a/tests/functional/lang/eval-fail-zipAttrsWith-4.err.exp
+++ b/tests/functional/lang/eval-fail-zipAttrsWith-4.err.exp
@@ -7,12 +7,6 @@ error:
              |                        ^
             2|   { foo = 1; }
 
-       … while calling anonymous lambda
-         at /pwd/lang/eval-fail-zipAttrsWith-4.nix:1:27:
-            1| builtins.zipAttrsWith (a: b: a + b) [
-             |                           ^
-            2|   { foo = 1; }
-
        … while evaluating a path segment
          at /pwd/lang/eval-fail-zipAttrsWith-4.nix:1:34:
             1| builtins.zipAttrsWith (a: b: a + b) [

--- a/tests/functional/repl/debugger-fail-throw-env-1.expected
+++ b/tests/functional/repl/debugger-fail-throw-env-1.expected
@@ -20,12 +20,6 @@ error:
              | ^
             2|
 
-       … while calling anonymous lambda
-         at /path/to/tests/functional/repl/debugger-fail-throw-env-1.in.debugexpr.nix:1:2:
-            1| (_: throw "oh snap") 42
-             |  ^
-            2|
-
        … while calling the 'throw' builtin
          at /path/to/tests/functional/repl/debugger-fail-throw-env-1.in.debugexpr.nix:1:5:
             1| (_: throw "oh snap") 42

--- a/tests/functional/repl/debugger-fail-throw-env-2.expected
+++ b/tests/functional/repl/debugger-fail-throw-env-2.expected
@@ -67,27 +67,6 @@ nix-repl> :bt
 error:
        … while evaluating the file '/path/to/tests/functional/repl/debugger-fail-throw-env-2.in.debugexpr.nix':
 
-       … from call site
-         at /path/to/tests/functional/repl/debugger-fail-throw-env-2.in.debugexpr.nix:5:1:
-            4| with x;
-            5| (_: builtins.seq x.a (throw "oh snap")) x.a
-             | ^
-            6|
-
-       … while calling anonymous lambda
-         at /path/to/tests/functional/repl/debugger-fail-throw-env-2.in.debugexpr.nix:5:2:
-            4| with x;
-            5| (_: builtins.seq x.a (throw "oh snap")) x.a
-             |  ^
-            6|
-
-       … while calling the 'seq' builtin
-         at /path/to/tests/functional/repl/debugger-fail-throw-env-2.in.debugexpr.nix:5:5:
-            4| with x;
-            5| (_: builtins.seq x.a (throw "oh snap")) x.a
-             |     ^
-            6|
-
        … while calling the 'throw' builtin
          at /path/to/tests/functional/repl/debugger-fail-throw-env-2.in.debugexpr.nix:5:23:
             4| with x;

--- a/tests/functional/repl/doc-functor.expected
+++ b/tests/functional/repl/doc-functor.expected
@@ -30,13 +30,6 @@ nix-repl> :doc recursive2
 error:
        … while partially calling '__functor' to retrieve documentation
 
-       … while calling '__functor'
-         at /path/to/tests/functional/repl/doc-functor.nix:90:17:
-           89|     */
-           90|     __functor = self: self.__functor self;
-             |                 ^
-           91|   };
-
        … from call site
          at /path/to/tests/functional/repl/doc-functor.nix:90:23:
            89|     */
@@ -44,7 +37,7 @@ error:
              |                       ^
            91|   };
 
-       (199 duplicate frames omitted)
+       (99 duplicate frames omitted)
 
        error: stack overflow; max-call-depth exceeded
        at /path/to/tests/functional/repl/doc-functor.nix:90:23:
@@ -58,13 +51,6 @@ error:
        … while partially calling '__functor' to retrieve documentation
 
        (100 duplicate frames omitted)
-
-       … while calling '__functor'
-         at /path/to/tests/functional/repl/doc-functor.nix:103:21:
-          102|       f = x: {
-          103|         __functor = self: (f (x + 1));
-             |                     ^
-          104|       };
 
        error: stack overflow; max-call-depth exceeded
        at /path/to/tests/functional/repl/doc-functor.nix:103:28:


### PR DESCRIPTION
Now let's see if I can get away with a meatier change...

## Motivation

<img width="1960" height="844" alt="A Nix error with traces" src="https://github.com/user-attachments/assets/b89366ee-6bce-4646-9c58-2a47fc9cee9f" />

The top two trace items here are redundant.

The `throw` trace already points the user to the expression being evaluated. Because the `throw` call expression is contained in both of the operator expressions, there's no need to also have traces that point out that, to get to the `throw`, the evaluator had to go through the operators.

Had the expression been `let x = throw "oops" + 3; in 10 - x`, then the trace corresponding to the subtraction would no longer be redundant. This is because the `throw` call is not a subexpression of `10 - x`.

The general principle here is that, if the last trace on the stack (or the error position, if no traces have been added yet) points to a location that is contained within the expression being evaluated, that expression should not add its own trace item when there is an error. We can use this principle to make traces a fair bit briefer without making things any less debuggable, which is pretty exciting, since the size of Nix traces is one of the perennial complaints about them.

The general principle seems to merit a few exceptions. Most notably, we want the repeated call site traces that are generated by a recursive function not to be dropped (as in tests/functional/lang/eval-fail-mutual-recursion) — at least, not without a ‘frames omitted’ message. So call sites get more of a pass than other expressions. I'm still working out the logic of the other edge cases.

## Context

The first commit is a mechanical refactoring that allows the last `PosIdx` used in an error or trace to be stored in `ErrorInfo`. Many files were touched but it shouldn't take much brainpower to verify that the right things are happening. (Focus your brainpower on the libutil header files; I may have botched the `std::shared_ptr`/r-value reference juggling.)

The tricky question is whether a given position appears within a given expression. This question is answered by the new `comparePos` virtual method on `Expr` (‘compare’ because it actually returns a `std::partial_ordering`, indicating where the expression is relative to the position). In a world where we didn't care about increasing memory usage, `comparePos` could be simply implemented by adding end positions to expressions during parsing. Instead, `comparePos` walks the expression tree looking for matches; this is a bit gnarly and also a bit dishonest, as described in the comments. In particular, the dishonesty part means that `comparePos` is *not* suitable for, say, highlighting expressions in traces, if someone had their heart set on that. But it is honest enough to use for filtering lexically redundant traces.

With `comparePos` in place, most of the rest of the implementation consists of scattering `hasNewPos` checks before `addTrace` calls, mostly in src/libexpr/eval.cc. (`Expr::hasNewPos` is a small helper that runs `comparePos` against the last position to be added to an error.) The form of the checks varies, because sometimes I have to do a bit of digging to find a suitable expression to compare against the last trace position. I introduced `Value::maybeGetThunkExpr()` to help with a common pattern of capturing an expression from a value before it is forced, to be used in the error handler. These checks are not yet comprehensive; I did the easy ones and just enough of the trickier ones to demonstrate the value of the approach.

### Things ready for review
 * [x] Overall approach
 * [x] Naming and code quality for what has been done so far
 * [x] The `comparePos` logic in nixexpr.cc
 * [x] That every trace removed so far in the expected test outputs is in fact redundant

### Things still for me to do before you bother reviewing them
 * [ ] Comprehensively search for traces and add either a filter or a comment explaining why a filter isn't desirable
 * [ ] Ensure that both branches of every filter are tested; remove filters that can never fail, and remove traces that can never appear

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
