### PR TITLE
libutil: return 0 from setEnv on success on Windows

### DIFF
--- a/src/libutil-tests/environment-variables.cc
+++ b/src/libutil-tests/environment-variables.cc
@@ -1,0 +1,21 @@
+#include "nix/util/environment-variables.hh"
+
+#include <gtest/gtest.h>
+
+namespace nix {
+
+/* The header says "like POSIX `setenv`", so success is 0. On Windows these wrap
+   `SetEnvironmentVariable`, which reports success as nonzero. */
+TEST(setEnv, returnsZeroOnSuccess)
+{
+    EXPECT_EQ(setEnv("NIX_TEST_SETENV_RET", "value"), 0);
+    EXPECT_EQ(unsetEnvOs(OS_STR("NIX_TEST_SETENV_RET")), 0);
+}
+
+TEST(setEnvOs, returnsZeroOnSuccess)
+{
+    EXPECT_EQ(setEnvOs(OS_STR("NIX_TEST_SETENVOS_RET"), OS_STR("value")), 0);
+    EXPECT_EQ(unsetEnvOs(OS_STR("NIX_TEST_SETENVOS_RET")), 0);
+}
+
+} // namespace nix

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -49,6 +49,7 @@ sources = files(
   'compression.cc',
   'config.cc',
   'current-process.cc',
+  'environment-variables.cc',
   'executable-path.cc',
   'file-content-address.cc',
   'file-descriptor.cc',

--- a/src/libutil/windows/environment-variables.cc
+++ b/src/libutil/windows/environment-variables.cc
@@ -65,22 +65,22 @@ StringMap getEnv()
 
 int unsetenv(const char * name)
 {
-    return -SetEnvironmentVariableA(name, nullptr);
+    return SetEnvironmentVariableA(name, nullptr) ? 0 : -1;
 }
 
 int unsetEnvOs(const OsChar * name)
 {
-    return -SetEnvironmentVariableW(name, nullptr);
+    return SetEnvironmentVariableW(name, nullptr) ? 0 : -1;
 }
 
 int setEnv(const char * name, const char * value)
 {
-    return -SetEnvironmentVariableA(name, value);
+    return SetEnvironmentVariableA(name, value) ? 0 : -1;
 }
 
 int setEnvOs(const OsString & name, const OsString & value)
 {
-    return -SetEnvironmentVariableW(name.c_str(), value.c_str());
+    return SetEnvironmentVariableW(name.c_str(), value.c_str()) ? 0 : -1;
 }
 
 } // namespace nix


### PR DESCRIPTION
`environment-variables.hh` describes these as POSIX-like: "Like POSIX `setenv`, but
always overrides." POSIX returns 0 on success and -1 on failure.
`SetEnvironmentVariable` reports the opposite, nonzero for success, and negating it
produced -1 for success and 0 for failure.

So on Windows all four of `setEnv`, `setEnvOs`, `unsetenv` and `unsetEnvOs` returned
-1 when they worked.

Nothing is broken by this today: no caller in the tree checks the return value. The
first thing to look at it was a test I was writing for a different change, which
failed on `ASSERT_EQ(setEnvOs(name, OS_STR("")), 0)` with "Which is: -1".

Two tests in `libutil-tests` covering the convention. They pass on both platforms
and fail on Windows without this change.

`nix-util-tests` passes at 784 under Wine and builds clean natively.
