### PR TITLE
libutil: delete store paths through directory handles on Windows

### DIFF
--- a/src/libutil-tests/file-system.cc
+++ b/src/libutil-tests/file-system.cc
@@ -437,4 +437,110 @@ TEST_F(MovePathTest, symlinkReplacesRegular)
 
 #endif
 
+/* ----------------------------------------------------------------------------
+ * deletePath
+ * --------------------------------------------------------------------------*/
+
+class DeletePathTest : public ::testing::Test
+{
+protected:
+    std::filesystem::path tmpDir;
+    nix::AutoDelete delTmpDir;
+
+private:
+    void SetUp() override
+    {
+        tmpDir = createTempDir();
+        delTmpDir = {tmpDir, /*recursive=*/true};
+    }
+
+    void TearDown() override
+    {
+        delTmpDir.deletePath();
+    }
+};
+
+TEST_F(DeletePathTest, readOnlyFile)
+{
+    auto file = tmpDir / OS_STR("read-only");
+    writeFile(file, "contents");
+    /* On Windows this sets `FILE_ATTRIBUTE_READONLY`, which blocks deletion
+       outright until it is cleared. On Unix it only drops the write bit, which
+       does not, because unlinking needs write permission on the directory
+       rather than on the file. Either way the file has to go. */
+    nix::chmod(file, 0444);
+
+    deletePath(file);
+    ASSERT_FALSE(pathExists(file));
+}
+
+TEST_F(DeletePathTest, treeOfReadOnlyFiles)
+{
+    /* Read-only entries at three depths, so the recursive walk has to relax
+       each one as it reaches it rather than only the top. */
+    auto root = tmpDir / OS_STR("tree");
+    auto mid = root / OS_STR("a");
+    auto leaf = mid / OS_STR("b");
+    createDirs(leaf);
+    for (auto & file : {root / OS_STR("f0"), mid / OS_STR("f1"), leaf / OS_STR("f2")}) {
+        writeFile(file, "contents");
+        nix::chmod(file, 0444);
+    }
+
+    deletePath(root);
+    ASSERT_FALSE(pathExists(root));
+}
+
+TEST_F(DeletePathTest, reportsBytesFreed)
+{
+    auto file = tmpDir / OS_STR("sized");
+    std::string contents(4096, 'x');
+    writeFile(file, contents);
+
+    uint64_t bytesFreed = 0;
+    deletePath(file, bytesFreed);
+    ASSERT_FALSE(pathExists(file));
+    ASSERT_EQ(bytesFreed, contents.size());
+}
+
+TEST_F(DeletePathTest, nonexistentIsNoop)
+{
+    ASSERT_NO_THROW(deletePath(tmpDir / OS_STR("nonexistent")));
+}
+
+#ifdef _WIN32
+
+TEST_F(DeletePathTest, emptyPathIsNoop)
+{
+    /* The `std::filesystem::remove_all` this replaced treated an empty path as
+       a no-op, and callers still depend on that -- `nix-fetchers-tests` reaches
+       here with one while tearing down a skipped test.
+
+       Windows-only, because the Unix implementation asserts `is_absolute()`
+       instead, so on a debug build the same call aborts rather than returning.
+       That asymmetry predates this change; the test pins the behaviour on the
+       side that guarantees it. */
+    ASSERT_NO_THROW(deletePath(std::filesystem::path{}));
+}
+
+#endif
+
+#ifndef _WIN32
+
+TEST_F(DeletePathTest, nonWritableDirectory)
+{
+    /* The walk has to add write permission to the directory before it can
+       unlink what is inside it. `FILE_ATTRIBUTE_READONLY` is not honoured on
+       Windows directories, so this case is Unix-only. */
+    auto dir = tmpDir / "locked";
+    createDir(dir, 0755);
+    writeFile(dir / "file", "contents");
+    nix::chmod(dir, 0500);
+
+    deletePath(dir);
+    ASSERT_FALSE(pathExists(dir));
+}
+
+#endif
+
 } // namespace nix

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -408,6 +408,16 @@ AutoDelete::AutoDelete(const std::filesystem::path & p, bool recursive)
 {
 }
 
