### PR TITLE
libutil: ensure lossless Windows paths, handle UNC

### DIFF
--- a/src/libutil-tests/file-path-impl.cc
+++ b/src/libutil-tests/file-path-impl.cc
@@ -1,0 +1,140 @@
+#include <gtest/gtest.h>
+
+#include "nix/util/file-path-impl.hh"
+
+namespace nix {
+
+using WinChar = WindowsPathTrait<char>;
+
+/* ----------------------------------------------------------------------------
+ * Traditional DOS drives -- behaviour that predates UNC support
+ * --------------------------------------------------------------------------*/
+
+TEST(rootNameLen, driveLetter)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(C:\foo)"), 2u);
+}
+
+TEST(rootNameLen, driveLetterIsCaseInsensitive)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(c:\foo)"), 2u);
+}
+
+TEST(rootNameLen, bareDrive)
+{
+    EXPECT_EQ(WinChar::rootNameLen("C:"), 2u);
+}
+
+TEST(rootNameLen, nonLetterBeforeColonIsNotADrive)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(1:\foo)"), 0u);
+}
+
+TEST(rootNameLen, relativePathHasNoRoot)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(foo\bar)"), 0u);
+}
+
+TEST(rootNameLen, singleSeparatorHasNoRoot)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\foo)"), 0u);
+}
+
+/* ----------------------------------------------------------------------------
+ * UNC shares. All of these returned 0 before, so canonicalisation treated
+ * them as relative and could resolve `..` out of a share.
+ * --------------------------------------------------------------------------*/
+
+TEST(rootNameLen, uncShareWithTrailingPath)
+{
+    /* Root is `\\server\share`, 14 characters; `\dir` is inside it. */
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\server\share\dir)"), 14u);
+}
+
+TEST(rootNameLen, uncShareAlone)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\server\share)"), 14u);
+}
+
+TEST(rootNameLen, uncServerWithoutShareIsEntirelyRoot)
+{
+    /* There is no directory to be relative to, so the whole thing is the
+       root name. A shorter answer would let `..` traverse into a sibling
+       share. */
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\server)"), 8u);
+}
+
+TEST(rootNameLen, uncAcceptsForwardSlashes)
+{
+    /* `isPathSep` accepts both separators, so this must too. */
+    EXPECT_EQ(WinChar::rootNameLen("//server/share/dir"), 14u);
+}
+
+/* ----------------------------------------------------------------------------
+ * Extended-length and device namespaces
+ * --------------------------------------------------------------------------*/
+
+TEST(rootNameLen, extendedLengthDrive)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\?\C:\foo)"), 6u);
+}
+
+TEST(rootNameLen, extendedLengthDriveLowercase)
+{
+    /* `maybePath` accepted only an uppercase drive letter in this position
+       while accepting either case in the plain `C:\` form. */
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\?\c:\foo)"), 6u);
+}
+
+TEST(rootNameLen, deviceNamespaceDrive)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\.\C:\foo)"), 6u);
+}
+
+TEST(rootNameLen, extendedLengthUnc)
+{
+    /* `\\?\UNC\server\share` is 20 characters. */
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\?\UNC\server\share\dir)"), 20u);
+}
+
+TEST(rootNameLen, extendedLengthUncIsCaseInsensitive)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\?\unc\server\share\dir)"), 20u);
+}
+
+TEST(rootNameLen, deviceName)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\.\PhysicalDrive0)"), 18u);
+}
+
+TEST(rootNameLen, deviceNameWithTrailingPath)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\.\pipe\mypipe)"), 8u);
+}
+
+/* ----------------------------------------------------------------------------
+ * The wide instantiation must agree. Before, `rootNameLen` narrowed the
+ * drive letter to `char` regardless of `CharT`.
+ * --------------------------------------------------------------------------*/
+
+TEST(rootNameLen, wideCharAgreesWithNarrow)
+{
+    using WinWide = WindowsPathTrait<wchar_t>;
+    EXPECT_EQ(WinWide::rootNameLen(LR"(C:\foo)"), 2u);
+    EXPECT_EQ(WinWide::rootNameLen(LR"(\\server\share\dir)"), 14u);
+    EXPECT_EQ(WinWide::rootNameLen(LR"(\\?\C:\foo)"), 6u);
+    EXPECT_EQ(WinWide::rootNameLen(LR"(\\?\UNC\server\share)"), 20u);
+}
+
+/* ----------------------------------------------------------------------------
+ * Unix paths have no root name, on any input
+ * --------------------------------------------------------------------------*/
+
+TEST(rootNameLen, unixTraitIsAlwaysZero)
+{
+    EXPECT_EQ(UnixPathTrait::rootNameLen("/foo/bar"), 0u);
+    EXPECT_EQ(UnixPathTrait::rootNameLen("//server/share"), 0u);
+    EXPECT_EQ(UnixPathTrait::rootNameLen("C:/foo"), 0u);
+}
+
+} // namespace nix

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -85,6 +85,7 @@ sources = files(
   'topo-sort.cc',
   'url.cc',
   'util.cc',
+  'wtf8.cc',
   'xml-writer.cc',
 )
 

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -53,6 +53,7 @@ sources = files(
   'executable-path.cc',
   'file-content-address.cc',
   'file-descriptor.cc',
+  'file-path-impl.cc',
   'file-system-at.cc',
   'file-system.cc',
   'fun.cc',

--- a/src/libutil-tests/wtf8.cc
+++ b/src/libutil-tests/wtf8.cc
@@ -1,0 +1,174 @@
+#include <gtest/gtest.h>
+
+#include "nix/util/wtf8.hh"
+
+namespace nix {
+
+/* ----------------------------------------------------------------------------
+ * Round trips
+ * --------------------------------------------------------------------------*/
+
+TEST(wtf8, asciiRoundTrips)
+{
+    std::u16string in = u"C:\\Users\\test\\file.txt";
+    EXPECT_EQ(wtf8FromUtf16(in), "C:\\Users\\test\\file.txt");
+    EXPECT_EQ(utf16FromWtf8(wtf8FromUtf16(in)), in);
+}
+
+TEST(wtf8, emptyRoundTrips)
+{
+    EXPECT_EQ(wtf8FromUtf16(u""), "");
+    EXPECT_EQ(utf16FromWtf8(""), u"");
+}
+
+TEST(wtf8, twoAndThreeByteCodePointsRoundTrip)
+{
+    /* U+00E9 (2 bytes) and U+65E5 (3 bytes). */
+    std::u16string in = u"caf\u00e9 \u65e5";
+    auto encoded = wtf8FromUtf16(in);
+    EXPECT_EQ(encoded, "caf\xc3\xa9 \xe6\x97\xa5");
+    EXPECT_EQ(utf16FromWtf8(encoded), in);
+}
+
+TEST(wtf8, supplementaryCodePointUsesFourBytesNotTwoSurrogates)
+{
+    /* U+1F600 arrives as a surrogate pair in UTF-16. A valid pair must be
+       combined into the four-byte form, otherwise WTF-8 would not be a
+       superset of UTF-8 for well-formed input. */
+    std::u16string in = {0xD83D, 0xDE00};
+    auto encoded = wtf8FromUtf16(in);
+    EXPECT_EQ(encoded, "\xf0\x9f\x98\x80");
+    EXPECT_EQ(encoded.size(), 4u);
+    EXPECT_EQ(utf16FromWtf8(encoded), in);
+}
+
+/* ----------------------------------------------------------------------------
+ * Unpaired surrogates: the entire reason this exists
+ * --------------------------------------------------------------------------*/
+
+TEST(wtf8, unpairedHighSurrogateRoundTrips)
+{
+    /* A file named with a lone high surrogate is creatable on NTFS. The
+       previous `codecvt_utf8_utf16` conversion threw `std::range_error`
+       here, so such a name could not be handled at all. */
+    std::u16string in = {u'a', 0xD800, u'b'};
+    auto encoded = wtf8FromUtf16(in);
+    EXPECT_EQ(utf16FromWtf8(encoded), in);
+}
+
+TEST(wtf8, unpairedLowSurrogateRoundTrips)
+{
+    std::u16string in = {u'a', 0xDC00, u'b'};
+    EXPECT_EQ(utf16FromWtf8(wtf8FromUtf16(in)), in);
+}
+
+TEST(wtf8, unpairedSurrogateAtEndRoundTrips)
+{
+    /* A high surrogate with nothing after it exercises the bounds check in
+       the pairing test rather than the pairing itself. */
+    std::u16string in = {u'x', 0xD800};
+    EXPECT_EQ(utf16FromWtf8(wtf8FromUtf16(in)), in);
+}
+
+TEST(wtf8, highSurrogateFollowedByNonLowSurrogateRoundTrips)
+{
+    /* Two high surrogates in a row are both unpaired. Combining them would
+       silently invent a code point. */
+    std::u16string in = {0xD800, 0xD801};
+    auto encoded = wtf8FromUtf16(in);
+    EXPECT_EQ(encoded.size(), 6u);
+    EXPECT_EQ(utf16FromWtf8(encoded), in);
+}
+
+TEST(wtf8, surrogateEncodesAsItsOwnThreeByteSequence)
+{
+    std::u16string in = {0xD800};
+    EXPECT_EQ(wtf8FromUtf16(in), "\xed\xa0\x80");
+}
+
+TEST(wtf8, everySurrogateValueRoundTrips)
+{
+    /* Exhaustive over the surrogate range, so no single value can be
+       mishandled unnoticed. The counter is `unsigned` rather than
+       `char16_t` both to avoid wrapping at the top of the range and
+       because `operator<<(std::ostream &, char16_t)` is deleted, so a
+       `char16_t` cannot be streamed into a failure message. */
+    for (unsigned u = 0xD800; u <= 0xDFFF; ++u) {
+        std::u16string in = {static_cast<char16_t>(u)};
+        EXPECT_EQ(utf16FromWtf8(wtf8FromUtf16(in)), in) << "failed at U+" << std::hex << u;
+    }
+}
+
+/* ----------------------------------------------------------------------------
+ * Malformed input is replaced, never accepted as the value it spells
+ * --------------------------------------------------------------------------*/
+
+/* Counts below follow the maximal-subpart convention: a malformed sequence
+   costs one replacement character for the byte that could not begin or
+   continue a valid sequence, and the bytes after it are then examined on
+   their own terms rather than being swallowed. All were measured. */
+
+TEST(wtf8, overlongTwoByteEncodingIsRejected)
+{
+    /* C0 80 spells U+0000 in two bytes. Accepting it would let a caller
+       smuggle a NUL past a check that inspected the bytes. C0 cannot begin
+       any valid sequence, so it and the orphaned 80 each yield U+FFFD. */
+    auto decoded = utf16FromWtf8("\xc0\x80");
+    EXPECT_NE(decoded, std::u16string(1, u'\0'));
+    EXPECT_EQ(decoded, std::u16string({0xFFFD, 0xFFFD}));
+}
+
+TEST(wtf8, overlongThreeByteEncodingIsRejected)
+{
+    /* E0 80 AF spells '/' in three bytes. Same hazard, separator edition:
+       a path check that ran on the bytes would not see a separator here. */
+    auto decoded = utf16FromWtf8("\xe0\x80\xaf");
+    EXPECT_EQ(decoded, std::u16string({0xFFFD, 0xFFFD, 0xFFFD}));
+    EXPECT_EQ(decoded.find(u'/'), std::u16string::npos);
+}
+
+TEST(wtf8, truncatedSequenceIsReplaced)
+{
+    EXPECT_EQ(utf16FromWtf8("\xe6\x97"), std::u16string({0xFFFD, 0xFFFD}));
+}
+
+TEST(wtf8, strayContinuationByteIsReplaced)
+{
+    EXPECT_EQ(utf16FromWtf8("\x80"), std::u16string({0xFFFD}));
+}
+
+TEST(wtf8, invalidLeadByteIsReplaced)
+{
+    /* F7 cannot begin a valid sequence at all; in strict UTF-8 it would
+       spell U+1FFFFF, past U+10FFFF. */
+    EXPECT_EQ(utf16FromWtf8("\xf7\xbf\xbf\xbf"), std::u16string({0xFFFD, 0xFFFD, 0xFFFD, 0xFFFD}));
+}
+
+TEST(wtf8, fourByteSequenceAboveMaxCodePointIsRejected)
+{
+    /* F4 90 80 80 spells U+110000. F4 is a legal lead, so this is caught by
+       the restriction on its second byte rather than by the lead itself. */
+    EXPECT_EQ(utf16FromWtf8("\xf4\x90\x80\x80"), std::u16string({0xFFFD, 0xFFFD, 0xFFFD, 0xFFFD}));
+}
+
+TEST(wtf8, surrogateThreeByteSequenceIsAcceptedNotReplaced)
+{
+    /* ED A0 80 is rejected by a strict UTF-8 decoder and must be accepted
+       here. This is the decoder's one intentional divergence from UTF-8,
+       and the reason the whole file exists. */
+    EXPECT_EQ(utf16FromWtf8("\xed\xa0\x80"), std::u16string({0xD800}));
+}
+
+TEST(wtf8, decodingAlwaysTerminates)
+{
+    /* Every byte value as a one-byte input. The guarantee under test is
+       that the decoder consumes at least one byte per iteration; a decoder
+       that did not would hang rather than fail. */
+    for (int b = 0; b < 256; ++b) {
+        std::string in(1, static_cast<char>(b));
+        auto out = utf16FromWtf8(in);
+        EXPECT_FALSE(out.empty()) << "byte " << b << " produced nothing";
+    }
+}
+
+} // namespace nix

--- a/src/libutil/include/nix/util/file-path-impl.hh
+++ b/src/libutil/include/nix/util/file-path-impl.hh
@@ -89,16 +89,68 @@ struct WindowsPathTrait
         return p1 == String::npos ? p2 : p2 == String::npos ? p1 : std::max(p1, p2);
     }
 
