### PR TITLE
fix "warning: 'warn-short-path-literals' is deprecated [...]" in REPL

### DIFF
--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -39,6 +39,11 @@ public:
     void assign(const bool & v) override;
     void appendOrSet(bool newValue, bool append) override;
     void override(const bool & v) override;
+
+    bool excludedFromFullSerialisation() const override
+    {
+        return true;
+    }
 };
 
 struct EvalSettings : Config

--- a/src/libutil-tests/config.cc
+++ b/src/libutil-tests/config.cc
@@ -333,4 +333,22 @@ TEST(Config, toKeyValue)
     ASSERT_EQ(config.toKeyValue(), "name-of-the-setting = default\n");
 }
 
+TEST(Config, toKeyValueOmitsDeprecatedSettings)
+{
+    struct DeprecatedSetting : Setting<std::string>
+    {
+        using Setting<std::string>::Setting;
+
+        bool excludedFromFullSerialisation() const override
+        {
+            return true;
+        }
+    };
+
+    Config config;
+    Setting<std::string> foo{&config, "default", "name-of-the-setting", "description"};
+    DeprecatedSetting bar{&config, "default", "deprecated-name-of-the-setting", "description"};
+    ASSERT_EQ(config.toKeyValue(), "name-of-the-setting = default\n");
+}
+
 } // namespace nix

--- a/src/libutil/config-global.cc
+++ b/src/libutil/config-global.cc
@@ -49,7 +49,8 @@ std::string GlobalConfig::toKeyValue()
     std::map<std::string, Config::SettingInfo> settings;
     globalConfig.getSettings(settings);
     for (const auto & s : settings)
-        res += fmt("%s = %s\n", s.first, s.second.value);
+        if (!s.second.excludedFromFullSerialisation)
+            res += fmt("%s = %s\n", s.first, s.second.value);
     return res;
 }
 

--- a/src/libutil/configuration.cc
+++ b/src/libutil/configuration.cc
@@ -96,7 +96,12 @@ void Config::getSettings(std::map<std::string, SettingInfo> & res, bool overridd
     for (const auto & opt : _settings)
         if (!opt.second.isAlias && (!overriddenOnly || opt.second.setting->overridden)
             && experimentalFeatureSettings.isEnabled(opt.second.setting->experimentalFeature))
-            res.emplace(opt.first, SettingInfo{opt.second.setting->to_string(), opt.second.setting->description});
+            res.emplace(
+                opt.first,
+                SettingInfo{
+                    opt.second.setting->to_string(),
+                    opt.second.setting->description,
+                    opt.second.setting->excludedFromFullSerialisation()});
 }
 
 /**
@@ -216,7 +221,7 @@ std::string Config::toKeyValue()
 {
     std::string res;
     for (const auto & s : _settings)
-        if (!s.second.isAlias)
+        if (!s.second.isAlias && !s.second.setting->excludedFromFullSerialisation())
             res += fmt("%s = %s\n", s.first, s.second.setting->to_string());
     return res;
 }

--- a/src/libutil/include/nix/util/configuration.hh
+++ b/src/libutil/include/nix/util/configuration.hh
@@ -74,6 +74,7 @@ public:
     {
         std::string value;
         std::string description;
+        bool excludedFromFullSerialisation = false;
     };
 
     /**
@@ -198,6 +199,11 @@ public:
     std::optional<ExperimentalFeature> experimentalFeature;
 
     bool isOverridden() const;
+
+    virtual bool excludedFromFullSerialisation() const
+    {
+        return false;
+    }
 
 protected:
 

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -67,6 +67,10 @@ testRepl () {
     replOutput=$(nix repl "${nixArgs[@]}" 2>&1 <<< ":sh import $testDir/simple.nix")
     echo "$replOutput" | grepInverse "error: Cannot run 'nix-shell'"
 
+    # `:sh` and `:u` pass full config to the child process via NIX_CONFIG.
+    # Previously we had warnings about deprecated unasked settings.
+    echo "$replOutput" | grepInverse "'warn-short-path-literals' is deprecated"
+
     expectStderr 1 nix repl "${testDir}/simple.nix" \
       | grepQuiet -s "error: path \"$testDir/simple.nix\" is not a flake"
 }


### PR DESCRIPTION
## Motivation

Got this warning that i could seemingly not get rid of by configuration:

```shell
$ nix repl
Nix 2.36.0pre20260820_61b6332
Type :? for help.
nix-repl> pkgs = import <nixpkgs> {}

nix-repl> :u pkgs.hello              
warning: 'warn-short-path-literals' is deprecated, use 'lint-short-path-literals = ignore' instead

[nix-shell:~]$ 
```

With these patches its gone:

```shell
$ nix repl
Nix 2.36.0pre20260820_dirty
Type :? for help.
nix-repl> pkgs = import <nixpkgs> {}

nix-repl> :u pkgs.hello              

[nix-shell:~]$
```

LLM-attribution: Used claude

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
