### PR TITLE
libutil: escape XML attribute names in XMLWriter

### DIFF
--- a/src/libutil-tests/xml-writer.cc
+++ b/src/libutil-tests/xml-writer.cc
@@ -62,8 +62,7 @@ TEST(XMLWriter, objectWithElementWithAttrsEscaping)
         t.openElement("foobar", attrs);
     }
 
-    // XXX: While "<value>" is escaped, "<key>" isn't which I think is a bug.
-    ASSERT_EQ(out.str(), "<?xml version='1.0' encoding='utf-8'?>\n<foobar <key>=\"&lt;value&gt;\"></foobar>");
+    ASSERT_EQ(out.str(), "<?xml version='1.0' encoding='utf-8'?>\n<foobar &lt;key&gt;=\"&lt;value&gt;\"></foobar>");
 }
 
 TEST(XMLWriter, objectWithElementWithAttrsIndented)

--- a/src/libutil/xml-writer.cc
+++ b/src/libutil/xml-writer.cc
@@ -70,10 +70,8 @@ void XMLWriter::writeEmptyElement(std::string_view name, const XMLAttrs & attrs)
 
 void XMLWriter::writeAttrs(const XMLAttrs & attrs)
 {
-    for (auto & i : attrs) {
-        output << " " << i.first << "=\"";
-        for (size_t j = 0; j < i.second.size(); ++j) {
-            char c = i.second[j];
+    auto escape = [&](std::string_view s) {
+        for (char c : s) {
             if (c == '"')
                 output << "&quot;";
             else if (c == '<')
@@ -89,6 +87,13 @@ void XMLWriter::writeAttrs(const XMLAttrs & attrs)
             else
                 output << c;
         }
+    };
+
+    for (auto & i : attrs) {
+        output << " ";
+        escape(i.first);
+        output << "=\"";
+        escape(i.second);
         output << "\"";
     }
 }


### PR DESCRIPTION
fixing TODOs:

writeAttrs() escaped attribute values but not names, producing invalid XML for names containing <, >, &, ", or newlines. Reuse the existing escaping logic for both.

Low priority: shouldn't be user-visible.