### PR TITLE
Windows: cover libstore in CI, and let it build content-addressed derivations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,6 @@ jobs:
     needs: basic-checks
     name: windows unit tests
     runs-on: ubuntu-24.04
-    continue-on-error: true
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -159,7 +158,7 @@ jobs:
         dogfood: ${{ github.event_name == 'workflow_dispatch' && inputs.dogfood || github.event_name != 'workflow_dispatch' }}
     - name: Build and test Windows components
       run: |
-        nix build --file ci/gha/tests/windows.nix crossBuild unitTests.nix-util-tests -L
+        nix build --file ci/gha/tests/windows.nix crossBuild unitTests.nix-util-tests unitTests.nix-store-tests -L
 
   installer_test:
     needs: [tests]

--- a/ci/gha/tests/windows.nix
+++ b/ci/gha/tests/windows.nix
@@ -26,8 +26,8 @@ in
 {
   unitTests = {
     "nix-util-tests" = fixOutput packages."nix-util-tests-x86_64-w64-mingw32".passthru.tests.run;
+    "nix-store-tests" = fixOutput packages."nix-store-tests-x86_64-w64-mingw32".passthru.tests.run;
   };
 
-  # `unitTests` builds one suite, which links neither libmain nor libstore.
   crossBuild = packages."nix-everything-x86_64-w64-mingw32";
 }

--- a/ci/gha/tests/windows.nix
+++ b/ci/gha/tests/windows.nix
@@ -16,6 +16,13 @@ let
       # hide/show sequences, making logs unreadable in GitHub Actions.
       buildCommand = ''
         set -o pipefail
+        # The outer build sets `NIX_STORE` to the host's POSIX store directory,
+        # and Wine passes it through to the Windows test binary. A store
+        # configured as `FilePathType::Native` then validates that value with
+        # `std::filesystem::path::is_absolute()`, which is false for a
+        # POSIX-rooted path on Windows because it has no root name. Clearing
+        # both lets each store type fall back to its own correct default.
+        unset NIX_STORE NIX_STORE_DIR
         {
           ${prev.buildCommand}
         } 2>&1 | ansi2txt

--- a/src/libstore-tests/local-overlay-store.cc
+++ b/src/libstore-tests/local-overlay-store.cc
@@ -44,14 +44,19 @@ TEST(LocalOverlayStore, upperLayer_notOverridden)
 
 TEST(LocalOverlayStore, upperLayer_overridden)
 {
+#ifdef _WIN32
+    constexpr std::string_view upper = "C:\\some\\upper";
+#else
+    constexpr std::string_view upper = "/some/upper";
+#endif
     LocalOverlayStoreConfig config{
         "",
         {
-            {"upper-layer", "/some/upper"},
+            {"upper-layer", std::string{upper}},
         },
     };
     EXPECT_TRUE(config.upperLayer.isOverridden());
-    EXPECT_EQ(config.upperLayer.get(), std::filesystem::path{"/some/upper"});
+    EXPECT_EQ(config.upperLayer.get(), std::optional<AbsolutePath>{std::string{upper}});
 }
 
 } // namespace nix

--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -11,6 +11,9 @@
 #include "nix/util/tests/string_callback.hh"
 #include "nix/util/tests/test-data.hh"
 #include "nix/util/url.hh"
+#ifdef _WIN32
+#  include "nix/util/windows-known-folders.hh"
+#endif
 
 #include "store-tests-config.hh"
 
@@ -50,8 +53,17 @@ TEST_F(nix_api_util_context, nix_store_get_storedir_default)
     assert_ctx_ok();
     ASSERT_EQ(NIX_OK, ret);
 
-    // These tests run with a unique storeDir, but not a relocated store
+    // These tests run with a unique storeDir, but not a relocated store.
+    //
+    // The default store is a local store, whose store dir is a *native* path.
+    // `NIX_STORE_DIR` is the Unix spelling, and on Windows it is not even a
+    // valid absolute path, so the native default is used there instead. See
+    // `StoreConfigBase::StoreDirSetting` for where that default comes from.
+#ifdef _WIN32
+    ASSERT_EQ((nix::windows::known_folders::getProgramData() / "nix" / "store").string(), str);
+#else
     ASSERT_STREQ(NIX_STORE_DIR, str.c_str());
+#endif
 
     nix_store_free(store);
 }

