### PR TITLE
Don't mask flake ref URL interpretation errors

### DIFF
--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -11,6 +11,7 @@
 #include "nix/util/configuration.hh"
 #include "nix/util/error.hh"
 #include "nix/util/experimental-features.hh"
+#include "nix/util/terminal.hh"
 
 namespace nix {
 
@@ -321,6 +322,24 @@ TEST(to_string, doesntReencodeUrl)
     auto expected = "http://localhost:8181/test/%2B3d.tar.gz";
 
     ASSERT_EQ(unparsed, expected);
+}
+
+TEST(parseFlakeRef, urlInterpretationErrorsAreNotMasked)
+{
+    fetchers::Settings fetchSettings;
+
+    // Errors that occur while interpreting a syntactically valid URL
+    // (such as an unsupported query parameter) should be shown to the
+    // user, rather than causing the flake ref to be reinterpreted as a
+    // path, leading to a confusing "not an absolute path" error.
+    try {
+        parseFlakeRef("github:foo/bar?xyzzy=1");
+        FAIL() << "expected parseFlakeRef to throw";
+    } catch (BadURL & e) {
+        auto msg = filterANSIEscapes(e.msg());
+        EXPECT_NE(msg.find("xyzzy"), std::string::npos) << msg;
+        EXPECT_EQ(msg.find("not an absolute path"), std::string::npos) << msg;
+    }
 }
 
 TEST(parseFlakeRef, malformedGithubUrlDoesNotCrash)

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -239,18 +239,27 @@ static std::optional<std::pair<FlakeRef, std::string>> parseFlakeIdRef(std::stri
 std::optional<std::pair<FlakeRef, std::string>>
 parseURLFlakeRef(std::string_view url, const std::optional<std::filesystem::path> & baseDir, bool isFlake)
 {
+    std::optional<ParsedURL> parsed;
     try {
-        auto parsed = parseURL(url, /*lenient=*/true);
-        if (baseDir && (parsed.scheme == "path" || parsed.scheme == "git+file")) {
-            /* Here we know that the path must not contain encoded '/' or NUL bytes. */
-            auto path = urlPathToPath(parsed.path);
-            if (!path.is_absolute())
-                parsed.path = pathToUrlPath(absPath(path, get(baseDir)));
-        }
-        return fromParsedURL(std::move(parsed), isFlake);
+        parsed = parseURL(url, /*lenient=*/true);
     } catch (BadURL &) {
+        /* The string is not a URL, so try to interpret it as a path
+           instead (in the caller). Note that errors that occur while
+           *interpreting* a syntactically valid URL (such as an
+           unsupported query parameter) are not caught here; they
+           should be shown to the user rather than masked by a
+           confusing error about the flake ref not being a valid
+           path. */
         return std::nullopt;
     }
+
+    if (baseDir && (parsed->scheme == "path" || parsed->scheme == "git+file")) {
+        /* Here we know that the path must not contain encoded '/' or NUL bytes. */
+        auto path = urlPathToPath(parsed->path);
+        if (!path.is_absolute())
+            parsed->path = pathToUrlPath(absPath(path, get(baseDir)));
+    }
+    return fromParsedURL(std::move(*parsed), isFlake);
 }
 
 std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Improves the misleading error message
```
$ nix eval --expr 'builtins.parseFlakeRef "github:NixOS/nix?xyzzy=1"'
error:
       … while calling the 'parseFlakeRef' builtin
         at «string»:1:1:
            1| builtins.parseFlakeRef "github:NixOS/nix?xyzzy=1"
             | ^

       error: flake reference 'github:NixOS/nix?xyzzy=1' is not an absolute path
```
to
```
error:
       … while calling the 'parseFlakeRef' builtin
         at «string»:1:1:
            1| builtins.parseFlakeRef "github:NixOS/nix?xyzzy=1"
             | ^

       error: URL 'github:NixOS/nix?xyzzy=1' contains unknown parameter 'xyzzy'
```
and
```
$ nix build 'github:NixOS/nix?xyzzy=1'
error: getting status of "/home/eelco/github:NixOS/nix": No such file or directory
```
to
```
$ nix build 'github:NixOS/nix?xyzzy=1'
error: URL 'github:NixOS/nix?xyzzy=1' contains unknown parameter 'xyzzy'
```


Taken from https://github.com/DeterminateSystems/nix-src/pull/604.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
