### PR TITLE
git: reuse cached history for exact revision fetches

### DIFF
--- a/doc/manual/rl-next/exact-git-revision-fetch-negotiation.md
+++ b/doc/manual/rl-next/exact-git-revision-fetch-negotiation.md
@@ -1,0 +1,7 @@
+---
+synopsis: Exact Git revision fetches reuse cached history
+---
+
+Repeated Git fetches of related exact revisions now negotiate from the previously fetched revision, avoiding redundant object transfers.
+
+This requires Git 2.19 or newer.

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -35,6 +35,7 @@
 #include <git2/status.h>
 #include <git2/submodule.h>
 #include <git2/sys/odb_backend.h>
+#include <git2/sys/errors.h>
 #include <git2/sys/repository.h>
 #include <git2/sys/mempack.h>
 #include <git2/tag.h>
@@ -137,6 +138,7 @@ typedef std::unique_ptr<git_blob, Deleter<git_blob_free>> Blob;
 typedef std::unique_ptr<git_object, Deleter<git_object_free>> Object;
 typedef std::unique_ptr<git_commit, Deleter<git_commit_free>> Commit;
 typedef std::unique_ptr<git_reference, Deleter<git_reference_free>> Reference;
+typedef std::unique_ptr<git_reference_iterator, Deleter<git_reference_iterator_free>> ReferenceIterator;
 typedef std::unique_ptr<git_describe_result, Deleter<git_describe_result_free>> DescribeResult;
 typedef std::unique_ptr<git_status_list, Deleter<git_status_list_free>> StatusList;
 typedef std::unique_ptr<git_remote, Deleter<git_remote_free>> Remote;
@@ -777,6 +779,35 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
             gitArgs.push_back(OS_STR("--depth"));
             gitArgs.push_back(OS_STR("1"));
         }
+
+        Object fetchHead;
+        auto fetchHeadErr = git_revparse_single(Setter(fetchHead), *this, "FETCH_HEAD^{commit}");
+        if (fetchHeadErr == GIT_OK) {
+            auto fetchHeadOid = toHash(*git_object_id(fetchHead.get())).gitRev();
+            // Exact revision fetches may leave the cached commit referenced only by FETCH_HEAD.
+            // Git normally negotiates from refs, so it does not advertise that cached history and
+            // downloads it again. --negotiation-tip replaces the default tip set, so preserve
+            // refs/* when present and add the previous commit's OID explicitly.
+            // TODO: when the minimum Git version is 2.55, replace this workaround with additive
+            // --negotiation-include=<oid>.
+            ReferenceIterator refIterator;
+            if (git_reference_iterator_glob_new(Setter(refIterator), *this, "refs/*"))
+                throw GitError("creating Git reference iterator");
+
+            const char * refName;
+            if (auto err = git_reference_next_name(&refName, refIterator.get()); err == GIT_OK)
+                gitArgs.push_back(OS_STR("--negotiation-tip=refs/*"));
+            else if (err != GIT_ITEROVER)
+                throw GitError("iterating Git references");
+
+            gitArgs.push_back(string_to_os_string(std::string("--negotiation-tip=") + fetchHeadOid));
+        } else if (
+            fetchHeadErr == GIT_ENOTFOUND || fetchHeadErr == GIT_EINVALIDSPEC || fetchHeadErr == GIT_EPEEL) {
+            git_error_clear();
+        } else {
+            throw GitError("resolving FETCH_HEAD");
+        }
+
         gitArgs.push_back(OS_STR("--"));
         gitArgs.push_back(string_to_os_string(url));
         gitArgs.push_back(string_to_os_string(refspec));

