### PR TITLE
Fix nix-functional-tests build in container

### DIFF
--- a/tests/functional/common/vars.sh
+++ b/tests/functional/common/vars.sh
@@ -75,7 +75,7 @@ export IMPURE_VAR2=bar
 # shellcheck disable=SC2034
 cacheDir=$TEST_ROOT/binary-cache
 
-if [[ $(uname) == Linux ]] && [[ -L /proc/self/ns/user ]] && unshare --user true; then
+if [[ $(uname) == Linux ]] && [[ -L /proc/self/ns/user ]] && unshare --user --mount-proc true; then
     _canUseSandbox=1
 fi
 


### PR DESCRIPTION
Skip functional sandbox tests when proc cannot be remounted.

Building nix-functional-tests currently fails in a container because `nix` has a stricter check for sandboxing than the tests. The C++ mountAndPidNamespacesSupported check errors if proc cannot be remounted, but the test check for _canUseSandbox does not check that condition.

Tighten the check in tests to more closely mirror the C++ check mountAndPidNamespacesSupported.

Claude suggests tightening the check even more to more closely mirror the behavior of mountAndPidNamespacesSupported, but I opted for the more minimal change that would unblock my builds.
Claude suggests `--fork --user --pid --mount-proc`

Reproducer:
> podman run --rm -it docker.io/nixos/nix
bash-5.3# nix build --extra-experimental-features "nix-command flakes" github:NixOS/nix#nix-functional-tests error: Cannot build '/nix/store/f39w8gzm2l7j9h48pdwbw8snfh55bgrp-nix-functional-tests-2.36.0pre20260826_46bc30b.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/i074zxb5zjgg69ricdh7rlqs2kkhwwya-nix-functional-tests-2.36.0pre20260826_46bc30b
       Last 25 log lines:
       >  14/221 main - nix-functional-tests:build-remote-trustless-should-pass-3    FAIL            0.19s   exit status 1
       >  16/221 main - nix-functional-tests:build-remote-trustless-should-pass-1    FAIL            0.27s   exit status 1
       >  20/221 main - nix-functional-tests:chroot-store                            FAIL            0.60s   exit status 1
       >  26/221 main - nix-functional-tests:build                                   FAIL            1.49s   exit status 1
       >  72/221 main - nix-functional-tests:linux-sandbox                           FAIL            0.34s   exit status 1
       >  80/221 main - nix-functional-tests:nested-sandboxing                       FAIL            0.44s   exit status 1
       > 115/221 main - nix-functional-tests:shell                                   FAIL            1.91s   exit status 1
       > 121/221 main - nix-functional-tests:supplementary-groups                    FAIL            0.57s   exit status 1
       > 148/221 ca - nix-functional-tests:new-build-cmd                             FAIL            1.14s   exit status 1
       > 206/221 local-overlay-store - nix-functional-tests:check-post-init          FAIL            0.26s   exit status 1
       > 207/221 local-overlay-store - nix-functional-tests:redundant-add            FAIL            0.25s   exit status 1
       > 210/221 local-overlay-store - nix-functional-tests:build                    FAIL            0.21s   exit status 1
       > 211/221 local-overlay-store - nix-functional-tests:add-lower                FAIL            0.20s   exit status 1
       > 213/221 local-overlay-store - nix-functional-tests:delete-refs              FAIL            0.20s   exit status 1
       > 214/221 local-overlay-store - nix-functional-tests:delete-duplicate         FAIL            0.21s   exit status 1
       > 215/221 local-overlay-store - nix-functional-tests:gc                       FAIL            0.20s   exit status 1
       > 216/221 local-overlay-store - nix-functional-tests:verify                   FAIL            0.21s   exit status 1
       > 217/221 local-overlay-store - nix-functional-tests:optimise                 FAIL            0.20s   exit status 1
       > 218/221 local-overlay-store - nix-functional-tests:stale-file-handle        FAIL            0.23s   exit status 1
       >
       > Ok:                188
       > Fail:              25
       > Skipped:           8
       >
       > Full log written to /nix/var/nix/builds/nix-2-738763327/source/tests/functional/build/meson-logs/testlog.txt
       For full logs, run:
         nix log /nix/store/f39w8gzm2l7j9h48pdwbw8snfh55bgrp-nix-functional-tests-2.36.0pre20260826_46bc30b.drv

With this patch:
> podman run --rm -it docker.io/nixos/nix
bash-5.3# nix build --extra-experimental-features "nix-command flakes" github:flox/nix/fix-container-build#nix-functional-tests bash-5.3#