### PR TITLE
nix flake prefetch-inputs: fix inputs being randomly skipped

### DIFF
--- a/src/nix/flake-prefetch-inputs.cc
+++ b/src/nix/flake-prefetch-inputs.cc
@@ -56,11 +56,11 @@ struct CmdFlakePrefetchInputs : FlakeCommand
 
             for (auto & [inputName, input] : node.inputs) {
                 if (auto inputNode = std::get_if<0>(&input))
-                    pool.enqueue(std::bind(visit, **inputNode));
+                    pool.enqueue([&visit, inputNode(*inputNode)] { visit(*inputNode); });
             }
         };
 
-        pool.enqueue(std::bind(visit, *flake.lockFile.root));
+        pool.enqueue([&] { visit(*flake.lockFile.root); });
 
         pool.process();
 


### PR DESCRIPTION
## Motivation

`nix flake prefetch-inputs` deduplicates lock nodes by address, but `std::bind` decay-copies its argument, so `visit` got a reference to a temporary copy inside the bind object. Once a work item finished, a later bind object could land at the same address and `done.insert(&node)` reported it as already visited. Those inputs were silently never fetched while the command still exited 0.

On a flake with 232 lock nodes (170 unique inputs) only ~150 `fetching` activities showed up, with a different set missing each run.

Fix by passing the actual lock graph node by reference.

## Context

https://github.com/Mic92/nixbot/issues/153