### PR TITLE
[Backport 2.34-maintenance] Validate NAR padding when skipping file contents

### DIFF
--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -6,7 +6,6 @@
 #include <strings.h> // for strcasecmp
 
 #include "nix/util/archive.hh"
-#include "nix/util/alignment.hh"
 #include "nix/util/config-global.hh"
 #include "nix/util/posix-source-accessor.hh"
 #include "nix/util/source-path.hh"
@@ -139,21 +138,20 @@ static void parseContents(CreateRegularFileSink & sink, Source & source)
     sink.preallocateContents(size);
 
     if (sink.skipContents) {
-        source.skip(alignUp(size, 8));
-        return;
-    }
+        source.skip(size);
+    } else {
+        uint64_t left = size;
+        std::array<char, 65536> buf;
 
-    uint64_t left = size;
-    std::array<char, 65536> buf;
-
-    while (left) {
-        checkInterrupt();
-        auto n = buf.size();
-        if ((uint64_t) n > left)
-            n = left;
-        source(buf.data(), n);
-        sink({buf.data(), n});
-        left -= n;
+        while (left) {
+            checkInterrupt();
+            auto n = buf.size();
+            if ((uint64_t) n > left)
+                n = left;
+            source(buf.data(), n);
+            sink({buf.data(), n});
+            left -= n;
+        }
     }
 
     readPadding(size, source);


### PR DESCRIPTION
## Motivation

Backport the parser fix from #16325 to `2.34-maintenance`.

## Context

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