--- a/src/libstore/build/derivation-builder-impl.cc
+++ b/src/libstore/build/derivation-builder-impl.cc
@@ -764,4 +764,88 @@ SingleDrvOutputs DerivationBuilderImpl::checkSubmittedOutputs()
     return builtOutputs;
 }
 
+StorePath DerivationBuilderImpl::makeFallbackPath(OutputNameView outputName)
+{
+    // This is a bogus path type, constructed this way to ensure that it doesn't collide with any other store path
+    // See doc/manual/source/protocols/store-path.md for details
+    // TODO: We may want to separate the responsibilities of constructing the path fingerprint and of actually doing the
+    // hashing
+    auto pathType = "rewrite:" + std::string(drvPath.to_string()) + ":name:" + std::string(outputName);
+    return store.makeStorePath(
+        pathType,
+        // pass an all-zeroes hash
+        Hash(HashAlgorithm::SHA256),
+        outputPathName(drv.name, outputName));
+}
+
+StorePath DerivationBuilderImpl::makeFallbackPath(const StorePath & path)
+{
+    // This is a bogus path type, constructed this way to ensure that it doesn't collide with any other store path
+    // See doc/manual/source/protocols/store-path.md for details
+    auto pathType = "rewrite:" + std::string(drvPath.to_string()) + ":" + std::string(path.to_string());
+    return store.makeStorePath(
+        pathType,
+        // pass an all-zeroes hash
+        Hash(HashAlgorithm::SHA256),
+        path.name());
+}
+
+void DerivationBuilderImpl::prepareScratchOutputs()
+{
+    for (auto & [outputName, status] : initialOutputs) {
+        /* Set scratch path we'll actually use during the build.
+
+           If we're not doing a chroot build, but we have some valid
+           output paths.  Since we can't just overwrite or delete
+           them, we have to do hash rewriting: i.e. in the
+           environment/arguments passed to the build, we replace the
+           hashes of the valid outputs with unique dummy strings;
+           after the build, we discard the redirected outputs
+           corresponding to the valid outputs, and rewrite the
+           contents of the new outputs to replace the dummy strings
+           with the actual hashes. */
+        auto scratchPath = !status.known ? makeFallbackPath(outputName)
+                           : !needsHashRewrite()
+                               /* Can always use original path in sandbox */
+                               ? status.known->path
+                               : !status.known->isPresent()
+                                     /* If path doesn't yet exist can just use it */
+                                     ? status.known->path
+                                     : buildMode != bmRepair && !status.known->isValid()
+                                           /* If we aren't repairing we'll delete a corrupted path, so we
+                                              can use original path */
+                                           ? status.known->path
+                                           : /* If we are repairing or the path is totally valid, we'll need
+                                                to use a temporary path */
+                                           makeFallbackPath(status.known->path);
+        scratchOutputs.insert_or_assign(outputName, scratchPath);
+
+        /* Substitute output placeholders with the scratch output paths.
+           We'll use during the build. */
+        inputRewrites[hashPlaceholder(outputName)] = store.printStorePath(scratchPath);
+
+        /* Additional tasks if we know the final path a priori. */
+        if (!status.known)
+            continue;
+        auto fixedFinalPath = status.known->path;
+
+        /* Additional tasks if the final and scratch are both known and
+           differ. */
+        if (fixedFinalPath == scratchPath)
+            continue;
+
+        /* Ensure scratch path is ours to use. */
+        deletePath(store.printStorePath(scratchPath));
+
+        /* Rewrite and unrewrite paths */
+        {
+            std::string h1{fixedFinalPath.hashPart()};
+            std::string h2{scratchPath.hashPart()};
+            inputRewrites[h1] = h2;
+        }
+
+        redirectedOutputs.insert_or_assign(std::move(fixedFinalPath), std::move(scratchPath));
+    }
+}
+
 } // namespace nix

--- a/src/libstore/build/derivation-builder-impl.hh
+++ b/src/libstore/build/derivation-builder-impl.hh
@@ -127,6 +127,44 @@ protected:
      * and attach them to the derivation
      */
     SingleDrvOutputs checkSubmittedOutputs();
