### PR TITLE
Improve mutation coverage on `libutil/file-descriptor.cc`

### DIFF
--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -135,6 +135,18 @@ TEST(DupDescriptor, ThrowsOnInvalidDescriptor)
     EXPECT_THROW(dupDescriptor(INVALID_DESCRIPTOR), NativeSysError);
 }
 
+TEST(SyncDescriptor, SucceedsOnRegularFile)
+{
+    auto fd = createAnonymousTempFile();
+    writeFull(fd.get(), "data", /*allowInterrupts=*/false);
+    EXPECT_NO_THROW(syncDescriptor(fd.get()));
+}
+
+TEST(SyncDescriptor, ThrowsOnInvalidDescriptor)
+{
+    EXPECT_THROW(syncDescriptor(INVALID_DESCRIPTOR), NativeSysError);
+}
+
 TEST(ReadLine, ReadsLinesFromPipe)
 {
     Pipe pipe;

--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -113,6 +113,28 @@ TEST(ReadOffset, RespectsInterrupts)
     EXPECT_EQ(n, data.size());
 }
 
+TEST(DupDescriptor, DuplicateIsUsableAndIndependentlyCloseable)
+{
+    Pipe pipe;
+    pipe.create();
+
+    auto dup = dupDescriptor(pipe.writeSide.get());
+    ASSERT_TRUE(dup);
+    EXPECT_NE(dup.get(), pipe.writeSide.get());
+
+    writeFull(pipe.writeSide.get(), "hi", /*allowInterrupts=*/false);
+    pipe.writeSide.close();
+    // The pipe isn't at EOF yet: the duplicate still holds the write side open.
+    dup.close();
+
+    EXPECT_EQ(readLine(pipe.readSide.get(), /*eofOk=*/true), "hi");
+}
+
+TEST(DupDescriptor, ThrowsOnInvalidDescriptor)
+{
+    EXPECT_THROW(dupDescriptor(INVALID_DESCRIPTOR), NativeSysError);
+}
+
 TEST(ReadLine, ReadsLinesFromPipe)
 {
     Pipe pipe;

--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -85,6 +85,14 @@ TEST(DrainFD, ExpectedSizeThrowsOnEarlyEOF)
     EXPECT_THROW(drainFD(pipe.readSide.get(), {.size = 10, .expected = true}), EndOfFile);
 }
 
+TEST(GetFileSize, ReturnsActualFileSize)
+{
+    auto fd = createAnonymousTempFile();
+    std::string data(12345, 'x');
+    writeFull(fd.get(), data);
+    EXPECT_EQ(getFileSize(fd.get()), data.size());
+}
+
 TEST(ReadLine, ReadsLinesFromPipe)
 {
     Pipe pipe;

--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -43,6 +43,48 @@ protected:
     }
 };
 
+TEST(DrainFD, BlockingReadsUntilEOF)
+{
+    Pipe pipe;
+    pipe.create();
+
+    writeFull(pipe.writeSide.get(), "hello", /*allowInterrupts=*/false);
+    pipe.writeSide.close();
+
+    auto got = drainFD(pipe.readSide.get());
+    EXPECT_EQ(got, "hello");
+}
+
+TEST(DrainFD, ExpectedSizeReadsExactly)
+{
+    Pipe pipe;
+    pipe.create();
+
+    writeFull(pipe.writeSide.get(), "0123456789", /*allowInterrupts=*/false);
+    // Don't close the write side: with .expected=true and a matching size,
+    // drainFD must return as soon as it has read the requested bytes.
+
+    auto got = drainFD(pipe.readSide.get(), {.size = 5, .expected = true});
+    EXPECT_EQ(got, "01234");
+
+    // The pipe is still open with five bytes remaining; a follow-up drain
+    // should pick them up.
+    pipe.writeSide.close();
+    auto got2 = drainFD(pipe.readSide.get());
+    EXPECT_EQ(got2, "56789");
+}
+
+TEST(DrainFD, ExpectedSizeThrowsOnEarlyEOF)
+{
+    Pipe pipe;
+    pipe.create();
+
+    writeFull(pipe.writeSide.get(), "abc", /*allowInterrupts=*/false);
+    pipe.writeSide.close();
+
+    EXPECT_THROW(drainFD(pipe.readSide.get(), {.size = 10, .expected = true}), EndOfFile);
+}
+
 TEST(ReadLine, ReadsLinesFromPipe)
 {
     Pipe pipe;

--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -303,6 +303,31 @@ TEST(BufferedSourceReadLine, BufferExhaustedThenEof)
     EXPECT_EQ(source.readLine(/*eofOk=*/true), "");
 }
 
