### PR TITLE
libexpr-c: allow null primop docs

### DIFF
--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -121,7 +121,7 @@ PrimOp * nix_alloc_primop(
                     .name = name,
                     .args = {},
                     .arity = (size_t) arity,
-                    .doc = doc,
+                    .doc = doc ? std::optional<std::string>{doc} : std::nullopt,
                     .impl = std::bind(nix_c_primop_wrapper, fun, user_data, arity, _1, _2, _3, _4)};
         if (args)
             for (size_t i = 0; args[i]; i++)

--- a/src/libexpr-tests/nix_api_expr.cc
+++ b/src/libexpr-tests/nix_api_expr.cc
@@ -299,6 +299,16 @@ primop_square(void * user_data, nix_c_context * context, EvalState * state, nix_
     nix_init_int(context, ret, i * i);
 }
 
+TEST_F(nix_api_expr_test, nix_alloc_primop_without_doc)
+{
+    PrimOp * primop = nix_alloc_primop(ctx, primop_square, 1, "undocumented", nullptr, nullptr, nullptr);
+    assert_ctx_ok();
+    ASSERT_NE(nullptr, primop);
+
+    nix_gc_decref(ctx, primop);
+    assert_ctx_ok();
+}
+
 TEST_F(nix_api_expr_test, nix_expr_primop)
 {
     PrimOp * primop = nix_alloc_primop(


### PR DESCRIPTION
**Problem**: `nix_alloc_primop` crashes when the doc pointer is null, despite the C API documenting it as optional.

**Solution**: treat null as `std::nullopt` (and add a regression test).

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
