### PR TITLE
remote-fs-accessor: return null for missing store objects

### DIFF
--- a/src/libstore-tests/local-binary-cache-store.cc
+++ b/src/libstore-tests/local-binary-cache-store.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "nix/store/local-binary-cache-store.hh"
+#include "nix/util/file-system.hh"
 
 namespace nix {
 
@@ -20,6 +21,15 @@ TEST(LocalBinaryCacheStore, constructConfig)
 {
     LocalBinaryCacheStoreConfig config{std::filesystem::path("/foo/bar/baz"), {}};
     EXPECT_EQ(config.binaryCacheDir, "/foo/bar/baz");
+}
+
+TEST(LocalBinaryCacheStore, fsAccessorsHandleMissingObject)
+{
+    auto cacheDir = createTempDir();
+    AutoDelete delCacheDir{cacheDir};
+    auto store = make_ref<LocalBinaryCacheStoreConfig>(cacheDir, LocalBinaryCacheStoreConfig::Params{})->openStore();
+    EXPECT_EQ(store->getFSAccessor(StorePath::dummy), nullptr);
+    EXPECT_EQ(store->getFSAccessor()->maybeLstat(CanonPath(StorePath::dummy.to_string())), std::nullopt);
 }
 
 } // namespace nix

--- a/src/libstore/include/nix/store/remote-fs-accessor.hh
+++ b/src/libstore/include/nix/store/remote-fs-accessor.hh
@@ -23,8 +23,6 @@ class RemoteFSAccessor : public SourceAccessor
 
     NarCache narCache;
 
-    bool requireValidPath;
-
     std::pair<ref<SourceAccessor>, CanonPath> fetch(const CanonPath & path);
 
     friend struct BinaryCacheStore;
@@ -33,8 +31,6 @@ public:
 
     /**
      * @return nullptr if the store does not contain any object at that path.
-     *
-     * @todo This actually doesn't return nullptr, but throws on invalid paths.
      */
     std::shared_ptr<SourceAccessor> accessObject(const StorePath & path);
 

--- a/src/libstore/remote-fs-accessor.cc
+++ b/src/libstore/remote-fs-accessor.cc
@@ -4,19 +4,19 @@ namespace nix {
 
 void RemoteFSAccessor::anchor() {}
 
-RemoteFSAccessor::RemoteFSAccessor(ref<Store> store, bool requireValidPath, std::optional<AbsolutePath> cacheDir)
+RemoteFSAccessor::RemoteFSAccessor(ref<Store> store, bool, std::optional<AbsolutePath> cacheDir)
     : store(store)
     , narCache(cacheDir)
-    , requireValidPath(requireValidPath)
 {
 }
 
 std::pair<ref<SourceAccessor>, CanonPath> RemoteFSAccessor::fetch(const CanonPath & path)
 {
     auto [storePath, restPath] = store->toStorePath(store->storeDir + path.abs());
-    if (requireValidPath && !store->isValidPath(storePath))
+    auto accessor = accessObject(storePath);
+    if (!accessor)
         throw InvalidPath("path '%1%' is not a valid store path", store->printStorePath(storePath));
-    return {ref{accessObject(storePath)}, restPath};
+    return {ref{std::move(accessor)}, restPath};
 }
 
 std::shared_ptr<SourceAccessor> RemoteFSAccessor::accessObject(const StorePath & storePath)
@@ -25,8 +25,12 @@ std::shared_ptr<SourceAccessor> RemoteFSAccessor::accessObject(const StorePath &
     if (auto * narHash = get(narHashes, storePath.hashPart()))
         return narCache.getOrInsert(*narHash, [&](Sink & sink) { store->narFromPath(storePath, sink); });
 
-    // Query the path info to get the NAR hash
-    auto info = store->queryPathInfo(storePath);
+    std::shared_ptr<const ValidPathInfo> info;
+    try {
+        info = store->queryPathInfo(storePath);
+    } catch (InvalidPath &) {
+        return nullptr;
+    }
 
     // Cache the mapping from store path to NAR hash
     narHashes.emplace(storePath.hashPart(), info->narHash);
@@ -39,10 +43,12 @@ std::optional<SourceAccessor::Stat> RemoteFSAccessor::maybeLstat(const CanonPath
 {
     if (path.isRoot())
         return Stat{.type = tDirectory};
-    /* FIXME: Correctly handle invalid names (return nullopt) and don't fail on
-       non-existent paths. */
-    auto res = fetch(path);
-    return res.first->maybeLstat(res.second);
+    /* FIXME: Correctly handle invalid names (return nullopt). */
+    auto [storePath, restPath] = store->toStorePath(store->storeDir + path.abs());
+    auto accessor = accessObject(storePath);
+    if (!accessor)
+        return std::nullopt;
+    return accessor->maybeLstat(restPath);
 }
 
 SourceAccessor::DirEntries RemoteFSAccessor::readDirectory(const CanonPath & path)


### PR DESCRIPTION
## Motivation

`Store::getFSAccessor(path)` promises to return `nullptr` when the store object is missing. `RemoteFSAccessor::accessObject` instead propagated `InvalidPath` from `queryPathInfo`.

## Context

Found while reviewing the profile-store work in #16395. Catch `InvalidPath` at the path-info lookup boundary and return `nullptr`, preserving other accessor errors. Includes a regression test using a local binary cache.