### PR TITLE
libstore: read SSL_CERT_FILE after main, not in a static initializer

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -100,37 +100,6 @@ std::optional<std::filesystem::path> FileTransferSettings::getDefaultSSLCertFile
 
 void FileTransferSettings::anchor() {}
 
-FileTransferSettings::FileTransferSettings()
-{
-    /* This runs during static initialization, where an escaping exception
-       cannot be reported: on Unix it reaches `std::terminate` before `main`,
-       and on Windows the loader absorbs it and the process dies having printed
-       nothing at all (see #16356). `AbsolutePath` rejects a non-absolute value
-       by throwing, and the value comes from the environment, so it can be
-       invalid. Warn and carry on rather than dying undiagnosably. */
-    try {
-        std::optional<AbsolutePath> sslOverride =
-            getEnvOs(OS_STR("NIX_SSL_CERT_FILE"))
-                .or_else([] { return getEnvOs(OS_STR("SSL_CERT_FILE")); })
-                .and_then([](OsString s) -> std::optional<OsString> {
-                    return s.empty() ? std::nullopt : std::optional{std::move(s)};
-                })
-                .transform([](OsString s) { return AbsolutePath{std::filesystem::path{std::move(s)}}; });
-        if (sslOverride)
-            caFile = *sslOverride;
-    } catch (Error & e) {
-        e.addTrace(
-            {},
-            "while applying the 'NIX_SSL_CERT_FILE' or 'SSL_CERT_FILE' environment variable; "
-            "ignoring it for now, but this may become an error again in the future");
-        logWarning(e.info());
-    } catch (...) {
-        /* Nothing at all may escape a static initializer, so this is a
-           backstop for anything that is not an `Error`. */
-        ignoreExceptionExceptInterrupt();
-    }
-}
-
 FileTransferSettings fileTransferSettings;
 
 static GlobalConfig::Register rFileTransferSettings(&fileTransferSettings);

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -118,6 +118,36 @@ void loadConfFile(AbstractConfig & config)
         }
     };
 
+    /* `NIX_SSL_CERT_FILE` / `SSL_CERT_FILE` used to be read in
+       `FileTransferSettings`' constructor. That runs during static
+       initialization, where a bad value cannot be reported: on Unix an escaping
+       exception reaches `std::terminate` before `main`, and on Windows the
+       loader absorbs it and the process dies having printed nothing (#16356).
+       Applying it here instead routes it through the normal `Setting`
+       conversion, so a non-absolute path is an ordinary error.
+
+       Before the config files, so that an `ssl-cert-file` in `nix.conf` keeps
+       the precedence it had when the constructor assigned during static
+       initialization.
+
+       `getEnvOs` rather than `getEnvOsNonEmpty`, with the empty check *after*
+       the fallback: setting `NIX_SSL_CERT_FILE` to the empty string suppresses
+       `SSL_CERT_FILE` rather than falling through to it, because `or_else` sees
+       the variable as present. `getEnvOsNonEmpty` cannot express that, since it
+       reports set-but-empty and unset identically. */
+    if (auto sslCertFile = getEnvOs(OS_STR("NIX_SSL_CERT_FILE"))
+                               .or_else([] { return getEnvOs(OS_STR("SSL_CERT_FILE")); })
+                               .and_then([](OsString s) -> std::optional<OsString> {
+                                   return s.empty() ? std::nullopt : std::optional{std::move(s)};
+                               })) {
+        try {
+            config.set("ssl-cert-file", os_string_to_string(*sslCertFile));
+        } catch (Error & e) {
+            e.addTrace({}, "while applying the 'NIX_SSL_CERT_FILE' or 'SSL_CERT_FILE' environment variable");
+            throw;
+        }
+    }
+
     applyConfigFile(nixConfFile());
 
     /* We only want to send overrides to the daemon, i.e. stuff from

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -30,7 +30,6 @@ class FileTransferSettings : public Config
     void anchor() override;
 
 public:
-    FileTransferSettings();
 
     Setting<bool> enableHttp2{this, true, "http2", "Whether to enable HTTP/2 support."};
 


### PR DESCRIPTION
Follow-up to xokdvium's review comment on the merged #16364, which
[asked](https://github.com/NixOS/nix/pull/16364#issuecomment-5454858338) whether we could avoid running this
in a static initializer rather than defending against it. That's the right call, and this does it.

`NIX_SSL_CERT_FILE` / `SSL_CERT_FILE` were read in `FileTransferSettings`' constructor. That object is a
global, so the read ran during static initialization, where a bad value cannot be reported: on Unix an
escaping exception reaches `std::terminate` before `main`, and on Windows the loader absorbs it and the
process dies having printed nothing at all (#16356). #16364 worked around that by catching and warning.

Every other config source is converted post-`main` through `Setting::set()`, so this one is now applied
there too — in `loadConfFile()`, next to the existing `NIX_CONFIG` handling. The constructor goes away
entirely, along with its `try`/`catch`.

### Behaviour

A non-absolute value is an ordinary reportable error again, which is what the trace text added in #16364
said should eventually happen:

```
before:  warning: … while applying the 'NIX_SSL_CERT_FILE' or 'SSL_CERT_FILE' environment
                  variable; ignoring it for now, but this may become an error again in the future
after:   error: not an absolute path: "relative/ca.crt"
```

Everything else is unchanged. Measured with `nix config show ssl-cert-file` against master:

```
case                        this branch                        master
env only, absolute          /etc/from-env.crt                  same
no env (default)            /etc/ssl/certs/ca-certificates.crt same
ssl-cert-file in nix.conf   /etc/from-nix-conf.crt             same
  + env var set             (nix.conf wins)                    same
```

The override is applied *before* the config files so that `nix.conf` keeps the precedence it had when the
constructor assigned during static initialization — verified above rather than assumed.

### One behaviour change worth flagging

Callers using `initLibStore(false)` no longer get the override, where previously it applied
unconditionally because it happened in a constructor. That seems consistent with asking not to load config,
but it is a change.

Verified `nix build .#checks.x86_64-linux.pre-commit` (7/7 hooks, no diff) and that both `nix-store` and
`nix-store-x86_64-w64-mingw32` compile.