--- a/tests/functional/git/exact-rev-fetch-cache.sh
+++ b/tests/functional/git/exact-rev-fetch-cache.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+source ../common.sh
+
+requireGit
+
+repo=$TEST_ROOT/repo
+trace=$TEST_ROOT/git-trace
+
+rm -rf "$repo" "$TEST_HOME/.cache/nix"
+
+git init --initial-branch=master "$repo"
+git -C "$repo" config user.email "nix-tests@example.com"
+git -C "$repo" config user.name "Nix Tests"
+
+echo first > "$repo/first"
+git -C "$repo" add first
+git -C "$repo" commit -m 'First commit.'
+rev1=$(git -C "$repo" rev-parse HEAD)
+
+echo second > "$repo/second"
+git -C "$repo" add second
+git -C "$repo" commit -m 'Second commit.'
+rev2=$(git -C "$repo" rev-parse HEAD)
+
+export GIT_TRACE_PACKET=$trace
+export _NIX_FORCE_HTTP=1
+
+nix eval --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"master\"; rev = \"$rev1\"; }).outPath" >/dev/null
+second_stderr=$TEST_ROOT/second-fetch.stderr
+nix eval --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"master\"; rev = \"$rev2\"; }).outPath" >/dev/null 2>"$second_stderr"
+
+if grep -Eq -- "--negotiation-tip=refs/\\*|does not match any refs" "$second_stderr"; then
+    echo "Git emitted an unmatched negotiation-tip warning during the second exact fetch." >&2
+    cat "$second_stderr" >&2
+    exit 1
+fi
+
+totals=$(grep -oE 'sideband< .*Total [0-9]+' "$trace" || true)
+totals=$(printf '%s\n' "$totals" | sed -E 's/.*Total ([0-9]+)/\1/' | tr '\n' ' ')
+totals=${totals% }
+
+if ! grep -q "fetch> have $rev1" "$trace"; then
+    echo "Expected fetch to advertise the first revision as a negotiation tip." >&2
+    exit 1
+fi
+
+if [[ $totals != '3 3' ]]; then
+    echo "Expected fetchGit to receive 3 objects per fetch, got: ${totals:-none}" >&2
+    exit 1
+fi

--- a/tests/functional/git/exact-rev-fetch-head-cache.sh
+++ b/tests/functional/git/exact-rev-fetch-head-cache.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+source ../common.sh
+
+requireGit
+
+repo=$TEST_ROOT/repo
+
+rm -rf "$repo" "$TEST_HOME/.cache/nix"
+
+git init --initial-branch=master "$repo"
+git -C "$repo" config user.email "nix-tests@example.com"
+git -C "$repo" config user.name "Nix Tests"
+
+echo valid > "$repo/file"
+git -C "$repo" add file
+git -C "$repo" commit -m 'Valid commit.'
+valid_rev=$(git -C "$repo" rev-parse HEAD)
+
+blob_oid=$(git -C "$repo" rev-parse HEAD:file)
+git -C "$repo" tag -a bad-tag -m 'Annotated tag pointing to a blob.' "$blob_oid"
+bad_tag_oid=$(git -C "$repo" rev-parse refs/tags/bad-tag)
+
+export _NIX_FORCE_HTTP=1
+
+# Fetching the annotated tag object succeeds at the Git layer, but Nix cannot
+# use it as a commit. This leaves the tag object in FETCH_HEAD.
+first_stderr=$TEST_ROOT/first-fetch.stderr
+if nix eval --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; rev = \"$bad_tag_oid\"; }).outPath" \
+    >/dev/null 2>"$first_stderr"; then
+    echo "Expected fetchGit to reject an annotated tag pointing to a blob." >&2
+    exit 1
+fi
+
+fetch_head=$(find "$TEST_HOME/.cache/nix/gitv3" -type f -name FETCH_HEAD -print -quit 2>/dev/null || true)
+if [[ -z $fetch_head || ! -s $fetch_head ]] || ! grep -q "$bad_tag_oid" "$fetch_head"; then
+    echo "Expected the failed tag fetch to populate FETCH_HEAD with the tag object." >&2
+    cat "$first_stderr" >&2
+    exit 1
+fi
+
+# A subsequent exact fetch must not be blocked by the invalid FETCH_HEAD entry.
+second_stderr=$TEST_ROOT/second-fetch.stderr
+if ! nix eval --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; rev = \"$valid_rev\"; }).outPath" \
+    >/dev/null 2>"$second_stderr"; then
+    echo "Expected a valid commit fetch to succeed after the invalid tag fetch." >&2
+    cat "$second_stderr" >&2
+    exit 1
+fi

