### PR TITLE
ci: cross-build all Windows components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,9 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         dogfood: ${{ github.event_name == 'workflow_dispatch' && inputs.dogfood || github.event_name != 'workflow_dispatch' }}
-    - name: Run Windows unit tests
+    - name: Build and test Windows components
       run: |
-        nix build --file ci/gha/tests/windows.nix unitTests.nix-util-tests -L
+        nix build --file ci/gha/tests/windows.nix crossBuild unitTests.nix-util-tests -L
 
   installer_test:
     needs: [tests]

--- a/ci/gha/tests/windows.nix
+++ b/ci/gha/tests/windows.nix
@@ -27,4 +27,7 @@ in
   unitTests = {
     "nix-util-tests" = fixOutput packages."nix-util-tests-x86_64-w64-mingw32".passthru.tests.run;
   };
+
+  # `unitTests` builds one suite, which links neither libmain nor libstore.
+  crossBuild = packages."nix-everything-x86_64-w64-mingw32";
 }


### PR DESCRIPTION
The `windows unit tests` job builds one suite:

```yaml
nix build --file ci/gha/tests/windows.nix unitTests.nix-util-tests -L
```

`nix-util-tests` links neither libmain nor libstore, so a change can break the Windows build outright
while that job stays green.

That is what happened to me. A `Pid` comparison valid only on Unix left
`nix build .#nix-main-x86_64-w64-mingw32` failing to compile for days, behind 15 green checks
including the Windows one:

```
src/libmain/shared.cc:419: error: no match for 'operator!=' (operand types are 'nix::Pid' and 'int')
```

I only found it by merging my open PRs and building the result. A reviewer would not have seen it, and
neither did CI.

This adds `crossBuild`, which is `nix-everything-x86_64-w64-mingw32`, and builds it in the same job
before the unit tests. No emulator is involved and it cannot be flaky — it either compiles or it does
not — so it is the cheapest useful signal available for this target.

### Verified

From a clone of this branch, running the new step exactly as the workflow does:

```
$ nix eval  --file ci/gha/tests/windows.nix crossBuild.name
"nix-x86_64-w64-mingw32-2.36.0pre20260826_52e5994"
$ nix build --file ci/gha/tests/windows.nix crossBuild -L
(exit 0)
```

`actionlint` against master as the control: 2 findings before, 2 findings after, the same two
pre-existing shellcheck notes (one shifts from line 299 to 302 because of the three added lines). No
new findings.

### Two notes

The job keeps its existing `continue-on-error: true`. Whether a deterministic compile check for this
target should be allowed to block is a separate decision, and I did not want to bundle it.

This touches `ci/gha/tests/windows.nix`, which #16362 also touches. They do not conflict — that PR
adds helpers inside the `let` block, this adds an attribute to the trailing set — and I checked with a
trial merge.

Relates to #16360, which is about this job's coverage more broadly.
