### PR TITLE
libutil: Make Verbosity an enum class, use clamped conversions from raw integers

### DIFF
--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -9,6 +9,8 @@
 #include "nix/util/util.hh"
 #include "nix/main/plugin.hh"
 
+#include <utility>
+
 namespace nix {
 
 MixCommonArgs::MixCommonArgs(const std::string & programName)
@@ -20,7 +22,7 @@ MixCommonArgs::MixCommonArgs(const std::string & programName)
         .description = "Increase the logging verbosity level.",
         .category = loggingCategory,
         .handler = {[]() {
-            verbosity = (Verbosity) std::min<std::underlying_type_t<Verbosity>>(verbosity + 1, lvlVomit);
+            verbosity = (verbosity >= lvlVomit ? lvlVomit : static_cast<Verbosity>(std::to_underlying(verbosity) + 1));
         }},
     });
 
@@ -28,7 +30,9 @@ MixCommonArgs::MixCommonArgs(const std::string & programName)
         .longName = "quiet",
         .description = "Decrease the logging verbosity level.",
         .category = loggingCategory,
-        .handler = {[]() { verbosity = verbosity > lvlError ? (Verbosity) (verbosity - 1) : lvlError; }},
+        .handler = {[]() {
+            verbosity = (verbosity <= lvlError ? lvlError : static_cast<Verbosity>(std::to_underlying(verbosity) - 1));
+        }},
     });
 
     addFlag({

--- a/src/libstore/common-protocol.cc
+++ b/src/libstore/common-protocol.cc
@@ -1,4 +1,5 @@
 #include "nix/util/serialise.hh"
+#include "nix/util/error.hh"
 #include "nix/store/path-with-outputs.hh"
 #include "nix/store/build-result.hh"
 #include "nix/store/common-protocol.hh"
@@ -8,6 +9,8 @@
 #include "nix/util/signature/local-keys.hh"
 
 #include <nlohmann/json.hpp>
+
+#include <utility>
 
 namespace nix {
 
@@ -134,6 +137,17 @@ void CommonProto::Serialise<BuildResultStatus>::write(
             return;
         }
     unreachable();
+}
+
+Verbosity CommonProto::Serialise<Verbosity>::read(const StoreDirConfig & store, CommonProto::ReadConn conn)
+{
+    return verbosityFromIntClamped(readInt(conn.from));
+}
+
+void CommonProto::Serialise<Verbosity>::write(
+    const StoreDirConfig & store, CommonProto::WriteConn conn, const Verbosity & verbosity)
+{
+    conn.to << std::to_underlying(verbosity);
 }
 
 } // namespace nix

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -22,7 +22,9 @@
 #include "nix/util/args.hh"
 #include "nix/util/logging.hh"
 #include "nix/store/globals.hh"
+
 #include <variant>
+#include <utility>
 
 #ifndef _WIN32 // TODO need graceful async exit support on Windows?
 #  include "nix/util/monitor-fd.hh"
@@ -170,7 +172,7 @@ struct TunnelLogger : public Logger
         }
 
         StringSink buf;
-        buf << STDERR_START_ACTIVITY << act << lvl << type << s << fields << parent;
+        buf << STDERR_START_ACTIVITY << act << std::to_underlying(lvl) << type << s << fields << parent;
         enqueueMsg(buf.s);
     }
 
