### PR TITLE
libfetchers/git: render submodules as empty dirs in workdir accessor

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -24,6 +24,7 @@
 #include <git2/describe.h>
 #include <git2/errors.h>
 #include <git2/global.h>
+#include <git2/index.h>
 #include <git2/indexer.h>
 #include <git2/object.h>
 #include <git2/odb.h>
@@ -145,6 +146,7 @@ typedef std::unique_ptr<git_config_iterator, Deleter<git_config_iterator_free>> 
 typedef std::unique_ptr<git_odb, Deleter<git_odb_free>> ObjectDb;
 typedef std::unique_ptr<git_packbuilder, Deleter<git_packbuilder_free>> PackBuilder;
 typedef std::unique_ptr<git_indexer, Deleter<git_indexer_free>> Indexer;
+typedef std::unique_ptr<git_index, Deleter<git_index_free>> Index;
 
 static Hash toHash(const git_oid & oid)
 {
@@ -690,10 +692,27 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         if (git_status_foreach_ext(*this, &options, &statusCallbackTrampoline, &statusCallback))
             throw GitError("getting working directory status");
 
-        /* Get submodule info. */
+        /* Gitlinks in the index are the submodules; .gitmodules only
+           supplies their URLs. */
+        std::map<CanonPath, Submodule> configured;
         auto modulesFile = path / ".gitmodules";
         if (pathExists(modulesFile))
-            info.submodules = parseSubmodules(modulesFile);
+            for (auto & submodule : parseSubmodules(modulesFile))
+                configured.emplace(submodule.path, submodule);
+
+        Index index;
+        if (git_repository_index(Setter(index), *this))
+            throw GitError("opening index of Git repository %s", PathFmt(path));
+        for (size_t n = 0, count = git_index_entrycount(index.get()); n < count; ++n) {
+            auto entry = git_index_get_byindex(index.get(), n);
+            if (entry->mode != GIT_FILEMODE_COMMIT || git_index_entry_stage(entry) != 0)
+                continue;
+            CanonPath entryPath(entry->path);
+            if (auto it = configured.find(entryPath); it != configured.end())
+                info.submodules.push_back(std::move(it->second));
+            else
+                info.submodules.push_back(Submodule{.path = entryPath});
+        }
 
         return info;
     }

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -987,10 +987,9 @@ struct GitInputScheme : InputScheme
     {
         auto repoPath = repoInfo.getPath().value();
 
-        if (getSubmodulesAttr(input))
-            /* Create mountpoints for the submodules. */
-            for (auto & submodule : repoInfo.workdirInfo.submodules)
-                repoInfo.workdirInfo.files.insert(submodule.path);
+        /* Create mountpoints for the submodules. */
+        for (auto & submodule : repoInfo.workdirInfo.submodules)
+            repoInfo.workdirInfo.files.insert(submodule.path);
 
         auto repo = GitRepo::openRepo(repoPath, {});
 
@@ -1000,12 +999,19 @@ struct GitInputScheme : InputScheme
             repo->getAccessor(repoInfo.workdirInfo, {.exportIgnore = exportIgnore}, makeNotAllowedError(repoPath));
 
         /* If the repo has submodules, return a mounted input accessor
-           consisting of the accessor for the top-level repo and the
-           accessors for the submodule workdirs. */
-        if (getSubmodulesAttr(input) && !repoInfo.workdirInfo.submodules.empty()) {
+           consisting of the accessor for the top-level repo and, per
+           submodule, either its workdir accessor or an empty directory
+           where getAccessorFromCommit() would produce one (submodules
+           disabled, or a gitlink without a .gitmodules entry). */
+        if (!repoInfo.workdirInfo.submodules.empty()) {
             std::map<CanonPath, nix::ref<SourceAccessor>> mounts;
 
             for (auto & submodule : repoInfo.workdirInfo.submodules) {
+                if (!getSubmodulesAttr(input) || submodule.url.empty()) {
+                    mounts.insert_or_assign(submodule.path, makeEmptySourceAccessor());
+                    continue;
+                }
+
                 auto submodulePath = repoPath / submodule.path.rel();
                 fetchers::Attrs attrs;
                 attrs.insert_or_assign("type", "git");

--- a/tests/functional/fetchGitSubmodules.sh
+++ b/tests/functional/fetchGitSubmodules.sh
@@ -36,7 +36,21 @@ git -C "$rootRepo" commit -m "Add submodule"
 
 rev=$(git -C "$rootRepo" rev-parse HEAD)
 
+# A clean workdir must yield the same tree as fetching its HEAD rev: the
+# submodule is an empty directory, whether or not it is checked out.
+r0=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$rootRepo\"; }).outPath")
+[[ -d $r0/sub ]]
+[[ -z "$(ls -A "$r0/sub")" ]]
+# Both paths share a fingerprint, so compare narHashes with separate caches.
+hashWorkdir=$(XDG_CACHE_HOME=$TEST_ROOT/cache-workdir nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$rootRepo\"; }).narHash")
+hashRev=$(XDG_CACHE_HOME=$TEST_ROOT/cache-rev nix eval --raw --expr "(builtins.fetchGit { url = \"file://$rootRepo\"; rev = \"$rev\"; }).narHash")
+[[ $hashWorkdir == "$hashRev" ]]
+# The non-local (clone-to-cache) code path must agree as well.
+hashHttp=$(_NIX_FORCE_HTTP=1 XDG_CACHE_HOME=$TEST_ROOT/cache-http nix eval --raw --expr "(builtins.fetchGit { url = \"file://$rootRepo\"; rev = \"$rev\"; }).narHash")
+[[ $hashWorkdir == "$hashHttp" ]]
+
 r1=$(nix eval --raw --expr "(builtins.fetchGit { url = \"file://$rootRepo\"; rev = \"$rev\"; }).outPath")
+[[ $r0 == "$r1" ]]
 r2=$(nix eval --raw --expr "(builtins.fetchGit { url = \"file://$rootRepo\"; rev = \"$rev\"; submodules = false; }).outPath")
 r3=$(nix eval --raw --expr "(builtins.fetchGit { url = \"file://$rootRepo\"; rev = \"$rev\"; submodules = true; }).outPath")
 
@@ -226,3 +240,28 @@ test_submodule_nested() {
 
 }
 test_submodule_nested
+
+
+# A gitlink without a .gitmodules entry is still a submodule (#15423): it must
+# render the same (empty directory) from the workdir and by rev.
+test_gitlink_without_gitmodules() {
+  local repo=$TEST_ROOT/nogitmodules
+  createGitRepo "$repo"
+  git -C "$repo" submodule add "$subRepo" sub
+  git -C "$repo" commit -m "Add submodule"
+  git -C "$repo" rm .gitmodules
+  git -C "$repo" commit -m "Remove .gitmodules"
+  local rev
+  rev=$(git -C "$repo" rev-parse HEAD)
+
+  for submodules in true false; do
+    local hashWorkdir hashRev outWorkdir
+    hashWorkdir=$(XDG_CACHE_HOME=$TEST_ROOT/ngm-workdir-$submodules nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; submodules = $submodules; }).narHash")
+    hashRev=$(XDG_CACHE_HOME=$TEST_ROOT/ngm-rev-$submodules nix eval --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; rev = \"$rev\"; submodules = $submodules; }).narHash")
+    [[ $hashWorkdir == "$hashRev" ]]
+    outWorkdir=$(XDG_CACHE_HOME=$TEST_ROOT/ngm-workdir-$submodules nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; submodules = $submodules; }).outPath")
+    [[ -d $outWorkdir/sub ]]
+    [[ -z "$(ls -A "$outWorkdir/sub")" ]]
+  done
+}
+test_gitlink_without_gitmodules


### PR DESCRIPTION
With `submodules = false`, fetching a local workdir omitted submodule paths entirely, while fetching the same repo by rev renders them as empty dirs. Same fingerprint, different narHash -> fetcher cache poisoning / narHash mismatch (e.g. in nix-eval-jobs).

Enumerate submodules in the workdir from gitlinks in the index (`.gitmodules` only supplies URLs) and render every submodule that is not fetched as an empty dir, matching `getAccessorFromCommit()`.

Fixes #13698. Fixes #15423. Split out of #16391, supersedes #14779.