### PR TITLE
libstore: Canonicalise permissions in addToStoreFromDump and addToStore in restorePath

### DIFF
--- a/src/libstore-tests/local-store.cc
+++ b/src/libstore-tests/local-store.cc
@@ -1,7 +1,10 @@
 #include <gtest/gtest.h>
 
 #include "nix/store/local-store.hh"
+#include "nix/store/globals.hh"
 
+#include "nix/util/archive.hh"
+#include "nix/util/memory-source-accessor.hh"
 // Needed for template specialisations. This is not good! When we
 // overhaul how store configs work, this should be fixed.
 #include "nix/util/args.hh"
@@ -71,5 +74,161 @@ TEST(LocalStore, constructConfig_to_string)
     LocalStoreConfig config{"", {}};
     EXPECT_EQ(config.getReference().to_string(), "local");
 }
+
+#ifndef _WIN32 /* Windows doesn't exactly have a notion of canonicalation for now. */
+
+class LocalStoreCanonicalisationTest : public ::testing::TestWithParam<std::tuple<HashAlgorithm>>
+{
+protected:
+    AutoDelete tempStoreDir;
+    std::shared_ptr<LocalStoreConfig> config;
+    std::shared_ptr<LocalStore> store; // Inexplicably, ref doesn't have a .release() method.
+
+    void SetUp() override
+    {
+        tempStoreDir = canonPath(createTempDir(), /*resolveSymlinks=*/true);
+        config = std::make_shared<LocalStoreConfig>(tempStoreDir.path(), StoreConfig::Params{});
+        store = std::make_shared<LocalStore>(ref{config});
+    }
+
+    void TearDown() override
+    {
+        tempStoreDir.deletePath();
+        store.reset();
+    }
+
+    void assertCanonicalPermissions(const std::filesystem::path & path)
+    {
+        auto st = lstat(path);
+
+        /* TODO: Figure out how to test xattrs properly. Maybe with posix ACLs?
+           But xattrs are unavailable in the nix sandbox, so that would have to
+           also run in NixOS tests? */
+
+        auto modeTypeMaskedOut = st.st_mode & ~S_IFMT;
+
+        /* Store mtime is always 1 sec into the epoch. */
+        ASSERT_EQ(st.st_mtime, 1);
+
+        if (S_ISLNK(st.st_mode)) {
+            /* Not much to check for symlinks. */
+        } else if (S_ISREG(st.st_mode)) {
+            ASSERT_TRUE(modeTypeMaskedOut == 0555 || modeTypeMaskedOut == 0444);
+        } else if (S_ISDIR(st.st_mode)) {
+            ASSERT_EQ(modeTypeMaskedOut, 0555);
+            for (const auto & p : DirectoryIterator{path})
+                assertCanonicalPermissions(p.path());
+        } else {
+            FAIL() << fmt("unknown file type at %1%", PathFmt(path));
+        }
+    }
+
+    HashAlgorithm getHashAlgo() const
+    {
+        return std::get<HashAlgorithm>(GetParam());
+    }
+};
+
+TEST_P(LocalStoreCanonicalisationTest, flatFitsInMemory)
+{
+    using namespace std::string_view_literals;
+    StringSource source{"very simple file"sv};
+    auto sp = store->addToStoreFromDump(
+        source,
+        "flat",
+        FileSerialisationMethod::Flat,
+        /* For the purposes of this test, it doesn't really matter to vary the hashing method. */
+        ContentAddressMethod::Raw::NixArchive,
+        getHashAlgo(),
+        {},
+        NoRepair);
+    assertCanonicalPermissions(store->toRealPath(sp));
+    StringSink narDump;
+    dumpString(source.s, narDump);
+    StringSource narSource{narDump.s};
+    auto sp2 = store->addToStoreFromDump(
+        narSource,
+        "nar",
+        FileSerialisationMethod::NixArchive,
+        /* For the purposes of this test, it doesn't really matter to vary the hashing method. */
+        ContentAddressMethod::Raw::NixArchive,
+        getHashAlgo(),
+        {},
+        NoRepair);
+    assertCanonicalPermissions(store->toRealPath(sp2));
+}
+
+TEST_P(LocalStoreCanonicalisationTest, simpleNar)
+{
+    auto accessor = make_ref<MemorySourceAccessor>();
+    MemorySink memorySink{*accessor};
+    memorySink.createDirectory(CanonPath::root);
+    memorySink.createRegularFile(CanonPath("/regular"), [](auto & crf) { crf("test"); });
+    memorySink.createRegularFile(CanonPath("/executable"), [](auto & crf) {
+        crf("test");
+        crf.isExecutable();
+    });
+    memorySink.createDirectory(CanonPath("/dir"));
+    memorySink.createRegularFile(CanonPath("/dir/regular"), [](auto & crf) { crf("test 2"); });
+    memorySink.createRegularFile(CanonPath("/dir/executable"), [](auto & crf) {
+        crf("test 2");
+        crf.isExecutable();
+    });
+    memorySink.createSymlink(CanonPath("/symlink"), "some target");
+    memorySink.createSymlink(CanonPath("/dir/symlink"), "..");
+    auto source = sinkToSource([&accessor](Sink & sink) { accessor->dumpPath(CanonPath::root, sink); });
+    auto sp = store->addToStoreFromDump(
+        *source,
+        "nar-from-dump",
+        FileSerialisationMethod::NixArchive,
+        /* For the purposes of this test, it doesn't really matter to vary the hashing method. */
+        ContentAddressMethod::Raw::NixArchive,
+        getHashAlgo(),
+        {},
+        NoRepair);
+    assertCanonicalPermissions(store->toRealPath(sp));
+
+    memorySink.createRegularFile(CanonPath("/other"), [](auto & crf) { crf(""); });
+    auto sp2 = store->addToStoreSlow("nar-slow", {accessor}, ContentAddressMethod::Raw::NixArchive, getHashAlgo()).path;
+    assertCanonicalPermissions(store->toRealPath(sp2));
+
+    Finally restoreNarBufferSize{[oldSize = settings.getLocalSettings().narBufferSize]() {
+        settings.getLocalSettings().narBufferSize.assign(oldSize);
+    }};
+    // So that we always spill to the file system.
+    settings.getLocalSettings().narBufferSize = 0;
+
+    memorySink.createDirectory(CanonPath("/dir/entirely-something-else"));
+    StringSink narDump;
+    accessor->dumpPath(CanonPath::root, narDump);
+    StringSource narSource{narDump.s};
+    auto sp3 = store->addToStoreFromDump(
+        narSource,
+        "nar-from-dump-spilled",
+        FileSerialisationMethod::NixArchive,
+        /* For the purposes of this test, it doesn't really matter to vary the hashing method. */
+        ContentAddressMethod::Raw::NixArchive,
+        getHashAlgo(),
+        {},
+        NoRepair);
+    assertCanonicalPermissions(store->toRealPath(sp3));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LocalStoreCanonicalisation,
+    LocalStoreCanonicalisationTest,
+    ::testing::Combine(
+        ::testing::Values(
+            HashAlgorithm::SHA256,
+            /* Other algorithms are included because SHA256 is special-cased in some places,
+               to avoid computing narHash twice. */
+            HashAlgorithm::SHA1,
+            HashAlgorithm::SHA512,
+            HashAlgorithm::MD5)),
+    [](const ::testing::TestParamInfo<LocalStoreCanonicalisationTest::ParamType> & info) {
+        return std::string(printHashAlgo(std::get<HashAlgorithm>(info.param)));
+    });
+
+#endif
 
 } // namespace nix

