### PR TITLE
git fetcher: avoid resolving HEAD for pinned revisions

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -765,7 +765,10 @@ struct GitInputScheme : InputScheme
     {
         auto head = std::visit(
             overloaded{
-                [&](const std::filesystem::path & path) { return GitRepo::openRepo(path, {})->getWorkdirRef(); },
+                [&](const std::filesystem::path & path) -> std::optional<std::string> {
+                    /* A detached HEAD is still resolvable by libgit2. */
+                    return GitRepo::openRepo(path, {})->getWorkdirRef().value_or("HEAD");
+                },
                 [&](const ParsedURL & url) { return readHeadCached(settings, url.to_string(), shallow); }},
             repoInfo.location);
         if (!head) {

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -211,6 +211,9 @@ createGitRepo "$TEST_ROOT"/minimal
 git -C "$TEST_ROOT"/minimal fetch "$repo" "$rev2"
 git -C "$TEST_ROOT"/minimal checkout "$rev2"
 [[ $(nix eval --impure --raw --expr "(builtins.fetchGit { url = $TEST_ROOT/minimal; }).rev") = "$rev2" ]]
+# Detached HEAD must not fall back to a guessed 'master' ref.
+expectStderr 0 nix eval --raw --expr "(builtins.fetchGit { url = $TEST_ROOT/minimal; rev = \"$rev2\"; }).outPath" \
+    | grepQuietInverse "could not read HEAD ref"
 
 # Explicit ref = "HEAD" should work, and produce the same outPath as without ref
 path7=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"HEAD\"; }).outPath")


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Fix a questionable fetcher behavior that leads to issues when using [nix-eval-job](https://github.com/NixOS/nix-eval-jobs) with a detached HEAD.

A Git revision fully identifies the commit, so resolving the default ref is unnecessary.
On detached checkouts this fell back to master and could cause a `narHash` mismatch.
Use `HEAD` as ref metadata for pinned inputs without an explicit ref.

## Context

I encountered a bug when running [nix-fast-build](https://github.com/Mic92/nix-fast-build) in a CI environment.
There, the repo was checked out on a merge commit, i.e. HEAD was detached from any ref.
`nix-fast-build` relies on [nix-eval-jobs](https://github.com/NixOS/nix-eval-jobs) which then fails to re-fetch the repo.

Example failure:
```
warning: could not read HEAD ref from repo at '/workspace/build/buildkite', using 'master'
error:
       … while fetching the input 'git+file:///workspace/build/buildkite?rev=e374a4ebd0dbf7b23e077a94fd5cefb7a9d65ffa'
       error: mismatch in field 'narHash' of input '{"__final":true,"lastModified":1787929854,"narHash":"sha256-UEzJabo6ObaQc0Rc5XJOf43NR5Rp3e0WwpWi55c79R8=","rev":"e374a4ebd0dbf7b23e077a94fd5cefb7a9d65ffa","revCount":20538,"type":"git","url":"file:///workspace/build/buildkite"}', got '{"__final":true,"lastModified":1787929854,"narHash":"sha256-q2mgMIPLqHSx0pSEJ42rrZpYxcjkgL1U1UvCTHTw+Oo=","ref":"master","rev":"e374a4ebd0dbf7b23e077a94fd5cefb7a9d65ffa","revCount":20538,"type":"git","url":"file:///workspace/build/buildkite"}'
```

---

**Disclaimer, this submission was assisted by GPT-5.6 Sol.**

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
