### PR TITLE
readString: do not preallocate the announced length

### DIFF
--- a/src/libutil-tests/serialise.cc
+++ b/src/libutil-tests/serialise.cc
@@ -24,6 +24,26 @@ TEST(readNum, negativeValuesSerialiseWellDefined)
     EXPECT_EQ(readNum<uint64_t>(*makeNumSource(int16_t(-1))), std::numeric_limits<uint64_t>::max());
 }
 
+TEST(readString, roundTrip)
+{
+    for (auto & s : std::vector<std::string>{"", "x", "1234567", "12345678", "123456789", std::string(300'000, 'a')}) {
+        StringSink sink;
+        sink << s;
+        StringSource source(sink.s);
+        EXPECT_EQ(readString(source), s);
+    }
+}
+
+TEST(readString, bogusLengthDoesNotPreallocate)
+{
+    // 1 TiB length prefix followed by EOF: must fail on the read, not by
+    // allocating (and zeroing) the announced size up front.
+    StringSink sink;
+    sink << (uint64_t(1) << 40);
+    StringSource source(sink.s);
+    EXPECT_THROW(readString(source), EndOfFile);
+}
+
 TEST(readPadding, works)
 {
     for (unsigned i = 0; i < 8; ++i)

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -600,8 +600,25 @@ std::string readString(Source & source, size_t max)
     auto len = readNum<size_t>(source);
     if (len > max)
         throw SerialisationError("string is too long");
-    std::string res(len, 0);
-    source(res.data(), len);
+    /* Grow with the data actually received rather than trusting `len` for
+       the allocation, so a bogus length prefix costs the peer as many bytes
+       as it costs us. */
+    std::string res;
+    while (res.size() < len) {
+        size_t filled = res.size();
+        size_t want = std::min(len, std::max<size_t>(2 * filled, 64 * 1024));
+        std::exception_ptr ex;
+        res.resize_and_overwrite(want, [&](char * buf, size_t) -> size_t {
+            try {
+                return filled + source.read(buf + filled, want - filled);
+            } catch (...) {
+                ex = std::current_exception();
+                return filled;
+            }
+        });
+        if (ex)
+            std::rethrow_exception(ex);
+    }
     readPadding(len, source);
     return res;
 }


### PR DESCRIPTION
I was fuzzing locally and this seems like a saner approach to potentially untrusted input.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
