### PR TITLE
Support "return"-ing result values from Goal::Coroutines

### DIFF
--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -29,12 +29,7 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
 {
     Goals waitees;
 
-    using ValueComparison = decltype([]<typename T>(const ref<T> & lhs, const ref<T> & rhs) {
-        /* Compare the values, not the pointers themselves. */
-        return *lhs < *rhs;
-    });
-
-    std::map<ref<const SingleDerivedPath>, GoalPtr, ValueComparison> inputGoals;
+    std::map<ref<const SingleDerivedPath>, GoalPtr, RefDeepComparator> inputGoals;
 
     /* Ensure that pure, non-fixed-output derivations don't depend on
        impure derivations. Only worth checking each input derivation

--- a/src/libstore/build/derivation-resolution-goal.cc
+++ b/src/libstore/build/derivation-resolution-goal.cc
@@ -11,10 +11,8 @@ namespace nix {
 
 DerivationResolutionGoal::DerivationResolutionGoal(
     const StorePath & drvPath, ref<const Derivation> drv, Worker & worker, BuildMode buildMode)
-    : Goal(worker, resolveDerivation())
+    : Goal(worker, init(std::move(drv), buildMode))
     , drvPath(drvPath)
-    , drv(std::move(drv))
-    , buildMode{buildMode}
 {
     name = fmt("resolving derivation '%s'", worker.store.printStorePath(drvPath));
     trace("created");
@@ -25,20 +23,21 @@ std::string DerivationResolutionGoal::key()
     return "dc$" + std::string(drvPath.name()) + "$" + worker.store.printStorePath(drvPath);
 }
 
-Goal::Co DerivationResolutionGoal::resolveDerivation()
+Goal::BasicCo<DerivationResolutionGoal::InputsGoalMap>
+DerivationResolutionGoal::realiseInputs(const Derivation & drv, BuildMode buildMode)
 {
     Goals waitees;
-
-    std::map<ref<const SingleDerivedPath>, GoalPtr, RefDeepComparator> inputGoals;
+    InputsGoalMap inputGoals;
 
     /* Ensure that pure, non-fixed-output derivations don't depend on
        impure derivations. Only worth checking each input derivation
        once, however many of its outputs we depend on. */
     bool checkImpureInputs =
-        experimentalFeatureSettings.isEnabled(Xp::ImpureDerivations) && !type(*drv).isImpure() && !type(*drv).isFixed();
+        experimentalFeatureSettings.isEnabled(Xp::ImpureDerivations) && !type(drv).isImpure() && !type(drv).isFixed();
+
     StorePathSet checkedInputDrvs;
 
-    for (const auto & input : drv->inputs) {
+    for (const auto & input : drv.inputs) {
         std::visit(
             overloaded{
                 [&](const SingleDerivedPath::Opaque &) {
@@ -73,8 +72,6 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
 
     co_await await(std::move(waitees));
 
-    trace("all inputs realised");
-
     if (nrFailed != 0) {
         auto msg =
             fmt("Cannot build '%s'.\n"
@@ -82,7 +79,7 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
                 Magenta(worker.store.printStorePath(drvPath)),
                 nrFailed,
                 nrFailed == 1 ? "dependency" : "dependencies");
-        msg += showKnownOutputs(worker.store, *drv);
+        msg += showKnownOutputs(worker.store, drv);
         co_return doneFailure(
             ecFailed,
             BuildResult::Failure{{
@@ -91,73 +88,75 @@ Goal::Co DerivationResolutionGoal::resolveDerivation()
             }});
     }
 
-    /* Gather information necessary for computing the closure and/or
-       running the build hook. */
+    trace("all inputs realised");
 
-    /* Determine the full set of input paths. */
+    co_return inputGoals;
+}
 
-    /* First, the input derivations. */
-    auto & fullDrv = *drv;
+Goal::BasicCo<decltype(DerivationResolutionGoal::resolvedDrv)>
+DerivationResolutionGoal::resolveDerivation(const Derivation & drv, const InputsGoalMap & inputGoals)
+{
+    experimentalFeatureSettings.require(Xp::CaDerivations);
 
-    if (derivation::shouldResolve(fullDrv)) {
-        experimentalFeatureSettings.require(Xp::CaDerivations);
+    /* We are be able to resolve this derivation based on the
+       now-known results of dependencies. If so, we become a
+       stub goal aliasing that resolved derivation goal. */
 
-        /* We are be able to resolve this derivation based on the
-           now-known results of dependencies. If so, we become a
-           stub goal aliasing that resolved derivation goal. */
-
-        auto attempt = tryResolve(
-            fullDrv,
-            worker.store,
-            [&](ref<const SingleDerivedPath> inputDrvPath, const std::string & outputName) -> std::optional<StorePath> {
-                auto inputDrvRef = make_ref<SingleDerivedPath>(SingleDerivedPath::Built{inputDrvPath, outputName});
-                auto mEntry = get(inputGoals, inputDrvRef);
-                if (!mEntry)
-                    return std::nullopt;
-                auto & buildResult = (*mEntry)->buildResult;
-                return std::visit(
-                    overloaded{
-                        [](const BuildResult::Failure &) -> std::optional<StorePath> { return std::nullopt; },
-                        [&](const BuildResult::Success & success) -> std::optional<StorePath> {
-                            auto i = get(success.builtOutputs, outputName);
-                            if (i)
-                                return i->outPath;
-                            return std::nullopt;
-                        },
+    auto attempt = tryResolve(
+        drv,
+        worker.store,
+        [&](ref<const SingleDerivedPath> inputDrvPath, const std::string & outputName) -> std::optional<StorePath> {
+            auto inputDrvRef = make_ref<SingleDerivedPath>(SingleDerivedPath::Built{inputDrvPath, outputName});
+            auto mEntry = get(inputGoals, inputDrvRef);
+            if (!mEntry)
+                return std::nullopt;
+            auto & buildResult = (*mEntry)->buildResult;
+            return std::visit(
+                overloaded{
+                    [](const BuildResult::Failure &) -> std::optional<StorePath> { return std::nullopt; },
+                    [&](const BuildResult::Success & success) -> std::optional<StorePath> {
+                        auto i = get(success.builtOutputs, outputName);
+                        if (i)
+                            return i->outPath;
+                        return std::nullopt;
                     },
-                    buildResult.inner);
-            });
+                },
+                buildResult.inner);
+        });
 
-        if (!attempt) {
-            /* TODO (impure derivations-induced tech debt) (see below):
-               The above attempt should have found it, but because we manage
-               inputDrvOutputs statefully, sometimes it gets out of sync with
-               the real source of truth (store). So we query the store
-               directly if there's a problem. */
-            attempt = tryResolve(fullDrv, worker.store, &worker.evalStore);
-        }
-        assert(attempt);
-
-        auto pathResolved = computeStorePath(worker.store, unresolve(*attempt));
-
-        auto msg =
-            fmt("resolved derivation: '%s' -> '%s'",
-                worker.store.printStorePath(drvPath),
-                worker.store.printStorePath(pathResolved));
-        act = std::make_unique<Activity>(
-            *logger,
-            lvlInfo,
-            actBuildWaiting,
-            msg,
-            std::to_array<Logger::Field>({
-                worker.store.printStorePath(drvPath),
-                worker.store.printStorePath(pathResolved),
-            }));
-
-        resolvedDrv =
-            std::make_unique<std::pair<StorePath, BasicDerivation>>(std::move(pathResolved), std::move(*attempt));
+    if (!attempt) {
+        /* TODO (impure derivations-induced tech debt) (see below):
+           The above attempt should have found it, but because we manage
+           inputDrvOutputs statefully, sometimes it gets out of sync with
+           the real source of truth (store). So we query the store
+           directly if there's a problem. */
+        attempt = tryResolve(drv, worker.store, &worker.evalStore);
     }
 
+    assert(attempt);
+
+    auto pathResolved = computeStorePath(worker.store, unresolve(*attempt));
+
+    Activity act(
+        *logger,
+        lvlInfo,
+        actBuildWaiting, /* TODO: Is this the right type of activity? */
+        fmt("resolved derivation: '%s' -> '%s'",
+            worker.store.printStorePath(drvPath),
+            worker.store.printStorePath(pathResolved)),
+        std::to_array<Logger::Field>({
+            worker.store.printStorePath(drvPath),
+            worker.store.printStorePath(pathResolved),
+        }));
+
+    co_return std::make_unique<std::pair<StorePath, BasicDerivation>>(std::move(pathResolved), std::move(*attempt));
+}
+
+Goal::Co DerivationResolutionGoal::init(ref<const Derivation> drv, BuildMode buildMode)
+{
+    auto inputGoals = co_await realiseInputs(*drv, buildMode);
+    if (shouldResolve(*drv))
+        resolvedDrv = co_await resolveDerivation(*drv, inputGoals);
     co_return amDone(ecSuccess);
 }
 

--- a/src/libstore/build/derivation-trampoline-goal.cc
+++ b/src/libstore/build/derivation-trampoline-goal.cc
@@ -9,7 +9,7 @@ namespace nix {
 
 DerivationTrampolineGoal::DerivationTrampolineGoal(
     ref<const SingleDerivedPath> drvReq, const OutputsSpec & wantedOutputs, Worker & worker, BuildMode buildMode)
-    : Goal(worker, init())
+    : Goal(worker, haveToLoadFromStore())
     , drvReq(drvReq)
     , wantedOutputs(wantedOutputs)
     , buildMode(buildMode)
@@ -66,7 +66,14 @@ std::string DerivationTrampolineGoal::key()
     }.to_string(worker.store);
 }
 
-Goal::Co DerivationTrampolineGoal::init()
+Goal::Co DerivationTrampolineGoal::haveToLoadFromStore()
+{
+    auto [drvPath, drv] = co_await loadDerivation();
+    co_await haveDerivation(std::move(drvPath), std::move(drv));
+    unreachable(); /* Keep in mind that we *still* end coroutines early. */
+}
+
+Goal::BasicCo<std::pair<StorePath, Derivation>> DerivationTrampolineGoal::loadDerivation()
 {
     trace("need to load derivation from file");
 
@@ -128,7 +135,7 @@ Goal::Co DerivationTrampolineGoal::init()
         assert(false);
     }();
 
-    co_return haveDerivation(std::move(drvPath), std::move(drv));
+    co_return std::pair{std::move(drvPath), std::move(drv)};
 }
 
 Goal::Co DerivationTrampolineGoal::haveDerivation(StorePath drvPath, Derivation drv)

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -59,7 +59,7 @@ void Worker::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMo
             if (auto i2 = dynamic_cast<DerivationTrampolineGoal *>(i.get()))
                 failed.insert(i2->drvReq->to_string(store));
             else if (auto i2 = dynamic_cast<PathSubstitutionGoal *>(i.get()))
-                failed.insert(store.printStorePath(i2->storePath));
+                failed.insert(store.printStorePath(i2->getStorePath()));
         }
     }
 

--- a/src/libstore/build/goal-impl.hh
+++ b/src/libstore/build/goal-impl.hh
@@ -5,7 +5,7 @@
 namespace nix {
 
 template<typename T>
-auto Goal::AwaitableFrame::await_transform(AsyncCallback<T> && ac)
+auto Goal::AwaitableFrameBase::await_transform(AsyncCallback<T> && ac)
 {
     struct Awaiter
     {
@@ -17,8 +17,9 @@ auto Goal::AwaitableFrame::await_transform(AsyncCallback<T> && ac)
             return false;
         }
 
-        void await_suspend(HandleType h)
+        void await_suspend(std::coroutine_handle<> handle)
         {
+            auto h = HandleTypeBase::from_address(handle.address());
             auto goal = h.promise().goal;
             promise = std::make_shared<std::promise<T>>();
 

--- a/src/libstore/build/goal-impl.hh
+++ b/src/libstore/build/goal-impl.hh
@@ -5,7 +5,7 @@
 namespace nix {
 
 template<typename T>
-auto Goal::promise_type::await_transform(AsyncCallback<T> && ac)
+auto Goal::AwaitableFrame::await_transform(AsyncCallback<T> && ac)
 {
     struct Awaiter
     {
@@ -17,7 +17,7 @@ auto Goal::promise_type::await_transform(AsyncCallback<T> && ac)
             return false;
         }
 
-        void await_suspend(handle_type h)
+        void await_suspend(HandleType h)
         {
             auto goal = h.promise().goal;
             promise = std::make_shared<std::promise<T>>();

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -72,6 +72,8 @@ Co::Co(Co && rhs) noexcept
 
 Co & Co::operator=(Co && rhs) noexcept
 {
+    if (this == &rhs)
+        return *this;
     if (handle) {
         handle.promise().alive = false;
         handle.destroy();

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -17,7 +17,7 @@ void TimedOut::anchor() {}
 void Goal::anchor() {}
 
 using Co = nix::Goal::Co;
-using promise_type = nix::Goal::promise_type;
+using PromiseType = nix::Goal::AwaitableFrame;
 
 void Goal::ChildEvents::pushChildEvent(ChildOutput event)
 {
@@ -61,7 +61,7 @@ Goal::ChildEvent Goal::ChildEvents::popChildEvent()
     unreachable();
 }
 
-using handle_type = nix::Goal::handle_type;
+using handle_type = nix::Goal::HandleType;
 using Suspend = nix::Goal::Suspend;
 
 Co::Co(Co && rhs) noexcept
@@ -91,13 +91,13 @@ Co::~Co()
     }
 }
 
-Co promise_type::get_return_object()
+Co PromiseType::get_return_object()
 {
-    auto handle = handle_type::from_promise(*this);
+    auto handle = HandleType::from_promise(*this);
     return Co{handle};
 };
 
-std::coroutine_handle<> promise_type::final_awaiter::await_suspend(handle_type h) noexcept
+std::coroutine_handle<> PromiseType::final_awaiter::await_suspend(HandleType h) noexcept
 {
     auto & p = h.promise();
     auto goal = p.goal;
@@ -138,7 +138,7 @@ std::coroutine_handle<> promise_type::final_awaiter::await_suspend(handle_type h
     }
 }
 
-void promise_type::return_value(Co && next)
+void PromiseType::return_value(Co && next)
 {
     goal->trace("return_value(Co&&)");
     // Save old continuation.
@@ -153,7 +153,7 @@ void promise_type::return_value(Co && next)
     continuation->handle.promise().continuation = std::move(old_continuation);
 }
 
-std::coroutine_handle<> nix::Goal::Co::await_suspend(handle_type caller)
+std::coroutine_handle<> nix::Goal::Co::await_suspend(HandleType caller)
 {
     assert(handle); // we must be a valid coroutine
     auto & p = handle.promise();

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -4,6 +4,17 @@
 
 namespace nix {
 
+Goal::Goal(Worker & worker, Co init)
+    : worker(worker)
+    , top_co(std::move(init))
+{
+    // top_co shouldn't have a goal already, should be nullptr.
+    auto handle = HandleType<void>::from_address(top_co->handle.address());
+    assert(!handle.promise().goal);
+    // we set it such that top_co can pass it down to its subcoroutines.
+    handle.promise().goal = this;
+}
+
 void WorkerSettings::anchor() {}
 
 TimedOut::TimedOut(time_t maxDuration)
@@ -15,9 +26,6 @@ TimedOut::TimedOut(time_t maxDuration)
 void TimedOut::anchor() {}
 
 void Goal::anchor() {}
-
-using Co = nix::Goal::Co;
-using PromiseType = nix::Goal::AwaitableFrame;
 
 void Goal::ChildEvents::pushChildEvent(ChildOutput event)
 {
@@ -61,84 +69,31 @@ Goal::ChildEvent Goal::ChildEvents::popChildEvent()
     unreachable();
 }
 
-using handle_type = nix::Goal::HandleType;
 using Suspend = nix::Goal::Suspend;
 
-Co::Co(Co && rhs) noexcept
-{
-    this->handle = rhs.handle;
-    rhs.handle = nullptr;
-}
-
-Co & Co::operator=(Co && rhs) noexcept
+Goal::CoBase & Goal::CoBase::operator=(CoBase && rhs) noexcept
 {
     if (this == &rhs)
         return *this;
     if (handle) {
-        handle.promise().alive = false;
+        auto baseHandle = HandleTypeBase::from_address(handle.address());
+        baseHandle.promise().alive = false;
         handle.destroy();
     }
-    handle = rhs.handle;
-    rhs.handle = nullptr;
+    handle = std::exchange(rhs.handle, nullptr);
     return *this;
 }
 
-Co::~Co()
+Goal::CoBase::~CoBase()
 {
     if (handle) {
-        handle.promise().alive = false;
+        auto baseHandle = HandleTypeBase::from_address(handle.address());
+        baseHandle.promise().alive = false;
         handle.destroy();
     }
 }
 
-Co PromiseType::get_return_object()
-{
-    auto handle = HandleType::from_promise(*this);
-    return Co{handle};
-};
-
-std::coroutine_handle<> PromiseType::final_awaiter::await_suspend(HandleType h) noexcept
-{
-    auto & p = h.promise();
-    auto goal = p.goal;
-    assert(goal);
-    goal->trace("in final_awaiter");
-    auto c = std::move(p.continuation);
-
-    if (c) {
-        // We still have a continuation, i.e. work to do.
-        // We assert that the goal is still busy.
-        assert(goal->exitCode == ecBusy);
-        assert(goal->top_co);              // Goal must have an active coroutine.
-        assert(goal->top_co->handle == h); // The active coroutine must be us.
-        assert(p.alive);                   // We must not have been destructed.
-
-        // we move continuation to the top,
-        // note: previous top_co is actually h, so by moving into it,
-        // we're calling the destructor on h, DON'T use h and p after this!
-
-        // We move our continuation into `top_co`, i.e. the marker for the active continuation.
-        // By doing this we destruct the old `top_co`, i.e. us, so `h` can't be used anymore.
-        // Be careful not to access freed memory!
-        goal->top_co = std::move(c);
-
-        // We resume `top_co`.
-        return goal->top_co->handle;
-    } else {
-        // We have no continuation, i.e. no more work to do,
-        // so the goal must not be busy anymore.
-        assert(goal->exitCode != ecBusy);
-
-        // We reset `top_co` for good measure.
-        p.goal->top_co = {};
-
-        // We jump to the noop coroutine, which doesn't do anything and immediately suspends.
-        // This passes control back to the caller of goal.work().
-        return std::noop_coroutine();
-    }
-}
-
-void PromiseType::return_value(Co && next)
+void Goal::AwaitableFrame<void>::return_value(Co && next)
 {
     goal->trace("return_value(Co&&)");
     // Save old continuation.
@@ -146,25 +101,12 @@ void PromiseType::return_value(Co && next)
     // We set next as our continuation.
     continuation = std::move(next);
     // We set next's goal, and thus it must not have one already.
-    assert(!continuation->handle.promise().goal);
-    continuation->handle.promise().goal = goal;
+    auto continuationHandle = HandleTypeBase::from_address(continuation->handle.address());
+    assert(!continuationHandle.promise().goal);
+    continuationHandle.promise().goal = goal;
     // Nor can next have a continuation, as we set it to our old one.
-    assert(!continuation->handle.promise().continuation);
-    continuation->handle.promise().continuation = std::move(old_continuation);
-}
-
-std::coroutine_handle<> nix::Goal::Co::await_suspend(HandleType caller)
-{
-    assert(handle); // we must be a valid coroutine
-    auto & p = handle.promise();
-    assert(!p.continuation); // we must have no continuation
-    assert(!p.goal);         // we must not have a goal yet
-    auto goal = caller.promise().goal;
-    assert(goal);
-    p.goal = goal;
-    p.continuation = std::move(goal->top_co); // we set our continuation to be top_co (i.e. caller)
-    goal->top_co = std::move(*this);          // we set top_co to ourselves, don't use this anymore after this!
-    return p.goal->top_co->handle;            // we execute ourselves
+    assert(!continuationHandle.promise().continuation);
+    continuationHandle.promise().continuation = std::move(old_continuation);
 }
 
 bool CompareGoalPtrs::operator()(const GoalPtr & a, const GoalPtr & b) const
@@ -179,7 +121,7 @@ void addToWeakGoals(WeakGoals & goals, GoalPtr p)
     goals.insert(p);
 }
 
-Co Goal::await(Goals new_waitees)
+Goal::Co Goal::await(Goals new_waitees)
 {
     assert(waitees.empty());
     if (!new_waitees.empty()) {
@@ -260,10 +202,11 @@ Goal::Done Goal::amDone(ExitCode result)
     cleanup();
 
     // We drop the continuation.
-    // In `final_awaiter` this will signal that there is no more work to be done.
-    top_co->handle.promise().continuation = {};
+    // In `FinalAwaiter` this will signal that there is no more work to be done.
+    auto baseHandle = HandleTypeBase::from_address(top_co->handle.address());
+    baseHandle.promise().continuation = {};
 
-    // won't return to caller because of logic in final_awaiter
+    // won't return to caller because of logic in FinalAwaiter
     return Done{};
 }
 
@@ -276,8 +219,9 @@ void Goal::work()
 {
     assert(top_co);
     assert(top_co->handle);
-    assert(top_co->handle.promise().alive);
-    top_co->handle.resume();
+    auto baseHandle = HandleTypeBase::from_address(top_co->handle.address());
+    assert(baseHandle.promise().alive);
+    baseHandle.resume();
     // We either should be in a state where we can be work()-ed again,
     // or we should be done.
     assert(top_co || exitCode != ecBusy);

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -133,10 +133,21 @@ Goal::Co PathSubstitutionGoal::init()
 
         co_await await(std::move(waitees));
 
-        // FIXME: consider returning boolean instead of passing in reference
-        bool out = false; // is mutated by tryToRun
-        co_await tryToRun(subPath ? *subPath : storePath, sub, info, out);
-        substituterFailed = substituterFailed || out;
+        if (nrFailed > 0) {
+            co_return doneFailure(
+                nrNoSubstituters > 0 ? ecNoSubstituters : ecFailed,
+                BuildResult::Failure{{
+                    .status = BuildResult::Failure::DependencyFailed,
+                    .msg = HintFmt(
+                        "some references of path '%s' could not be realised", worker.store.printStorePath(storePath)),
+                }});
+        }
+
+        SubstitutionResult res = co_await tryToRun(subPath ? *subPath : storePath, sub, info);
+        if (res == SubstitutionResult::Ok)
+            co_return doneSuccess(BuildResult::Success{.status = BuildResult::Success::Substituted});
+
+        substituterFailed = substituterFailed || (res == SubstitutionResult::SubstituterFailed);
     }
 
     /* None left.  Terminate this goal and let someone else deal
@@ -166,20 +177,10 @@ Goal::Co PathSubstitutionGoal::init()
         }});
 }
 
-Goal::Co PathSubstitutionGoal::tryToRun(
-    StorePath subPath, nix::ref<Store> sub, std::shared_ptr<const ValidPathInfo> info, bool & substituterFailed)
+Goal::BasicCo<PathSubstitutionGoal::SubstitutionResult>
+PathSubstitutionGoal::tryToRun(StorePath subPath, nix::ref<Store> sub, std::shared_ptr<const ValidPathInfo> info)
 {
     trace("all references realised");
-
-    if (nrFailed > 0) {
-        co_return doneFailure(
-            nrNoSubstituters > 0 ? ecNoSubstituters : ecFailed,
-            BuildResult::Failure{{
-                .status = BuildResult::Failure::DependencyFailed,
-                .msg = HintFmt(
-                    "some references of path '%s' could not be realised", worker.store.printStorePath(storePath)),
-            }});
-    }
 
     for (auto & i : info->references)
         /* ignore self-references */
@@ -274,12 +275,13 @@ Goal::Co PathSubstitutionGoal::tryToRun(
             /* Missing NARs are expected when they've been garbage collected.
                This is not a failure, so log as a warning instead of an error. */
             logWarning({.msg = sg.info().msg});
+            co_return SubstitutionResult::SubstituteGone;
         } catch (...) {
             printError(e.what());
-            substituterFailed = true;
+            co_return SubstitutionResult::SubstituterFailed;
         }
 
-        co_return Return{};
+        unreachable();
     }
 
     worker.markContentsGood(storePath);
@@ -303,7 +305,7 @@ Goal::Co PathSubstitutionGoal::tryToRun(
 
     worker.updateProgress();
 
-    co_return doneSuccess(BuildResult::Success{.status = BuildResult::Success::Substituted});
+    co_return SubstitutionResult::Ok;
 }
 
 void PathSubstitutionGoal::cleanup()

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -159,7 +159,7 @@ void Worker::removeGoal(GoalPtr goal)
     } else if (auto drvBuildingGoal = std::dynamic_pointer_cast<DerivationBuildingGoal>(goal)) {
         derivationBuildingGoals.erase(drvBuildingGoal->drvPath);
     } else if (auto subGoal = std::dynamic_pointer_cast<PathSubstitutionGoal>(goal)) {
-        substitutionGoals.erase(subGoal->storePath);
+        substitutionGoals.erase(subGoal->getStorePath());
     } else if (auto subGoal = std::dynamic_pointer_cast<DrvOutputSubstitutionGoal>(goal)) {
         drvOutputSubstitutionGoals.erase(subGoal->id);
     } else {

--- a/src/libstore/include/nix/store/build/derivation-resolution-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-resolution-goal.hh
@@ -53,25 +53,15 @@ private:
      */
     StorePath drvPath;
 
-    /**
-     * The derivation stored at drvPath.
-     */
-    ref<const Derivation> drv;
-
-    /**
-     * The remainder is state held during the build.
-     */
-
-    BuildMode buildMode;
-
     std::unique_ptr<Activity> act;
 
     std::string key() override;
 
-    /**
-     * The states.
-     */
-    Co resolveDerivation();
+    using InputsGoalMap = std::map<ref<const SingleDerivedPath>, GoalPtr, RefDeepComparator>;
+
+    Co init(ref<const Derivation> drv, BuildMode buildMode);
+    BasicCo<InputsGoalMap> realiseInputs(const Derivation & drv, BuildMode buildMode);
+    BasicCo<decltype(resolvedDrv)> resolveDerivation(const Derivation & drv, const InputsGoalMap & inputGoals);
 
     JobCategory jobCategory() const override
     {

--- a/src/libstore/include/nix/store/build/derivation-trampoline-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-trampoline-goal.hh
@@ -118,10 +118,12 @@ struct DerivationTrampolineGoal : public Goal
 
 private:
 
-    BuildMode buildMode;
+    BasicCo<std::pair<StorePath, Derivation>> loadDerivation();
 
-    Co init();
+    Co haveToLoadFromStore();
     Co haveDerivation(StorePath drvPath, Derivation drv);
+
+    BuildMode buildMode;
 
     /**
      * Shared between both constructors

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -595,6 +595,12 @@ public:
             return BasicCo<T>{HandleType<T>::from_promise(*this)};
         }
 
+        /**
+         * Does nothing, but provides an opportunity for
+         * @ref final_suspend to happen.
+         */
+        void return_value(Done &&) {}
+
         template<typename R>
         void return_value(R && r)
         {

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -205,13 +205,53 @@ public:
     struct WaitForChildEvent
     {};
 
-    // forward declaration of promise_type, see below
-    struct AwaitableFrame;
+    template<typename T>
+    class AwaitableFrame;
+    class AwaitableFrameBase;
 
     /**
      * Handle to coroutine using @ref Co and @ref promise_type.
      */
-    using HandleType = std::coroutine_handle<AwaitableFrame>;
+    template<typename T>
+    using HandleType = std::coroutine_handle<AwaitableFrame<T>>;
+    using HandleTypeBase = std::coroutine_handle<AwaitableFrameBase>;
+
+    template<typename T = void>
+    struct BasicCo;
+
+    using Co = BasicCo<void>;
+
+    class CoBase
+    {
+    protected:
+        friend struct Goal;
+
+        /**
+         * The underlying handle.
+         */
+        std::coroutine_handle<> handle;
+
+        explicit CoBase(std::coroutine_handle<> h) noexcept
+            : handle(h)
+        {
+        }
+
+    public:
+        CoBase() noexcept
+            : handle(nullptr)
+        {
+        }
+
+        CoBase(CoBase && rhs) noexcept
+            : handle(std::exchange(rhs.handle, nullptr))
+        {
+        }
+
+        CoBase & operator=(CoBase && rhs) noexcept;
+        CoBase(const CoBase &) = delete;
+        CoBase & operator=(const CoBase &) = delete;
+        ~CoBase();
+    };
 
     /**
      * C++20 coroutine wrapper for use in goal logic.
@@ -251,44 +291,25 @@ public:
      * @todo Allocate explicitly on stack since HALO thing doesn't really work,
      *       specifically, there's no way to uphold the requirements when trying to do
      *       tail-calls without using a trampoline AFAICT.
-     *
-     * @todo Support returning data natively
      */
-    struct [[nodiscard]] Co
+    template<typename T>
+    struct [[nodiscard]] BasicCo : CoBase
     {
-        /**
-         * The underlying handle.
-         */
-        HandleType handle;
+        BasicCo() noexcept = default;
 
-        explicit Co(HandleType handle)
-            : handle(handle) {};
-        Co & operator=(Co &&) noexcept;
-        Co(Co && rhs) noexcept;
-        Co & operator=(const Co &) = delete;
-        Co(const Co & rhs) = delete;
-        ~Co();
-
-        bool await_ready()
+        explicit BasicCo(HandleType<T> h) noexcept
+            : CoBase(h)
         {
-            return false;
-        };
+        }
 
-        /**
-         * When we `co_await` another `Co`-returning coroutine,
-         * we tell the caller of `caller_coroutine.resume()` to switch to our coroutine (@ref handle).
-         * To make sure we return to the original coroutine, we set it as the continuation of our
-         * coroutine. In @ref promise_type::final_awaiter we check if it's set and if so we return to it.
-         *
-         * To explain in more understandable terms:
-         * When we `co_await Co_returning_function()`, this function is called on the resultant @ref Co of
-         * the _called_ function, and C++ automatically passes the caller in.
-         *
-         * `goal` field of @ref promise_type is also set here by copying it from the caller.
-         */
-        std::coroutine_handle<> await_suspend(HandleType handle);
-        void await_resume() {};
+        AwaitableFrame<T> & frame() const
+        {
+            assert(handle);
+            return HandleType<T>::from_address(handle.address()).promise();
+        }
     };
+
+    static_assert(sizeof(BasicCo<void>) == sizeof(CoBase));
 
     template<typename T>
     struct AsyncCallback
@@ -296,51 +317,19 @@ public:
         fun<void(Callback<T>)> fn;
     };
 
-    /**
-     * Used on initial suspend, does the same as `std::suspend_always`,
-     * but asserts that everything has been set correctly.
-     */
-    struct InitialSuspend
+    class AwaitableFrameBase
     {
-        /**
-         * Handle of coroutine that does the
-         * initial suspend
-         */
-        HandleType handle;
+        friend struct Goal;
 
-        bool await_ready()
-        {
-            return false;
-        };
-
-        void await_suspend(HandleType handle_)
-        {
-            handle = handle_;
-        }
-
-        void await_resume()
-        {
-            assert(handle);
-            assert(handle.promise().goal);                           // goal must be set
-            assert(handle.promise().goal->top_co);                   // top_co of goal must be set
-            assert(handle.promise().goal->top_co->handle == handle); // top_co of goal must be us
-        }
-    };
-
-    /**
-     * Promise type for coroutines defined using @ref Co.
-     * Attached to coroutine handle.
-     *
-     * @see boost::asio::detail::awaitable_frame for a reference implementation
-     * of a similar pattern.
-     */
-    struct AwaitableFrame
-    {
+    protected:
         /**
          * Either this is who called us, or it is who we will tail-call.
          * It is what we "jump" to once we are done.
          */
-        std::optional<Co> continuation;
+        std::optional<CoBase> continuation;
+
+        void * resultSlot = nullptr;
+        void (*moveResult)(AwaitableFrameBase * from, void * to) noexcept = nullptr;
 
         /**
          * The goal that we're a part of.
@@ -354,10 +343,126 @@ public:
          */
         bool alive = true;
 
+    private:
+        /**
+         * Used on initial suspend, does the same as `std::suspend_always`,
+         * but asserts that everything has been set correctly.
+         */
+        struct InitialSuspend
+        {
+            /**
+             * Handle of coroutine that does the
+             * initial suspend
+             */
+            HandleTypeBase handle;
+
+            bool await_ready()
+            {
+                return false;
+            };
+
+            template<class Promise>
+            void await_suspend(std::coroutine_handle<Promise> h)
+            {
+                handle = HandleTypeBase::from_address(h.address());
+            }
+
+            void await_resume()
+            {
+                assert(handle);
+                assert(handle.promise().goal);                           // goal must be set
+                assert(handle.promise().goal->top_co);                   // top_co of goal must be set
+                assert(handle.promise().goal->top_co->handle == handle); // top_co of goal must be us
+            }
+        };
+
+        template<typename T, typename Derived>
+        class CoAwaiterBase
+        {
+            CoAwaiterBase() = default;
+
+            CoAwaiterBase(BasicCo<T> c)
+                : co(std::move(c))
+            {
+            }
+
+        public:
+            BasicCo<T> co;
+
+            bool await_ready() const noexcept
+            {
+                return false;
+            }
+
+            template<class Promise>
+            std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> caller)
+            {
+                auto & promise = co.frame();
+                auto goal = caller.promise().goal;
+                assert(goal);
+                assert(!promise.continuation); // we must have no continuation
+                assert(!promise.goal);         // we must not have a goal yet
+                promise.goal = goal;
+                promise.continuation = std::move(goal->top_co); // we set our continuation to be top_co (i.e. caller)
+                if constexpr (!std::is_void_v<T>) {
+                    promise.resultSlot = &static_cast<Derived *>(this)->result;
+                }
+                goal->top_co = std::move(co); // we set top_co to ourselves, don't use this anymore after this!
+                return goal->top_co->handle;  // we execute ourselves
+            }
+
+            friend Derived;
+        };
+
+        template<typename T>
+        struct CoAwaiter : CoAwaiterBase<T, CoAwaiter<T>>
+        {
+            CoAwaiter() = default;
+
+            explicit CoAwaiter(BasicCo<T> co)
+                : CoAwaiterBase<T, CoAwaiter<T>>(std::move(co))
+            {
+            }
+
+            std::optional<T> result;
+
+            T await_resume()
+            {
+                assert(result);
+                return std::move(*result);
+            }
+        };
+
+        /**
+         * Awaiter for child events. Suspends and returns the
+         * pending child event when resumed.
+         */
+        struct ChildEventAwaiter
+        {
+            HandleTypeBase handle;
+
+            bool await_ready()
+            {
+                return handle && handle.promise().goal->childEvents.hasChildEvent();
+            }
+
+            template<class Promise>
+            void await_suspend(std::coroutine_handle<Promise> h)
+            {
+                handle = HandleTypeBase::from_address(h.address());
+            }
+
+            ChildEvent await_resume()
+            {
+                assert(handle);
+                return handle.promise().goal->childEvents.popChildEvent();
+            }
+        };
+
         /**
          * The awaiter used by @ref final_suspend.
          */
-        struct final_awaiter
+        struct FinalAwaiter
         {
             bool await_ready() noexcept
             {
@@ -370,7 +475,8 @@ public:
              * `h` is the handle for the coroutine that is finishing execution,
              * thus it must be destroyed.
              */
-            std::coroutine_handle<> await_suspend(HandleType h) noexcept;
+            template<class Promise>
+            std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> h) noexcept;
 
             void await_resume() noexcept
             {
@@ -379,11 +485,29 @@ public:
         };
 
         /**
-         * Called by compiler generated code to construct the `Co`
-         * that is returned from a `Co`-returning coroutine.
+         * Awaiter for @ref Suspend. Always suspends, but asserts
+         * there are no pending child events (those should be
+         * consumed first via @ref WaitForChildEvent).
          */
-        Co get_return_object();
+        struct SuspendAwaiter
+        {
+            AwaitableFrameBase & promise;
 
+            bool await_ready()
+            {
+                assert(!promise.goal->childEvents.hasChildEvent());
+                return false;
+            }
+
+            template<class Promise>
+            void await_suspend([[maybe_unused]] std::coroutine_handle<Promise> h)
+            {
+            }
+
+            void await_resume() {}
+        };
+
+    public:
         /**
          * Called by compiler generated code before body of coroutine.
          * We use this opportunity to set the @ref goal field
@@ -395,40 +519,13 @@ public:
         };
 
         /**
-         * Called on `co_return`. Creates @ref final_awaiter which
+         * Called on `co_return`. Creates @ref FinalAwaiter which
          * either jumps to continuation or suspends goal.
          */
-        final_awaiter final_suspend() noexcept
+        FinalAwaiter final_suspend() noexcept
         {
             return {};
         };
-
-        /**
-         * Does nothing, but provides an opportunity for
-         * @ref final_suspend to happen.
-         */
-        void return_value(Return) {}
-
-        /**
-         * Does nothing, but provides an opportunity for
-         * @ref final_suspend to happen.
-         */
-        void return_value(Done) {}
-
-        /**
-         * When "returning" another coroutine, what happens is that
-         * we set it as our own continuation, thus once the final suspend
-         * happens, we transfer control to it.
-         * The original continuation we had is set as the continuation
-         * of the coroutine passed in.
-         * @ref final_suspend is called after this, and @ref final_awaiter will
-         * pass control off to @ref continuation.
-         *
-         * If we already have a continuation, that continuation is set as
-         * the continuation of the new continuation. Thus, the continuation
-         * passed to @ref return_value must not have a continuation set.
-         */
-        void return_value(Co &&);
 
         /**
          * If an exception is thrown inside a coroutine,
@@ -439,36 +536,14 @@ public:
             throw;
         };
 
-        /**
-         * Allows awaiting a @ref Co.
-         */
-        Co && await_transform(Co && co)
+        template<typename T>
+        CoAwaiter<T> await_transform(BasicCo<T> && co)
         {
-            return static_cast<Co &&>(co);
+            return CoAwaiter<T>{std::move(co)};
         }
 
         template<typename T>
         auto await_transform(AsyncCallback<T> && acb);
-
-        /**
-         * Awaiter for @ref Suspend. Always suspends, but asserts
-         * there are no pending child events (those should be
-         * consumed first via @ref WaitForChildEvent).
-         */
-        struct SuspendAwaiter
-        {
-            AwaitableFrame & promise;
-
-            bool await_ready()
-            {
-                assert(!promise.goal->childEvents.hasChildEvent());
-                return false;
-            }
-
-            void await_suspend(HandleType) {}
-
-            void await_resume() {}
-        };
 
         /**
          * Allows awaiting a @ref Suspend.
@@ -480,37 +555,52 @@ public:
         };
 
         /**
-         * Awaiter for child events. Suspends and returns the
-         * pending child event when resumed.
-         */
-        struct ChildEventAwaiter
-        {
-            HandleType handle;
-
-            bool await_ready()
-            {
-                return handle && handle.promise().goal->childEvents.hasChildEvent();
-            }
-
-            void await_suspend(HandleType h)
-            {
-                handle = h;
-            }
-
-            ChildEvent await_resume()
-            {
-                assert(handle);
-                return handle.promise().goal->childEvents.popChildEvent();
-            }
-        };
-
-        /**
          * Allows awaiting child events (output, EOF, timeout).
          */
         ChildEventAwaiter await_transform(WaitForChildEvent)
         {
-            return ChildEventAwaiter{HandleType::from_promise(*this)};
+            return ChildEventAwaiter{HandleTypeBase::from_promise(*this)};
         };
+    };
+
+    /**
+     * Promise type for coroutines defined using @ref Co.
+     * Attached to coroutine handle.
+     *
+     * @see boost::asio::detail::awaitable_frame for a reference implementation
+     * of a similar pattern.
+     */
+    template<typename T>
+    class AwaitableFrame : public AwaitableFrameBase
+    {
+        /**
+         * The return value.
+         */
+        std::optional<T> result;
+
+        static void doMoveResult(AwaitableFrameBase * from, void * to) noexcept
+        {
+            auto * self = static_cast<AwaitableFrame *>(from);
+            auto * slot = static_cast<std::optional<T> *>(to);
+            slot->emplace(std::move(*self->result));
+        }
+
+    public:
+        /**
+         * Called by compiler generated code to construct the `Co`
+         * that is returned from a `Co`-returning coroutine.
+         */
+        BasicCo<T> get_return_object()
+        {
+            return BasicCo<T>{HandleType<T>::from_promise(*this)};
+        }
+
+        template<typename R>
+        void return_value(R && r)
+        {
+            result.emplace(std::forward<R>(r));
+            moveResult = &doMoveResult;
+        }
     };
 
 protected:
@@ -521,7 +611,7 @@ protected:
      * coroutine executed.
      * Destroying this should destroy all coroutines created for this goal.
      */
-    std::optional<Co> top_co;
+    std::optional<CoBase> top_co;
 
     /**
      * Signals that the goal is done.
@@ -562,15 +652,7 @@ public:
      */
     bool preserveFailure = false;
 
-    Goal(Worker & worker, Co init)
-        : worker(worker)
-        , top_co(std::move(init))
-    {
-        // top_co shouldn't have a goal already, should be nullptr.
-        assert(!top_co->handle.promise().goal);
-        // we set it such that top_co can pass it down to its subcoroutines.
-        top_co->handle.promise().goal = this;
-    }
+    Goal(Worker & worker, Co init);
 
     virtual ~Goal()
     {
@@ -657,10 +739,104 @@ protected:
 
 void addToWeakGoals(WeakGoals & goals, GoalPtr p);
 
+template<typename Promise>
+std::coroutine_handle<> Goal::AwaitableFrameBase::FinalAwaiter::await_suspend(std::coroutine_handle<Promise> h) noexcept
+{
+    auto & p = h.promise();
+    auto goal = p.goal;
+    assert(goal);
+    goal->trace("in FinalAwaiter");
+    auto c = std::move(p.continuation);
+
+    if (p.resultSlot && p.moveResult)
+        p.moveResult(&p, p.resultSlot);
+
+    if (c) {
+        // We still have a continuation, i.e. work to do.
+        // We assert that the goal is still busy.
+        assert(goal->exitCode == ecBusy);
+        assert(goal->top_co);              // Goal must have an active coroutine.
+        assert(goal->top_co->handle == h); // The active coroutine must be us.
+        assert(p.alive);                   // We must not have been destructed.
+
+        // we move continuation to the top,
+        // note: previous top_co is actually h, so by moving into it,
+        // we're calling the destructor on h, DON'T use h and p after this!
+
+        // We move our continuation into `top_co`, i.e. the marker for the active continuation.
+        // By doing this we destruct the old `top_co`, i.e. us, so `h` can't be used anymore.
+        // Be careful not to access freed memory!
+        goal->top_co = std::move(c);
+
+        // We resume `top_co`.
+        return goal->top_co->handle;
+    } else {
+        // We have no continuation, i.e. no more work to do,
+        // so the goal must not be busy anymore.
+        assert(goal->exitCode != ecBusy);
+
+        // We reset `top_co` for good measure.
+        p.goal->top_co = {};
+
+        // We jump to the noop coroutine, which doesn't do anything and immediately suspends.
+        // This passes control back to the caller of goal.work().
+        return std::noop_coroutine();
+    }
+}
+
+template<>
+struct Goal::AwaitableFrameBase::CoAwaiter<void> : CoAwaiterBase<void, CoAwaiter<void>>
+{
+    CoAwaiter() = default;
+
+    explicit CoAwaiter(BasicCo<void> co)
+        : CoAwaiterBase<void, CoAwaiter<void>>(std::move(co))
+    {
+    }
+
+    void await_resume() {}
+};
+
+template<>
+struct Goal::AwaitableFrame<void> : Goal::AwaitableFrameBase
+{
+    Co get_return_object()
+    {
+        return Co{HandleType<void>::from_promise(*this)};
+    }
+
+    /**
+     * Does nothing, but provides an opportunity for
+     * @ref final_suspend to happen.
+     */
+    void return_value(Return) {}
+
+    /**
+     * Does nothing, but provides an opportunity for
+     * @ref final_suspend to happen.
+     */
+    void return_value(Done) {}
+
+    /**
+     * When "returning" another coroutine, what happens is that
+     * we set it as our own continuation, thus once the final suspend
+     * happens, we transfer control to it.
+     * The original continuation we had is set as the continuation
+     * of the coroutine passed in.
+     * @ref final_suspend is called after this, and @ref FinalAwaiter will
+     * pass control off to @ref continuation.
+     *
+     * If we already have a continuation, that continuation is set as
+     * the continuation of the new continuation. Thus, the continuation
+     * passed to @ref return_value must not have a continuation set.
+     */
+    void return_value(Co &&);
+};
+
 } // namespace nix
 
-template<typename... ArgTypes>
-struct std::coroutine_traits<nix::Goal::Co, ArgTypes...>
+template<typename T, typename... ArgTypes>
+struct std::coroutine_traits<nix::Goal::BasicCo<T>, ArgTypes...>
 {
-    using promise_type = nix::Goal::AwaitableFrame;
+    using promise_type = nix::Goal::AwaitableFrame<T>;
 };

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -206,12 +206,12 @@ public:
     {};
 
     // forward declaration of promise_type, see below
-    struct promise_type;
+    struct AwaitableFrame;
 
     /**
      * Handle to coroutine using @ref Co and @ref promise_type.
      */
-    using handle_type = std::coroutine_handle<promise_type>;
+    using HandleType = std::coroutine_handle<AwaitableFrame>;
 
     /**
      * C++20 coroutine wrapper for use in goal logic.
@@ -259,9 +259,9 @@ public:
         /**
          * The underlying handle.
          */
-        handle_type handle;
+        HandleType handle;
 
-        explicit Co(handle_type handle)
+        explicit Co(HandleType handle)
             : handle(handle) {};
         Co & operator=(Co &&) noexcept;
         Co(Co && rhs) noexcept;
@@ -286,7 +286,7 @@ public:
          *
          * `goal` field of @ref promise_type is also set here by copying it from the caller.
          */
-        std::coroutine_handle<> await_suspend(handle_type handle);
+        std::coroutine_handle<> await_suspend(HandleType handle);
         void await_resume() {};
     };
 
@@ -306,14 +306,14 @@ public:
          * Handle of coroutine that does the
          * initial suspend
          */
-        handle_type handle;
+        HandleType handle;
 
         bool await_ready()
         {
             return false;
         };
 
-        void await_suspend(handle_type handle_)
+        void await_suspend(HandleType handle_)
         {
             handle = handle_;
         }
@@ -330,8 +330,11 @@ public:
     /**
      * Promise type for coroutines defined using @ref Co.
      * Attached to coroutine handle.
+     *
+     * @see boost::asio::detail::awaitable_frame for a reference implementation
+     * of a similar pattern.
      */
-    struct promise_type
+    struct AwaitableFrame
     {
         /**
          * Either this is who called us, or it is who we will tail-call.
@@ -367,7 +370,7 @@ public:
              * `h` is the handle for the coroutine that is finishing execution,
              * thus it must be destroyed.
              */
-            std::coroutine_handle<> await_suspend(handle_type h) noexcept;
+            std::coroutine_handle<> await_suspend(HandleType h) noexcept;
 
             void await_resume() noexcept
             {
@@ -454,7 +457,7 @@ public:
          */
         struct SuspendAwaiter
         {
-            promise_type & promise;
+            AwaitableFrame & promise;
 
             bool await_ready()
             {
@@ -462,7 +465,7 @@ public:
                 return false;
             }
 
-            void await_suspend(handle_type) {}
+            void await_suspend(HandleType) {}
 
             void await_resume() {}
         };
@@ -482,14 +485,14 @@ public:
          */
         struct ChildEventAwaiter
         {
-            handle_type handle;
+            HandleType handle;
 
             bool await_ready()
             {
                 return handle && handle.promise().goal->childEvents.hasChildEvent();
             }
 
-            void await_suspend(handle_type h)
+            void await_suspend(HandleType h)
             {
                 handle = h;
             }
@@ -506,7 +509,7 @@ public:
          */
         ChildEventAwaiter await_transform(WaitForChildEvent)
         {
-            return ChildEventAwaiter{handle_type::from_promise(*this)};
+            return ChildEventAwaiter{HandleType::from_promise(*this)};
         };
     };
 
@@ -659,5 +662,5 @@ void addToWeakGoals(WeakGoals & goals, GoalPtr p);
 template<typename... ArgTypes>
 struct std::coroutine_traits<nix::Goal::Co, ArgTypes...>
 {
-    using promise_type = nix::Goal::promise_type;
+    using promise_type = nix::Goal::AwaitableFrame;
 };

--- a/src/libstore/include/nix/store/build/substitution-goal.hh
+++ b/src/libstore/include/nix/store/build/substitution-goal.hh
@@ -10,7 +10,7 @@
 
 namespace nix {
 
-struct PathSubstitutionGoal : public Goal
+class PathSubstitutionGoal : public Goal
 {
     /**
      * The store path that should be realised through a substitute.
@@ -41,6 +41,7 @@ public:
         Worker & worker,
         RepairFlag repair = NoRepair,
         std::optional<ContentAddress> ca = std::nullopt);
+
     ~PathSubstitutionGoal();
 
     std::string key() override
@@ -48,14 +49,17 @@ public:
         return "a$" + std::string(storePath.name()) + "$" + worker.store.printStorePath(storePath);
     }
 
+    const StorePath & getStorePath() const &
+    {
+        return storePath;
+    }
+
     /**
      * The states.
      */
     Co init();
-    Co gotInfo();
     Co tryToRun(
         StorePath subPath, nix::ref<Store> sub, std::shared_ptr<const ValidPathInfo> info, bool & substituterFailed);
-    Co finished();
 
     /* Called by destructor, can't be overridden */
     void cleanup() override final;

--- a/src/libstore/include/nix/store/build/substitution-goal.hh
+++ b/src/libstore/include/nix/store/build/substitution-goal.hh
@@ -35,6 +35,15 @@ class PathSubstitutionGoal : public Goal
      */
     std::optional<ContentAddress> ca;
 
+    enum class SubstitutionResult {
+        SubstituterFailed,
+        SubstituteGone,
+        Ok,
+    };
+
+    BasicCo<SubstitutionResult>
+    tryToRun(StorePath subPath, nix::ref<Store> sub, std::shared_ptr<const ValidPathInfo> info);
+
 public:
     PathSubstitutionGoal(
         const StorePath & storePath,
@@ -58,8 +67,6 @@ public:
      * The states.
      */
     Co init();
-    Co tryToRun(
-        StorePath subPath, nix::ref<Store> sub, std::shared_ptr<const ValidPathInfo> info, bool & substituterFailed);
 
     /* Called by destructor, can't be overridden */
     void cleanup() override final;

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -23,7 +23,7 @@ struct DerivationTrampolineGoal;
 struct DerivationGoal;
 struct DerivationResolutionGoal;
 struct DerivationBuildingGoal;
-struct PathSubstitutionGoal;
+class PathSubstitutionGoal;
 class DrvOutputSubstitutionGoal;
 
 /**

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -537,7 +537,7 @@ private:
 
     void addBuildLog(const StorePath & drvPath, std::string_view log) override;
 
-    friend struct PathSubstitutionGoal;
+    friend class PathSubstitutionGoal;
     friend struct DerivationGoal;
     /* Only used for createTempDirInStore. */
     friend class DerivationBuilderImpl;

--- a/src/libutil/include/nix/util/ref.hh
+++ b/src/libutil/include/nix/util/ref.hh
@@ -173,7 +173,16 @@ template<typename T, typename... Args>
 inline ref<T> make_ref(Args &&... args)
 {
     auto p = std::make_shared<T>(std::forward<Args>(args)...);
-    return ref<T>(p);
+    return ref<T>(std::move(p));
 }
+
+struct RefDeepComparator
+{
+    template<typename T>
+    bool operator()(const ref<T> & lhs, const ref<T> & rhs) const
+    {
+        return *lhs < *rhs;
+    }
+};
 
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Briefly:

I think the current mechanism that the callee is responsible to choose which coroutine to jump to next is quite a bit ill-behaved. It makes it much easier to write bugs when one is unfamiliar with such an approach. It's also outlived it's immediate need because that's what the old code used to do (back when goals were hand-rolled state machines).

If one thinks hard enough, then each "Goal" is effectively a deduplicated unit of computation which is itself represented by an implicit coroutine frame stack. That's effectively what other coroutine runtimes do too - `asio::awaitable` is already that. Each asynchronous task is itself composed of multiple coroutines that form an implicit stack via backlinks. Our ownership semantics is explicit precisely because of the need for tail-calling, but without it the stack "unwinds" naturally.

Secondly, if we want to integrate into a more well-behaved asynchronous event loop with coroutines, we can no longer rely on tail-talling but that would dissolve the need to differentiate between different asynchronous events (of which we have not nearly enough of).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