+
+    /**
+     * Whether we need to perform hash rewriting if there are valid output paths.
+     *
+     * Only a sandbox that can present the outputs at their final paths can skip
+     * this, which on Unix means a chroot. Windows has no such mechanism, so the
+     * default is the answer there.
+     */
+    virtual bool needsHashRewrite()
+    {
+        return true;
+    }
+
+    /**
+     * Create alternative path calculated from but distinct from the
+     * input, so we can avoid overwriting outputs (or other store paths)
+     * that already exist.
+     */
+    StorePath makeFallbackPath(const StorePath & path);
+
+    /**
+     * Make a path to another based on the output name along with the
+     * derivation hash.
+     *
+     * @todo Add option to randomize, so we can audit whether our
+     * rewrites caught everything
+     */
+    StorePath makeFallbackPath(OutputNameView outputName);
+
+    /**
+     * Decide the scratch path for each output and populate `inputRewrites`
+     * so the builder sees placeholders substituted.
+     *
+     * Platform-neutral, and needed by every builder: without it
+     * `hashPlaceholder(outputName)` is never substituted, so a derivation
+     * cannot refer to its own outputs.
+     */
+    void prepareScratchOutputs();
 };
 
 } // namespace nix

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -35,9 +35,15 @@ public:
           Must be used as OverlayFS lower layer for this store's store dir.
         )"};
 
