### PR TITLE
libfetchers: Support building against libgit2 2.0 (release candidate)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,3 +34,4 @@ BinPackArguments: false
 BreakBeforeTernaryOperators: true
 SeparateDefinitionBlocks: Always
 QualifierAlignment: Left
+OneLineFormatOffRegex: "// NOFORMAT$"

--- a/packaging/hydra.nix
+++ b/packaging/hydra.nix
@@ -267,6 +267,21 @@ rec {
               withMimalloc = false;
               withPluginCApi = false;
             };
+            # Also, temporarily stuff newer libgit2 for more coverage of ifdefs.
+            # Would be nicer for this to be somehow a private input, but we can't
+            # override nixDependencies easily.
+            libgit2 = self.callPackage (
+              { pkgs, fetchFromGitHub }:
+              pkgs.libgit2.overrideAttrs {
+                version = "2.0.0-rc.1";
+                src = fetchFromGitHub {
+                  owner = "libgit2";
+                  repo = "libgit2";
+                  rev = "ae45d0d168f7e8dbfdb8c623589cb51caac96ab3";
+                  hash = "sha256-3sbqHm37SOwBeFgtjI2DLN6kx1F7G2N1m6rRIkqDXNI=";
+                };
+              }
+            ) { };
           }
         )
       );

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -365,11 +365,19 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
                enabling the specific backend.
                */
 
+#if LIBGIT2_VERSION_CHECK(2, 0, 0)
+            git_odb_options odbOpts = GIT_ODB_OPTIONS_INIT;
+            odbOpts.oid_type = git_repository_oid_type(repo.get());
+            if (git_odb_new_ext(Setter(odb), &odbOpts))
+                throw GitError("creating Git object database");
+#else
             if (git_odb_new(Setter(odb)))
                 throw GitError("creating Git object database");
+#endif
 
 #if LIBGIT2_VERSION_CHECK(2, 0, 0)
             git_odb_backend_pack_options packOpts = GIT_ODB_OPTIONS_INIT;