--- a/tests/functional/git/meson.build
+++ b/tests/functional/git/meson.build
@@ -2,6 +2,8 @@ suites += {
   'name' : 'git',
   'deps' : [],
   'tests' : [
+    'exact-rev-fetch-cache.sh',
+    'exact-rev-fetch-head-cache.sh',
     'packed-refs-no-cache.sh',
     'symlinked-repo.sh',
   ],


### PR DESCRIPTION
## Motivation

TL;DR: Nix was downloading 500 MiB from the same Git repository on every update, even though the previous revision and its history were already in Nix's Git cache.

This repository advances through merges into `master`, so every revision fetched during an update is a descendant of the previous one.
Git should only need to send the objects added since that revision.
Instead, it was sending the whole reachable history again on every update.

When Nix fetches an exact Git revision, it runs roughly:

```console
git fetch <url> <commit-oid>
````

Git stores the received objects in Nix's local bare repository cache and writes the fetched object to `FETCH_HEAD`, but it does not create a persistent ref.

On the next exact-revision fetch, Git normally negotiates from local refs.
The previous revision is only referenced by `FETCH_HEAD`, so Git does not advertise it to the server as a `have`.
The server assumes the client does not have that history and sends it again.

A minimal repository with two commits reproduces the same problem.
Each commit adds three objects: a commit, a tree, and a blob.

Before this change:

```text
first fetch:  Total 3
second fetch: Total 6
```

The second fetch receives both commits and their trees and blobs, even though the first three objects are already cached.

After this change:

```text
first fetch:  Total 3
second fetch: Total 3
```

The fetched revision does not change.
Git just stops sending objects that are already present locally.

## Context

### Implementation

Before running the external `git fetch`, `GitRepoImpl::fetch()` asks libgit2 to resolve:

```text
FETCH_HEAD^{commit}
```

If that succeeds, Nix passes the resulting commit OID as a Git negotiation tip.

`--negotiation-tip` replaces Git's normal tip set rather than extending it.
To preserve normal negotiation, Nix also passes `refs/*` when the cached repository contains refs.
When the repository has no refs, it passes only the previous commit OID, avoiding Git's warning about an unmatched `refs/*` pattern.

If `FETCH_HEAD` is missing or does not resolve to a commit, Nix runs the previous fetch command without extra negotiation tips.
`GIT_ENOTFOUND`, `GIT_EINVALIDSPEC`, and `GIT_EPEEL` are treated as an unusable hint.
Other libgit2 errors remain fatal.

### Why this is safe

Negotiation tips only tell the server which objects the client already has.
They do not change the URL, refspec, or requested revision.

The additional OID comes from the local object database and is explicitly peeled to a commit.
Existing refs are still included when present.

If the previous commit is unrelated to the requested revision, the server cannot use it as common history and sends the normal pack.
If `FETCH_HEAD` is missing or unusable, Nix falls back to the previous behavior.

This can only reduce the transfer.
It cannot select a different revision or make Nix accept an invalid object.

### Alternative considered

I first considered storing the previous revision in a persistent internal ref such as `refs/nix/fetch-cache`.

That would be straightforward for Git, but unsafe for Nix.
Users can request arbitrary full ref names, so an internal ref could collide with a real remote ref and affect revision resolution.

Reusing `FETCH_HEAD` provides the negotiation hint without adding an internal ref namespace.

### Git compatibility

`--negotiation-tip` requires Git 2.19 or newer. It's a release from 2018 so everyone should have it it guess.
The requirement is documented in the release note.

Git 2.55 added the additive option:

```text
--negotiation-include=<oid>
```

There is a TODO to replace the current negotiation-tip workaround with this option once Git 2.55 becomes the minimum supported version. 

## Testing

Added two functional tests:

* `exact-rev-fetch-cache.sh` performs two related exact-revision fetches, checks that the second fetch sends `have <first-revision>`, and expects both fetches to receive exactly three objects. It also checks that Git does not emit an unmatched `refs/*` warning.
* `exact-rev-fetch-head-cache.sh` leaves an annotated tag pointing to a blob in `FETCH_HEAD`, verifies that Nix rejects it as a revision, and then verifies that a valid exact-revision fetch from the same cache still succeeds.

Also ran:

* the `libnixfetchers` build;
* shell syntax checks for both functional tests;