@@ -821,11 +823,11 @@ static void performOp(
         clientSettings.keepFailed = readInt(conn.from);
         clientSettings.keepGoing = readInt(conn.from);
         clientSettings.tryFallback = readInt(conn.from);
-        clientSettings.verbosity = (Verbosity) readInt(conn.from);
+        clientSettings.verbosity = WorkerProto::Serialise<Verbosity>::read(*store, conn);
         clientSettings.maxBuildJobs = readInt(conn.from);
         clientSettings.maxSilentTime = readInt(conn.from);
         readInt(conn.from); // obsolete useBuildHook
-        clientSettings.verboseBuild = lvlError == (Verbosity) readInt(conn.from);
+        clientSettings.verboseBuild = (readInt(conn.from) == 0);
         readInt(conn.from); // obsolete logType
         readInt(conn.from); // obsolete printBuildTrace
         clientSettings.buildCores = readInt(conn.from);

--- a/src/libstore/include/nix/store/common-protocol.hh
+++ b/src/libstore/include/nix/store/common-protocol.hh
@@ -118,6 +118,8 @@ using BuildResultStatus = std::variant<BuildResultSuccessStatus, BuildResultFail
 
 template<>
 DECLARE_COMMON_SERIALISER(BuildResultStatus);
+template<>
+DECLARE_COMMON_SERIALISER(Verbosity);
 
 #undef COMMA_
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -22,7 +22,9 @@
 #include "nix/store/filetransfer.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/socket.hh"
+
 #include <variant>
+#include <utility>
 
 #ifndef _WIN32
 #  include <sys/socket.h>
@@ -132,10 +134,10 @@ void RemoteStore::initConnection(Connection & conn)
 void RemoteStore::setOptions(Connection & conn)
 {
     conn.to << WorkerProto::Op::SetOptions << settings.keepFailed << settings.getWorkerSettings().keepGoing
-            << settings.getWorkerSettings().tryFallback << verbosity << settings.getWorkerSettings().maxBuildJobs
-            << settings.getWorkerSettings().maxSilentTime << true << (settings.verboseBuild ? lvlError : lvlVomit)
-            << 0 // obsolete log type
-            << 0 /* obsolete print build trace */
+            << settings.getWorkerSettings().tryFallback << std::to_underlying(verbosity)
+            << settings.getWorkerSettings().maxBuildJobs << settings.getWorkerSettings().maxSilentTime << true
+            << std::to_underlying(settings.verboseBuild ? lvlError : lvlVomit) << 0 // obsolete log type
+            << 0                                                                    /* obsolete print build trace */
             << settings.getLocalSettings().buildCores << settings.getWorkerSettings().useSubstitutes;
 
     std::map<std::string, nix::Config::SettingInfo> overrides;

--- a/src/libstore/unix/build/hook-instance.cc
+++ b/src/libstore/unix/build/hook-instance.cc
@@ -3,7 +3,9 @@
 #include "nix/store/build/child.hh"
 #include "nix/util/strings.hh"
 #include "nix/util/executable-path.hh"
+
 #include <chrono>
+#include <utility>
 
 namespace nix {
 
@@ -32,7 +34,7 @@ HookInstance::HookInstance(const Strings & _buildHook, std::chrono::milliseconds
     for (auto & arg : buildHookArgs)
         args.push_back(arg);
 
-    args.push_back(std::to_string(verbosity));
+    args.push_back(std::to_string(std::to_underlying(verbosity)));
 
     /* Create a pipe to get the output of the child. */
     fromHook.create();

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -82,7 +82,7 @@ WorkerProto::BasicClientConnection::processStderrReturn(Sink * sink, Source * so
 
         else if (msg == STDERR_START_ACTIVITY) {
             auto act = readNum<ActivityId>(from);
-            auto lvl = (Verbosity) readInt(from);
+            auto lvl = verbosityFromIntClamped(readInt(from));
             auto type = (ActivityType) readInt(from);
             auto s = readString(from);
             auto fields = readFields(from);

--- a/src/libutil-tests/serialise.cc
+++ b/src/libutil-tests/serialise.cc
@@ -3,6 +3,9 @@
 
 #include <boost/context/detail/exception.hpp>
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <limits>
 
 namespace nix {
 
@@ -42,6 +45,30 @@ TEST(readString, bogusLengthDoesNotPreallocate)
     sink << (uint64_t(1) << 40);
     StringSource source(sink.s);
     EXPECT_THROW(readString(source), EndOfFile);
+}
+
+TEST(readError, bogusLevelIsClamped)
+{
+    for (uint64_t level : {
+             uint64_t(8),
+             uint64_t(1234),
+             uint64_t(std::numeric_limits<unsigned>::max()),
+         }) {
+        StringSink sink;
+        sink << "Error" << level << "Error" << "oops" << uint64_t(0) << uint64_t(0);
+        StringSource source(sink.s);
+        auto e = readError(source);
+        EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("oops"));
+        EXPECT_EQ(e.info().level, Verbosity::lvlVomit);
+    }
+}
+
+TEST(readError, uint64LevelError)
+{
+    StringSink sink;
+    sink << "Error" << std::numeric_limits<uint64_t>::max() << "Error" << "oops" << uint64_t(0) << uint64_t(0);
+    StringSource source(sink.s);
+    EXPECT_THROW(readError(source), SerialisationError);
 }
 
 TEST(readPadding, works)

--- a/src/libutil/include/nix/util/error.hh
+++ b/src/libutil/include/nix/util/error.hh
@@ -26,6 +26,9 @@
 #include <memory>
 #include <optional>
 #include <utility>
+#include <algorithm>
+#include <concepts>
+#include <type_traits>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -36,7 +39,35 @@
 
 namespace nix {
 
-typedef enum { lvlError = 0, lvlWarn, lvlNotice, lvlInfo, lvlTalkative, lvlChatty, lvlDebug, lvlVomit } Verbosity;
+enum class Verbosity : unsigned {
+    lvlError = 0,
+    lvlWarn,
+    lvlNotice,
+    lvlInfo,
+    lvlTalkative,
+    lvlChatty,
+    lvlDebug,
+    lvlVomit,
+};
+
+/* For less churn. */
+using enum Verbosity;
+
+template<std::integral T>
+    requires(std::is_unsigned_v<T> && !std::is_same_v<bool, T>)
+inline Verbosity verbosityFromIntClamped(T val)
+{
+    /* Clamp, same as https://git.lix.systems/lix-project/lix/commit/f2fff1faa4c6a308ad30da691e18ceccf6626e0d and
+       what was effectively the behavior before b9f8c4af4057c2ed0ec5d1ff16ac49e0612ad57c because logErrorInfo
+       and friends do a <= nix::verbosity. */
+    return static_cast<Verbosity>(std::min<T>(val, std::to_underlying(lvlVomit)));
+}
+
+/* So that we don't accidentally run into 2s complement conversion issues.
+   Nothing actually needs this conversion. */
+template<std::integral T>
+    requires std::is_signed_v<T>
+Verbosity verbosityFromIntClamped(T) = delete;
 
 /**
  * The lines of code surrounding an error.

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -441,14 +441,23 @@ bool handleJSONLogMessage(
     try {
         std::string action = json["action"];
 
+        // XXX: UB provoking C-style casts to enums. Fuzz the hell out of this
+        // code!
         if (action == "start") {
             auto type = (ActivityType) json["type"];
-            if (trusted || type == actFileTransfer)
+            if (trusted || type == actFileTransfer) {
+                auto level = json["level"].get<nlohmann::json::number_unsigned_t>();
                 activities.emplace(
                     std::piecewise_construct,
                     std::forward_as_tuple(json["id"]),
                     std::forward_as_tuple(
-                        *logger, (Verbosity) json["level"], type, json["text"], getFields(json["fields"]), act.id));
+                        *logger,
+                        verbosityFromIntClamped(level),
+                        type,
+                        json["text"],
+                        getFields(json["fields"]),
+                        act.id));
+            }
         }
 
         else if (action == "stop")
@@ -466,8 +475,9 @@ bool handleJSONLogMessage(
         }
 
         else if (action == "msg") {
+            auto level = json["level"].get<nlohmann::json::number_unsigned_t>();
             std::string msg = json["msg"];
-            logger->log((Verbosity) json["level"], msg);
+            logger->log(verbosityFromIntClamped(level), msg);
         }
 
         return true;

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <limits>
 #include <memory>
+#include <utility>
 
 #include <boost/coroutine2/coroutine.hpp>
 #include <boost/coroutine2/protected_fixedsize_stack.hpp>
@@ -564,8 +565,8 @@ Sink & operator<<(Sink & sink, const StringSet & s)
 Sink & operator<<(Sink & sink, const Error & ex)
 {
     auto & info = ex.info();
-    sink << "Error" << info.level << "Error" // removed
-         << info.msg.str() << 0              // FIXME: info.errPos
+    sink << "Error" << std::to_underlying(info.level) << "Error" // removed
+         << info.msg.str() << 0                                  // FIXME: info.errPos
          << info.traces.size();
     for (auto & trace : info.traces) {
         sink << 0; // FIXME: trace.pos
@@ -647,7 +648,7 @@ Error readError(Source & source)
     auto type = readString(source);
     if (type != "Error")
         throw SerialisationError("unexpected error type '%s'", type);
-    auto level = (Verbosity) readInt(source);
+    auto level = verbosityFromIntClamped(readInt(source));
     [[maybe_unused]] auto name = readString(source); // removed
     auto msg = readString(source);
     ErrorInfo info{

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -19,6 +19,7 @@
 #include "nix/store/build-result.hh"
 #include "nix/store/store-open.hh"
 #include "nix/util/strings.hh"
+#include "nix/util/util.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/derivation/full-inputs.hh"
 #include "nix/store/local-store.hh"
@@ -84,7 +85,10 @@ static int main_build_remote(int argc, char ** argv)
         if (argc != 2)
             throw UsageError("called without required arguments");
 
-        verbosity = (Verbosity) std::stoll(argv[1]);
+        auto rawVerbosity = string2Int<unsigned>(argv[1]);
+        if (!rawVerbosity)
+            throw UsageError("invalid verbosity '%s'", argv[1]);
+        verbosity = verbosityFromIntClamped(*rawVerbosity);
 
         FdSource source(STDIN_FILENO);
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

(Amended, rebased and clamping added by @xokdvium)

It's not a great idea to use C-style casts to convert values that
we get from an untrusted peer into enums. It's UB strictly speaking,
just one that we weren't bitten much before.

See https://github.com/Mic92/nix-1/commit/b9f8c4af4057c2ed0ec5d1ff16ac49e0612ad57c for some history there.
Clamping is the historically reasonable behavior.
See lix's https://github.com/Mic92/nix-1/commit/f2fff1faa4c6a308ad30da691e18ceccf6626e0d too.

Also, showErrorInfo() asserts on levels outside the Verbosity enum, so a
remote daemon could abort the client with a single STDERR_ERROR
message. Clamp unknown levels to lvlVomit, consistent with how that
would behave previously.

Co-authored-by: Jörg Thalheim <joerg@thalheim.io>
Co-authored-by: Jade Lovelace <lix@jade.fyi>
Co-authored-by: Bernardo Meurer <beme@anthropic.com>

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Closes https://github.com/NixOS/nix/pull/14657.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