+            packOpts.oid_type = git_repository_oid_type(repo.get());
 #endif
             if (git_odb_backend_pack(
                     &packBackend,
@@ -436,6 +444,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         Indexer indexer;
 #if LIBGIT2_VERSION_CHECK(2, 0, 0)
         git_indexer_options indexerOpts = GIT_INDEXER_OPTIONS_INIT;
+        indexerOpts.oid_type = git_repository_oid_type(repo.get());
 #endif
         if (git_indexer_new(
                 Setter(indexer),

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -15,6 +15,7 @@
 #include "nix/util/pool.hh"
 #include "nix/util/deleter.hh"
 
+#include <git2/version.h>
 #include <git2/attr.h>
 #include <git2/blob.h>
 #include <git2/branch.h>
@@ -147,10 +148,22 @@ typedef std::unique_ptr<git_indexer, Deleter<git_indexer_free>> Indexer;
 
 static Hash toHash(const git_oid & oid)
 {
-#ifdef GIT_EXPERIMENTAL_SHA256
-    assert(oid.type == GIT_OID_SHA1);
+    HashAlgorithm algo;
+#if LIBGIT2_VERSION_CHECK(2, 0, 0)
+    switch (oid.type) {
+    case GIT_OID_SHA1:
+        algo = HashAlgorithm::SHA1;
+        break;
+    case GIT_OID_SHA256:
+        algo = HashAlgorithm::SHA256;
+        break;
+    default:
+        unreachable();
+    }
+#else
+    algo = HashAlgorithm::SHA1;
 #endif
-    Hash hash(HashAlgorithm::SHA1);
+    Hash hash(algo);
     memcpy(hash.hash, oid.id, hash.hashSize);
     return hash;
 }
@@ -167,8 +180,29 @@ static void initLibGit2()
 static git_oid hashToOID(const Hash & hash)
 {
     git_oid oid;
+#if LIBGIT2_VERSION_CHECK(2, 0, 0)
+    git_oid_t t;
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wswitch-enum"
+    switch (hash.algo) {
+    case HashAlgorithm::SHA1:
+        t = GIT_OID_SHA1;
+        break;
+    case HashAlgorithm::SHA256:
+        t = GIT_OID_SHA256;
+        break;
+    default:
+        throw Error("unsupported hash algorithm for Git: %s", printHashAlgo(hash.algo));
+    }
+#  pragma GCC diagnostic pop
+    if (git_oid_from_raw(&oid, hash.hash, t))
+        /* This can really never happen, since libgit2 just reads out our raw bytes.
+           The only failure mode is us specifying an invalid `type` parameter. */
+        unreachable();
+#else
     if (git_oid_fromstr(&oid, hash.gitRev().c_str()))
         throw GitError("cannot convert '%s' to a Git OID", hash.gitRev());
+#endif
     return oid;
 }
 
@@ -334,7 +368,16 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
             if (git_odb_new(Setter(odb)))
                 throw GitError("creating Git object database");
 
-            if (git_odb_backend_pack(&packBackend, (path / "objects").string().c_str()))
+#if LIBGIT2_VERSION_CHECK(2, 0, 0)
+            git_odb_backend_pack_options packOpts = GIT_ODB_OPTIONS_INIT;
+#endif
+            if (git_odb_backend_pack(
+                    &packBackend,
+                    (path / "objects").string().c_str()
+#if LIBGIT2_VERSION_CHECK(2, 0, 0)
+                        , &packOpts // NOFORMAT
+#endif
+                    ))
                 throw GitError("creating pack backend");
 
             if (git_odb_add_backend(odb.get(), packBackend, 1))
@@ -391,7 +434,20 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         auto packFilesPath = std::filesystem::path(git_repository_path(repo.get())) / "objects/pack";
 
         Indexer indexer;
-        if (git_indexer_new(Setter(indexer), packFilesPath.string().c_str(), 0, nullptr, nullptr))
+#if LIBGIT2_VERSION_CHECK(2, 0, 0)
+        git_indexer_options indexerOpts = GIT_INDEXER_OPTIONS_INIT;
+#endif
+        if (git_indexer_new(
+                Setter(indexer),
+                packFilesPath.string().c_str(),
+#if LIBGIT2_VERSION_CHECK(2, 0, 0)
+                &indexerOpts
+#else
+                0,
+                nullptr,
+                nullptr
+#endif
+                ))
             throw GitError("creating git packfile indexer");
 
         struct State

--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -269,6 +269,47 @@ INSTANTIATE_TEST_SUITE_P(
                 },
             .description = "gitlab_ref_slashes_in_path_everywhere_with_pct_encoding",
             .expectedUrl = "gitlab:owner%252Fsubgroup/repoA/branchC",
+        },
+        InputFromURLTestCase{
+            // Can specify in the path
+            .url = "github:nixos/nix/0000000000000000000000000000000000000000",
+            .attrs =
+                {
+                    {"type", Attr("github")},
+                    {"owner", Attr("nixos")},
+                    {"repo", Attr("nix")},
+                    {"rev", Attr("0000000000000000000000000000000000000000")},
+                },
+            .description = "github_rev_in_url_path",
+            .expectedUrl = "github:nixos/nix/0000000000000000000000000000000000000000",
+        },
+        InputFromURLTestCase{
+            // Also in query parameter
+            .url = "github:nixos/nix?rev=0000000000000000000000000000000000000000",
+            .attrs =
+                {
+                    {"type", Attr("github")},
+                    {"owner", Attr("nixos")},
+                    {"repo", Attr("nix")},
+                    {"rev", Attr("0000000000000000000000000000000000000000")},
+                },
+            .description = "github_rev_in_url_query",
+            .expectedUrl = "github:nixos/nix/0000000000000000000000000000000000000000",
+        },
+        InputFromURLTestCase{
+            .url = "github:nixos/nix//master///something/",
+            .attrs =
+                {
+                    {"type", Attr("github")},
+                    {"owner", Attr("nixos")},
+                    {"repo", Attr("nix")},
+                    {"ref", Attr("master/something")},
+                },
+            .description = "github_slashes_in_url_path",
+            // XXX: Very strange that slashes get re-encoded in the path, even though they
+            // weren't initially. Also consecutive slashes get nuked. That seems wrong, but
+            // apparently has been the case since at least 2.18.
+            .expectedUrl = "github:nixos/nix/master%2Fsomething",
         }),
     [](const ::testing::TestParamInfo<InputFromURLTestCase> & info) { return info.param.description; });
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Tested against the interface from https://github.com/libgit2/libgit2/pull/7337.
Also adds a configuration for clang-tidy to disable formatting on just a single line,
because if doesn't really format nicely with arguments which need a comma in an
ifdef.

Some changes needed to be made since https://github.com/NixOS/nix/pull/14526.

Co-authored-by: John Ericson <git@JohnEricson.me>

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