-    const Setting<AbsolutePath> upperLayer{
+    /* Has no default: the constructor rejects a config that leaves it unset.
+       Spelling that as `std::nullopt` rather than a sentinel path matters
+       because `AbsolutePath` validates on construction, and a POSIX-rooted
+       sentinel is not absolute on Windows -- `is_absolute()` wants a root name
+       as well as a root directory -- so the sentinel made the config
+       unconstructible there regardless of what the caller passed. */
+    const Setting<std::optional<AbsolutePath>> upperLayer{
         (StoreConfig *) this,
-        "/upper-layer-must-be-set",
+        std::nullopt,
         "upper-layer",
         R"(
           Directory containing the OverlayFS upper layer for this store's store dir.

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -39,7 +39,7 @@ StoreReference LocalOverlayStoreConfig::getReference() const
 
 std::filesystem::path LocalOverlayStoreConfig::toUpperPath(const StorePath & path) const
 {
-    return upperLayer.get() / path.to_string();
+    return *upperLayer.get() / path.to_string();
 }
 
 LocalOverlayStore::LocalOverlayStore(ref<const Config> config)
@@ -49,7 +49,7 @@ LocalOverlayStore::LocalOverlayStore(ref<const Config> config)
     , config{config}
     , lowerStore(openStore(config->lowerStoreUri.get()).dynamic_pointer_cast<LocalFSStore>())
 {
-    if (!config->upperLayer.isOverridden())
+    if (!config->upperLayer.get())
         throw Error("overlay store at %s requires the 'upper-layer' setting", PathFmt(config->realStoreDir.get()));
 
     if (config->checkMount.get()) {
@@ -70,9 +70,9 @@ LocalOverlayStore::LocalOverlayStore(ref<const Config> config)
         };
 
         auto expectedLowerDir = lowerStore->config.realStoreDir.get();
-        if (!checkOption("lowerdir", expectedLowerDir) || !checkOption("upperdir", config->upperLayer.get())) {
+        if (!checkOption("lowerdir", expectedLowerDir) || !checkOption("upperdir", *config->upperLayer.get())) {
             debug("expected lowerdir: %s", PathFmt(lowerStore->config.realStoreDir.get()));
-            debug("expected upperdir: %s", PathFmt(config->upperLayer.get()));
+            debug("expected upperdir: %s", PathFmt(*config->upperLayer.get()));
             debug("actual mount: %s", mountInfo);
             throw Error("overlay filesystem %s mounted incorrectly", PathFmt(config->realStoreDir.get()));
         }

--- a/src/libstore/store-dir-config.cc
+++ b/src/libstore/store-dir-config.cc
@@ -10,14 +10,19 @@ StorePath StoreDirConfig::parseStorePath(std::string_view path) const
 {
     if (path.empty())
         throw BadStorePath("empty path is not a valid store path");
-    // On Windows, `/nix/store` is not a canonical path. More broadly it
-    // is unclear whether this function should be using the native
-    // notion of a canonical path at all. For example, it makes to
-    // support remote stores whose store dir is a non-native path (e.g.
-    // Windows <-> Unix ssh-ing).
+    /* Canonicalise in whatever syntax the store directory itself uses, not
+       necessarily the native one. A store dir is a *logical* path: a
+       Unix-style one stays Unix-style even on Windows -- that is what
+       `FilePathType::Unix` means, and it is what lets a Windows client talk to
+       a Unix store over ssh -- so normalising it with native semantics would
+       rewrite the separators to `\` and the comparison below would stop
+       matching. Previously Windows did not normalise at all, so
+       `<storeDir>/./x`, `<storeDir>/y/../x` and a trailing separator were all
+       rejected rather than accepted-and-normalised. */
     auto p =
 #ifdef _WIN32
-        std::filesystem::path(path)
+        storeDir.starts_with('/') ? std::filesystem::path(CanonPath(std::string(path)).abs())
+                                  : std::filesystem::path(path).lexically_normal()
 #else
         canonPath(std::string(path))
 #endif

--- a/src/libstore/unix/build/unix-derivation-builder-impl.hh
+++ b/src/libstore/unix/build/unix-derivation-builder-impl.hh
@@ -131,14 +131,6 @@ protected:
 
     friend struct RestrictedStore;
 
-    /**
-     * Whether we need to perform hash rewriting if there are valid output paths.
-     */
-    virtual bool needsHashRewrite()
-    {
-        return true;
-    }
-
 public:
 
     std::optional<Descriptor> startBuild() override;
@@ -332,22 +324,6 @@ public:
 private:
 
     bool decideWhetherDiskFull();
-
-    /**
-     * Create alternative path calculated from but distinct from the
-     * input, so we can avoid overwriting outputs (or other store paths)
-     * that already exist.
-     */
-    StorePath makeFallbackPath(const StorePath & path);
-
-    /**
-     * Make a path to another based on the output name along with the
-     * derivation hash.
-     *
-     * @todo Add option to randomize, so we can audit whether our
-     * rewrites caught everything
-     */
-    StorePath makeFallbackPath(OutputNameView outputName);
 };
 
 } // namespace nix

--- a/src/libstore/unix/build/unix-derivation-builder.cc
+++ b/src/libstore/unix/build/unix-derivation-builder.cc
@@ -303,60 +303,7 @@ std::optional<Descriptor> UnixDerivationBuilderImpl::startBuild()
 
     chownToBuilder(tmpDirFd.get(), tmpDir);
 
-    for (auto & [outputName, status] : initialOutputs) {
-        /* Set scratch path we'll actually use during the build.
-
-           If we're not doing a chroot build, but we have some valid
-           output paths.  Since we can't just overwrite or delete
-           them, we have to do hash rewriting: i.e. in the
-           environment/arguments passed to the build, we replace the
-           hashes of the valid outputs with unique dummy strings;
-           after the build, we discard the redirected outputs
-           corresponding to the valid outputs, and rewrite the
-           contents of the new outputs to replace the dummy strings
-           with the actual hashes. */
-        auto scratchPath = !status.known ? makeFallbackPath(outputName)
-                           : !needsHashRewrite()
-                               /* Can always use original path in sandbox */
-                               ? status.known->path
-                               : !status.known->isPresent()
-                                     /* If path doesn't yet exist can just use it */
-                                     ? status.known->path
-                                     : buildMode != bmRepair && !status.known->isValid()
-                                           /* If we aren't repairing we'll delete a corrupted path, so we
-                                              can use original path */
-                                           ? status.known->path
-                                           : /* If we are repairing or the path is totally valid, we'll need
-                                                to use a temporary path */
-                                           makeFallbackPath(status.known->path);
-        scratchOutputs.insert_or_assign(outputName, scratchPath);
-
-        /* Substitute output placeholders with the scratch output paths.
-           We'll use during the build. */
-        inputRewrites[hashPlaceholder(outputName)] = store.printStorePath(scratchPath);
-
-        /* Additional tasks if we know the final path a priori. */
-        if (!status.known)
-            continue;
-        auto fixedFinalPath = status.known->path;
-
-        /* Additional tasks if the final and scratch are both known and
-           differ. */
-        if (fixedFinalPath == scratchPath)
-            continue;
-
-        /* Ensure scratch path is ours to use. */
-        deletePath(store.printStorePath(scratchPath));
-
-        /* Rewrite and unrewrite paths */
-        {
-            std::string h1{fixedFinalPath.hashPart()};
-            std::string h2{scratchPath.hashPart()};
-            inputRewrites[h1] = h2;
-        }
-
-        redirectedOutputs.insert_or_assign(std::move(fixedFinalPath), std::move(scratchPath));
-    }
+    prepareScratchOutputs();
 
     /* Construct the environment passed to the builder. */
     initEnv();
@@ -1037,32 +984,6 @@ void UnixDerivationBuilderImpl::cleanupBuild(bool force)
         topTmpDir = "";
         tmpDir = "";
     }
-}
-
-StorePath UnixDerivationBuilderImpl::makeFallbackPath(OutputNameView outputName)
-{
-    // This is a bogus path type, constructed this way to ensure that it doesn't collide with any other store path
-    // See doc/manual/source/protocols/store-path.md for details
-    // TODO: We may want to separate the responsibilities of constructing the path fingerprint and of actually doing the
-    // hashing
-    auto pathType = "rewrite:" + std::string(drvPath.to_string()) + ":name:" + std::string(outputName);
-    return store.makeStorePath(
-        pathType,
-        // pass an all-zeroes hash
-        Hash(HashAlgorithm::SHA256),
-        outputPathName(drv.name, outputName));
-}
-
-StorePath UnixDerivationBuilderImpl::makeFallbackPath(const StorePath & path)
-{
-    // This is a bogus path type, constructed this way to ensure that it doesn't collide with any other store path
-    // See doc/manual/source/protocols/store-path.md for details
-    auto pathType = "rewrite:" + std::string(drvPath.to_string()) + ":" + std::string(path.to_string());
-    return store.makeStorePath(
-        pathType,
-        // pass an all-zeroes hash
-        Hash(HashAlgorithm::SHA256),
-        path.name());
 }
 
 } // namespace nix

