### PR TITLE
libstore: say what actually blocks SSH on Windows

### DIFF
--- a/src/libstore/include/nix/store/ssh.hh
+++ b/src/libstore/include/nix/store/ssh.hh
@@ -40,7 +40,7 @@ private:
     void addCommonSSHOpts(OsStrings & args);
     bool isMasterRunning();
 
-#ifndef _WIN32 // TODO re-enable on Windows, once we can fork.
+#ifndef _WIN32 // TODO re-enable on Windows; needs startProcess(), which forks to run a child callback.
     std::filesystem::path startMaster();
 #endif
 

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -150,8 +150,9 @@ Strings createSSHEnv()
 
 std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(OsStrings && command, OsStrings && extraSshArgs)
 {
-#ifdef _WIN32 // TODO re-enable on Windows, once we can fork.
-    throw UnimplementedError("cannot yet SSH on windows because spawning processes is not yet implemented");
+#ifdef _WIN32 // TODO re-enable on Windows; needs startProcess(), which forks to run a child callback.
+    throw UnimplementedError(
+        "cannot yet SSH on Windows: this needs startProcess(), which forks to run a child callback");
 #else
     std::filesystem::path socketPath = startMaster();
 
@@ -229,7 +230,7 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(OsStrings && comm
 #endif
 }
 
-#ifndef _WIN32 // TODO re-enable on Windows, once we can fork.
+#ifndef _WIN32 // TODO re-enable on Windows; needs startProcess(), which forks to run a child callback.
 
 std::filesystem::path SSHMaster::startMaster()
 {


### PR DESCRIPTION
Follow-up to a review comment on the merged #16347: xokdvium
[pointed out](https://github.com/NixOS/nix/pull/16347#discussion_r3876901264) that the TODOs there now read
"once we can fork", which is a precondition Windows is never going to meet.

He's right about the wording. Reverting to the previous "once we can start processes" would be stale in the
other direction, though, because #16347 is what made `Pid` and ordinary process spawning work on Windows.
What these three sites actually need is `startProcess(fun<void()>)`, declared inside `#ifndef _WIN32` at
`processes.hh:128`, which runs its callback *in the forked child* — that is where `startCommand` does its
`dup2`s over stdin, stdout and stderr, and `CreateProcess` has no equivalent step.

So this names the missing primitive rather than reverting. The `UnimplementedError` on the Windows branch
gets the same treatment, since it still claimed "because spawning processes is not yet implemented", which
is no longer the reason.

Comments and one error message; no behaviour change. Verified `nix build .#checks.x86_64-linux.pre-commit`
(7/7 hooks) and that `nix-store-x86_64-w64-mingw32` still compiles, since the changed error message sits in
an `#ifdef _WIN32` branch that a native build never sees.
