### PR TITLE
doc: Document the derivation ATerm format

### DIFF
--- a/doc/manual/source/protocols/derivation-aterm.md
+++ b/doc/manual/source/protocols/derivation-aterm.md
@@ -4,6 +4,8 @@ For historical reasons, [store derivations][store derivation] are stored on-disk
 ([guide](https://homepages.cwi.nl/~daybuild/daily-books/technology/aterm-guide/aterm-guide.html),
 [paper](https://doi.org/10.1002/(SICI)1097-024X(200003)30:3%3C259::AID-SPE298%3E3.0.CO;2-Y)).
 
+Only a small fragment of ATerm is used: the constructors below, string literals, lists, and tuples.
+
 ## The ATerm format used
 
 Derivations are serialised in one of the following formats:
@@ -22,6 +24,203 @@ Derivations are serialised in one of the following formats:
 
   - `"xp-dyn-drv"` for the [`dynamic-derivations`](@docroot@/development/experimental-features.md#xp-feature-dynamic-derivations) experimental feature.
 
+## Grammar
+
+```ebnf
+derivation = "Derive(" fields ")"
+           | "DrvWithVersion(" version "," fields ")" ;
+
+fields = outputs "," input-drvs "," input-srcs ","
+         platform "," builder "," args "," env ;
+
+outputs    = "[" [ output { "," output } ] "]" ;
+output     = "(" output-name "," output-path "," hash-algo "," hash ")" ;
+
+input-drvs = "[" [ input-drv { "," input-drv } ] "]" ;
+input-drv  = "(" drv-path "," input-drv-node ")" ;
+
+input-srcs = "[" [ store-path { "," store-path } ] "]" ;
+
+builder    = string ;
+args       = "[" [ string { "," string } ] "]" ;
+
+env        = "[" [ env-entry { "," env-entry } ] "]" ;
+env-entry  = "(" string "," string ")" ;
+```
+
+The leaves are all double-quoted, but fall into two kinds.
+
+```ebnf
+(* may contain escape sequences *)
+string      = '"' { char | escape } '"' ;
+
+(* drawn from restricted alphabets, so never escaped *)
+verbatim    = '"' { char } '"' ;
+
+(* Not an alternation but a parameter of the grammar: the store
+   directory fixes which one holds, for the whole file at once.
+   See the note below. *)
+store-path  = ? verbatim under a Unix store directory,
+                string under a Windows one ? ;
+
+drv-path    = store-path ; (* a store path whose name ends in ".drv" *)
+output-path = store-path | '""' ;
+output-name = verbatim ;
+platform    = verbatim ;
+version     = verbatim ;
+
+hash-algo     = '"' [ method-prefix ] algorithm '"' | '""' ;
+method-prefix = "r:" | "text:" | "git:" ;      (* flat has none *)
+algorithm     = "blake3" | "md5" | "sha1" | "sha256" | "sha512" ;
+
+hash        = '"' hex-digit { hex-digit } '"' | '""' | '"impure"' ;
+```
+
+A `store-path` is a [store path](@docroot@/protocols/store-path.md) written in full, store directory included.
+
+Note that the derivation *name* does not appear anywhere.
+It is taken from the store path of the derivation, and so must be supplied out-of-band; see below.
+
+> **Note**
+>
+> `store-path` is the one leaf that is not pinned down by the grammar, and the reason is the store directory.
+> A Unix one, `/nix/store`, happens to hold no character the format escapes, so the path can be written verbatim.
+> A Windows one does: `C:\ProgramData\nix\store` contains backslashes, which must be escaped, making the leaf a `string`:
+>
+> ```
+> "C:\\ProgramData\\nix\\store/ib3sh3pcz10wsmavxvkdbayhqivbghlq-foo"
+> ```
+>
+> Only the store directory is affected; the `/` separating it from the rest of the path is a forward slash either way.
+> Nothing else moves: `output-name`, `platform`, `version` and the two hash fields are drawn from alphabets that never need escaping, whichever store directory is in use.
+>
+> This is a mode, not a choice made afresh at each store path: one of the two holds throughout a given file, and every store path in it is written that way.
+> The mode is not recorded in the file and cannot be recovered from the bytes — a verbatim path is also a well-formed `string` — so it has to be supplied out of band, like the derivation name.
+> Nix takes it from the store it is reading or writing for, defaulting to the platform it was built for, and then holds the parser to it: under a Unix store directory a store path carrying an escape is *rejected* rather than accepted as a second spelling of the same path.
+> That is what keeps the encoding [canonical](#canonical-form) in either case.
+
+### Strings
+
+Every leaf above is a double-quoted string.
+Within one, `"` and `\` are escaped with a backslash, and newline, carriage return, and tab are written `\n`, `\r`, and `\t`.
+Those five are the only escapes there are, and each of those five characters is only ever written escaped; see [canonical form](#canonical-form).
+
+Fields drawn from restricted alphabets — output names, the platform, and the hash fields — cannot contain any of them, and so are written verbatim.
+Store paths are written verbatim too, unless the store directory itself needs escaping; see the note above.
+
+### Outputs
+
+Which sort of output is meant is not tagged; it is inferred from which of the three fields are empty.
+
+| `output-path` | `hash-algo` | `hash` | output |
+| --- | --- | --- | --- |
+| set | empty | empty | [input-addressed](@docroot@/store/derivation/outputs/input-address.md) |
+| empty | empty | empty | [deferred input-addressed](@docroot@/store/derivation/outputs/input-address.md#deferred) |
+| set | set | set | [fixed-output content-addressed](@docroot@/store/derivation/outputs/content-address.md#fixed) |
+| empty | set | empty | [floating content-addressed](@docroot@/store/derivation/outputs/content-address.md#floating) |
+| empty | set | `"impure"` | [impure][xp-feature-impure-derivations] |
+
+A deferred output does not use a kind of addressing of its own: it is input-addressed, but its path is not yet known, which happens downstream of a floating content-addressed input.
+Nothing gates it.
+Floating outputs require [`ca-derivations`][xp-feature-ca-derivations] and impure ones [`impure-derivations`][xp-feature-impure-derivations]; a fixed-output one additionally requires [`dynamic-derivations`][xp-feature-dynamic-derivations] if its method is `text:`.
+
+The `method-prefix` of `hash-algo` is the [content addressing method](@docroot@/store/store-object/content-address.md):
+
+| prefix | method |
+| --- | --- |
+| *(none)* | [Flat](@docroot@/store/store-object/content-address.md#method-flat) |
+| `r:` | [Nix Archive](@docroot@/store/store-object/content-address.md#method-nix-archive) |
+| `text:` | [Text](@docroot@/store/store-object/content-address.md#method-text) |
+| `git:` | [Git](@docroot@/store/store-object/content-address.md#method-git) |
+
+`hash` is lowercase, and carries no algorithm prefix of its own — the algorithm is named by `hash-algo`.
+
+For a fixed-output derivation the `output-path` is redundant — it is a function of the content address — but it must still agree with it.
+Two derivations that mean the same thing would otherwise have different encodings, and so different store paths.
+
+### Input derivations
+
+Each entry pairs the store path of an input derivation with the outputs of it that are used:
+
+```ebnf
+input-drv-node = output-names ;
+output-names   = "[" [ output-name { "," output-name } ] "]" ;
+```
+
+In the `DrvWithVersion("xp-dyn-drv", ...)` form
+— which requires the [`dynamic-derivations`][xp-feature-dynamic-derivations] experimental feature —
+a node may instead nest, to name an output of a derivation that is *itself* an output of a derivation:
+
+```ebnf
+input-drv-node = output-names
+               | "(" output-names "," "[" [ child { "," child } ] "]" ")" ;
+child          = "(" output-name "," input-drv-node ")" ;
+```
+
+### Canonical form
+
+The encoding is meant to be canonical: each derivation has exactly one.
+This matters because the bytes are hashed, both to content-address the derivation itself and to compute [input-addressed](@docroot@/protocols/store-path.md) output paths, so two spellings of the same derivation would be two different derivations.
+
+Accordingly:
+
+- Outputs, input derivations, input sources, and environment variables appear in ascending order of their keys, with no duplicates.
+  The same holds of the `output-names` naming which outputs of an input derivation are used.
+
+- A character that can be escaped must be escaped, and no other escape sequence is valid.
+  Both halves matter: a literal newline byte inside a string, and `\q`, are each a second way to write something that already has a spelling.
+
+- The fields drawn from restricted alphabets — output names and the platform — contain no escape sequences at all, since an escape there would be a second encoding of the same value rather than a necessary one.
+  Store paths are held to the same rule, except where the store directory needs escaping, in which case the escapes are the necessary kind.
+
+- Store paths are written in their canonical form, and the key of an `inputDrvs` entry is a derivation path, ending in `.drv`.
+
+- There is no trailing content after the closing parenthesis.
+
+One exception is known.
+The JSON held in the [`__json` environment variable](@docroot@/store/derivation/index.md#structured-attrs) of a derivation using structured attributes is *not* required to be canonical JSON.
+It must instead be preserved verbatim rather than reserialised.
+Since the bytes are hashed, whatever encoding a derivation happens to carry is part of its identity.
+Re-emitting it — even as equivalent JSON — would change the derivation.
+
+> **Note**
+>
+> This is not because canonicity is unwanted here, but because there is no settled notion of it to require.
+> "Canonical JSON" has several competing definitions, disagreeing on key ordering, number representation, and Unicode escaping.
+> It is also technically fraught:
+> for example, without hex literals for floating point, number representation is barely tractable.
+> Structured attributes have been in the wild for many years, so any such choice would also have to reckon with the encodings already out there.
+> Committing to one of them is therefore not a choice we are yet in a position to make with this format.
+
+## Quotient derivations {#input-address-encoding}
+
+An [input-addressed](@docroot@/store/derivation/outputs/input-address.md) output path is computed by hashing this same ATerm, but of a derivation that has been rewritten first: its ["quotient derivation"](@docroot@/store/derivation/outputs/input-address.md#hash-quotient-drv), so called because the rewriting partitions derivations into equivalence classes.
+
+Their encoding differs from the grammar above in two productions:
+
+```ebnf
+quotient-derivation = "Derive(" fields ")" ;
+
+input-drv           = "(" drv-hash "," output-names ")" ;
+drv-hash            = verbatim ;   (* lowercase hexadecimal *)
+```
+
+That is:
+
+- There is no version header.
+  A quotient derivation is only ever constructed once dynamic derivations have been resolved away, so it never needs one, and `DrvWithVersion(...)` does not occur.
+
+- An `inputDrvs` key is a hash rather than a store path, and its node is always the flat `output-names` — the nested form the `dynamic-derivations` version allows cannot appear, for the same reason.
+
+See [input addressing](@docroot@/store/derivation/outputs/input-address.md#hash-quotient-drv) for how those hashes are derived and why; in short, they identify an input derivation up to what it produces rather than how, so that changing where a fixed-output input is fetched from does not change anything downstream.
+
+Whether the outputs carry their paths depends on what is being hashed.
+When computing a derivation's own output paths they are masked — `output-path`, and the environment variable named after each output, are empty — since those paths are what is being computed.
+When hashing a derivation to stand in for it as an *input* to another, they are left as they are.
+
+The result is not a derivation that can be built, written to the store, or read back by `parse`: its inputs name hashes, not paths.
+It exists only to be hashed.
+
 ## Use for encoding to store object
 
 When derivation is encoded to a [store object] we make the following choices:
@@ -38,3 +237,6 @@ but we reserve the option to encode new sorts of derivations differently in the 
 [store derivation]: @docroot@/glossary.md#gloss-store-derivation
 [store object]: @docroot@/glossary.md#gloss-store-object
 ["Text" method]: @docroot@/store/store-object/content-address.md#method-text
+[xp-feature-ca-derivations]: @docroot@/development/experimental-features.md#xp-feature-ca-derivations
+[xp-feature-dynamic-derivations]: @docroot@/development/experimental-features.md#xp-feature-dynamic-derivations
+[xp-feature-impure-derivations]: @docroot@/development/experimental-features.md#xp-feature-impure-derivations

--- a/doc/manual/source/protocols/store-path.md
+++ b/doc/manual/source/protocols/store-path.md
@@ -89,7 +89,7 @@ where
 
     - For input-addressed derivation outputs:
 
-      the [ATerm](@docroot@/protocols/derivation-aterm.md) serialization of the derivation modulo fixed output derivations.
+      the [ATerm](@docroot@/protocols/derivation-aterm.md#input-address-encoding) serialization of the ["quotient derivation"](@docroot@/store/derivation/outputs/input-address.md#hash-quotient-drv), in which fixed-output inputs are replaced by their content addresses.
 
     - For content-addressed store paths:
 

--- a/doc/manual/source/store/derivation/outputs/input-address.md
+++ b/doc/manual/source/store/derivation/outputs/input-address.md
@@ -86,11 +86,14 @@ We replace each element in the derivation's `inputDrvOutputs` using data from a 
 When `hashOutputsOrQuotientDerivation` returns a single drv hash (because the input derivation in question is input-addressing), we simply swap out the `drvPath` for that hash, and keep the same output name.
 When `hashOutputsOrQuotientDerivation` returns a map of content addresses per-output, we look up the output in question, and pair it with the output name `out`.
 
-The resulting pseudo-derivation (with hashes instead of store paths in `inputDrvs`) is then printed (in the ["ATerm" format](@docroot@/protocols/derivation-aterm.md)) and hashed, and this becomes the hash of the "quotient derivation".
+The resulting pseudo-derivation (with hashes instead of store paths in `inputDrvs`) is then printed (in the ["ATerm" format](@docroot@/protocols/derivation-aterm.md#input-address-encoding)) and hashed, and this becomes the hash of the "quotient derivation".
 
 When calculating output hashes, `hashQuotientDerivation` is called on an almost-complete input-addressing derivation, which is just missing its input-addressed outputs paths.
-The derivation hash is then used to calculate output paths for each output.
-<!-- TODO describe how this is done. -->
+The derivation hash is then used to calculate output paths for each output, as the [complete store path calculation](@docroot@/protocols/store-path.md#fingerprint) specifies: it is the digest of the hashed ATerm that specification calls for, under the `"output:" id` case, where `id` is the output name.
+The store object's name is the derivation's name, with `-` and the output name appended --- unless the output is named `out`, in which case the derivation's name is used as-is.
+
+Note that one derivation hash serves every output; what distinguishes their paths is only the output name, which enters twice over, as both `id` and part of the name.
+
 Those output paths can then be substituted into the almost-complete input-addressed derivation to complete it.
 
 > **Note**
@@ -128,6 +131,30 @@ If the outputs are [content-addressed](./content-address.md), then it computes a
 > In this case, the algorithm is *stuck* until the input in question is built, and we know what the actual contents of the output in question is.
 >
 > That is OK however, because there is no problem with delaying the assigning of input addresses (which, remember, is what `hashQuotientDerivation` is ultimately for) until all inputs are known.
+
+### Deferring input-addressing when downstream of unknown CA store objects {#deferred}
+
+As the previous note says, the algorithm is *stuck* when an input is a [floating content-addressed](./content-address.md#floating) output that has not been built yet: there is no content address to substitute for it, so the quotient derivation cannot be completed and no input address can be computed.
+
+The derivation is still written to the store, with its outputs *deferred*: an output in this state has no store path at all, and the environment variable named after it is empty.
+This costs nothing, because a derivation's own store path is [content-addressed](@docroot@/store/store-object/content-address.md#method-text) on the bytes of its serialization, which do not depend on its output paths being known.
+
+A deferred output does not use a third kind of addressing alongside input- and content-addressing.
+It is input-addressed; it just does not know its path yet.
+
+Being stuck is contagious.
+A derivation with deferred outputs has, for this purpose, unknown outputs of its own, so `hashOutputsOrQuotientDerivation` is stuck on it in turn, and anything depending on it must also defer.
+The condition therefore propagates downstream from the floating output that caused it.
+
+Deferral is resolved by building, not by revisiting the same derivation.
+Once the offending inputs are built, their content addresses are known, and the derivation can be [resolved](@docroot@/store/resolution.md): its inputs are replaced by the plain store paths they turned out to denote.
+The resolved derivation is a *different* derivation, with its own store path --- necessarily so, since it has different bytes.
+It has no input derivations left to be stuck on, so its input addresses are computable, and it is what actually gets built.
+
+> **Note**
+>
+> Nothing gates deferred outputs themselves.
+> They only *arise* downstream of [floating content-addressed](./content-address.md#floating) outputs.
 
 ### Performance
 
@@ -220,6 +247,12 @@ where \\(\\mathrm{caInputs}(d)\\) returns the content-addressed inputs of \\(d\\
 > \\(\\sim_\mathrm{Drv}\\) from [derivation resolution](@docroot@/store/resolution.md) is such an equivalence relation.
 > It is coarser than this one: any two derivations which are "'hash quotient derivation'-equivalent" (\\(\\sim_\mathrm{IADrv}\\)) are also "resolution-equivalent" (\\(\\sim_\mathrm{Drv}\\)).
 > It also relates derivations whose `inputDrvOutputs` have been rewritten into `inputSrcs`.
+>
+> Input-addressing downstream of content addressing, as described above, anticipates this.
+> Since a content-addressed input contributes only its content address, and not the derivation that produced it, derivations differing only in *how* an identical content-addressed input was produced are already \\(\\sim_\mathrm{IADrv}\\)-equivalent.
+> And since a deferred derivation is completely resolved before it is input-addressed, its input-addressed `inputDrvOutputs` are normalized to `inputSrcs` as well --- so derivations differing only in how an identical *input-addressed* input was produced are \\(\\sim_\mathrm{IADrv}\\)-equivalent too.
+> That is the same "identify an input by what it is, rather than by how it was made" move as \\(\\sim_\mathrm{Drv}\\).
+> The difference is that \\(\\sim_\mathrm{Drv}\\) makes it unconditionally, whereas here it falls out for content-addressed inputs always, and for the rest only where deferral forced a resolution first.
 
 [deriving-path]: @docroot@/store/derivation/index.md#deriving-path
 [xp-feature-dynamic-derivations]: @docroot@/development/experimental-features.md#xp-feature-dynamic-derivations

--- a/doc/manual/source/store/store-object/content-address.md
+++ b/doc/manual/source/store/store-object/content-address.md
@@ -92,7 +92,7 @@ References to other store objects are supported, but self-references are not.
 
 This is the only store-object content-addressing method that is not named identically with a corresponding file system object method.
 It is somewhat obscure, mainly used for "drv files"
-(derivations serialized as store objects in their ["ATerm" file format](@docroot@/protocols/derivation-aterm.md)).
+(derivations serialized as store objects in their ["ATerm" file format](@docroot@/protocols/derivation-aterm.md#use-for-encoding-to-store-object)).
 Prefer another method if possible.
 
 ### Nix Archive { #method-nix-archive }


### PR DESCRIPTION
`protocols/derivation-aterm.md` named the two constructors and said nothing about what goes inside them, though these are the bytes every input-addressed store path is computed from. It was a dangling reference besides: `store-path.md` already sent the reader here for a serialization described nowhere.

The canonicity invariants listed are the ones `drv-fuzz` enforces.

The computation behind the form hashed for input addressing is deliberately not repeated. `store/derivation/outputs/input-address.md` already gives it, in more detail and more precisely than a summary would, so this page describes only the encoding and links there. Now that this page has sections worth pointing at, the references from `store-path.md`, `input-address.md` and `content-address.md` point at the relevant one rather than at the file.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
