### PR TITLE
libcmd: fix the uppercase proxy variable names

### DIFF
--- a/src/libcmd/network-proxy.cc
+++ b/src/libcmd/network-proxy.cc
@@ -12,9 +12,10 @@ static StringSet getAllVariables()
 {
     StringSet variables = lowercaseVariables;
     for (const auto & variable : lowercaseVariables) {
-        std::string upperVariable;
-        std::transform(
-            variable.begin(), variable.end(), upperVariable.begin(), [](unsigned char c) { return std::toupper(c); });
+        std::string upperVariable{variable};
+        std::transform(upperVariable.begin(), upperVariable.end(), upperVariable.begin(), [](unsigned char c) {
+            return std::toupper(c);
+        });
         variables.insert(std::move(upperVariable));
     }
     return variables;


### PR DESCRIPTION
`getAllVariables()` means to add `HTTP_PROXY` and friends alongside the lowercase
names. It transforms into `upperVariable.begin()` while `upperVariable` is still
empty, which writes past the end of a zero-length string, and since `transform`
through an iterator does not resize, `upperVariable` stays empty.

So the uppercase names are never added. What goes into the set is the empty string,
once. `haveNetworkProxyConnection()` therefore never sees `HTTP_PROXY`, and looks up
an environment variable with an empty name instead. `nix-build`'s `keepVars`
inherits the same gap.

The fix copies first, then transforms in place.

Running the old code standalone at `-O0`:

```
resulting set has 6 entries:
  [ALL_PROXY   ] (len 0)     <- prints as text, reports length zero
  [all_proxy] (len 9)
  [ftp_proxy] (len 9)
  [http_proxy] (len 10)
  [https_proxy] (len 11)
  [no_proxy] (len 8)
contains HTTP_PROXY? NO
```

That first entry is the tell: the characters landed past the end of the empty
string's buffer, so the set key is empty while the adjacent bytes still print. With
the fix there are ten entries, `HTTP_PROXY` is present, and there is no empty string.

This is not Windows-specific; it affects every platform.

## Testing

There is no `libcmd` test target, and adding one for this seemed worse than the fix
itself, so this is verified by the reproduction above and by building `nix-cmd`.
Happy to add a test target if you'd rather have one.
