### PR TITLE
fix(packaging): do not add boost fiber patch if duplicate

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -126,9 +126,14 @@ scope: {
         "--with-iostreams"
         "--with-url"
       ];
-      patches = [
-        ./patches/0001-Fix-uncaught_exceptions-not-accounting-for-forced_un.patch
-      ];
+      patches = lib.optional (
+        lib.versionAtLeast pkgs.boost.version "1.88"
+        && lib.versionOlder pkgs.boost.version "1.92"
+        # may already be done in nixpkgs: https://github.com/NixOS/nixpkgs/pull/546405
+        && !lib.any (patch: lib.hasInfix "5883212311535a0046031d74d1568ae173c1e35b" (baseNameOf patch)) (
+          pkgs.boost.patches or [ ]
+        )
+      ) ./patches/0001-Fix-uncaught_exceptions-not-accounting-for-forced_un.patch;
       enableIcu = false;
     }).overrideAttrs
       (old: {


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->
Makes the flake with newer nixpkgs, e.g. with input overrides.

## Context

- Builds with nixpkgs master.
- No change in `nix-store.drvPath` between before/after (without the nixpkgs input override)
- https://github.com/NixOS/nixpkgs/pull/546405
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
