### PR TITLE
libutil: reject borrowing URL accessors on temporaries

### DIFF
--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -1324,8 +1324,9 @@ class ParsedURLPathSegmentsTest : public ::testing::TestWithParam<ParsedURLPathS
 TEST_P(ParsedURLPathSegmentsTest, segmentsAreCorrect)
 {
     const auto & testCase = GetParam();
-    auto segments = parseURL(testCase.url).pathSegments(/*skipEmpty=*/testCase.skipEmpty)
-                    | std::ranges::to<decltype(testCase.segments)>();
+    /* Named, because `pathSegments()` borrows the URL and so rejects rvalues. */
+    auto url = parseURL(testCase.url);
+    auto segments = url.pathSegments(/*skipEmpty=*/testCase.skipEmpty) | std::ranges::to<decltype(testCase.segments)>();
     EXPECT_EQ(segments, testCase.segments);
     EXPECT_EQ(encodeUrlPath(segments), testCase.path);
 }

--- a/src/libutil/include/nix/util/url.hh
+++ b/src/libutil/include/nix/util/url.hh
@@ -207,6 +207,13 @@ struct ParsedURL
             return true;
         });
     }
+
+    /**
+     * The returned range borrows `path`, so it must not outlive the URL it
+     * came from. A `const &`-qualified member still binds to temporaries, so
+     * reject those explicitly.
+     */
+    auto pathSegments(bool skipEmpty) && = delete;
 };
 
 std::ostream & operator<<(std::ostream & os, const ParsedURL & url);
@@ -401,6 +408,14 @@ struct VerbatimURL
                 [](const ParsedURL & url) -> std::string_view { return url.scheme; }},
             raw);
     }
+
+    /**
+     * The returned view borrows `raw`, so it must not outlive the URL it came
+     * from. A `const &`-qualified member still binds to temporaries, so
+     * reject those explicitly: `VerbatimURL{url}.scheme()` would otherwise
+     * compile and read freed memory.
+     */
+    std::string_view scheme() && = delete;
 
     /**
      * Get the last non-empty path segment from the URL.


### PR DESCRIPTION
`VerbatimURL::scheme()` and `ParsedURL::pathSegments()` return non-owning views into the object they are called on. However, their `const &` qualifiers still allow calls on rvalues. If a returned view is retained past the end of that full expression, it refers to an already-destroyed URL.

Add deleted `const &&` overloads so these unsafe calls are rejected at compile time. Callers must keep the owning URL alive; update the path-segment test accordingly.

Assisted-by: Claude Code (Claude Opus 5)

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