--- a/src/libstore/include/nix/store/posix-fs-canonicalise.hh
+++ b/src/libstore/include/nix/store/posix-fs-canonicalise.hh
@@ -5,6 +5,7 @@
 #include <sys/time.h>
 
 #include <filesystem>
+#include <memory>
 
 #include "nix/util/types.hh"
 #include "nix/util/error.hh"
@@ -45,8 +46,10 @@ struct CanonicalizePathMetadataOptions
  */
 #if NIX_SUPPORT_ACL
 #  define NIX_WHEN_SUPPORT_ACLS(ARG) .ignoredAcls = ARG,
+#  define NIX_WHEN_SUPPORT_ACLS2(ARG) ARG
 #else
 #  define NIX_WHEN_SUPPORT_ACLS(ARG)
+#  define NIX_WHEN_SUPPORT_ACLS2(ARG)
 #endif
 
 /**
@@ -68,5 +71,13 @@ void canonicalisePathMetaData(
 void canonicalisePathMetaData(const std::filesystem::path & path, CanonicalizePathMetadataOptions options);
 
 void canonicaliseTimestampAndPermissions(const std::filesystem::path & path);
+
+class RestoreSinkHooks;
+
+std::unique_ptr<RestoreSinkHooks> makeCanonicalisingRestoreHooks(
+#if NIX_SUPPORT_ACL
+    const StringSet & ignoredAcls
+#endif
+);
 
 } // namespace nix

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1101,8 +1101,14 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
                 HashSink hashSink(HashAlgorithm::SHA256);
 
                 TeeSource wrapperSource{source, hashSink};
+                auto canonicalisingRestoreHooks =
+                    makeCanonicalisingRestoreHooks(NIX_WHEN_SUPPORT_ACLS2(config->getLocalSettings().ignoredAcls));
 
-                restorePath(realPath, wrapperSource, config->getLocalSettings().fsyncStorePaths);
+                restorePath(
+                    realPath,
+                    wrapperSource,
+                    config->getLocalSettings().fsyncStorePaths,
+                    canonicalisingRestoreHooks.get());
 
                 auto hashResult = hashSink.finish();
 
@@ -1156,8 +1162,6 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
                 }
 
                 autoGC();
-
-                canonicalisePathMetaData(realPath, {NIX_WHEN_SUPPORT_ACLS(config->getLocalSettings().ignoredAcls)});
 
                 optimisePath(realPath, repair); // FIXME: combine with hashPath()
 
@@ -1260,6 +1264,8 @@ StorePath LocalStore::addToStoreFromDump(
        wrong sort, and we need to rehash.
        References are also in store path, if scanning we will need to move */
     bool inMemoryAndDontNeedRestore = inMemory && methodsMatch && !filterReferences;