+TEST(WriteLine, AppendsNewlineAndWrites)
+{
+    Pipe pipe;
+    pipe.create();
+
+    writeLine(pipe.writeSide.get(), "first");
+    writeLine(pipe.writeSide.get(), "second");
+    pipe.writeSide.close();
+
+    EXPECT_EQ(readLine(pipe.readSide.get()), "first");
+    EXPECT_EQ(readLine(pipe.readSide.get()), "second");
+}
+
+TEST(WriteLine, EmptyPayloadStillWritesNewline)
+{
+    Pipe pipe;
+    pipe.create();
+
+    writeLine(pipe.writeSide.get(), "");
+    pipe.writeSide.close();
+
+    // The empty payload + newline should produce a single empty line.
+    EXPECT_EQ(readLine(pipe.readSide.get()), "");
+}
+
 TEST(ReadFull, ReadsExactlyRequestedBytes)
 {
     Pipe pipe;
@@ -383,6 +408,16 @@ TEST(ReadFull, AdvancesBufferAcrossShortReads)
     readFull(pipe.readSide.get(), buf, 8);
     EXPECT_EQ(std::string_view(buf, 8), "AAAABBBB");
     writer.join();
+}
+
+TEST(WriteFull, EmptyStringIsNoop)
+{
+    Pipe pipe;
+    pipe.create();
+    pipe.writeSide.close();
+
+    // An empty payload must not even attempt to write; the loop never enters.
+    EXPECT_NO_THROW(writeFull(pipe.writeSide.get(), "", /*allowInterrupts=*/false));
 }
 
 TEST(WriteFull, RespectsAllowInterrupts)

--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -93,6 +93,26 @@ TEST(GetFileSize, ReturnsActualFileSize)
     EXPECT_EQ(getFileSize(fd.get()), data.size());
 }
 
