### PR TITLE
libutil: initialise Winsock

### DIFF
--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -31,7 +31,7 @@ AutoCloseFD createUnixDomainSocket()
         ,
         0));
     if (!fdSocket)
-        throw SysError("cannot create Unix domain socket");
+        throw NativeSysError("cannot create Unix domain socket");
 #ifndef _WIN32
     unix::closeOnExec(fdSocket.get());
 #endif
@@ -47,7 +47,7 @@ AutoCloseFD createUnixDomainSocket(const std::filesystem::path & path, mode_t mo
     chmod(path, mode);
 
     if (listen(toSocket(fdSocket.get()), 100) == -1)
-        throw SysError("cannot listen on socket %s", PathFmt(path));
+        throw NativeSysError("cannot listen on socket %s", PathFmt(path));
 
     return fdSocket;
 }
@@ -180,7 +180,7 @@ static void bindConnectProcHelper(
     } else {
         memcpy(addr.sun_path, pathStr.c_str(), pathStr.size() + 1);
         if (operation(fd, psaddr, sizeof(addr)) == -1)
-            throw SysError("cannot %s to socket at '%s'", operationName, PathFmt(path));
+            throw NativeSysError("cannot %s to socket at '%s'", operationName, PathFmt(path));
     }
 }
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -12,6 +12,10 @@
 #include <boost/lexical_cast.hpp>
 #include <stdint.h>
 
+#ifdef _WIN32
+#  include <winsock2.h>
+#endif
+
 #ifdef NDEBUG
 #  error "Nix may not be built with assertions disabled (i.e. with -DNDEBUG)."
 #endif
@@ -62,6 +66,18 @@ void initLibUtil()
            effect. */
         if (OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, nullptr) != 1)
             throw Error("could not initialise OpenSSL");
+
+#ifdef _WIN32
+        /* Winsock needs this once per process before any socket call; without
+           it every socket() fails with WSANOTINITIALISED. No matching
+           WSACleanup(), for the same reason the OpenSSL atexit() handler is
+           suppressed above. The error code comes from the return value because
+           WSAGetLastError() is not usable until Winsock is up, and must be a
+           DWORD to pick the explicit-code WinError constructor. */
+        WSADATA wsaData;
+        if (DWORD err = static_cast<DWORD>(WSAStartup(MAKEWORD(2, 2), &wsaData)); err != 0)
+            throw windows::WinError(err, "could not initialise Winsock");
+#endif
     });
 }
 


### PR DESCRIPTION
Nothing in the tree ever called `WSAStartup`, so on Windows every `socket()` in the
process failed with `WSANOTINITIALISED`. That is why the daemon and every `unix://`
store were unreachable: it failed at socket creation, before any path or protocol
handling ran.

Before and after in one process, with a `ws2_32`-only probe:

```
no-WSAStartup     AF_INET   socket=INVALID  err=10093
no-WSAStartup     AF_UNIX   socket=INVALID  err=10093
WSAStartup rc=0
after-WSAStartup  AF_INET   socket=ok       err=0
after-WSAStartup  AF_UNIX   socket=INVALID  err=10047
```

It goes in `initLibUtil` so the ordering comes from the existing init path. There is
no matching `WSACleanup`, for the same reason the OpenSSL `atexit` handler is
suppressed a few lines above: tearing it down while another thread holds a socket
invalidates that socket, and we are exiting anyway. `ws2_32` was already linked, so
no build change.

`AF_UNIX` still fails afterwards with `WSAEAFNOSUPPORT`. That is Wine not
implementing it; real Windows has had `AF_UNIX` since build 17063. So this removes
the Nix-side blocker, and whether the daemon then works on Windows is untested here
for want of Windows hardware.

The second commit uses `NativeSysError` for socket failures instead of `SysError`.
Winsock does not set `errno`, so a socket failure was rendering whatever unrelated
value `errno` held: a `socket()` that failed with `WSANOTINITIALISED` reported "Bad
file descriptor". Thanks to @Ericson2314 for pointing out `NativeSysError` is
sufficient here; `GetLastError` and `WSAGetLastError` returned the same value on
both socket failures I checked.

Off Windows this is inert: every hunk is inside `#ifdef _WIN32`, and the helper
that replaced it expands to the previous `throw SysError`. `nix-util-tests` is
unmoved under Wine at 782 passed / 8 skipped, and native builds clean.
