### PR TITLE
libfetchers-tests: Add a lot of tests for rev parsing in Inputs

### DIFF
--- a/src/libfetchers-tests/input.cc
+++ b/src/libfetchers-tests/input.cc
@@ -2,6 +2,7 @@
 #include "nix/fetchers/attrs.hh"
 #include "nix/fetchers/fetchers.hh"
 #include "nix/fetchers/fetch-settings.hh"
+#include "nix/store/tests/libstore.hh"
 #include "nix/util/tests/gmock-matchers.hh"
 #include "nix/util/url.hh"
 
@@ -20,6 +21,7 @@ struct InputFromAttrsTestCase
     std::string expectedUrl;
     std::string description;
     fetchers::Attrs expectedAttrs = attrs;
+    bool needsFlakes = false;
 };
 
 class InputFromAttrsTest : public ::testing::WithParamInterface<InputFromAttrsTestCase>, public ::testing::Test
@@ -27,7 +29,10 @@ class InputFromAttrsTest : public ::testing::WithParamInterface<InputFromAttrsTe
 
 TEST_P(InputFromAttrsTest, attrsAreCorrectAndRoundTrips)
 {
-    const auto & testCase = GetParam();
+    std::optional<EnableExperimentalFeature> enableFlakesMaybe;
+    auto & testCase = GetParam();
+    if (testCase.needsFlakes)
+        enableFlakesMaybe.emplace("flakes");
 
     auto input = fetchers::Input::fromAttrs(fetchers::Attrs(testCase.attrs));
 
@@ -37,6 +42,19 @@ TEST_P(InputFromAttrsTest, attrsAreCorrectAndRoundTrips)
     auto input2 = fetchers::Input::fromAttrs(input.toAttrs());
     EXPECT_EQ(input, input2);
     EXPECT_EQ(input.toAttrs(), input2.toAttrs());
+
+    auto url = input.toURL();
+    auto inputFromUrl = fetchers::Input::fromURL(url);
+
+#if 0
+    // Roundtripping doesn't hold (and never can) because there are multiple
+    // equivalent representations. At least the idempotency holds (next assertions).
+    EXPECT_EQ(inputFromUrl.toAttrs(), input.toAttrs());
+#endif
+    EXPECT_EQ(inputFromUrl.toURL(), url);
+    EXPECT_EQ(fetchers::Input::fromAttrs(inputFromUrl.toAttrs()).toAttrs(), inputFromUrl.toAttrs());
+
+    enableFlakesMaybe.reset();
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -57,6 +75,135 @@ INSTANTIATE_TEST_SUITE_P(
                     {"url", Attr("ssh://git@github.com/NixOS/nixpkgs")},
                     {"type", Attr("git")},
                 },
+        },
+        InputFromAttrsTestCase{
+            .attrs =
+                {
+                    {"url", Attr("git://user@github.com/NixOS/nixpkgs")},
+                    {"type", Attr("git")},
+                    {"rev", Attr("sha1-AAAAAAAAAAAAAAAAAAAAAAAAAAA=")},
+                },
+            .expectedUrl = "git://user@github.com/NixOS/nixpkgs?rev=0000000000000000000000000000000000000000",
+            .description = "git_rev_in_base64_sri_sha1",
+            .expectedAttrs =
+                {
+                    {"url", Attr("git://user@github.com/NixOS/nixpkgs")},
+                    {"type", Attr("git")},
+                    {"rev", Attr("sha1-AAAAAAAAAAAAAAAAAAAAAAAAAAA=")},
+                },
+        },
+        InputFromAttrsTestCase{
+            .attrs =
+                {
+                    {"url", Attr("git+https://user@github.com/NixOS/nix.git")},
+                    {"type", Attr("git")},
+                    // Same as above, just unprefixed (defaults to sha1)
+                    {"rev", Attr("AAAAAAAAAAAAAAAAAAAAAAAAAAA=")},
+                },
+            .expectedUrl = "git+https://user@github.com/NixOS/nix.git?rev=0000000000000000000000000000000000000000",
+            .description = "git_rev_in_base64_implicitly_sha1",
+            .expectedAttrs =
+                {
+                    {"url", Attr("https://user@github.com/NixOS/nix.git")},
+                    {"type", Attr("git")},
+                    {"rev", Attr("AAAAAAAAAAAAAAAAAAAAAAAAAAA=")},
+                },
+        },
+        InputFromAttrsTestCase{
+            .attrs =
+                {
+                    {"url", Attr("git+something://user@github.com/NixOS/nix.git")},
+                    {"type", Attr("git")},
+                    // Plain base16, just prefixed.
+                    {"rev", Attr("sha1:0000000000000000000000000000000000000000")},
+                },
+            .expectedUrl = "git+something://user@github.com/NixOS/nix.git?rev=0000000000000000000000000000000000000000",
+            .description = "git_rev_in_base16_explicit_sha1",
+            .expectedAttrs =
+                {
+                    // Remote helpers can be specified this way (a.k.a custom schemes).
+                    {"url", Attr("something://user@github.com/NixOS/nix.git")},
+                    {"type", Attr("git")},
+                    {"rev", Attr("sha1:0000000000000000000000000000000000000000")},
+                },
+        },
+        InputFromAttrsTestCase{
+            .attrs =
+                {
+                    {"url", Attr("git+http://somewhere/some/repo/path%2Fwith%2Fspaces")},
+                    {"type", Attr("git")},
+                    // Yes, also can in nix32 (inexplicably).
+                    {"rev", Attr("89144hj289144hj289144hj289144hj2")},
+                },
+            .expectedUrl =
+                "git+http://somewhere/some/repo/path%2Fwith%2Fspaces?rev=4242424242424242424242424242424242424242",
+            .description = "git_rev_in_nix32_implicitly_sha1",
+            .expectedAttrs =
+                {
+                    // Remote helpers can be specified this way (a.k.a custom schemes).
+                    {"url", Attr("http://somewhere/some/repo/path%2Fwith%2Fspaces")},
+                    {"type", Attr("git")},
+                    {"rev", Attr("89144hj289144hj289144hj289144hj2")},
+                },
+        },
+        InputFromAttrsTestCase{
+            .attrs =
+                {
+                    {"url", Attr("http://somewhere?something=abcd#a")},
+                    {"type", Attr("git")},
+                    // Yes, also can in nix32 (inexplicably).
+                    {"rev", Attr("sha1:89144hj289144hj289144hj289144hj2")},
+                },
+            // Query parameters are merged and fragments are accepted too?
+            .expectedUrl = "git+http://somewhere?rev=4242424242424242424242424242424242424242&something=abcd#a",
+            .description = "git_rev_in_nix32_explicit_sha1",
+            .expectedAttrs =
+                {
+                    {"url", Attr("http://somewhere?something=abcd#a")},
+                    {"type", Attr("git")},
+                    {"rev", Attr("sha1:89144hj289144hj289144hj289144hj2")},
+                },
+        },
+        InputFromAttrsTestCase{
+            .attrs =
+                {
+                    {"url", Attr("proprietaryhelper:///something///else///?hello=goodbye&test=%2F%3f")},
+                    {"type", Attr("git")},
+                    // And again, but now in base64.
+                    {"rev", Attr("sha1:QkJCQkJCQkJCQkJCQkJCQkJCQkI=")},
+                },
+            /// XXX: Is it ok that the query parameter loses pct-encoding there? Seems very sketchy.
+            .expectedUrl =
+                "git+proprietaryhelper:///something///else///?hello=goodbye&rev=4242424242424242424242424242424242424242&test=/?",
+            .description = "git_rev_in_base64_explicit_sha1",
+            .expectedAttrs =
+                {
+                    {"url", Attr("proprietaryhelper:///something///else///?hello=goodbye&test=/?")},
+                    {"type", Attr("git")},
+                    {"rev", Attr("sha1:QkJCQkJCQkJCQkJCQkJCQkJCQkI=")},
+                },
+        },
+        InputFromAttrsTestCase{
+            .attrs =
+                {
+                    {"type", Attr("indirect")},
+                    {"id", Attr("some_Id_-1234567890")},
+                    // And again, but now in base64.
+                    {"ref", Attr("sOmE/BRANCH%2f/definitely/Not1/HEAD")},
+                    {"rev", Attr("sha1-QkJCQkJCQkJCQkJCQkJCQkJCQkI====aaaaaaaaa even more trailing%2Fgarbage")},
+                },
+            // As we can see, garbage in the hash is ignored.
+            .expectedUrl =
+                "flake:some_Id_-1234567890/sOmE%2FBRANCH%252f%2Fdefinitely%2FNot1%2FHEAD/4242424242424242424242424242424242424242",
+            .description = "indirect_sri_sha1_trailing_garbage",
+            .expectedAttrs =
+                {
+                    {"type", Attr("indirect")},
+                    {"id", Attr("some_Id_-1234567890")},
+                    {"ref", Attr("sOmE/BRANCH%2f/definitely/Not1/HEAD")},
+                    {"rev", Attr("sha1-QkJCQkJCQkJCQkJCQkJCQkJCQkI====aaaaaaaaa even more trailing%2Fgarbage")},
+                },
+            .needsFlakes = true,
         }),
     [](const ::testing::TestParamInfo<InputFromAttrsTestCase> & info) { return info.param.description; });
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Motivated by https://github.com/NixOS/nix/pull/14526. We definitely are very creative about what types of hashes we accept here... Better not break that.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
