### PR TITLE
CachingFilteringSourceAccessor: Make the isAllowed() cache thread-safe

### DIFF
--- a/src/libfetchers/filtering-source-accessor.cc
+++ b/src/libfetchers/filtering-source-accessor.cc
@@ -1,6 +1,8 @@
 #include "nix/fetchers/filtering-source-accessor.hh"
 #include "nix/util/sync.hh"
+#include "nix/util/util.hh"
 
+#include <boost/unordered/concurrent_flat_map.hpp>
 #include <boost/unordered/concurrent_flat_set.hpp>
 
 namespace nix {
@@ -108,13 +110,19 @@ ref<AllowListSourceAccessor> AllowListSourceAccessor::create(
     return make_ref<AllowListSourceAccessorImpl>(next, allowedPrefixes, allowedPaths, std::move(makeNotAllowedError));
 }
 
+CachingFilteringSourceAccessor::CachingFilteringSourceAccessor(
+    const SourcePath & src, MakeNotAllowedError && makeNotAllowedError)
+    : FilteringSourceAccessor(src, std::move(makeNotAllowedError))
+    , cache(make_ref<boost::concurrent_flat_map<CanonPath, bool>>())
+{
+}
+
 bool CachingFilteringSourceAccessor::isAllowed(const CanonPath & path)
 {
-    auto i = cache.find(path);
-    if (i != cache.end())
-        return i->second;
+    if (auto allowed = getConcurrent(*cache, path))
+        return *allowed;
     auto res = isAllowedUncached(path);
-    cache.emplace(path, res);
+    cache->emplace(path, res);
     return res;
 }
 

--- a/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
+++ b/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
@@ -5,6 +5,8 @@
 #include <set>
 #include <unordered_set>
 
+#include <boost/unordered/concurrent_flat_map_fwd.hpp>
+
 namespace nix {
 
 /**
@@ -95,9 +97,9 @@ struct AllowListSourceAccessor : public FilteringSourceAccessor
  */
 struct CachingFilteringSourceAccessor : FilteringSourceAccessor
 {
-    std::map<CanonPath, bool> cache;
+    const ref<boost::concurrent_flat_map<CanonPath, bool>> cache;
 
-    using FilteringSourceAccessor::FilteringSourceAccessor;
+    CachingFilteringSourceAccessor(const SourcePath & src, MakeNotAllowedError && makeNotAllowedError);
 
     bool isAllowed(const CanonPath & path) override;
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The cache in CachingFilteringSourceAccessor was a plain std::map mutated on every cache miss. With parallel evaluation, multiple eval threads can call isAllowed() on the same accessor concurrently (e.g. via builtins.readDir on a Git input fetched with exportIgnore), racing find() against emplace() and corrupting the tree. This caused segfaults like DETERMINATE-NIX-8W (a SEGV_MAPERR at offset 0x10, i.e. reading _M_left of a null red-black tree node).

Use boost::concurrent_flat_map instead, following the same pattern as CachingSourceAccessor.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
