### PR TITLE
libstore: Replace linear realloc with amortized resize_and_overwrite …

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -11,7 +11,6 @@
 #include "nix/store/references.hh"
 #include "nix/util/callback.hh"
 #include "nix/util/topo-sort.hh"
-#include "nix/util/finally.hh"
 #include "nix/util/compression.hh"
 #include "nix/util/signals.hh"
 #include "nix/store/posix-fs-canonicalise.hh"
@@ -1219,38 +1218,35 @@ StorePath LocalStore::addToStoreFromDump(
        path. */
     bool inMemory = false;
 
-    struct Free
-    {
-        void operator()(void * v)
-        {
-            free(v);
-        }
-    };
-
-    std::unique_ptr<char, Free> dumpBuffer(nullptr);
-    std::string_view dump;
+    /* Because std::string has resize_and_overwrite. */
+    std::string dump;
 
     /* Fill out buffer, and decide whether we are working strictly in
        memory based on whether we break out because the buffer is full
        or the original source is empty */
     while (dump.size() < localSettings.narBufferSize) {
-        auto oldSize = dump.size();
+        const auto oldSize = dump.size();
         constexpr size_t chunkSize = 65536;
         auto want = std::min(chunkSize, localSettings.narBufferSize - oldSize);
-        if (auto tmp = realloc(dumpBuffer.get(), oldSize + want)) {
-            dumpBuffer.release();
-            dumpBuffer.reset((char *) tmp);
-        } else {
-            throw std::bad_alloc();
-        }
-        auto got = 0;
-        Finally cleanup([&]() { dump = {dumpBuffer.get(), dump.size() + got}; });
-        try {
-            got = source.read(dumpBuffer.get() + oldSize, want);
-        } catch (EndOfFile &) {
-            inMemory = true;
+        std::exception_ptr ex;
+        dump.resize_and_overwrite(
+            oldSize + want,
+            [&inMemory, &source, &ex, sz = oldSize](char * buf, std::size_t bufSize) -> std::string::size_type {
+                try {
+                    auto got = source.read(buf + sz, bufSize - sz);
+                    return sz + got;
+                } catch (EndOfFile &) {
+                    inMemory = true;
+                    return sz;
+                } catch (...) {
+                    ex = std::current_exception();
+                    return sz;
+                }
+            });
+        if (ex)
+            std::rethrow_exception(ex);
+        if (inMemory)
             break;
-        }
     }
 
     std::unique_ptr<AutoDelete> delTempDir;
@@ -1276,8 +1272,7 @@ StorePath LocalStore::addToStoreFromDump(
 
         restorePath(tempPath, bothSource, dumpMethod, localSettings.fsyncStorePaths);
 
-        dumpBuffer.reset();
-        dump = {};
+        std::string().swap(dump);
     }
 
     auto [dumpHash, size] = hashSink->finish();


### PR DESCRIPTION
…in addToStoreFromDump

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Manual memory management is a pain and this was doing realloc for each `read` chunk (even a couple of bytes). That doesn't necessarily move memory of course but it's still wasted allocator work and was doing a bit too much memmove for in-memory NARs.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
