### PR TITLE
libstore: warn instead of dying when SSL_CERT_FILE is not absolute

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -5,6 +5,7 @@
 #include "nix/util/finally.hh"
 #include "nix/util/callback.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/logging.hh"
 #include "nix/util/util.hh"
 
 #include "nix/store/s3-url.hh"
@@ -101,15 +102,33 @@ void FileTransferSettings::anchor() {}
 
 FileTransferSettings::FileTransferSettings()
 {
-    std::optional<AbsolutePath> sslOverride =
-        getEnvOs(OS_STR("NIX_SSL_CERT_FILE"))
-            .or_else([] { return getEnvOs(OS_STR("SSL_CERT_FILE")); })
-            .and_then([](OsString s) -> std::optional<OsString> {
-                return s.empty() ? std::nullopt : std::optional{std::move(s)};
-            })
-            .transform([](OsString s) { return AbsolutePath{std::filesystem::path{std::move(s)}}; });
-    if (sslOverride)
-        caFile = *sslOverride;
+    /* This runs during static initialization, where an escaping exception
+       cannot be reported: on Unix it reaches `std::terminate` before `main`,
+       and on Windows the loader absorbs it and the process dies having printed
+       nothing at all (see #16356). `AbsolutePath` rejects a non-absolute value
+       by throwing, and the value comes from the environment, so it can be
+       invalid. Warn and carry on rather than dying undiagnosably. */
+    try {
+        std::optional<AbsolutePath> sslOverride =
+            getEnvOs(OS_STR("NIX_SSL_CERT_FILE"))
+                .or_else([] { return getEnvOs(OS_STR("SSL_CERT_FILE")); })
+                .and_then([](OsString s) -> std::optional<OsString> {
+                    return s.empty() ? std::nullopt : std::optional{std::move(s)};
+                })
+                .transform([](OsString s) { return AbsolutePath{std::filesystem::path{std::move(s)}}; });
+        if (sslOverride)
+            caFile = *sslOverride;
+    } catch (Error & e) {
+        e.addTrace(
+            {},
+            "while applying the 'NIX_SSL_CERT_FILE' or 'SSL_CERT_FILE' environment variable; "
+            "ignoring it for now, but this may become an error again in the future");
+        logWarning(e.info());
+    } catch (...) {
+        /* Nothing at all may escape a static initializer, so this is a
+           backstop for anything that is not an `Error`. */
+        ignoreExceptionExceptInterrupt();
+    }
 }
 
 FileTransferSettings fileTransferSettings;


### PR DESCRIPTION
`FileTransferSettings`'s constructor runs during static initialization, and `AbsolutePath` rejects a
non-absolute value by throwing. The value comes from the environment, so it can be invalid, and an
exception escaping a static initializer cannot be reported: on Unix it reaches `std::terminate` before
`main`, and on Windows the loader absorbs it and the process dies having printed nothing at all
(#16356).

With `SSL_CERT_FILE` set to a non-absolute path:

```
master:
  terminate called after throwing an instance of 'nix::Error'
    what():  error: not an absolute path: "relative/x"

this branch:
  warning:
           … while applying the 'NIX_SSL_CERT_FILE' or 'SSL_CERT_FILE' environment variable; ignoring it for now, but this may become an error again in the future
           warning: not an absolute path: "relative/x"
  nix (Nix) 2.36.0pre...
```

The initialization stays where it is. The body is wrapped, a trace is added, and the warning carries
the error's own info via `logWarning(e.info())`, matching `local-store.cc`, `store-api.cc` and
`store-registration.cc`. The trace says the value is ignored for now and that this may become an error
again in the future.

A `catch (...)` backstop sits alongside it, because nothing at all may escape a static initializer,
not merely nothing of type `Error`.

Verified: native and cross (`x86_64-w64-mingw32`) both compile, and the before/after above is measured
rather than described. Note that both `NIX_SSL_CERT_FILE` and `SSL_CERT_FILE` have to be set to
reproduce it — the code consults the former first, and many environments already set it to a valid
path.
