### PR TITLE
docs(manual): move command examples before options

### DIFF
--- a/doc/manual/source/command-ref/nix-build.md
+++ b/doc/manual/source/command-ref/nix-build.md
@@ -49,33 +49,6 @@ derivation).
 > Nix garbage collector. This root disappears automatically when the
 > `result` symlink is deleted or renamed. So don’t rename the symlink.
 
-# Options
-
-All options not listed here are passed to
-[`nix-store --realise`](./nix-store/realise.md),
-except for `--arg` and `--attr` / `-A` which are passed to [`nix-instantiate`](./nix-instantiate.md).
-
-- <span id="opt-no-out-link">[`--no-out-link`](#opt-no-out-link)<span>
-
-  Do not create a symlink to the output path. Note that as a result
-  the output does not become a root of the garbage collector, and so
-  might be deleted by `nix-store --gc`.
-
-- <span id="opt-dry-run">[`--dry-run`](#opt-dry-run)</span>
-
-  Show what store paths would be built or downloaded.
-
-- <span id="opt-out-link">[`--out-link`](#opt-out-link)</span> / `-o` *outlink*
-
-  Change the name of the symlink to the output path created from
-  `result` to *outlink*.
-
-{{#include ./status-build-failure.md}}
-
-{{#include ./opt-common.md}}
-
-{{#include ./env-common.md}}
-
 # Examples
 
 ```console
@@ -123,3 +96,30 @@ branch of Nixpkgs:
 ```console
 $ nix-build https://github.com/NixOS/nixpkgs/archive/master.tar.gz --attr hello
 ```
+
+# Options
+
+All options not listed here are passed to
+[`nix-store --realise`](./nix-store/realise.md),
+except for `--arg` and `--attr` / `-A` which are passed to [`nix-instantiate`](./nix-instantiate.md).
+
+- <span id="opt-no-out-link">[`--no-out-link`](#opt-no-out-link)<span>
+
+  Do not create a symlink to the output path. Note that as a result
+  the output does not become a root of the garbage collector, and so
+  might be deleted by `nix-store --gc`.
+
+- <span id="opt-dry-run">[`--dry-run`](#opt-dry-run)</span>
+
+  Show what store paths would be built or downloaded.
+
+- <span id="opt-out-link">[`--out-link`](#opt-out-link)</span> / `-o` *outlink*
+
+  Change the name of the symlink to the output path created from
+  `result` to *outlink*.
+
+{{#include ./status-build-failure.md}}
+
+{{#include ./opt-common.md}}
+
+{{#include ./env-common.md}}

--- a/doc/manual/source/command-ref/nix-channel.md
+++ b/doc/manual/source/command-ref/nix-channel.md
@@ -73,16 +73,6 @@ This command has the following operations:
   Revert channels to the state before the last call to `nix-channel --update`.
   Optionally, you can specify a specific channel *generation* number to restore.
 
-{{#include ./opt-common.md}}
-
-{{#include ./env-common.md}}
-
-# Files
-
-`nix-channel` operates on the following files.
-
-{{#include ./files/channels.md}}
-
 # Examples
 
 Subscribe to the Nixpkgs channel and run `hello` from the GNU Hello package:
@@ -115,3 +105,13 @@ Remove a channel:
 $ nix-channel --remove nixpkgs
 $ nix-channel --list
 ```
+
+{{#include ./opt-common.md}}
+
+{{#include ./env-common.md}}
+
+# Files
+
+`nix-channel` operates on the following files.
+
+{{#include ./files/channels.md}}

--- a/doc/manual/source/command-ref/nix-copy-closure.md
+++ b/doc/manual/source/command-ref/nix-copy-closure.md
@@ -25,6 +25,34 @@ Since `nix-copy-closure` calls `ssh`, you may need to authenticate with the remo
 In fact, you may be asked for authentication _twice_ because `nix-copy-closure` currently connects twice to the remote machine: first to get the set of paths missing on the target machine, and second to send the dump of those paths.
 When using public key authentication, you can avoid typing the passphrase with `ssh-agent`.
 
+# Examples
+
+> **Example**
+>
+> Copy GNU Hello with all its dependencies to a remote machine:
+>
+> ```shell-session
+> $ storePath="$(nix-build '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable -A hello --no-out-link)"
+> $ nix-copy-closure --to alice@itchy.example.org "$storePath"
+> copying 5 paths...
+> copying path '/nix/store/h6q8sqsqfbd3252f9gixqn3z282wds7m-xgcc-13.2.0-libgcc' to 'ssh://alice@itchy.example.org'...
+> copying path '/nix/store/imnwvn96lw355giswsk36hx105j4wnpj-libunistring-1.1' to 'ssh://alice@itchy.example.org'...
+> copying path '/nix/store/85301indj7scg34spnfczkz72jgv8wa9-libidn2-2.3.7' to 'ssh://alice@itchy.example.org'...
+> copying path '/nix/store/ypwfsaljwhzw9iffiysxmxnhjj8v7np0-glibc-2.39-31' to 'ssh://alice@itchy.example.org'...
+> copying path '/nix/store/0dklv59zppdsqdvgf0qdvjgzcs5wbwxa-hello-2.12.1' to 'ssh://alice@itchy.example.org'...
+> ```
+
+> **Example**
+>
+> Copy GNU Hello from a remote machine using a known store path, and run it:
+>
+> ```shell-session
+> $ storePath="$(nix-instantiate --eval --raw '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable -A hello.outPath)"
+> $ nix-copy-closure --from alice@itchy.example.org "$storePath"
+> $ "$storePath"/bin/hello
+> Hello, world!
+> ```
+
 # Options
 
 - `--to`
@@ -61,31 +89,3 @@ When using public key authentication, you can avoid typing the passphrase with `
   Additional options to be passed to `ssh` on the command line.
 
 {{#include ./env-common.md}}
-
-# Examples
-
-> **Example**
->
-> Copy GNU Hello with all its dependencies to a remote machine:
->
-> ```shell-session
-> $ storePath="$(nix-build '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable -A hello --no-out-link)"
-> $ nix-copy-closure --to alice@itchy.example.org "$storePath"
-> copying 5 paths...
-> copying path '/nix/store/h6q8sqsqfbd3252f9gixqn3z282wds7m-xgcc-13.2.0-libgcc' to 'ssh://alice@itchy.example.org'...
-> copying path '/nix/store/imnwvn96lw355giswsk36hx105j4wnpj-libunistring-1.1' to 'ssh://alice@itchy.example.org'...
-> copying path '/nix/store/85301indj7scg34spnfczkz72jgv8wa9-libidn2-2.3.7' to 'ssh://alice@itchy.example.org'...
-> copying path '/nix/store/ypwfsaljwhzw9iffiysxmxnhjj8v7np0-glibc-2.39-31' to 'ssh://alice@itchy.example.org'...
-> copying path '/nix/store/0dklv59zppdsqdvgf0qdvjgzcs5wbwxa-hello-2.12.1' to 'ssh://alice@itchy.example.org'...
-> ```
-
-> **Example**
->
-> Copy GNU Hello from a remote machine using a known store path, and run it:
->
-> ```shell-session
-> $ storePath="$(nix-instantiate --eval --raw '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable -A hello.outPath)"
-> $ nix-copy-closure --from alice@itchy.example.org "$storePath"
-> $ "$storePath"/bin/hello
-> Hello, world!
-> ```

--- a/doc/manual/source/command-ref/nix-env/delete-generations.md
+++ b/doc/manual/source/command-ref/nix-env/delete-generations.md
@@ -54,14 +54,6 @@ The is because profiles are also garbage collection roots — any [store object]
 
 [store object]: @docroot@/store/store-object.md
 
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ./env-common.md}}
-
-{{#include ../env-common.md}}
-
 # Examples
 
 ## Delete explicit generation numbers
@@ -96,3 +88,11 @@ This command will delete all generations older than 30 days, except for the gene
 ```console
 $ nix-env --profile other_profile --delete-generations old
 ```
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ./env-common.md}}
+
+{{#include ../env-common.md}}

--- a/doc/manual/source/command-ref/nix-env/install.md
+++ b/doc/manual/source/command-ref/nix-env/install.md
@@ -124,38 +124,6 @@ The arguments *args* map to store paths in a number of possible ways:
 
 [store derivation]: @docroot@/glossary.md#gloss-store-derivation
 
-# Options
-
-- `--prebuilt-only` / `-b`
-
-  Use only derivations for which a substitute is registered, i.e.,
-  there is a pre-built binary available that can be downloaded in lieu
-  of building the derivation. Thus, no packages will be built from
-  source.
-
-- `--preserve-installed` / `-P`
-
-  Do not remove derivations with a name matching one of the
-  derivations being installed. Usually, trying to have two versions of
-  the same package installed in the same generation of a profile will
-  lead to an error in building the generation, due to file name
-  clashes between the two versions. However, this is not the case for
-  all packages.
-
-- `--remove-all` / `-r`
-
-  Remove all previously installed packages first. This is equivalent
-  to running `nix-env --uninstall '.*'` first, except that everything happens
-  in a single transaction.
-
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ./env-common.md}}
-
-{{#include ../env-common.md}}
-
 # Examples
 
 To install a package using a specific attribute path from the active Nix expression:
@@ -242,3 +210,35 @@ channel:
 ```console
 $ nix-env --file https://github.com/NixOS/nixpkgs/archive/nixos-14.12.tar.gz --install --attr firefox
 ```
+
+# Options
+
+- `--prebuilt-only` / `-b`
+
+  Use only derivations for which a substitute is registered, i.e.,
+  there is a pre-built binary available that can be downloaded in lieu
+  of building the derivation. Thus, no packages will be built from
+  source.
+
+- `--preserve-installed` / `-P`
+
+  Do not remove derivations with a name matching one of the
+  derivations being installed. Usually, trying to have two versions of
+  the same package installed in the same generation of a profile will
+  lead to an error in building the generation, due to file name
+  clashes between the two versions. However, this is not the case for
+  all packages.
+
+- `--remove-all` / `-r`
+
+  Remove all previously installed packages first. This is equivalent
+  to running `nix-env --uninstall '.*'` first, except that everything happens
+  in a single transaction.
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ./env-common.md}}
+
+{{#include ../env-common.md}}

--- a/doc/manual/source/command-ref/nix-env/list-generations.md
+++ b/doc/manual/source/command-ref/nix-env/list-generations.md
@@ -13,14 +13,6 @@ for the active profile. These may be switched to using the
 `--switch-generation` operation. It also prints the creation date of the
 generation, and indicates the current generation.
 
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ./env-common.md}}
-
-{{#include ../env-common.md}}
-
 # Examples
 
 ```console
@@ -31,3 +23,11 @@ $ nix-env --list-generations
   98   2004-02-06 16:24:33   (current)
 ```
 
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ./env-common.md}}
+
+{{#include ../env-common.md}}

--- a/doc/manual/source/command-ref/nix-env/query.md
+++ b/doc/manual/source/command-ref/nix-env/query.md
@@ -30,6 +30,88 @@ about derivations whose symbolic name matches one of *names*.
 
 The derivations are sorted by their `name` attributes.
 
+# Examples
+
+To show installed packages:
+
+```console
+$ nix-env --query
+bison-1.875c
+docbook-xml-4.2
+firefox-1.0.4
+MPlayer-1.0pre7
+ORBit2-2.8.3
+…
+```
+
+To show available packages:
+
+```console
+$ nix-env --query --available
+firefox-1.0.7
+GConf-2.4.0.1
+MPlayer-1.0pre7
+ORBit2-2.8.3
+…
+```
+
+To show the status of available packages:
+
+```console
+$ nix-env --query --available --status
+-P- firefox-1.0.7   (not installed but present)
+--S GConf-2.4.0.1   (not present, but there is a substitute for fast installation)
+--S MPlayer-1.0pre3 (i.e., this is not the installed MPlayer, even though the version is the same!)
+IP- ORBit2-2.8.3    (installed and by definition present)
+…
+```
+
+To show available packages in the Nix expression `foo.nix`:
+
+```console
+$ nix-env --file ./foo.nix --query --available
+foo-1.2.3
+```
+
+To compare installed versions to what’s available:
+
+```console
+$ nix-env --query --compare-versions
+...
+acrobat-reader-7.0 - ?      (package is not available at all)
+autoconf-2.59      = 2.59   (same version)
+firefox-1.0.4      < 1.0.7  (a more recent version is available)
+...
+```
+
+To show all packages with “`zip`” in the name:
+
+```console
+$ nix-env --query --available '.*zip.*'
+bzip2-1.0.6
+gzip-1.6
+zip-3.0
+…
+```
+
+To show all packages with “`firefox`” or “`chromium`” in the name:
+
+```console
+$ nix-env --query --available '.*(firefox|chromium).*'
+chromium-37.0.2062.94
+chromium-beta-38.0.2125.24
+firefox-32.0.3
+firefox-with-plugins-13.0.1
+…
+```
+
+To show all packages in the latest revision of the Nixpkgs repository:
+
+```console
+$ nix-env --file https://github.com/NixOS/nixpkgs/archive/master.tar.gz --query --available
+```
+
+
 # Source selection
 
 The following flags specify the set of things on which the query
@@ -152,85 +234,3 @@ derivation is shown unless `--no-name` is specified.
 {{#include ./env-common.md}}
 
 {{#include ../env-common.md}}
-
-# Examples
-
-To show installed packages:
-
-```console
-$ nix-env --query
-bison-1.875c
-docbook-xml-4.2
-firefox-1.0.4
-MPlayer-1.0pre7
-ORBit2-2.8.3
-…
-```
-
-To show available packages:
-
-```console
-$ nix-env --query --available
-firefox-1.0.7
-GConf-2.4.0.1
-MPlayer-1.0pre7
-ORBit2-2.8.3
-…
-```
-
-To show the status of available packages:
-
-```console
-$ nix-env --query --available --status
--P- firefox-1.0.7   (not installed but present)
---S GConf-2.4.0.1   (not present, but there is a substitute for fast installation)
---S MPlayer-1.0pre3 (i.e., this is not the installed MPlayer, even though the version is the same!)
-IP- ORBit2-2.8.3    (installed and by definition present)
-…
-```
-
-To show available packages in the Nix expression `foo.nix`:
-
-```console
-$ nix-env --file ./foo.nix --query --available
-foo-1.2.3
-```
-
-To compare installed versions to what’s available:
-
-```console
-$ nix-env --query --compare-versions
-...
-acrobat-reader-7.0 - ?      (package is not available at all)
-autoconf-2.59      = 2.59   (same version)
-firefox-1.0.4      < 1.0.7  (a more recent version is available)
-...
-```
-
-To show all packages with “`zip`” in the name:
-
-```console
-$ nix-env --query --available '.*zip.*'
-bzip2-1.0.6
-gzip-1.6
-zip-3.0
-…
-```
-
-To show all packages with “`firefox`” or “`chromium`” in the name:
-
-```console
-$ nix-env --query --available '.*(firefox|chromium).*'
-chromium-37.0.2062.94
-chromium-beta-38.0.2125.24
-firefox-32.0.3
-firefox-with-plugins-13.0.1
-…
-```
-
-To show all packages in the latest revision of the Nixpkgs repository:
-
-```console
-$ nix-env --file https://github.com/NixOS/nixpkgs/archive/master.tar.gz --query --available
-```
-

--- a/doc/manual/source/command-ref/nix-env/rollback.md
+++ b/doc/manual/source/command-ref/nix-env/rollback.md
@@ -13,14 +13,6 @@ profile, that is, the highest numbered generation lower than the current
 generation, if it exists. It is just a convenience wrapper around
 `--list-generations` and `--switch-generation`.
 
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ./env-common.md}}
-
-{{#include ../env-common.md}}
-
 # Examples
 
 ```console
@@ -32,3 +24,11 @@ switching from generation 92 to 91
 $ nix-env --rollback
 error: no generation older than the current (91) exists
 ```
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ./env-common.md}}
+
+{{#include ../env-common.md}}

--- a/doc/manual/source/command-ref/nix-env/set-flag.md
+++ b/doc/manual/source/command-ref/nix-env/set-flag.md
@@ -32,12 +32,6 @@ environment build script:
   remains part of the profile (so it won’t be garbage-collected). It
   can be set back to `true` to re-enable the package.
 
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ../env-common.md}}
-
 # Examples
 
 To prevent the currently installed Firefox from being upgraded:
@@ -80,3 +74,9 @@ $ nix-env --set-flag priority 5 binutils
 $ nix-env --set-flag priority 10 gcc
 ```
 
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ../env-common.md}}

--- a/doc/manual/source/command-ref/nix-env/set.md
+++ b/doc/manual/source/command-ref/nix-env/set.md
@@ -11,14 +11,6 @@
 The `--set` operation modifies the current generation of a profile so
 that it contains exactly the specified derivation, and nothing else.
 
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ./env-common.md}}
-
-{{#include ../env-common.md}}
-
 ## Examples
 
 The following updates a profile such that its current generation will
@@ -28,3 +20,11 @@ contain just Firefox:
 $ nix-env --profile /nix/var/nix/profiles/browser --set firefox
 ```
 
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ./env-common.md}}
+
+{{#include ../env-common.md}}

--- a/doc/manual/source/command-ref/nix-env/switch-generation.md
+++ b/doc/manual/source/command-ref/nix-env/switch-generation.md
@@ -16,14 +16,6 @@ environment in the Nix store.
 
 Switching will fail if the specified generation does not exist.
 
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ./env-common.md}}
-
-{{#include ../env-common.md}}
-
 # Examples
 
 ```console
@@ -31,3 +23,11 @@ $ nix-env --switch-generation 42
 switching from generation 50 to 42
 ```
 
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ./env-common.md}}
+
+{{#include ../env-common.md}}

--- a/doc/manual/source/command-ref/nix-env/switch-profile.md
+++ b/doc/manual/source/command-ref/nix-env/switch-profile.md
@@ -11,6 +11,12 @@
 This operation makes *path* the current profile for the user. That is,
 the symlink `~/.nix-profile` is made to point to *path*.
 
+# Examples
+
+```console
+$ nix-env --switch-profile ~/my-profile
+```
+
 {{#include ./opt-common.md}}
 
 {{#include ../opt-common.md}}
@@ -18,9 +24,3 @@ the symlink `~/.nix-profile` is made to point to *path*.
 {{#include ./env-common.md}}
 
 {{#include ../env-common.md}}
-
-# Examples
-
-```console
-$ nix-env --switch-profile ~/my-profile
-```

--- a/doc/manual/source/command-ref/nix-env/uninstall.md
+++ b/doc/manual/source/command-ref/nix-env/uninstall.md
@@ -12,6 +12,13 @@ The uninstall operation creates a new user environment, based on the
 current generation of the active profile, from which the store paths
 designated by the symbolic names *drvnames* are removed.
 
+# Examples
+
+```console
+$ nix-env --uninstall gcc
+$ nix-env --uninstall '.*' (remove everything)
+```
+
 {{#include ./opt-common.md}}
 
 {{#include ../opt-common.md}}
@@ -19,10 +26,3 @@ designated by the symbolic names *drvnames* are removed.
 {{#include ./env-common.md}}
 
 {{#include ../env-common.md}}
-
-# Examples
-
-```console
-$ nix-env --uninstall gcc
-$ nix-env --uninstall '.*' (remove everything)
-```

--- a/doc/manual/source/command-ref/nix-env/upgrade.md
+++ b/doc/manual/source/command-ref/nix-env/upgrade.md
@@ -26,6 +26,36 @@ For a description of how *args* is mapped to a set of store paths, see
 store paths with the same symbolic name, only the one with the highest
 version is installed.
 
+# Examples
+
+```console
+$ nix-env --upgrade --attr nixpkgs.gcc
+upgrading `gcc-3.3.1' to `gcc-3.4'
+```
+
+When there are no updates available, nothing will happen:
+
+```console
+$ nix-env --upgrade --attr nixpkgs.pan
+```
+
+Using `-A` is preferred when possible, as it is faster and unambiguous but
+it is also possible to upgrade to a specific version by matching the derivation name:
+
+```console
+$ nix-env --upgrade gcc-3.3.2 --always
+upgrading `gcc-3.4' to `gcc-3.3.2'
+```
+
+To try to upgrade everything
+(matching packages based on the part of the derivation name without version):
+
+```console
+$ nix-env --upgrade
+upgrading `hello-2.1.2' to `hello-2.1.3'
+upgrading `mozilla-1.2' to `mozilla-1.4'
+```
+
 # Flags
 
 - `--lt`
@@ -78,36 +108,6 @@ version is installed.
 {{#include ./env-common.md}}
 
 {{#include ../env-common.md}}
-
-# Examples
-
-```console
-$ nix-env --upgrade --attr nixpkgs.gcc
-upgrading `gcc-3.3.1' to `gcc-3.4'
-```
-
-When there are no updates available, nothing will happen:
-
-```console
-$ nix-env --upgrade --attr nixpkgs.pan
-```
-
-Using `-A` is preferred when possible, as it is faster and unambiguous but
-it is also possible to upgrade to a specific version by matching the derivation name:
-
-```console
-$ nix-env --upgrade gcc-3.3.2 --always
-upgrading `gcc-3.4' to `gcc-3.3.2'
-```
-
-To try to upgrade everything
-(matching packages based on the part of the derivation name without version):
-
-```console
-$ nix-env --upgrade
-upgrading `hello-2.1.2' to `hello-2.1.3'
-upgrading `mozilla-1.2' to `mozilla-1.4'
-```
 
 # Versions
 

--- a/doc/manual/source/command-ref/nix-hash.md
+++ b/doc/manual/source/command-ref/nix-hash.md
@@ -27,68 +27,6 @@ md5sum`.
 
 [Nix Archive]: @docroot@/store/file-system-object/content-address.md#serial-nix-archive
 
-# Options
-
-- `--flat`
-
-  Print the cryptographic hash of the contents of each regular file *path*.
-  That is, instead of computing
-  the hash of the [Nix Archive (NAR)](@docroot@/store/file-system-object/content-address.md#serial-nix-archive) of *path*,
-  just [directly hash](@docroot@/store/file-system-object/content-address.md#serial-flat) *path* as is.
-  This requires *path* to resolve to a regular file rather than directory.
-  The result is identical to that produced by the GNU commands
-  `md5sum` and `sha1sum`.
-
-- `--base16`
-
-  Print the hash in a hexadecimal representation (default).
-
-- `--base32`
-
-  Print the hash in [Nix32](@docroot@/protocols/nix32.md) representation rather than hexadecimal.
-  This representation is more compact and can be used in Nix
-  expressions (such as in calls to `fetchurl`).
-
-- `--base64`
-
-  Similar to `--base32`, but print the hash in a [Base64](https://en.wikipedia.org/wiki/Base64) representation,
-  which is more compact than the Nix32 one.
-
-- `--sri`
-
-  Print the hash in [SRI](@docroot@/glossary.md#gloss-sri) format with Base64 encoding.
-  The type of hash algorithm will be prepended to the hash string,
-  followed by a hyphen (-) and the Base64 hash body.
-
-- `--truncate`
-
-  Truncate hashes longer than 160 bits (such as SHA-256) to 160 bits.
-
-- `--type` *hashAlgo*
-
-  Use the specified cryptographic hash algorithm, which can be one of
-  `blake3`, `md5`, `sha1`, `sha256`, and `sha512`.
-
-- `--to-base16`
-
-  Don’t hash anything, but convert the [Nix32](@docroot@/protocols/nix32.md) hash representation
-  *hash* to hexadecimal.
-
-- `--to-base32`
-
-  Don’t hash anything, but convert the hexadecimal hash representation
-  *hash* to [Nix32](@docroot@/protocols/nix32.md).
-
-- `--to-base64`
-
-  Don’t hash anything, but convert the hexadecimal hash representation
-  *hash* to Base64.
-
-- `--to-sri`
-
-  Don’t hash anything, but convert the hexadecimal hash representation
-  *hash* to SRI.
-
 # Examples
 
 Computing the same hash as `nix-prefetch-url`:
@@ -152,3 +90,65 @@ sha1-5P2Lpfe76upazon+ECVVNs1g2rY=
 $ nix-hash --to-base16 sha1-5P2Lpfe76upazon+ECVVNs1g2rY=
 e4fd8ba5f7bbeaea5ace89fe10255536cd60dab6
 ```
+
+# Options
+
+- `--flat`
+
+  Print the cryptographic hash of the contents of each regular file *path*.
+  That is, instead of computing
+  the hash of the [Nix Archive (NAR)](@docroot@/store/file-system-object/content-address.md#serial-nix-archive) of *path*,
+  just [directly hash](@docroot@/store/file-system-object/content-address.md#serial-flat) *path* as is.
+  This requires *path* to resolve to a regular file rather than directory.
+  The result is identical to that produced by the GNU commands
+  `md5sum` and `sha1sum`.
+
+- `--base16`
+
+  Print the hash in a hexadecimal representation (default).
+
+- `--base32`
+
+  Print the hash in [Nix32](@docroot@/protocols/nix32.md) representation rather than hexadecimal.
+  This representation is more compact and can be used in Nix
+  expressions (such as in calls to `fetchurl`).
+
+- `--base64`
+
+  Similar to `--base32`, but print the hash in a [Base64](https://en.wikipedia.org/wiki/Base64) representation,
+  which is more compact than the Nix32 one.
+
+- `--sri`
+
+  Print the hash in [SRI](@docroot@/glossary.md#gloss-sri) format with Base64 encoding.
+  The type of hash algorithm will be prepended to the hash string,
+  followed by a hyphen (-) and the Base64 hash body.
+
+- `--truncate`
+
+  Truncate hashes longer than 160 bits (such as SHA-256) to 160 bits.
+
+- `--type` *hashAlgo*
+
+  Use the specified cryptographic hash algorithm, which can be one of
+  `blake3`, `md5`, `sha1`, `sha256`, and `sha512`.
+
+- `--to-base16`
+
+  Don’t hash anything, but convert the [Nix32](@docroot@/protocols/nix32.md) hash representation
+  *hash* to hexadecimal.
+
+- `--to-base32`
+
+  Don’t hash anything, but convert the hexadecimal hash representation
+  *hash* to [Nix32](@docroot@/protocols/nix32.md).
+
+- `--to-base64`
+
+  Don’t hash anything, but convert the hexadecimal hash representation
+  *hash* to Base64.
+
+- `--to-sri`
+
+  Don’t hash anything, but convert the hexadecimal hash representation
+  *hash* to SRI.

--- a/doc/manual/source/command-ref/nix-instantiate.md
+++ b/doc/manual/source/command-ref/nix-instantiate.md
@@ -28,6 +28,81 @@ of the resulting store derivations are printed on standard output.
 If *files* is the character `-`, then a Nix expression will be read from
 standard input.
 
+# Examples
+
+Instantiate [store derivation]s from a Nix expression, and build them using `nix-store`:
+
+```console
+$ nix-instantiate test.nix (instantiate)
+/nix/store/cigxbmvy6dzix98dxxh9b6shg7ar5bvs-perl-BerkeleyDB-0.26.drv
+
+$ nix-store --realise $(nix-instantiate test.nix) (build)
+...
+/nix/store/qhqk4n8ci095g3sdp93x7rgwyh9rdvgk-perl-BerkeleyDB-0.26 (output path)
+
+$ ls -l /nix/store/qhqk4n8ci095g3sdp93x7rgwyh9rdvgk-perl-BerkeleyDB-0.26
+dr-xr-xr-x    2 eelco    users        4096 1970-01-01 01:00 lib
+...
+```
+
+You can also give a Nix expression on the command line:
+
+```console
+$ nix-instantiate --expr 'with import <nixpkgs> { }; hello'
+/nix/store/j8s4zyv75a724q38cb0r87rlczaiag4y-hello-2.8.drv
+```
+
+This is equivalent to:
+
+```console
+$ nix-instantiate '<nixpkgs>' --attr hello
+```
+
+Parsing and evaluating Nix expressions:
+
+```console
+$ nix-instantiate --parse --expr '1 + 2'
+1 + 2
+```
+
+```console
+$ nix-instantiate --eval --expr '1 + 2'
+3
+```
+
+```console
+$ nix-instantiate --eval --xml --expr '1 + 2'
+<?xml version='1.0' encoding='utf-8'?>
+<expr>
+  <int value="3" />
+</expr>
+```
+
+The difference between non-strict and strict evaluation:
+
+```console
+$ nix-instantiate --eval --xml --expr '{ x = {}; }'
+<?xml version='1.0' encoding='utf-8'?>
+<expr>
+  <attrs>
+    <attr column="3" line="1" name="x">
+      <unevaluated />
+    </attr>
+  </attrs>
+</expr>
+
+$ nix-instantiate --eval --xml --strict --expr '{ x = {}; }'
+<?xml version='1.0' encoding='utf-8'?>
+<expr>
+  <attrs>
+    <attr column="3" line="1" name="x">
+      <attrs>
+      </attrs>
+    </attr>
+  </attrs>
+</expr>
+```
+
 # Options
 
 - `--add-root` *path*
@@ -130,78 +205,3 @@ standard input.
 {{#include ./opt-common.md}}
 
 {{#include ./env-common.md}}
-
-# Examples
-
-Instantiate [store derivation]s from a Nix expression, and build them using `nix-store`:
-
-```console
-$ nix-instantiate test.nix (instantiate)
-/nix/store/cigxbmvy6dzix98dxxh9b6shg7ar5bvs-perl-BerkeleyDB-0.26.drv
-
-$ nix-store --realise $(nix-instantiate test.nix) (build)
-...
-/nix/store/qhqk4n8ci095g3sdp93x7rgwyh9rdvgk-perl-BerkeleyDB-0.26 (output path)
-
-$ ls -l /nix/store/qhqk4n8ci095g3sdp93x7rgwyh9rdvgk-perl-BerkeleyDB-0.26
-dr-xr-xr-x    2 eelco    users        4096 1970-01-01 01:00 lib
-...
-```
-
-You can also give a Nix expression on the command line:
-
-```console
-$ nix-instantiate --expr 'with import <nixpkgs> { }; hello'
-/nix/store/j8s4zyv75a724q38cb0r87rlczaiag4y-hello-2.8.drv
-```
-
-This is equivalent to:
-
-```console
-$ nix-instantiate '<nixpkgs>' --attr hello
-```
-
-Parsing and evaluating Nix expressions:
-
-```console
-$ nix-instantiate --parse --expr '1 + 2'
-1 + 2
-```
-
-```console
-$ nix-instantiate --eval --expr '1 + 2'
-3
-```
-
-```console
-$ nix-instantiate --eval --xml --expr '1 + 2'
-<?xml version='1.0' encoding='utf-8'?>
-<expr>
-  <int value="3" />
-</expr>
-```
-
-The difference between non-strict and strict evaluation:
-
-```console
-$ nix-instantiate --eval --xml --expr '{ x = {}; }'
-<?xml version='1.0' encoding='utf-8'?>
-<expr>
-  <attrs>
-    <attr column="3" line="1" name="x">
-      <unevaluated />
-    </attr>
-  </attrs>
-</expr>
-
-$ nix-instantiate --eval --xml --strict --expr '{ x = {}; }'
-<?xml version='1.0' encoding='utf-8'?>
-<expr>
-  <attrs>
-    <attr column="3" line="1" name="x">
-      <attrs>
-      </attrs>
-    </attr>
-  </attrs>
-</expr>
-```

--- a/doc/manual/source/command-ref/nix-prefetch-url.md
+++ b/doc/manual/source/command-ref/nix-prefetch-url.md
@@ -37,6 +37,25 @@ in which case it's printed using base-16.
 Additionally, if the option `--print-path` is used,
 the path of the downloaded file in the Nix store is also printed.
 
+# Examples
+
+```console
+$ nix-prefetch-url ftp://ftp.gnu.org/pub/gnu/hello/hello-2.10.tar.gz
+0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i
+```
+
+```console
+$ nix-prefetch-url --print-path mirror://gnu/hello/hello-2.10.tar.gz
+0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i
+/nix/store/8alrpdaasjd1x6g1fczchmzbpqm936a3-hello-2.10.tar.gz
+```
+
+```console
+$ nix-prefetch-url --unpack --print-path https://github.com/NixOS/patchelf/archive/0.8.tar.gz
+079agjlv0hrv7fxnx9ngipx14gyncbkllxrp9cccnh3a50fxcmy7
+/nix/store/19zrmhm3m40xxaw81c8cqm6aljgrnwj2-0.8.tar.gz
+```
+
 # Options
 
 - `--type` *hashAlgo*
@@ -65,22 +84,3 @@ the path of the downloaded file in the Nix store is also printed.
   `hash-basename`, where *basename* is the last component of *url*.
   Overriding the name is necessary when *basename* contains characters
   that are not allowed in Nix store paths.
-
-# Examples
-
-```console
-$ nix-prefetch-url ftp://ftp.gnu.org/pub/gnu/hello/hello-2.10.tar.gz
-0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i
-```
-
-```console
-$ nix-prefetch-url --print-path mirror://gnu/hello/hello-2.10.tar.gz
-0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i
-/nix/store/8alrpdaasjd1x6g1fczchmzbpqm936a3-hello-2.10.tar.gz
-```
-
-```console
-$ nix-prefetch-url --unpack --print-path https://github.com/NixOS/patchelf/archive/0.8.tar.gz
-079agjlv0hrv7fxnx9ngipx14gyncbkllxrp9cccnh3a50fxcmy7
-/nix/store/19zrmhm3m40xxaw81c8cqm6aljgrnwj2-0.8.tar.gz
-```

--- a/doc/manual/source/command-ref/nix-shell.md
+++ b/doc/manual/source/command-ref/nix-shell.md
@@ -54,6 +54,71 @@ shellHook =
 will cause `nix-shell` to print `Hello shell` and set the `SOME_API_TOKEN`
 environment variable to a user-configured value.
 
+# Examples
+
+To build the dependencies of the package Pan, and start an interactive
+shell in which to build it:
+
+```console
+$ nix-shell '<nixpkgs>' --attr pan
+[nix-shell]$ eval ${unpackPhase:-unpackPhase}
+[nix-shell]$ cd $sourceRoot
+[nix-shell]$ eval ${patchPhase:-patchPhase}
+[nix-shell]$ eval ${configurePhase:-configurePhase}
+[nix-shell]$ eval ${buildPhase:-buildPhase}
+[nix-shell]$ ./pan/gui/pan
+```
+
+The reason we use form `eval ${configurePhase:-configurePhase}` here is because
+those packages that override these phases do so by exporting the overridden
+values in the environment variable of the same name.
+Here bash is being told to either evaluate the contents of 'configurePhase',
+if it exists as a variable, otherwise evaluate the configurePhase function.
+
+To clear the environment first, and do some additional automatic
+initialisation of the interactive shell:
+
+```console
+$ nix-shell '<nixpkgs>' --attr pan --pure \
+    --command 'export NIX_DEBUG=1; export NIX_CORES=8; return'
+```
+
+Nix expressions can also be given on the command line using the `-E` and
+`-p` flags. For instance, the following starts a shell containing the
+packages `sqlite` and `libX11`:
+
+```console
+$ nix-shell --expr 'with import <nixpkgs> { }; runCommand "dummy" { buildInputs = [ sqlite xorg.libX11 ]; } ""'
+```
+
+A shorter way to do the same is:
+
+```console
+$ nix-shell --packages sqlite xorg.libX11
+[nix-shell]$ echo $NIX_LDFLAGS
+… -L/nix/store/j1zg5v…-sqlite-3.8.0.2/lib -L/nix/store/0gmcz9…-libX11-1.6.1/lib …
+```
+
+Note that `-p` accepts multiple full nix expressions that are valid in
+the `buildInputs = [ ... ]` shown above, not only package names. So the
+following is also legal:
+
+```console
+$ nix-shell --packages sqlite 'git.override { withManual = false; }'
+```
+
+The `-p` flag looks up Nixpkgs in the Nix search path. You can override
+it by passing `-I` or setting `NIX_PATH`. For example, the following
+gives you a shell containing the Pan package from a specific revision of
+Nixpkgs:
+
+```console
+$ nix-shell --packages pan -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/8a3eea054838b55aca962c3fbde9c83c102b8bf2.tar.gz
+
+[nix-shell:~]$ pan --version
+Pan 0.139
+```
+
 # Options
 
 All options not listed here are passed to `nix-store
@@ -140,71 +205,6 @@ All options not listed here are passed to `nix-store
   > ```
 
 {{#include ./env-common.md}}
-
-# Examples
-
-To build the dependencies of the package Pan, and start an interactive
-shell in which to build it:
-
-```console
-$ nix-shell '<nixpkgs>' --attr pan
-[nix-shell]$ eval ${unpackPhase:-unpackPhase}
-[nix-shell]$ cd $sourceRoot
-[nix-shell]$ eval ${patchPhase:-patchPhase}
-[nix-shell]$ eval ${configurePhase:-configurePhase}
-[nix-shell]$ eval ${buildPhase:-buildPhase}
-[nix-shell]$ ./pan/gui/pan
-```
-
-The reason we use form `eval ${configurePhase:-configurePhase}` here is because
-those packages that override these phases do so by exporting the overridden
-values in the environment variable of the same name.
-Here bash is being told to either evaluate the contents of 'configurePhase',
-if it exists as a variable, otherwise evaluate the configurePhase function.
-
-To clear the environment first, and do some additional automatic
-initialisation of the interactive shell:
-
-```console
-$ nix-shell '<nixpkgs>' --attr pan --pure \
-    --command 'export NIX_DEBUG=1; export NIX_CORES=8; return'
-```
-
-Nix expressions can also be given on the command line using the `-E` and
-`-p` flags. For instance, the following starts a shell containing the
-packages `sqlite` and `libX11`:
-
-```console
-$ nix-shell --expr 'with import <nixpkgs> { }; runCommand "dummy" { buildInputs = [ sqlite xorg.libX11 ]; } ""'
-```
-
-A shorter way to do the same is:
-
-```console
-$ nix-shell --packages sqlite xorg.libX11
-[nix-shell]$ echo $NIX_LDFLAGS
-… -L/nix/store/j1zg5v…-sqlite-3.8.0.2/lib -L/nix/store/0gmcz9…-libX11-1.6.1/lib …
-```
-
-Note that `-p` accepts multiple full nix expressions that are valid in
-the `buildInputs = [ ... ]` shown above, not only package names. So the
-following is also legal:
-
-```console
-$ nix-shell --packages sqlite 'git.override { withManual = false; }'
-```
-
-The `-p` flag looks up Nixpkgs in the Nix search path. You can override
-it by passing `-I` or setting `NIX_PATH`. For example, the following
-gives you a shell containing the Pan package from a specific revision of
-Nixpkgs:
-
-```console
-$ nix-shell --packages pan -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/8a3eea054838b55aca962c3fbde9c83c102b8bf2.tar.gz
-
-[nix-shell:~]$ pan --version
-Pan 0.139
-```
 
 # Use as a `#!`-interpreter
 

--- a/doc/manual/source/command-ref/nix-store/export.md
+++ b/doc/manual/source/command-ref/nix-store/export.md
@@ -25,12 +25,6 @@ This command is different from [`nix-store --dump`](./dump.md), which produces a
 
 [Nix Archive]: @docroot@/store/file-system-object/content-address.md#serial-nix-archive
 
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ../env-common.md}}
-
 # Examples
 
 > **Example**
@@ -51,3 +45,9 @@ This command is different from [`nix-store --dump`](./dump.md), which produces a
 > [bob@scratchy]$ $hello/bin/hello
 > Hello, world!
 > ```
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ../env-common.md}}

--- a/doc/manual/source/command-ref/nix-store/gc.md
+++ b/doc/manual/source/command-ref/nix-store/gc.md
@@ -50,12 +50,6 @@ configuration file.
 By default, the collector prints the total number of freed bytes when it
 finishes (or when it is interrupted).
 
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ../env-common.md}}
-
 # Examples
 
 To delete all unreachable paths, just do:
@@ -73,3 +67,9 @@ To delete at least 100 MiBs of unreachable paths:
 $ nix-store --gc --max-freed $((100 * 1024 * 1024))
 ```
 
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ../env-common.md}}

--- a/doc/manual/source/command-ref/nix-store/import.md
+++ b/doc/manual/source/command-ref/nix-store/import.md
@@ -18,12 +18,6 @@ If a path [refers](@docroot@/glossary.md#gloss-reference) to another path that d
 >
 > For efficient transfer of closures to remote machines over SSH, use [`nix-copy-closure`](@docroot@/command-ref/nix-copy-closure.md).
 
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ../env-common.md}}
-
 # Examples
 
 > **Example**
@@ -41,3 +35,9 @@ If a path [refers](@docroot@/glossary.md#gloss-reference) to another path that d
 > $ nix-store --import --store ssh://alice@itchy.example.org < hello.closure
 > ```
 
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ../env-common.md}}

--- a/doc/manual/source/command-ref/nix-store/query.md
+++ b/doc/manual/source/command-ref/nix-store/query.md
@@ -22,6 +22,85 @@ The paths *paths* may also be symlinks from outside of the Nix store, to
 the Nix store. In that case, the query is applied to the target of the
 symlink.
 
+# Examples
+
+Print the closure (runtime dependencies) of the `svn` program in the
+current user environment:
+
+```console
+$ nix-store --query --requisites $(which svn)
+/nix/store/5mbglq5ldqld8sj57273aljwkfvj22mc-subversion-1.1.4
+/nix/store/9lz9yc6zgmc0vlqmn2ipcpkjlmbi51vv-glibc-2.3.4
+...
+```
+
+Print the build-time dependencies of `svn`:
+
+```console
+$ nix-store --query --requisites $(nix-store --query --deriver $(which svn))
+/nix/store/y6qa66l9h0pw161crnlk6y16rdrcljx4-grep-2.5.1.tar.bz2.drv
+/nix/store/z716h753s97jhnzvfank2srqbljswpgm-gcc-wrapper.sh
+/nix/store/f39x0q73rjdyvzm93y9wrkfr6x39lb7f-glibc-2.3.4.drv
+... lots of other paths ...
+```
+
+The difference with the previous example is that we ask the closure of
+the derivation (`-qd`), not the closure of the output path that contains
+`svn`.
+
+Show the build-time dependencies as a tree:
+
+```console
+$ nix-store --query --tree $(nix-store --query --deriver $(which svn))
+/nix/store/7i5082kfb6yjbqdbiwdhhza0am2xvh6c-subversion-1.1.4.drv
++---/nix/store/vxnmkc8l8d2ijjha4xwhkfgx9vvc3q4c-builder.sh
++---/nix/store/rn9776dy82n5qrgz7xbcl1iw4vfkcrkk-bash-3.0.drv
+|   +---/nix/store/x9j20hz6bln1crzn55qifk0bbsm8v5ac-bash
+|   +---/nix/store/ajnn1mcm45wjvn0rlc22gvx2cwhjnazx-builder.sh
+...
+```
+
+Show all paths that depend on the same OpenSSL library as `svn`:
+
+```console
+$ nix-store --query --referrers $(nix-store --query --binding openssl $(nix-store --query --deriver $(which svn)))
+/nix/store/23ny9l9wixx21632y2wi4p585qhva1q8-sylpheed-1.0.0
+/nix/store/5mbglq5ldqld8sj57273aljwkfvj22mc-subversion-1.1.4
+/nix/store/dpmvp969yhdqs7lm2r1a3gng7pyq6vy4-subversion-1.1.3
+/nix/store/l51240xqsgg8a7yrbqdx1rfzyv6l26fx-lynx-2.8.5
+```
+
+Show all paths that directly or indirectly depend on the Glibc (C
+library) used by `svn`:
+
+```console
+$ nix-store --query --referrers-closure $(ldd $(which svn) | grep /libc.so | awk '{print $3}')
+/nix/store/034a6h4vpz9kds5r6kzb9lhh81mscw43-libgnomeprintui-2.8.2
+/nix/store/15l3yi0d45prm7a82pcrknxdh6nzmxza-gawk-3.1.4
+...
+```
+
+Note that `ldd` is a command that prints out the dynamic libraries used
+by an ELF executable.
+
+Make a picture of the runtime dependency graph of the current user
+environment:
+
+```console
+$ nix-store --query --graph ~/.nix-profile | dot -Tps > graph.ps
+$ gv graph.ps
+```
+
+Show every garbage collector root that points to a store path that
+depends on `svn`:
+
+```console
+$ nix-store --query --roots $(which svn)
+/nix/var/nix/profiles/default-81-link
+/nix/var/nix/profiles/default-82-link
+/home/eelco/.local/state/nix/profiles/profile-97-link
+```
+
 # Common query options
 
 - `--use-output` / `-u`
@@ -167,82 +246,3 @@ symlink.
 {{#include ../opt-common.md}}
 
 {{#include ../env-common.md}}
-
-# Examples
-
-Print the closure (runtime dependencies) of the `svn` program in the
-current user environment:
-
-```console
-$ nix-store --query --requisites $(which svn)
-/nix/store/5mbglq5ldqld8sj57273aljwkfvj22mc-subversion-1.1.4
-/nix/store/9lz9yc6zgmc0vlqmn2ipcpkjlmbi51vv-glibc-2.3.4
-...
-```
-
-Print the build-time dependencies of `svn`:
-
-```console
-$ nix-store --query --requisites $(nix-store --query --deriver $(which svn))
-/nix/store/y6qa66l9h0pw161crnlk6y16rdrcljx4-grep-2.5.1.tar.bz2.drv
-/nix/store/z716h753s97jhnzvfank2srqbljswpgm-gcc-wrapper.sh
-/nix/store/f39x0q73rjdyvzm93y9wrkfr6x39lb7f-glibc-2.3.4.drv
-... lots of other paths ...
-```
-
-The difference with the previous example is that we ask the closure of
-the derivation (`-qd`), not the closure of the output path that contains
-`svn`.
-
-Show the build-time dependencies as a tree:
-
-```console
-$ nix-store --query --tree $(nix-store --query --deriver $(which svn))
-/nix/store/7i5082kfb6yjbqdbiwdhhza0am2xvh6c-subversion-1.1.4.drv
-+---/nix/store/vxnmkc8l8d2ijjha4xwhkfgx9vvc3q4c-builder.sh
-+---/nix/store/rn9776dy82n5qrgz7xbcl1iw4vfkcrkk-bash-3.0.drv
-|   +---/nix/store/x9j20hz6bln1crzn55qifk0bbsm8v5ac-bash
-|   +---/nix/store/ajnn1mcm45wjvn0rlc22gvx2cwhjnazx-builder.sh
-...
-```
-
-Show all paths that depend on the same OpenSSL library as `svn`:
-
-```console
-$ nix-store --query --referrers $(nix-store --query --binding openssl $(nix-store --query --deriver $(which svn)))
-/nix/store/23ny9l9wixx21632y2wi4p585qhva1q8-sylpheed-1.0.0
-/nix/store/5mbglq5ldqld8sj57273aljwkfvj22mc-subversion-1.1.4
-/nix/store/dpmvp969yhdqs7lm2r1a3gng7pyq6vy4-subversion-1.1.3
-/nix/store/l51240xqsgg8a7yrbqdx1rfzyv6l26fx-lynx-2.8.5
-```
-
-Show all paths that directly or indirectly depend on the Glibc (C
-library) used by `svn`:
-
-```console
-$ nix-store --query --referrers-closure $(ldd $(which svn) | grep /libc.so | awk '{print $3}')
-/nix/store/034a6h4vpz9kds5r6kzb9lhh81mscw43-libgnomeprintui-2.8.2
-/nix/store/15l3yi0d45prm7a82pcrknxdh6nzmxza-gawk-3.1.4
-...
-```
-
-Note that `ldd` is a command that prints out the dynamic libraries used
-by an ELF executable.
-
-Make a picture of the runtime dependency graph of the current user
-environment:
-
-```console
-$ nix-store --query --graph ~/.nix-profile | dot -Tps > graph.ps
-$ gv graph.ps
-```
-
-Show every garbage collector root that points to a store path that
-depends on `svn`:
-
-```console
-$ nix-store --query --roots $(which svn)
-/nix/var/nix/profiles/default-81-link
-/nix/var/nix/profiles/default-82-link
-/home/eelco/.local/state/nix/profiles/profile-97-link
-```

--- a/doc/manual/source/command-ref/nix-store/realise.md
+++ b/doc/manual/source/command-ref/nix-store/realise.md
@@ -40,6 +40,30 @@ For non-derivation arguments, the argument itself is printed.
 
 {{#include ../status-build-failure.md}}
 
+# Examples
+
+This operation is typically used to build [store derivation]s produced by
+[`nix-instantiate`](@docroot@/command-ref/nix-instantiate.md):
+
+```console
+$ nix-store --realise $(nix-instantiate ./test.nix)
+/nix/store/6gwmy5jcnwdlz6aqqhksz863f1l8xc2w-aterm-2.3.1
+```
+
+This is essentially what [`nix-build`](@docroot@/command-ref/nix-build.md) does.
+
+To test whether a previously-built derivation is deterministic:
+
+```console
+$ nix-build '<nixpkgs>' --attr hello --check -K
+```
+
+Use [`nix-store --read-log`](./read-log.md) to show the stderr and stdout of a build:
+
+```console
+$ nix-store --read-log $(nix-instantiate ./test.nix)
+```
+
 # Options
 
 - `--dry-run`
@@ -68,27 +92,3 @@ For non-derivation arguments, the argument itself is printed.
 {{#include ../opt-common.md}}
 
 {{#include ../env-common.md}}
-
-# Examples
-
-This operation is typically used to build [store derivation]s produced by
-[`nix-instantiate`](@docroot@/command-ref/nix-instantiate.md):
-
-```console
-$ nix-store --realise $(nix-instantiate ./test.nix)
-/nix/store/6gwmy5jcnwdlz6aqqhksz863f1l8xc2w-aterm-2.3.1
-```
-
-This is essentially what [`nix-build`](@docroot@/command-ref/nix-build.md) does.
-
-To test whether a previously-built derivation is deterministic:
-
-```console
-$ nix-build '<nixpkgs>' --attr hello --check -K
-```
-
-Use [`nix-store --read-log`](./read-log.md) to show the stderr and stdout of a build:
-
-```console
-$ nix-store --read-log $(nix-instantiate ./test.nix)
-```

--- a/doc/manual/source/command-ref/nix-store/serve.md
+++ b/doc/manual/source/command-ref/nix-store/serve.md
@@ -20,12 +20,6 @@ The following flags are available:
   derivations. In effect, this can be used to make the host act as a
   remote builder.
 
-{{#include ./opt-common.md}}
-
-{{#include ../opt-common.md}}
-
-{{#include ../env-common.md}}
-
 # Examples
 
 To turn a host into a build server, the `authorized_keys` file can be
@@ -37,3 +31,9 @@ command="nice -n20 nix-store --serve --write" ssh-rsa AAAAB3NzaC1yc2EAAAA...
 EOF
 ```
 
+
+{{#include ./opt-common.md}}
+
+{{#include ../opt-common.md}}
+
+{{#include ../env-common.md}}


### PR DESCRIPTION
## Motivation

Classic command pages currently place their examples after long lists of
options and environment variables. This makes practical usage harder to find
when scanning the documentation.

Move the examples directly after each command description so they are visible
before the reference material.

## Context

This change reorders the existing example sections in 24 classic command
pages. It does not modify the examples or add new documentation.

The manual was validated with:

```console
nix build .#nix-manual --no-link
```
Closes #10717

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).