### PR TITLE
Benchmarks for `nix::rewriteStrings`

### DIFF
--- a/ci/gha/tests/default.nix
+++ b/ci/gha/tests/default.nix
@@ -57,6 +57,7 @@ rec {
 
       nix-store-tests = prev.nix-store-tests.override { withBenchmarks = true; };
       nix-expr-tests = prev.nix-expr-tests.override { withBenchmarks = true; };
+      nix-util-tests = prev.nix-util-tests.override { withBenchmarks = true; };
       # Boehm is incompatible with ASAN.
       nix-expr = prev.nix-expr.override { enableGC = !withSanitizers; };
 

--- a/src/libutil-tests/bench-main.cc
+++ b/src/libutil-tests/bench-main.cc
@@ -1,0 +1,14 @@
+#include <benchmark/benchmark.h>
+#include "nix/util/util.hh"
+
+// Custom main to initialize Nix before running benchmarks
+int main(int argc, char ** argv)
+{
+    // Initialize libutil
+    nix::initLibUtil();
+
+    // Initialize and run benchmarks
+    ::benchmark::Initialize(&argc, argv);
+    ::benchmark::RunSpecifiedBenchmarks();
+    return 0;
+}

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -160,4 +160,34 @@ if build_unit_tests
       )
     endif
   endif
+
+  # Build benchmarks if enabled
+  if get_option('benchmarks')
+    gbenchmark = dependency('benchmark', required : true)
+
+    benchmark_sources = files(
+      'bench-main.cc',
+    )
+
+    benchmark_exe = executable(
+      'nix-util-benchmarks',
+      benchmark_sources,
+      config_priv_h,
+      dependencies : unit_dependencies + [
+        gbenchmark,
+      ],
+      include_directories : include_dirs,
+      link_args : linker_export_flags,
+      install : true,
+      cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
+    )
+
+    benchmark(
+      'nix-util-benchmarks',
+      benchmark_exe,
+      env : {
+        '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
+      },
+    )
+  endif
 endif

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -167,6 +167,7 @@ if build_unit_tests
 
     benchmark_sources = files(
       'bench-main.cc',
+      'reference-rewrite-bench.cc',
     )
 
     benchmark_exe = executable(
@@ -188,6 +189,7 @@ if build_unit_tests
       env : {
         '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
       },
+      timeout : 90,
     )
   endif
 endif

--- a/src/libutil-tests/meson.options
+++ b/src/libutil-tests/meson.options
@@ -9,6 +9,14 @@ option(
 )
 
 option(
+  'benchmarks',
+  type : 'boolean',
+  value : false,
+  description : 'Build benchmarks (requires gbenchmark)',
+  yield : true,
+)
+
+option(
   'fuzzers',
   type : 'boolean',
   value : false,

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -10,6 +10,7 @@
 
   rapidcheck,
   gtest,
+  gbenchmark,
   zstd,
   runCommand,
   util-linux,
@@ -17,12 +18,14 @@
   # Configuration Options
 
   version,
+  withBenchmarks ? false,
   withUnitTests ? true,
   withFuzzTargets ? false,
 }:
 
 let
   inherit (lib) fileset;
