### PR TITLE
tests: guard derived SetUp() against a skip in the base

### DIFF
--- a/src/libexpr-test-support/include/nix/expr/tests/nix_api_expr.hh
+++ b/src/libexpr-test-support/include/nix/expr/tests/nix_api_expr.hh
@@ -15,6 +15,9 @@ protected:
     void SetUp() override
     {
         nix_api_store_test::SetUp();
+        /* A skip in the base returns from the base only, leaving `store` null. */
+        if (IsSkipped())
+            return;
         nix_libexpr_init(ctx);
         state = nix_state_create(nullptr, nullptr, store);
         value = nix_alloc_value(nullptr, state);
@@ -22,8 +25,11 @@ protected:
 
     void TearDown() override
     {
-        nix_gc_decref(nullptr, value);
-        nix_state_free(state);
+        /* Also runs for skipped tests, where these are null. */
+        if (value)
+            nix_gc_decref(nullptr, value);
+        if (state)
+            nix_state_free(state);
     }
 
     EvalState * state = nullptr;

--- a/src/libstore-test-support/https-store.cc
+++ b/src/libstore-test-support/https-store.cc
@@ -29,6 +29,10 @@ void HttpsBinaryCacheStoreTest::SetUp()
 {
     LibStoreNetworkTest::SetUp();
 
+    /* A skip in the base returns from the base only, so guard the setup below. */
+    if (IsSkipped())
+        return;
+
 #ifdef _WIN32
     GTEST_SKIP() << "HTTPS store tests are not supported on Windows";
 #endif


### PR DESCRIPTION
`GTEST_SKIP()` returns from the function it appears in. So when a base fixture's
`SetUp()` skips, a derived `SetUp()` that called it keeps going with the base's
initialisation incomplete.

Two fixtures have that shape, and they fail differently:

`src/libstore-test-support/https-store.cc` — five `HttpsBinaryCacheStore*` cases
report FAILED where the author meant SKIPPED, whenever the network-test
precondition does not hold. Visible on Linux.

`src/libexpr-test-support/include/nix/expr/tests/nix_api_expr.hh` — the derived
`SetUp()` runs on with `store` still null and dereferences it, killing the test
process rather than failing a test. On a stock tree you will not see this: an
unrelated assertion in `posix-source-accessor.cc` fires first.

Both get an `IsSkipped()` check after the base call.
`src/libstore-tests/nix_api_store.cc` already gets this right by a different route,
putting its own skip before the work it needs to guard.

22 `GTEST_SKIP()` occurrences exist tree-wide. 20 are fine, sitting either in test
bodies where the return ends the test, or in a `SetUp()` nothing derives from. Only
these two have a base that can skip and a derived body that continues.

On a native build five tests move from FAILED to SKIPPED and the pass count is
unchanged at 764, so this reclassifies rather than fixes or breaks anything.

One ordering note. This wants to land before anything that narrows the Windows skip
guard in these fixtures. That guard is currently the only thing keeping the null
dereference unreachable, so removing it first turns a clean skip into a crash.