+TEST(ReadOffset, RespectsInterrupts)
+{
+#ifdef _WIN32
+    GTEST_SKIP() << "Broken on Windows";
+#endif
+    auto fd = createAnonymousTempFile();
+    std::string data = "hello world";
+    writeFull(fd.get(), data);
+
+    setInterrupted(true);
+    std::array<std::byte, 16> buf;
+    EXPECT_THROW(readOffset(fd.get(), 0, buf), Interrupted);
+    setInterrupted(false);
+
+    // Confirm a normal call still works afterwards (interrupt flag was properly cleared,
+    // and the throw above didn't leave the fd or offset math in a bad state).
+    auto n = readOffset(fd.get(), 0, buf);
+    EXPECT_EQ(n, data.size());
+}
+
 TEST(ReadLine, ReadsLinesFromPipe)
 {
     Pipe pipe;

--- a/src/libutil-tests/file-descriptor.cc
+++ b/src/libutil-tests/file-descriptor.cc
@@ -6,6 +6,7 @@
 #include "nix/util/serialise.hh"
 #include "nix/util/signals.hh"
 
+#include <chrono>
 #include <cstring>
 #include <random>
 #include <algorithm>
@@ -300,6 +301,88 @@ TEST(BufferedSourceReadLine, BufferExhaustedThenEof)
 
     EXPECT_EQ(source.readLine(/*eofOk=*/true), "abcdefgh");
     EXPECT_EQ(source.readLine(/*eofOk=*/true), "");
+}
+
+TEST(ReadFull, ReadsExactlyRequestedBytes)
+{
+    Pipe pipe;
+    pipe.create();
+
+    writeFull(pipe.writeSide.get(), "hello world", /*allowInterrupts=*/false);
+    pipe.writeSide.close();
+
+    char buf[5];
+    readFull(pipe.readSide.get(), buf, 5);
+    EXPECT_EQ(std::string_view(buf, 5), "hello");
+
+    char buf2[6];
+    readFull(pipe.readSide.get(), buf2, 6);
+    EXPECT_EQ(std::string_view(buf2, 6), " world");
+}
+
+TEST(ReadFull, ThrowsOnEofBeforeFullRead)
+{
+    Pipe pipe;
+    pipe.create();
+
+    writeFull(pipe.writeSide.get(), "hi", /*allowInterrupts=*/false);
+    pipe.writeSide.close();
+
+    char buf[10];
+    EXPECT_THROW(readFull(pipe.readSide.get(), buf, 10), EndOfFile);
+}
+
+TEST(ReadFull, ZeroCountIsNoop)
+{
+    Pipe pipe;
+    pipe.create();
+    pipe.writeSide.close();
+
+    // count=0 must not read or throw, even on a closed pipe.
+    char buf[1] = {'X'};
+    readFull(pipe.readSide.get(), buf, 0);
+    EXPECT_EQ(buf[0], 'X');
+}
+
+TEST(ReadFull, HonoursInterruptFlag)
+{
+#ifdef _WIN32
+    GTEST_SKIP() << "no checkInterrupt on Windows readFull path";
+#endif
+    Pipe pipe;
+    pipe.create();
+    // No data written; readFull would block. The interrupt flag must
+    // make it throw before any read.
+    setInterrupted(true);
+    char buf[1];
+    EXPECT_THROW(readFull(pipe.readSide.get(), buf, 1), Interrupted);
+    setInterrupted(false);
+}
+
+TEST(ReadFull, AdvancesBufferAcrossShortReads)
+{
+#ifdef _WIN32
+    GTEST_SKIP() << "pipe-write semantics differ on Windows";
+#endif
+    // Force at least two reads by writing the second chunk only after the
+    // first read has consumed the pipe. Done in a thread so readFull sees
+    // a short read first, then blocks waiting for the rest.
+    Pipe pipe;
+    pipe.create();
+
+    writeFull(pipe.writeSide.get(), "AAAA", /*allowInterrupts=*/false);
+
+    std::thread writer([&]() {
+        // Small delay to ensure the reader has consumed the first chunk.
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        writeFull(pipe.writeSide.get(), "BBBB", /*allowInterrupts=*/false);
+        pipe.writeSide.close();
+    });
+
+    char buf[8] = {};
+    readFull(pipe.readSide.get(), buf, 8);
+    EXPECT_EQ(std::string_view(buf, 8), "AAAABBBB");
+    writer.join();
 }
 
 TEST(WriteFull, RespectsAllowInterrupts)

--- a/src/libutil-tests/unix/file-descriptor.cc
+++ b/src/libutil-tests/unix/file-descriptor.cc
@@ -294,4 +294,15 @@ TEST(closeExtraFDs, works)
     ASSERT_TRUE(statusOk(pid.wait()));
 }
 
+TEST(DupDescriptor, SetsCloseOnExecFlag)
+{
+    Pipe pipe;
+    pipe.create();
+
+    auto dup = dupDescriptor(pipe.writeSide.get());
+    int flags = fcntl(dup.get(), F_GETFD);
+    ASSERT_NE(flags, -1);
+    EXPECT_TRUE(flags & FD_CLOEXEC);
+}
+
 } // namespace nix

--- a/src/libutil-tests/unix/file-descriptor.cc
+++ b/src/libutil-tests/unix/file-descriptor.cc
@@ -305,4 +305,26 @@ TEST(DupDescriptor, SetsCloseOnExecFlag)
     EXPECT_TRUE(flags & FD_CLOEXEC);
 }
 
