### PR TITLE
libstore: move `checkSubmittedOutputs` to the shared builder

### DIFF
--- a/src/libstore/build/derivation-builder-impl.cc
+++ b/src/libstore/build/derivation-builder-impl.cc
@@ -708,4 +708,60 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
     return builtOutputs;
 }
 
+SingleDrvOutputs DerivationBuilderImpl::checkSubmittedOutputs()
+{
+    // Submitted outputs from the recursive nix daemon
+    // It's fine to lock here since all other threads with the reference have been shut down.
+    auto submittedOutputs(this->submittedOutputs.lock());
+
+    SingleDrvOutputs builtOutputs;
+
+    std::map<std::string, ValidPathInfo> infos;
+
+    for (auto & [outputName, outputPath] : *submittedOutputs) {
+        infos.emplace(outputName, *store.queryPathInfo(outputPath));
+    }
+
+    // checkOutputs only performs checks that make sense for both submitting and non-submitting derivations,
+    // more verification steps needed afterward
+    checkOutputs(store, drvPath, drv, drvOptions.outputChecks, infos);
+
+    for (auto & [outputName, output] : drv.outputs) {
+        // For some reason cannot be moved to checkOutputs, needs debugging
+        if (!submittedOutputs->contains(outputName)) {
+            throw BuildError(
+                BuildResult::Failure::OutputRejected,
+                "builder for '%s' failed to submit output path for '%s'",
+                store.printStorePath(drvPath),
+                outputName);
+        }
+
+        // We should have already checked that the derivation is content-addressing in startBuild
+        // and that the outputs of a content-addressing derivation is content-addressed in checkOutputs.
+        // Add an assert here just in case, but it should never trigger.
+        assert(
+            std::get_if<DerivationOutput::CAFloating>(&output.raw)
+            || std::get_if<DerivationOutput::CAFixed>(&output.raw));
+
+        // No need to sign CA outputs, only the realisation matters
+        auto realisation = Realisation{
+            {
+                .outPath = *get(*submittedOutputs, outputName),
+            },
+            DrvOutput{
+                .drvPath = drvPath,
+                .outputName = outputName,
+            },
+        };
+
+        store.signRealisation(realisation);
+        store.registerDrvOutput(realisation, NoCheckSigs);
+        builtOutputs.emplace(outputName, realisation);
+
+        // TODO: handle --check
+    }
+
+    return builtOutputs;
+}
+
 } // namespace nix

--- a/src/libstore/build/derivation-builder-impl.hh
+++ b/src/libstore/build/derivation-builder-impl.hh
@@ -3,6 +3,7 @@
 
 #include "nix/store/build/derivation-builder.hh"
 #include "nix/store/local-store.hh"
+#include "nix/util/sync.hh"
 #ifndef _WIN32
 #  include "nix/store/user-lock.hh"
 #endif
@@ -115,6 +116,17 @@ protected:
      * For subclasses to call at the end of `unprepareBuild`.
      */
     SingleDrvOutputs registerOutputs();
+
+    /**
+     * Output paths from the `SubmitOutput` store command
+     */
+    Sync<OutputPathMap> submittedOutputs;
+
+    /**
+     * Check that the derivation outputs submitted by recursive-nix exist
+     * and attach them to the derivation
+     */
+    SingleDrvOutputs checkSubmittedOutputs();
 };
 
 } // namespace nix

--- a/src/libstore/unix/build/unix-derivation-builder-impl.hh
+++ b/src/libstore/unix/build/unix-derivation-builder-impl.hh
@@ -75,10 +75,6 @@ protected:
      * Whether or not derivation is using outputs submitted via recursive-nix
      */
     bool usingSubmitted;
-    /**
-     * Output paths from the `SubmitOutput` store command
-     */
-    Sync<OutputPathMap> submittedOutputs;
 
     static const std::filesystem::path homeDir;
 
@@ -313,13 +309,6 @@ protected:
      */
     virtual void execBuilder(const Strings & args, const Strings & envStrs);
 
-private:
-
-    /**
-     * Check that the derivation outputs submitted by recursive-nix exist
-     * and attach them to the derivation
-     */
-    SingleDrvOutputs checkSubmittedOutputs();
 protected:
 
     /**

--- a/src/libstore/unix/build/unix-derivation-builder.cc
+++ b/src/libstore/unix/build/unix-derivation-builder.cc
@@ -1008,62 +1008,6 @@ void UnixDerivationBuilderImpl::execBuilder(const Strings & args, const Strings 
     execve(requireCString(drv.builder), stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
 }
 
-SingleDrvOutputs UnixDerivationBuilderImpl::checkSubmittedOutputs()
-{
-    // Submitted outputs from the recursive nix daemon
-    // It's fine to lock here since all other threads with the reference have been shut down.
-    auto submittedOutputs(this->submittedOutputs.lock());
-
-    SingleDrvOutputs builtOutputs;
-
-    std::map<std::string, ValidPathInfo> infos;
-
-    for (auto & [outputName, outputPath] : *submittedOutputs) {
-        infos.emplace(outputName, *store.queryPathInfo(outputPath));
-    }
-
-    // checkOutputs only performs checks that make sense for both submitting and non-submitting derivations,
-    // more verification steps needed afterward
-    checkOutputs(store, drvPath, drv, drvOptions.outputChecks, infos);
-
-    for (auto & [outputName, output] : drv.outputs) {
-        // For some reason cannot be moved to checkOutputs, needs debugging
-        if (!submittedOutputs->contains(outputName)) {
-            throw BuildError(
-                BuildResult::Failure::OutputRejected,
-                "builder for '%s' failed to submit output path for '%s'",
-                store.printStorePath(drvPath),
-                outputName);
-        }
-
-        // We should have already checked that the derivation is content-addressing in startBuild
-        // and that the outputs of a content-addressing derivation is content-addressed in checkOutputs.
-        // Add an assert here just in case, but it should never trigger.
-        assert(
-            std::get_if<DerivationOutput::CAFloating>(&output.raw)
-            || std::get_if<DerivationOutput::CAFixed>(&output.raw));
-
-        // No need to sign CA outputs, only the realisation matters
-        auto realisation = Realisation{
-            {
-                .outPath = *get(*submittedOutputs, outputName),
-            },
-            DrvOutput{
-                .drvPath = drvPath,
-                .outputName = outputName,
-            },
-        };
-
-        store.signRealisation(realisation);
-        store.registerDrvOutput(realisation, NoCheckSigs);
-        builtOutputs.emplace(outputName, realisation);
-
-        // TODO: handle --check
-    }
-
-    return builtOutputs;
-}
-
 void UnixDerivationBuilderImpl::cleanupBuild(bool force)
 {
     if (force) {


### PR DESCRIPTION
## Motivation

Nothing about checking submitted outputs is really Unix specific.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
