### PR TITLE
Replay fuzz seeds in package checks

### DIFF
--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -465,6 +465,8 @@ in
     scope.mesonComponentOverrides
   ];
 
+  mkFuzzSeedCheck = callPackage ./fuzz-seed-check.nix { };
+
   nix-util = callPackage ../src/libutil/package.nix { };
   nix-util-c = callPackage ../src/libutil-c/package.nix { };
   nix-util-test-support = callPackage ../src/libutil-test-support/package.nix { };

--- a/packaging/fuzz-seed-check.nix
+++ b/packaging/fuzz-seed-check.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  coreutils,
+  runCommand,
+  stdenv,
+}:
+
+{
+  package,
+  targets,
+}:
+
+{
+  runs ? 0,
+}:
+
+assert lib.assertMsg (builtins.isInt runs) "fuzz seed runs must be an integer";
+assert lib.assertMsg (runs >= 0) "fuzz seed runs must not be negative";
+assert lib.assertMsg stdenv.hostPlatform.isLinux "fuzz seed checks require a Linux host";
+assert lib.assertMsg (stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+  "fuzz seed checks require a native build";
+
+runCommand "${package.pname}-fuzz-seeds${lib.optionalString (runs > 0) "-${toString runs}-runs"}"
+  { }
+  ''
+    set -euo pipefail
+
+    export UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+
+    run_target() {
+      local target=$1
+      local corpus=$2
+      local dictionary=$3
+      local seeds=("$corpus"/*)
+      local args=(
+        -timeout=5
+        -rss_limit_mb=1024
+        -malloc_limit_mb=1024
+      )
+
+      if (( ''${#seeds[@]} == 0 )); then
+        echo "fuzz corpus is empty: $corpus" >&2
+        return 1
+      fi
+
+      if [[ -n "$dictionary" ]]; then
+        args+=("-dict=$dictionary")
+      fi
+
+      ${lib.getExe' coreutils "timeout"} --kill-after=10s 90s \
+        "${package}/bin/$target${stdenv.hostPlatform.extensions.executable}" \
+        -runs=1 \
+        "''${args[@]}" \
+        "''${seeds[@]}"
+
+      if (( ${toString runs} > 0 )); then
+        local writable_corpus="$TMPDIR/$target-corpus"
+        local total_runs=$(( ''${#seeds[@]} + 1 + ${toString runs} ))
+        mkdir "$writable_corpus"
+
+        "${package}/bin/$target${stdenv.hostPlatform.extensions.executable}" \
+          "-runs=$total_runs" \
+          -detect_leaks=0 \
+          "''${args[@]}" \
+          "$writable_corpus" \
+          "$corpus"
+      fi
+    }
+
+    shopt -s nullglob
+
+    ${lib.concatMapStringsSep "\n" (
+      {
+        name,
+        corpus,
+        dictionary ? null,
+      }:
+      "run_target ${lib.escapeShellArg name} ${corpus}"
+      + (if dictionary == null then " ''" else " ${dictionary}")
+    ) targets}
+
+    touch $out
+  ''

--- a/src/libstore-tests/fuzz/seed-check.nix
+++ b/src/libstore-tests/fuzz/seed-check.nix
@@ -1,0 +1,24 @@
+{
+  mkFuzzSeedCheck,
+  package,
+}:
+
+mkFuzzSeedCheck {
+  inherit package;
+  targets = [
+    {
+      name = "fuzz-parse-derivation";
+      corpus = ./data/derivations;
+      dictionary = ./data/derivations.dict;
+    }
+    {
+      name = "fuzz-parse-derivation-experimental";
+      corpus = ./data/derivations;
+      dictionary = ./data/derivations.dict;
+    }
+    {
+      name = "fuzz-store-path";
+      corpus = ./data/store-paths;
+    }
+  ];
+}

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildPackages,
   stdenv,
+  mkFuzzSeedCheck,
   mkMesonExecutable,
   writableTmpDirAsHomeHook,
 
@@ -105,13 +106,37 @@ mkMesonExecutable (finalAttrs: {
             + ''
               ${if withUnitTests then "test -x" else "test ! -e"} \
                 "${finalAttrs.finalPackage}/bin/${finalAttrs.pname}${stdenv.hostPlatform.extensions.executable}"
-              for target in fuzz-parse-derivation fuzz-parse-derivation-experimental; do
+              for target in fuzz-parse-derivation fuzz-parse-derivation-experimental fuzz-store-path; do
                 ${if withFuzzTargets then "test -x" else "test ! -e"} \
                   "${finalAttrs.finalPackage}/bin/$target${stdenv.hostPlatform.extensions.executable}"
               done
+            ''
+            +
+              # Sanitizer CI also builds fuzzers with unit tests. Replay only
+              # in the fuzzer-only check to avoid running every seed twice.
+              lib.optionalString
+                (
+                  !withUnitTests
+                  && withFuzzTargets
+                  && stdenv.hostPlatform.isLinux
+                  && stdenv.buildPlatform.canExecute stdenv.hostPlatform
+                )
+                ''
+                  test -e ${finalAttrs.finalPackage.runFuzzSeeds { }}
+                ''
+            + ''
               touch $out
             ''
           );
+    };
+  }
+  // lib.optionalAttrs withFuzzTargets {
+    /**
+      Replay every checked-in seed, then optionally run the fuzzer for `runs` mutations.
+    */
+    runFuzzSeeds = import ./fuzz/seed-check.nix {
+      inherit mkFuzzSeedCheck;
+      package = finalAttrs.finalPackage;
     };
   };
 

--- a/src/libutil-tests/fuzz/seed-check.nix
+++ b/src/libutil-tests/fuzz/seed-check.nix
@@ -1,0 +1,19 @@
+{
+  mkFuzzSeedCheck,
+  package,
+}:
+
+mkFuzzSeedCheck {
+  inherit package;
+  targets =
+    map
+      (name: {
+        inherit name;
+        corpus = ./data/nars;
+        dictionary = ./data/nars.dict;
+      })
+      [
+        "fuzz-parse-dump"
+        "fuzz-parse-dump-case-hacked"
+      ];
+}

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildPackages,
   stdenv,
+  mkFuzzSeedCheck,
   mkMesonExecutable,
 
   nix-util,
@@ -88,6 +89,21 @@ mkMesonExecutable (finalAttrs: {
                 ${if withFuzzTargets then "test -x" else "test ! -e"} \
                   "${finalAttrs.finalPackage}/bin/$target${stdenv.hostPlatform.extensions.executable}"
               done
+            ''
+            +
+              # Sanitizer CI also builds fuzzers with unit tests. Replay only
+              # in the fuzzer-only check to avoid running every seed twice.
+              lib.optionalString
+                (
+                  !withUnitTests
+                  && withFuzzTargets
+                  && stdenv.hostPlatform.isLinux
+                  && stdenv.buildPlatform.canExecute stdenv.hostPlatform
+                )
+                ''
+                  test -e ${finalAttrs.finalPackage.runFuzzSeeds { }}
+                ''
+            + ''
               touch $out
             ''
           );
@@ -117,6 +133,15 @@ mkMesonExecutable (finalAttrs: {
                 touch $out
               '';
         };
+  }
+  // lib.optionalAttrs withFuzzTargets {
+    /**
+      Replay every checked-in seed, then optionally run the fuzzer for `runs` mutations.
+    */
+    runFuzzSeeds = import ./fuzz/seed-check.nix {
+      inherit mkFuzzSeedCheck;
+      package = finalAttrs.finalPackage;
+    };
   };
 
   meta = {


### PR DESCRIPTION
## Motivation

Sanitizer CI builds the fuzz targets but does not run their checked-in seeds, so harness and corpus regressions can pass unnoticed.

## Context

Extend the existing fuzzer-only package checks to replay each NAR, derivation, and StorePath seed once through its target. The checks only run on Linux with time and memory limits.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