+TEST(CloseOnExec, SetsFlag)
+{
+    Pipe pipe;
+    pipe.create();
+
+    // pipe.create() already sets close-on-exec via pipe2/O_CLOEXEC; clear it first so this
+    // test actually exercises unix::closeOnExec rather than observing pipe2's own flag.
+    ASSERT_NE(fcntl(pipe.writeSide.get(), F_SETFD, 0), -1);
+    ASSERT_EQ(fcntl(pipe.writeSide.get(), F_GETFD), 0);
+
+    unix::closeOnExec(pipe.writeSide.get());
+
+    int flags = fcntl(pipe.writeSide.get(), F_GETFD);
+    ASSERT_NE(flags, -1);
+    EXPECT_TRUE(flags & FD_CLOEXEC);
+}
+
+TEST(CloseOnExec, ThrowsOnInvalidDescriptor)
+{
+    EXPECT_THROW(unix::closeOnExec(INVALID_DESCRIPTOR), SysError);
+}
+
 } // namespace nix

--- a/src/libutil-tests/unix/file-descriptor.cc
+++ b/src/libutil-tests/unix/file-descriptor.cc
@@ -12,6 +12,92 @@
 
 namespace nix {
 
+TEST(AutoCloseFD, DestructorClosesFd)
+{
+    Pipe pipe;
+    pipe.create();
+    int rawFd = pipe.readSide.get();
+
+    // Move the fd into an inner scope; on exit, the destructor must close it.
+    {
+        AutoCloseFD owner(pipe.readSide.release());
+        ASSERT_EQ(owner.get(), rawFd);
+    }
+
+    // Confirm the kernel closed the fd: an explicit close() must now fail
+    // with EBADF, proving the destructor did the close (otherwise we'd
+    // succeed in closing a still-open fd).
+    int rc = ::close(rawFd);
+    EXPECT_EQ(rc, -1);
+    EXPECT_EQ(errno, EBADF);
+}
+
+TEST(AutoCloseFD, MoveAssignClosesPreviousFd)
+{
+    Pipe pipe1;
+    pipe1.create();
+    Pipe pipe2;
+    pipe2.create();
+
+    int prevFd = pipe1.readSide.get();
+    AutoCloseFD a(pipe1.readSide.release());
+    AutoCloseFD b(pipe2.readSide.release());
+
+    // Move-assign: a's previous fd must be closed, then b's fd moved into a.
+    a = std::move(b);
+
+    int rc = ::close(prevFd);
+    EXPECT_EQ(rc, -1);
+    EXPECT_EQ(errno, EBADF) << "operator= must close the previously-owned fd";
+
+    EXPECT_FALSE(b);
+}
+
+TEST(AutoCloseFD, ReleaseSurrendersOwnership)
+{
+    Pipe pipe;
+    pipe.create();
+    int rawFd = pipe.readSide.get();
+
+    Descriptor surrendered;
+    {
+        AutoCloseFD owner(pipe.readSide.release());
+        surrendered = owner.release();
+        EXPECT_EQ(surrendered, rawFd);
+        EXPECT_FALSE(owner) << "after release, the AutoCloseFD must look empty";
+    }
+    // Destructor must NOT have closed: the released fd is still usable.
+    int rc = ::close(surrendered);
+    EXPECT_EQ(rc, 0);
+}
+
+TEST(AutoCloseFD, BoolConversionReflectsFdValidity)
+{
+    AutoCloseFD empty;
+    EXPECT_FALSE(empty);
+
+    Pipe pipe;
+    pipe.create();
+    AutoCloseFD owner(pipe.readSide.release());
+    EXPECT_TRUE(owner);
+}
+
+TEST(Pipe, CloseClosesBothEnds)
+{
+    Pipe pipe;
+    pipe.create();
+    int r = pipe.readSide.get();
+    int w = pipe.writeSide.get();
+
+    pipe.close();
+
+    // Both raw fds must now be unusable.
+    EXPECT_EQ(::close(r), -1);
+    EXPECT_EQ(errno, EBADF);
+    EXPECT_EQ(::close(w), -1);
+    EXPECT_EQ(errno, EBADF);
+}
+
 TEST(ReadFile, ReadsFullContentsOfRegularFile)
 {
     // Build the file via a pipe so we don't depend on the filesystem; use

--- a/src/libutil-tests/unix/file-descriptor.cc
+++ b/src/libutil-tests/unix/file-descriptor.cc
@@ -2,6 +2,8 @@
 #include <gmock/gmock.h>
 
 #include "nix/util/file-descriptor.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/finally.hh"
 #include "nix/util/processes.hh"
 
 #include <chrono>
@@ -9,6 +11,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/resource.h>
 
 namespace nix {
 
@@ -231,6 +234,38 @@ TEST(WriteFull, LoopsUntilAllBytesWritten)
 
     ASSERT_EQ(drained.size(), total);
     EXPECT_EQ(drained, payload);
+}
+
+TEST(PipeCreate, ThrowsWhenDescriptorLimitReached)
+{
+    struct rlimit orig;
+    ASSERT_EQ(getrlimit(RLIMIT_NOFILE, &orig), 0);
+    // Restore via Finally rather than a bare trailing setrlimit call, so a
+    // failed assertion below still leaves the process at its original fd
+    // limit instead of a lowered one for the rest of the test binary.
+    Finally restoreLimit([&] { EXPECT_EQ(setrlimit(RLIMIT_NOFILE, &orig), 0); });
+
+    /* Lower the soft limit to just above the highest fd currently in use, so
+       the pipe2() call inside Pipe::create() below has no room left and
+       fails with EMFILE. */
+    int highest = -1;
+#ifdef __linux__
+    for (auto & entry : DirectoryIterator{"/proc/self/fd"}) {
+        highest = std::max(highest, std::stoi(entry.path().filename()));
+    }
+#else
+    // No /proc on macOS/BSD: probe each candidate fd directly instead.
+    int maxFD = sysconf(_SC_OPEN_MAX);
+    for (int fd = 0; fd < maxFD; ++fd)
+        if (fcntl(fd, F_GETFD) != -1)
+            highest = fd;
+#endif
+    struct rlimit lowered = orig;
+    lowered.rlim_cur = highest + 1;
+    ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &lowered), 0);
+
+    Pipe pipe;
+    EXPECT_THROW(pipe.create(), SysError);
 }
 
 TEST(closeExtraFDs, works)

