### PR TITLE
No warn on non-canonical structured attrs

### DIFF
--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -12,21 +12,10 @@ namespace nix {
 StructuredAttrs StructuredAttrs::parse(std::string_view encoded)
 {
     try {
-        auto parsed = nlohmann::json::parse(encoded);
-        /* nlohmann does not have a built-in way to check for canonical
-           form, we must reserialise ourselves. We cannot reject a
-           non-canonical encoding --- derivations in the wild have one,
-           and it is part of their identity --- so keep it verbatim in
-           order to round-trip, and merely warn. */
-        std::optional<std::string> verbatim;
-        if (parsed.dump() != encoded) {
-            warn("%s attribute is not in canonical JSON form", envVarName);
-            verbatim = std::string{encoded};
-        }
-
         return StructuredAttrs{
-            .structuredAttrs = std::move(parsed),
-            .verbatim = std::move(verbatim),
+            .structuredAttrs = nlohmann::json::parse(encoded),
+            /* Defensively assume it is not canonical */
+            .verbatim = std::string{encoded},
         };
     } catch (std::exception & e) {
         throw Error("cannot process %s attribute: %s", envVarName, e.what());


### PR DESCRIPTION
When parsing, always store verbatim, even if it is, in fact, canonical. This is quiet and avoids a somewhat expensive check (as previously implemented).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
