### PR TITLE
fetchers/git: negotiate rev-pinned fetches from bucketed refs

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -866,7 +866,7 @@ struct GitInputScheme : InputScheme
                 bool shallow = getShallowAttr(input);
                 try {
                     static constexpr std::string_view reservedRefNamespace =
-                        "__nix_internal_ref_namespace_reserved_for_fetchers_2c17c6393771ee3048ae34d6b380c5ec__";
+                        "__nix_internal_fetchers_48ae34d6b380c5ec__";
                     /* Fetch into a bucketed ref instead of leaving the rev
                        un-refed, so a later fetch of a nearby rev can
                        negotiate against it instead of re-downloading. */

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -865,8 +865,15 @@ struct GitInputScheme : InputScheme
             if (doFetch) {
                 bool shallow = getShallowAttr(input);
                 try {
-                    auto fetchRef = getAllRefsAttr(input)             ? "refs/*:refs/*"
-                                    : input.getRev()                  ? input.getRev()->gitRev()
+                    static constexpr std::string_view reservedRefNamespace =
+                        "__nix_internal_ref_namespace_reserved_for_fetchers_2c17c6393771ee3048ae34d6b380c5ec__";
+                    /* Fetch into a bucketed ref instead of leaving the rev
+                       un-refed, so a later fetch of a nearby rev can
+                       negotiate against it instead of re-downloading. */
+                    auto rev = input.getRev();
+                    auto revStr = rev ? rev->gitRev() : "";
+                    auto fetchRef = getAllRefsAttr(input) ? "refs/*:refs/*"
+                                    : rev ? fmt("%s:refs/%s/tip-%s", revStr, reservedRefNamespace, revStr.substr(0, 2))
                                     : ref.compare(0, 5, "refs/") == 0 ? fmt("%1%:%1%", ref)
                                     : ref == "HEAD"                   ? "HEAD:HEAD"
                                                                       : fmt("%1%:%1%", "refs/heads/" + ref);

--- a/tests/functional/common/functions.sh
+++ b/tests/functional/common/functions.sh
@@ -374,7 +374,7 @@ initGitRepo() {
     local extraArgs="${2-}"
 
     # shellcheck disable=SC2086 # word splitting of extraArgs is intended
-    git -C "$repo" init $extraArgs
+    git -C "$repo" init --initial-branch=master $extraArgs
     git -C "$repo" config user.email "foobar@example.com"
     git -C "$repo" config user.name "Foobar"
 }

--- a/tests/functional/git/exact-rev-fetch-bucketed-refs.sh
+++ b/tests/functional/git/exact-rev-fetch-bucketed-refs.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Rev-pinned fetches used to leave the fetched commit un-refed (only in
+# FETCH_HEAD), so a later rev-pinned fetch of the same URL had nothing to
+# negotiate from and re-downloaded objects already on disk. Nix now fetches
+# into refs/<reservedRefNamespace>/tip-<first two hex chars of the rev>, so a later fetch of a
+# rev in the same bucket can negotiate against it.
+
+source ../common.sh
+
+requireGit
+
+repo=$TEST_ROOT/repo
+trace=$TEST_ROOT/git-trace
+
+createGitRepo "$repo"
+
+echo first > "$repo/first"
+git -C "$repo" add first
+git -C "$repo" commit -m 'First commit.'
+rev1=$(git -C "$repo" rev-parse HEAD)
+
+echo second > "$repo/second"
+git -C "$repo" add second
+git -C "$repo" commit -m 'Second commit.'
+rev2=$(git -C "$repo" rev-parse HEAD)
+
+export _NIX_FORCE_HTTP=1
+
+nix-instantiate --eval --raw -E "(builtins.fetchGit { url = \"file://$repo\"; rev = \"$rev1\"; }).outPath" >/dev/null
+
+reservedRefNamespace="__nix_internal_ref_namespace_reserved_for_fetchers_2c17c6393771ee3048ae34d6b380c5ec__"
+cacheDir=$(find "$TEST_HOME/.cache/nix/gitv3" -maxdepth 1 -mindepth 1 -type d)
+
+bucket1=${rev1:0:2}
+if ! git -C "$cacheDir" rev-parse --verify -q "refs/$reservedRefNamespace/tip-$bucket1" >/dev/null; then
+    echo "Expected refs/nix/tip-$bucket1 to exist after fetching $rev1." >&2
+    exit 1
+fi
+if [[ $(git -C "$cacheDir" rev-parse "refs/$reservedRefNamespace/tip-$bucket1") != "$rev1" ]]; then
+    echo "Expected refs/nix/tip-$bucket1 to point at $rev1." >&2
+    exit 1
+fi
+
+export GIT_TRACE_PACKET=$trace
+nix-instantiate --eval --raw -E "(builtins.fetchGit { url = \"file://$repo\"; rev = \"$rev2\"; }).outPath" >/dev/null
+unset GIT_TRACE_PACKET
+
+if ! grep -q "fetch> have $rev1" "$trace"; then
+    echo "Expected the second fetch to advertise $rev1 (via refs/$reservedRefNamespace/tip-$bucket1) as a negotiation tip." >&2
+    cat "$trace" >&2
+    exit 1
+fi
+
+totals=$(grep -oE 'sideband< .*Total [0-9]+' "$trace" | sed -E 's/.*Total ([0-9]+)/\1/')
+if [[ $totals -ge 6 ]]; then
+    echo "Expected the second fetch to receive only new objects (got Total $totals, same as a full re-fetch would)." >&2
+    exit 1
+fi
+
+bucket2=${rev2:0:2}
+if [[ $(git -C "$cacheDir" rev-parse "refs/$reservedRefNamespace/tip-$bucket2") != "$rev2" ]]; then
+    echo "Expected refs/nix/tip-$bucket2 to point at $rev2 after the second fetch." >&2
+    exit 1
+fi
+
+if ! git -C "$cacheDir" cat-file -e "$rev1"; then
+    echo "Expected $rev1 to remain resolvable after the second fetch." >&2
+    exit 1
+fi

--- a/tests/functional/git/exact-rev-fetch-bucketed-refs.sh
+++ b/tests/functional/git/exact-rev-fetch-bucketed-refs.sh
@@ -29,7 +29,8 @@ export _NIX_FORCE_HTTP=1
 
 nix-instantiate --eval --raw -E "(builtins.fetchGit { url = \"file://$repo\"; rev = \"$rev1\"; }).outPath" >/dev/null
 
-reservedRefNamespace="__nix_internal_ref_namespace_reserved_for_fetchers_2c17c6393771ee3048ae34d6b380c5ec__"
+reservedRefNamespace="__nix_internal_fetchers_48ae34d6b380c5ec__";
+
 cacheDir=$(find "$TEST_HOME/.cache/nix/gitv3" -maxdepth 1 -mindepth 1 -type d)
 
 bucket1=${rev1:0:2}

--- a/tests/functional/git/meson.build
+++ b/tests/functional/git/meson.build
@@ -2,6 +2,7 @@ suites += {
   'name' : 'git',
   'deps' : [],
   'tests' : [
+    'exact-rev-fetch-bucketed-refs.sh',
     'packed-refs-no-cache.sh',
     'symlinked-repo.sh',
   ],

--- a/tests/functional/git/packed-refs-no-cache.sh
+++ b/tests/functional/git/packed-refs-no-cache.sh
@@ -21,11 +21,7 @@ repo=$TEST_ROOT/./git
 
 export _NIX_FORCE_HTTP=1
 
-rm -rf "$repo" "${repo}-tmp" "$TEST_HOME/.cache/nix"
-
-git init --initial-branch="master" "$repo"
-git -C "$repo" config user.email "nix-tests@example.com"
-git -C "$repo" config user.name "Nix Tests"
+createGitRepo "$repo"
 
 echo "hello world" > "$repo/hello_world"
 git -C "$repo" add hello_world


### PR DESCRIPTION
Shallow fetching was less efficient than expected in CI. Turns out our shallow fetches don't save refs and thus can't do efficient exchange with git servers.

## Design
- when fetching a rev create a made-up ref to include into the git cache
  - note that if given a rev, the ref was already not used as a fetch refspec
  - note that this is true for both shallow and non-shallow fetches, this improves both cases, but mostly interested in the shallow one for now
- ~~turn on `maintenance.incremental-repack`~~ removing because older git meant a blocking maintenance call

## Outcome
Faster fetches that can re-use local objects in more situations. Less disk space used.

## Before/after performance: bucketed negotiation refs

| Scenario | Baseline (master) | Patched (bucketed refs) | Δ |
|---|---|---|---|
| **cold** (1 fresh shallow rev fetch) | 13.4s, 89,361 objects | 12.2s, 89,362 objects | ~same (expected — nothing to negotiate against yet) |
| **repeat-samerev** (fetch same rev twice) | 0.52s, 0 network calls | 0.49s, 0 network calls | ~same (pure cache hit either way) |
| **second-different-rev** (rev A, then different rev B) | 12.5s, **88,933** objects, 0 haves | 6.1s, **9,033** objects, 2 haves | ~90% fewer objects transferred, ~2x faster |
| **six-sequential** (6 distinct revs, same URL) | 72.8s, **531,339** total objects, 385 MB cache | 45.3s, **129,095** total objects, 143 MB cache | ~76% fewer objects, ~63% smaller cache, ~38% faster |
| **bucket-collision** (rev A, then rev B in same bucket) | 12.5s, 89,338 objects | 4.1s, **849** objects | ~99% fewer objects transferred, ~3x faster |
| **ref-based** (no rev pinned — control) | 129.8s, 2,628,555 objects | 118.8s, 2,628,555 objects | byte-identical objects (unchanged code path); timing noise only |

## Notes

- **ref-based** transferred byte-identical object counts (2,628,555 both), confirming the change doesn't touch that code path at all — timing difference is pure network/machine variance.
- **repeat-samerev** is unaffected (both hit pure cache, 0 network calls) — the fix only changes behavior when fetching a *different* rev against an existing cache.
- The core win (**second-different-rev**, **six-sequential**, **bucket-collision**) all show large reductions in objects re-transferred and cache growth. **bucket-collision** is the worst case for the bucketing scheme (two unrelated revs sharing a bucket) and still far outperforms baseline rather than regressing to it.

## Design questions
- should we make up a ref if one is provided?
- Currently using 2-hex chars of the rev. this creates a bound for how many packs and refs are stored. Should this be unbounded, larger, smaller?
- ~~call `git maintenance` directly?~~ git defaults are good
- ~~update existing repos with the relevant settings?~~ the setting cause older git to do it in blocking mode, removing...
- go to `gitv4`?

### Also investigated
- tried to add repacking+gc, but turns out our `git fetch` already does it.
- `multi-pack-index` and `geometric-repack`: will be upgraded naturally with Git itself
- `commit-graph` is not usable


Related: https://github.com/NixOS/nix/pull/16393
Note: Iterated many variations of this with Claude