--- a/src/libutil-tests/unix/file-descriptor.cc
+++ b/src/libutil-tests/unix/file-descriptor.cc
@@ -327,4 +327,66 @@ TEST(CloseOnExec, ThrowsOnInvalidDescriptor)
     EXPECT_THROW(unix::closeOnExec(INVALID_DESCRIPTOR), SysError);
 }
 
+TEST(SelfPipe, NotifyAndDrainRoundTrip)
+{
+    unix::SelfPipe sp;
+    sp.create();
+    sp.notify();
+    EXPECT_NO_THROW(sp.drain());
+}
+
+TEST(SelfPipe, DrainOnEmptyPipeReturnsPromptly)
+{
+    unix::SelfPipe sp;
+    sp.create();
+    // No notify() was called; the pipe is empty. Because create() makes it non-blocking,
+    // drain() must return immediately (on EAGAIN) rather than block waiting for data.
+    EXPECT_NO_THROW(sp.drain());
+}
+
+TEST(SelfPipe, NotifyWhenFullDoesNotThrow)
+{
+    unix::SelfPipe sp;
+    sp.create();
+    // Notify comfortably past any default pipe capacity, driving the pipe to EAGAIN (full).
+    // notify() must swallow that, not throw.
+    for (int i = 0; i < 200000; i++) {
+        EXPECT_NO_THROW(sp.notify());
+    }
+    sp.drain();
+}
+
+TEST(SelfPipe, DrainEmptiesAllPendingNotifies)
+{
+    unix::SelfPipe sp;
+    sp.create();
+    // More bytes than drain()'s 128-byte read buffer, forcing multiple read() calls inside
+    // a single drain().
+    for (int i = 0; i < 300; i++)
+        sp.notify();
+    sp.drain();
+
+    // The pipe must now be fully drained: a direct non-blocking read returns EAGAIN.
+    char c;
+    ssize_t n = ::read(sp.pipe.readSide.get(), &c, 1);
+    EXPECT_EQ(n, -1);
+    EXPECT_EQ(errno, EAGAIN);
+}
+
+TEST(SelfPipe, NotifyThrowsOnWriteFailureOtherThanEagain)
+{
+    unix::SelfPipe sp;
+    sp.create();
+    sp.pipe.writeSide.close();
+    EXPECT_THROW(sp.notify(), SysError);
+}
+
+TEST(SelfPipe, DrainThrowsOnReadFailureOtherThanEagain)
+{
+    unix::SelfPipe sp;
+    sp.create();
+    sp.pipe.readSide.close();
+    EXPECT_THROW(sp.drain(), SysError);
+}
+
 } // namespace nix

