### PR TITLE
Split derivation resolution into its own file

### DIFF
--- a/src/libstore-tests/derivation/resolution.cc
+++ b/src/libstore-tests/derivation/resolution.cc
@@ -2,6 +2,7 @@
 #include <nlohmann/json.hpp>
 
 #include "nix/store/derivations.hh"
+#include "nix/store/derivation/resolution.hh"
 #include "nix/store/derivation-options.hh"
 #include "nix/store/downstream-placeholder.hh"
 #include "nix/store/parsed-derivations.hh"

--- a/src/libstore-tests/worker-substitution.cc
+++ b/src/libstore-tests/worker-substitution.cc
@@ -3,6 +3,7 @@
 
 #include "nix/store/build/worker.hh"
 #include "nix/store/derivations.hh"
+#include "nix/store/derivation/resolution.hh"
 #include "nix/store/derivation/full-inputs.hh"
 #include "nix/store/dummy-store-impl.hh"
 #include "nix/store/globals.hh"

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -2,6 +2,7 @@
 #include "nix/store/build/drv-output-substitution-goal.hh"
 #include "nix/store/build/derivation-building-goal.hh"
 #include "nix/store/build/derivation-resolution-goal.hh"
+#include "nix/store/derivation/resolution.hh"
 #include "nix/store/build/worker.hh"
 #include "nix/util/util.hh"
 #include "nix/store/common-protocol.hh"

--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -1,6 +1,7 @@
 #include "nix/store/build/derivation-resolution-goal.hh"
 #include "nix/store/build/worker.hh"
 #include "nix/util/util.hh"
+#include "nix/store/derivation/resolution.hh"
 
 #include <nlohmann/json.hpp>
 

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -1,4 +1,5 @@
 #include "nix/store/derivations.hh"
+#include "nix/store/derivation/resolution.hh"
 #include "nix/store/build/worker.hh"
 #include "nix/store/build/substitution-goal.hh"
 #include "nix/store/build/derivation-trampoline-goal.hh"

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -17,6 +17,7 @@
 #include "nix/util/finally.hh"
 #include "nix/util/archive.hh"
 #include "nix/store/derivations.hh"
+#include "nix/store/derivation/resolution.hh"
 #include "nix/store/derivation/aterm.hh"
 #include "nix/util/args.hh"
 #include "nix/util/logging.hh"