+    auto canonicalisingRestoreHooks =
+        makeCanonicalisingRestoreHooks(NIX_WHEN_SUPPORT_ACLS2(config->getLocalSettings().ignoredAcls));
 
     if (!inMemoryAndDontNeedRestore) {
         /* Drain what we pulled so far, and then keep on pulling */
@@ -1270,7 +1276,7 @@ StorePath LocalStore::addToStoreFromDump(
         delTempDir = std::make_unique<AutoDelete>(tempDir);
         tempPath = tempDir / "x";
 
-        restorePath(tempPath, bothSource, dumpMethod, localSettings.fsyncStorePaths);
+        restorePath(tempPath, bothSource, dumpMethod, localSettings.fsyncStorePaths, canonicalisingRestoreHooks.get());
 
         std::string().swap(dump);
     }
@@ -1321,7 +1327,12 @@ StorePath LocalStore::addToStoreFromDump(
                 switch (fim) {
                 case FileIngestionMethod::Flat:
                 case FileIngestionMethod::NixArchive:
-                    restorePath(realPath, dumpSource, (FileSerialisationMethod) fim, localSettings.fsyncStorePaths);
+                    restorePath(
+                        realPath,
+                        dumpSource,
+                        (FileSerialisationMethod) fim,
+                        localSettings.fsyncStorePaths,
+                        canonicalisingRestoreHooks.get());
                     break;
                 case FileIngestionMethod::Git:
                     // doesn't correspond to serialization method, so
@@ -1331,17 +1342,18 @@ StorePath LocalStore::addToStoreFromDump(
             } else {
                 /* Move the temporary path we restored above. */
                 try {
-                    renameFile(tempPath, realPath);
+                    /* movePath and not renameFile because at this point the top-level directory is
+                       read-only. */
+                    movePath(tempPath, realPath);
                 } catch (const SystemError & e) {
                     if (!e.is(std::errc::cross_device_link))
                         throw;
 
                     /* Apparently this can happen even on the same filesystem (and the paths that are renamed above
                        are on the same filesystem) with overlayfs https://github.com/NixOS/nix/issues/6262.
-                       Since we couldn't rename, this won't be atomic and we have to gradually copy to the realPath.
-                       Note that copyRecursive doesn't copy over permissions, but those will be canonicalised below. */
+                       Since we couldn't rename, this won't be atomic and we have to gradually copy to the realPath. */
                     warn("can't rename %s as %s, copying instead", PathFmt(tempPath), PathFmt(realPath));
-                    RestoreSink copySink{/*startFsync=*/false};
+                    RestoreSink copySink{/*startFsync=*/false, /*hooks=*/canonicalisingRestoreHooks.get()};
                     copySink.dstPath = realPath;
                     copyRecursive(*makeFSSourceAccessor(tempPath), CanonPath::root, copySink, CanonPath::root);
                     delTempDir->deletePath();
@@ -1356,9 +1368,6 @@ StorePath LocalStore::addToStoreFromDump(
                 dumpPath(realPath, narSink);
                 narHash = narSink.finish();
             }
-
-            canonicalisePathMetaData(
-                realPath, {NIX_WHEN_SUPPORT_ACLS(localSettings.ignoredAcls)}); // FIXME: merge into restorePath
 
             optimisePath(realPath, repair);
 

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -40,25 +40,70 @@ void canonicaliseTimestampAndPermissions(const std::filesystem::path & path)
 
 #if NIX_SUPPORT_ACL
 
-static void stripXAttrs(const std::filesystem::path & path, const StringSet & ignoredAcls)
+static ssize_t listXAttr(const std::filesystem::path & path, char * list, size_t size, FinalSymlink finalSymlink)
 {
-    ssize_t eaSize = llistxattr(path.c_str(), nullptr, 0);
+    if (finalSymlink == FinalSymlink::DontFollow)
+        return ::llistxattr(path.c_str(), list, size);
+    return ::listxattr(path.c_str(), list, size);
+}
+
+static ssize_t listXAttr(Descriptor fd, char * list, size_t size, [[maybe_unused]] FinalSymlink finalSymlink)
+{
+    return ::flistxattr(fd, list, size);
+}
+
+static int removeXAttr(const std::filesystem::path & path, const char * name, FinalSymlink finalSymlink)
+{
+    if (finalSymlink == FinalSymlink::DontFollow)
+        return ::lremovexattr(path.c_str(), name);
+    return ::removexattr(path.c_str(), name);
+}
+
+static int removeXAttr(Descriptor fd, const char * name, [[maybe_unused]] FinalSymlink finalSymlink)
+{
+    return ::fremovexattr(fd, name);
+}
+
+static std::filesystem::path renderXAttrsFuncArgumentPath(Descriptor fd)
+{
+    return descriptorToPath(fd);
+}
+
+static std::filesystem::path renderXAttrsFuncArgumentPath(std::filesystem::path path)
+{
+    return path;
+}
+
+template<typename T>
+static void
+stripXAttrs(const T & pathOrFd, const StringSet & ignoredAcls, FinalSymlink finalSymlink = FinalSymlink::DontFollow)
+{
+    ssize_t eaSize = listXAttr(pathOrFd, nullptr, 0, finalSymlink);
 
     if (eaSize < 0) {
         if (errno != ENOTSUP && errno != ENODATA)
-            throw SysError("querying extended attributes of %s", PathFmt(path));
+            throw SysError([&]() {
+                return HintFmt("querying extended attributes of %s", PathFmt(renderXAttrsFuncArgumentPath(pathOrFd)));
+            });
     } else if (eaSize > 0) {
         std::vector<char> eaBuf(eaSize);
 
-        if ((eaSize = llistxattr(path.c_str(), eaBuf.data(), eaBuf.size())) < 0)
-            throw SysError("querying extended attributes of %s", PathFmt(path));
+        if ((eaSize = listXAttr(pathOrFd, eaBuf.data(), eaBuf.size(), finalSymlink)) < 0)
+            throw SysError([&]() {
+                return HintFmt("querying extended attributes of %s", PathFmt(renderXAttrsFuncArgumentPath(pathOrFd)));
+            });
 
         using namespace std::string_view_literals;
         for (auto & eaName : tokenizeString<Strings>(std::string_view(eaBuf.data(), eaSize), "\0"sv)) {
             if (ignoredAcls.count(eaName))
                 continue;
-            if (lremovexattr(path.c_str(), eaName.c_str()) == -1)
-                throw SysError("removing extended attribute '%s' from %s", eaName, PathFmt(path));
+            if (removeXAttr(pathOrFd, eaName.c_str(), finalSymlink) == -1)
+                throw SysError([&]() {
+                    return HintFmt(
+                        "removing extended attribute '%s' from %s",
+                        eaName,
+                        PathFmt(renderXAttrsFuncArgumentPath(pathOrFd)));
+                });
         }
     }
 }

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -53,7 +53,8 @@ static void stripXAttrs(const std::filesystem::path & path, const StringSet & ig
         if ((eaSize = llistxattr(path.c_str(), eaBuf.data(), eaBuf.size())) < 0)
             throw SysError("querying extended attributes of %s", PathFmt(path));
 
-        for (auto & eaName : tokenizeString<Strings>(std::string(eaBuf.data(), eaSize), std::string("\000", 1))) {
+        using namespace std::string_view_literals;
+        for (auto & eaName : tokenizeString<Strings>(std::string_view(eaBuf.data(), eaSize), "\0"sv)) {
             if (ignoredAcls.count(eaName))
                 continue;
             if (lremovexattr(path.c_str(), eaName.c_str()) == -1)

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -3,14 +3,17 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/signals.hh"
 #include "nix/store/store-api.hh"
+#include "nix/util/fs-sink.hh"
 
 #if NIX_SUPPORT_ACL
 #  include <sys/xattr.h>
 #endif
 
+#include <sys/stat.h>
+
 namespace nix {
 
-const time_t mtimeStore = 1; /* 1 second into the epoch */
+static constexpr time_t mtimeStore = 1; /* 1 second into the epoch */
 
 static void canonicaliseTimestampAndPermissions(const std::filesystem::path & path, const PosixStat & st)
 {
@@ -183,6 +186,104 @@ void canonicalisePathMetaData(const std::filesystem::path & path, CanonicalizePa
 {
     InodesSeen inodesSeen;
     canonicalisePathMetaData_(path, options, inodesSeen);
+}
+
+#ifndef _WIN32
+static void setStoreWriteTime(Descriptor fd)
+{
+    struct ::timespec times[2] = {
+        {.tv_sec = 0, .tv_nsec = UTIME_OMIT}, /* Leave alone. tv_sec is ignored. */
+        {.tv_sec = mtimeStore, .tv_nsec = 0},
+    };
+
+    if (::futimens(fd, times) == -1)
+        throw SysError([&]() {
+            return HintFmt("changing modification time of %s (using `futimens`)", PathFmt(descriptorToPath(fd)));
+        });
+}
+#endif
+
+/* These hooks are supposed to be used only for freshly created files, not
+   something we get from the builder output -- that needs additional validation.
+   Use this for creating store objects with canonicalised permissions in a
+   single restorePath pass. */
+class CanonicalisingRestoreHooks : public RestoreSinkHooks
+{
+#if NIX_SUPPORT_ACL
+    const StringSet & ignoredAcls;
+#endif
+
+    void canonicaliseTimestampAndPermissions(Descriptor fd, mode_t mode)
+    {
+#ifndef _WIN32 /* TODO: Figure out what sort of canonicalisation we even want. */
+#  if NIX_SUPPORT_ACL
+        stripXAttrs(fd, ignoredAcls);
+#  endif
+        if (::fchmod(fd, mode) == -1)
+            throw SysError([&]() { return HintFmt("setting permissions on %s", PathFmt(descriptorToPath(fd))); });
+        setStoreWriteTime(fd);
+#endif
+    }
+
+    void anchor() override;
+
+public:
+#if NIX_SUPPORT_ACL
+    explicit CanonicalisingRestoreHooks(const StringSet & ignoredAcls)
+        : ignoredAcls(ignoredAcls)
+    {
+    }
+#else
+    CanonicalisingRestoreHooks() = default;
+#endif
+
+    void directoryDone(Descriptor dirFd) override
+    {
+        canonicaliseTimestampAndPermissions(dirFd, 0555);
+    }
+
+    void regularFileCreated(Descriptor fd, bool executable) override
+    {
+        canonicaliseTimestampAndPermissions(fd, executable ? 0555 : 0444);
+    }
+
+    void symlinkCreated(Descriptor parentFd, const CanonPath & name) override
+    {
+#ifndef _WIN32 /* Handling of symlinks on windows needs a ton more work. */
+#  if NIX_SUPPORT_ACL
+        AutoCloseFD fd = ::openat(parentFd, name.rel_c_str(), O_PATH | O_NOFOLLOW | O_CLOEXEC);
+        if (!fd)
+            throw SysError(
+                [&]() { return HintFmt("failed to open %1%", PathFmt(descriptorToPath(parentFd) / name.rel())); });
+        /* Would be nice to use the *at family of syscalls with AT_EMPTY_PATH added in (6.13)
+           https://github.com/torvalds/linux/commit/6140be90ec70c39fa844741ca3cc807dd0866394,
+           but there are no glibc wrappers and apparently no manpages for them too? */
+        stripXAttrs<std::filesystem::path>(
+            "/proc/self/fd/" + std::to_string(fd.get()),
+            ignoredAcls,
+            FinalSymlink::Follow /* Need to follow the magic link. */
+        );
+#  endif
+        struct ::timespec times[2] = {
+            {.tv_sec = 0, .tv_nsec = UTIME_OMIT}, /* Leave alone. tv_sec is ignored. */
+            {.tv_sec = mtimeStore, .tv_nsec = 0},
+        };
+
+        if (::utimensat(parentFd, name.rel_c_str(), times, AT_SYMLINK_NOFOLLOW) == -1)
+            throw SysError([&]() {
+                return HintFmt(
+                    "changing modification time of %s (using `utimensat`)",
+                    PathFmt(descriptorToPath(parentFd) / name.rel()));
+            });
+#endif
+    }
+};
+
+void CanonicalisingRestoreHooks::anchor() {}
+
+std::unique_ptr<RestoreSinkHooks> makeCanonicalisingRestoreHooks(NIX_WHEN_SUPPORT_ACLS2(const StringSet & ignoredAcls))
+{
+    return std::make_unique<CanonicalisingRestoreHooks>(NIX_WHEN_SUPPORT_ACLS2(ignoredAcls));
 }
 
 } // namespace nix

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -38,6 +38,32 @@ void canonicaliseTimestampAndPermissions(const std::filesystem::path & path)
     canonicaliseTimestampAndPermissions(path, lstat(path));
 }
 
+#if NIX_SUPPORT_ACL
+
+static void stripXAttrs(const std::filesystem::path & path, const StringSet & ignoredAcls)
+{
+    ssize_t eaSize = llistxattr(path.c_str(), nullptr, 0);
+
+    if (eaSize < 0) {
+        if (errno != ENOTSUP && errno != ENODATA)
+            throw SysError("querying extended attributes of %s", PathFmt(path));
+    } else if (eaSize > 0) {
+        std::vector<char> eaBuf(eaSize);
+
+        if ((eaSize = llistxattr(path.c_str(), eaBuf.data(), eaBuf.size())) < 0)
+            throw SysError("querying extended attributes of %s", PathFmt(path));
+
+        for (auto & eaName : tokenizeString<Strings>(std::string(eaBuf.data(), eaSize), std::string("\000", 1))) {
+            if (ignoredAcls.count(eaName))
+                continue;
+            if (lremovexattr(path.c_str(), eaName.c_str()) == -1)
+                throw SysError("removing extended attribute '%s' from %s", eaName, PathFmt(path));
+        }
+    }
+}
+
+#endif
+
 static void canonicalisePathMetaData_(
     const std::filesystem::path & path, CanonicalizePathMetadataOptions options, InodesSeen & inodesSeen)
 {
@@ -60,25 +86,7 @@ static void canonicalisePathMetaData_(
         throw Error("file %1% has an unsupported type", PathFmt(path));
 
 #if NIX_SUPPORT_ACL
-    /* Remove extended attributes / ACLs. */
-    ssize_t eaSize = llistxattr(path.c_str(), nullptr, 0);
-
-    if (eaSize < 0) {
-        if (errno != ENOTSUP && errno != ENODATA)
-            throw SysError("querying extended attributes of %s", PathFmt(path));
-    } else if (eaSize > 0) {
-        std::vector<char> eaBuf(eaSize);
-
-        if ((eaSize = llistxattr(path.c_str(), eaBuf.data(), eaBuf.size())) < 0)
-            throw SysError("querying extended attributes of %s", PathFmt(path));
-
-        for (auto & eaName : tokenizeString<Strings>(std::string(eaBuf.data(), eaSize), std::string("\000", 1))) {
-            if (options.ignoredAcls.count(eaName))
-                continue;
-            if (lremovexattr(path.c_str(), eaName.c_str()) == -1)
-                throw SysError("removing extended attribute '%s' from %s", eaName, PathFmt(path));
-        }
-    }
+    stripXAttrs(path, options.ignoredAcls);
 #endif
 
 #ifndef _WIN32

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -307,9 +307,9 @@ void parseDump(FileSystemObjectSink & sink, Source & source)
     parse(sink, source, CanonPath::root, 0);
 }
 
-void restorePath(const std::filesystem::path & path, Source & source, bool startFsync)
+void restorePath(const std::filesystem::path & path, Source & source, bool startFsync, RestoreSinkHooks * hooks)
 {
-    RestoreSink sink{startFsync};
+    RestoreSink sink{startFsync, hooks};
     sink.dstPath = path;
     parseDump(sink, source);
 }

--- a/src/libutil/file-content-address.cc
+++ b/src/libutil/file-content-address.cc
@@ -2,6 +2,7 @@
 #include "nix/util/archive.hh"
 #include "nix/util/git.hh"
 #include "nix/util/source-path.hh"
+#include "nix/util/fs-sink.hh"
 
 namespace nix {
 
@@ -75,14 +76,42 @@ void dumpPath(const SourcePath & path, Sink & sink, FileSerialisationMethod meth
     }
 }
 
-void restorePath(const std::filesystem::path & path, Source & source, FileSerialisationMethod method, bool startFsync)
+void restorePath(
+    const std::filesystem::path & path,
+    Source & source,
+    FileSerialisationMethod method,
+    bool startFsync,
+    RestoreSinkHooks * hooks)
 {
     switch (method) {
-    case FileSerialisationMethod::Flat:
-        writeFile(path, source, 0666, startFsync ? FsSync::Yes : FsSync::No, FinalSymlink::DontFollow);
+    case FileSerialisationMethod::Flat: {
+        AutoCloseFD fd = openNewFileForWrite(
+            path,
+            0666,
+            {
+                .truncateExisting = true,
+                .followSymlinksOnTruncate = false,
+                .writeOnly = true,
+            });
+
+        if (!fd)
+            throw NativeSysError("opening %1%", PathFmt(path));
+
+        writeFile(fd.get(), source, FsSync::No, &path);
+
+        /* We need to manually invoke the hook with the file descriptor in the
+           flat case. File is always non-executable. */
+        if (hooks)
+            hooks->regularFileCreated(fd.get(), /*executable=*/false);
+
+        if (startFsync)
+            fd.fsync();
+
+        fd.close();
         break;
+    }
     case FileSerialisationMethod::NixArchive:
-        restorePath(path, source, startFsync);
+        restorePath(path, source, startFsync, hooks);
         break;
     }
 }

--- a/src/libutil/file-content-address.cc
+++ b/src/libutil/file-content-address.cc
@@ -89,7 +89,7 @@ void restorePath(
             path,
             0666,
             {
-                .truncateExisting = true,
+                .truncateExisting = false, /* Like RestoreSink, we can only create new files. */
                 .followSymlinksOnTruncate = false,
                 .writeOnly = true,
             });

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -300,27 +300,33 @@ void writeFile(const std::filesystem::path & path, Source & source, mode_t mode,
     if (!fd)
         throw NativeSysError("opening file %s", PathFmt(path));
 
-    std::array<char, 64 * 1024> buf;
-
-    try {
-        while (true) {
-            try {
-                auto n = source.read(buf.data(), buf.size());
-                writeFull(fd.get(), {buf.data(), n});
-            } catch (EndOfFile &) {
-                break;
-            }
-        }
-    } catch (Error & e) {
-        e.addTrace({}, "writing file %s", PathFmt(path));
-        throw;
-    }
-    if (sync == FsSync::Yes)
-        fd.fsync();
+    writeFile(fd.get(), source, sync, &path);
     // Explicitly close to make sure exceptions are propagated.
     fd.close();
     if (sync == FsSync::Yes)
         syncParent(path);
+}
+
+void writeFile(Descriptor fd, Source & source, FsSync sync, const std::filesystem::path * origPath)
+{
+    std::array<char, 64 * 1024> buf;
+
+    try {
+        while (true) {
+            size_t n;
+            try {
+                n = source.read(buf.data(), buf.size());
+            } catch (EndOfFile &) {
+                break;
+            }
+            writeFull(fd, {buf.data(), n});
+        }
+    } catch (Error & e) {
+        e.addTrace({}, "writing file %1%", origPath ? PathFmt(*origPath) : PathFmt(descriptorToPath(fd)));
+        throw;
+    }
+    if (sync == FsSync::Yes)
+        syncDescriptor(fd);
 }
 
 void syncParent(const std::filesystem::path & path)

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -26,6 +26,8 @@ void RestoreSink::anchor() {}
 
 void CreateRegularFileSink::anchor() {}
 
+void RestoreSinkHooks::anchor() {}
+
 void copyRecursive(SourceAccessor & accessor, const CanonPath & from, FileSystemObjectSink & sink, const CanonPath & to)
 {
     auto stat = accessor.lstat(from);
@@ -148,13 +150,18 @@ void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallba
     if (path.isRoot()) {
         createDirectory(path);
         callback(*this, path);
+#ifndef _WIN32 /* TODO: Have dirFd equivalent for the root directory. */
+        assert(dirFd);
+        if (hooks)
+            hooks->directoryDone(dirFd.get());
+#endif
         return;
     }
 
     createDirectory(path);
     assert(dirFd); // If that's not true the above call must have thrown an exception.
 
-    RestoreSink dirSink{startFsync};
+    RestoreSink dirSink{startFsync, hooks};
     dirSink.dstPath = append(dstPath, path);
     dirSink.dirFd = openFileEnsureBeneathNoSymlinks(
         dirFd.get(),
@@ -172,6 +179,8 @@ void RestoreSink::createDirectory(const CanonPath & path, DirectoryCreatedCallba
         throw SysError("opening directory %s", PathFmt(dirSink.dstPath));
 
     callback(dirSink, CanonPath::root);
+    if (hooks)
+        hooks->directoryDone(dirSink.dirFd.get());
 }
 
 void RestoreSink::createDirectory(const CanonPath & path)
@@ -204,11 +213,13 @@ struct RestoreRegularFile : CreateRegularFileSink, FdSink
 {
     AutoCloseFD fd;
     bool startFsync = false;
+    bool executable = false;
 
     RestoreRegularFile(bool startFSync_, AutoCloseFD fd_)
         : FdSink(fd_.get())
         , fd(std::move(fd_))
         , startFsync(startFSync_)
+        , executable(false)
     {
         isRegularFile = true; /* Hint for copying contents via CoW copy_file_range. */
     }
@@ -268,6 +279,8 @@ void RestoreSink::createRegularFile(const CanonPath & path, fun<void(CreateRegul
         throw NativeSysError("creating file %1%", PathFmt(append(dstPath, path)));
     func(crf);
     crf.flush();
+    if (hooks)
+        hooks->regularFileCreated(crf.fd.get(), crf.executable);
 }
 
 void RestoreRegularFile::isExecutable()
@@ -278,6 +291,7 @@ void RestoreRegularFile::isExecutable()
     auto st = nix::fstat(fd.get());
     if (fchmod(fd.get(), st.st_mode | (S_IXUSR | S_IXGRP | S_IXOTH)) == -1)
         throw SysError("fchmod");
+    executable = true;
 #endif
 }
 
@@ -308,6 +322,8 @@ void RestoreSink::createSymlink(const CanonPath & path, const std::string & targ
     auto [_parentFd, fd, name] = getParentFdAndName(dirFd.get(), dstPath, path);
     if (::symlinkat(requireCString(target), fd, name.rel_c_str()) == -1)
         throw SysError("creating symlink from %1% -> '%2%'", PathFmt(append(dstPath, path)), target);
+    if (hooks)
+        hooks->symlinkCreated(fd, name);
 #else
     nix::createSymlink(target, append(dstPath, path).string());
 #endif

--- a/src/libutil/include/nix/util/archive.hh
+++ b/src/libutil/include/nix/util/archive.hh
@@ -71,7 +71,12 @@ void dumpString(std::string_view s, Sink & sink);
 
 void parseDump(FileSystemObjectSink & sink, Source & source);
 
-void restorePath(const std::filesystem::path & path, Source & source, bool startFsync = false);
+void restorePath(
+    const std::filesystem::path & path, /**< Root where to unpack the NAR. */
+    Source & source,                    /**< NAR source */
+    bool startFsync = false,
+    RestoreSinkHooks * hooks = nullptr /**< Hooks for canonicalising metadata. */
+);
 
 /**
  * Read a NAR from 'source' and write it to 'sink'.

--- a/src/libutil/include/nix/util/file-content-address.hh
+++ b/src/libutil/include/nix/util/file-content-address.hh
@@ -59,13 +59,19 @@ std::string_view renderFileSerialisationMethod(FileSerialisationMethod method);
 void dumpPath(
     const SourcePath & path, Sink & sink, FileSerialisationMethod method, PathFilter & filter = defaultPathFilter);
 
+class RestoreSinkHooks;
+
 /**
  * Restore a serialisation of the given file system object.
  *
  * \todo use an arbitrary `FileSystemObjectSink`.
  */
 void restorePath(
-    const std::filesystem::path & path, Source & source, FileSerialisationMethod method, bool startFsync = false);
+    const std::filesystem::path & path,
+    Source & source,
+    FileSerialisationMethod method,
+    bool startFsync = false,
+    RestoreSinkHooks * hooks = nullptr);
 
 /**
  * Compute the hash of the given file system object according to the

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -258,6 +258,8 @@ void writeFile(
     FsSync sync = FsSync::No,
     FinalSymlink finalSymlink = FinalSymlink::Follow);
 
+void writeFile(Descriptor fd, Source & source, FsSync sync, const std::filesystem::path * origPath = nullptr);
+
 void writeFile(
     Descriptor fd, std::string_view s, FsSync sync = FsSync::No, const std::filesystem::path * origPath = nullptr);
 

--- a/src/libutil/include/nix/util/fs-sink.hh
+++ b/src/libutil/include/nix/util/fs-sink.hh
@@ -111,6 +111,8 @@ public:
     void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)>) override;
 };
 
+class RestoreSinkHooks;
+
 /**
  * Write files at the given path
  */
@@ -118,6 +120,8 @@ struct RestoreSink : FileSystemObjectSink
 {
 private:
     void anchor() override;
+
+    RestoreSinkHooks * hooks = nullptr;
 
 public:
     std::filesystem::path dstPath;
@@ -133,11 +137,15 @@ public:
     AutoCloseFD dirFd;
     bool startFsync = false;
 
-    explicit RestoreSink(bool startFsync)
-        : startFsync{startFsync}
+    explicit RestoreSink(bool startFsync, RestoreSinkHooks * hooks = nullptr)
+        : hooks{hooks}
+        , startFsync{startFsync}
     {
     }
 
+    /**
+     * @todo Remove. Only keep the callback driven function (at least for recursive traversal).
+     */
     void createDirectory(const CanonPath & path) override;
 
     void createDirectory(const CanonPath & path, DirectoryCreatedCallback callback) override;
@@ -145,6 +153,50 @@ public:
     void createRegularFile(const CanonPath & path, fun<void(CreateRegularFileSink &)>) override;
 
     void createSymlink(const CanonPath & path, const std::string & target) override;
+};
+
+/**
+ * Hooks invoked when filesystem objects created by `RestoreSink` are complete,
+ * so callers can post-process them (e.g. metadata canonicalisation). By doing
+ * this in the hooks, the whole operation can be done in a single recursive tree
+ * traversal during unpacking.
+ *
+ * @todo Do something on Windows.
+ */
+class RestoreSinkHooks
+{
+    virtual void anchor();
+
+public:
+    virtual ~RestoreSinkHooks() = default;
+
+    /**
+     * @brief Called when the callback passed to @ref nix::RestoreSink::createDirectory()
+     * returns.
+     *
+     * Naturally, this means that recursive copying and @ref nix::restorePath()
+     * drives these in post-order when walking up the directory tree. This makes
+     * it suitable for canonicalising permissions of directories.
+     *
+     * @param dirFd File descriptor of the directory.
+     */
+    virtual void directoryDone(Descriptor dirFd) = 0;
+
+    /**
+     * Called when the callback passed to @ref nix::RestoreSink::createRegularFile() returns.
+     *
+     * @param fd File descriptor of the file.
+     * @param executable Whether @ref nix::CreateRegularFileSink::isExecutable() was called.
+     */
+    virtual void regularFileCreated(Descriptor fd, bool executable) = 0;
+
+    /**
+     * @brief Called after a symlink is created.
+     *
+     * @param parentFd Directory file descriptor of the symlink parent (immediate one).
+     * @param name Relative path of the symlink beneath the parent directory.
+     */
+    virtual void symlinkCreated(Descriptor parentFd, const CanonPath & name) = 0;
 };
 
 /**


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

By using the hooks for this we:

1) Avoid a bunch of unnecessary syscalls.
2) Keep TOCTOU at bay. We operate on the same file descriptor that was used
   for writing the contents.
   
Also addresses the existing FIXME in the code.

For `nix store add-path /path/to/nixpkgs --store /path/to/local/store` this shaves off 2956014 -> 2506809 syscalls (450k less syscalls).

Since `RestoreSink` always creates new files (and enforces that invariant - existing file is an error - there's a tiny case in restorePath on Flat serialiasation that truncates, but that should also be ~~unreachable~~ fixed in the last commit), we can benefit from some invariants. Namely:

- The files are always owned by the current euid, since they are created by us.

We also skip double iteration over directories.

Some `strace -c` output for posterity:

(before)

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 19.84    3.574965           7    481018           openat2
 13.32    2.400979           6    367465       137 newfstatat
 12.31    2.218857           7    303418           getdents64
  9.77    1.759694          46     37924           mkdirat
  8.88    1.600463           9    166012           pread64
  8.57    1.544829           2    519057           close
  6.67    1.201136          13     91813           chmod
  4.68    0.844045           2    314305           fstat
  4.02    0.723885           2    303495           fcntl
  3.63    0.653937           7     91817           utimensat
  3.51    0.632414          11     55341           write
  2.44    0.440586           4     91817           llistxattr
  1.24    0.224196           2     91820           geteuid
  1.00    0.180604           4     38533       497 openat
```

(after)

```
 24.55    3.278420           6    481018           openat2
 13.18    1.759813          46     37924           mkdirat
 10.30    1.375646           2    481135           close
  9.13    1.219067           5    227568           getdents64
  7.61    1.016089           3    275646       137 newfstatat
  7.36    0.982459          10     92644           fchmod
  7.34    0.980382           5    166012           pread64
  5.32    0.709709           2    276379           fstat
  4.69    0.625970          11     55341           write
  4.09    0.545791           5     91817           utimensat
  3.89    0.519868           2    227647           fcntl
  2.45    0.327160           3     91813           flistxattr
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