--- a/src/libutil-tests/unix/file-descriptor.cc
+++ b/src/libutil-tests/unix/file-descriptor.cc
@@ -4,9 +4,51 @@
 #include "nix/util/file-descriptor.hh"
 #include "nix/util/processes.hh"
 
+#include <chrono>
+#include <thread>
 #include <unistd.h>
 
 namespace nix {
+
+TEST(WriteFull, LoopsUntilAllBytesWritten)
+{
+    // Use a non-blocking pipe so write() returns short once the kernel
+    // buffer is full. writeFull's retryOnBlock then polls for room and
+    // resumes; the reader drains in small chunks to keep room scarce.
+    // Verifies the loop's both `count` and `buf` (via remove_prefix)
+    // advance: a single-shot variant would write only ~PIPE_BUF and stop.
+    Pipe pipe;
+    pipe.create(/*nonBlocking=*/true);
+
+    constexpr size_t total = 256 * 1024; // 256 KiB exceeds typical pipe buf
+    std::string payload(total, '\0');
+    for (size_t i = 0; i < total; ++i)
+        payload[i] = static_cast<char>(i & 0xff);
+
+    std::string drained;
+    std::thread reader([&]() {
+        // Use raw POSIX read so we can tolerate EAGAIN with a small sleep,
+        // mirroring what retryOnBlock does on the writer side. Stops on EOF.
+        char buf[2048];
+        while (drained.size() < total) {
+            ssize_t n = ::read(pipe.readSide.get(), buf, sizeof(buf));
+            if (n > 0) {
+                drained.append(buf, n);
+            } else if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            } else {
+                break;
+            }
+        }
+    });
+
+    writeFull(pipe.writeSide.get(), payload, /*allowInterrupts=*/false);
+    reader.join();
+    pipe.writeSide.close();
+
+    ASSERT_EQ(drained.size(), total);
+    EXPECT_EQ(drained, payload);
+}
 
 TEST(closeExtraFDs, works)
 {

--- a/src/libutil-tests/unix/file-descriptor.cc
+++ b/src/libutil-tests/unix/file-descriptor.cc
@@ -6,9 +6,106 @@
 
 #include <chrono>
 #include <thread>
+#include <fcntl.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 namespace nix {
+
+TEST(ReadFile, ReadsFullContentsOfRegularFile)
+{
+    // Build the file via a pipe so we don't depend on the filesystem; use
+    // a memfd-equivalent so getFileSize returns the actual byte count.
+    char tmpl[] = "/tmp/nix-readfile-XXXXXX";
+    int fd = mkstemp(tmpl);
+    ASSERT_NE(fd, -1);
+    unlink(tmpl);
+
+    std::string payload(8192, 'x');
+    for (size_t i = 0; i < payload.size(); ++i)
+        payload[i] = static_cast<char>((i * 7 + 3) & 0xff);
+    ASSERT_EQ(::write(fd, payload.data(), payload.size()), (ssize_t) payload.size());
+    ASSERT_EQ(lseek(fd, 0, SEEK_SET), 0);
+
+    auto got = readFile(fd);
+    EXPECT_EQ(got, payload);
+    close(fd);
+}
+
+#ifdef __linux__
+TEST(ReadFile, ToleratesNominalSizeZeroFromProc)
+{
+    // /proc files like /proc/version report size 0 from fstat, yet hold real
+    // content. readFile must drain to EOF without trusting getFileSize.
+    int fd = open("/proc/version", O_RDONLY);
+    if (fd == -1) {
+        GTEST_SKIP() << "/proc/version not available";
+    }
+    if (getFileSize(fd) != 0) {
+        close(fd);
+        GTEST_SKIP() << "/proc/version did not report a nominal size of 0 on this system";
+    }
+    auto got = readFile(fd);
+    EXPECT_FALSE(got.empty());
+    EXPECT_NE(got.find("Linux"), std::string::npos);
+    close(fd);
+}
+#endif
+
+TEST(DrainFD, NonBlockingStopsAtEAGAIN)
+{
+    // With block=false, drainFD must set O_NONBLOCK, return the bytes
+    // currently available, then restore the original flags.
+    Pipe pipe;
+    pipe.create(); // default: blocking
+
+    writeFull(pipe.writeSide.get(), "ready", /*allowInterrupts=*/false);
+    // Leave the write side OPEN: blocking-mode drainFD would deadlock
+    // here, so passing the test proves block=false took effect.
+
+    auto got = drainFD(pipe.readSide.get(), {.block = false});
+    EXPECT_EQ(got, "ready");
+
+    // Original flags must be restored: a subsequent blocking read still
+    // works synchronously when more data arrives.
+    writeFull(pipe.writeSide.get(), "more", /*allowInterrupts=*/false);
+    pipe.writeSide.close();
+    auto got2 = drainFD(pipe.readSide.get());
+    EXPECT_EQ(got2, "more");
+
+    // Sanity-check by inspecting the flags directly: O_NONBLOCK must be
+    // cleared after both drainFD calls return.
+    int flags = fcntl(pipe.readSide.get(), F_GETFL);
+    ASSERT_NE(flags, -1);
+    EXPECT_EQ(flags & O_NONBLOCK, 0);
+}
+
+TEST(DrainFD, NonBlockingRestoresOriginalFlags)
+{
+    // Set a custom flag (O_APPEND on the read side of a pipe is benign but
+    // visible via F_GETFL) and verify drainFD's Finally restores it.
+    Pipe pipe;
+    pipe.create();
+
+    int initial = fcntl(pipe.readSide.get(), F_GETFL);
+    ASSERT_NE(initial, -1);
+    ASSERT_NE(fcntl(pipe.readSide.get(), F_SETFL, initial | O_APPEND), -1);
+    int after = fcntl(pipe.readSide.get(), F_GETFL);
+    ASSERT_EQ(after & O_APPEND, O_APPEND);
+
+    writeFull(pipe.writeSide.get(), "x", /*allowInterrupts=*/false);
+    auto got = drainFD(pipe.readSide.get(), {.block = false});
+    EXPECT_EQ(got, "x");
+
+    // O_APPEND must still be set after drainFD returns (Finally restored
+    // the saved flags including O_APPEND, not just zeroed them).
+    int restored = fcntl(pipe.readSide.get(), F_GETFL);
+    ASSERT_NE(restored, -1);
+    EXPECT_EQ(restored & O_APPEND, O_APPEND);
+    EXPECT_EQ(restored & O_NONBLOCK, 0);
+
+    pipe.writeSide.close();
+}
 
 TEST(WriteFull, LoopsUntilAllBytesWritten)
 {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Mutation testing means generating "bugs" (mutations) and making sure the test suite catches them.

These are the result of an experiment I ran 3 months ago but didn't get around to upstreaming.
I can follow up with more if you're interested.

The mutations, coverage and rationale are LLM-generated. I've given them superficial review only.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
