### PR TITLE
libutil: read the environment from the Win32 process block on Windows

### DIFF
--- a/src/libutil-tests/environment-variables.cc
+++ b/src/libutil-tests/environment-variables.cc
@@ -18,4 +18,22 @@ TEST(setEnvOs, returnsZeroOnSuccess)
     EXPECT_EQ(unsetEnvOs(OS_STR("NIX_TEST_SETENVOS_RET")), 0);
 }
 
+/* `getEnv` is defined in terms of `getEnvOs`, so they must agree. Fails on
+   Windows if `getEnv` reads the CRT copy, which `setEnv` does not update. */
+TEST(getEnv, agreesWithGetEnvOs)
+{
+    constexpr auto name = "NIX_TEST_GETENV_AGREE";
+    constexpr auto nameOS = OS_STR("NIX_TEST_GETENV_AGREE");
+
+    ASSERT_EQ(setEnv(name, "value"), 0);
+
+    EXPECT_EQ(getEnv(name), "value");
+    EXPECT_EQ(getEnvOs(nameOS), OS_STR("value"));
+
+    EXPECT_EQ(unsetEnvOs(nameOS), 0);
+
+    EXPECT_EQ(getEnv(name), std::nullopt);
+    EXPECT_EQ(getEnvOs(nameOS), std::nullopt);
+}
+
 } // namespace nix

--- a/src/libutil/environment-variables.cc
+++ b/src/libutil/environment-variables.cc
@@ -4,10 +4,12 @@ namespace nix {
 
 std::optional<std::string> getEnv(const std::string & key)
 {
-    char * value = getenv(key.c_str());
+    /* Always via `getEnvOs`, which each platform implements against its own
+       primitive. */
+    auto value = getEnvOs(string_to_os_string(key));
     if (!value)
         return {};
-    return std::string(value);
+    return os_string_to_string(*value);
 }
 
 std::optional<std::string> getEnvNonEmpty(const std::string & key)

--- a/src/libutil/unix/environment-variables.cc
+++ b/src/libutil/unix/environment-variables.cc
@@ -14,7 +14,10 @@ int setEnv(const char * name, const char * value)
 
 std::optional<std::string> getEnvOs(const std::string & key)
 {
-    return getEnv(key);
+    char * value = getenv(key.c_str());
+    if (!value)
+        return {};
+    return std::string(value);
 }
 
 OsStringMap getEnvOs()

--- a/src/libutil/windows/environment-variables.cc
+++ b/src/libutil/windows/environment-variables.cc
@@ -4,6 +4,10 @@
 
 namespace nix {
 
+/* The primitive on Windows, with `getEnv` delegating here rather than the other
+   way round. `getenv` would read the CRT's copy of the environment, snapshotted
+   at process start, which `setEnv` does not update, so it cannot see anything
+   this process has set. */
 std::optional<OsString> getEnvOs(const OsString & key)
 {
     // Determine the required buffer size for the environment variable value


### PR DESCRIPTION
`getEnv` used `getenv`, which reads the C runtime's copy of the environment. That
copy is snapshotted at process start and `setEnv` does not update it, because
`setEnv` goes through `SetEnvironmentVariable` and writes the Win32 block. So on
Windows `getEnv` could not see anything the process itself had set, and would report
a variable absent that `getEnvOs` reported present.

Following review this is no longer a Windows special case: `getEnv` now always goes
through `getEnvOs`, and each platform implements `getEnvOs` against its own
primitive. Thanks @Ericson2314.

That needed one more change than it looks. The Unix `getEnvOs` was defined as
`return getEnv(key)`, so making the shared `getEnv` call `getEnvOs` would have
recursed forever. `getEnvOs` is now the primitive on both platforms: `getenv` on
Unix, the Win32 block on Windows. Since `OsString` is `std::string` on Unix the
conversions are identity, so behaviour there is unchanged.

Two tests in `libutil-tests`, per @xokdvium. Both fail on Windows without this.
`nix-util-tests` passes at 806 natively and the suite compiles for mingw.
