### PR TITLE
ci: name the DLL when static initializers throw on Windows

### DIFF
--- a/ci/gha/tests/windows.nix
+++ b/ci/gha/tests/windows.nix
@@ -7,6 +7,49 @@
 let
   packages = nixFlake.packages.${system};
 
+  /*
+    Name the DLL whose static initializers threw.
+
+    When a C++ exception escapes a DLL's static initializers, Wine's loader
+    catches it in `MODULE_InitDLL` and the process dies having printed nothing
+    at all, with an exit status that says nothing about the cause. Wine's own
+    `err:module:loader_init ... failed to initialize` message, which would name
+    the module, does not appear either. So there is nothing for a reader to act
+    on.
+
+    The information is still recoverable from a loader trace: the culprit is
+    the DLL whose `PROCESS_ATTACH` is entered and never returns. `CALL` lines
+    carry the base address and the module name, `RETURN` lines carry only the
+    base, so pairing them by base identifies it.
+
+    Uses only bash builtins, so it needs no extra build input.
+  */
+  reportFailedDllInit = ''
+    reportFailedDllInit() {
+      local log="$1" base found=0
+      local -A names=() returned=()
+
+      while IFS= read -r line; do
+        if [[ $line =~ MODULE_InitDLL\ \(([0-9A-F]+)\ L\"([^\"]+)\",PROCESS_ATTACH ]]; then
+          names[''${BASH_REMATCH[1]}]=''${BASH_REMATCH[2]}
+        elif [[ $line =~ MODULE_InitDLL\ \(([0-9A-F]+),PROCESS_ATTACH.*-\ RETURN ]]; then
+          returned[''${BASH_REMATCH[1]}]=1
+        fi
+      done < "$log"
+
+      for base in "''${!names[@]}"; do
+        if [[ -z ''${returned[$base]:-} ]]; then
+          echo "error: ''${names[$base]} failed to initialize: its static initializers were entered and never returned."
+          found=1
+        fi
+      done
+
+      if (( ! found )); then
+        echo "note: every DLL finished initializing, so this failure is not a static-initializer fault."
+      fi
+    }
+  '';
+
   fixOutput =
     test:
     test.overrideAttrs (prev: {
@@ -16,8 +59,51 @@ let
       # hide/show sequences, making logs unreadable in GitHub Actions.
       buildCommand = ''
         set -o pipefail
-        {
+
+        ${reportFailedDllInit}
+
+        runTests() {
           ${prev.buildCommand}
+        }
+
+        # `set -e` aborting at the failing test command is what makes the build
+        # fail, so the run must not sit anywhere that suppresses it -- not an
+        # `if` condition, not the left of `||`, and not a subshell reached
+        # through either, since the suppression is inherited. That rules out
+        # checking its status directly. Hook ERR instead, which stdenv leaves
+        # unset, and leave its EXIT handler (`exitHandler`) alone.
+        diagnoseWineFailure() {
+          local rc=$?
+
+          # ERR can fire both in the pipeline's subshell and in the shell that
+          # owns the pipeline, which would repeat the report and, worse, repeat
+          # the traced re-run. A file guard settles it whichever fires first,
+          # since a subshell cannot report back through a variable.
+          local guard="''${NIX_BUILD_TOP:-$PWD}/.wine-failure-diagnosed"
+          [[ -e $guard ]] && return 0
+          : > "$guard"
+
+          echo "---"
+          echo "The test run failed with status $rc."
+          echo "If nothing was reported above, a DLL's static initializers may have thrown:"
+          echo "Wine's loader absorbs that and prints nothing. See NixOS/nix#16356."
+          echo "Re-running under a loader trace to identify the module."
+
+          local traceLog="''${NIX_BUILD_TOP:-$PWD}/wine-module-trace.log"
+
+          # This run's exit status is deliberately not consulted. It sits on the
+          # left of `||`, so `set -e` is suppressed inside it and it would
+          # report success whatever happens. The trace is the point.
+          ( export WINEDEBUG=+module
+            runTests
+          ) > "$traceLog" 2>&1 || true
+
+          reportFailedDllInit "$traceLog"
+        }
+        trap diagnoseWineFailure ERR
+
+        {
+          runTests
         } 2>&1 | ansi2txt
       '';
     });


### PR DESCRIPTION
Closes the practical half of #16356: when a Windows test binary dies during static initialization, CI now names the DLL responsible instead of printing nothing.

**This is not the change #16356 suggested, and the reason matters.** That issue proposed moving the emulator to a Wine carrying the fix for WineHQ bug 59850, and flagged the suggestion as untested. I have now tested it and it does not work — details in the last section. So this takes a different route to the same goal.

### The problem

When a C++ exception escapes a DLL's static initializers, Wine's loader catches it in `MODULE_InitDLL`. The process dies having printed nothing whatsoever, with an exit status that carries no information. Wine's own `err:module:loader_init ... failed to initialize` message, which would name the module, does not appear either.

This is not hypothetical. Four of the five unit-test suites currently die this way when cross-compiled, which is why only `nix-util-tests` is wired into `ci/gha/tests/windows.nix`. Anyone trying to enable the others meets a silent exit 5.

### What this does

The information survives in a loader trace: the failing DLL is the one whose `PROCESS_ATTACH` is entered and never returns. `CALL` lines carry the base address and the module name, `RETURN` lines carry only the base, so pairing them by base identifies it.

On a test failure, the harness re-runs under `WINEDEBUG=+module` and reports that name. A full trace is far too verbose to keep in a passing build's log, so it is only produced once something has already gone wrong.

Bash builtins only, so no new build input.

### Two details that are easy to get wrong

**The run has to stay somewhere `set -e` can abort at it.** That abort is what turns a failing test binary into a failing build. Putting the run in an `if` condition, or on the left of `||`, suppresses `set -e` — and the suppression is inherited by subshells, so execution continues past the failing `wine` line to the trailing `touch $out` and the build reports **success having run zero tests**. An earlier draft of this patch did exactly that, and I only caught it because the store suite came out green with no test output.

So the status cannot be inspected directly. This uses an ERR trap: stdenv leaves `ERR` unset, while `EXIT` is already taken by its own `exitHandler`, which must not be clobbered.

**ERR can fire twice** — once in the pipeline's subshell and once in the shell owning the pipeline — which would repeat both the report and the expensive re-run. A file guard rather than a variable settles it, since a subshell cannot report back through a variable.

### Verification

Both paths were built and run with a MinGW cross-build under Wine.

Success path, the suite CI runs today:

```
RC=0
[  PASSED  ] 782 tests.
[  SKIPPED ] 8 tests
diagnostic occurrences: 0
```

Failure path, pointed at `nix-store-tests` (which currently dies during static initialization). The build still fails, with the status unchanged, and reports the module:

```
RC=1
The test run failed with status 5.
Re-running under a loader trace to identify the module.
error: libnixstore-2.36.0.dll failed to initialize: its static initializers were entered and never returned.
...
Reason: builder failed with exit code 5.
```

Exactly one report and one re-run. `libnixstore-2.36.0.dll` is precisely the name Wine declines to give.

`nixfmt` leaves the file byte-identical, and the generated shell passes `bash -n`.

The store suite is **not** added to `windows.nix` here — it was only used to exercise the failure path. Enabling the remaining suites is a separate question, tracked in #16360.

### Why the Wine bump does not work

Recorded because #16356 recommends it and someone may otherwise act on it.

`wineWow64Packages.unstable` at a nixpkgs revision giving Wine **11.15** produces output **byte-identical** to the pinned 11.0 for this failure: same exit 5, same 358 bytes, same three `err:seh` lines, and still no `err:module:loader_init`. Addresses differ only by per-run ASLR.

11.15 does contain the fix — `dlls/ntdll/signal_x86_64.c` in the source nixpkgs builds has the `last_frame` bound at lines 778-781, which is what the bug-59850 commit introduces. So the fix is present and the diagnostic is still absent.

**Correction (edited after the fact).** The paragraph that stood here said 59850 was *not* the condition being hit, on the grounds that the unwind had a non-null `end_frame`. That was wrong: I had read an earlier `RtlUnwindEx` line rather than the fatal one. The fatal unwind is `flags=7 end_frame=0000000000000000`, which is exactly 59850's condition, so the attribution in #16356 was right.

What is true is that 59850's fix is **not sufficient**. On 11.15, which carries it, the fixed TEB-frame walk does engage -- `calling TEB handler` goes from 1 to 2 -- and the outcome is unchanged: no `err:module:loader_init`, the same two `invalid frame` errors, the same exit 5. A ~20-line reproducer isolates it: a DLL static-initializer throw is reported correctly (exit 67, DLL named) until the throwing frame has a cleanup landing pad, at which point it goes silent on both 11.0 and 11.15. So there is a residual Wine defect beyond 59850.

Worth adding that the channel swap could not have taken effect anyway: `inputs.nixpkgs` tracks the `nixos-26.05` release channel, where `stable`, `unstable` and `staging` are 11.0, 11.8 and 11.8 today — all below 11.13 — and release branches do not take Wine version bumps.