+    static inline bool isDriveLetter(CharT c)
+    {
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+    }
+
+    /**
+     * Given `from` positioned just past a UNC prefix, return the offset one
+     * past the share name in `\\server\share...`.
+     *
+     * A UNC path naming a server but no share has no directory to be
+     * relative to, so all of what is present is the root name. Reporting
+     * anything shorter would let canonicalisation treat `\\server` as a
+     * directory and resolve `..` through it into a different share.
+     */
+    static size_t uncRootEnd(StringView path, size_t from)
+    {
+        size_t afterServer = findPathSep(path, from);
+        if (afterServer == StringView::npos)
+            return path.size();
+        size_t afterShare = findPathSep(path, afterServer + 1);
+        return afterShare == StringView::npos ? path.size() : afterShare;
+    }
+
+    /**
+     * Length of the root name: the leading portion that names a volume and
+     * is not itself a directory anything can be relative to.
+     *
+     * Covers the forms documented at
+     * https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+     * -- traditional DOS drives, UNC shares, and the extended-length and
+     * device namespaces, including `\\?\UNC\`.
+     */
     static size_t rootNameLen(StringView path)
     {
-        if (path.size() >= 2 && path[1] == ':') {
-            char driveLetter = path[0];
-            if ((driveLetter >= 'A' && driveLetter <= 'Z') || (driveLetter >= 'a' && driveLetter <= 'z'))
-                return 2;
+        /* `X:` -- traditional DOS drive. */
+        if (path.size() >= 2 && path[1] == ':' && isDriveLetter(path[0]))
+            return 2;
+
+        /* Everything remaining begins with two separators. `//` is accepted
+           alongside `\\`, consistent with `isPathSep` and the rest of this
+           trait. */
+        if (!(path.size() >= 3 && isPathSep(path[0]) && isPathSep(path[1])))
+            return 0;
+
+        /* `\\?\` (extended-length) and `\\.\` (device) namespaces. */
+        if ((path[2] == '?' || path[2] == '.') && path.size() >= 4 && isPathSep(path[3])) {
+            /* `\\?\X:` */
+            if (path.size() >= 6 && path[5] == ':' && isDriveLetter(path[4]))
+                return 6;
+
+            /* `\\?\UNC\server\share`. The literal is case-insensitive. */
+            if (path.size() >= 8 && (path[4] == 'U' || path[4] == 'u') && (path[5] == 'N' || path[5] == 'n')
+                && (path[6] == 'C' || path[6] == 'c') && isPathSep(path[7]))
+                return uncRootEnd(path, 8);
+
+            /* A device name, which runs to the next separator. */
+            size_t end = findPathSep(path, 4);
+            return end == StringView::npos ? path.size() : end;
         }
-        /* TODO: This needs to also handle UNC paths.
-         * https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths */
-        return 0;
+
+        /* `\\server\share` */
+        return uncRootEnd(path, 2);
     }
 };
 

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -103,5 +103,6 @@ headers = [ config_pub_h ] + files(
   'users.hh',
   'util.hh',
   'variant-wrapper.hh',
+  'wtf8.hh',
   'xml-writer.hh',
 )