--- a/src/libstore/derivation/resolution.cc
+++ b/src/libstore/derivation/resolution.cc
@@ -1,0 +1,129 @@
+#include "nix/store/derivations.hh"
+#include "nix/store/derivation/resolution.hh"
+#include "nix/store/downstream-placeholder.hh"
+#include "nix/store/store-api.hh"
+
+#include <algorithm>
+#include <optional>
+#include <ranges>
+
+namespace nix {
+
+namespace derivation {
+
+Full unresolve(const Basic & drv)
+{
+    return drv.mapInputs([](const StorePathSet & inputs) -> std::set<SingleDerivedPath> {
+        auto view = inputs | std::views::transform([](const StorePath & p) -> SingleDerivedPath {
+                        return SingleDerivedPath::Opaque{p};
+                    });
+        return std::set<SingleDerivedPath>(view.begin(), view.end());
+    });
+}
+
+bool shouldResolve(const Full & drv)
+{
+    bool hasInputDrvs = std::ranges::any_of(
+        drv.inputs, [](const auto & input) { return std::holds_alternative<SingleDerivedPath::Built>(input.raw()); });
+
+    /* No input drvs means nothing to resolve. */
+    if (!hasInputDrvs)
+        return false;
+
+    auto drvType = type(drv);
+
+    bool typeNeedsResolve = std::visit(
+        overloaded{
+            [&](const Type::InputAddressed & ia) {
+                /* Must resolve if deferred. */
+                return ia.deferred;
+            },
+            [&](const Type::ContentAddressed & ca) {
+                return ca.fixed
+                           /* Can optionally resolve if fixed, which is good
+                              for avoiding unnecessary rebuilds. */
+                           ? experimentalFeatureSettings.isEnabled(Xp::CaDerivations)
+                           /* Must resolve if floating. */
+                           : true;
+            },
+            [&](const Type::Impure &) { return true; },
+        },
+        drvType.raw);
+
+    return typeNeedsResolve ||
+           /* Also need to resolve if any inputs are outputs of dynamic derivations. */
+           hasDynamicDrvDep(drv.inputs);
+}
+
+std::optional<Basic> tryResolve(const Full & drv, Store & store, Store * evalStore)
+{
+    return tryResolve(
+        drv,
+        store,
+        [&](ref<const SingleDerivedPath> drvPath, const std::string & outputName) -> std::optional<StorePath> {
+            try {
+                return resolveDerivedPath(store, SingleDerivedPath::Built{drvPath, outputName}, evalStore);
+            } catch (Error &) {
+                return std::nullopt;
+            }
+        });
+}
+
+std::optional<Basic> tryResolve(
+    const Full & drv,
+    Store & store,
+    fun<std::optional<StorePath>(ref<const SingleDerivedPath> drvPath, const std::string & outputName)>
+        queryResolutionChain)
+{
+    StorePathSet resolvedInputs;
+    StringMap inputRewrites;
+
+    for (const auto & input : drv.inputs) {
+        auto resolved = std::visit(
+            overloaded{
+                [&](const SingleDerivedPath::Opaque & op) -> std::optional<StorePath> { return op.path; },
+                [&](const SingleDerivedPath::Built & built) -> std::optional<StorePath> {
+                    auto actualPathOpt = queryResolutionChain(built.drvPath, built.output);
+                    if (!actualPathOpt)
+                        return std::nullopt;
+
+                    if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations)) {
+                        /* This handles both the static case (opaque
+                           derivation path) and the dynamic case
+                           (derivation path that is itself an output of
+                           a derivation), recursively. */
+                        auto placeholder = DownstreamPlaceholder::fromSingleDerivedPathBuilt(built);
+                        inputRewrites.emplace(placeholder.render(), store.printStorePath(*actualPathOpt));
+                    }
+
+                    return actualPathOpt;
+                },
+            },
+            input.raw());
+
+        if (!resolved)
+            return std::nullopt;
+        resolvedInputs.insert(*resolved);
+    }
+
+    Basic result{
+        .outputs = drv.outputs,
+        .inputs = resolvedInputs,
+        .platform = drv.platform,
+        .builder = drv.builder,
+        .args = drv.args,
+        .env = drv.env,
+        .structuredAttrs = drv.structuredAttrs,
+        .name = drv.name,
+    };
+
+    result.applyRewrites(inputRewrites);
+
+    fillInOutputPaths(result, store);
+
+    return result;
+}
+
+} // namespace derivation
+
+} // namespace nix

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -307,125 +307,9 @@ void Derivation<Inputs, Out>::applyRewrites(const StringMap & rewrites)
     }
 }
 