+  doBenchmarks = withUnitTests && withBenchmarks;
 in
 
 assert lib.assertMsg (
@@ -58,10 +61,14 @@ mkMesonExecutable (finalAttrs: {
   ]
   ++ lib.optionals (withUnitTests && stdenv.hostPlatform.isLinux) [
     util-linux
+  ]
+  ++ lib.optionals doBenchmarks [
+    gbenchmark
   ];
 
   mesonFlags = [
     (lib.mesonBool "unit-tests" withUnitTests)
+    (lib.mesonBool "benchmarks" doBenchmarks)
     (lib.mesonBool "fuzzers" withFuzzTargets)
   ];
 
@@ -80,6 +87,9 @@ mkMesonExecutable (finalAttrs: {
             + lib.optionalString withUnitTests ''
               export _NIX_TEST_UNIT_DATA=${./data}
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
+            ''
+            + lib.optionalString doBenchmarks ''
+              ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe' finalAttrs.finalPackage "nix-store-benchmarks"}
             ''
             + ''
               ${if withUnitTests then "test -x" else "test ! -e"} \

--- a/src/libutil-tests/reference-rewrite-bench.cc
+++ b/src/libutil-tests/reference-rewrite-bench.cc
@@ -1,0 +1,380 @@
+#include "nix/util/hash.hh"
+#include "nix/util/types.hh"
+#include "nix/util/util.hh"
+
+#include <benchmark/benchmark.h>
+
+#include <format>
+#include <numeric>
+#include <random>
+#include <ranges>
+#include <vector>
+
+namespace nix {
+
+/** Roughly 1 placeholder per 5k characters in practice on the store path shape. */
+constexpr double defaultCharWeight = 100.0;
+
+/** Deterministic seed for the generators. */
+constexpr std::size_t urngSeed = 0;
+
+/** A variant of the placeholder rewrite shape, there are two that interest us, with one exposing a quadratic behaviour.
+ */
+enum struct RewriteShape {
+    /** Placeholder -> store path, as in CA or dynamic derivations, paths are longer and cause the rewrite subject to
+       shift indices. */
+    PlaceholderToStorePath,
+    /** Hash -> hash, as in @ref nix::RewritingSink, causes no shifting. */
+    EqualLengthHashes,
+};
+
+/** A simple container to keep rewrites and their shape together. */
+struct Rewrites
+{
+    StringMap map;
+    RewriteShape shape;
+};
+
+/**
+ *  Generate a single rewrite pair of the given index and shape.
+ *
+ *  @param i     the rewrite index in map, so that the rewrites remain subsets of themselves deterministically.
+ *  @param shape the shape of the rewrite to generate.
+ */
+static std::pair<std::string, std::string> makeRewrite(std::size_t i, RewriteShape shape)
+{
+    auto name = std::format("some-file-{}", i);
+    auto hash = hashString(HashAlgorithm::SHA256, std::format("nix-output:{}", name));
+
+    switch (shape) {
+    case RewriteShape::PlaceholderToStorePath:
+        return {
+            std::format("/{}", hash.to_string(HashFormat::Nix32, false)),
+            std::format("/nix/store/{}-{}", compressHash(hash, 20).to_string(HashFormat::Nix32, false), name),
+        };
+    case RewriteShape::EqualLengthHashes: {
+        auto other = hashString(HashAlgorithm::SHA256, "nix-scratch:" + name);
+
+        return {
+            compressHash(hash, 20).to_string(HashFormat::Nix32, false),
+            compressHash(other, 20).to_string(HashFormat::Nix32, false),
+        };
+    }
+    }
+
+    unreachable();
+}
+
+/**
+ *  Generate a map of rewrites.
+ *
+ *  @param count the number of rewrites to generate.
+ *  @param shape the shape of the rewrites to generate.
+ */
+static Rewrites makeRewrites(std::size_t count, RewriteShape shape)
+{
+    Rewrites rewrites;
+
+    rewrites.shape = shape;
+
+    for (std::size_t i = 0; i < count; ++i) {
+        auto [key, value] = makeRewrite(i, shape);
+
+        rewrites.map.insert_or_assign(std::move(key), std::move(value));
+    }
+
+    return rewrites;
+}
+
+/**
+ * Generate a random byte sequence with placeholders taken from a map of rewrites.
+ *
+ * @param urng                 the random generator to use.
+ * @param length               the byte length of the resulting string.
+ * @param charWeight           the relative frequency of a non-reference byte in the sequence.
+ * @param rewrites             the collection from which to sample rewriteable placeholders.
+ * @param realPlaceholderRatio the ratio of placeholders that will have actual replacements in `rewrites`.
+ */
+static std::string randomBytesWithReferences(
+    std::mt19937 & urng, std::size_t length, double charWeight, Rewrites & rewrites, double realPlaceholderRatio = 1.0)
+{
+    std::string result;
+
+    result.reserve(length);
+
+    // NOTE: std::uniform_int_distribution isn't guaranteed to be implemented for char.
+    auto contentDistribution = std::uniform_int_distribution<int>{
+        std::numeric_limits<char>::min(),
+        std::numeric_limits<char>::max(),
+    };
+
+    std::vector<std::string> placeholders;
+    std::size_t rewriteCount = rewrites.map.size();
+
+    placeholders.reserve(rewriteCount);
+
+    // Optional partial replacement with decoys
+    std::size_t trueReplacements = rewriteCount * realPlaceholderRatio;
+    std::size_t decoyReplacements = rewriteCount - trueReplacements;
+    std::ranges::sample(std::views::keys(rewrites.map), std::back_inserter(placeholders), trueReplacements, urng);
+
+    for (std::size_t i = 0; i < decoyReplacements; i++) {
+        auto [placeholder, _] = makeRewrite(rewriteCount + i, rewrites.shape);
+
+        placeholders.push_back(placeholder);
+    }
+
+    placeholders.shrink_to_fit();
+
+    if (!placeholders.empty()) {
+        auto placeholderDistribution = std::uniform_int_distribution<std::size_t>(0, placeholders.size() - 1);
+        auto firstPlaceholder = *placeholders.begin();
+        std::discrete_distribution<std::size_t> branchDist{1.0, firstPlaceholder.size() * charWeight};
+
+        while (result.size() < length) {
+            if (branchDist(urng) == 0)
+                result += placeholders[placeholderDistribution(urng)];
+            else
+                result.push_back(static_cast<char>(contentDistribution(urng)));
+        }
+    } else {
+        for (std::size_t i = 0; i < length; i++) {
+            result.push_back(static_cast<char>(contentDistribution(urng)));
+        }
+    }
+
+    result.resize(length);
+
+    return result;
+}
+
+// Benchmarks
+
+/**
+ * This one shows O(n²) behaviour from string replacement having to copy the remainder of the subject each time the
+ * replacement is longer than the placeholder.
+ */
+static void BM_RewriteStrings_ToStorePath_VarySubjectLength(benchmark::State & state)
+{
+    std::mt19937 urng(urngSeed);
+
+    auto subjectLength = state.range();
+    auto rewriteCount = 2 << 6;
+
+    Rewrites rewrites = makeRewrites(rewriteCount, RewriteShape::PlaceholderToStorePath);
+    std::string contents = randomBytesWithReferences(urng, subjectLength, defaultCharWeight, rewrites);
+
+    // Ensure we actually rewrite something
+    assert(nix::rewriteStrings(contents, rewrites.map) != contents);
+
+    state.SetComplexityN(subjectLength);
+
+    std::size_t processed = 0;
+
+    for (auto _ : state) {
+        auto result = nix::rewriteStrings(contents, rewrites.map);
+
+        benchmark::DoNotOptimize(result);
+
+        processed += contents.size();
+    }
+
+    state.SetBytesProcessed(processed);
+}
+
+BENCHMARK(BM_RewriteStrings_ToStorePath_VarySubjectLength)
+    ->RangeMultiplier(2)
+    ->Range(2 << 14, 2 << 23)
+    ->Complexity(benchmark::oNSquared)
+    ->Unit(benchmark::kMillisecond);
+
+/**
+ * This one shows O(n²) behaviour in typical real-world granular dynamic derivation builds, where both the number of
+ * paths to rewrite and artefact size end up growing. Notice how it still occurs even if we don't need to shift the
+ * string.
+ */
+static void BM_RewriteStrings_ToHash_VaryBothSubjectLengthAndRewriteCount(benchmark::State & state)
+{
+    std::mt19937 urng(urngSeed);
+
+    auto subjectLength = state.range();
+    auto rewriteCount = subjectLength / (2 << 12);
+
+    Rewrites rewrites = makeRewrites(rewriteCount, RewriteShape::EqualLengthHashes);
+    std::string contents = randomBytesWithReferences(urng, subjectLength, defaultCharWeight, rewrites);
+
+    // Ensure we actually rewrite something
+    assert(nix::rewriteStrings(contents, rewrites.map) != contents);
+
+    state.SetComplexityN(subjectLength);
+
+    std::size_t processed = 0;
+
+    for (auto _ : state) {
+        auto result = nix::rewriteStrings(contents, rewrites.map);
+
+        benchmark::DoNotOptimize(result);
+
+        processed += contents.size();
+    }
+
+    state.SetBytesProcessed(processed);
+}
+
+BENCHMARK(BM_RewriteStrings_ToHash_VaryBothSubjectLengthAndRewriteCount)
+    ->RangeMultiplier(2)
+    ->Range(2 << 20, 2 << 23)
+    ->Complexity(benchmark::oNSquared)
+    ->Unit(benchmark::kMillisecond);
+
+/**
+ * One component of the quadratic behaviour – runtime is O(n) in rewrite count.
+ */
+static void BM_RewriteStrings_ToHash_VaryRewriteCount(benchmark::State & state)
+{
+    std::mt19937 urng(urngSeed);
+
+    auto subjectLength = 2 << 20;
+    auto rewriteCount = state.range();
+
+    Rewrites rewrites = makeRewrites(rewriteCount, RewriteShape::EqualLengthHashes);
+    std::string contents = randomBytesWithReferences(urng, subjectLength, defaultCharWeight, rewrites);
+
+    // Ensure we actually rewrite something
+    assert(nix::rewriteStrings(contents, rewrites.map) != contents);
+
+    state.SetComplexityN(rewriteCount);
+
+    std::size_t processed = 0;
+
+    for (auto _ : state) {
+        auto result = nix::rewriteStrings(contents, rewrites.map);
+
+        benchmark::DoNotOptimize(result);
+
+        processed += contents.size();
+    }
+
+    state.SetBytesProcessed(processed);
+}
+
+BENCHMARK(BM_RewriteStrings_ToHash_VaryRewriteCount)
+    ->RangeMultiplier(2)
+    ->Range(8, 8'192)
+    ->Complexity(benchmark::oN)
+    ->Unit(benchmark::kMillisecond);
+
+/**
+ * The other component of the quadratic behaviour – runtime is O(n) in subject length.
+ */
+static void BM_RewriteStrings_ToHash_VarySubjectLength(benchmark::State & state)
+{
+    std::mt19937 urng(urngSeed);
+
+    auto subjectLength = state.range();
+    auto rewriteCount = 2 << 6;
+
+    Rewrites rewrites = makeRewrites(rewriteCount, RewriteShape::EqualLengthHashes);
+    std::string contents = randomBytesWithReferences(urng, subjectLength, defaultCharWeight, rewrites);
+
+    // Ensure we actually rewrite something
+    assert(nix::rewriteStrings(contents, rewrites.map) != contents);
+
+    state.SetComplexityN(subjectLength);
+
+    std::size_t processed = 0;
+
+    for (auto _ : state) {
+        auto result = nix::rewriteStrings(contents, rewrites.map);
+
+        benchmark::DoNotOptimize(result);
+
+        processed += contents.size();
+    }
+
+    state.SetBytesProcessed(processed);
+}
+
+BENCHMARK(BM_RewriteStrings_ToHash_VarySubjectLength)
+    ->RangeMultiplier(2)
+    ->Range(2 << 14, 2 << 23)
+    ->Complexity(benchmark::oN)
+    ->Unit(benchmark::kMillisecond);
+
+/**
+ * Runtime is not affected by how many paths are actually present in the subject.
+ */
+static void BM_RewriteStrings_ToHash_VaryRewriteRatio(benchmark::State & state)
+{
+    std::mt19937 urng(urngSeed);
+
+    auto subjectLength = 2 << 20;
+    auto rewriteCount = 2 << 10;
+    auto rewriteRatio = state.range() / 100.0;
+
+    Rewrites rewrites = makeRewrites(rewriteCount, RewriteShape::EqualLengthHashes);
+    std::string contents = randomBytesWithReferences(urng, subjectLength, defaultCharWeight, rewrites, rewriteRatio);
+
+    // Ensure we actually rewrite something
+    if (state.range() > 0) {
+        assert(nix::rewriteStrings(contents, rewrites.map) != contents);
+    }
+
+    state.SetComplexityN(state.range());
+
+    std::size_t processed = 0;
+
+    for (auto _ : state) {
+        auto result = nix::rewriteStrings(contents, rewrites.map);
+
+        benchmark::DoNotOptimize(result);
+
+        processed += contents.size();
+    }
+
+    state.SetBytesProcessed(processed);
+}
+
+BENCHMARK(BM_RewriteStrings_ToHash_VaryRewriteRatio)
+    ->DenseRange(0, 100, 10)
+    ->Complexity(benchmark::o1)
+    ->Unit(benchmark::kMillisecond);
+
+/**
+ * Runtime is still O(n) in subject length even if there are no paths to rewrite. The culprit of this linearity is
+ * copying the subject into the function.
+ */
+static void BM_RewriteStrings_EmptyRewrites_VarySubjectLength(benchmark::State & state)
+{
+    std::mt19937 urng(urngSeed);
+
+    auto subjectLength = state.range();
+
+    Rewrites rewrites;
+    std::string contents = randomBytesWithReferences(urng, subjectLength, defaultCharWeight, rewrites);
+
+    // Ensure nothing had been rewritten
+    assert(nix::rewriteStrings(contents, rewrites.map) == contents);
+
+    state.SetComplexityN(subjectLength);
+
+    std::size_t processed = 0;
+
+    for (auto _ : state) {
+        auto result = nix::rewriteStrings(contents, rewrites.map);
+
+        benchmark::DoNotOptimize(result);
+
+        processed += contents.size();
+    }
+
+    state.SetBytesProcessed(processed);
+}
+
+BENCHMARK(BM_RewriteStrings_EmptyRewrites_VarySubjectLength)
+    ->RangeMultiplier(2)
+    ->Range(2 << 14, 2 << 22)
+    ->Complexity(benchmark::oN)
+    ->Unit(benchmark::kMillisecond);
+
+} // namespace nix


### PR DESCRIPTION
## Motivation

Adds benchmarking support to `libutil` and benchmarks that demonstrate pathological behaviour of `nix::rewriteStrings` on large inputs and rewrite counts.

<details>

<summary>Benchmark results</summary>

Ran via `meson test -C build --benchmark nix-util-benchmarks` on a Ryzen 9 9900X:

```
BM_RewriteStrings_ToStorePath_VarySubjectLength/32768                       0.083 ms        0.083 ms         8300 bytes_per_second=376.29Mi/s
BM_RewriteStrings_ToStorePath_VarySubjectLength/65536                       0.166 ms        0.165 ms         4126 bytes_per_second=377.986Mi/s
BM_RewriteStrings_ToStorePath_VarySubjectLength/131072                      0.347 ms        0.346 ms         2005 bytes_per_second=360.82Mi/s
BM_RewriteStrings_ToStorePath_VarySubjectLength/262144                      0.793 ms        0.784 ms          877 bytes_per_second=318.76Mi/s
BM_RewriteStrings_ToStorePath_VarySubjectLength/524288                       2.21 ms         2.17 ms          322 bytes_per_second=230.548Mi/s
BM_RewriteStrings_ToStorePath_VarySubjectLength/1048576                      6.14 ms         6.07 ms          112 bytes_per_second=164.803Mi/s
BM_RewriteStrings_ToStorePath_VarySubjectLength/2097152                      16.5 ms         16.3 ms           44 bytes_per_second=122.37Mi/s
BM_RewriteStrings_ToStorePath_VarySubjectLength/4194304                      39.4 ms         39.3 ms           17 bytes_per_second=101.849Mi/s
BM_RewriteStrings_ToStorePath_VarySubjectLength/8388608                       100 ms          100 ms            7 bytes_per_second=79.9522Mi/s
BM_RewriteStrings_ToStorePath_VarySubjectLength/16777216                      285 ms          282 ms            3 bytes_per_second=56.7259Mi/s
BM_RewriteStrings_ToStorePath_VarySubjectLength_BigO                         0.00 N^2        0.00 N^2  
BM_RewriteStrings_ToStorePath_VarySubjectLength_RMS                            26 %            27 %    
BM_RewriteStrings_ToHash_VaryBothSubjectLengthAndRewriteCount/2097152        26.0 ms         25.5 ms           27 bytes_per_second=78.3792Mi/s
BM_RewriteStrings_ToHash_VaryBothSubjectLengthAndRewriteCount/4194304         111 ms          109 ms            6 bytes_per_second=36.6366Mi/s
BM_RewriteStrings_ToHash_VaryBothSubjectLengthAndRewriteCount/8388608         485 ms          476 ms            2 bytes_per_second=16.8022Mi/s
BM_RewriteStrings_ToHash_VaryBothSubjectLengthAndRewriteCount/16777216       1813 ms         1804 ms            1 bytes_per_second=8.87013Mi/s
BM_RewriteStrings_ToHash_VaryBothSubjectLengthAndRewriteCount_BigO           0.00 N^2        0.00 N^2  
BM_RewriteStrings_ToHash_VaryBothSubjectLengthAndRewriteCount_RMS               3 %             2 %    
BM_RewriteStrings_ToHash_VaryRewriteCount/8                                 0.863 ms        0.860 ms          818 bytes_per_second=2.27198Gi/s
BM_RewriteStrings_ToHash_VaryRewriteCount/16                                 1.78 ms         1.77 ms          399 bytes_per_second=1.10105Gi/s
BM_RewriteStrings_ToHash_VaryRewriteCount/32                                 3.49 ms         3.48 ms          200 bytes_per_second=574.597Mi/s
BM_RewriteStrings_ToHash_VaryRewriteCount/64                                 6.89 ms         6.87 ms          104 bytes_per_second=291.268Mi/s
BM_RewriteStrings_ToHash_VaryRewriteCount/128                                13.3 ms         13.3 ms           52 bytes_per_second=150.807Mi/s
BM_RewriteStrings_ToHash_VaryRewriteCount/256                                25.1 ms         25.1 ms           27 bytes_per_second=79.8122Mi/s
BM_RewriteStrings_ToHash_VaryRewriteCount/512                                47.0 ms         46.6 ms           15 bytes_per_second=42.9197Mi/s
BM_RewriteStrings_ToHash_VaryRewriteCount/1024                               86.6 ms         85.0 ms            8 bytes_per_second=23.5239Mi/s
BM_RewriteStrings_ToHash_VaryRewriteCount/2048                                143 ms          140 ms            5 bytes_per_second=14.2488Mi/s
BM_RewriteStrings_ToHash_VaryRewriteCount/4096                                244 ms          239 ms            3 bytes_per_second=8.35767Mi/s
BM_RewriteStrings_ToHash_VaryRewriteCount/8192                                405 ms          400 ms            2 bytes_per_second=4.99486Mi/s
BM_RewriteStrings_ToHash_VaryRewriteCount_BigO                           52833.49 N      52162.59 N    
BM_RewriteStrings_ToHash_VaryRewriteCount_RMS                                  23 %            22 %    
BM_RewriteStrings_ToHash_VarySubjectLength/32768                            0.076 ms        0.076 ms         9204 bytes_per_second=410.041Mi/s
BM_RewriteStrings_ToHash_VarySubjectLength/65536                            0.163 ms        0.163 ms         4386 bytes_per_second=384.42Mi/s
BM_RewriteStrings_ToHash_VarySubjectLength/131072                           0.449 ms        0.448 ms         1570 bytes_per_second=279.031Mi/s
BM_RewriteStrings_ToHash_VarySubjectLength/262144                            1.03 ms         1.03 ms          690 bytes_per_second=243.877Mi/s
BM_RewriteStrings_ToHash_VarySubjectLength/524288                            2.30 ms         2.30 ms          303 bytes_per_second=217.695Mi/s
BM_RewriteStrings_ToHash_VarySubjectLength/1048576                           5.64 ms         5.62 ms          125 bytes_per_second=177.795Mi/s
BM_RewriteStrings_ToHash_VarySubjectLength/2097152                           13.0 ms         13.0 ms           54 bytes_per_second=153.82Mi/s
BM_RewriteStrings_ToHash_VarySubjectLength/4194304                           27.3 ms         27.2 ms           25 bytes_per_second=147.016Mi/s
BM_RewriteStrings_ToHash_VarySubjectLength/8388608                           56.3 ms         56.1 ms           13 bytes_per_second=142.549Mi/s
BM_RewriteStrings_ToHash_VarySubjectLength/16777216                           112 ms          112 ms            6 bytes_per_second=143.332Mi/s
BM_RewriteStrings_ToHash_VarySubjectLength_BigO                              6.66 N          6.64 N    
BM_RewriteStrings_ToHash_VarySubjectLength_RMS                                  3 %             3 %    
BM_RewriteStrings_ToHash_VaryRewriteRatio/0                                   148 ms          147 ms            5 bytes_per_second=13.5739Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio/10                                  146 ms          146 ms            5 bytes_per_second=13.7375Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio/20                                  145 ms          144 ms            5 bytes_per_second=13.8581Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio/30                                  141 ms          140 ms            5 bytes_per_second=14.2852Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio/40                                  144 ms          141 ms            5 bytes_per_second=14.1503Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio/50                                  146 ms          145 ms            5 bytes_per_second=13.7578Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio/60                                  145 ms          144 ms            5 bytes_per_second=13.873Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio/70                                  143 ms          141 ms            5 bytes_per_second=14.1477Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio/80                                  142 ms          141 ms            5 bytes_per_second=14.2018Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio/90                                  139 ms          139 ms            5 bytes_per_second=14.4031Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio/100                                 144 ms          143 ms            5 bytes_per_second=13.9481Mi/s
BM_RewriteStrings_ToHash_VaryRewriteRatio_BigO                         143783743.91 (1)  142960877.38 (1)  
BM_RewriteStrings_ToHash_VaryRewriteRatio_RMS                                   2 %             2 %    
BM_RewriteStrings_EmptyRewrites_VarySubjectLength/32768                     0.000 ms        0.000 ms      2212031 bytes_per_second=99.0227Gi/s
BM_RewriteStrings_EmptyRewrites_VarySubjectLength/65536                     0.001 ms        0.001 ms      1140412 bytes_per_second=98.2531Gi/s
BM_RewriteStrings_EmptyRewrites_VarySubjectLength/131072                    0.001 ms        0.001 ms       569056 bytes_per_second=102.51Gi/s
BM_RewriteStrings_EmptyRewrites_VarySubjectLength/262144                    0.002 ms        0.002 ms       351636 bytes_per_second=123.507Gi/s
BM_RewriteStrings_EmptyRewrites_VarySubjectLength/524288                    0.005 ms        0.005 ms       132424 bytes_per_second=91.9476Gi/s
BM_RewriteStrings_EmptyRewrites_VarySubjectLength/1048576                   0.014 ms        0.014 ms        49011 bytes_per_second=69.3677Gi/s
BM_RewriteStrings_EmptyRewrites_VarySubjectLength/2097152                   0.030 ms        0.030 ms        23343 bytes_per_second=65.1888Gi/s
BM_RewriteStrings_EmptyRewrites_VarySubjectLength/4194304                   0.053 ms        0.052 ms        13384 bytes_per_second=74.5127Gi/s
BM_RewriteStrings_EmptyRewrites_VarySubjectLength/8388608                   0.103 ms        0.101 ms         6846 bytes_per_second=77.5115Gi/s
BM_RewriteStrings_EmptyRewrites_VarySubjectLength_BigO                       0.01 N          0.01 N    
BM_RewriteStrings_EmptyRewrites_VarySubjectLength_RMS                           7 %             8 %    
```

</details>

Note that `ToStorePath_VarySubjectLength` and `ToHash_VaryRewriteCount` have a bit of a higher error for reasons I'm not sure why — for the first one clanker suggest that below ~1.4MB that the 128 linear scans are still more expensive that repeated copying, for the latter it has no suggestions — but the one closest to the real workload, `ToHash_VaryBothSubjectLengthAndRewriteCount` has a very low error O(n²) fit, so hopefully it demonstrates the issue clearly enough.

## Context

For benchmark setup — copied over the test setup from `libstore`.

For benchmarks themselves — copied over `src/libstore-tests/ref-scan-bench.cc`, then modified and expanded accordingly. Didn't extract a common helper for subject generation yet, because wasn't sure if generalising this would be desired. Can do that if there is a need to.

This is motivated by my "webscale" dynamic derivation prototypes, this comes specifically from a mocked Chromium graph (88k build edges, 178k derivations) where this function turned out to be one of the bottlenecks.

Specifically, it is O(n²) for two separate reasons:

  * the runtime scales linearly both in the subject size and number of potential rewrites provided in the map, both of which grow as the build progresses,
  * any placeholder that expands into a path longer than it is, causes a copy due to the string shifting down to acommodate new characters, another source of linear scaling that compounds with subject length linearity.

I am now preparing to upstream a patch for this, but figured it'd be better received if I first motivate it. So here it is.

Choosing to publish it as a draft with just the benchmarks for discussion — this had been an actual issue at my scale, but it might not be obvious it's worth to fix it without demonstration. It is also unclear if it's worth merging on its own without the fix going in together either.

---

The original performance issues discovery and patch were done by LLM agents (Opus 5 & Fable 5 via Claude Code) in a separate repo, but this PR is written by me from scratch, referencing a description of the issue and the solution (and it was not codified as benchmark in the experiments anyway) for clean copyright provenance. I did also ask the LLM for review of the code I've written — because boy, is C++ so much harder than Rust — but I fixed each issue myself, sometimes differently from what it suggested.

From what I understand that would be covered as an exemption by:

> Use of AI tools for research, testing, debugging, or review is out of scope, if no substantial amount of their output is included in the resulting contribution.

and as such I didn't include the `Assisted-by:` footer, as I would stand behind authorship and copyright holder status of this code. But if that's not enough then I'm fine with just adding the footer on your say-so, only explaining why it had not been included already.