### PR TITLE
libstore: define `submitOutput` out of line

### DIFF
--- a/src/libstore/unix/build/unix-derivation-builder-impl.hh
+++ b/src/libstore/unix/build/unix-derivation-builder-impl.hh
@@ -131,27 +131,7 @@ protected:
         return !usingSubmitted;
     }
 
-    void submitOutput(const SingleDerivedPath & path, const OutputName & output) override
-    {
-        auto submittedOutputs(this->submittedOutputs.lock());
-
-        auto * opaque = std::get_if<SingleDerivedPath::Opaque>(&path.raw());
-        if (!opaque)
-            throw Error(
-                "Attempted to submit Built path '%s' for output '%s'.\n"
-                " Only Opaque paths are supported, see https://github.com/NixOS/nix/issues/12727",
-                path.to_string(store),
-                output);
-
-        if (submittedOutputs->contains(output))
-            throw Error(
-                "Attempted to submit duplicate output '%s' (old '%s', new '%s')",
-                output,
-                store.printStorePath(*get(*submittedOutputs, output)),
-                store.printStorePath(opaque->path));
-
-        submittedOutputs->insert_or_assign(output, opaque->path);
-    };
+    void submitOutput(const SingleDerivedPath & path, const OutputName & output) override;
 
     friend struct RestrictedStore;
 

--- a/src/libstore/unix/build/unix-derivation-builder.cc
+++ b/src/libstore/unix/build/unix-derivation-builder.cc
@@ -818,6 +818,28 @@ void UnixDerivationBuilderImpl::stopDaemon()
     daemonSocket.close();
 }
 
+void UnixDerivationBuilderImpl::submitOutput(const SingleDerivedPath & path, const OutputName & output)
+{
+    auto submittedOutputs(this->submittedOutputs.lock());
+
+    auto * opaque = std::get_if<SingleDerivedPath::Opaque>(&path.raw());
+    if (!opaque)
+        throw Error(
+            "Attempted to submit Built path '%s' for output '%s'.\n"
+            " Only Opaque paths are supported, see https://github.com/NixOS/nix/issues/12727",
+            path.to_string(store),
+            output);
+
+    if (submittedOutputs->contains(output))
+        throw Error(
+            "Attempted to submit duplicate output '%s' (old '%s', new '%s')",
+            output,
+            store.printStorePath(*get(*submittedOutputs, output)),
+            store.printStorePath(opaque->path));
+
+    submittedOutputs->insert_or_assign(output, opaque->path);
+}
+
 void UnixDerivationBuilderImpl::addDependencyImpl(const StorePath & path) {}
 
 void UnixDerivationBuilderImpl::chownToBuilder(const std::filesystem::path & path)


### PR DESCRIPTION
## Motivation

The definition moves from `unix-derivation-builder-impl.hh` into `unix-derivation-builder.cc` next to the other `UnixDerivationBuilderImpl` methods.

## Context

This is in prep for a future follow-up that grows this function.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
