### PR TITLE
Draft: libgit2 and tarball unpacking performance improvements

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -112,6 +112,7 @@ scope: {
       };
       patches = prevAttrs.patches or [ ] ++ [
         ./patches/0001-zlib-ng-support.patch
+        ./patches/0002-memory-config.patch
       ];
       cmakeFlags = prevAttrs.cmakeFlags ++ [ "-DUSE_COMPRESSION=zlib-ng" ];
       buildInputs = prevAttrs.buildInputs ++ [ pkgs.zlib-ng ];

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -101,20 +101,22 @@ scope: {
         ];
       });
 
-  libgit2 =
-    if lib.versionAtLeast pkgs.libgit2.version "1.9.4" then
-      pkgs.libgit2
-    else
-      # Grab newer libgit2.
-      pkgs.libgit2.overrideAttrs rec {
-        version = "1.9.4";
-        src = pkgs.fetchFromGitHub {
-          owner = "libgit2";
-          repo = "libgit2";
-          tag = "v${version}";
-          hash = "sha256-ZKUiz3pdFE2SKxh53X2oyr7hs32Njj5YVA0OXDXz7h0=";
-        };
+  libgit2 = pkgs.libgit2.overrideAttrs (
+    finalAttrs: prevAttrs: {
+      version = "2.0.0-rc.1";
+      src = pkgs.fetchFromGitHub {
+        owner = "libgit2";
+        repo = "libgit2";
+        rev = "ae45d0d168f7e8dbfdb8c623589cb51caac96ab3";
+        hash = "sha256-3sbqHm37SOwBeFgtjI2DLN6kx1F7G2N1m6rRIkqDXNI=";
       };
+      patches = prevAttrs.patches or [ ] ++ [
+        ./patches/0001-zlib-ng-support.patch
+      ];
+      cmakeFlags = prevAttrs.cmakeFlags ++ [ "-DUSE_COMPRESSION=zlib-ng" ];
+      buildInputs = prevAttrs.buildInputs ++ [ pkgs.zlib-ng ];
+    }
+  );
 
   # TODO Hack until https://github.com/NixOS/nixpkgs/issues/45462 is fixed.
   boost =

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -113,6 +113,7 @@ scope: {
       patches = prevAttrs.patches or [ ] ++ [
         ./patches/0001-zlib-ng-support.patch
         ./patches/0002-memory-config.patch
+        ./patches/0003-packbuilder-correct-config.patch
       ];
       cmakeFlags = prevAttrs.cmakeFlags ++ [ "-DUSE_COMPRESSION=zlib-ng" ];
       buildInputs = prevAttrs.buildInputs ++ [ pkgs.zlib-ng ];

--- a/packaging/patches/0001-zlib-ng-support.patch
+++ b/packaging/patches/0001-zlib-ng-support.patch
@@ -1,0 +1,379 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 87b33a9bc..19ec37c3c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,7 +35,7 @@ option(BUILD_FUZZERS           "Build the fuzz targets"
+    set(USE_AUTH_NEGOTIATE      "" CACHE STRING "Enable Negotiate (SPNEGO) authentication support. One of GSSAPI or win32.")
+ #  set(USE_XDIFF               "" CACHE STRING "Specifies the xdiff implementation; either system or builtin.")
+    set(USE_REGEX               "" CACHE STRING "Selects regex provider. One of regcomp_l, pcre2, pcre, regcomp, or builtin.")
+-   set(USE_COMPRESSION         "" CACHE STRING "Selects compression backend. Either builtin or zlib.")
++   set(USE_COMPRESSION         "" CACHE STRING "Selects compression backend. Either builtin, zlib or zlib-ng.")
+    set(USE_NSEC                "" CACHE STRING "Enable nanosecond precision timestamps. One of ON, OFF, or a specific provider: mtimespec, mtim, mtime, or win32. (Defaults to ON).")
+ 
+ if(APPLE)
+diff --git a/cmake/SelectCompression.cmake b/cmake/SelectCompression.cmake
+index d0a4b5664..764af5197 100644
+--- a/cmake/SelectCompression.cmake
++++ b/cmake/SelectCompression.cmake
+@@ -32,6 +32,19 @@ elseif(USE_COMPRESSION STREQUAL "zlib")
+ 	endif()
+ 
+ 	set(GIT_COMPRESSION_ZLIB 1)
++elseif(USE_COMPRESSION STREQUAL "zlib-ng")
++	find_package(zlib-ng)
++	find_package(ZLIB) # For reftable library
++
++	if(NOT zlib-ng_FOUND)
++		message(FATAL_ERROR "system zlib-ng was requested but not found")
++	endif()
++
++	if(NOT ZLIB_FOUND)
++		message(FATAL_ERROR "system zlib was requested but not found")
++	endif()
++
++	set(GIT_COMPRESSION_ZLIB_NG 1)
+ elseif(USE_COMPRESSION STREQUAL "builtin")
+ 	set(GIT_COMPRESSION_BUILTIN 1)
+ endif()
+@@ -45,6 +58,18 @@ if(GIT_COMPRESSION_ZLIB)
+ 		list(APPEND LIBGIT2_PC_REQUIRES "zlib")
+ 	endif()
+ 	add_feature_info("Compression" ON "using system zlib")
++elseif(GIT_COMPRESSION_ZLIB_NG)
++	list(APPEND LIBGIT2_SYSTEM_INCLUDES ${zlib-ng_INCLUDE_DIR})
++	list(APPEND LIBGIT2_SYSTEM_LIBS "z-ng") # FIXME
++	list(APPEND LIBGIT2_SYSTEM_INCLUDES ${ZLIB_INCLUDE_DIRS})
++	list(APPEND LIBGIT2_SYSTEM_LIBS ${ZLIB_LIBRARIES})
++	if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
++		list(APPEND LIBGIT2_PC_LIBS "-lz")
++	else()
++		list(APPEND LIBGIT2_PC_REQUIRES "zlib")
++	endif()
++	list(APPEND LIBGIT2_PC_REQUIRES "zlib-ng;zlib")
++	add_feature_info("Compression" ON "using system zlib-ng")
+ elseif(GIT_COMPRESSION_BUILTIN)
+ 	add_subdirectory("${PROJECT_SOURCE_DIR}/deps/zlib" "${PROJECT_BINARY_DIR}/deps/zlib")
+ 	list(APPEND LIBGIT2_DEPENDENCY_INCLUDES "${PROJECT_SOURCE_DIR}/deps/zlib")
+diff --git a/src/libgit2/indexer.c b/src/libgit2/indexer.c
+index 68f595696..580628e65 100644
+--- a/src/libgit2/indexer.c
++++ b/src/libgit2/indexer.c
+@@ -345,14 +345,14 @@ static int crc_object(uint32_t *crc_out, git_mwindow_file *mwf, off64_t start, o
+ 	unsigned int left, len;
+ 	git_mwindow *w = NULL;
+ 
+-	crc = crc32(0L, Z_NULL, 0);
++	crc = GIT_ZLIB_SYMBOL(crc32)(0L, Z_NULL, 0);
+ 	while (size) {
+ 		ptr = git_mwindow_open(mwf, &w, start, (size_t)size, &left);
+ 		if (ptr == NULL)
+ 			return -1;
+ 
+ 		len = min(left, (unsigned int)size);
+-		crc = crc32(crc, ptr, len);
++		crc = GIT_ZLIB_SYMBOL(crc32)(crc, ptr, len);
+ 		size -= len;
+ 		start += len;
+ 		git_mwindow_close(&w);
+@@ -606,7 +606,7 @@ static int hash_and_save(git_indexer *idx, git_rawobj *obj, off64_t entry_start)
+ 
+ 	git_oid_cpy(&pentry->id, &oid);
+ 	git_oid_cpy(&entry->oid, &oid);
+-	entry->crc = crc32(0L, Z_NULL, 0);
++	entry->crc = GIT_ZLIB_SYMBOL(crc32)(0L, Z_NULL, 0);
+ 
+ 	entry_size = (size_t)(idx->off - entry_start);
+ 	if (crc_object(&entry->crc, &idx->pack->mwf, entry_start, entry_size) < 0)
+@@ -1008,7 +1008,7 @@ static int inject_object(git_indexer *idx, git_oid *id)
+ 	entry = git__calloc(1, sizeof(*entry));
+ 	GIT_ERROR_CHECK_ALLOC(entry);
+ 
+-	entry->crc = crc32(0L, Z_NULL, 0);
++	entry->crc = GIT_ZLIB_SYMBOL(crc32)(0L, Z_NULL, 0);
+ 
+ 	/* Write out the object header */
+ 	if ((error = git_packfile__object_header(&hdr_len, hdr, len, git_odb_object_type(obj))) < 0 ||
+@@ -1016,7 +1016,7 @@ static int inject_object(git_indexer *idx, git_oid *id)
+ 		goto cleanup;
+ 
+ 	idx->pack->mwf.size += hdr_len;
+-	entry->crc = crc32(entry->crc, hdr, (uInt)hdr_len);
++	entry->crc = GIT_ZLIB_SYMBOL(crc32)(entry->crc, hdr, (uInt)hdr_len);
+ 
+ 	if ((error = git_zstream_deflatebuf(&buf, data, len)) < 0)
+ 		goto cleanup;
+@@ -1026,7 +1026,7 @@ static int inject_object(git_indexer *idx, git_oid *id)
+ 		goto cleanup;
+ 
+ 	idx->pack->mwf.size += buf.size;
+-	entry->crc = htonl(crc32(entry->crc, (unsigned char *)buf.ptr, (uInt)buf.size));
++	entry->crc = htonl(GIT_ZLIB_SYMBOL(crc32)(entry->crc, (unsigned char *)buf.ptr, (uInt)buf.size));
+ 	git_str_dispose(&buf);
+ 
+ 	/* Write a fake trailer so the pack functions play ball */
+diff --git a/src/libgit2/libgit2.c b/src/libgit2/libgit2.c
+index 081a25087..0c8a8ea81 100644
+--- a/src/libgit2/libgit2.c
++++ b/src/libgit2/libgit2.c
+@@ -233,6 +233,8 @@ const char *git_libgit2_feature_backend(git_feature_t feature)
+ 	case GIT_FEATURE_COMPRESSION:
+ #if defined(GIT_COMPRESSION_ZLIB)
+ 		return "zlib";
++#elif defined(GIT_COMPRESSION_ZLIB_NG)
++		return "zlib-ng";
+ #elif defined(GIT_COMPRESSION_BUILTIN)
+ 		return "builtin";
+ #else
+diff --git a/src/libgit2/odb.c b/src/libgit2/odb.c
+index 3b2306c3c..72bae5088 100644
+--- a/src/libgit2/odb.c
++++ b/src/libgit2/odb.c
+@@ -7,7 +7,6 @@
+ 
+ #include "odb.h"
+ 
+-#include <zlib.h>
+ #include "git2/object.h"
+ #include "git2/sys/odb_backend.h"
+ #include "futils.h"
+diff --git a/src/libgit2/odb_loose.c b/src/libgit2/odb_loose.c
+index 0b3a51732..ed0ebcc7c 100644
+--- a/src/libgit2/odb_loose.c
++++ b/src/libgit2/odb_loose.c
+@@ -7,7 +7,6 @@
+ 
+ #include "common.h"
+ 
+-#include <zlib.h>
+ #include "git2/object.h"
+ #include "git2/sys/odb_backend.h"
+ #include "futils.h"
+diff --git a/src/libgit2/odb_pack.c b/src/libgit2/odb_pack.c
+index 6fbc1952a..0ccce7c06 100644
+--- a/src/libgit2/odb_pack.c
++++ b/src/libgit2/odb_pack.c
+@@ -7,7 +7,6 @@
+ 
+ #include "common.h"
+ 
+-#include <zlib.h>
+ #include "git2/repository.h"
+ #include "git2/indexer.h"
+ #include "git2/sys/odb_backend.h"
+diff --git a/src/util/filebuf.c b/src/util/filebuf.c
+index 7afb76b88..a307dacd9 100644
+--- a/src/util/filebuf.c
++++ b/src/util/filebuf.c
+@@ -117,7 +117,11 @@ void git_filebuf_cleanup(git_filebuf *file)
+ 	/* use the presence of z_buf to decide if we need to deflateEnd */
+ 	if (file->z_buf) {
+ 		git__free(file->z_buf);
++#ifdef GIT_COMPRESSION_ZLIB_NG
++		zng_deflateEnd(&file->zs);
++#else
+ 		deflateEnd(&file->zs);
++#endif
+ 	}
+ 
+ 	if (file->path_original)
+@@ -158,7 +162,7 @@ static int write_normal(git_filebuf *file, void *source, size_t len)
+ 
+ static int write_deflate(git_filebuf *file, void *source, size_t len)
+ {
+-	z_stream *zs = &file->zs;
++	GIT_ZLIB_STREAM *zs = &file->zs;
+ 
+ 	if (len > 0 || file->flush_mode == Z_FINISH) {
+ 		zs->next_in = source;
+@@ -170,7 +174,7 @@ static int write_deflate(git_filebuf *file, void *source, size_t len)
+ 			zs->next_out = file->z_buf;
+ 			zs->avail_out = (uInt)file->buf_size;
+ 
+-			if (deflate(zs, file->flush_mode) == Z_STREAM_ERROR) {
++			if (GIT_ZLIB_SYMBOL(deflate)(zs, file->flush_mode) == Z_STREAM_ERROR) {
+ 				file->last_error = BUFERR_ZLIB;
+ 				return -1;
+ 			}
+@@ -319,7 +323,7 @@ int git_filebuf_open_withsize(git_filebuf *file, const char *path, int flags, mo
+ 	/* If we are deflating on-write, */
+ 	if (compression != 0) {
+ 		/* Initialize the ZLib stream */
+-		if (deflateInit(&file->zs, compression) != Z_OK) {
++		if (GIT_ZLIB_SYMBOL(deflateInit)(&file->zs, compression) != Z_OK) {
+ 			git_error_set(GIT_ERROR_ZLIB, "failed to initialize zlib");
+ 			goto cleanup;
+ 		}
+diff --git a/src/util/filebuf.h b/src/util/filebuf.h
+index e23b9ed2a..c4cb4cb02 100644
+--- a/src/util/filebuf.h
++++ b/src/util/filebuf.h
+@@ -11,7 +11,7 @@
+ 
+ #include "futils.h"
+ #include "hash.h"
+-#include <zlib.h>
++#include "zstream.h"
+ 
+ #ifdef GIT_THREADS
+ #	define GIT_FILEBUF_THREADS
+@@ -42,7 +42,7 @@ struct git_filebuf {
+ 	unsigned char *buffer;
+ 	unsigned char *z_buf;
+ 
+-	z_stream zs;
++	GIT_ZLIB_STREAM zs;
+ 	int flush_mode;
+ 
+ 	size_t buf_size, buf_pos;
+diff --git a/src/util/git2_features.h.in b/src/util/git2_features.h.in
+index e890670bb..8e8f5ae14 100644
+--- a/src/util/git2_features.h.in
++++ b/src/util/git2_features.h.in
+@@ -32,6 +32,7 @@
+ 
+ #cmakedefine GIT_COMPRESSION_BUILTIN 1
+ #cmakedefine GIT_COMPRESSION_ZLIB 1
++#cmakedefine GIT_COMPRESSION_ZLIB_NG 1
+ 
+ #cmakedefine GIT_NSEC 1
+ #cmakedefine GIT_NSEC_MTIM 1
+diff --git a/src/util/git2_util.h b/src/util/git2_util.h
+index 556671e6e..9803bd315 100644
+--- a/src/util/git2_util.h
++++ b/src/util/git2_util.h
+@@ -27,6 +27,9 @@ typedef struct git_str git_str;
+ #endif
+ #define GIT_INLINE(type) static GIT_INLINE_KEYWORD type
+ 
++#define GIT_CONCAT_RAW(a, b) a ## b
++#define GIT_CONCAT(a, b) GIT_CONCAT_RAW(a, b)
++
+ /** Support for gcc/clang __has_builtin intrinsic */
+ #ifndef __has_builtin
+ # define __has_builtin(x) 0
+diff --git a/src/util/zstream.c b/src/util/zstream.c
+index efc0883c9..7eabef36d 100644
+--- a/src/util/zstream.c
++++ b/src/util/zstream.c
+@@ -7,8 +7,6 @@
+ 
+ #include "zstream.h"
+ 
+-#include <zlib.h>
+-
+ #include "str.h"
+ 
+ #define ZSTREAM_BUFFER_SIZE (1024 * 1024)
+@@ -39,26 +37,26 @@ int git_zstream_init(git_zstream *zstream, git_zstream_t type)
+ 	zstream->type = type;
+ 
+ 	if (zstream->type == GIT_ZSTREAM_INFLATE)
+-		zstream->zerr = inflateInit(&zstream->z);
++		zstream->zerr = GIT_ZLIB_SYMBOL(inflateInit)(&zstream->z);
+ 	else
+-		zstream->zerr = deflateInit(&zstream->z, Z_DEFAULT_COMPRESSION);
++		zstream->zerr = GIT_ZLIB_SYMBOL(deflateInit)(&zstream->z, Z_DEFAULT_COMPRESSION);
+ 	return zstream_seterr(zstream);
+ }
+ 
+ void git_zstream_free(git_zstream *zstream)
+ {
+ 	if (zstream->type == GIT_ZSTREAM_INFLATE)
+-		inflateEnd(&zstream->z);
++		GIT_ZLIB_SYMBOL(inflateEnd)(&zstream->z);
+ 	else
+-		deflateEnd(&zstream->z);
++		GIT_ZLIB_SYMBOL(deflateEnd)(&zstream->z);
+ }
+ 
+ void git_zstream_reset(git_zstream *zstream)
+ {
+ 	if (zstream->type == GIT_ZSTREAM_INFLATE)
+-		inflateReset(&zstream->z);
++		GIT_ZLIB_SYMBOL(inflateReset)(&zstream->z);
+ 	else
+-		deflateReset(&zstream->z);
++		GIT_ZLIB_SYMBOL(deflateReset)(&zstream->z);
+ 	zstream->in = NULL;
+ 	zstream->in_len = 0;
+ 	zstream->zerr = Z_STREAM_END;
+@@ -120,9 +118,9 @@ int git_zstream_get_output_chunk(
+ 
+ 	/* compress next chunk */
+ 	if (zstream->type == GIT_ZSTREAM_INFLATE)
+-		zstream->zerr = inflate(&zstream->z, zstream->flush);
++		zstream->zerr = GIT_ZLIB_SYMBOL(inflate)(&zstream->z, zstream->flush);
+ 	else
+-		zstream->zerr = deflate(&zstream->z, zstream->flush);
++		zstream->zerr = GIT_ZLIB_SYMBOL(deflate)(&zstream->z, zstream->flush);
+ 
+ 	if (zstream_seterr(zstream))
+ 		return -1;
+diff --git a/src/util/zstream.h b/src/util/zstream.h
+index d78b11291..001036d4f 100644
+--- a/src/util/zstream.h
++++ b/src/util/zstream.h
+@@ -9,7 +9,15 @@
+ 
+ #include "git2_util.h"
+ 
++#ifdef GIT_COMPRESSION_ZLIB_NG
++#include <zlib-ng.h>
++# define GIT_ZLIB_SYMBOL(name) GIT_CONCAT(zng_, name)
++# define GIT_ZLIB_STREAM zng_stream
++#else
+ #include <zlib.h>
++# define GIT_ZLIB_SYMBOL(name) name
++# define GIT_ZLIB_STREAM z_stream
++#endif
+ 
+ #include "str.h"
+ 
+@@ -19,7 +27,7 @@ typedef enum {
+ } git_zstream_t;
+ 
+ typedef struct {
+-	z_stream z;
++	GIT_ZLIB_STREAM z;
+ 	git_zstream_t type;
+ 	const char *in;
+ 	size_t in_len;
+diff --git a/tests/libgit2/core/features.c b/tests/libgit2/core/features.c
+index 780d29853..5891be3bc 100644
+--- a/tests/libgit2/core/features.c
++++ b/tests/libgit2/core/features.c
+@@ -200,6 +200,8 @@ void test_core_features__backends(void)
+ 	cl_assert_equal_s("builtin", compression);
+ #elif defined(GIT_COMPRESSION_ZLIB)
+ 	cl_assert_equal_s("zlib", compression);
++#elif defined(GIT_COMPRESSION_ZLIB_NG)
++	cl_assert_equal_s("zlib-ng", compression);
+ #else
+ 	cl_assert(0);
+ #endif
+diff --git a/tests/util/zstream.c b/tests/util/zstream.c
+index ea7ffb1d0..9481676e7 100644
+--- a/tests/util/zstream.c
++++ b/tests/util/zstream.c
+@@ -10,7 +10,7 @@ static void assert_zlib_equal_(
+ 	const void *compressed, size_t c_len,
+ 	const char *msg, const char *file, const char *func, int line)
+ {
+-	z_stream stream;
++	GIT_ZLIB_STREAM stream;
+ 	char *expanded = git__calloc(1, e_len + INFLATE_EXTRA);
+ 	cl_assert(expanded);
+ 
+@@ -20,9 +20,9 @@ static void assert_zlib_equal_(
+ 	stream.next_in   = (Bytef *)compressed;
+ 	stream.avail_in  = (uInt)c_len;
+ 
+-	cl_assert(inflateInit(&stream) == Z_OK);
+-	cl_assert(inflate(&stream, Z_FINISH));
+-	inflateEnd(&stream);
++	cl_assert(GIT_ZLIB_SYMBOL(inflateInit)(&stream) == Z_OK);
++	cl_assert(GIT_ZLIB_SYMBOL(inflate)(&stream, Z_FINISH));
++	GIT_ZLIB_SYMBOL(inflateEnd)(&stream);
+ 
+ 	clar__assert_equal(
+ 		file, func, line, msg, 1,

--- a/packaging/patches/0002-memory-config.patch
+++ b/packaging/patches/0002-memory-config.patch
@@ -1,0 +1,22 @@
+diff --git a/include/git2/sys/config.h b/include/git2/sys/config.h
+index dcce18e6f..8945a3285 100644
+--- a/include/git2/sys/config.h
++++ b/include/git2/sys/config.h
+@@ -200,7 +200,7 @@ GIT_EXTERN(int) git_config_backend_memory_options_init(
+  * @param opts the options to initialize this backend with, or NULL
+  * @return 0 on success or an error code
+  */
+-extern int git_config_backend_from_string(
++GIT_EXTERN(int) git_config_backend_from_string(
+ 	git_config_backend **out,
+ 	const char *cfg,
+ 	size_t len,
+@@ -216,7 +216,7 @@ extern int git_config_backend_from_string(
+  * @param opts the options to initialize this backend with, or NULL
+  * @return 0 on success or an error code
+  */
+-extern int git_config_backend_from_values(
++GIT_EXTERN(int) git_config_backend_from_values(
+ 	git_config_backend **out,
+ 	const char **values,
+ 	size_t len,

--- a/packaging/patches/0003-packbuilder-correct-config.patch
+++ b/packaging/patches/0003-packbuilder-correct-config.patch
@@ -1,0 +1,45 @@
+diff --git a/src/libgit2/pack-objects.c b/src/libgit2/pack-objects.c
+index 0da84b657..d540795f9 100644
+--- a/src/libgit2/pack-objects.c
++++ b/src/libgit2/pack-objects.c
+@@ -115,8 +115,9 @@ static int packbuilder_config(git_packbuilder *pb)
+ 		   GIT_PACK_DELTA_CACHE_SIZE);
+ 	config_get("pack.deltaCacheLimit", pb->cache_max_small_delta_size,
+ 		   GIT_PACK_DELTA_CACHE_LIMIT);
+-	config_get("pack.deltaCacheSize", pb->big_file_threshold,
++	config_get("core.bigFileThreshold", pb->big_file_threshold,
+ 		   GIT_PACK_BIG_FILE_THRESHOLD);
++	config_get("pack.window", pb->window_size, GIT_PACK_WINDOW);
+ 	config_get("pack.windowMemory", pb->window_memory_limit, 0);
+ 
+ #undef config_get
+@@ -1341,7 +1342,7 @@ int git_packbuilder__prepare(git_packbuilder *pb)
+ 	size_t i, n = 0;
+ 	int error;
+ 
+-	if (pb->nr_objects == 0 || pb->done)
++	if (pb->nr_objects == 0 || pb->done || pb->window_size == 0)
+ 		return 0; /* nothing to do */
+ 
+ 	/*
+@@ -1369,7 +1370,7 @@ int git_packbuilder__prepare(git_packbuilder *pb)
+ 	if (n > 1) {
+ 		git__tsort((void **)delta_list, n, type_size_sort);
+ 		if ((error = ll_find_deltas(pb, delta_list, n,
+-				   GIT_PACK_WINDOW + 1,
++				   pb->window_size + 1,
+ 				   GIT_PACK_DEPTH)) < 0) {
+ 			git__free(delta_list);
+ 			return error;
+diff --git a/src/libgit2/pack-objects.h b/src/libgit2/pack-objects.h
+index ad04fb0ab..d9e03df60 100644
+--- a/src/libgit2/pack-objects.h
++++ b/src/libgit2/pack-objects.h
+@@ -94,6 +94,7 @@ struct git_packbuilder {
+ 	size_t cache_max_small_delta_size;
+ 	size_t big_file_threshold;
+ 	size_t window_memory_limit;
++	size_t window_size;
+ 
+ 	unsigned int nr_threads; /* nr of threads to use */
+ 

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -21,6 +21,7 @@
 #include <git2/branch.h>
 #include <git2/commit.h>
 #include <git2/config.h>
+#include <git2/sys/config.h>
 #include <git2/describe.h>
 #include <git2/errors.h>
 #include <git2/global.h>
@@ -142,6 +143,11 @@ typedef std::unique_ptr<git_describe_result, Deleter<git_describe_result_free>> 
 typedef std::unique_ptr<git_status_list, Deleter<git_status_list_free>> StatusList;
 typedef std::unique_ptr<git_remote, Deleter<git_remote_free>> Remote;
 typedef std::unique_ptr<git_config, Deleter<git_config_free>> GitConfig;
+typedef std::unique_ptr<git_config_backend, decltype([](git_config_backend * backend) {
+                            if (backend)
+                                backend->free(backend);
+                        })>
+    GitConfigBackend;
 typedef std::unique_ptr<git_config_iterator, Deleter<git_config_iterator_free>> ConfigIterator;
 typedef std::unique_ptr<git_odb, Deleter<git_odb_free>> ObjectDb;
 typedef std::unique_ptr<git_packbuilder, Deleter<git_packbuilder_free>> PackBuilder;
@@ -362,6 +368,28 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
         initRepoAtomically(path, options);
         if (git_repository_open(Setter(repo), path.string().c_str()))
             throw GitError("opening Git repository %s", PathFmt(path));
+
+        GitConfig config;
+        if (git_repository_config(Setter(config), *this))
+            throw GitError("getting Git repository config");
+
+        /* Create an in-memory configuration so that we can set config options without modifying the
+           config file on-disk. */
+        git_config_backend_memory_options configOpts = GIT_CONFIG_BACKEND_MEMORY_OPTIONS_INIT;
+        configOpts.backend_type = "nix";
+
+        std::vector<const char *> configValues;
+        if (options.dontFindDeltas)
+            configValues.push_back("pack.deltacachesize=1");
+
+        GitConfigBackend memBackend;
+        if (git_config_backend_from_values(Setter(memBackend), configValues.data(), configValues.size(), &configOpts))
+            throw GitError("creating an in-memory Git config");
+
+        if (git_config_add_backend(config.get(), memBackend.get(), GIT_CONFIG_LEVEL_APP, *this, /*force=*/false))
+            throw GitError("adding the in-memory Git configuration backend");
+
+        memBackend.release();
 
         ObjectDb odb;
         if (options.packfilesOnly) {
@@ -1706,7 +1734,16 @@ ref<GitRepo> Settings::getTarballCache() const
      * for optimal packfiles.
      */
     static auto repoDir = std::filesystem::path(getCacheDir()) / "tarball-cache-v2";
-    return GitRepo::openRepo(repoDir, {.create = true, .bare = true, .packfilesOnly = true});
+    return GitRepo::openRepo(
+        repoDir,
+        {
+            .create = true,
+            .bare = true,
+            .packfilesOnly = true,
+            /* Tarball unpacking is not expected to benefit from deltas much,
+               compared to how much CPU times it takes to find. */
+            .dontFindDeltas = true,
+        });
 }
 
 } // namespace fetchers

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -380,7 +380,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
         std::vector<const char *> configValues;
         if (options.dontFindDeltas)
-            configValues.push_back("pack.deltacachesize=1");
+            configValues.push_back("pack.window=0");
 
         GitConfigBackend memBackend;
         if (git_config_backend_from_values(Setter(memBackend), configValues.data(), configValues.size(), &configOpts))

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -176,6 +176,12 @@ static void initLibGit2()
     std::call_once(initialized, []() {
         if (git_libgit2_init() < 0)
             throw GitError("initialising libgit2");
+
+        /* Nuke the "hashing on all reads" behavior, since that can lead to bad
+           performance https://github.com/libgit2/libgit2/issues/4951. It's a
+           compromise of course, but one that is mostly in line with git cli and
+           like how we don't recalculate narHash when reading from a store. */
+        git_libgit2_opts(GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, 0);
     });
 }
 

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -41,6 +41,12 @@ struct GitRepo
         bool create = false;
         bool bare = false;
         bool packfilesOnly = false;
+        /**
+         * Whether to avoid finding deltas when writing packfiles. It's an
+         * expensive operation, which should be avoided if no benefit is
+         * expected from possible deduplication in the same packfile.
+         */
+        bool dontFindDeltas = false;
     };
 
     static ref<GitRepo> openRepo(const std::filesystem::path & path, Options options);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Use these 3 simple hacks to get 3x less CPU time for tarball unpacking (that's a fresh nixpkgs tarball import into a new cache):

```
Command being timed: "nix flake metadata file:///home/xokdvium/work/code/nix/unstable.tar.zst --refresh -vvvv"
        User time (seconds): 20.51
        System time (seconds): 0.66
        Percent of CPU this job got: 381%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:05.55
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1087388
```

With this whole stack applied:

```
Command being timed: "result/bin/nix flake metadata file:///home/xokdvium/work/code/nix/unstable.tar.zst --refresh -vvvv"
        User time (seconds): 6.29
        System time (seconds): 0.43
        Percent of CPU this job got: 220%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:03.04
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 631872
```

I'll try to upstream all this stuff (patches 2 TBD and fix for patch 3 is up in https://github.com/libgit2/libgit2/pull/7366). Draft for now because obviously we won't be patching libgit2.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
