### PR TITLE
build: enable big COFF objects for all Windows targets

### DIFF
--- a/nix-meson-build-support/big-objs/meson.build
+++ b/nix-meson-build-support/big-objs/meson.build
@@ -1,6 +1,0 @@
-if host_machine.system() == 'windows'
-  # libexpr's primops creates a large object
-  # Without the following flag, we'll get errors when cross-compiling to mingw32:
-  # Fatal error: can't write 66 bytes to section .text of src/libexpr/libnixexpr.dll.p/primops.cc.obj: 'file too big'
-  add_project_arguments([ '-Wa,-mbig-obj' ], language : 'cpp')
-endif

--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -14,6 +14,13 @@ if host_machine.system() == 'cygwin'
   )
 endif
 
+if host_machine.system() == 'windows'
+  # A unity build, or a single large file like libexpr's primops.cc, can exceed
+  # the COFF section limit:
+  #   Fatal error: can't write 16 bytes to section .text of ...: 'file too big'
+  add_project_arguments([ '-Wa,-mbig-obj' ], language : 'cpp')
+endif
+
 warning_flags = [
   '-Wdeprecated-copy',
   '-Werror=suggest-override',

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -26,7 +26,6 @@ deps_public_maybe_subproject = [
   dependency('nix-fetchers'),
 ]
 subdir('nix-meson-build-support/subprojects')
-subdir('nix-meson-build-support/big-objs')
 
 # Check for each of these functions, and create a define like `#define HAVE_SYSCONF 1`.
 check_funcs = [


### PR DESCRIPTION
`nix-store-tests` cannot be cross-compiled for `x86_64-w64-mingw32` at all on master. The unity build
puts the whole suite into one object and the mingw assembler refuses it:

```
x86_64-w64-mingw32-as: nix-store-tests.exe.p/meson-generated_nix-store-tests-unity0.cpp.obj: too many sections (32814)
Fatal error: can't write 16 bytes to section .text of nix-store-tests.exe.p/meson-generated_nix-store-tests-unity0.cpp.obj: 'file too big'
```

The fix already exists in the tree. `nix-meson-build-support/big-objs` adds `-Wa,-mbig-obj` on
Windows, and its comment describes exactly this failure — but only `src/libexpr` includes it, added
for `primops.cc`. This includes it wherever `windows-version` already is, so it applies to every
target rather than only the one that happened to need it first. One line per file, 22 files; the
fragment is already a no-op off Windows.

Reported as #16366; this is @xokdvium's suggestion there ("instead of nuking unity we can
unconditionally enable large objects for all targets") rather than mine, which was to disable unity
for that target. Theirs is better: it keeps the unity build, and it avoids picking a `unity_size`
threshold that the suite would grow past again.

### Verified

Built from this branch with no overrides:

| target | before | after |
| --- | --- | --- |
| `nix-store-tests-x86_64-w64-mingw32` | fails, too many sections | **builds** |
| `nix-util-tests-x86_64-w64-mingw32` | builds | builds |
| `nix-cli-x86_64-w64-mingw32` | builds | builds |
| `nix-store-tests` (native) | builds | builds |

The native build is the check that matters for regressions, since this touches 22 `meson.build` files
and the flag must stay Windows-only.

For what it unblocks: with this plus #16364, `nix-store-tests.exe` runs under Wine for the first time
— 784 tests, 745 passing, 31 skipped, 8 failing. All 8 pass natively at the same revision, and all 8
are the POSIX-versus-host path-model question (#16365).
