### PR TITLE
Miscellaneous packaging fixes

### DIFF
--- a/packaging/installer/default.nix
+++ b/packaging/installer/default.nix
@@ -32,7 +32,7 @@ runCommand "installer-script"
           in
           ''
             \
-                   --replace '@tarballHash_${system}@' $(nix --experimental-features nix-command hash-file --base16 --type sha256 ${tarball}/*.tar.xz) \
+                   --replace '@tarballHash_${system}@' $(nix-hash --type sha256 --base16 --flat ${tarball}/*.tar.xz) \
                    --replace '@tarballPath_${system}@' $(tarballPath ${tarball}/*.tar.xz) \
           ''
         ) tarballs

--- a/tests/installer/default.nix
+++ b/tests/installer/default.nix
@@ -238,12 +238,12 @@ let
           [[ \$(cat \$out) = foobar ]]
 
           if pgrep nix-daemon; then
-            MAYBESUDO="sudo"
+            MAYBESUDO="sudo --preserve-env=NIX_CONFIG"
           else
             MAYBESUDO=""
           fi
 
-
+          export NIX_CONFIG="substituters = "
           $MAYBESUDO \$(which nix-channel) --add file://\$HOME/channel myChannel
           $MAYBESUDO \$(which nix-channel) --update
           [[ \$(nix-instantiate --eval --expr 'builtins.readFile <myChannel/someFile>') = '"someContent"' ]]


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

1. Silence deprecated alias warning for `nix hash-file`. Switch to a stable command while we are at it.
2. Speed up installer tests by avoiding resolving (and failing) cache.nixos.org in the VM. It's a bit tricky to do because apparently `nix-channel` and friends don't pass through cli overrides to children processes.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
