### PR TITLE
libutil: fix the Windows environment-variable accessors

### DIFF
--- a/src/libutil-tests/environment-variables.cc
+++ b/src/libutil-tests/environment-variables.cc
@@ -18,4 +18,40 @@ TEST(setEnvOs, returnsZeroOnSuccess)
     EXPECT_EQ(unsetEnvOs(OS_STR("NIX_TEST_SETENVOS_RET")), 0);
 }
 
+/* An existing variable whose value is empty is present, not absent. Fails on
+   Windows if a zero character count is read as failure. */
+TEST(getEnvOs, emptyValueIsPresent)
+{
+    constexpr auto name = OS_STR("NIX_TEST_GETENVOS_EMPTY");
+
+    ASSERT_EQ(setEnvOs(name, OS_STR("")), 0);
+
+    auto value = getEnvOs(name);
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(*value, OS_STR(""));
+
+    EXPECT_EQ(unsetEnvOs(name), 0);
+}
+
+TEST(getEnvOs, absentIsNullopt)
+{
+    constexpr auto name = OS_STR("NIX_TEST_GETENVOS_ABSENT");
+
+    unsetEnvOs(name);
+
+    EXPECT_EQ(getEnvOs(name), std::nullopt);
+}
+
+/* `getEnvOsNonEmpty` folds the two together, so it must not distinguish them. */
+TEST(getEnvOsNonEmpty, emptyAndAbsentBothNullopt)
+{
+    constexpr auto name = OS_STR("NIX_TEST_GETENVOS_NONEMPTY");
+
+    ASSERT_EQ(setEnvOs(name, OS_STR("")), 0);
+    EXPECT_EQ(getEnvOsNonEmpty(name), std::nullopt);
+
+    EXPECT_EQ(unsetEnvOs(name), 0);
+    EXPECT_EQ(getEnvOsNonEmpty(name), std::nullopt);
+}
+
 } // namespace nix

--- a/src/libutil-tests/environment-variables.cc
+++ b/src/libutil-tests/environment-variables.cc
@@ -54,4 +54,22 @@ TEST(getEnvOsNonEmpty, emptyAndAbsentBothNullopt)
     EXPECT_EQ(getEnvOsNonEmpty(name), std::nullopt);
 }
 
+/* `getEnv` is defined in terms of `getEnvOs`, so they must agree. Fails on
+   Windows if `getEnv` reads the CRT copy, which `setEnv` does not update. */
+TEST(getEnv, agreesWithGetEnvOs)
+{
+    constexpr auto name = "NIX_TEST_GETENV_AGREE";
+    constexpr auto nameOS = OS_STR("NIX_TEST_GETENV_AGREE");
+
+    ASSERT_EQ(setEnv(name, "value"), 0);
+
+    EXPECT_EQ(getEnv(name), "value");
+    EXPECT_EQ(getEnvOs(nameOS), OS_STR("value"));
+
+    EXPECT_EQ(unsetEnvOs(nameOS), 0);
+
+    EXPECT_EQ(getEnv(name), std::nullopt);
+    EXPECT_EQ(getEnvOs(nameOS), std::nullopt);
+}
+
 } // namespace nix

--- a/src/libutil/environment-variables.cc
+++ b/src/libutil/environment-variables.cc
@@ -4,10 +4,12 @@ namespace nix {
 
 std::optional<std::string> getEnv(const std::string & key)
 {
-    char * value = getenv(key.c_str());
+    /* Always via `getEnvOs`, which each platform implements against its own
+       primitive. */
+    auto value = getEnvOs(string_to_os_string(key));
     if (!value)
         return {};
-    return std::string(value);
+    return os_string_to_string(*value);
 }
 
 std::optional<std::string> getEnvNonEmpty(const std::string & key)

--- a/src/libutil/unix/environment-variables.cc
+++ b/src/libutil/unix/environment-variables.cc
@@ -14,7 +14,10 @@ int setEnv(const char * name, const char * value)
 
 std::optional<std::string> getEnvOs(const std::string & key)
 {
-    return getEnv(key);
+    char * value = getenv(key.c_str());
+    if (!value)
+        return {};
+    return std::string(value);
 }
 
 OsStringMap getEnvOs()

--- a/src/libutil/windows/environment-variables.cc
+++ b/src/libutil/windows/environment-variables.cc
@@ -19,11 +19,10 @@ std::optional<OsString> getEnvOs(const OsString & key)
 
     // Retrieve the environment variable value
     DWORD resultSize = GetEnvironmentVariableW(key.c_str(), &value[0], bufferSize);
-    if (resultSize == 0) {
-        return std::nullopt;
-    }
 
-    // Resize the string to remove the extra null characters
+    /* Resize to remove the extra null characters. A zero count is not a failure
+       here: the sizing call already told us the variable exists, so it means the
+       value is empty, and resizing to zero returns it as such. */
     value.resize(resultSize);
 
     return value;

--- a/src/libutil/windows/environment-variables.cc
+++ b/src/libutil/windows/environment-variables.cc
@@ -4,6 +4,10 @@
 
 namespace nix {
 
+/* The primitive on Windows, with `getEnv` delegating here rather than the other
+   way round. `getenv` would read the CRT's copy of the environment, snapshotted
+   at process start, which `setEnv` does not update, so it cannot see anything
+   this process has set. */
 std::optional<OsString> getEnvOs(const OsString & key)
 {
     // Determine the required buffer size for the environment variable value


### PR DESCRIPTION
Two related fixes to the environment-variable accessors, combined into one PR
because their tests share a file and kept conflicting.

## getEnvOs treated an empty value as absent

`getEnvOs` returned `nullopt` when the second `GetEnvironmentVariableW` stored
zero characters. But reaching that call means the sizing call succeeded, which
means the variable exists, so zero there means the value is empty rather than
missing.

Windows distinguishes the two: an existing empty variable returns 1 from the
sizing call and 0 from the buffered one, while an absent one returns 0 from both
and sets `ERROR_ENVVAR_NOT_FOUND`. Unix already got this right, so the same
calling code took different branches on the two platforms. One consequence is
that an empty-string guard in `FileTransferSettings` is unreachable on Windows.

The branch is gone rather than corrected: `value.resize(resultSize)` on a zero
count gives the empty string, and returning it gives an engaged optional.

## getEnv did not go through getEnvOs

`getEnv` used `getenv`, which reads the C runtime's copy of the environment. That
copy is snapshotted at process start and `setEnv` does not update it, because
`setEnv` writes the Win32 block. So on Windows `getEnv` could not see anything
the process itself had set, and reported a variable absent that `getEnvOs`
reported present.

It now always goes through `getEnvOs`, with each platform implementing that
against its own primitive, so there is no `#ifdef` in the shared file.

That needed the Unix delegation inverted too: `getEnvOs` there was
`return getEnv(key)`, so making the shared `getEnv` call `getEnvOs` would have
recursed forever. `getEnvOs` is now the primitive on both platforms. `OsString`
is `std::string` on Unix, so the conversions are identity and behaviour there is
unchanged.

## Tests

Four tests in `libutil-tests`, alongside the two that came in with #16354.
`getEnvOs.emptyValueIsPresent` and `getEnv.agreesWithGetEnvOs` both fail on
Windows without their respective fix.

All six pass under Wine (789 total) and natively.