--- a/src/libutil/include/nix/util/os-string.hh
+++ b/src/libutil/include/nix/util/os-string.hh
@@ -50,6 +50,22 @@ using OsStringMap = std::map<OsString, OsString, std::less<>>;
  */
 using OsStrings = std::list<OsString>;
 
+/**
+ * Convert between the native path encoding and an 8-bit one.
+ *
+ * On Unix both are the same arbitrary byte string and these are the
+ * identity. On Windows the 8-bit form is WTF-8, not strict UTF-8, because a
+ * Windows file name is an arbitrary sequence of 16-bit code units and may
+ * contain an unpaired surrogate that UTF-8 cannot represent. WTF-8 encodes
+ * those, so every name round-trips.
+ *
+ * Neither direction throws. They previously went through
+ * `std::codecvt_utf8_utf16`, which raised `std::range_error` on an unpaired
+ * surrogate -- so a file with such a name could not be named at all, and the
+ * failure surfaced far from the conversion.
+ *
+ * @see nix/util/wtf8.hh
+ */
 std::string os_string_to_string(OsStringView s);
 std::string os_string_to_string(OsString s);
 

--- a/src/libutil/include/nix/util/wtf8.hh
+++ b/src/libutil/include/nix/util/wtf8.hh
@@ -1,0 +1,56 @@
+#pragma once
+/**
+ * @file
+ *
+ * Conversion between UTF-16 code-unit sequences and WTF-8.
+ *
+ * Windows file names are sequences of 16-bit code units with no validity
+ * requirement: an unpaired surrogate is a legal name component, and such
+ * files can be created. UTF-8 cannot represent one, so a strict UTF-8
+ * conversion has to either fail or corrupt the name.
+ *
+ * WTF-8 is UTF-8 extended to encode unpaired surrogates as their own
+ * three-byte sequences, while still combining valid surrogate pairs into
+ * the four-byte form for the supplementary code point they denote. That
+ * makes `utf16FromWtf8(wtf8FromUtf16(s)) == s` for every `s`, including
+ * names no UTF-8 encoder accepts.
+ *
+ * Both directions are total: neither throws, and neither has a failure
+ * mode a caller must handle. Byte sequences that are not valid WTF-8 are
+ * decoded to U+FFFD rather than rejected, so a caller cannot be handed a
+ * path that silently lost content.
+ *
+ * These live here, rather than beside the Windows-only string conversion
+ * that uses them, so that they are compiled and tested on every platform.
+ *
+ * @see https://simonsapin.github.io/wtf-8/
+ */
+
+#include <string>
+#include <string_view>
+
+namespace nix {
+
+/**
+ * Encode a UTF-16 code-unit sequence as WTF-8.
+ *
+ * Valid surrogate pairs become the four-byte encoding of the code point
+ * they denote. Every other code unit, unpaired surrogates included, is
+ * encoded on its own.
+ */
+std::string wtf8FromUtf16(std::u16string_view s);
+
+/**
+ * Decode WTF-8 into a UTF-16 code-unit sequence.
+ *
+ * Three-byte sequences denoting surrogates are restored as the unpaired
+ * surrogates they came from. Code points above the basic multilingual
+ * plane become surrogate pairs.
+ *
+ * Input that is not valid WTF-8 -- a truncated sequence, a stray
+ * continuation byte, an overlong encoding, or a value above U+10FFFF --
+ * yields U+FFFD for the offending byte or sequence.
+ */
+std::u16string utf16FromWtf8(std::string_view s);
+
+} // namespace nix

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -209,6 +209,7 @@ sources = [ config_priv_h ] + files(
   'url.cc',
   'users.cc',
   'util.cc',
+  'wtf8.cc',
   'xml-writer.cc',
 )
 

