### PR TITLE
libstore: pass `StorePath` to `realPathInHost`

### DIFF
--- a/src/libstore/build/derivation-builder-impl.cc
+++ b/src/libstore/build/derivation-builder-impl.cc
@@ -152,7 +152,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
     for (auto & [outputName, _] : drv.outputs) {
         auto scratchOutput = get(scratchOutputs, outputName);
         assert(scratchOutput);
-        auto actualPath = realPathInHost(store.printStorePath(*scratchOutput));
+        auto actualPath = realPathInHost(*scratchOutput);
 
         outputsToSort.insert(outputName);
 
@@ -276,7 +276,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         auto output = get(drv.outputs, outputName);
         auto scratchPath = get(scratchOutputs, outputName);
         assert(output && scratchPath);
-        auto actualPath = realPathInHost(store.printStorePath(*scratchPath));
+        auto actualPath = realPathInHost(*scratchPath);
 
         /* An optional file descriptor of a directory used for intermediate
            operations. */

--- a/src/libstore/build/derivation-builder-impl.hh
+++ b/src/libstore/build/derivation-builder-impl.hh
@@ -89,9 +89,9 @@ protected:
      * Sandboxing can put it somewhere other than its final home, so this
      * is a hook rather than just `Store::toRealPath`.
      */
-    virtual std::filesystem::path realPathInHost(const std::filesystem::path & p)
+    virtual std::filesystem::path realPathInHost(const StorePath & p)
     {
-        return store.toRealPath(store.parseStorePath(p.string()));
+        return store.toRealPath(p);
     }
 
 

--- a/src/libstore/unix/build/chroot-derivation-builder.cc
+++ b/src/libstore/unix/build/chroot-derivation-builder.cc
@@ -76,11 +76,11 @@ Strings ChrootDerivationBuilder::getPreBuildHookArgs()
     return Strings({store.printStorePath(drvPath), chrootRootDir.native()});
 }
 
-std::filesystem::path ChrootDerivationBuilder::realPathInHost(const std::filesystem::path & p)
+std::filesystem::path ChrootDerivationBuilder::realPathInHost(const StorePath & p)
 {
     // FIXME: why the needsHashRewrite() conditional?
-    return !needsHashRewrite() ? chrootRootDir / p.relative_path()
-                               : std::filesystem::path(store.toRealPath(store.parseStorePath(p.native())));
+    return !needsHashRewrite() ? chrootRootDir / std::filesystem::path{store.printStorePath(p)}.relative_path()
+                               : store.toRealPath(p);
 }
 
 void ChrootDerivationBuilder::cleanupBuild(bool force)

--- a/src/libstore/unix/build/chroot-derivation-builder.hh
+++ b/src/libstore/unix/build/chroot-derivation-builder.hh
@@ -43,7 +43,7 @@ public:
 
     Strings getPreBuildHookArgs() override;
 
-    std::filesystem::path realPathInHost(const std::filesystem::path & p) override;
+    std::filesystem::path realPathInHost(const StorePath & p) override;
 
     void cleanupBuild(bool force) override;
 


### PR DESCRIPTION
## Motivation

`realPathInHost` is only called with store paths, so accepting a
`StorePath` avoids printing and parsing them again.

## Context

- Peeled out of https://github.com/NixOS/nix/pull/16381#discussion_r3928912294

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
