### PR TITLE
Fix quadratic key disambiguation in lock files

### DIFF
--- a/src/libflake/lockfile.cc
+++ b/src/libflake/lockfile.cc
@@ -1,4 +1,5 @@
 #include <boost/unordered/unordered_flat_set.hpp>
+#include <boost/unordered/unordered_flat_map.hpp>
 #include <nlohmann/json.hpp>
 #include <assert.h>
 #include <boost/unordered/unordered_flat_set_fwd.hpp>
@@ -187,14 +188,20 @@ std::pair<nlohmann::json, LockFile::KeyMap> LockFile::toJSON() const
     KeyMap nodeKeys;
     boost::unordered_flat_set<std::string> keys;
 
+    /* The next numeric suffix to try for a given base key. Suffixes start at 2, since the
+       unsuffixed key occupies the _1 slot. Used to amortise name deduplication by memoising
+       the lower bound of suffixes that definitely cannot be used. */
+    boost::unordered_flat_map<std::string, int> keySuffixes;
+
     auto dumpNode = [&](this auto & dumpNode, std::string key, ref<const Node> node) -> std::string {
         auto k = nodeKeys.find(node);
         if (k != nodeKeys.end())
             return k->second;
 
         if (!keys.insert(key).second) {
-            for (int n = 2;; ++n) {
-                auto k = fmt("%s_%d", key, n);
+            auto & suffix = keySuffixes.try_emplace(key, 2).first->second;
+            for (;;) {
+                auto k = fmt("%s_%d", key, suffix++);
                 if (keys.insert(k).second) {
                     key = k;
                     break;


### PR DESCRIPTION
## Motivation

I am working on a new idea :bulb: and I ran into this performance problem when evaluating many Nix flakes.

`LockFile::toJSON()` gives every node a unique key, disambiguating collisions by appending `_2`, `_3`, … The search restarts at `2` on every collision:

```cpp
if (!keys.insert(key).second) {
    for (int n = 2;; ++n) {
        auto k = fmt("%s_%d", key, n);
        if (keys.insert(k).second) { key = k; break; }
    }
}
```

So the k-th node sharing a base name costs k iterations, making the pass O(n²) in the number of colliding nodes.

This is easy to hit in practice. A flake that depends on many other flakes accumulates one `systems` / `flake-compat` / `nixpkgs` node **per dependency**, and they all share a base name. In a 4000-input flake, 3999 nodes are named `systems_2` … `systems_4000`, costing ~8M `fmt()` calls.

The cost is not confined to writing the file. [flake.cc](https://github.com/NixOS/nix/blob/master/src/libflake/flake.cc#L940) passes the serialized lock to `call-flake.nix` on **every evaluation**:  `nix eval`, `nix flake metadata` and `nix flake lock` are all  O(n²) for this name determination

## Context

I hit this building a flake with a very large number of inputs. Evaluating an output that touches **no** input at all took 11.5s, which was surprising given inputs are lazy. 

## The fix

Track the highest suffix already handed out per base key and resume from there instead of rescanning from 2. The `keys.insert` check is retained, so a name that legitimately appears in the lock file (an input actually called `systems_2`) is still skipped and the resulting keys are unchanged.

## Benchmarks

A flake with n inputs that each pull in their own `systems`, timing `nix eval` of an output touching no input:

| inputs | nodes | before | after | speedup |
|-------:|------:|-------:|------:|--------:|
| 500 | 1,000 | 0.64s | 0.15s | 4.3x |
| 1,000 | 2,000 | 0.88s | 0.16s | 5.5x |
| 2,000 | 4,000 | 3.05s | 0.28s | 10.9x |
| 4,000 | 8,000 | 11.49s | 0.54s | 21.3x |

The before column is quadratic (2x inputs → ~3.8x time); the after column is linear.

Reproducer:

```bash
python3 -c '
REV="11707dc2f618dd54ca8739b309ec4fc024de578b"
n=4000
L=["{"]
for i in range(n): L.append(f"  inputs.f{i}.url = \"github:numtide/flake-utils/{REV}\";")
L.append("  outputs = { self, ... }@inputs: { trivial = \"hi\"; };")
L.append("}")
open("flake.nix","w").write("\n".join(L))'
git init -q . && git add -N flake.nix && nix flake lock
time nix eval .#trivial
```

## Correctness

Lock files produced before and after are byte-identical, verified on:

- the synthetic cases above (500/2000/4000 inputs, ~3.9MB lock)
- an adversarial lock containing pre-existing `systems_2`, `systems_3` and `systems_5` inputs interleaved with 41 auto-disambiguated `systems` nodes
- an existing real-world flake's `flake.lock`, regenerated and compared

## Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