--- a/src/libstore/windows/build/windows-derivation-builder.cc
+++ b/src/libstore/windows/build/windows-derivation-builder.cc
@@ -7,6 +7,7 @@
 #include "nix/util/muxable-pipe.hh"
 #include "nix/util/os-string.hh"
 #include "nix/util/processes.hh"
+#include "nix/util/util.hh"
 
 #include <windows.h>
 
@@ -73,19 +74,23 @@ OsString escapeArg(OsString arg)
 }
 
 /**
- * A minimal, unsandboxed `DerivationBuilder` for Windows: enough to run a
- * builder and register its outputs, and no more. Missing, relative to Unix:
+ * An unsandboxed `DerivationBuilder` for Windows. Missing, relative to Unix:
  *
  * - no sandbox, chroot, or filesystem isolation
  * - no build user; the builder runs as whoever ran Nix
  * - no network isolation
  * - no recursive Nix (`submitOutput` throws)
- * - no content-addressed or fixed-output derivations
  *
  * Registering the outputs is `DerivationBuilderImpl::registerOutputs`, the
  * same code Unix runs, so reference scanning and the `allowedReferences`
- * checks do apply. Without a sandbox the scratch paths are the final ones,
- * so it finds nothing to rewrite.
+ * checks do apply.
+ *
+ * Scratch paths come from the shared `prepareScratchOutputs`, so an output
+ * whose final path is not known up front -- content-addressed, or fixed-output
+ * being repaired -- gets a temporary one and is rewritten afterwards, exactly
+ * as on Unix. Because there is no sandbox, the placeholder substitution in
+ * `inputRewrites` is the only way a derivation can name its own outputs, so
+ * both the environment block and the command line go through it.
  */
 class WindowsDerivationBuilderImpl : public DerivationBuilderImpl
 {
@@ -212,9 +217,14 @@ OsString WindowsDerivationBuilderImpl::makeEnvBlock()
         if (auto value = getEnvOs(os(name)))
             env[os(name)] = *value;
 
-    /* The derivation's own environment wins over all of the above. */
+    /* The derivation's own environment wins over all of the above.
+
+       `inputRewrites` substitutes each output placeholder with the scratch path
+       chosen for it, which is how a derivation refers to its own outputs. The
+       Unix builder does the same to its environment block; without it the
+       placeholder reaches the builder verbatim. */
     for (auto & [name, entry] : desugaredEnv.variables)
-        env[os(name)] = os(entry.value);
+        env[os(name)] = os(rewriteStrings(entry.value, inputRewrites));
 
     OsString block;
     for (auto & [name, value] : env) {
@@ -244,10 +254,11 @@ void WindowsDerivationBuilderImpl::spawnBuilder()
     startInfo.hStdOutput = builderPipe.writeSide.get();
     startInfo.hStdError = builderPipe.writeSide.get();
 
-    OsString cmdline = escapeArg(string_to_os_string(std::string_view{drv.builder}));
+    /* Same placeholder substitution as the environment block above. */
+    OsString cmdline = escapeArg(string_to_os_string(rewriteStrings(drv.builder, inputRewrites)));
     for (auto & arg : drv.args) {
         cmdline += L' ';
-        cmdline += escapeArg(string_to_os_string(std::string_view{arg}));
+        cmdline += escapeArg(string_to_os_string(rewriteStrings(arg, inputRewrites)));
     }
 
     auto envBlock = makeEnvBlock();

--- a/src/libstore/windows/build/windows-derivation-builder.cc
+++ b/src/libstore/windows/build/windows-derivation-builder.cc
@@ -305,15 +305,14 @@ std::optional<Descriptor> WindowsDerivationBuilderImpl::startBuild()
     if (drv.isBuiltin())
         throw UnimplementedError("builtin builders are not yet supported on Windows");
 
-    for (auto & [name, output] : drv.outputs) {
-        auto * ia = std::get_if<DerivationOutput::InputAddressed>(&output.raw);
-        if (!ia)
-            throw UnimplementedError(
-                "only input-addressed derivation outputs are supported on Windows, but output '%s' is not one", name);
-        /* Without a sandbox there is nowhere else to build, so the scratch
-           path is the final one and `registerOutputs` has nothing to rewrite. */
-        scratchOutputs.insert_or_assign(name, ia->path);
-    }
+    /* Decides the scratch path per output and fills in `inputRewrites`. This
+       replaces a loop that assumed every output was input-addressed and threw
+       otherwise, which is what previously kept content-addressed and
+       fixed-output derivations from building here at all: they were rejected
+       before the build started rather than by anything downstream. The shared
+       version works off `initialOutputs`, so it handles the cases where the
+       final path is not known up front. */
+    prepareScratchOutputs();
 
     /* A fresh build directory per attempt. */
     tmpDir = createTempDir(defaultTempDir(), "nix-build");

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -804,7 +804,23 @@ void WindowsSourceAccessor::assertNoSymlinks(CanonPath path)
 
 ref<SourceAccessor> getFSSourceAccessor()
 {
-    static auto rootFS = makeFSSourceAccessor("/", /*trackLastModified=*/false);
+    static auto rootFS = makeFSSourceAccessor(
+#ifdef _WIN32
+        /* Windows has no single filesystem root to anchor to: paths are rooted
+           per drive, so `/` is not an absolute path there --- it has a root
+           directory but no root name, and `is_absolute()` wants both. An empty
+           root is how this accessor already spells "no prefix, the paths handed
+           to me are absolute already"; see `WindowsSourceAccessor::makeAbsPath`,
+           and the `root.empty()` arm of the assertion in its constructor.
+
+           Passing `/` made that assertion fail, which aborted every command
+           that evaluates, since `EvalState` reaches here through
+           `getFSSourceAccessor`. */
+        std::filesystem::path{},
+#else
+        "/",
+#endif
+        /*trackLastModified=*/false);
     return rootFS;
 }
 


### PR DESCRIPTION
Windows had no libstore test coverage at all, and the Windows derivation builder refused any output whose final path was not known before the build. This wires libstore into the Windows CI job, fixes what that exposed, and moves the shared part of the builder's output setup somewhere both platforms can use it.

Measured under Wine: `nix-store-tests` goes from not being built to 784 tests with 753 passing and zero failures.

## Windows CI now covers libstore, and can fail

`ci/gha/tests/windows.nix` built only `nix-util-tests`, which as its own comment noted "links neither libmain nor libstore". So output checking, content-addressing and fixed-output derivations were all reached through platform-neutral code that nothing on Windows ever exercised.

The job also carried `continue-on-error: true`, so a Windows failure had never blocked a merge. Both together meant Windows could regress silently. That flag is gone, which is only reasonable because the suite is green.

One environment fix was needed to get there: the outer build exports `NIX_STORE` pointing at the host's POSIX store directory and Wine passes it through, so a store declared `FilePathType::Native` validated that value with `is_absolute()` and rejected it. Clearing it lets each store type use its own default. That alone took the failure count from 24 to 8.

## Three pre-existing Windows defects the coverage exposed

**`LocalOverlayStoreConfig` could not be constructed on Windows at all.** `upperLayer` was a `Setting<AbsolutePath>` defaulting to the sentinel `/upper-layer-must-be-set`. `AbsolutePath` validates on construction, and a POSIX-rooted sentinel is not absolute on Windows, so the config threw before the caller's parameters were looked at. It is now `Setting<std::optional<AbsolutePath>>` defaulting to `std::nullopt`, which is what "must be set" means; the serialiser for that type already existed and the constructor already rejected the unset case, so the sentinel was never meaningfully read.

**`parseStorePath` did not normalise on Windows.** It wrapped the input in `std::filesystem::path` and compared `parent_path()`, so `<storeDir>/./x`, `<storeDir>/y/../x` and a trailing separator were rejected rather than normalised. It now canonicalises in whatever syntax the store directory itself uses: a Unix-style store dir stays Unix-style on Windows, which is what `FilePathType::Unix` is for and what lets a Windows client address a Unix store. Normalising natively would rewrite the separators and break the comparison instead. The comment saying these semantics were "unclear" is replaced with one stating them.

**A C-API test asserted the Unix default store dir.** The default store is local, hence native, so on Windows it is `getProgramData()/nix/store`.

## Content-addressed and fixed-output derivations on Windows

`WindowsDerivationBuilderImpl::startBuild` had its own cut-down copy of the scratch-output loop which assumed every output was input-addressed:

```c++
if (!ia)
    throw UnimplementedError(
        "only input-addressed derivation outputs are supported on Windows, but output '%s' is not one", name);
```

That is what stopped content-addressed and fixed-output derivations from building there. They were refused before the build started, so the platform-neutral output checking and content-addressing in `registerOutputs` was unreachable for them.

The real loop lived in `UnixDerivationBuilderImpl::startBuild` but contains nothing POSIX — only `needsHashRewrite()`, `makeFallbackPath()`, `scratchOutputs`, `hashPlaceholder()` and `redirectedOutputs`. It moves to `DerivationBuilderImpl::prepareScratchOutputs()` with the two virtuals it needs. `needsHashRewrite()` keeps its `true` default and the chroot builder keeps its override; Windows has no chroot, so the default is correct there.

With that shared, the Windows builder also applies `inputRewrites` to its environment block and command line, as Unix does. Without a sandbox that substitution is the only way a Windows derivation can name its own outputs, since there is no chroot that could present them at their final paths instead.

`extraFiles` is still unimplemented on Windows. It needs a `writeBuilderFile` equivalent, and the natural one to reuse is the `OsFilename`-typed version from #15244, which has not landed.

## The evaluator could not start on Windows

`getFSSourceAccessor` passed the literal `"/"` as its root. `std::filesystem::path("/").is_absolute()` is false on Windows — that path has a root directory but no root name, and `is_absolute()` wants both — so `WindowsSourceAccessor`'s constructor assertion fired. `EvalState` reaches here through `getFSSourceAccessor`, so every command that evaluated anything aborted:

```
Assertion failed: root.empty() || root.is_absolute(), file src/libutil/posix-source-accessor.cc, line 648
```

An empty root is how this accessor already spells "no prefix, the paths I am given are absolute already" — `WindowsSourceAccessor::makeAbsPath` handles it explicitly and the assertion permits it — and it is the honest description of Windows, where paths are rooted per drive rather than under one root.

Measured with a cross-compiled `nix.exe` under Wine: before, `nix eval --expr '1 + 1'` aborted; after, it prints `2`. `nix --version` and `nix store info` worked either way, since neither constructs an evaluator.

## These are one bug, not five

Every fix above is the same mistake at a different site: treating a POSIX-rooted path as absolute on Windows, where `is_absolute()` requires a root name as well as a root directory. The overlay-store sentinel, the SSL cert path in #16383, `parseStorePath`, and the source accessor are all instances.

There is a sixth site, not fixed here, and it needs a decision rather than a patch — filed separately. Reading a `.nix` file gives `path '/Z:\tmp\t.nix' does not exist`, because `CanonPath` unconditionally prepends `/` while the caller hands it a native path. That one is a type confusion between virtual and native paths, and picking a fix requires deciding what `SourcePath` means on Windows.

## Verification

- `checks.x86_64-linux.pre-commit`: 7/7 hooks
- native `nix-store-tests` 792/787 and `nix-util-tests` 813/811, both unchanged from before these commits
- `nix-store-tests` under Wine: 784 run, 753 pass, zero failures, confirmed by a forced rebuild rather than a cache hit
- `x86_64-w64-mingw32` cross-compile clean