-Full unresolve(const Basic & drv)
-{
-    return drv.mapInputs([](const StorePathSet & inputs) -> std::set<SingleDerivedPath> {
-        auto view = inputs | std::views::transform([](const StorePath & p) -> SingleDerivedPath {
-                        return SingleDerivedPath::Opaque{p};
-                    });
-        return std::set<SingleDerivedPath>(view.begin(), view.end());
-    });
-}
-
-bool shouldResolve(const Full & drv)
-{
-    bool hasInputDrvs = std::ranges::any_of(
-        drv.inputs, [](const auto & input) { return std::holds_alternative<SingleDerivedPath::Built>(input.raw()); });
-
-    /* No input drvs means nothing to resolve. */
-    if (!hasInputDrvs)
-        return false;
-
-    auto drvType = type(drv);
-
-    bool typeNeedsResolve = std::visit(
-        overloaded{
-            [&](const Type::InputAddressed & ia) {
-                /* Must resolve if deferred. */
-                return ia.deferred;
-            },
-            [&](const Type::ContentAddressed & ca) {
-                return ca.fixed
-                           /* Can optionally resolve if fixed, which is good
-                              for avoiding unnecessary rebuilds. */
-                           ? experimentalFeatureSettings.isEnabled(Xp::CaDerivations)
-                           /* Must resolve if floating. */
-                           : true;
-            },
-            [&](const Type::Impure &) { return true; },
-        },
-        drvType.raw);
-
-    return typeNeedsResolve ||
-           /* Also need to resolve if any inputs are outputs of dynamic derivations. */
-           hasDynamicDrvDep(drv.inputs);
-}
-
 bool hasDynamicDrvDep(const std::set<SingleDerivedPath> & inputs)
 {
     return std::ranges::any_of(inputs, [](const auto & input) { return input.isDynamicDrvOutput(); });
-}
-
-template<bool fillIn>
-static void processDerivationOutputPaths(Store & store, auto && drv, std::string_view drvName);
-
-std::optional<Basic> tryResolve(const Full & drv, Store & store, Store * evalStore)
-{
-    return tryResolve(
-        drv,
-        store,
-        [&](ref<const SingleDerivedPath> drvPath, const std::string & outputName) -> std::optional<StorePath> {
-            try {
-                return resolveDerivedPath(store, SingleDerivedPath::Built{drvPath, outputName}, evalStore);
-            } catch (Error &) {
-                return std::nullopt;
-            }
-        });
-}
-
-std::optional<Basic> tryResolve(
-    const Full & drv,
-    Store & store,
-    fun<std::optional<StorePath>(ref<const SingleDerivedPath> drvPath, const std::string & outputName)>
-        queryResolutionChain)
-{
-    StorePathSet resolvedInputs;
-    StringMap inputRewrites;
-
-    for (const auto & input : drv.inputs) {
-        auto resolved = std::visit(
-            overloaded{
-                [&](const SingleDerivedPath::Opaque & op) -> std::optional<StorePath> { return op.path; },
-                [&](const SingleDerivedPath::Built & built) -> std::optional<StorePath> {
-                    auto actualPathOpt = queryResolutionChain(built.drvPath, built.output);
-                    if (!actualPathOpt)
-                        return std::nullopt;
-
-                    if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations)) {
-                        /* This handles both the static case (opaque
-                           derivation path) and the dynamic case
-                           (derivation path that is itself an output of
-                           a derivation), recursively. */
-                        auto placeholder = DownstreamPlaceholder::fromSingleDerivedPathBuilt(built);
-                        inputRewrites.emplace(placeholder.render(), store.printStorePath(*actualPathOpt));
-                    }
-
-                    return actualPathOpt;
-                },
-            },
-            input.raw());
-
-        if (!resolved)
-            return std::nullopt;
-        resolvedInputs.insert(*resolved);
-    }
-
-    Basic result{
-        .outputs = drv.outputs,
-        .inputs = resolvedInputs,
-        .platform = drv.platform,
-        .builder = drv.builder,
-        .args = drv.args,
-        .env = drv.env,
-        .structuredAttrs = drv.structuredAttrs,
-        .name = drv.name,
-    };
-
-    result.applyRewrites(inputRewrites);
-
-    processDerivationOutputPaths</*fillIn=*/true>(store, result, result.name);
-
-    return result;
 }
 
 /**
@@ -635,6 +519,11 @@ void checkInvariants(const Basic & drv, Store & store)
 void checkInvariants(const Full & drv, Store & store)
 {
     processDerivationOutputPaths<false>(store, drv, drv.name);
+}
+
+void fillInOutputPaths(Basic & drv, Store & store)
+{
+    processDerivationOutputPaths<true>(store, drv, drv.name);
 }
 
 void fillInOutputPaths(Full & drv, Store & store)

--- a/src/libstore/include/nix/store/derivation/resolution.hh
+++ b/src/libstore/include/nix/store/derivation/resolution.hh
@@ -1,0 +1,56 @@
+#pragma once
+///@file
+
+#include "nix/store/derivations.hh"
+
+namespace nix {
+
+class Store;
+
+namespace derivation {
+
+/**
+ * Determine whether this derivation should be resolved before building.
+ *
+ * Resolution is needed when:
+ * - Input-addressed derivations are deferred (depend on CA derivations)
+ * - Content-addressed derivations have input drvs and are either:
+ *   - Floating (non-fixed), which must always be resolved
+ *   - Fixed, which can optionally be resolved when ca-derivations is enabled
+ * - Impure derivations always need resolution
+ * - Any input derivations have outputs from dynamic derivations
+ */
+bool shouldResolve(const Full & drv);
+
+/**
+ * Return the underlying basic derivation but with these changes:
+ *
+ * 1. Input drvs are emptied, but the outputs of them that were used
+ *    are added directly to input sources.
+ *
+ * 2. Input placeholders are replaced with realized input store
+ *    paths.
+ */
+std::optional<Basic> tryResolve(const Full & drv, Store & store, Store * evalStore = nullptr);
+
+/**
+ * Like the above, but instead of querying the Nix database for
+ * realisations, uses a given mapping from input derivation paths +
+ * output names to actual output store paths.
+ */
+std::optional<Basic> tryResolve(
+    const Full & drv,
+    Store & store,
+    fun<std::optional<StorePath>(ref<const SingleDerivedPath> drvPath, const std::string & outputName)>
+        queryResolutionChain);
+
+/**
+ * Convert a `Basic` derivation to a `Full` derivation.
+ * The resulting derivation has empty input drvs since a `Basic`
+ * derivation is already resolved.
+ */
+Full unresolve(const Basic & drv);
+
+} // namespace derivation
+
+} // namespace nix

