### PR TITLE
Move `OutputChecks` out of `DerivationOptions`

### DIFF
--- a/src/libstore-tests/derivation/advanced-attrs.cc
+++ b/src/libstore-tests/derivation/advanced-attrs.cc
@@ -189,7 +189,7 @@ using ExportReferencesMap = decltype(DerivationOptions<SingleDerivedPath>::expor
 
 static const DerivationOptions<SingleDerivedPath> advancedAttributes_defaults = {
     .outputChecks =
-        DerivationOptions<SingleDerivedPath>::OutputChecks{
+        derivation::OutputChecks<SingleDerivedPath>{
             .ignoreSelfRefs = true,
         },
     .unsafeDiscardReferences = {},
@@ -237,7 +237,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes)
 {
     DerivationOptions<SingleDerivedPath> expected = {
         .outputChecks =
-            DerivationOptions<SingleDerivedPath>::OutputChecks{
+            derivation::OutputChecks<SingleDerivedPath>{
                 .ignoreSelfRefs = true,
             },
         .unsafeDiscardReferences = {},
@@ -262,7 +262,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes)
         EXPECT_TRUE(!got.structuredAttrs);
 
         // Reset fields that vary between test cases to enable whole-object comparison
-        options.outputChecks = DerivationOptions<SingleDerivedPath>::OutputChecks{.ignoreSelfRefs = true};
+        options.outputChecks = derivation::OutputChecks<SingleDerivedPath>{.ignoreSelfRefs = true};
         options.exportReferencesGraph = {};
 
         EXPECT_EQ(options, expected);
@@ -274,7 +274,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes)
 
 DerivationOptions<SingleDerivedPath> advancedAttributes_ia = {
     .outputChecks =
-        DerivationOptions<SingleDerivedPath>::OutputChecks{
+        derivation::OutputChecks<SingleDerivedPath>{
             .ignoreSelfRefs = true,
             .allowedReferences = std::set<DrvRef<SingleDerivedPath>>{pathFoo},
             .disallowedReferences = std::set<DrvRef<SingleDerivedPath>>{pathBar, OutputName{"dev"}},
@@ -304,7 +304,7 @@ TEST_F(DerivationAdvancedAttrsTest, advancedAttributes_ia)
 
 DerivationOptions<SingleDerivedPath> advancedAttributes_ca = {
     .outputChecks =
-        DerivationOptions<SingleDerivedPath>::OutputChecks{
+        derivation::OutputChecks<SingleDerivedPath>{
             .ignoreSelfRefs = true,
             .allowedReferences = std::set<DrvRef<SingleDerivedPath>>{placeholderFoo},
             .disallowedReferences = std::set<DrvRef<SingleDerivedPath>>{placeholderBar, OutputName{"dev"}},
@@ -333,7 +333,7 @@ TEST_F(CaDerivationAdvancedAttrsTest, advancedAttributes)
 };
 
 DerivationOptions<SingleDerivedPath> advancedAttributes_structuredAttrs_defaults = {
-    .outputChecks = std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks, std::less<>>{},
+    .outputChecks = std::map<std::string, derivation::OutputChecks<SingleDerivedPath>, std::less<>>{},
     .unsafeDiscardReferences = {},
     .passAsFile = {},
     .exportReferencesGraph = {},
@@ -379,9 +379,9 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs)
 {
     DerivationOptions<SingleDerivedPath> expected = {
         .outputChecks =
-            std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks, std::less<>>{
+            std::map<std::string, derivation::OutputChecks<SingleDerivedPath>, std::less<>>{
                 {"dev",
-                 DerivationOptions<SingleDerivedPath>::OutputChecks{
+                 derivation::OutputChecks<SingleDerivedPath>{
                      .maxSize = 789,
                      .maxClosureSize = 5909,
                  }},
@@ -412,7 +412,7 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs)
         {
             // Delete all keys but "dev" in options.outputChecks
             auto * outputChecksMapP =
-                std::get_if<std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks, std::less<>>>(
+                std::get_if<std::map<std::string, derivation::OutputChecks<SingleDerivedPath>, std::less<>>>(
                     &options.outputChecks);
             ASSERT_TRUE(outputChecksMapP);
             auto & outputChecksMap = *outputChecksMapP;
@@ -433,19 +433,19 @@ TYPED_TEST(DerivationAdvancedAttrsBothTest, advancedAttributes_structuredAttrs)
 
 DerivationOptions<SingleDerivedPath> advancedAttributes_structuredAttrs_ia = {
     .outputChecks =
-        std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks, std::less<>>{
+        std::map<std::string, derivation::OutputChecks<SingleDerivedPath>, std::less<>>{
             {"out",
-             DerivationOptions<SingleDerivedPath>::OutputChecks{
+             derivation::OutputChecks<SingleDerivedPath>{
                  .allowedReferences = std::set<DrvRef<SingleDerivedPath>>{pathFoo},
                  .allowedRequisites = std::set<DrvRef<SingleDerivedPath>>{pathFooDev, OutputName{"bin"}},
              }},
             {"bin",
-             DerivationOptions<SingleDerivedPath>::OutputChecks{
+             derivation::OutputChecks<SingleDerivedPath>{
                  .disallowedReferences = std::set<DrvRef<SingleDerivedPath>>{pathBar, OutputName{"dev"}},
                  .disallowedRequisites = std::set<DrvRef<SingleDerivedPath>>{pathBarDev},
              }},
             {"dev",
-             DerivationOptions<SingleDerivedPath>::OutputChecks{
+             derivation::OutputChecks<SingleDerivedPath>{
                  .maxSize = 789,
                  .maxClosureSize = 5909,
              }},
@@ -475,19 +475,19 @@ TEST_F(DerivationAdvancedAttrsTest, advancedAttributes_structuredAttrs)
 
 DerivationOptions<SingleDerivedPath> advancedAttributes_structuredAttrs_ca = {
     .outputChecks =
-        std::map<std::string, DerivationOptions<SingleDerivedPath>::OutputChecks, std::less<>>{
+        std::map<std::string, derivation::OutputChecks<SingleDerivedPath>, std::less<>>{
             {"out",
-             DerivationOptions<SingleDerivedPath>::OutputChecks{
+             derivation::OutputChecks<SingleDerivedPath>{
                  .allowedReferences = std::set<DrvRef<SingleDerivedPath>>{placeholderFoo},
                  .allowedRequisites = std::set<DrvRef<SingleDerivedPath>>{placeholderFooDev, OutputName{"bin"}},
              }},
             {"bin",
-             DerivationOptions<SingleDerivedPath>::OutputChecks{
+             derivation::OutputChecks<SingleDerivedPath>{
                  .disallowedReferences = std::set<DrvRef<SingleDerivedPath>>{placeholderBar, OutputName{"dev"}},
                  .disallowedRequisites = std::set<DrvRef<SingleDerivedPath>>{placeholderBarDev},
              }},
             {"dev",
-             DerivationOptions<SingleDerivedPath>::OutputChecks{
+             derivation::OutputChecks<SingleDerivedPath>{
                  .maxSize = 789,
                  .maxClosureSize = 5909,
              }},
@@ -545,7 +545,7 @@ static const StorePath spFoo{"p0hax2lzvjpfc2gwkk62xdglz0fcqfzn-foo"},
 
 static const DerivationOptions<StorePath> advancedAttributes_sp_defaults = {
     .outputChecks =
-        DerivationOptions<StorePath>::OutputChecks{
+        derivation::OutputChecks<StorePath>{
             .ignoreSelfRefs = true,
         },
     .unsafeDiscardReferences = {},
@@ -563,7 +563,7 @@ static const DerivationOptions<StorePath> advancedAttributes_sp_defaults = {
 
 static const DerivationOptions<StorePath> advancedAttributes_sp_all_set = {
     .outputChecks =
-        DerivationOptions<StorePath>::OutputChecks{
+        derivation::OutputChecks<StorePath>{
             .ignoreSelfRefs = true,
             .allowedReferences = std::set<DrvRef<StorePath>>{spFoo},
             .disallowedReferences = std::set<DrvRef<StorePath>>{spBar, OutputName{"dev"}},
@@ -587,7 +587,7 @@ static const DerivationOptions<StorePath> advancedAttributes_sp_all_set = {
 };
 
 static const DerivationOptions<StorePath> advancedAttributes_sp_structuredAttrs_defaults = {
-    .outputChecks = std::map<std::string, DerivationOptions<StorePath>::OutputChecks, std::less<>>{},
+    .outputChecks = std::map<std::string, derivation::OutputChecks<StorePath>, std::less<>>{},
     .unsafeDiscardReferences = {},
     .passAsFile = {},
     .exportReferencesGraph = {},
@@ -603,19 +603,19 @@ static const DerivationOptions<StorePath> advancedAttributes_sp_structuredAttrs_
 
 static const DerivationOptions<StorePath> advancedAttributes_sp_structuredAttrs_all_set = {
     .outputChecks =
-        std::map<std::string, DerivationOptions<StorePath>::OutputChecks, std::less<>>{
+        std::map<std::string, derivation::OutputChecks<StorePath>, std::less<>>{
             {"out",
-             DerivationOptions<StorePath>::OutputChecks{
+             derivation::OutputChecks<StorePath>{
                  .allowedReferences = std::set<DrvRef<StorePath>>{spFoo},
                  .allowedRequisites = std::set<DrvRef<StorePath>>{spFooDev, OutputName{"bin"}},
              }},
             {"bin",
-             DerivationOptions<StorePath>::OutputChecks{
+             derivation::OutputChecks<StorePath>{
                  .disallowedReferences = std::set<DrvRef<StorePath>>{spBar, OutputName{"dev"}},
                  .disallowedRequisites = std::set<DrvRef<StorePath>>{spBarDev},
              }},
             {"dev",
-             DerivationOptions<StorePath>::OutputChecks{
+             derivation::OutputChecks<StorePath>{
                  .maxSize = 789,
                  .maxClosureSize = 5909,
              }},

--- a/src/libstore/build/derivation-check.cc
+++ b/src/libstore/build/derivation-check.cc
@@ -150,7 +150,7 @@ void checkOutputs(
             return std::make_pair(std::move(pathsDone), closureSize);
         };
 
-        auto applyChecks = [&](const DerivationOptions<StorePath>::OutputChecks & checks) {
+        auto applyChecks = [&](const derivation::OutputChecks<StorePath> & checks) {
             if (checks.maxSize && info.narSize > *checks.maxSize)
                 throw BuildError(
                     BuildResult::Failure::OutputRejected,
@@ -248,9 +248,8 @@ void checkOutputs(
 
         std::visit(
             overloaded{
-                [&](const DerivationOptions<StorePath>::OutputChecks & checks) { applyChecks(checks); },
-                [&](const std::map<std::string, DerivationOptions<StorePath>::OutputChecks, std::less<>> &
-                        checksPerOutput) {
+                [&](const derivation::OutputChecks<StorePath> & checks) { applyChecks(checks); },
+                [&](const std::map<std::string, derivation::OutputChecks<StorePath>, std::less<>> & checksPerOutput) {
                     if (auto outputChecks = get(checksPerOutput, outputName))
 
                         applyChecks(*outputChecks);

--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -69,11 +69,8 @@ getStringSetAttr(const StringMap & env, const StructuredAttrs * parsed, const st
 }
 
 template<typename Inputs>
-using OutputChecks = DerivationOptions<Inputs>::OutputChecks;
-
-template<typename Inputs>
-using OutputChecksVariant =
-    std::variant<OutputChecks<Inputs>, std::map<std::string, OutputChecks<Inputs>, std::less<>>>;
+using OutputChecksVariant = std::
+    variant<derivation::OutputChecks<Inputs>, std::map<std::string, derivation::OutputChecks<Inputs>, std::less<>>>;
 
 DerivationOptions<StorePath> derivationOptionsFromStructuredAttrs(
     const StoreDirConfig & store,
@@ -122,6 +119,8 @@ DerivationOptions<SingleDerivedPath> derivationOptionsFromStructuredAttrs(
     bool shouldWarn,
     const ExperimentalFeatureSettings & mockXpSettings)
 {
+    using namespace derivation;
+
     DerivationOptions<SingleDerivedPath> defaults = {};
 
     std::map<std::string, SingleDerivedPath::Built, std::less<>> placeholders;
@@ -410,8 +409,8 @@ std::optional<Options<StorePath>> tryResolve(
     };
 
     // Helper function to try resolving OutputChecks using functional style
-    auto tryResolveOutputChecks = [&](const Options<SingleDerivedPath>::OutputChecks & checks)
-        -> std::optional<Options<StorePath>::OutputChecks> {
+    auto tryResolveOutputChecks =
+        [&](const OutputChecks<SingleDerivedPath> & checks) -> std::optional<OutputChecks<StorePath>> {
         std::optional<std::set<DrvRef<StorePath>>> resolvedAllowedReferences;
         if (checks.allowedReferences) {
             resolvedAllowedReferences = tryResolveRefSet(*checks.allowedReferences);
@@ -434,7 +433,7 @@ std::optional<Options<StorePath>> tryResolve(
         if (!resolvedDisallowedRequisites)
             return std::nullopt;
 
-        return Options<StorePath>::OutputChecks{
+        return OutputChecks<StorePath>{
             .ignoreSelfRefs = checks.ignoreSelfRefs,
             .maxSize = checks.maxSize,
             .maxClosureSize = checks.maxClosureSize,
@@ -466,31 +465,31 @@ std::optional<Options<StorePath>> tryResolve(
     // Resolve outputChecks using functional style with std::visit
     auto resolvedOutputChecks = std::visit(
         overloaded{
-            [&](const Options<SingleDerivedPath>::OutputChecks & checks)
+            [&](const OutputChecks<SingleDerivedPath> & checks)
                 -> std::optional<std::variant<
-                    Options<StorePath>::OutputChecks,
-                    std::map<std::string, Options<StorePath>::OutputChecks, std::less<>>>> {
+                    OutputChecks<StorePath>,
+                    std::map<std::string, OutputChecks<StorePath>, std::less<>>>> {
                 auto resolved = tryResolveOutputChecks(checks);
                 if (!resolved)
                     return std::nullopt;
-                return std::variant<
-                    Options<StorePath>::OutputChecks,
-                    std::map<std::string, Options<StorePath>::OutputChecks, std::less<>>>(*resolved);
+                return std::
+                    variant<OutputChecks<StorePath>, std::map<std::string, OutputChecks<StorePath>, std::less<>>>(
+                        *resolved);
             },
-            [&](const std::map<std::string, Options<SingleDerivedPath>::OutputChecks, std::less<>> & checksMap)
+            [&](const std::map<std::string, OutputChecks<SingleDerivedPath>, std::less<>> & checksMap)
                 -> std::optional<std::variant<
-                    Options<StorePath>::OutputChecks,
-                    std::map<std::string, Options<StorePath>::OutputChecks, std::less<>>>> {
-                std::map<std::string, Options<StorePath>::OutputChecks, std::less<>> resolvedMap;
+                    OutputChecks<StorePath>,
+                    std::map<std::string, OutputChecks<StorePath>, std::less<>>>> {
+                std::map<std::string, OutputChecks<StorePath>, std::less<>> resolvedMap;
                 for (const auto & [outputName, checks] : checksMap) {
                     auto resolved = tryResolveOutputChecks(checks);
                     if (!resolved)
                         return std::nullopt;
                     resolvedMap.emplace(outputName, *resolved);
                 }
-                return std::variant<
-                    Options<StorePath>::OutputChecks,
-                    std::map<std::string, Options<StorePath>::OutputChecks, std::less<>>>(resolvedMap);
+                return std::
+                    variant<OutputChecks<StorePath>, std::map<std::string, OutputChecks<StorePath>, std::less<>>>(
+                        resolvedMap);
             }},
         drvOptions.outputChecks);
 
@@ -532,6 +531,7 @@ template<typename Inputs>
 static nix::DerivationOptions<Inputs> derivationOptionsFromJson(const nlohmann::json & json_)
 {
     using namespace nix;
+    using namespace derivation;
 
     auto & json = getObject(json_);
 
@@ -571,6 +571,7 @@ template<typename Inputs>
 static void derivationOptionsToJson(nlohmann::json & json, const nix::DerivationOptions<Inputs> & o)
 {
     using namespace nix;
+    using namespace derivation;
 
     json["outputChecks"] = std::visit(
         overloaded{
@@ -603,7 +604,7 @@ static void derivationOptionsToJson(nlohmann::json & json, const nix::Derivation
 }
 
 template<typename Inputs>
-static nix::OutputChecks<Inputs> outputChecksFromJson(const nlohmann::json & json_)
+static nix::derivation::OutputChecks<Inputs> outputChecksFromJson(const nlohmann::json & json_)
 {
     using namespace nix;
 
@@ -621,7 +622,7 @@ static nix::OutputChecks<Inputs> outputChecksFromJson(const nlohmann::json & jso
 }
 
 template<typename Inputs>
-static void outputChecksToJson(nlohmann::json & json, const nix::OutputChecks<Inputs> & c)
+static void outputChecksToJson(nlohmann::json & json, const nix::derivation::OutputChecks<Inputs> & c)
 {
     json["ignoreSelfRefs"] = c.ignoreSelfRefs;
     json["maxSize"] = c.maxSize;
@@ -656,25 +657,26 @@ void adl_serializer<nix::DerivationOptions<nix::StorePath>>::to_json(
     derivationOptionsToJson<nix::StorePath>(json, o);
 }
 
-nix::OutputChecks<nix::SingleDerivedPath>
-adl_serializer<nix::OutputChecks<nix::SingleDerivedPath>>::from_json(const json & json_)
+nix::derivation::OutputChecks<nix::SingleDerivedPath>
+adl_serializer<nix::derivation::OutputChecks<nix::SingleDerivedPath>>::from_json(const json & json_)
 {
     return outputChecksFromJson<nix::SingleDerivedPath>(json_);
 }
 
-void adl_serializer<nix::OutputChecks<nix::SingleDerivedPath>>::to_json(
-    json & json, const nix::OutputChecks<nix::SingleDerivedPath> & c)
+void adl_serializer<nix::derivation::OutputChecks<nix::SingleDerivedPath>>::to_json(
+    json & json, const nix::derivation::OutputChecks<nix::SingleDerivedPath> & c)
 {
     outputChecksToJson<nix::SingleDerivedPath>(json, c);
 }
 
-nix::OutputChecks<nix::StorePath> adl_serializer<nix::OutputChecks<nix::StorePath>>::from_json(const json & json_)
+nix::derivation::OutputChecks<nix::StorePath>
+adl_serializer<nix::derivation::OutputChecks<nix::StorePath>>::from_json(const json & json_)
 {
     return outputChecksFromJson<nix::StorePath>(json_);
 }
 
-void adl_serializer<nix::OutputChecks<nix::StorePath>>::to_json(
-    json & json, const nix::OutputChecks<nix::StorePath> & c)
+void adl_serializer<nix::derivation::OutputChecks<nix::StorePath>>::to_json(
+    json & json, const nix::derivation::OutputChecks<nix::StorePath> & c)
 {
     outputChecksToJson<nix::StorePath>(json, c);
 }

--- a/src/libstore/derivation/json.cc
+++ b/src/libstore/derivation/json.cc
@@ -138,7 +138,8 @@ static void inputsToJson(json & res, const nix::derivation::FullInputs & inputs)
 
 static void inputsToJson(json & res, const std::set<nix::SingleDerivedPath> & inputs)
 {
-    inputsToJson(res, nix::derivation::FullInputs::fromSet(inputs));
+    using namespace nix::derivation;
+    inputsToJson(res, FullInputs::fromSet(inputs));
 }
 
 template<typename Inputs>
@@ -187,9 +188,10 @@ nix::derivation::FullInputs inputsFromJson<nix::derivation::FullInputs>(
     const json & inputsJson, const nix::ExperimentalFeatureSettings & xpSettings)
 {
     using namespace nix;
+    using namespace derivation;
 
     auto inputsObj = getObject(inputsJson);
-    derivation::FullInputs inputs;
+    FullInputs inputs;
 
     try {
         for (auto & input : getArray(valueAt(inputsObj, "srcs")))
@@ -225,7 +227,8 @@ template<>
 std::set<nix::SingleDerivedPath> inputsFromJson<std::set<nix::SingleDerivedPath>>(
     const json & inputsJson, const nix::ExperimentalFeatureSettings & xpSettings)
 {
-    return inputsFromJson<nix::derivation::FullInputs>(inputsJson, xpSettings).toSet();
+    using namespace nix::derivation;
+    return inputsFromJson<FullInputs>(inputsJson, xpSettings).toSet();
 }
 
 template<typename Inputs>
@@ -233,6 +236,7 @@ nix::derivation::Derivation<Inputs> adl_serializer<nix::derivation::Derivation<I
     const json & _json, const nix::ExperimentalFeatureSettings & xpSettings)
 {
     using namespace nix;
+    using namespace derivation;
 
     auto & json = getObject(_json);
     {
@@ -247,7 +251,7 @@ nix::derivation::Derivation<Inputs> adl_serializer<nix::derivation::Derivation<I
     return derivation::Derivation<Inputs>{
         .outputs =
             [&] {
-                derivation::Outputs<> outputs;
+                Outputs<> outputs;
                 try {
                     for (auto & [outputName, output] : getObject(valueAt(json, "outputs")))
                         outputs.insert_or_assign(

--- a/src/libstore/include/nix/store/derivation-options.hh
+++ b/src/libstore/include/nix/store/derivation-options.hh
@@ -30,6 +30,51 @@ struct StructuredAttrs;
 template<typename V>
 struct DerivedPathMap;
 
+namespace derivation {
+
+template<typename Input>
+struct OutputChecks
+{
+    bool ignoreSelfRefs = false;
+    std::optional<uint64_t> maxSize, maxClosureSize;
+
+    using DrvRef = nix::DrvRef<Input>;
+
+    /**
+     * env: allowedReferences
+     *
+     * A value of `nullopt` indicates that the check is skipped.
+     * This means that all references are allowed.
+     */
+    std::optional<std::set<DrvRef>> allowedReferences;
+
+    /**
+     * env: disallowedReferences
+     *
+     * No needed for `std::optional`, because skipping the check is
+     * the same as disallowing the references.
+     */
+    std::set<DrvRef> disallowedReferences;
+
+    /**
+     * env: allowedRequisites
+     *
+     * See `allowedReferences`
+     */
+    std::optional<std::set<DrvRef>> allowedRequisites;
+
+    /**
+     * env: disallowedRequisites
+     *
+     * See `disallowedReferences`
+     */
+    std::set<DrvRef> disallowedRequisites;
+
+    bool operator==(const OutputChecks &) const = default;
+};
+
+} // namespace derivation
+
 /**
  * This represents all the special options on a `Derivation`.
  *
@@ -52,51 +97,12 @@ namespace derivation {
 template<typename Input>
 struct Options
 {
-    struct OutputChecks
-    {
-        bool ignoreSelfRefs = false;
-        std::optional<uint64_t> maxSize, maxClosureSize;
-
-        using DrvRef = nix::DrvRef<Input>;
-
-        /**
-         * env: allowedReferences
-         *
-         * A value of `nullopt` indicates that the check is skipped.
-         * This means that all references are allowed.
-         */
-        std::optional<std::set<DrvRef>> allowedReferences;
-
-        /**
-         * env: disallowedReferences
-         *
-         * No needed for `std::optional`, because skipping the check is
-         * the same as disallowing the references.
-         */
-        std::set<DrvRef> disallowedReferences;
-
-        /**
-         * env: allowedRequisites
-         *
-         * See `allowedReferences`
-         */
-        std::optional<std::set<DrvRef>> allowedRequisites;
-
-        /**
-         * env: disallowedRequisites
-         *
-         * See `disallowedReferences`
-         */
-        std::set<DrvRef> disallowedRequisites;
-
-        bool operator==(const OutputChecks &) const = default;
-    };
-
     /**
      * Either one set of checks for all outputs, or separate checks
      * per-output.
      */
-    std::variant<OutputChecks, std::map<std::string, OutputChecks, std::less<>>> outputChecks = OutputChecks{};
+    std::variant<derivation::OutputChecks<Input>, std::map<std::string, derivation::OutputChecks<Input>, std::less<>>>
+        outputChecks = derivation::OutputChecks<Input>{};
 
     /**
      * Whether to avoid scanning for references for a given output.
@@ -255,5 +261,5 @@ std::optional<Options<StorePath>> tryResolve(
 
 JSON_IMPL(nix::DerivationOptions<nix::StorePath>);
 JSON_IMPL(nix::DerivationOptions<nix::SingleDerivedPath>);
-JSON_IMPL(nix::DerivationOptions<nix::StorePath>::OutputChecks)
-JSON_IMPL(nix::DerivationOptions<nix::SingleDerivedPath>::OutputChecks)
+JSON_IMPL(nix::derivation::OutputChecks<nix::StorePath>)
+JSON_IMPL(nix::derivation::OutputChecks<nix::SingleDerivedPath>)


### PR DESCRIPTION
Instead, it is in the new `nix::derivation` namespace.

This commit is the purest of refactors --- absolutely nothing is changed by identifiers and definition membership. But this churn now will reduce churn in a future commit.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
