### PR TITLE
libexpr: readFile respects allowed-uris

### DIFF
--- a/doc/manual/rl-next/allowed-uris-read-file.md
+++ b/doc/manual/rl-next/allowed-uris-read-file.md
@@ -1,0 +1,10 @@
+---
+synopsis: "`allowed-uris` now also applies to `builtins.readFile`/`readDir`/`readFileType`"
+prs: []
+issues: [2596]
+---
+
+Under `restrict-eval`, the `allowed-uris` setting previously only granted access to fetchers
+like `builtins.fetchurl` and `fetchGit`. `builtins.readFile`, `builtins.readDir`, and
+`builtins.readFileType` ignored it and only consulted the paths allow-listed via `-I`/
+`NIX_PATH`. These builtins now also respect `allowed-uris`, consistent with the fetchers.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -372,6 +372,26 @@ EvalState::EvalState(
         for (auto & i : lookupPath.elements)
             resolveLookupPathPath(i.path, true);
 
+    /* Also allow access to local paths named in `allowed-uris`, matching what fetchers can access. */
+    if (auto rootFS2 = rootFS.dynamic_pointer_cast<AllowListSourceAccessor>()) {
+        for (auto & uri : settings.allowedUris.get()) {
+            // A trailing slash means descendants only, which allowPrefix can't express, so skip it.
+            if (uri.empty() || uri.back() == '/')
+                continue;
+            std::filesystem::path path(uri);
+            if (path.is_absolute()) {
+                rootFS2->allowPrefix(CanonPath(path.string()));
+                continue;
+            }
+            try {
+                ParsedURL parsed = parseURL(uri);
+                if (parsed.scheme == "file")
+                    rootFS2->allowPrefix(CanonPath(urlPathToPath(parsed.path).string()));
+            } catch (BadURL &) {
+            }
+        }
+    }
+
     corepkgsFS->addFile(
         CanonPath("fetchurl.nix"),
         {

--- a/tests/functional/restricted.sh
+++ b/tests/functional/restricted.sh
@@ -33,6 +33,39 @@ cmp "$p" "${_NIX_TEST_SOURCE_DIR}/restricted.sh"
 
 nix eval --raw --expr "builtins.fetchurl \"file://${_NIX_TEST_SOURCE_DIR}/restricted.sh\"" --impure --restrict-eval --allowed-uris "file://${_NIX_TEST_SOURCE_DIR}/restricted.sh"
 
+# `allowed-uris` should also grant `readFile`/`readDir` access, not just fetchers (#2596).
+(! nix eval --raw --expr "builtins.readFile \"${_NIX_TEST_SOURCE_DIR}/restricted.sh\"" --impure --restrict-eval)
+[[ $(nix eval --raw --expr "builtins.readFile \"${_NIX_TEST_SOURCE_DIR}/restricted.sh\"" --impure --restrict-eval --allowed-uris "${_NIX_TEST_SOURCE_DIR}") == "$(cat "${_NIX_TEST_SOURCE_DIR}/restricted.sh")" ]]
+[[ $(nix eval --expr "builtins.readDir \"${_NIX_TEST_SOURCE_DIR}\"" --impure --restrict-eval --allowed-uris "${_NIX_TEST_SOURCE_DIR}" --json | jq -r 'keys | length') -gt 0 ]]
+(! nix eval --raw --expr "builtins.readFile \"${_NIX_TEST_SOURCE_DIR}/restricted.sh\"" --impure --restrict-eval --allowed-uris "${_NIX_TEST_SOURCE_DIR}/other-dir")
+
+# A symlink under an `allowed-uris`-granted directory that points elsewhere in
+# that same directory should still resolve, not spuriously fail as unresolvable.
+mkdir -p "$TEST_ROOT/allowed-uris-dir"
+echo -n "hello" > "$TEST_ROOT/allowed-uris-dir/target"
+ln -sfn "$TEST_ROOT/allowed-uris-dir/target" "$TEST_ROOT/allowed-uris-dir/link"
+[[ $(nix eval --raw --expr "builtins.readFile \"$TEST_ROOT/allowed-uris-dir/link\"" --impure --restrict-eval --allowed-uris "$TEST_ROOT/allowed-uris-dir") == "hello" ]]
+
+# `allowed-uris` in `file://` form should also grant `readFile` etc., not just
+# fetchers, matching the bare-path form.
+[[ $(nix eval --raw --expr "builtins.readFile \"$TEST_ROOT/allowed-uris-dir/target\"" --impure --restrict-eval --allowed-uris "file://$TEST_ROOT/allowed-uris-dir") == "hello" ]]
+
+# `import` of a file reached through a symlink should also be granted by
+# `allowed-uris`, not just a direct, non-symlink path.
+echo '"imported-ok"' > "$TEST_ROOT/allowed-uris-dir/target.nix"
+ln -sfn "$TEST_ROOT/allowed-uris-dir/target.nix" "$TEST_ROOT/allowed-uris-dir/link.nix"
+[[ $(nix eval --raw --expr "import \"$TEST_ROOT/allowed-uris-dir/link.nix\"" --impure --restrict-eval --allowed-uris "$TEST_ROOT/allowed-uris-dir") == "imported-ok" ]]
+
+# A relative import inside a file reached through a symlinked directory
+# should resolve against the symlink's logical location, not the resolved
+# target's physical location, even when `allowed-uris` (not `-I`) is what
+# grants access.
+mkdir -p "$TEST_ROOT/allowed-uris-symlink/foo/lib" "$TEST_ROOT/allowed-uris-symlink/overlays"
+echo '"sibling-ok"' > "$TEST_ROOT/allowed-uris-symlink/foo/lib/default.nix"
+echo 'import ../lib' > "$TEST_ROOT/allowed-uris-symlink/overlays/overlay.nix"
+ln -sfn "../overlays" "$TEST_ROOT/allowed-uris-symlink/foo/overlays"
+[[ $(nix eval --raw --expr "import \"$TEST_ROOT/allowed-uris-symlink/foo/overlays/overlay.nix\"" --impure --restrict-eval --allowed-uris "$TEST_ROOT/allowed-uris-symlink") == "sibling-ok" ]]
+
 (! nix eval --raw --expr "builtins.fetchurl \"https://github.com/NixOS/patchelf/archive/master.tar.gz\"" --impure --restrict-eval)
 (! nix eval --raw --expr "builtins.fetchTarball \"https://github.com/NixOS/patchelf/archive/master.tar.gz\"" --impure --restrict-eval)
 (! nix eval --raw --expr "fetchGit \"git://github.com/NixOS/patchelf.git\"" --impure --restrict-eval)


### PR DESCRIPTION
This is a behavior change. It expands the set of things allowed to be accessed under restrict-eval

--------------

readFile/readDir/readFileType only checked -I/NIX_PATH under
restrict-eval, so allowed-uris did nothing for them even though
fetchurl/fetchGit already respect it.

Fix: realisePath now grants access on rootFS's allow-list when the
path matches allowed-uris, so the read that follows isn't rejected.
checkURI itself is untouched.

Fixes https://github.com/NixOS/nix/issues/2596.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>