--- a/src/libstore/include/nix/store/derivations.hh
+++ b/src/libstore/include/nix/store/derivations.hh
@@ -272,48 +272,6 @@ OutputsAndOptPaths outputsAndOptPaths(const Derivation<Inputs, Output> & drv, co
 bool hasDynamicDrvDep(const std::set<SingleDerivedPath> & inputs);
 
 /**
- * Determine whether this derivation should be resolved before building.
- *
- * Resolution is needed when:
- * - Input-addressed derivations are deferred (depend on CA derivations)
- * - Content-addressed derivations have input drvs and are either:
- *   - Floating (non-fixed), which must always be resolved
- *   - Fixed, which can optionally be resolved when ca-derivations is enabled
- * - Impure derivations always need resolution
- * - Any input derivations have outputs from dynamic derivations
- */
-bool shouldResolve(const Full & drv);
-
-/**
- * Return the underlying basic derivation but with these changes:
- *
- * 1. Input drvs are emptied, but the outputs of them that were used
- *    are added directly to input sources.
- *
- * 2. Input placeholders are replaced with realized input store
- *    paths.
- */
-std::optional<Basic> tryResolve(const Full & drv, Store & store, Store * evalStore = nullptr);
-
-/**
- * Like the above, but instead of querying the Nix database for
- * realisations, uses a given mapping from input derivation paths +
- * output names to actual output store paths.
- */
-std::optional<Basic> tryResolve(
-    const Full & drv,
-    Store & store,
-    fun<std::optional<StorePath>(ref<const SingleDerivedPath> drvPath, const std::string & outputName)>
-        queryResolutionChain);
-
-/**
- * Convert a `Basic` derivation to a `Full` derivation.
- * The resulting derivation has empty input drvs since a `Basic`
- * derivation is already resolved.
- */
-Full unresolve(const Basic & drv);
-
-/**
  * Check that the derivation is valid and does not present any
  * illegal states.
  *
@@ -361,6 +319,7 @@ void checkInvariants(const Derivation<Inputs, Output> & drv, Store & store, cons
  *
  * @param store The store to use for path computation
  */
+void fillInOutputPaths(Basic & drv, Store & store);
 void fillInOutputPaths(Full & drv, Store & store);
 
 /**

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -38,6 +38,7 @@ headers = [ config_pub_h ] + files(
   'derivation/full-inputs.hh',
   'derivation/modulo.hh',
   'derivation/output.hh',
+  'derivation/resolution.hh',
   'derivations.hh',
   'derived-path-map.hh',
   'derived-path.hh',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -284,6 +284,7 @@ sources = files(
   'derivation/json.cc',
   'derivation/modulo.cc',
   'derivation/output.cc',
+  'derivation/resolution.cc',
   'derivations.cc',
   'derived-path-map.cc',
   'derived-path.cc',

--- a/src/libstore/outputs-query.cc
+++ b/src/libstore/outputs-query.cc
@@ -1,5 +1,6 @@
 #include "nix/store/outputs-query.hh"
 #include "nix/store/derivations.hh"
+#include "nix/store/derivation/resolution.hh"
 #include "nix/store/realisation.hh"
 #include "nix/util/util.hh"
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -6,6 +6,7 @@
 #include "nix/store/derived-path.hh"
 #include "nix/store/realisation.hh"
 #include "nix/store/derivations.hh"
+#include "nix/store/derivation/resolution.hh"
 #include "nix/store/derivation/aterm.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/build.hh"

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -16,6 +16,7 @@
 #include "nix/store/globals.hh"
 #include "nix/store/realisation.hh"
 #include "nix/store/derivations.hh"
+#include "nix/store/derivation/resolution.hh"
 #include "nix/store/outputs-query.hh"
 #include "nix/main/shared.hh"
 #include "nix/store/path-with-outputs.hh"


### PR DESCRIPTION
## Motivation

`shouldResolve`, `tryResolve`, and `unresolve` move out of `derivations.{cc,hh}` into `derivation/resolution.{cc,hh}`, matching the existing `src/libstore-tests/derivation/resolution.cc` and the `derivation/modulo.{cc,hh}` split that preceded it.

## Context

`tryResolve` previously reached the file-static `processDerivationOutputPaths</*fillIn=*/true>` template directly.
`fillInOutputPaths` is the corresponding public interface, but was only declared for `Full`, so add the `Basic` overload next to it --- `checkInvariants` already has both.

`hasDynamicDrvDep` stays in `derivations.{cc,hh}`: `shouldResolve` uses it, but so does `derivation/aterm.cc`, and it is a general predicate about inputs rather than resolution machinery.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
