### PR TITLE
repl: continue incomplete multiline bindings

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -179,6 +179,13 @@ static bool isIncompleteInput(const ParseError & e)
     return e.msg().find("unexpected end of file") != std::string::npos;
 }
 
+static bool isIncompleteReplBinding(const ParseError & e)
+{
+    // A bare expression such as `x` is incomplete as a binding because the
+    // binding parser expects `=`, but it is complete as an expression.
+    return isIncompleteInput(e) && e.msg().find("'='") == std::string::npos;
+}
+
 void IncompleteReplExpr::anchor() {}
 
 static bool isFirstRepl = true;
@@ -898,11 +905,13 @@ Expr * NixRepl::parseString(std::string s)
 ExprAttrs * NixRepl::parseReplBindings(std::string s)
 {
     auto basePath = state->rootPath(".");
+    bool originalInputIncomplete = false;
 
     // Try parsing as bindings
     try {
         return state->parseReplBindings(s, basePath, staticEnv);
-    } catch (ParseError &) {
+    } catch (ParseError & e) {
+        originalInputIncomplete = isIncompleteReplBinding(e);
     }
 
     // Try with semicolon appended (for `inherit foo` shorthand)
@@ -910,7 +919,7 @@ ExprAttrs * NixRepl::parseReplBindings(std::string s)
     try {
         return state->parseReplBindings(s + ";", s, basePath, staticEnv);
     } catch (ParseError & e) {
-        if (isIncompleteInput(e))
+        if (originalInputIncomplete || isIncompleteInput(e))
             throw IncompleteReplExpr(e.msg());
         // Semicolon retry also failed; not valid binding syntax.
         return nullptr;

--- a/tests/functional/suites/repl/cases/multiline-if-binding.expected
+++ b/tests/functional/suites/repl/cases/multiline-if-binding.expected
@@ -1,0 +1,11 @@
+Nix <nix version>
+Type :? for help.
+
+nix-repl> enable = true
+
+nix-repl> message = if enable
+        >   then "true"
+        >   else "false"
+
+nix-repl> message
+"true"

--- a/tests/functional/suites/repl/cases/multiline-if-binding.in
+++ b/tests/functional/suites/repl/cases/multiline-if-binding.in
@@ -1,0 +1,6 @@
+# COM: Multi-line if in binding should trigger continuation
+enable = true
+message = if enable
+  then "true"
+  else "false"
+message


### PR DESCRIPTION
## Motivation

When entering an incomplete binding such as:

```nix
message = if enable
```

`nix repl` reports `unexpected '=', expecting end of file` instead of waiting for the continuation lines. The binding parser first sees an EOF while parsing the right-hand side, but its semicolon retry changes that into an `unexpected ';'` error. The REPL then incorrectly falls through to expression parsing.

This change preserves the original incomplete-input classification across the semicolon retry, so multiline `if` bindings continue reading input. It also avoids treating a complete expression such as `x` as an incomplete binding when the binding parser is merely expecting `.` or `=`.

## Context

The implementation updates `NixRepl::parseReplBindings` in `src/libcmd/repl.cc` and adds a functional regression case covering the exact multiline binding behavior.

Verification performed:

- `nix build .#nix-cli -o ./result-repl-fix`
- Built CLI smoke test for the multiline `if` binding, producing `"true"`
- Built CLI smoke test for `x = 1` followed by `x`, producing `1`
- Built CLI smoke test confirming malformed syntax still reports an error
- `git diff --check`

A full `nix build .#nix` was also attempted, but its functional-test derivation reported five suite-level failures; the focused CLI build and smoke scenarios above passed.

## Translation and AI disclosure

My English is not good, so I used AI to translate the Chinese description below into English. I reviewed the implementation, test behavior, commit, and this pull request before submission. The commit contains the required `Assisted-by:` trailer.

### Original Chinese description

我的英文不好，所以我使用 AI 将下面的中文内容翻译成英文。

在使用 `nix repl` 时，输入 `message = if enable` 后，REPL 错误地报告 `unexpected '=', expecting end of file`，而不是等待后续的 `then` 和 `else`。原因是绑定解析第一次遇到 EOF，追加分号重试后却变成了 `unexpected ';'`，导致 REPL 丢失了输入未完成状态并回退到普通表达式解析。这个修改保留第一次解析的不完整状态，使多行 `if` 绑定能够继续输入，同时确保普通表达式不会被误判为不完整绑定。新增了对应的功能回归测试。