### PR TITLE
PosixDirectorySourceAccessor: Reduce dirFd cache churn

### DIFF
--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -257,10 +257,32 @@ private:
     std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> openParentAndUpsert(const CanonPath & path, bool ignoreMissing);
 
     /**
-     * Get the parent directory of path. The second pair element might be an owning file descriptor
-     * if path.parent().isRoot() is false.
+     * Result of `openParent()`.
      */
-    std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> openParent(const CanonPath & path);
+    struct OpenedParent
+    {
+        Descriptor fd;
+
+        /**
+         * Owning file descriptor, unless `path.parent().isRoot()`.
+         */
+        std::shared_ptr<AutoCloseFD> fdOwning;
+
+        /**
+         * `path.parent()`, so that callers don't recompute it (which copies a string).
+         */
+        std::optional<CanonPath> parent;
+
+        /**
+         * Whether `fdOwning` came out of `dirFdCache` under exactly `parent`.
+         */
+        bool fromCache = false;
+    };
+
+    /**
+     * Get the parent directory of path.
+     */
+    OpenedParent openParent(const CanonPath & path);
 
     std::function<void(AutoCloseFD, CanonPath)> makeDirFdCallback();
 
@@ -339,12 +361,12 @@ std::function<void(AutoCloseFD, CanonPath)> PosixDirectorySourceAccessor::makeDi
     };
 }
 
-std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> PosixDirectorySourceAccessor::openParent(const CanonPath & path)
+PosixDirectorySourceAccessor::OpenedParent PosixDirectorySourceAccessor::openParent(const CanonPath & path)
 {
     assert(!path.isRoot());
     auto parent = path.parent().value();
     if (parent.isRoot())
-        return {dirFd.get(), nullptr};
+        return {dirFd.get(), nullptr, std::move(parent)};
 
     maybeEvictFromGlobalCaches();
 
@@ -357,7 +379,12 @@ std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> PosixDirectorySourceAccessor
         while (true) {
             if (auto intermediateDirFdHit = cache->get(p)) {
                 if (p == parent)
-                    return {(*intermediateDirFdHit)->get(), *intermediateDirFdHit};
+                    return {
+                        .fd = (*intermediateDirFdHit)->get(),
+                        .fdOwning = *intermediateDirFdHit,
+                        .parent = std::move(parent),
+                        .fromCache = true,
+                    };
                 intermediateParentFd = intermediateDirFdHit->get_ptr();
                 anchor = p;
                 break;
@@ -397,7 +424,7 @@ std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> PosixDirectorySourceAccessor
                 O_DIRECTORY | O_CLOEXEC,
             0,
             std::move(cb));
-        return {parentFdOwning.get(), make_ref<AutoCloseFD>(std::move(parentFdOwning))};
+        return {parentFdOwning.get(), make_ref<AutoCloseFD>(std::move(parentFdOwning)), std::move(parent)};
     } catch (SymlinkNotAllowed & e) {
         /* Need to fixup the error message to include the actual path relative to the (possibly) cached fd. */
         throw SymlinkNotAllowed(anchor / e.path, "path '%s' (or its ancestor) is a symlink", showPath(anchor / e.path));
@@ -407,7 +434,7 @@ std::pair<Descriptor, std::shared_ptr<AutoCloseFD>> PosixDirectorySourceAccessor
 std::pair<Descriptor, std::shared_ptr<AutoCloseFD>>
 PosixDirectorySourceAccessor::openParentAndUpsert(const CanonPath & path, bool ignoreMissing)
 {
-    auto [parentFd, parentFdOwning] = openParent(path);
+    auto [parentFd, parentFdOwning, parent, fromCache] = openParent(path);
     if (parentFd == INVALID_DESCRIPTOR) {
         if (errno == ENOENT || errno == ENOTDIR) /* Intermediate component might not exist. */ {
             if (ignoreMissing)
@@ -415,12 +442,13 @@ PosixDirectorySourceAccessor::openParentAndUpsert(const CanonPath & path, bool i
             else
                 throw FileNotFound("path '%s' does not exist", showPath(path));
         }
-        throw SysError("opening directory '%1%'", showPath(path.parent().value()));
+        throw SysError("opening directory '%1%'", showPath(*parent));
     }
 
-    if (dirFdCache && parentFdOwning) {
+    /* A cached fd needs no upsert: `LRUCache::get()` has already promoted it. */
+    if (dirFdCache && parentFdOwning && !fromCache) {
         assert(*parentFdOwning);
-        insertIntoDirFdCache(path.parent().value(), ref<AutoCloseFD>(parentFdOwning));
+        insertIntoDirFdCache(*parent, ref<AutoCloseFD>(parentFdOwning));
     }
 
     return {parentFd, parentFdOwning};


### PR DESCRIPTION
## Motivation

this is a perf improvement. a faster nix is a better nix!

<!-- Briefly explain what the change is about and why it is desirable. -->
## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

this change should be very self-contained.

openParent returns early on a known cache hit. We don't need to reinsert that fd into the cache, so propagate that information out to openParentAndUpsert. LRUCache::get() already calls promote() (lru-cache.hh:109), so the entry is alredy at the top of the cache.

llm usage disclosure: i set out looking for a clean perf improvement i could make to nix and used claude-opus-4-8 to set up instrumentation, so this is a bit of a drive-by, but i hope its focused enough to be useful. the code is my own.

## Perf

running nix-env -qa --meta against nixpkgs 52705f708cbb resulted in -1.32% instruction count with `perf stat -e instructions`, though actual timings did not present enough evidence to prove wall-clock perf improvements.

perf numbers before:
```
 Performance counter stats for 'build/src/nix/nix-env -qa --meta -f ../nixpkgs' (3 runs):

   205,157,349,269 instructions:u  ( +-  0.00% )
   27.971140512 +- 0.408977754 seconds time elapsed  ( +-  1.46% )
```
perf numbers after:
```
 Performance counter stats for 'build/src/nix/nix-env -qa --meta -f ../nixpkgs' (3 runs):

   202,448,603,027 instructions:u  ( +-  0.01% )
   27.520502725 +- 0.257127251 seconds time elapsed  ( +-  0.93% )
```
Assisted-by: Claude Code (claude-opus-4.8)

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
