### PR TITLE
libcmd: fix the uppercase proxy variable names

### DIFF
--- a/src/libcmd/network-proxy.cc
+++ b/src/libcmd/network-proxy.cc
@@ -12,9 +12,10 @@ static StringSet getAllVariables()
 {
     StringSet variables = lowercaseVariables;
     for (const auto & variable : lowercaseVariables) {
-        std::string upperVariable;
-        std::transform(
-            variable.begin(), variable.end(), upperVariable.begin(), [](unsigned char c) { return std::toupper(c); });
+        std::string upperVariable{variable};
+        std::transform(upperVariable.begin(), upperVariable.end(), upperVariable.begin(), [](unsigned char c) {
+            return std::toupper(c);
+        });
         variables.insert(std::move(upperVariable));
     }
     return variables;


### PR DESCRIPTION
`getAllVariables()` in `src/libcmd/network-proxy.cc` intends to add `HTTP_PROXY` and the other four uppercase spellings alongside the lowercase ones. It doesn't. The uppercase names have never been in `networkProxyVariables`; an empty string has been there instead.

```c++
std::string upperVariable;
std::transform(
    variable.begin(), variable.end(), upperVariable.begin(), [](unsigned char c) { return std::toupper(c); });
variables.insert(std::move(upperVariable));
```

`upperVariable` is empty when `begin()` is taken, so the write is out of bounds. And `std::transform` writes through the output iterator without ever resizing the destination, so `upperVariable.size()` is still 0 when it is inserted. The five iterations all insert the same empty string, and `std::set` keeps one.

Measured with a standalone reproduction of the old and new bodies:

```
old: 6 entries  ["", all_proxy, ftp_proxy, http_proxy, https_proxy, no_proxy]
     contains HTTP_PROXY? NO    contains empty string? YES
new: 10 entries (five lowercase, five uppercase)
     contains HTTP_PROXY? YES   contains empty string? NO
```

### What it affects

`haveNetworkProxyConnection()` iterates the set minus `no_proxy`/`NO_PROXY`, so it never checks `HTTP_PROXY`. On a host with no non-loopback address whose only route out is a proxy configured under the uppercase spelling, `haveInternet()` (`src/nix/main.cc:56`) therefore returns false. At `main.cc:560` that produces

```
warning: you don't have Internet access; disabling some network-dependent features
```

and then turns off substituters, pins `tarball-ttl` to its maximum, sets file-transfer `tries` to 0 and `connect-timeout` to 1. It also calls `getEnv("")` once per invocation, looking up a variable with an empty name.

`nix-build`/`nix-shell` has the same gap from the other end: `keepVars` at `src/nix/nix-build/nix-build.cc:169` takes the whole set, so the uppercase proxy variables are not carried into the shell environment, and the empty string goes into `keepVars`.

### The fix

Copy first, then transform in place. Four lines.

### How this survived

Nothing flags it. The old code runs to completion with the wrong result and exit status 0, printing no diagnostic, under all four of:

- `-O0`
- `-D_GLIBCXX_ASSERTIONS`
- `-D_GLIBCXX_DEBUG`
- `-fsanitize=address,undefined` (GCC 15.3.0)

I expected at least the last two to catch it and they don't. The reason, offered as reasoning rather than something I measured: the out-of-bounds write lands inside the `std::string`'s own small-string buffer, which is a valid allocation, so there is no bounds violation for a checker to see. The string's stored length stays 0, which is why it prints as empty.

### Testing

There is no libcmd test target — the test subprojects are `libutil-tests`, `libstore-tests`, `libfetchers-tests`, `libexpr-tests`, `libflake-tests` and `nix-functional-tests`. Adding a subproject for this seemed worse than the fix, but I'm happy to add one if you'd prefer the coverage.

Verified by the reproduction above, and `src/libcmd/network-proxy.cc` compiles clean as a translation unit. I ran a negative control (injecting a type error) to confirm that compile check actually fails when it should, rather than passing vacuously.