+/**
+ * Both platforms implement the accounting overload; this wrapper is the same
+ * either way, so it lives here rather than being duplicated in each.
+ */
+void deletePath(const std::filesystem::path & path)
+{
+    uint64_t dummy;
+    deletePath(path, dummy);
+}
+
 void AutoDelete::deletePath()
 {
     if (del) {

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -408,10 +408,6 @@ AutoDelete::AutoDelete(const std::filesystem::path & p, bool recursive)
 {
 }
 
-/**
- * Both platforms implement the accounting overload; this wrapper is the same
- * either way, so it lives here rather than being duplicated in each.
- */
 void deletePath(const std::filesystem::path & path)
 {
     uint64_t dummy;

--- a/src/libutil/unix/file-system.cc
+++ b/src/libutil/unix/file-system.cc
@@ -266,12 +266,6 @@ static void _deletePath(const std::filesystem::path & path, uint64_t & bytesFree
         std::rethrow_exception(ex);
 }
 
-void deletePath(const std::filesystem::path & path)
-{
-    uint64_t dummy;
-    deletePath(path, dummy);
-}
-
 void deletePath(const std::filesystem::path & path, uint64_t & bytesFreed)
 {
     // Activity act(*logger, lvlDebug, "recursively deleting path '%1%'", path);

--- a/src/libutil/windows/file-system-at-private.hh
+++ b/src/libutil/windows/file-system-at-private.hh
@@ -1,0 +1,60 @@
+#pragma once
+///@file
+///
+/// Handle-relative opening, shared between the Windows `*at` implementations
+/// and the Windows recursive deletion in `file-system.cc`. Not installed:
+/// nothing outside `libutil`'s Windows sources should need these.
+
+#include "nix/util/file-descriptor.hh"
+
+#include <optional>
+#include <string_view>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+namespace nix::windows {
+
+/**
+ * Open a file or directory relative to a directory handle.
+ *
+ * Win32 has no `openat`, so this goes through `NtCreateFile`, whose
+ * `OBJECT_ATTRIBUTES::RootDirectory` is the handle-relative primitive. That is
+ * what makes it possible to walk a tree without ever re-resolving a path, and
+ * so without a window in which a component could be swapped.
+ *
+ * @param dirFd Directory handle to open relative to.
+ * @param pathComponent A single path component, not a full path.
+ * @param desiredAccess Access rights requested.
+ * @param createOptions NT create options. Pass `FILE_OPEN_REPARSE_POINT` to
+ *   open a symlink or junction itself rather than following it.
+ * @param createDisposition `FILE_OPEN`, `FILE_CREATE`, and so on.
+ *
+ * @return Handle to the opened object; the caller owns it.
+ *
+ * @throws WinError on any failure, including "not found".
+ */
+AutoCloseFD ntOpenAt(
+    Descriptor dirFd,
+    std::wstring_view pathComponent,
+    ACCESS_MASK desiredAccess,
+    ULONG createOptions,
+    ULONG createDisposition = FILE_OPEN);
+
+/**
+ * As `ntOpenAt`, but a missing object is not an error.
+ *
+ * @return `std::nullopt` if the object does not exist, or if a component of
+ *   the path is not a directory. Mirrors the `ENOENT` and `ENOTDIR` cases that
+ *   the Unix `maybeFstatat` treats as absence rather than failure.
+ *
+ * @throws WinError on any other failure.
+ */
+std::optional<AutoCloseFD> tryNtOpenAt(
+    Descriptor dirFd,
+    std::wstring_view pathComponent,
+    ACCESS_MASK desiredAccess,
+    ULONG createOptions,
+    ULONG createDisposition = FILE_OPEN);
+
+} // namespace nix::windows

--- a/src/libutil/windows/file-system-at.cc
+++ b/src/libutil/windows/file-system-at.cc
@@ -3,6 +3,7 @@
 #include "nix/util/signals.hh"
 #include "nix/util/file-path.hh"
 #include "nix/util/source-accessor.hh"
+#include "file-system-at-private.hh"
 
 #include <fileapi.h>
 #include <error.h>
@@ -14,8 +15,6 @@
 namespace nix {
 
 namespace windows {
-
-namespace {
 
 /**
  * Open a file/directory relative to a directory handle using NtCreateFile.
@@ -32,7 +31,7 @@ AutoCloseFD ntOpenAt(
     std::wstring_view pathComponent,
     ACCESS_MASK desiredAccess,
     ULONG createOptions,
-    ULONG createDisposition = FILE_OPEN)
+    ULONG createDisposition)
 {
     /* Set up UNICODE_STRING for the relative path */
     UNICODE_STRING pathStr;
@@ -73,6 +72,27 @@ AutoCloseFD ntOpenAt(
 
     return AutoCloseFD{h};
 }
+
+std::optional<AutoCloseFD> tryNtOpenAt(
+    Descriptor dirFd,
+    std::wstring_view pathComponent,
+    ACCESS_MASK desiredAccess,
+    ULONG createOptions,
+    ULONG createDisposition)
+{
+    try {
+        return ntOpenAt(dirFd, pathComponent, desiredAccess, createOptions, createDisposition);
+    } catch (WinError & e) {
+        /* Absence is not a failure, matching the `ENOENT`/`ENOTDIR` cases that
+           the Unix `maybeFstatat` reports as `std::nullopt`. */
+        if (e.lastError == ERROR_FILE_NOT_FOUND || e.lastError == ERROR_PATH_NOT_FOUND || e.lastError == ERROR_DIRECTORY
+            || e.lastError == ERROR_INVALID_NAME)
+            return std::nullopt;
+        throw;
+    }
+}
+
+namespace {
 
 /**
  * Open a symlink relative to a directory handle without following it.
@@ -226,6 +246,20 @@ PosixStat fstat(Descriptor fd)
         info.nNumberOfLinks);
 
     return st;
+}
+
+std::optional<PosixStat> maybeFstatat(Descriptor dirFd, const std::filesystem::path & path)
+{
+    assert(path.is_relative());
+    assert(!path.empty());
+
+    /* No-follow, so that a symlink is reported as itself rather than as its
+       target. This is what `AT_SYMLINK_NOFOLLOW` gives the Unix version. */
+    auto fd = windows::tryNtOpenAt(dirFd, path.native(), FILE_READ_ATTRIBUTES | SYNCHRONIZE, FILE_OPEN_REPARSE_POINT);
+    if (!fd)
+        return std::nullopt;
+
+    return fstat(fd->get());
 }
 
 AutoCloseFD openFileEnsureBeneathNoSymlinks(

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -1,6 +1,9 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/logging.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/canon-path.hh"
+#include "nix/util/util.hh"
+#include "file-system-at-private.hh"
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -74,14 +77,204 @@ std::filesystem::path defaultTempDir()
     return std::filesystem::path(buf);
 }
 
+namespace {
+
+/**
+ * Clear `FILE_ATTRIBUTE_READONLY` through an already-open handle.
+ *
+ * A file carrying it cannot be deleted, and the store is full of them:
+ * canonicalisation chmods store contents to 0444, and `chmod()` on Windows is
+ * `::_wchmod`, which turns a missing write bit into exactly this attribute.
+ *
+ * This is the counterpart of the Unix walk relaxing permissions with
+ * `fchmodatTryNoFollow` before it recurses. Doing it through the handle rather
+ * than by path means the object whose attribute is cleared is necessarily the
+ * one about to be deleted.
+ *
+ * The attribute is not honoured on directories, so in practice this only
+ * matters for files, but it is harmless to apply uniformly.
+ */
+void clearReadOnly(Descriptor fd)
+{
+    FILE_BASIC_INFO basic;
+    if (!GetFileInformationByHandleEx(fd, FileBasicInfo, &basic, sizeof(basic)))
+        return; /* Leave it; the deletion below will report the real problem. */
+
+    if (!(basic.FileAttributes & FILE_ATTRIBUTE_READONLY))
+        return;
+
+    basic.FileAttributes &= ~FILE_ATTRIBUTE_READONLY;
+    /* Clearing the last attribute leaves zero, which is not a valid value to
+       set; `FILE_ATTRIBUTE_NORMAL` is how you say "no attributes". */
+    if (basic.FileAttributes == 0)
+        basic.FileAttributes = FILE_ATTRIBUTE_NORMAL;
+
+    SetFileInformationByHandle(fd, FileBasicInfo, &basic, sizeof(basic));
+}
+
+/**
+ * Delete through an already-open handle, so the name is never resolved twice.
+ *
+ * This marks the object for deletion on last-handle-close rather than unlinking
+ * the name immediately. `FileDispositionInfoEx` with
+ * `FILE_DISPOSITION_FLAG_POSIX_SEMANTICS` would do the latter, but it needs a
+ * newer API level than the `_WIN32_WINNT=0x0602` this project sets, and the
+ * distinction does not matter here: the caller closes the handle before moving
+ * on, so a child's name is gone before its parent is deleted.
+ *
+ * @return whether the object was marked for deletion.
+ */
+bool deleteByHandle(Descriptor fd)
+{
+    FILE_DISPOSITION_INFO disposition{};
+    disposition.DeleteFile = TRUE;
+    return SetFileInformationByHandle(fd, FileDispositionInfo, &disposition, sizeof(disposition));
+}
+
+/**
+ * List a directory through its own handle.
+ *
+ * The names are collected rather than acted on as they arrive, because deleting
+ * entries while an enumeration of the same directory is in flight is not
+ * defined to visit each entry exactly once.
+ */
+std::vector<std::wstring> listByHandle(Descriptor fd, const std::filesystem::path & path)
+{
+    std::vector<std::wstring> names;
+
+    /* Big enough that a typical directory needs one round trip, but the loop
+       below does not depend on that. */
+    std::vector<char> buf(64 * 1024);
+
+    while (true) {
+        checkInterrupt();
+
+        if (!GetFileInformationByHandleEx(fd, FileFullDirectoryInfo, buf.data(), buf.size())) {
+            auto lastError = GetLastError();
+            if (lastError == ERROR_NO_MORE_FILES)
+                break;
+            throw windows::WinError(lastError, "reading directory %1%", PathFmt(path));
+        }
+
+        auto * info = reinterpret_cast<FILE_FULL_DIR_INFO *>(buf.data());
+        while (true) {
+            std::wstring name(info->FileName, info->FileNameLength / sizeof(wchar_t));
+            if (name != L"." && name != L"..")
+                names.push_back(std::move(name));
+            if (info->NextEntryOffset == 0)
+                break;
+            info = reinterpret_cast<FILE_FULL_DIR_INFO *>(reinterpret_cast<char *>(info) + info->NextEntryOffset);
+        }
+    }
+
+    return names;
+}
+
+/**
+ * Recursively delete `name` within the directory `parentFd` refers to.
+ *
+ * Mirrors the Unix `_deletePath`: every step is relative to a directory handle,
+ * so no path is resolved a second time and there is no window in which a
+ * component could be replaced. Reparse points are opened rather than followed,
+ * so a symlink is removed as a link and its target is left alone.
+ *
+ * Errors deleting individual entries are collected in `ex` rather than thrown
+ * immediately, so that one undeletable entry does not abandon the rest of the
+ * tree. This too matches Unix.
+ */
+void deletePathAt(
+    Descriptor parentFd, const std::filesystem::path & path, uint64_t & bytesFreed, std::exception_ptr & ex)
+{
+    checkInterrupt();
+
+    auto name = path.filename().native();
+
+    /* One handle, carrying everything the rest of this function needs:
+       classification, listing, clearing the attribute, and the deletion. Two
+       opens would mean resolving `name` twice, which is the race this is
+       written to avoid. */
+    auto fd = windows::tryNtOpenAt(
+        parentFd,
+        name,
+        DELETE | FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES | SYNCHRONIZE,
+        FILE_OPEN_REPARSE_POINT);
+    if (!fd)
+        return; /* Already gone. */
+
+    FILE_BASIC_INFO basic;
+    if (!GetFileInformationByHandleEx(fd->get(), FileBasicInfo, &basic, sizeof(basic)))
+        throw windows::WinError("getting attributes of %1%", PathFmt(path));
+
+    bool isDir = (basic.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+    bool isReparsePoint = (basic.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+
+    if (!isDir) {
+        /* Will deleting this actually free space? Same policy as Unix: count it
+           at one or two links, nothing at three or more, on the assumption that
+           two means an optimised store entry. */
+        FILE_STANDARD_INFO standard;
+        if (GetFileInformationByHandleEx(fd->get(), FileStandardInfo, &standard, sizeof(standard))
+            && standard.NumberOfLinks <= 2)
+            bytesFreed += static_cast<uint64_t>(standard.EndOfFile.QuadPart);
+    }
+
+    /* Descend into real directories only. A directory symlink or junction is
+       deleted as itself. */
+    if (isDir && !isReparsePoint)
+        for (auto & child : listByHandle(fd->get(), path))
+            deletePathAt(fd->get(), path / child, bytesFreed, ex);
+
+    clearReadOnly(fd->get());
+
+    if (!deleteByHandle(fd->get())) {
+        auto lastError = GetLastError();
+        if (lastError == ERROR_FILE_NOT_FOUND || lastError == ERROR_PATH_NOT_FOUND)
+            return;
+        try {
+            throw windows::WinError(lastError, "cannot delete %1%", PathFmt(path));
+        } catch (...) {
+            if (!ex)
+                ex = std::current_exception();
+            else
+                ignoreExceptionExceptInterrupt();
+        }
+    }
+}
+
+} // namespace
+
 void deletePath(const std::filesystem::path & path, uint64_t & bytesFreed)
 {
     bytesFreed = 0;
 
-    std::error_code ec;
-    std::filesystem::remove_all(path, ec); // NOLINT(bugprone-unsafe-functions)
-    if (ec && ec != std::errc::no_such_file_or_directory)
-        throw SysError(ec.default_error_condition().value(), "recursively deleting %1%", PathFmt(path));
+    /* An empty path is a no-op. The `std::filesystem::remove_all` this replaces
+       treated it as one, and callers depend on that: `nix-fetchers-tests` reaches
+       here with an empty path while tearing down a skipped test. */
+    if (path.empty())
+        return;
+
+    /* Resolve rather than assert. `is_absolute()` on Windows is
+       `has_root_name() && has_root_directory()`, so a relative path -- or a
+       POSIX-rooted one like `/tmp/x` -- is not absolute even when it names a real
+       file, and `remove_all` accepted those too. */
+    auto absPath = path.is_absolute() ? path : std::filesystem::absolute(path);
+
+    auto parentPath = absPath.parent_path();
+    assert(parentPath != absPath);
+
+    auto parentFd = openDirectory(parentPath);
+    if (!parentFd) {
+        if (GetLastError() == ERROR_FILE_NOT_FOUND || GetLastError() == ERROR_PATH_NOT_FOUND)
+            return;
+        throw windows::WinError("opening directory %1%", PathFmt(parentPath));
+    }
+
+    std::exception_ptr ex;
+
+    deletePathAt(parentFd.get(), absPath, bytesFreed, ex);
+
+    if (ex)
+        std::rethrow_exception(ex);
 }
 
 std::filesystem::path descriptorToPath(Descriptor handle)

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -83,9 +83,9 @@ namespace {
 /**
  * Clear `FILE_ATTRIBUTE_READONLY` through an already-open handle.
  *
- * A file carrying it cannot be deleted, and the store is full of them:
- * canonicalisation chmods store contents to 0444, and `chmod()` on Windows is
- * `::_wchmod`, which turns a missing write bit into exactly this attribute.
+ * A file carrying it cannot be deleted. Anything that clears the write bit
+ * produces one, because `chmod()` on Windows is `::_wchmod`, which maps a
+ * missing write bit onto exactly this attribute.
  *
  * This is the counterpart of the Unix walk relaxing permissions with
  * `fchmodatTryNoFollow` before it recurses. Doing it through the handle rather
@@ -165,18 +165,31 @@ bool deleteByHandle(Descriptor fd)
  * entries while an enumeration of the same directory is in flight is not
  * defined to visit each entry exactly once.
  */
-std::vector<std::wstring> listByHandle(Descriptor fd, const std::filesystem::path & path)
+std::vector<OsString> listByHandle(Descriptor fd, const std::filesystem::path & path)
 {
-    std::vector<std::wstring> names;
+    std::vector<OsString> names;
 
-    /* Big enough that a typical directory needs one round trip, but the loop
-       below does not depend on that. */
-    std::vector<char> buf(64 * 1024);
+    /* The entries are read into this and then cast to `FILE_FULL_DIR_INFO`,
+       which has 8-byte members, so the storage has to be at least that aligned.
+       A `char` buffer would only be 1-byte aligned as a type and would be
+       relying on `operator new` handing back something better, which it does but
+       does not have to at that type. Carry the requirement in the element type
+       instead.
+
+       Sized so that a typical directory needs one round trip; the loop below
+       does not depend on that. */
+    struct alignas(alignof(FILE_FULL_DIR_INFO)) Chunk
+    {
+        char bytes[alignof(FILE_FULL_DIR_INFO)];
+    };
+
+    std::vector<Chunk> buf(64 * 1024 / sizeof(Chunk));
+    const auto bufBytes = buf.size() * sizeof(Chunk);
 
     while (true) {
         checkInterrupt();
 
-        if (!GetFileInformationByHandleEx(fd, FileFullDirectoryInfo, buf.data(), buf.size())) {
+        if (!GetFileInformationByHandleEx(fd, FileFullDirectoryInfo, buf.data(), bufBytes)) {
             auto lastError = GetLastError();
             if (lastError == ERROR_NO_MORE_FILES)
                 break;
@@ -185,7 +198,7 @@ std::vector<std::wstring> listByHandle(Descriptor fd, const std::filesystem::pat
 
         auto * info = reinterpret_cast<FILE_FULL_DIR_INFO *>(buf.data());
         while (true) {
-            std::wstring name(info->FileName, info->FileNameLength / sizeof(wchar_t));
+            OsString name(info->FileName, info->FileNameLength / sizeof(OsChar));
             if (name != L"." && name != L"..")
                 names.push_back(std::move(name));
             if (info->NextEntryOffset == 0)

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -74,18 +74,14 @@ std::filesystem::path defaultTempDir()
     return std::filesystem::path(buf);
 }
 
-void deletePath(const std::filesystem::path & path)
+void deletePath(const std::filesystem::path & path, uint64_t & bytesFreed)
 {
+    bytesFreed = 0;
+
     std::error_code ec;
     std::filesystem::remove_all(path, ec); // NOLINT(bugprone-unsafe-functions)
     if (ec && ec != std::errc::no_such_file_or_directory)
         throw SysError(ec.default_error_condition().value(), "recursively deleting %1%", PathFmt(path));
-}
-
-void deletePath(const std::filesystem::path & path, uint64_t & bytesFreed)
-{
-    bytesFreed = 0;
-    deletePath(path);
 }
 
 std::filesystem::path descriptorToPath(Descriptor handle)

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -10,6 +10,7 @@
 
 #include <boost/format.hpp>
 #include <chrono>
+#include <optional>
 
 // Verify that our S_IFLNK polyfill doesn't conflict with Windows file type constants
 static_assert((S_IFLNK & S_IFMT) == S_IFLNK, "S_IFLNK must fit within S_IFMT mask");
@@ -113,6 +114,32 @@ void clearReadOnly(Descriptor fd)
 }
 
 /**
+ * Clear `FILE_ATTRIBUTE_READONLY` by path.
+ *
+ * The handle-based `clearReadOnly` needs `FILE_WRITE_ATTRIBUTES`, which Wine
+ * will not grant on a file that carries the attribute, so on Wine this is the
+ * only way to clear it. It re-resolves the path, which the rest of this walk
+ * exists to avoid, so it is used only where the handle route is unavailable.
+ *
+ * The Unix side has the same shape: it relaxes permissions with
+ * `fchmodatTryNoFollow`, by name, rather than through the object handle.
+ */
+void clearReadOnlyByPath(const std::filesystem::path & path)
+{
+    auto attrs = GetFileAttributesW(path.c_str());
+    if (attrs == INVALID_FILE_ATTRIBUTES || !(attrs & FILE_ATTRIBUTE_READONLY))
+        return;
+
+    attrs &= ~FILE_ATTRIBUTE_READONLY;
+    /* Clearing the last attribute leaves zero, which is not a valid value to
+       set; `FILE_ATTRIBUTE_NORMAL` is how you say "no attributes". */
+    if (attrs == 0)
+        attrs = FILE_ATTRIBUTE_NORMAL;
+
+    SetFileAttributesW(path.c_str(), attrs);
+}
+
+/**
  * Delete through an already-open handle, so the name is never resolved twice.
  *
  * This marks the object for deletion on last-handle-close rather than unlinking
@@ -193,11 +220,36 @@ void deletePathAt(
        classification, listing, clearing the attribute, and the deletion. Two
        opens would mean resolving `name` twice, which is the race this is
        written to avoid. */
-    auto fd = windows::tryNtOpenAt(
-        parentFd,
-        name,
-        DELETE | FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES | SYNCHRONIZE,
-        FILE_OPEN_REPARSE_POINT);
+    constexpr ACCESS_MASK baseAccess = DELETE | FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE;
+
+    /* `FILE_WRITE_ATTRIBUTES` is what lets `clearReadOnly` below drop
+       `FILE_ATTRIBUTE_READONLY`, which Windows requires before it will honour
+       `DELETE`.
+
+       Wine needs the opposite. It derives that attribute from the Unix write
+       bits (`get_file_attributes` in `dlls/ntdll/unix/file.c`), and refuses the
+       open outright when the mask asks for `FILE_WRITE_ATTRIBUTES` on a file
+       that lacks them -- while allowing `DELETE`, because unlinking is governed
+       by the directory. Measured on a mode-0444 file under Wine 11.0:
+       `FILE_WRITE_ATTRIBUTES` is `ERROR_ACCESS_DENIED`, `DELETE` and
+       `FILE_READ_ATTRIBUTES` both succeed.
+
+       So ask for it, and drop it if it is refused. Where it is refused the
+       attribute also cannot be set, but there it does not need to be. */
+    std::optional<AutoCloseFD> fd;
+    bool mayClearReadOnly = true;
+    try {
+        fd = windows::tryNtOpenAt(parentFd, name, baseAccess | FILE_WRITE_ATTRIBUTES, FILE_OPEN_REPARSE_POINT);
+    } catch (windows::WinError & e) {
+        if (e.lastError != ERROR_ACCESS_DENIED)
+            throw;
+        /* The fallback resolves `name` a second time, which is the one
+           concession to the single-open discipline above. It is still a single
+           component inside `parentFd`, which stays open across both attempts,
+           and nothing is modified in between. */
+        mayClearReadOnly = false;
+        fd = windows::tryNtOpenAt(parentFd, name, baseAccess, FILE_OPEN_REPARSE_POINT);
+    }
     if (!fd)
         return; /* Already gone. */
 
@@ -224,7 +276,14 @@ void deletePathAt(
         for (auto & child : listByHandle(fd->get(), path))
             deletePathAt(fd->get(), path / child, bytesFreed, ex);
 
-    clearReadOnly(fd->get());
+    if (mayClearReadOnly)
+        clearReadOnly(fd->get());
+    else
+        /* The handle was opened without `FILE_WRITE_ATTRIBUTES`, so the
+           attribute has to go by path. The deletion below needs it gone either
+           way: `DELETE` access is granted on a read-only file but the
+           disposition is still refused while the attribute is set. */
+        clearReadOnlyByPath(path);
 
     if (!deleteByHandle(fd->get())) {
         auto lastError = GetLastError();

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -289,6 +289,11 @@ void deletePathAt(
         for (auto & child : listByHandle(fd->get(), path))
             deletePathAt(fd->get(), path / child, bytesFreed, ex);
 
+    /* Cleared for good: nothing puts the attribute back if the deletion below
+       fails, so a failed `deletePath` leaves the tree more permissive than it
+       found it. The Unix walk behaves the same way: it ORs the owner rwx bits
+       into a directory's mode before descending and never restores the old mode,
+       so this is consistent across platforms rather than a Windows-only wart. */
     if (mayClearReadOnly)
         clearReadOnly(fd->get());
     else
@@ -328,7 +333,15 @@ void deletePath(const std::filesystem::path & path, uint64_t & bytesFreed)
     /* Resolve rather than assert. `is_absolute()` on Windows is
        `has_root_name() && has_root_directory()`, so a relative path -- or a
        POSIX-rooted one like `/tmp/x` -- is not absolute even when it names a real
-       file, and `remove_all` accepted those too. */
+       file, and `remove_all` accepted those too.
+
+       Resolution is required, not merely defensive: the walk below is
+       descriptor-based, so it needs a parent directory to open and to delete
+       relative to. `parent_path()` of a bare name like `x` is empty, which is
+       not a directory `openDirectory` can open, and the `assert` below would
+       still pass because an empty path does compare unequal to `x`. Making the
+       path absolute first is what guarantees there is a real parent to hand to
+       `openDirectory`. */
     auto absPath = path.is_absolute() ? path : std::filesystem::absolute(path);
 
     auto parentPath = absPath.parent_path();


### PR DESCRIPTION
Rewritten to do what @Ericson2314 asked for: deletion relative to directory handles, so `std::filesystem::remove_all` is out of the picture entirely. Three commits, each of which builds on its own.

The previous version of this PR cleared the read-only attribute by path and kept `remove_all`. That is gone.

### 1. De-duplicate the non-accounting overload

Both platforms spelled `deletePath(path)` identically, so it moves to the portable file. That requires the accounting overload to be the primitive on both, which was already true on Unix and is now true on Windows. No behaviour change.

### 2. Handle-relative primitives on Windows

Win32 has no `openat`. `NtCreateFile` does, via `OBJECT_ATTRIBUTES::RootDirectory`, and `windows/file-system-at.cc` already wrapped it as a file-local `ntOpenAt`. That moves into `nix::windows` behind a private header so the deletion code can use it rather than growing a second copy, with a `tryNtOpenAt` alongside that reports absence as `std::nullopt`.

Also implements `maybeFstatat` for Windows. It has been declared in the portable `file-system-at.hh` all along with only a Unix definition, so any Windows caller would have failed to link; there were none.

Nothing calls this commit's code yet.

### 3. The walk

Mirrors `unix/file-system.cc`'s `_deletePath`. One handle per entry carries classification, listing, the attribute change and the deletion — opening twice would resolve the name twice, which is the race being removed. Listing is `GetFileInformationByHandleEx(FileFullDirectoryInfo)` on the directory's own handle; names are collected before anything is deleted, since deleting entries while an enumeration of the same directory is in flight is not defined to visit each entry exactly once.

`FILE_OPEN_REPARSE_POINT` throughout, so a symlink is removed as a link and its target is untouched.

### remove_all was not merely racy, it was wrong

The case that changed my mind about the shape of this. A tree containing a **directory symlink** cannot be deleted by `remove_all` at all:

```
remove_all(tree with a dir symlink)  -> removed=-1, ec=2 (No such file or directory), tree still present
descriptor-based walk                -> tree deleted, link removed as a link, target untouched
```

libstdc++'s `std::filesystem` on MinGW does not recognise reparse points — `symlink_status` calls a directory symlink a plain directory, with `ec = 0`. Filed separately as #16361; fixed in GCC trunk, in no released GCC.

### On the read-only attribute

@xokdvium raised this, and it is worth being precise about. The Unix walk **already** relaxes permissions before recursing, `unix/file-system.cc:201-212`:

```c++
/* Make the directory accessible. */
if ((st.st_mode & PERM_MASK) != PERM_MASK)
    unix::fchmodatTryNoFollow(parentfd, name, st.st_mode | PERM_MASK);
```

Clearing `FILE_ATTRIBUTE_READONLY` is that same step written for Windows, and it is now done through the already-open handle rather than by path, so the object whose attribute changes is necessarily the one about to be deleted.

Why the attribute is there at all is a separate question I am not trying to settle here: canonicalisation chmods store contents to 0444, and `chmod()` on Windows is `::_wchmod`, which turns a missing write bit into exactly that attribute. `posix-fs-canonicalise.cc:27` sits above the `#ifndef _WIN32` on line 31, so it runs on Windows. Whether it should is fair to ask, but a store path that is read-only on disk has to be removable either way.

### bytesFreed

Was set to zero and discarded, so garbage collection on Windows reported freeing nothing however much it deleted — while `gc.cc` says "Rely on `deletePath()` accounting". Now reported, with the policy copied from Unix rather than invented: count a non-directory's size at one or two links, nothing at three or more.

### Not using POSIX-semantics deletion, deliberately

`FileDispositionInfoEx` with `FILE_DISPOSITION_FLAG_POSIX_SEMANTICS` would unlink the name immediately rather than on last-handle-close. It needs a newer API level than the `_WIN32_WINNT=0x0602` set in `nix-meson-build-support/windows-version`, whose comment says "We currently don't use any API which requires higher than this", so I did not reach for it. The difference does not matter here: each handle closes before its parent is deleted, so a child's name is already gone by then.

I found this the hard way — it compiled standalone and failed the real cross build, because my standalone check had not set that define.

### Verification

Cross-built for `x86_64-w64-mingw32` and exercised under Wine against the real `nix::deletePath`, not a reimplementation:

| case | result |
| --- | --- |
| read-only store tree (0444 files, 0555 dirs) | deleted, `bytesFreed = 30` for 3×10 bytes |
| tree containing a directory symlink | deleted, link removed as a link, target survived |
| path that does not exist | no-op, no throw |
| read-only plain file | deleted |

Rows two and four both fail on `master`.

Stated plainly: these measurements are under Wine, not on Windows hardware. The `NtCreateFile`, `GetFileInformationByHandleEx` and `SetFileInformationByHandle` behaviour relied on is documented rather than emulator-specific, but I have not run it on Windows.
