### PR TITLE
libstore/derivation: Say "masking" not "modulo" for derivation changes

### DIFF
--- a/doc/manual/source/protocols/derivation-aterm.md
+++ b/doc/manual/source/protocols/derivation-aterm.md
@@ -192,14 +192,14 @@ Re-emitting it — even as equivalent JSON — would change the derivation.
 > Structured attributes have been in the wild for many years, so any such choice would also have to reckon with the encodings already out there.
 > Committing to one of them is therefore not a choice we are yet in a position to make with this format.
 
-## Quotient derivations {#input-address-encoding}
+## Masked derivations {#input-address-encoding}
 
-An [input-addressed](@docroot@/store/derivation/outputs/input-address.md) output path is computed by hashing this same ATerm, but of a derivation that has been rewritten first: its ["quotient derivation"](@docroot@/store/derivation/outputs/input-address.md#hash-quotient-drv), so called because the rewriting partitions derivations into equivalence classes.
+An [input-addressed](@docroot@/store/derivation/outputs/input-address.md) output path is computed by hashing the ATerm representation of a derivation that has been [masked](@docroot@/store/derivation/outputs/input-address.md#input-masked-drv) first: parts of it are blanked out before hashing, so that derivations differing only in what was blanked hash alike.
 
 Their encoding differs from the grammar above in two productions:
 
 ```ebnf
-quotient-derivation = "Derive(" fields ")" ;
+masked-derivation   = "Derive(" fields ")" ;
 
 input-drv           = "(" drv-hash "," output-names ")" ;
 drv-hash            = verbatim ;   (* lowercase hexadecimal *)
@@ -208,15 +208,17 @@ drv-hash            = verbatim ;   (* lowercase hexadecimal *)
 That is:
 
 - There is no version header.
-  A quotient derivation is only ever constructed once dynamic derivations have been resolved away, so it never needs one, and `DrvWithVersion(...)` does not occur.
+  A masked derivation is only ever constructed once dynamic derivations have been resolved away, so it never needs one, and `DrvWithVersion(...)` does not occur.
 
 - An `inputDrvs` key is a hash rather than a store path, and its node is always the flat `output-names` — the nested form the `dynamic-derivations` version allows cannot appear, for the same reason.
 
-See [input addressing](@docroot@/store/derivation/outputs/input-address.md#hash-quotient-drv) for how those hashes are derived and why; in short, they identify an input derivation up to what it produces rather than how, so that changing where a fixed-output input is fetched from does not change anything downstream.
+See [input addressing](@docroot@/store/derivation/outputs/input-address.md#input-masked-drv) for how those hashes are derived and why; in short, they identify an input derivation up to what it produces rather than how, so that changing where a fixed-output input is fetched from does not change anything downstream.
+
+Replacing the input derivation paths with hashes like this is *input masking*, and is performed on all derivations.
 
 Whether the outputs carry their paths depends on what is being hashed.
-When computing a derivation's own output paths they are masked — `output-path`, and the environment variable named after each output, are empty — since those paths are what is being computed.
-When hashing a derivation to stand in for it as an *input* to another, they are left as they are.
+When computing a derivation's own output paths they are *output masked* too — `output-path`, and the environment variable named after each output, are empty — since those paths are what is being computed; the result is *fully masked*.
+When hashing a derivation to stand in for it as an *input* to another, they are left as they are, and the result is *input-masked* only.
 
 The result is not a derivation that can be built, written to the store, or read back by `parse`: its inputs name hashes, not paths.
 It exists only to be hashed.

--- a/doc/manual/source/protocols/store-path.md
+++ b/doc/manual/source/protocols/store-path.md
@@ -89,7 +89,7 @@ where
 
     - For input-addressed derivation outputs:
 
-      the [ATerm](@docroot@/protocols/derivation-aterm.md#input-address-encoding) serialization of the ["quotient derivation"](@docroot@/store/derivation/outputs/input-address.md#hash-quotient-drv), in which fixed-output inputs are replaced by their content addresses.
+      the [ATerm](@docroot@/protocols/derivation-aterm.md#input-address-encoding) serialization of the ["fully masked derivation"](@docroot@/store/derivation/outputs/input-address.md#input-masked-drv), in which fixed-output inputs are replaced by their content addresses and the derivation's own output paths are blanked.
 
     - For content-addressed store paths:
 

--- a/doc/manual/source/store/derivation/outputs/input-address.md
+++ b/doc/manual/source/store/derivation/outputs/input-address.md
@@ -6,7 +6,7 @@
 That is to say, an input-addressed output's store path is a function not of the output itself, but of the derivation that produced it.
 Even if two store paths have the same contents, if they are produced in different ways, and one is input-addressed, then they will have different store paths, and thus guaranteed to not be the same store object.
 
-## Modulo content addressed derivation outputs {#hash-quotient-drv}
+## Masking content addressed derivation outputs {#input-masked-drv}
 
 A naive implementation of an output hash computation for input-addressed outputs would be to hash the derivation hash and output together.
 This clearly has the uniqueness properties we want for input-addressed outputs, but suffers from an inefficiency.
@@ -14,13 +14,28 @@ Specifically, new builds would be required whenever a change is made to a fixed-
 Concretely, this would cause a "mass rebuild" whenever any fetching detail changes, including mirror lists, certificate authority certificates, etc.
 
 To solve this problem, we compute output hashes differently, so that certain output hashes become identical.
-We call this concept quotient hashing, in reference to quotient types or sets.
+We do this by *masking*: before hashing, we rewrite the parts of the derivation whose differences we do not want to see.
+
+There are two maskings, and they are independent:
+
+- *Input masking* replaces each input derivation's store path with a hash standing for what that input *produces*, rather than for the derivation that produces it.
+  This is what makes different fixed-output derivation inputs that produce the same outputs stop mattering.
+
+- *Output masking* blanks the derivation's own output paths --- in `outputs`, and in the environment variables named after them.
+  This is needed when those very paths are what we are computing; it is not wanted when the derivation is merely being hashed to stand in for an input to something else, where the paths it already has are exactly what identifies it.
+
+A derivation with only the first applied is an *input-masked derivation*; one with both is a *fully masked derivation*.
+
+Every non-injective function induces an equivalence relation on its domain, by saying two elements are equivalent if they map to the same value.
+But the equivalence relation induced by input masking is also pleasant to characterize directly, without reference to input masking at all.
+Intuitively this makes sense, because the details of how exactly inputs are hashed (which hash function, say) shouldn't matter (ignoring hash collisions and the like) --- all that matters is which derivations are deemed equivalent.
+The [semantic properties](#semantic-properties) section below develops this further.
 
 So how do we compute the [hash part](@docroot@/store/store-path.md#digest) of the output paths of an input-addressed derivation?
-This is done by the function `hashQuotientDerivation`, shown below.
+This is done by the function `hashInputMaskedDerivation`, shown below, which does the input masking itself; its callers do any output masking.
 
 First, a word on inputs.
-`hashQuotientDerivation` is only defined on derivations whose [inputs](@docroot@/store/derivation/index.md#inputs) take the first-order form:
+`hashInputMaskedDerivation` is only defined on derivations whose [inputs](@docroot@/store/derivation/index.md#inputs) take the first-order form:
 ```typescript
 type ConstantPath = {
   path: StorePath;
@@ -51,12 +66,12 @@ Those derivations must be (partially) [resolved](@docroot@/store/resolution.md) 
 Then, and only then, can input addresses be assigned.
 
 ```
-function hashQuotientDerivation(drv) -> Hash:
+function hashInputMaskedDerivation(drv) -> Hash:
     assert(drv.outputs are input-addressed)
     drv′ ← drv with {
         inputDrvOutputs = ⋃(
             assert(drvPath is store path)
-            case hashOutputsOrQuotientDerivation(readDrv(drvPath)) of
+            case hashOutputsOrInputMaskedDerivation(readDrv(drvPath)) of
                 drvHash : Hash →
                     (drvHash.toBase16(), output)
                 outputHashes : Map[String, Hash] →
@@ -66,7 +81,7 @@ function hashQuotientDerivation(drv) -> Hash:
     }
     return hashSHA256(printDrv(drv′))
 
-function hashOutputsOrQuotientDerivation(drv) -> Map[String, Hash] | Hash:
+function hashOutputsOrInputMaskedDerivation(drv) -> Map[String, Hash] | Hash:
     if drv.outputs are content-addressed:
         return {
             outputName ↦ hashSHA256(
@@ -77,18 +92,19 @@ function hashOutputsOrQuotientDerivation(drv) -> Map[String, Hash] | Hash:
             , ca = output.contentAddress // or get from build trace if floating
         }
     else: // drv.outputs are input-addressed
-        return hashQuotientDerivation(drv)
+        return hashInputMaskedDerivation(drv)
 ```
 
-### `hashQuotientDerivation`
+### `hashInputMaskedDerivation`
 
-We replace each element in the derivation's `inputDrvOutputs` using data from a call to `hashOutputsOrQuotientDerivation` on the `drvPath` of that element.
-When `hashOutputsOrQuotientDerivation` returns a single drv hash (because the input derivation in question is input-addressing), we simply swap out the `drvPath` for that hash, and keep the same output name.
-When `hashOutputsOrQuotientDerivation` returns a map of content addresses per-output, we look up the output in question, and pair it with the output name `out`.
+We replace each element in the derivation's `inputDrvOutputs` using data from a call to `hashOutputsOrInputMaskedDerivation` on the `drvPath` of that element.
+When `hashOutputsOrInputMaskedDerivation` returns a single drv hash (because the input derivation in question is input-addressing), we simply swap out the `drvPath` for that hash, and keep the same output name.
+When `hashOutputsOrInputMaskedDerivation` returns a map of content addresses per-output, we look up the output in question, and pair it with the output name `out`.
 
-The resulting pseudo-derivation (with hashes instead of store paths in `inputDrvs`) is then printed (in the ["ATerm" format](@docroot@/protocols/derivation-aterm.md#input-address-encoding)) and hashed, and this becomes the hash of the "quotient derivation".
+That rewriting is the input masking.
+The resulting pseudo-derivation (with hashes instead of store paths in `inputDrvs`) is then printed (in the ["ATerm" format](@docroot@/protocols/derivation-aterm.md#input-address-encoding)) and hashed, and this becomes the hash of the input-masked derivation.
 
-When calculating output hashes, `hashQuotientDerivation` is called on an almost-complete input-addressing derivation, which is just missing its input-addressed outputs paths.
+When calculating output hashes, `hashInputMaskedDerivation` is called on an almost-complete input-addressing derivation, which is just missing its input-addressed outputs paths --- that is, one that is already output masked, making it fully masked.
 The derivation hash is then used to calculate output paths for each output, as the [complete store path calculation](@docroot@/protocols/store-path.md#fingerprint) specifies: it is the digest of the hashed ATerm that specification calls for, under the `"output:" id` case, where `id` is the output name.
 The store object's name is the derivation's name, with `-` and the output name appended --- unless the output is named `out`, in which case the derivation's name is used as-is.
 
@@ -102,20 +118,19 @@ Those output paths can then be substituted into the almost-complete input-addres
 > This is not fatal because the deviation would only apply for content-addressing derivations with more than one output, and that only occurs in the floating case, which is [experimental][xp-feature-ca-derivations].
 > Once this bug is fixed, this note will be removed.
 
-### `hashOutputsOrQuotientDerivation`
+### `hashOutputsOrInputMaskedDerivation`
 
-How does `hashOutputsOrQuotientDerivation` in turn work?
-It consists of two main cases, based on whether the outputs of the derivation are to be input-addressed or content-addressed.
+`hashOutputsOrInputMaskedDerivation` consists of two main cases, based on whether the outputs of the derivation are to be input-addressed or content-addressed.
 
 #### Input-addressed outputs case
 
-In the input-addressed case, it just calls `hashQuotientDerivation`, and returns that derivation hash.
-This makes `hashQuotientDerivation` and `hashOutputsOrQuotientDerivation` mutually-recursive.
+In the input-addressed case, it just calls `hashInputMaskedDerivation`, and returns that derivation hash.
+This makes `hashInputMaskedDerivation` and `hashOutputsOrInputMaskedDerivation` mutually-recursive.
 
 > **Note**
 >
-> In this case, `hashQuotientDerivation` is being called on a *complete* input-addressing derivation that already has its output paths calculated.
-> The `inputDrvs` substitution takes place anyways.
+> In this case, `hashInputMaskedDerivation` is being called on a *complete* input-addressing derivation that already has its output paths calculated: it is not output masked, so it is input-masked only, not fully masked.
+> The input masking takes place anyways.
 
 #### Content-addressed outputs case
 
@@ -130,11 +145,11 @@ If the outputs are [content-addressed](./content-address.md), then it computes a
 > This is what the "or get from [build trace](@docroot@/store/build-trace.md) if floating" comment refers to.
 > In this case, the algorithm is *stuck* until the input in question is built, and we know what the actual contents of the output in question is.
 >
-> That is OK however, because there is no problem with delaying the assigning of input addresses (which, remember, is what `hashQuotientDerivation` is ultimately for) until all inputs are known.
+> That is OK however, because there is no problem with delaying the assigning of input addresses (which, remember, is what `hashInputMaskedDerivation` is ultimately for) until all inputs are known.
 
 ### Deferring input-addressing when downstream of unknown CA store objects {#deferred}
 
-As the previous note says, the algorithm is *stuck* when an input is a [floating content-addressed](./content-address.md#floating) output that has not been built yet: there is no content address to substitute for it, so the quotient derivation cannot be completed and no input address can be computed.
+As the previous note says, the algorithm is *stuck* when an input is a [floating content-addressed](./content-address.md#floating) output that has not been built yet: there is no content address to substitute for it, so the input masking cannot be completed and no input address can be computed.
 
 The derivation is still written to the store, with its outputs *deferred*: an output in this state has no store path at all, and the environment variable named after it is empty.
 This costs nothing, because a derivation's own store path is [content-addressed](@docroot@/store/store-object/content-address.md#method-text) on the bytes of its serialization, which do not depend on its output paths being known.
@@ -143,7 +158,7 @@ A deferred output does not use a third kind of addressing alongside input- and c
 It is input-addressed; it just does not know its path yet.
 
 Being stuck is contagious.
-A derivation with deferred outputs has, for this purpose, unknown outputs of its own, so `hashOutputsOrQuotientDerivation` is stuck on it in turn, and anything depending on it must also defer.
+A derivation with deferred outputs has, for this purpose, unknown outputs of its own, so `hashOutputsOrInputMaskedDerivation` is stuck on it in turn, and anything depending on it must also defer.
 The condition therefore propagates downstream from the floating output that caused it.
 
 Deferral is resolved by building, not by revisiting the same derivation.
@@ -162,11 +177,12 @@ The recursion in the algorithm is potentially inefficient:
 it could call itself once for each path by which a subderivation can be reached, i.e., `O(V^k)` times for a derivation graph with `V` derivations and with out-degree of at most `k`.
 In the actual implementation, [memoisation](https://en.wikipedia.org/wiki/Memoization) is used to reduce this cost to be proportional to the total number of `inputDrvOutputs` encountered.
 
-### Semantic properties
+### Semantic properties {#semantic-properties}
 
 *See [this chapter's appendix](@docroot@/store/math-notation.md) on grammar and metavariable conventions.*
 
-In essence, `hashQuotientDerivation` partitions input-addressing derivations into equivalence classes: every derivation in that equivalence class is mapped to the same derivation hash.
+Masking is, mathematically, a quotient, in reference to quotient types or sets: what it discards is exactly what we want two derivations to be allowed to differ in.
+Accordingly, `hashInputMaskedDerivation` partitions input-addressing derivations into equivalence classes: every derivation in that equivalence class is mapped to the same derivation hash.
 We can characterize this equivalence relation directly, by working bottom up.
 
 We start by defining an equivalence relation on first-order output deriving paths that refer content-addressed derivation outputs. Two such paths are equivalent if they refer to the same store object:
@@ -245,7 +261,7 @@ where \\(\\mathrm{caInputs}(d)\\) returns the content-addressed inputs of \\(d\\
 > [Issue #9259](https://github.com/NixOS/nix/issues/9259) is about creating a coarser equivalence relation to address this.
 >
 > \\(\\sim_\mathrm{Drv}\\) from [derivation resolution](@docroot@/store/resolution.md) is such an equivalence relation.
-> It is coarser than this one: any two derivations which are "'hash quotient derivation'-equivalent" (\\(\\sim_\mathrm{IADrv}\\)) are also "resolution-equivalent" (\\(\\sim_\mathrm{Drv}\\)).
+> It is coarser than this one: any two derivations which are "'hash input-masked derivation'-equivalent" (\\(\\sim_\mathrm{IADrv}\\)) are also "resolution-equivalent" (\\(\\sim_\mathrm{Drv}\\)).
 > It also relates derivations whose `inputDrvOutputs` have been rewritten into `inputSrcs`.
 >
 > Input-addressing downstream of content addressing, as described above, anticipates this.

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1,5 +1,5 @@
 #include "nix/store/derivations.hh"
-#include "nix/store/derivation/modulo.hh"
+#include "nix/store/derivation/masked.hh"
 #include "nix/store/downstream-placeholder.hh"
 #include "nix/expr/eval-inline.hh"
 #include "nix/expr/eval.hh"
@@ -1926,8 +1926,8 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
        case we don't actually write store derivations, so we can't
        read them later. */
     {
-        auto h = derivation::modulo::hashInput(*state.store, drv);
-        derivation::modulo::hashes.insert_or_assign(drvPath, std::move(h));
+        auto h = derivation::masked::hashInput(*state.store, drv);
+        derivation::masked::hashes.insert_or_assign(drvPath, std::move(h));
     }
 
     auto result = state.buildBindings(1 + drv.outputs.size());

--- a/src/libstore-tests/derivation/masked.cc
+++ b/src/libstore-tests/derivation/masked.cc
@@ -2,12 +2,12 @@
 
 #include "nix/store/derivations.hh"
 #include "nix/store/derivation/aterm.hh"
-#include "nix/store/derivation/modulo.hh"
+#include "nix/store/derivation/masked.hh"
 #include "nix/store/dummy-store-impl.hh"
 #include "nix/store/tests/libstore.hh"
 #include "nix/util/tests/json-characterization.hh"
 
-namespace nix::derivation::modulo {
+namespace nix::derivation::masked {
 
 /**
  * Tests for `hash` and `hashInput`.
@@ -321,4 +321,4 @@ TEST_F(HashModuloTest, differingInputDrvsDiffer)
     EXPECT_NE(hash(*store, a), hash(*store, b));
 }
 
-} // namespace nix::derivation::modulo
+} // namespace nix::derivation::masked

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -40,7 +40,7 @@ sources = files(
   'derivation/external-formats.cc',
   'derivation/full-inputs.cc',
   'derivation/invariants.cc',
-  'derivation/modulo.cc',
+  'derivation/masked.cc',
   'derivation/resolution.cc',
   'derivation/write.cc',
   'derived-path.cc',

--- a/src/libstore/derivation/aterm.cc
+++ b/src/libstore/derivation/aterm.cc
@@ -1,6 +1,6 @@
 #include "nix/store/derivations.hh"
 #include "nix/store/derivation/aterm.hh"
-#include "nix/store/derivation/modulo.hh"
+#include "nix/store/derivation/masked.hh"
 #include "nix/store/derivation/full-inputs.hh"
 #include "nix/store/downstream-placeholder.hh"
 #include "nix/store/store-api.hh"
@@ -791,7 +791,7 @@ std::string unparse(const Derivation<Inputs, Out> & drv, const StoreDirConfig & 
         // Regular `FullInputs` case must have regular `Output` outputs
         (std::is_same_v<Inputs, FullInputs> && std::is_same_v<Out, Output>)
         // Hash modulo is only for input addressing, with masked (`Deferred`) or unmasked (`InputAddressed`) outputs
-        || (std::is_same_v<Inputs, modulo::HashInputs>
+        || (std::is_same_v<Inputs, masked::HashInputs>
             && (std::is_same_v<Out, Output::InputAddressed> || std::is_same_v<Out, Output::Deferred>) ))
 {
     using namespace std::literals::string_view_literals;
@@ -865,11 +865,11 @@ std::string unparse(const Derivation<Inputs, Out> & drv, const StoreDirConfig & 
     return s;
 }
 
-/* The hash modulo intermediate forms, unparsed by `modulo.cc`. */
+/* The hash modulo intermediate forms, unparsed by `masked.cc`. */
 template std::string
-unparse(const Derivation<modulo::HashInputs, Output::Deferred> & drv, const StoreDirConfig & store, bool);
+unparse(const Derivation<masked::HashInputs, Output::Deferred> & drv, const StoreDirConfig & store, bool);
 template std::string
-unparse(const Derivation<modulo::HashInputs, Output::InputAddressed> & drv, const StoreDirConfig & store, bool);
+unparse(const Derivation<masked::HashInputs, Output::InputAddressed> & drv, const StoreDirConfig & store, bool);
 
 std::string unparse(const Full & drv, const StoreDirConfig & store, bool supportWindowsStoreDir)
 {

--- a/src/libstore/derivation/masked.cc
+++ b/src/libstore/derivation/masked.cc
@@ -1,4 +1,4 @@
-#include "nix/store/derivation/modulo.hh"
+#include "nix/store/derivation/masked.hh"
 #include "nix/store/derivation/aterm.hh"
 #include "nix/store/derivation/full-inputs.hh"
 #include "nix/store/store-api.hh"
@@ -9,7 +9,7 @@
 
 namespace nix {
 
-namespace derivation::modulo {
+namespace derivation::masked {
 
 /* --------------------------------------------------------------------------
    Derivation hash modulo
@@ -87,7 +87,7 @@ static bool inputModulo(
  * dynamic derivation whose outputs are not yet known).
  */
 template<typename Out>
-static std::optional<Derivation<HashInputs, Out>> derivationModulo(Store & store, Derivation<FullInputs, Out> drv)
+static std::optional<Derivation<HashInputs, Out>> maskInputDrvs(Store & store, Derivation<FullInputs, Out> drv)
 {
     Derivation<HashInputs, Out> masked{
         .outputs = std::move(drv.outputs),
@@ -164,7 +164,7 @@ HashModulo hashInput(Store & store, const Full & drv)
         if (!std::get_if<Output::InputAddressed>(&output.raw))
             return HashModulo::DeferredDrv{};
 
-    auto inputAddressingModulo = derivationModulo(
+    auto inputAddressingModulo = maskInputDrvs(
         store,
         drv.mapOutputs([](const Output & output) { return std::get<Output::InputAddressed>(output.raw); })
             .mapInputs([](const std::set<SingleDerivedPath> & inputs) { return FullInputs::fromSet(inputs); }));
@@ -181,7 +181,7 @@ HashModulo hashInput(Store & store, const Full & drv)
  * derivations.
  */
 template<typename Inputs>
-static Derivation<Inputs, Output::Deferred> maskOutputsAndEnv(const Derivation<Inputs, Output> & drv)
+static Derivation<Inputs, Output::Deferred> maskOutputs(const Derivation<Inputs, Output> & drv)
 {
     auto masked = drv.mapOutputs([](const Output & output) -> Output::Deferred {
         std::visit(
@@ -212,10 +212,9 @@ static Derivation<Inputs, Output::Deferred> maskOutputsAndEnv(const Derivation<I
  */
 std::optional<std::string> unparseModulo(Store & store, const Full & drv)
 {
-    auto masked =
-        derivationModulo(store, maskOutputsAndEnv(drv).mapInputs([](const std::set<SingleDerivedPath> & inputs) {
-            return FullInputs::fromSet(inputs);
-        }));
+    auto masked = maskInputDrvs(store, maskOutputs(drv).mapInputs([](const std::set<SingleDerivedPath> & inputs) {
+        return FullInputs::fromSet(inputs);
+    }));
     if (!masked)
         return std::nullopt;
     return unparse(*masked, store);
@@ -225,7 +224,7 @@ std::string unparseModulo(Store & store, const Basic & drv)
 {
     /* A resolved derivation has no input derivations, so there is
        nothing to substitute. */
-    auto masked = maskOutputsAndEnv(drv).mapInputs([](const StorePathSet & srcs) {
+    auto masked = maskOutputs(drv).mapInputs([](const StorePathSet & srcs) {
         return HashInputs{
             .srcs = srcs,
             .drvs = {},
@@ -250,6 +249,6 @@ Hash hash(Store & store, const Basic & drv)
     return hashString(HashAlgorithm::SHA256, unparseModulo(store, drv));
 }
 
-} // namespace derivation::modulo
+} // namespace derivation::masked
 
 } // namespace nix

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -1,7 +1,7 @@
 #include "nix/store/derivations.hh"
 #include "nix/store/derivation-options.hh"
 #include "nix/store/derivation/aterm.hh"
-#include "nix/store/derivation/modulo.hh"
+#include "nix/store/derivation/masked.hh"
 #include "nix/store/downstream-placeholder.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/types.hh"
@@ -344,7 +344,7 @@ static void processDerivationOutputPaths(Store & store, auto && drv, std::string
     auto hashModulo = [&]() -> const std::optional<Hash> & {
         if (!hashModulo_) {
             // somewhat expensive so we do lazily
-            hashModulo_ = derivation::modulo::hash(store, drv);
+            hashModulo_ = derivation::masked::hash(store, drv);
         }
         return *hashModulo_;
     };

--- a/src/libstore/include/nix/store/derivation/aterm.hh
+++ b/src/libstore/include/nix/store/derivation/aterm.hh
@@ -34,17 +34,17 @@ inline constexpr bool defaultSupportWindowsStoreDir =
 std::string
 unparse(const Full & drv, const StoreDirConfig & store, bool supportWindowsStoreDir = defaultSupportWindowsStoreDir);
 
-namespace modulo {
+namespace masked {
 struct HashInputs;
 }
 
 /**
  * Print a derivation in one of the intermediate forms: with the inputs
  * already flattened (`FullInputs`), or with them replaced by their
- * hashes modulo (`modulo::HashInputs`), which is the form whose hash is
+ * hashes modulo (`masked::HashInputs`), which is the form whose hash is
  * an input address.
  *
- * The `modulo::HashInputs` cases are not round-trippable: `parse` cannot
+ * The `masked::HashInputs` cases are not round-trippable: `parse` cannot
  * read them back, as their input derivations are named by hash rather
  * than by store path.
  */
@@ -57,7 +57,7 @@ std::string unparse(
         // Regular `FullInputs` case must have regular `Output` outputs
         (std::is_same_v<Inputs, FullInputs> && std::is_same_v<Out, Output>)
         // Hash modulo is only for input addressing, with masked (`Deferred`) or unmasked (`InputAddressed`) outputs
-        || (std::is_same_v<Inputs, modulo::HashInputs>
+        || (std::is_same_v<Inputs, masked::HashInputs>
             && (std::is_same_v<Out, Output::InputAddressed> || std::is_same_v<Out, Output::Deferred>) ));
 
 /**

--- a/src/libstore/include/nix/store/derivation/masked.hh
+++ b/src/libstore/include/nix/store/derivation/masked.hh
@@ -9,7 +9,7 @@ namespace nix {
 
 class Store;
 
-namespace derivation::modulo {
+namespace derivation::masked {
 
 /**
  * Inputs in the intermediate form used to compute the hash modulo:
@@ -168,6 +168,6 @@ std::optional<std::string> unparseModulo(Store & store, const Full & drv);
  */
 std::string unparseModulo(Store & store, const Basic & drv);
 
-} // namespace derivation::modulo
+} // namespace derivation::masked
 
 } // namespace nix

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -36,7 +36,7 @@ headers = [ config_pub_h ] + files(
   'derivation-options.hh',
   'derivation/aterm.hh',
   'derivation/full-inputs.hh',
-  'derivation/modulo.hh',
+  'derivation/masked.hh',
   'derivation/output.hh',
   'derivation/resolution.hh',
   'derivations.hh',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -283,7 +283,7 @@ sources = files(
   'derivation/aterm.cc',
   'derivation/full-inputs.cc',
   'derivation/json.cc',
-  'derivation/modulo.cc',
+  'derivation/masked.cc',
   'derivation/output.cc',
   'derivation/resolution.cc',
   'derivations.cc',


### PR DESCRIPTION
## Motivation
The term "modulo" is unclear and does not describe the actual actions performed on the derivation.
The terms "Input masking" and "Output masking" explicitly state the changes to the derivation.

The phrase "hash modulo" was kept for the hash of a masked derivation.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