--- a/src/libutil/windows/file-path.cc
+++ b/src/libutil/windows/file-path.cc
@@ -1,40 +1,80 @@
 #include <algorithm>
-#include <codecvt>
-#include <iostream>
-#include <locale>
 
+#include "nix/util/error.hh"
 #include "nix/util/file-path.hh"
 #include "nix/util/file-path-impl.hh"
+#include "nix/util/os-string.hh"
 #include "nix/util/util.hh"
 
 namespace nix {
 
+namespace {
+
+using Trait = WindowsPathTrait<OsChar>;
+
+/**
+ * The `\\?\` prefix turns off Win32 path normalisation, so forward slashes
+ * are no longer translated on our behalf and have to be replaced here.
+ */
+std::filesystem::path::string_type useBackslashes(std::filesystem::path::string_type s)
+{
+    std::replace(s.begin(), s.end(), L'/', L'\\');
+    return s;
+}
+
+/** Is this already in the `\\?\` or `\\.\` namespace? */
+bool hasNamespacePrefix(PathView path)
+{
+    return path.size() >= 4 && Trait::isPathSep(path[0]) && Trait::isPathSep(path[1])
+           && (path[2] == '?' || path[2] == '.') && Trait::isPathSep(path[3]);
+}
+
+} // namespace
+
 std::optional<std::filesystem::path> maybePath(PathView path)
 {
-    if (path.length() >= 3 && (('A' <= path[0] && path[0] <= 'Z') || ('a' <= path[0] && path[0] <= 'z'))
-        && path[1] == ':' && WindowsPathTrait<char>::isPathSep(path[2])) {
-        std::filesystem::path::string_type sw = std::wstring{L"\\\\?\\"} + std::wstring{path};
-        std::replace(sw.begin(), sw.end(), '/', '\\');
-        return sw;
+    /* Already prefixed, so pass it through rather than double-prefixing.
+       Accepts either case of drive letter and `UNC\` spelling, which the
+       previous implementation did not: it required an uppercase letter here
+       while accepting either case in the plain `C:\` form. */
+    if (hasNamespacePrefix(path))
+        return useBackslashes(std::filesystem::path::string_type{path});
+
+    size_t rootLen = Trait::rootNameLen(path);
+    if (rootLen == 0)
+        return std::nullopt;
+
+    /* `X:\...`. A drive-relative path such as `C:foo` names a different
+       file depending on the process's per-drive working directory, which
+       these APIs have no way to honour, so it is rejected rather than
+       silently resolved against the wrong directory. */
+    if (rootLen == 2) {
+        if (path.size() >= 3 && Trait::isPathSep(path[2]))
+            return useBackslashes(
+                std::filesystem::path::string_type{L"\\\\?\\"} + std::filesystem::path::string_type{path});
+        return std::nullopt;
     }
-    if (path.length() >= 7 && path[0] == '\\' && path[1] == '\\' && (path[2] == '.' || path[2] == '?')
-        && path[3] == '\\' && ('A' <= path[4] && path[4] <= 'Z') && path[5] == ':'
-        && WindowsPathTrait<char>::isPathSep(path[6])) {
-        std::filesystem::path::string_type sw{path};
-        std::replace(sw.begin(), sw.end(), '/', '\\');
-        return sw;
-    }
-    return std::optional<std::filesystem::path::string_type>();
+
+    /* `\\server\share\...` becomes `\\?\UNC\server\share\...`: the two
+       leading separators are replaced by the prefix rather than kept. */
+    if (Trait::isPathSep(path[0]) && Trait::isPathSep(path[1]))
+        return useBackslashes(
+            std::filesystem::path::string_type{L"\\\\?\\UNC\\"} + std::filesystem::path::string_type{path.substr(2)});
+
+    return std::nullopt;
 }
 
 std::filesystem::path toOwnedPath(PathView path)
 {
-    std::optional<std::filesystem::path::string_type> sw = maybePath(path);
-    if (!sw) {
-        // FIXME why are we not using the regular error handling?
-        std::wcerr << L"invalid path for WinAPI call [" << path << L"]" << std::endl;
-        _exit(111);
-    }
+    auto sw = maybePath(path);
+    if (!sw)
+        /* Previously this printed to `wcerr` and called `_exit(111)`, which
+           took the process down with no unwinding, no error handler, and no
+           way for a caller to report which operation failed. */
+        throw Error(
+            "path '%s' cannot be used in a Win32 API call: it needs to be absolute, naming either a drive "
+            "(`C:\\...`), a UNC share (`\\\\server\\share\\...`), or an already-prefixed path (`\\\\?\\...`)",
+            os_string_to_string(path));
     return *sw;
 }
 

--- a/src/libutil/windows/os-string.cc
+++ b/src/libutil/windows/os-string.cc
@@ -1,17 +1,26 @@
 #include <algorithm>
-#include <codecvt>
 #include <iostream>
-#include <locale>
 
 #include "nix/util/os-string.hh"
 #include "nix/util/strings-inline.hh"
+#include "nix/util/wtf8.hh"
 
 namespace nix {
 
+#ifdef _WIN32
+/* Windows file names are arbitrary 16-bit code units, so `wchar_t` has to be
+   exactly that wide for the conversions below to be lossless. Guarded because
+   `wchar_t` is 32 bits on Linux, where this file is not built. */
+static_assert(sizeof(wchar_t) == 2, "Windows paths are UTF-16; wchar_t must be 16 bits");
+#endif
+
 std::string os_string_to_string(OsStringView s)
 {
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    return converter.to_bytes(s.data(), s.data() + s.size());
+    /* `wchar_t` and `char16_t` are distinct types with the same
+       representation here, so this copy is a reinterpretation without the
+       aliasing question a cast would raise. */
+    std::u16string units(s.begin(), s.end());
+    return wtf8FromUtf16(units);
 }
 
 std::string os_string_to_string(OsString s)
@@ -21,8 +30,8 @@ std::string os_string_to_string(OsString s)
 
 OsString string_to_os_string(std::string_view s)
 {
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    return converter.from_bytes(s.data(), s.data() + s.size());
+    auto units = utf16FromWtf8(s);
+    return OsString(units.begin(), units.end());
 }
 
 OsString string_to_os_string(std::string s)

--- a/src/libutil/wtf8.cc
+++ b/src/libutil/wtf8.cc
@@ -1,0 +1,187 @@
+#include <cstdint>
+
+#include "nix/util/wtf8.hh"
+
+namespace nix {
+
+namespace {
+
+constexpr char16_t highSurrogateFirst = 0xD800;
+constexpr char16_t highSurrogateLast = 0xDBFF;
+constexpr char16_t lowSurrogateFirst = 0xDC00;
+constexpr char16_t lowSurrogateLast = 0xDFFF;
+
+constexpr uint32_t maxCodePoint = 0x10FFFF;
+constexpr char16_t replacementChar = 0xFFFD;
+
+bool isHighSurrogate(char16_t c)
+{
+    return c >= highSurrogateFirst && c <= highSurrogateLast;
+}
+
+bool isLowSurrogate(char16_t c)
+{
+    return c >= lowSurrogateFirst && c <= lowSurrogateLast;
+}
+
+/**
+ * Append the UTF-8-style encoding of `cp`.
+ *
+ * Unlike a UTF-8 encoder this accepts surrogate values, which is the one
+ * way WTF-8 differs on the encoding side.
+ */
+void encodeCodePoint(std::string & out, uint32_t cp)
+{
+    if (cp < 0x80) {
+        out += static_cast<char>(cp);
+    } else if (cp < 0x800) {
+        out += static_cast<char>(0xC0 | (cp >> 6));
+        out += static_cast<char>(0x80 | (cp & 0x3F));
+    } else if (cp < 0x10000) {
+        out += static_cast<char>(0xE0 | (cp >> 12));
+        out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+        out += static_cast<char>(0x80 | (cp & 0x3F));
+    } else {
+        out += static_cast<char>(0xF0 | (cp >> 18));
+        out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+        out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+        out += static_cast<char>(0x80 | (cp & 0x3F));
+    }
+}
+
+} // namespace
+
+std::string wtf8FromUtf16(std::u16string_view s)
+{
+    std::string out;
+    /* Most path characters are ASCII, so this is usually exact. */
+    out.reserve(s.size());
+
+    for (size_t i = 0; i < s.size(); ++i) {
+        char16_t c = s[i];
+        if (isHighSurrogate(c) && i + 1 < s.size() && isLowSurrogate(s[i + 1])) {
+            /* A valid pair denotes one supplementary code point, and is
+               encoded as that code point rather than as two surrogates.
+               This is what keeps WTF-8 a superset of UTF-8 for names that
+               happen to be well formed. */
+            uint32_t cp = 0x10000 + ((static_cast<uint32_t>(c) - highSurrogateFirst) << 10)
+                          + (static_cast<uint32_t>(s[i + 1]) - lowSurrogateFirst);
+            encodeCodePoint(out, cp);
+            ++i;
+        } else {
+            /* Everything else, unpaired surrogates included. Encoding one
+               is the entire reason this function exists: a strict UTF-8
+               encoder rejects it, and rejecting it means being unable to
+               name a file that exists. */
+            encodeCodePoint(out, c);
+        }
+    }
+
+    return out;
+}
+
+std::u16string utf16FromWtf8(std::string_view s)
+{
+    std::u16string out;
+    out.reserve(s.size());
+
+    size_t i = 0;
+    while (i < s.size()) {
+        uint8_t b = static_cast<uint8_t>(s[i]);
+        uint32_t cp;
+        size_t len;
+
+        /* The range the *second* byte is restricted to. Constraining it,
+           rather than range-checking the assembled code point afterwards,
+           is what makes an overlong encoding unrepresentable instead of
+           merely detected. That matters because accepting one would let a
+           caller smuggle a separator or a NUL past a check that inspected
+           the bytes. */
+        uint8_t secondLo = 0x80;
+        uint8_t secondHi = 0xBF;
+
+        if (b < 0x80) {
+            cp = b;
+            len = 1;
+        } else if (b >= 0xC2 && b <= 0xDF) {
+            /* 0xC0 and 0xC1 are excluded: they can only ever begin an
+               overlong two-byte form of an ASCII character. */
+            cp = b & 0x1F;
+            len = 2;
+        } else if (b >= 0xE0 && b <= 0xEF) {
+            cp = b & 0x0F;
+            len = 3;
+            if (b == 0xE0)
+                secondLo = 0xA0;
+            /* 0xED is deliberately left alone. Strict UTF-8 restricts it to
+               0x80-0x9F to exclude surrogates; WTF-8 encodes surrogates, so
+               the full range is legal here. This is the one place the
+               decoder is intentionally more permissive than UTF-8. */
+        } else if (b >= 0xF0 && b <= 0xF4) {
+            cp = b & 0x07;
+            len = 4;
+            if (b == 0xF0)
+                secondLo = 0x90;
+            if (b == 0xF4)
+                secondHi = 0x8F; /* else the result would exceed U+10FFFF */
+        } else {
+            /* A stray continuation byte (0x80-0xBF), an overlong lead
+               (0xC0, 0xC1), or a lead that cannot begin any valid sequence
+               (0xF5-0xFF). */
+            out += replacementChar;
+            ++i;
+            continue;
+        }
+
+        /* Validate the whole sequence before consuming any of it, so that a
+           malformed one costs a single byte and the bytes after it get
+           examined on their own terms rather than being swallowed. */
+        bool wellFormed = true;
+        for (size_t k = 1; k < len; ++k) {
+            if (i + k >= s.size()) {
+                wellFormed = false;
+                break;
+            }
+            uint8_t c = static_cast<uint8_t>(s[i + k]);
+            uint8_t lo = k == 1 ? secondLo : 0x80;
+            uint8_t hi = k == 1 ? secondHi : 0xBF;
+            if (c < lo || c > hi) {
+                wellFormed = false;
+                break;
+            }
+        }
+
+        if (!wellFormed) {
+            /* Exactly one byte, so progress is guaranteed and the decoder
+               cannot loop. */
+            out += replacementChar;
+            ++i;
+            continue;
+        }
+
+        for (size_t k = 1; k < len; ++k)
+            cp = (cp << 6) | (static_cast<uint8_t>(s[i + k]) & 0x3F);
+        i += len;
+
+        /* Unreachable given the byte ranges above; kept as an assertion of
+           the invariant rather than as live error handling. */
+        if (cp > maxCodePoint) {
+            out += replacementChar;
+            continue;
+        }
+
+        if (cp < 0x10000) {
+            /* Includes the surrogate range, which is how an unpaired
+               surrogate survives the round trip. */
+            out += static_cast<char16_t>(cp);
+        } else {
+            cp -= 0x10000;
+            out += static_cast<char16_t>(highSurrogateFirst + (cp >> 10));
+            out += static_cast<char16_t>(lowSurrogateFirst + (cp & 0x3FF));
+        }
+    }
+
+    return out;
+}
+
+} // namespace nix


### PR DESCRIPTION
## Motivation

Two reachable problems in the Windows path layer.

The `OsString` conversions go through `std::wstring_convert<std::codecvt_utf8_utf16<>>`, which throws
`std::range_error` on unpaired surrogates. NTFS allows arbitrary UTF-16 code units in filenames, so
such a file is creatable and nothing catches the throw. `<codecvt>` is deprecated in C++17 besides.
And `rootNameLen` returns 0 for `\\server\share`, so a UNC path canonicalizes as relative; there are
existing TODOs for this at `file-path-impl.hh:99` and `url.cc:770`.

## What this does

Converts through WTF-8, which represents unpaired surrogates losslessly, and handles UNC and device
roots in `rootNameLen`. Two incidental fixes: the drive letter was read into a `char` regardless of
`CharT`, narrowing the `wchar_t` instantiation; and the uppercase-only drive check turned out to
affect `rootNameLen` too, not just `maybePath`.

## Verification

+37 tests in two new suites, 813 to 850, 849 passed and 0 failed. An unpaired surrogate encodes to
`%ED%A0%80` and restores byte-identical UTF-16; that test fails before the change. Run natively on
Linux, not under Wine, because the conversion is in portable code.

Not covered: `windows/os-string.cc` and `windows/file-path.cc` are excluded on Linux and were not
cross-compiled here.
