### PR TITLE
libutil: adopt RFC 8089 URIs for logical path holders

### DIFF
--- a/doc/uri-logical-paths.md
+++ b/doc/uri-logical-paths.md
@@ -1,0 +1,309 @@
+# A logical path that can hold a Windows root
+
+Status: design proposal with a proof of concept. Nothing here is wired into
+the evaluator.
+
+## Why this exists
+
+`CanonPath` is the type every abstract path in Nix passes through, and it
+cannot represent a Windows root at all. Its own doc comment says so
+plainly: paths "are always Unix-style paths, regardless of what OS Nix is
+running on."
+
+That is not an oversight, it is load-bearing. `canon-path.cc:16`
+canonicalises through `canonPathInner<UnixPathTrait>`, and
+`UnixPathTrait::rootNameLen` returns 0 unconditionally. The generic
+algorithm in `file-path-impl.hh` *does* handle a root name -- it copies it
+verbatim before walking components -- so the machinery exists and only the
+Unix trait declines to use it.
+
+The consequence is concrete. `\\server\share` handed to `CanonPath`
+becomes one relative component, because `\` is not a separator to
+`UnixPathTrait` and `\\server\share` contains no `/` at all. Nothing
+errors; the path is silently wrong.
+
+Fixing `WindowsPathTrait::rootNameLen` does not reach this. That trait
+governs *native* paths, and the two are deliberately separate layers.
+
+## What is proposed
+
+A `LogicalPath` (`src/libutil/include/nix/util/logical-path.hh`) that
+separates the two things `CanonPath` conflates: what a path is anchored
+to, and the components below it.
+
+```c++
+using Root = std::variant<Posix, Drive, Unc, Device>;
+
+Root root_;
+std::vector<std::string> components_;
+```
+
+Invariants, established in the constructor and preserved by every mutator:
+
+- no component is empty, `.`, or `..`
+- no component contains a NUL byte or a `/`
+- components are WTF-8, so a name that is not well-formed UTF-16 survives
+- a `Drive` letter is upper case and a `Unc` host is lower case
+
+The external form is a `file` URI per RFC 8089. That RFC is the only
+standard that describes how a Windows root maps onto a hierarchical name,
+and Nix already cites it twice -- `url.hh:82` and a `TODO` at
+`url.cc:682` -- so this continues an existing direction rather than
+starting a new one.
+
+## Root mapping
+
+| Native | Root | URI |
+| --- | --- | --- |
+| `/usr/lib` | `Posix` | `file:///usr/lib` |
+| `C:\foo` | `Drive{'C'}` | `file:///C:/foo` |
+| `c:\foo` | `Drive{'C'}` | `file:///C:/foo` |
+| `\\host\share\a` | `Unc{host,share}` | `file://host/share/a` |
+| `\\?\C:\foo` | `Drive{'C'}` | `file:///C:/foo` |
+| `\\?\UNC\h\s\f` | `Unc{h,s}` | `file://h/s/f` |
+| `\\.\PhysicalDrive0` | `Device{...}` | `nix-win32-device:///PhysicalDrive0` |
+
+The UNC row is RFC 8089 appendix E.3.1: host to authority, share and
+object names to path segments.
+
+**The extended-length prefixes are normalised away.** `\\?\C:` names the
+same volume as `C:`, and `\\?\UNC\h\s` the same share as `\\h\s`, so
+collapsing them keeps the type from having two spellings for one path.
+What that discards is discussed under non-goals.
+
+**Only a true device path needs the extension.** RFC 8089 states it "does
+not define a mechanism" for the Win32 File Namespace, so `Device` renders
+under `nix-win32-device:` and can never be mistaken for a conformant
+`file` URI. This matters less than it sounds: `\\.\PhysicalDrive0` is not
+a filesystem path, and no Nix store lives there.
+
+## Where WTF-8 and percent-encoding meet
+
+The order is: UTF-16 → WTF-8 → percent-encoded octets.
+
+- Components are held as WTF-8 bytes, using `wtf8FromUtf16` /
+  `utf16FromWtf8` from `wtf8.hh`. Both directions are total.
+- Rendering percent-encodes each component's bytes with
+  `percentEncode(s, ":@")`, so `/`, `%`, `#`, `?` and space are all
+  escaped and `:` survives to let a drive render as `C:` rather than
+  `C%3A`.
+- Parsing percent-decodes each segment back to WTF-8 bytes.
+
+**This is a Nix extension, not RFC conformance, and the distinction should
+not be blurred.** RFC 8089 section 4 says UTF-8 SHOULD be applied before
+percent-encoding and then states that "a decision not to use
+percent-encoded UTF-8 is outside the scope of this specification." An
+unpaired surrogate has no UTF-8 encoding, so carrying one means leaving
+that SHOULD behind.
+
+What is preserved is the *syntax*: percent-encoded WTF-8 is still a
+well-formed RFC 3986 URI, because RFC 3986 percent-encoding is defined
+over octets and does not care what they mean. So a conformant parser will
+accept and round-trip these URIs; it simply will not be able to display
+the offending component as text. Claiming more than that would be wrong.
+
+## Comparison and ordering
+
+Equality is structural over the root and the component vector. Case
+folding at construction is what makes it correct:
+
+- **Drive letters fold to upper case.** RFC 8089 appendix E.2 states
+  drive-letter comparison is case-insensitive and that some usages treat
+  URIs differing only in drive-letter case as identical. Folding at
+  construction gets this without a custom comparator, so `operator==`,
+  `operator<=>` and hashing all agree for free.
+- **UNC hosts fold to lower case**, because RFC 3986 section 3.2.2 makes
+  the authority case-insensitive.
+- **Shares do not fold.** RFC 3986 leaves the path case-sensitive. Windows
+  itself compares shares case-insensitively, so this is a deliberate
+  divergence: folding would make two distinct URIs compare equal, and the
+  URI is the thing being modelled. A caller that needs Windows semantics
+  has to ask for them.
+
+Ordering compares the root first, then components pairwise. That
+reproduces the property `CanonPath::operator<=>` documents -- a directory
+sorts immediately before its children -- which byte-wise comparison of a
+joined string does *not* have, because `!` is greater than `/` and so
+`/foo!` would sort between `/foo` and `/foo/bar`. Comparing the root first
+also stops two volumes from interleaving.
+
+`..` resolves against components and stops at the root. Letting it escape
+would resolve out of a share into a different volume, which is the same
+reason `WindowsPathTrait::uncRootEnd` treats a server-with-no-share as
+entirely root name.
+
+## The upstream blocker
+
+**`url.cc:184` rejects any `file` URL with a non-empty host, so the one
+mapping RFC 8089 gives for a UNC path cannot be parsed by Nix today.**
+
+```c++
+auto transportIsFile = parseUrlScheme(scheme).transport == "file";
+if (authority && authority->host.size() && transportIsFile)
+    throw BadURL("file:// URL '%s' has unexpected authority '%s'", ...);
+```
+
+This was found by execution, not by reading: three round-trip tests failed
+with `file:// URL 'file://host/share/a/b' has unexpected authority 'host'`
+before the proof of concept stopped calling `parseURL`.
+
+The comment above that guard cites RFC 3986 section 3.2.2, which says that
+for `file`, "no authority, an empty host, and `localhost` all mean the
+end-user's machine." That is true, and it does not say other hosts are
+invalid -- it says what those three *mean*. RFC 8089 appendix E.3.1 then
+defines the authority slot as where a UNC host goes. So the guard is
+stricter than either RFC requires.
+
+**Relaxing it is a maintainer decision, not a detail.** Two tests assert
+the current behaviour:
+
+- `src/libutil-tests/url.cc:390` -- `fixGitURL("file://var/repos/x")` must
+  throw
+- `src/libutil-tests/url.cc:676` -- `parseURL("file://www.example.org/video.mp4")`
+  must throw
+
+The second is the real question. `file://www.example.org/video.mp4` is
+almost certainly a user mistake for `https://`, and rejecting it is a
+kindness. Under E.3.1 it is instead a valid reference to
+`\\www.example.org\video.mp4`. Those two readings cannot both be the
+default. Options, with what each costs:
+
+1. **Permit a non-empty host for `file`.** One condition removed; both
+   tests above have to be rewritten. Users lose a helpful error on a
+   likely typo.
+2. **Permit it only when a Windows-paths feature is enabled.** Keeps the
+   error for everyone else, at the cost of a parser whose accepted
+   language depends on configuration -- which tends to produce bugs that
+   only appear on one platform.
+3. **Keep `parseURL` as it is and give logical paths their own parser.**
+   What the proof of concept does. No behaviour change anywhere, at the
+   cost of two parsers for one syntax, which will drift.
+
+This proposal does not choose. `LogicalPath::parseUri` currently does its
+own scheme/authority split, still using `percentEncode`/`percentDecode`
+from `url.hh`, and a test
+(`logicalPath.nixCannotYetParseTheRfc8089UncForm`) asserts the current
+rejection so that lifting it fails loudly and points here.
+
+## Blast radius
+
+Measured on `origin/master` at `72385de1b`:
+
+| Measure | Count |
+| --- | --- |
+| `CanonPath` occurrences | 949 |
+| files mentioning it | 102 |
+| constructor calls | 303 |
+| `CanonPath::root` uses | 97 |
+| `.abs()` calls | 71 |
+| `.rel()` calls | 57 |
+
+By component: libutil 29 files, libstore 15, libfetchers 15, `nix` 10,
+libutil-tests 9, libexpr 7, libexpr-tests 5, libflake 3, then single
+digits elsewhere.
+
+The split that matters is not by file but by what a call site does with
+the string:
+
+- **Mechanical.** The 303 constructor calls and most component
+  walking. A `LogicalPath` built from a `Posix` root behaves like today's
+  `CanonPath`, so these change type and not meaning.
+- **Semantic.** The 71 `.abs()` and 57 `.rel()` calls, because both hand
+  out a flat `std::string` and a rooted path has no single flat form worth
+  handing out. Every one has to be looked at: some want a display string,
+  some want a key, some want something to concatenate. These are the real
+  cost, and they are why this is a proposal rather than a patch.
+
+## What was rejected
+
+**Storing the URI string as the holder.** Tempting, since the URI is
+already the serialisation, and it would make the type trivially
+round-trippable. Rejected because it destroys the invariants: any
+`std::string` is then a candidate value, validity can only be checked by
+re-parsing, and every component access costs a parse. `CanonPath`'s value
+is that an instance is *known* canonical; a string-holding type gives that
+up to save a struct.
+
+**A flat string with the root encoded into it.** The minimal change:
+teach `CanonPath` that a leading `/C:/` or `//host/share/` is a root and
+keep everything else. The diff would be small and most of the 949 sites
+would not move. Rejected because it reintroduces exactly the ambiguity the
+root exists to remove -- `/host/share` and `//host/share` differ by one
+character and mean different volumes -- and because `.abs()` would keep
+returning a string whose first segments sometimes are and sometimes are
+not a root, which is the bug being fixed, relocated.
+
+**A variant of roots with no URI story.** This is half of what is
+proposed, and on its own it is defensible: the in-memory shape is what
+fixes the correctness problem, and the serialisation is a separate
+question. Rejected as insufficient rather than wrong, because logical
+paths already get written into lock files, store paths, error messages and
+the C API, and inventing an ad-hoc textual form for those is how you end
+up with several. RFC 8089 supplies one that is already cited in this
+codebase.
+
+## Non-goals
+
+- **Converting the evaluator.** Not attempted. The 128 semantic call sites
+  above are a separate piece of work.
+- **Preserving `\\?\` no-normalisation semantics.** The extended-length
+  prefix tells Win32 *not* to normalise a path, so `\\?\C:\a\..\b` is a
+  literal name rather than `C:\b`. A type whose purpose is canonicalisation
+  cannot preserve that, and this one does not: it normalises `\\?\C:` to
+  `Drive{'C'}` and resolves `..`. A caller needing the literal behaviour
+  must stay at the native layer.
+- **Drive-relative paths.** `C:foo` means "foo, relative to the working
+  directory *on* drive C", which is per-drive mutable process state. The
+  proof of concept does not distinguish it from `C:\foo`. A real
+  implementation must either represent it or reject it; silently treating
+  it as absolute is wrong.
+- **Windows share case semantics.** See the comparison section.
+- **Making `CanonPath` and `LogicalPath` interconvertible in general.**
+  Only a `Posix`-rooted `LogicalPath` has a `CanonPath` equivalent.
+
+## Known limitations of the proof of concept
+
+- A relative path parses to a `Posix` root, so `a/b` and `/a/b` are
+  indistinguishable. `CanonPath` has the same behaviour by design -- it
+  documents that it "does not need an absolute/relative distinction" --
+  but a type that models URIs should probably not inherit it.
+- `parseUri` does its own scheme/authority split rather than using
+  `parseURL`, for the reason above. Two parsers for one syntax is a defect
+  that should not survive into production.
+- Nothing is tested on Windows. Everything below ran natively on Linux,
+  which was a deliberate design choice: the WTF-8 conversion lives in a
+  portable `libutil/wtf8.cc` and `LogicalPath` is platform-independent, so
+  both are testable everywhere. No Wine run was performed, and no claim is
+  made about executed Windows behaviour.
+
+## Verification
+
+Built and run natively on Linux against `origin/master@72385de1b`.
+`src/libutil` configures as a standalone meson subproject, which is how
+this was built without a working `nix develop` on the host.
+
+- `libutil` compiles clean, 78 targets, zero errors.
+- `logical-path` tests: **32 tests, 32 passed, 0 failed.**
+
+Each claim was shown able to fail, by neutering the implementation and
+confirming the expected tests went red:
+
+| Neutered | Red |
+| --- | --- |
+| percent-encoding removed | 3: reserved characters, literal `%`, unpaired surrogate |
+| constructor case folding removed | **0** -- see below |
+| constructor case folding, after adding a direct test | 1: `theConstructorFoldsCaseToo` |
+| `..` resolution removed | 1: `dotAndDotDotAreResolved` |
+
+The zero is the useful row. The two case-folding tests went through
+`parseNative`, which folds in `parseNativeRoot` before the constructor
+ever sees the value, so the constructor's folding was untested and
+removing it changed nothing. The constructor is public, so it does need to
+fold; a test that builds a value directly was added, and the neuter then
+produced the expected red. Without that round the redundancy would have
+shipped as covered.
+
+One more measurement worth recording: an early run reported
+`EXIT=0` while three tests were failing, because the command piped
+through `tail` and the shell reported `tail`'s status. Read the gtest
+totals, never the exit code.

--- a/src/libutil-tests/file-path-impl.cc
+++ b/src/libutil-tests/file-path-impl.cc
@@ -1,0 +1,140 @@
+#include <gtest/gtest.h>
+
+#include "nix/util/file-path-impl.hh"
+
+namespace nix {
+
+using WinChar = WindowsPathTrait<char>;
+
+/* ----------------------------------------------------------------------------
+ * Traditional DOS drives -- behaviour that predates UNC support
+ * --------------------------------------------------------------------------*/
+
+TEST(rootNameLen, driveLetter)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(C:\foo)"), 2u);
+}
+
+TEST(rootNameLen, driveLetterIsCaseInsensitive)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(c:\foo)"), 2u);
+}
+
+TEST(rootNameLen, bareDrive)
+{
+    EXPECT_EQ(WinChar::rootNameLen("C:"), 2u);
+}
+
+TEST(rootNameLen, nonLetterBeforeColonIsNotADrive)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(1:\foo)"), 0u);
+}
+
+TEST(rootNameLen, relativePathHasNoRoot)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(foo\bar)"), 0u);
+}
+
+TEST(rootNameLen, singleSeparatorHasNoRoot)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\foo)"), 0u);
+}
+
+/* ----------------------------------------------------------------------------
+ * UNC shares. All of these returned 0 before, so canonicalisation treated
+ * them as relative and could resolve `..` out of a share.
+ * --------------------------------------------------------------------------*/
+
+TEST(rootNameLen, uncShareWithTrailingPath)
+{
+    /* Root is `\\server\share`, 14 characters; `\dir` is inside it. */
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\server\share\dir)"), 14u);
+}
+
+TEST(rootNameLen, uncShareAlone)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\server\share)"), 14u);
+}
+
+TEST(rootNameLen, uncServerWithoutShareIsEntirelyRoot)
+{
+    /* There is no directory to be relative to, so the whole thing is the
+       root name. A shorter answer would let `..` traverse into a sibling
+       share. */
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\server)"), 8u);
+}
+
+TEST(rootNameLen, uncAcceptsForwardSlashes)
+{
+    /* `isPathSep` accepts both separators, so this must too. */
+    EXPECT_EQ(WinChar::rootNameLen("//server/share/dir"), 14u);
+}
+
+/* ----------------------------------------------------------------------------
+ * Extended-length and device namespaces
+ * --------------------------------------------------------------------------*/
+
+TEST(rootNameLen, extendedLengthDrive)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\?\C:\foo)"), 6u);
+}
+
+TEST(rootNameLen, extendedLengthDriveLowercase)
+{
+    /* `maybePath` accepted only an uppercase drive letter in this position
+       while accepting either case in the plain `C:\` form. */
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\?\c:\foo)"), 6u);
+}
+
+TEST(rootNameLen, deviceNamespaceDrive)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\.\C:\foo)"), 6u);
+}
+
+TEST(rootNameLen, extendedLengthUnc)
+{
+    /* `\\?\UNC\server\share` is 20 characters. */
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\?\UNC\server\share\dir)"), 20u);
+}
+
+TEST(rootNameLen, extendedLengthUncIsCaseInsensitive)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\?\unc\server\share\dir)"), 20u);
+}
+
+TEST(rootNameLen, deviceName)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\.\PhysicalDrive0)"), 18u);
+}
+
+TEST(rootNameLen, deviceNameWithTrailingPath)
+{
+    EXPECT_EQ(WinChar::rootNameLen(R"(\\.\pipe\mypipe)"), 8u);
+}
+
+/* ----------------------------------------------------------------------------
+ * The wide instantiation must agree. Before, `rootNameLen` narrowed the
+ * drive letter to `char` regardless of `CharT`.
+ * --------------------------------------------------------------------------*/
+
+TEST(rootNameLen, wideCharAgreesWithNarrow)
+{
+    using WinWide = WindowsPathTrait<wchar_t>;
+    EXPECT_EQ(WinWide::rootNameLen(LR"(C:\foo)"), 2u);
+    EXPECT_EQ(WinWide::rootNameLen(LR"(\\server\share\dir)"), 14u);
+    EXPECT_EQ(WinWide::rootNameLen(LR"(\\?\C:\foo)"), 6u);
+    EXPECT_EQ(WinWide::rootNameLen(LR"(\\?\UNC\server\share)"), 20u);
+}
+
+/* ----------------------------------------------------------------------------
+ * Unix paths have no root name, on any input
+ * --------------------------------------------------------------------------*/
+
+TEST(rootNameLen, unixTraitIsAlwaysZero)
+{
+    EXPECT_EQ(UnixPathTrait::rootNameLen("/foo/bar"), 0u);
+    EXPECT_EQ(UnixPathTrait::rootNameLen("//server/share"), 0u);
+    EXPECT_EQ(UnixPathTrait::rootNameLen("C:/foo"), 0u);
+}
+
+} // namespace nix

--- a/src/libutil-tests/logical-path.cc
+++ b/src/libutil-tests/logical-path.cc
@@ -1,0 +1,264 @@
+#include <gtest/gtest.h>
+
+#include "nix/util/logical-path.hh"
+#include "nix/util/url.hh"
+#include "nix/util/wtf8.hh"
+
+namespace nix {
+
+/* --- Root recognition ------------------------------------------------- */
+
+TEST(logicalPath, posixAbsolute)
+{
+    auto p = LogicalPath::parseNative("/usr/lib");
+    EXPECT_TRUE(std::holds_alternative<LogicalPath::Posix>(p.root()));
+    EXPECT_EQ(p.components(), (std::vector<std::string>{"usr", "lib"}));
+    EXPECT_EQ(p.toUri(), "file:///usr/lib");
+}
+
+TEST(logicalPath, relativeIsAnchoredToPosixRoot)
+{
+    /* A relative path has no root name, so it lands on `Posix` -- the
+       same collapse `CanonPath` performs, and a known limitation. */
+    auto p = LogicalPath::parseNative("usr/lib");
+    EXPECT_TRUE(std::holds_alternative<LogicalPath::Posix>(p.root()));
+    EXPECT_EQ(p.components(), (std::vector<std::string>{"usr", "lib"}));
+}
+
+TEST(logicalPath, driveLetterUpperAndLowerAgree)
+{
+    auto upper = LogicalPath::parseNative("C:\\foo");
+    auto lower = LogicalPath::parseNative("c:\\foo");
+
+    /* RFC 8089 appendix E.2 states drive-letter comparison is
+       case-insensitive, so these must be one path, not two. */
+    EXPECT_EQ(upper, lower);
+    EXPECT_EQ(upper.toUri(), "file:///C:/foo");
+    EXPECT_EQ(lower.toUri(), "file:///C:/foo");
+}
+
+TEST(logicalPath, theConstructorFoldsCaseToo)
+{
+    /* `parseNative` folds in `parseNativeRoot`, so the two tests above
+       pass without the constructor doing anything. The constructor is
+       public, so it has to fold as well, and only building a value
+       directly reaches that code. */
+    LogicalPath lower{LogicalPath::Drive{'c'}, {"foo"}};
+    LogicalPath upper{LogicalPath::Drive{'C'}, {"foo"}};
+    EXPECT_EQ(lower, upper);
+    EXPECT_EQ(lower.toUri(), "file:///C:/foo");
+
+    LogicalPath mixedHost{LogicalPath::Unc{.host = "HoSt", .share = "s"}, {"f"}};
+    EXPECT_EQ(std::get<LogicalPath::Unc>(mixedHost.root()).host, "host");
+}
+
+TEST(logicalPath, unc)
+{
+    auto p = LogicalPath::parseNative("\\\\host.example.com\\Share\\path\\to\\file.txt");
+    auto * u = std::get_if<LogicalPath::Unc>(&p.root());
+    ASSERT_NE(u, nullptr);
+    EXPECT_EQ(u->host, "host.example.com");
+    EXPECT_EQ(u->share, "Share");
+    EXPECT_EQ(p.components(), (std::vector<std::string>{"path", "to", "file.txt"}));
+
+    /* The mapping given by RFC 8089 appendix E.3.1. */
+    EXPECT_EQ(p.toUri(), "file://host.example.com/Share/path/to/file.txt");
+}
+
+TEST(logicalPath, uncHostIsCaseFolded)
+{
+    EXPECT_EQ(LogicalPath::parseNative("\\\\HOST\\s\\f"), LogicalPath::parseNative("\\\\host\\s\\f"));
+}
+
+TEST(logicalPath, uncShareIsNotCaseFolded)
+{
+    /* RFC 3986 leaves the path case-sensitive even though Windows does
+       not. Folding it here would make two distinct URIs compare equal. */
+    EXPECT_NE(LogicalPath::parseNative("\\\\h\\SHARE\\f"), LogicalPath::parseNative("\\\\h\\share\\f"));
+}
+
+TEST(logicalPath, extendedLengthDriveNormalisesToDrive)
+{
+    /* `\\?\C:` names the same volume as `C:`. */
+    EXPECT_EQ(LogicalPath::parseNative("\\\\?\\C:\\foo"), LogicalPath::parseNative("C:\\foo"));
+}
+
+TEST(logicalPath, extendedLengthUncNormalisesToUnc)
+{
+    EXPECT_EQ(LogicalPath::parseNative("\\\\?\\UNC\\h\\s\\foo"), LogicalPath::parseNative("\\\\h\\s\\foo"));
+}
+
+TEST(logicalPath, deviceGetsItsOwnScheme)
+{
+    auto p = LogicalPath::parseNative("\\\\.\\PhysicalDrive0\\foo");
+    auto * d = std::get_if<LogicalPath::Device>(&p.root());
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(d->name, "PhysicalDrive0");
+
+    /* RFC 8089 states it does not define a mechanism for these, so this
+       must not masquerade as a conformant `file` URI. */
+    EXPECT_EQ(p.toUri(), "nix-win32-device:///PhysicalDrive0/foo");
+}
+
+/* --- Canonicalisation ------------------------------------------------- */
+
+TEST(logicalPath, dotAndDotDotAreResolved)
+{
+    EXPECT_EQ(LogicalPath::parseNative("C:\\a\\.\\b\\..\\c"), LogicalPath::parseNative("C:\\a\\c"));
+}
+
+TEST(logicalPath, dotDotCannotEscapeTheRoot)
+{
+    /* Escaping a share would silently reach a different volume. */
+    EXPECT_EQ(LogicalPath::parseNative("\\\\h\\s\\..\\..\\x"), LogicalPath::parseNative("\\\\h\\s\\x"));
+}
+
+/* --- URI round trips, one per input class ----------------------------- */
+
+struct RoundTrip
+{
+    const char * name;
+    const char * native;
+};
+
+class LogicalPathRoundTrip : public ::testing::TestWithParam<RoundTrip>
+{};
+
+TEST_P(LogicalPathRoundTrip, nativeToUriToNative)
+{
+    auto original = LogicalPath::parseNative(GetParam().native);
+    auto uri = original.toUri();
+    auto back = LogicalPath::parseUri(uri);
+    EXPECT_EQ(back, original) << "via URI " << uri;
+    EXPECT_EQ(back.toUri(), uri);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    inputClasses,
+    LogicalPathRoundTrip,
+    ::testing::Values(
+        RoundTrip{"posixAbsolute", "/usr/lib/x"},
+        RoundTrip{"posixRootOnly", "/"},
+        RoundTrip{"relative", "a/b"},
+        RoundTrip{"driveUpper", "C:\\foo\\bar"},
+        RoundTrip{"driveLower", "c:\\foo\\bar"},
+        RoundTrip{"driveRootOnly", "C:\\"},
+        RoundTrip{"unc", "\\\\host\\share\\a\\b"},
+        RoundTrip{"uncShareOnly", "\\\\host\\share"},
+        RoundTrip{"extendedDrive", "\\\\?\\C:\\foo"},
+        RoundTrip{"extendedUnc", "\\\\?\\UNC\\host\\share\\foo"},
+        RoundTrip{"device", "\\\\.\\PhysicalDrive0\\foo"}),
+    [](const auto & info) { return info.param.name; });
+
+TEST(logicalPath, reservedCharactersSurviveTheRoundTrip)
+{
+    /* Percent-encoding a name that already contains `%` is where a naive
+       implementation loses data: encode must produce `%25`, and decode
+       must not then re-decode it. `#` and `?` would otherwise be read as
+       the start of a fragment or query. */
+    std::vector<std::string> nasty{"100%", "a%2Fb", "has space", "hash#tag", "query?mark", "%", "%%", "%41"};
+
+    for (auto & name : nasty) {
+        LogicalPath p{LogicalPath::Drive{'C'}, {name}};
+        auto uri = p.toUri();
+        auto back = LogicalPath::parseUri(uri);
+        ASSERT_EQ(back.components().size(), 1u) << "name " << name << " via " << uri;
+        EXPECT_EQ(back.components()[0], name) << "via URI " << uri;
+    }
+}
+
+TEST(logicalPath, literalPercentIsEncodedNotPassedThrough)
+{
+    LogicalPath p{LogicalPath::Posix{}, {"100%"}};
+    EXPECT_EQ(p.toUri(), "file:///100%25");
+}
+
+TEST(logicalPath, aSlashInAComponentIsRejected)
+{
+    /* No real file name contains a separator, and allowing one would
+       make `toUri` and `toNative` disagree about how many components
+       there are. */
+    EXPECT_THROW(LogicalPath(LogicalPath::Posix{}, {"a/b"}), BadLogicalPath);
+}
+
+TEST(logicalPath, unpairedSurrogateSurvivesTheRoundTrip)
+{
+    /* An unpaired surrogate is a legal Windows file name and has no
+       UTF-8 encoding, so this is the case RFC 8089 section 4 explicitly
+       leaves out of scope. Percent-encoded WTF-8 carries it. */
+    std::u16string utf16;
+    utf16 += u'a';
+    utf16 += char16_t(0xD800);
+    utf16 += u'b';
+
+    auto name = wtf8FromUtf16(utf16);
+    ASSERT_EQ(name.size(), 5u); /* 'a' + 3 bytes + 'b' */
+
+    LogicalPath p{LogicalPath::Drive{'C'}, {name}};
+    auto uri = p.toUri();
+
+    /* The surrogate's WTF-8 bytes are ED A0 80. */
+    EXPECT_NE(uri.find("%ED%A0%80"), std::string::npos) << "uri " << uri;
+
+    auto back = LogicalPath::parseUri(uri);
+    ASSERT_EQ(back.components().size(), 1u);
+    EXPECT_EQ(back.components()[0], name);
+
+    /* And it is still the same UTF-16 sequence after the trip. */
+    EXPECT_TRUE(utf16FromWtf8(back.components()[0]) == utf16);
+}
+
+/* --- Ordering --------------------------------------------------------- */
+
+TEST(logicalPath, aDirectorySortsImmediatelyBeforeItsChildren)
+{
+    /* `CanonPath::operator<=>` documents this property; byte-wise
+       comparison of the joined form does not have it, because `!` is
+       greater than `/`. */
+    auto foo = LogicalPath::parseNative("/foo");
+    auto fooBar = LogicalPath::parseNative("/foo/bar");
+    auto fooBang = LogicalPath::parseNative("/foo!");
+
+    EXPECT_LT(foo, fooBar);
+    EXPECT_LT(fooBar, fooBang);
+}
+
+TEST(logicalPath, differentVolumesDoNotInterleave)
+{
+    auto c = LogicalPath::parseNative("C:\\z");
+    auto d = LogicalPath::parseNative("D:\\a");
+    EXPECT_LT(c, d);
+}
+
+/* --- Rejections ------------------------------------------------------- */
+
+TEST(logicalPath, aForeignSchemeIsRejected)
+{
+    EXPECT_THROW(LogicalPath::parseUri("https://example.com/a"), BadLogicalPath);
+}
+
+TEST(logicalPath, nulInAComponentIsRejected)
+{
+    EXPECT_THROW(LogicalPath(LogicalPath::Posix{}, {std::string("a\0b", 3)}), BadLogicalPath);
+}
+
+/* --- The upstream blocker this design runs into ----------------------- */
+
+TEST(logicalPath, nixCannotYetParseTheRfc8089UncForm)
+{
+    /* `url.cc:184` rejects any `file` URL with a non-empty host, so the
+       one mapping RFC 8089 appendix E.3.1 gives for a UNC path is not
+       parseable by Nix today. `LogicalPath::parseUri` therefore does its
+       own scheme/authority split.
+
+       This test exists to make the blocker visible and to fail loudly if
+       the restriction is ever lifted, at which point `parseUri` should
+       go back to using `parseURL`. */
+    EXPECT_THROW(parseURL("file://host.example.com/Share/f"), BadURL);
+
+    /* Whereas the same path does round-trip through this type. */
+    auto p = LogicalPath::parseNative("\\\\host.example.com\\Share\\f");
+    EXPECT_EQ(LogicalPath::parseUri(p.toUri()), p);
+}
+
+} // namespace nix

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -85,6 +85,7 @@ sources = files(
   'topo-sort.cc',
   'url.cc',
   'util.cc',
+  'wtf8.cc',
   'xml-writer.cc',
 )
 

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -63,6 +63,7 @@ sources = files(
   'json-utils.cc',
   'local-keys.cc',
   'logging.cc',
+  'logical-path.cc',
   'lru-cache.cc',
   'main.cc',
   'memo.cc',

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -53,6 +53,7 @@ sources = files(
   'executable-path.cc',
   'file-content-address.cc',
   'file-descriptor.cc',
+  'file-path-impl.cc',
   'file-system-at.cc',
   'file-system.cc',
   'fun.cc',

--- a/src/libutil-tests/wtf8.cc
+++ b/src/libutil-tests/wtf8.cc
@@ -1,0 +1,174 @@
+#include <gtest/gtest.h>
+
+#include "nix/util/wtf8.hh"
+
+namespace nix {
+
+/* ----------------------------------------------------------------------------
+ * Round trips
+ * --------------------------------------------------------------------------*/
+
+TEST(wtf8, asciiRoundTrips)
+{
+    std::u16string in = u"C:\\Users\\test\\file.txt";
+    EXPECT_EQ(wtf8FromUtf16(in), "C:\\Users\\test\\file.txt");
+    EXPECT_EQ(utf16FromWtf8(wtf8FromUtf16(in)), in);
+}
+
+TEST(wtf8, emptyRoundTrips)
+{
+    EXPECT_EQ(wtf8FromUtf16(u""), "");
+    EXPECT_EQ(utf16FromWtf8(""), u"");
+}
+
+TEST(wtf8, twoAndThreeByteCodePointsRoundTrip)
+{
+    /* U+00E9 (2 bytes) and U+65E5 (3 bytes). */
+    std::u16string in = u"caf\u00e9 \u65e5";
+    auto encoded = wtf8FromUtf16(in);
+    EXPECT_EQ(encoded, "caf\xc3\xa9 \xe6\x97\xa5");
+    EXPECT_EQ(utf16FromWtf8(encoded), in);
+}
+
+TEST(wtf8, supplementaryCodePointUsesFourBytesNotTwoSurrogates)
+{
+    /* U+1F600 arrives as a surrogate pair in UTF-16. A valid pair must be
+       combined into the four-byte form, otherwise WTF-8 would not be a
+       superset of UTF-8 for well-formed input. */
+    std::u16string in = {0xD83D, 0xDE00};
+    auto encoded = wtf8FromUtf16(in);
+    EXPECT_EQ(encoded, "\xf0\x9f\x98\x80");
+    EXPECT_EQ(encoded.size(), 4u);
+    EXPECT_EQ(utf16FromWtf8(encoded), in);
+}
+
+/* ----------------------------------------------------------------------------
+ * Unpaired surrogates: the entire reason this exists
+ * --------------------------------------------------------------------------*/
+
+TEST(wtf8, unpairedHighSurrogateRoundTrips)
+{
+    /* A file named with a lone high surrogate is creatable on NTFS. The
+       previous `codecvt_utf8_utf16` conversion threw `std::range_error`
+       here, so such a name could not be handled at all. */
+    std::u16string in = {u'a', 0xD800, u'b'};
+    auto encoded = wtf8FromUtf16(in);
+    EXPECT_EQ(utf16FromWtf8(encoded), in);
+}
+
+TEST(wtf8, unpairedLowSurrogateRoundTrips)
+{
+    std::u16string in = {u'a', 0xDC00, u'b'};
+    EXPECT_EQ(utf16FromWtf8(wtf8FromUtf16(in)), in);
+}
+
+TEST(wtf8, unpairedSurrogateAtEndRoundTrips)
+{
+    /* A high surrogate with nothing after it exercises the bounds check in
+       the pairing test rather than the pairing itself. */
+    std::u16string in = {u'x', 0xD800};
+    EXPECT_EQ(utf16FromWtf8(wtf8FromUtf16(in)), in);
+}
+
+TEST(wtf8, highSurrogateFollowedByNonLowSurrogateRoundTrips)
+{
+    /* Two high surrogates in a row are both unpaired. Combining them would
+       silently invent a code point. */
+    std::u16string in = {0xD800, 0xD801};
+    auto encoded = wtf8FromUtf16(in);
+    EXPECT_EQ(encoded.size(), 6u);
+    EXPECT_EQ(utf16FromWtf8(encoded), in);
+}
+
+TEST(wtf8, surrogateEncodesAsItsOwnThreeByteSequence)
+{
+    std::u16string in = {0xD800};
+    EXPECT_EQ(wtf8FromUtf16(in), "\xed\xa0\x80");
+}
+
+TEST(wtf8, everySurrogateValueRoundTrips)
+{
+    /* Exhaustive over the surrogate range, so no single value can be
+       mishandled unnoticed. The counter is `unsigned` rather than
+       `char16_t` both to avoid wrapping at the top of the range and
+       because `operator<<(std::ostream &, char16_t)` is deleted, so a
+       `char16_t` cannot be streamed into a failure message. */
+    for (unsigned u = 0xD800; u <= 0xDFFF; ++u) {
+        std::u16string in = {static_cast<char16_t>(u)};
+        EXPECT_EQ(utf16FromWtf8(wtf8FromUtf16(in)), in) << "failed at U+" << std::hex << u;
+    }
+}
+
+/* ----------------------------------------------------------------------------
+ * Malformed input is replaced, never accepted as the value it spells
+ * --------------------------------------------------------------------------*/
+
+/* Counts below follow the maximal-subpart convention: a malformed sequence
+   costs one replacement character for the byte that could not begin or
+   continue a valid sequence, and the bytes after it are then examined on
+   their own terms rather than being swallowed. All were measured. */
+
+TEST(wtf8, overlongTwoByteEncodingIsRejected)
+{
+    /* C0 80 spells U+0000 in two bytes. Accepting it would let a caller
+       smuggle a NUL past a check that inspected the bytes. C0 cannot begin
+       any valid sequence, so it and the orphaned 80 each yield U+FFFD. */
+    auto decoded = utf16FromWtf8("\xc0\x80");
+    EXPECT_NE(decoded, std::u16string(1, u'\0'));
+    EXPECT_EQ(decoded, std::u16string({0xFFFD, 0xFFFD}));
+}
+
+TEST(wtf8, overlongThreeByteEncodingIsRejected)
+{
+    /* E0 80 AF spells '/' in three bytes. Same hazard, separator edition:
+       a path check that ran on the bytes would not see a separator here. */
+    auto decoded = utf16FromWtf8("\xe0\x80\xaf");
+    EXPECT_EQ(decoded, std::u16string({0xFFFD, 0xFFFD, 0xFFFD}));
+    EXPECT_EQ(decoded.find(u'/'), std::u16string::npos);
+}
+
+TEST(wtf8, truncatedSequenceIsReplaced)
+{
+    EXPECT_EQ(utf16FromWtf8("\xe6\x97"), std::u16string({0xFFFD, 0xFFFD}));
+}
+
+TEST(wtf8, strayContinuationByteIsReplaced)
+{
+    EXPECT_EQ(utf16FromWtf8("\x80"), std::u16string({0xFFFD}));
+}
+
+TEST(wtf8, invalidLeadByteIsReplaced)
+{
+    /* F7 cannot begin a valid sequence at all; in strict UTF-8 it would
+       spell U+1FFFFF, past U+10FFFF. */
+    EXPECT_EQ(utf16FromWtf8("\xf7\xbf\xbf\xbf"), std::u16string({0xFFFD, 0xFFFD, 0xFFFD, 0xFFFD}));
+}
+
+TEST(wtf8, fourByteSequenceAboveMaxCodePointIsRejected)
+{
+    /* F4 90 80 80 spells U+110000. F4 is a legal lead, so this is caught by
+       the restriction on its second byte rather than by the lead itself. */
+    EXPECT_EQ(utf16FromWtf8("\xf4\x90\x80\x80"), std::u16string({0xFFFD, 0xFFFD, 0xFFFD, 0xFFFD}));
+}
+
+TEST(wtf8, surrogateThreeByteSequenceIsAcceptedNotReplaced)
+{
+    /* ED A0 80 is rejected by a strict UTF-8 decoder and must be accepted
+       here. This is the decoder's one intentional divergence from UTF-8,
+       and the reason the whole file exists. */
+    EXPECT_EQ(utf16FromWtf8("\xed\xa0\x80"), std::u16string({0xD800}));
+}
+
+TEST(wtf8, decodingAlwaysTerminates)
+{
+    /* Every byte value as a one-byte input. The guarantee under test is
+       that the decoder consumes at least one byte per iteration; a decoder
+       that did not would hang rather than fail. */
+    for (int b = 0; b < 256; ++b) {
+        std::string in(1, static_cast<char>(b));
+        auto out = utf16FromWtf8(in);
+        EXPECT_FALSE(out.empty()) << "byte " << b << " produced nothing";
+    }
+}
+
+} // namespace nix

--- a/src/libutil/include/nix/util/file-path-impl.hh
+++ b/src/libutil/include/nix/util/file-path-impl.hh
@@ -89,16 +89,68 @@ struct WindowsPathTrait
         return p1 == String::npos ? p2 : p2 == String::npos ? p1 : std::max(p1, p2);
     }
 
+    static inline bool isDriveLetter(CharT c)
+    {
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+    }
+
+    /**
+     * Given `from` positioned just past a UNC prefix, return the offset one
+     * past the share name in `\\server\share...`.
+     *
+     * A UNC path naming a server but no share has no directory to be
+     * relative to, so all of what is present is the root name. Reporting
+     * anything shorter would let canonicalisation treat `\\server` as a
+     * directory and resolve `..` through it into a different share.
+     */
+    static size_t uncRootEnd(StringView path, size_t from)
+    {
+        size_t afterServer = findPathSep(path, from);
+        if (afterServer == StringView::npos)
+            return path.size();
+        size_t afterShare = findPathSep(path, afterServer + 1);
+        return afterShare == StringView::npos ? path.size() : afterShare;
+    }
+
+    /**
+     * Length of the root name: the leading portion that names a volume and
+     * is not itself a directory anything can be relative to.
+     *
+     * Covers the forms documented at
+     * https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+     * -- traditional DOS drives, UNC shares, and the extended-length and
+     * device namespaces, including `\\?\UNC\`.
+     */
     static size_t rootNameLen(StringView path)
     {
-        if (path.size() >= 2 && path[1] == ':') {
-            char driveLetter = path[0];
-            if ((driveLetter >= 'A' && driveLetter <= 'Z') || (driveLetter >= 'a' && driveLetter <= 'z'))
-                return 2;
+        /* `X:` -- traditional DOS drive. */
+        if (path.size() >= 2 && path[1] == ':' && isDriveLetter(path[0]))
+            return 2;
+
+        /* Everything remaining begins with two separators. `//` is accepted
+           alongside `\\`, consistent with `isPathSep` and the rest of this
+           trait. */
+        if (!(path.size() >= 3 && isPathSep(path[0]) && isPathSep(path[1])))
+            return 0;
+
+        /* `\\?\` (extended-length) and `\\.\` (device) namespaces. */
+        if ((path[2] == '?' || path[2] == '.') && path.size() >= 4 && isPathSep(path[3])) {
+            /* `\\?\X:` */
+            if (path.size() >= 6 && path[5] == ':' && isDriveLetter(path[4]))
+                return 6;
+
+            /* `\\?\UNC\server\share`. The literal is case-insensitive. */
+            if (path.size() >= 8 && (path[4] == 'U' || path[4] == 'u') && (path[5] == 'N' || path[5] == 'n')
+                && (path[6] == 'C' || path[6] == 'c') && isPathSep(path[7]))
+                return uncRootEnd(path, 8);
+
+            /* A device name, which runs to the next separator. */
+            size_t end = findPathSep(path, 4);
+            return end == StringView::npos ? path.size() : end;
         }
-        /* TODO: This needs to also handle UNC paths.
-         * https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths */
-        return 0;
+
+        /* `\\server\share` */
+        return uncRootEnd(path, 2);
     }
 };
 

--- a/src/libutil/include/nix/util/logical-path.hh
+++ b/src/libutil/include/nix/util/logical-path.hh
@@ -1,0 +1,173 @@
+#pragma once
+/**
+ * @file
+ *
+ * Proof of concept for a logical path holder that can represent a Windows
+ * root. Not wired into anything; see `doc/uri-logical-paths.md`.
+ *
+ * `CanonPath` holds one flat `std::string` and has no notion of a root
+ * name, so every path it holds is anchored to a single virtual `/`. That
+ * is deliberate -- `canon-path.cc` canonicalises through
+ * `canonPathInner<UnixPathTrait>`, whose `rootNameLen` returns 0 -- but it
+ * means a drive-relative or UNC path cannot be held without first being
+ * flattened into something else.
+ *
+ * `LogicalPath` separates the two things `CanonPath` conflates: what the
+ * path is anchored to, and the components below it. The external form is
+ * a `file` URI per RFC 8089, which is the only standard that describes
+ * how a Windows root maps onto a hierarchical name.
+ */
+
+#include <compare>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+#include "nix/util/error.hh"
+
+namespace nix {
+
+MakeError(BadLogicalPath, Error);
+
+/**
+ * A path anchored to an explicit root, with its components held
+ * separately rather than joined.
+ *
+ * Invariants, all established by the constructors and preserved by every
+ * mutator:
+ *
+ * - No component is empty, `.`, or `..`.
+ * - No component contains a NUL byte or a `/`.
+ * - Components are WTF-8, so a name that is not well-formed UTF-16
+ *   survives (see `wtf8.hh`).
+ * - A `Drive` letter is upper case, and a `Unc` host is lower case, so
+ *   that `operator==` implements the case-insensitivity those two
+ *   comparisons actually have.
+ */
+class LogicalPath
+{
+public:
+
+    /**
+     * The POSIX root, `/`. Also the root of Nix's own virtual file
+     * systems, which is what `CanonPath` can already represent.
+     */
+    struct Posix
+    {
+        std::strong_ordering operator<=>(const Posix &) const = default;
+        bool operator==(const Posix &) const = default;
+    };
+
+    /** A traditional DOS drive, `C:`. Held upper case. */
+    struct Drive
+    {
+        char letter;
+
+        std::strong_ordering operator<=>(const Drive &) const = default;
+        bool operator==(const Drive &) const = default;
+    };
+
+    /**
+     * A UNC share, `\\host\share`.
+     *
+     * `host` is held lower case because RFC 3986 section 3.2.2 makes the
+     * authority case-insensitive. `share` is not folded, because it is a
+     * path segment and RFC 3986 leaves the path case-sensitive -- even
+     * though Windows itself compares it case-insensitively.
+     */
+    struct Unc
+    {
+        std::string host;
+        std::string share;
+
+        std::strong_ordering operator<=>(const Unc &) const = default;
+        bool operator==(const Unc &) const = default;
+    };
+
+    /**
+     * A Win32 device name, `\\.\PhysicalDrive0` or
+     * `\\?\Volume{...}`.
+     *
+     * RFC 8089 states it "does not define a mechanism" for these, so this
+     * root has no conformant `file` URI and renders under a Nix-specific
+     * scheme instead. Note that the *extended-length* prefixes `\\?\C:`
+     * and `\\?\UNC\host\share` are not this -- they name the same volumes
+     * as `C:` and `\\host\share` and are normalised to `Drive` and `Unc`.
+     */
+    struct Device
+    {
+        std::string name;
+
+        std::strong_ordering operator<=>(const Device &) const = default;
+        bool operator==(const Device &) const = default;
+    };
+
+    using Root = std::variant<Posix, Drive, Unc, Device>;
+
+    /** The scheme used for `Device`, which RFC 8089 cannot express. */
+    static constexpr std::string_view deviceScheme = "nix-win32-device";
+
+    LogicalPath() = default;
+
+    /**
+     * @throws BadLogicalPath if any component violates an invariant.
+     */
+    LogicalPath(Root root, std::vector<std::string> components);
+
+    /**
+     * Parse a native path, resolving `.` and `..` and recognising every
+     * root form `WindowsPathTrait::rootNameLen` does.
+     *
+     * A path with no root name is taken as `Posix`, which is what a
+     * relative path and a POSIX absolute path both become. This is a
+     * proof of concept, so it does not distinguish drive-relative
+     * (`C:foo`, relative to that drive's working directory) from
+     * drive-absolute (`C:\foo`); see the design document.
+     */
+    static LogicalPath parseNative(std::string_view path);
+
+    /** Render the native form, using `\` for the Windows roots. */
+    std::string toNative() const;
+
+    /**
+     * Render as a URI. `Posix`, `Drive` and `Unc` produce a `file` URI
+     * per RFC 8089; `Device` produces `deviceScheme`.
+     *
+     * Each component is percent-encoded from its WTF-8 bytes, so `%`,
+     * `#`, `?`, space and a lone surrogate all survive the round trip.
+     */
+    std::string toUri() const;
+
+    /**
+     * @throws BadLogicalPath on a scheme that is not `file` or
+     * `deviceScheme`, or on an authority a `file` URI may not carry.
+     */
+    static LogicalPath parseUri(std::string_view uri);
+
+    const Root & root() const
+    {
+        return root_;
+    }
+
+    const std::vector<std::string> & components() const
+    {
+        return components_;
+    }
+
+    bool operator==(const LogicalPath & other) const = default;
+
+    /**
+     * Orders a directory immediately before its children, matching
+     * `CanonPath::operator<=>`. The root sorts before the components so
+     * that paths on different volumes never interleave.
+     */
+    std::strong_ordering operator<=>(const LogicalPath & other) const;
+
+private:
+
+    Root root_;
+    std::vector<std::string> components_;
+};
+
+} // namespace nix

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -60,6 +60,7 @@ headers = [ config_pub_h ] + files(
   'json-utils.hh',
   'library-versions.hh',
   'logging.hh',
+  'logical-path.hh',
   'lru-cache.hh',
   'memo.hh',
   'memory-source-accessor.hh',

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -103,5 +103,6 @@ headers = [ config_pub_h ] + files(
   'users.hh',
   'util.hh',
   'variant-wrapper.hh',
+  'wtf8.hh',
   'xml-writer.hh',
 )

--- a/src/libutil/include/nix/util/os-string.hh
+++ b/src/libutil/include/nix/util/os-string.hh
@@ -50,6 +50,22 @@ using OsStringMap = std::map<OsString, OsString, std::less<>>;
  */
 using OsStrings = std::list<OsString>;
 
+/**
+ * Convert between the native path encoding and an 8-bit one.
+ *
+ * On Unix both are the same arbitrary byte string and these are the
+ * identity. On Windows the 8-bit form is WTF-8, not strict UTF-8, because a
+ * Windows file name is an arbitrary sequence of 16-bit code units and may
+ * contain an unpaired surrogate that UTF-8 cannot represent. WTF-8 encodes
+ * those, so every name round-trips.
+ *
+ * Neither direction throws. They previously went through
+ * `std::codecvt_utf8_utf16`, which raised `std::range_error` on an unpaired
+ * surrogate -- so a file with such a name could not be named at all, and the
+ * failure surfaced far from the conversion.
+ *
+ * @see nix/util/wtf8.hh
+ */
 std::string os_string_to_string(OsStringView s);
 std::string os_string_to_string(OsString s);
 

--- a/src/libutil/include/nix/util/wtf8.hh
+++ b/src/libutil/include/nix/util/wtf8.hh
@@ -1,0 +1,56 @@
+#pragma once
+/**
+ * @file
+ *
+ * Conversion between UTF-16 code-unit sequences and WTF-8.
+ *
+ * Windows file names are sequences of 16-bit code units with no validity
+ * requirement: an unpaired surrogate is a legal name component, and such
+ * files can be created. UTF-8 cannot represent one, so a strict UTF-8
+ * conversion has to either fail or corrupt the name.
+ *
+ * WTF-8 is UTF-8 extended to encode unpaired surrogates as their own
+ * three-byte sequences, while still combining valid surrogate pairs into
+ * the four-byte form for the supplementary code point they denote. That
+ * makes `utf16FromWtf8(wtf8FromUtf16(s)) == s` for every `s`, including
+ * names no UTF-8 encoder accepts.
+ *
+ * Both directions are total: neither throws, and neither has a failure
+ * mode a caller must handle. Byte sequences that are not valid WTF-8 are
+ * decoded to U+FFFD rather than rejected, so a caller cannot be handed a
+ * path that silently lost content.
+ *
+ * These live here, rather than beside the Windows-only string conversion
+ * that uses them, so that they are compiled and tested on every platform.
+ *
+ * @see https://simonsapin.github.io/wtf-8/
+ */
+
+#include <string>
+#include <string_view>
+
+namespace nix {
+
+/**
+ * Encode a UTF-16 code-unit sequence as WTF-8.
+ *
+ * Valid surrogate pairs become the four-byte encoding of the code point
+ * they denote. Every other code unit, unpaired surrogates included, is
+ * encoded on its own.
+ */
+std::string wtf8FromUtf16(std::u16string_view s);
+
+/**
+ * Decode WTF-8 into a UTF-16 code-unit sequence.
+ *
+ * Three-byte sequences denoting surrogates are restored as the unpaired
+ * surrogates they came from. Code points above the basic multilingual
+ * plane become surrogate pairs.
+ *
+ * Input that is not valid WTF-8 -- a truncated sequence, a stray
+ * continuation byte, an overlong encoding, or a value above U+10FFFF --
+ * yields U+FFFD for the offending byte or sequence.
+ */
+std::u16string utf16FromWtf8(std::string_view s);
+
+} // namespace nix

--- a/src/libutil/logical-path.cc
+++ b/src/libutil/logical-path.cc
@@ -1,0 +1,318 @@
+#include "nix/util/logical-path.hh"
+
+#include <algorithm>
+#include <cstring>
+
+#include "nix/util/file-path-impl.hh"
+#include "nix/util/strings-inline.hh"
+#include "nix/util/url.hh"
+#include "nix/util/util.hh"
+
+namespace nix {
+
+void BadLogicalPath::anchor() {}
+
+namespace {
+
+using Trait = WindowsPathTrait<char>;
+
+char toUpperAscii(char c)
+{
+    return (c >= 'a' && c <= 'z') ? char(c - 'a' + 'A') : c;
+}
+
+std::string toLowerAscii(std::string_view s)
+{
+    std::string out{s};
+    for (auto & c : out)
+        if (c >= 'A' && c <= 'Z')
+            c = char(c - 'A' + 'a');
+    return out;
+}
+
+bool isDriveSpec(std::string_view s)
+{
+    return s.size() == 2 && s[1] == ':' && Trait::isDriveLetter(s[0]);
+}
+
+/** Split on either separator, dropping empties. */
+std::vector<std::string> splitOnSeps(std::string_view s)
+{
+    std::vector<std::string> out;
+    size_t i = 0;
+    while (i < s.size()) {
+        while (i < s.size() && Trait::isPathSep(s[i]))
+            ++i;
+        if (i >= s.size())
+            break;
+        size_t end = Trait::findPathSep(s, i);
+        if (end == std::string_view::npos)
+            end = s.size();
+        out.emplace_back(s.substr(i, end - i));
+        i = end;
+    }
+    return out;
+}
+
+/** Resolve `.` and `..` over already-split components. */
+std::vector<std::string> resolveDotDot(const std::vector<std::string> & in)
+{
+    std::vector<std::string> out;
+    for (auto & c : in) {
+        if (c == ".")
+            continue;
+        if (c == "..") {
+            /* At the root, `..` is the root -- the same choice
+               `canonPathInner` makes, and the same one POSIX makes for
+               `/..`. */
+            if (!out.empty())
+                out.pop_back();
+            continue;
+        }
+        out.push_back(c);
+    }
+    return out;
+}
+
+/**
+ * Interpret the leading `rootNameLen` bytes of a native path.
+ *
+ * The extended-length prefixes are normalised away: `\\?\C:` names the
+ * same volume as `C:`, and `\\?\UNC\h\s` the same share as `\\h\s`. What
+ * they additionally mean -- that Win32 must not normalise the path -- is
+ * not representable here and is discussed in the design document.
+ */
+LogicalPath::Root parseNativeRoot(std::string_view root)
+{
+    /* `X:` */
+    if (isDriveSpec(root))
+        return LogicalPath::Drive{toUpperAscii(root[0])};
+
+    /* Everything else starts with two separators. */
+    if (!(root.size() >= 3 && Trait::isPathSep(root[0]) && Trait::isPathSep(root[1])))
+        throw BadLogicalPath("unrecognised path root '%s'", root);
+
+    bool extended = (root[2] == '?' || root[2] == '.') && root.size() >= 4 && Trait::isPathSep(root[3]);
+
+    if (extended) {
+        auto after = root.substr(4);
+
+        /* `\\?\X:` */
+        if (isDriveSpec(after))
+            return LogicalPath::Drive{toUpperAscii(after[0])};
+
+        /* `\\?\UNC\host\share`, the literal being case-insensitive. */
+        if (after.size() >= 4 && toUpperAscii(after[0]) == 'U' && toUpperAscii(after[1]) == 'N'
+            && toUpperAscii(after[2]) == 'C' && Trait::isPathSep(after[3])) {
+            auto parts = splitOnSeps(after.substr(4));
+            return LogicalPath::Unc{
+                .host = parts.empty() ? "" : toLowerAscii(parts[0]),
+                .share = parts.size() > 1 ? parts[1] : "",
+            };
+        }
+
+        /* A device name, which `rootNameLen` ran to the next separator. */
+        return LogicalPath::Device{std::string{after}};
+    }
+
+    /* `\\host\share` */
+    auto parts = splitOnSeps(root.substr(2));
+    return LogicalPath::Unc{
+        .host = parts.empty() ? "" : toLowerAscii(parts[0]),
+        .share = parts.size() > 1 ? parts[1] : "",
+    };
+}
+
+/** Rank the root alternatives so ordering is stable across volumes. */
+int rootRank(const LogicalPath::Root & r)
+{
+    return int(r.index());
+}
+
+} // namespace
+
+LogicalPath::LogicalPath(Root root, std::vector<std::string> components)
+    : root_(std::move(root))
+    , components_(std::move(components))
+{
+    for (auto & c : components_) {
+        if (c.empty())
+            throw BadLogicalPath("path component must not be empty");
+        if (c == "." || c == "..")
+            throw BadLogicalPath("path component '%s' is not allowed", c);
+        if (c.find('/') != std::string::npos)
+            throw BadLogicalPath("path component '%s' must not contain '/'", c);
+        if (std::memchr(c.data(), '\0', c.size()))
+            throw BadLogicalPath("path component must not contain a NUL byte");
+    }
+    /* Also fold here, not only in `parseNativeRoot`: this constructor is
+       public, so a caller can hand us `Drive{'c'}` or a mixed-case host
+       directly and must get the same canonical form. */
+    /* Also fold here, not only in `parseNativeRoot`: this constructor is
+       public, so a caller can hand us `Drive{'c'}` or a mixed-case host
+       directly and must get the same canonical form. */
+    if (auto * d = std::get_if<Drive>(&root_))
+        d->letter = toUpperAscii(d->letter);
+    if (auto * u = std::get_if<Unc>(&root_))
+        u->host = toLowerAscii(u->host);
+}
+
+LogicalPath LogicalPath::parseNative(std::string_view path)
+{
+    Root root = Posix{};
+    std::string_view rest = path;
+
+    if (auto rootLen = Trait::rootNameLen(path)) {
+        root = parseNativeRoot(path.substr(0, rootLen));
+        rest = path.substr(rootLen);
+    }
+
+    return LogicalPath{std::move(root), resolveDotDot(splitOnSeps(rest))};
+}
+
+std::string LogicalPath::toNative() const
+{
+    std::string res = std::visit(
+        overloaded{
+            [](const Posix &) -> std::string { return "/"; },
+            [](const Drive & d) -> std::string { return std::string{d.letter} + ":\\"; },
+            [](const Unc & u) -> std::string { return "\\\\" + u.host + "\\" + u.share + "\\"; },
+            [](const Device & d) -> std::string { return "\\\\?\\" + d.name + "\\"; },
+        },
+        root_);
+
+    for (size_t i = 0; i < components_.size(); ++i) {
+        if (i)
+            res += std::holds_alternative<Posix>(root_) ? '/' : '\\';
+        res += components_[i];
+    }
+
+    /* A root with no components keeps its trailing separator; one with
+       components must not have gained a duplicate. */
+    if (!components_.empty() && res.size() > 1) {
+        /* nothing to trim: the loop only inserts between components */
+    }
+    return res;
+}
+
+std::string LogicalPath::toUri() const
+{
+    /* `:` is legal unencoded in a path segment (RFC 3986 section 3.3),
+       which is what lets the drive render as `C:` rather than `C%3A`.
+       Everything else outside the unreserved set is encoded, including
+       `/`, `%`, `#`, `?` and space. */
+    static const std::string keepInSegment = ":@";
+
+    std::string res;
+    std::vector<std::string> segments;
+
+    std::visit(
+        overloaded{
+            [&](const Posix &) { res = "file://"; },
+            [&](const Drive & d) {
+                res = "file://";
+                segments.push_back(std::string{d.letter} + ":");
+            },
+            [&](const Unc & u) {
+                res = "file://" + percentEncode(u.host);
+                segments.push_back(u.share);
+            },
+            [&](const Device & d) {
+                res = std::string{deviceScheme} + "://";
+                segments.push_back(d.name);
+            },
+        },
+        root_);
+
+    for (auto & c : components_)
+        segments.push_back(c);
+
+    for (auto & s : segments) {
+        res += '/';
+        res += percentEncode(s, keepInSegment);
+    }
+
+    /* A rootless-looking `file://` with no segments is `file:///`. */
+    if (segments.empty())
+        res += '/';
+
+    return res;
+}
+
+LogicalPath LogicalPath::parseUri(std::string_view uri)
+{
+    /* This deliberately does not call `parseURL`.
+       `url.cc:184` rejects any `file` URL carrying a non-empty host, so
+       the RFC 8089 appendix E.3.1 form `file://host/share/...` -- the
+       only standard mapping for a UNC path -- cannot be parsed by it.
+       Two tests assert that rejection (`libutil-tests/url.cc:390` and
+       `:676`), so relaxing it is a decision for the Nix maintainers
+       rather than something this proof of concept should assume. See the
+       design document.
+
+       The percent-encoding primitives from `url.hh` are still used; only
+       the scheme/authority split is done here. */
+    auto sep = uri.find("://");
+    if (sep == std::string_view::npos)
+        throw BadLogicalPath("URI '%s' has no '://'", uri);
+
+    auto scheme = uri.substr(0, sep);
+    auto rest = uri.substr(sep + 3);
+
+    bool isFile = scheme == "file";
+    bool isDevice = scheme == deviceScheme;
+    if (!isFile && !isDevice)
+        throw BadLogicalPath("URI '%s' has scheme '%s', expected 'file' or '%s'", uri, scheme, deviceScheme);
+
+    auto slash = rest.find('/');
+    auto encodedAuthority = rest.substr(0, slash);
+    auto encodedPath = slash == std::string_view::npos ? std::string_view{} : rest.substr(slash);
+
+    std::vector<std::string> segments;
+    for (auto & s : splitString<std::vector<std::string>>(std::string{encodedPath}, "/"))
+        if (!s.empty())
+            segments.push_back(percentDecode(s));
+
+    auto shift = [&]() -> std::string {
+        if (segments.empty())
+            throw BadLogicalPath("URI '%s' is missing a path segment its root requires", uri);
+        auto s = std::move(segments.front());
+        segments.erase(segments.begin());
+        return s;
+    };
+
+    Root root = Posix{};
+
+    if (isDevice) {
+        root = Device{shift()};
+    } else if (!encodedAuthority.empty()) {
+        root = Unc{
+            .host = toLowerAscii(percentDecode(encodedAuthority)),
+            .share = shift(),
+        };
+    } else if (!segments.empty() && isDriveSpec(segments.front())) {
+        root = Drive{toUpperAscii(shift()[0])};
+    }
+
+    return LogicalPath{std::move(root), resolveDotDot(segments)};
+}
+
+std::strong_ordering LogicalPath::operator<=>(const LogicalPath & other) const
+{
+    if (auto cmp = rootRank(root_) <=> rootRank(other.root_); cmp != 0)
+        return cmp;
+    if (auto cmp = root_ <=> other.root_; cmp != 0)
+        return cmp;
+
+    /* Component-wise, so that a directory precedes its children and two
+       volumes never interleave. Comparing the joined strings would not
+       give this: `foo` < `foo!` < `foo/bar` byte-wise, but `foo/bar` must
+       sort directly after `foo`. */
+    auto n = std::min(components_.size(), other.components_.size());
+    for (size_t i = 0; i < n; ++i)
+        if (auto cmp = components_[i] <=> other.components_[i]; cmp != 0)
+            return cmp;
+    return components_.size() <=> other.components_.size();
+}
+
+} // namespace nix

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -209,6 +209,7 @@ sources = [ config_priv_h ] + files(
   'url.cc',
   'users.cc',
   'util.cc',
+  'wtf8.cc',
   'xml-writer.cc',
 )
 

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -181,6 +181,7 @@ sources = [ config_priv_h ] + files(
   'json-utils.cc',
   'library-versions.cc',
   'logging.cc',
+  'logical-path.cc',
   'memory-source-accessor.cc',
   'memory-source-accessor/json.cc',
   'mounted-source-accessor.cc',

--- a/src/libutil/windows/file-path.cc
+++ b/src/libutil/windows/file-path.cc
@@ -1,40 +1,80 @@
 #include <algorithm>
-#include <codecvt>
-#include <iostream>
-#include <locale>
 
+#include "nix/util/error.hh"
 #include "nix/util/file-path.hh"
 #include "nix/util/file-path-impl.hh"
+#include "nix/util/os-string.hh"
 #include "nix/util/util.hh"
 
 namespace nix {
 
+namespace {
+
+using Trait = WindowsPathTrait<OsChar>;
+
+/**
+ * The `\\?\` prefix turns off Win32 path normalisation, so forward slashes
+ * are no longer translated on our behalf and have to be replaced here.
+ */
+std::filesystem::path::string_type useBackslashes(std::filesystem::path::string_type s)
+{
+    std::replace(s.begin(), s.end(), L'/', L'\\');
+    return s;
+}
+
+/** Is this already in the `\\?\` or `\\.\` namespace? */
+bool hasNamespacePrefix(PathView path)
+{
+    return path.size() >= 4 && Trait::isPathSep(path[0]) && Trait::isPathSep(path[1])
+           && (path[2] == '?' || path[2] == '.') && Trait::isPathSep(path[3]);
+}
+
+} // namespace
+
 std::optional<std::filesystem::path> maybePath(PathView path)
 {
-    if (path.length() >= 3 && (('A' <= path[0] && path[0] <= 'Z') || ('a' <= path[0] && path[0] <= 'z'))
-        && path[1] == ':' && WindowsPathTrait<char>::isPathSep(path[2])) {
-        std::filesystem::path::string_type sw = std::wstring{L"\\\\?\\"} + std::wstring{path};
-        std::replace(sw.begin(), sw.end(), '/', '\\');
-        return sw;
+    /* Already prefixed, so pass it through rather than double-prefixing.
+       Accepts either case of drive letter and `UNC\` spelling, which the
+       previous implementation did not: it required an uppercase letter here
+       while accepting either case in the plain `C:\` form. */
+    if (hasNamespacePrefix(path))
+        return useBackslashes(std::filesystem::path::string_type{path});
+
+    size_t rootLen = Trait::rootNameLen(path);
+    if (rootLen == 0)
+        return std::nullopt;
+
+    /* `X:\...`. A drive-relative path such as `C:foo` names a different
+       file depending on the process's per-drive working directory, which
+       these APIs have no way to honour, so it is rejected rather than
+       silently resolved against the wrong directory. */
+    if (rootLen == 2) {
+        if (path.size() >= 3 && Trait::isPathSep(path[2]))
+            return useBackslashes(
+                std::filesystem::path::string_type{L"\\\\?\\"} + std::filesystem::path::string_type{path});
+        return std::nullopt;
     }
-    if (path.length() >= 7 && path[0] == '\\' && path[1] == '\\' && (path[2] == '.' || path[2] == '?')
-        && path[3] == '\\' && ('A' <= path[4] && path[4] <= 'Z') && path[5] == ':'
-        && WindowsPathTrait<char>::isPathSep(path[6])) {
-        std::filesystem::path::string_type sw{path};
-        std::replace(sw.begin(), sw.end(), '/', '\\');
-        return sw;
-    }
-    return std::optional<std::filesystem::path::string_type>();
+
+    /* `\\server\share\...` becomes `\\?\UNC\server\share\...`: the two
+       leading separators are replaced by the prefix rather than kept. */
+    if (Trait::isPathSep(path[0]) && Trait::isPathSep(path[1]))
+        return useBackslashes(
+            std::filesystem::path::string_type{L"\\\\?\\UNC\\"} + std::filesystem::path::string_type{path.substr(2)});
+
+    return std::nullopt;
 }
 
 std::filesystem::path toOwnedPath(PathView path)
 {
-    std::optional<std::filesystem::path::string_type> sw = maybePath(path);
-    if (!sw) {
-        // FIXME why are we not using the regular error handling?
-        std::wcerr << L"invalid path for WinAPI call [" << path << L"]" << std::endl;
-        _exit(111);
-    }
+    auto sw = maybePath(path);
+    if (!sw)
+        /* Previously this printed to `wcerr` and called `_exit(111)`, which
+           took the process down with no unwinding, no error handler, and no
+           way for a caller to report which operation failed. */
+        throw Error(
+            "path '%s' cannot be used in a Win32 API call: it needs to be absolute, naming either a drive "
+            "(`C:\\...`), a UNC share (`\\\\server\\share\\...`), or an already-prefixed path (`\\\\?\\...`)",
+            os_string_to_string(path));
     return *sw;
 }
 

--- a/src/libutil/windows/os-string.cc
+++ b/src/libutil/windows/os-string.cc
@@ -1,17 +1,26 @@
 #include <algorithm>
-#include <codecvt>
 #include <iostream>
-#include <locale>
 
 #include "nix/util/os-string.hh"
 #include "nix/util/strings-inline.hh"
+#include "nix/util/wtf8.hh"
 
 namespace nix {
 
+#ifdef _WIN32
+/* Windows file names are arbitrary 16-bit code units, so `wchar_t` has to be
+   exactly that wide for the conversions below to be lossless. Guarded because
+   `wchar_t` is 32 bits on Linux, where this file is not built. */
+static_assert(sizeof(wchar_t) == 2, "Windows paths are UTF-16; wchar_t must be 16 bits");
+#endif
+
 std::string os_string_to_string(OsStringView s)
 {
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    return converter.to_bytes(s.data(), s.data() + s.size());
+    /* `wchar_t` and `char16_t` are distinct types with the same
+       representation here, so this copy is a reinterpretation without the
+       aliasing question a cast would raise. */
+    std::u16string units(s.begin(), s.end());
+    return wtf8FromUtf16(units);
 }
 
 std::string os_string_to_string(OsString s)
@@ -21,8 +30,8 @@ std::string os_string_to_string(OsString s)
 
 OsString string_to_os_string(std::string_view s)
 {
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    return converter.from_bytes(s.data(), s.data() + s.size());
+    auto units = utf16FromWtf8(s);
+    return OsString(units.begin(), units.end());
 }
 
 OsString string_to_os_string(std::string s)

--- a/src/libutil/wtf8.cc
+++ b/src/libutil/wtf8.cc
@@ -1,0 +1,187 @@
+#include <cstdint>
+
+#include "nix/util/wtf8.hh"
+
+namespace nix {
+
+namespace {
+
+constexpr char16_t highSurrogateFirst = 0xD800;
+constexpr char16_t highSurrogateLast = 0xDBFF;
+constexpr char16_t lowSurrogateFirst = 0xDC00;
+constexpr char16_t lowSurrogateLast = 0xDFFF;
+
+constexpr uint32_t maxCodePoint = 0x10FFFF;
+constexpr char16_t replacementChar = 0xFFFD;
+
+bool isHighSurrogate(char16_t c)
+{
+    return c >= highSurrogateFirst && c <= highSurrogateLast;
+}
+
+bool isLowSurrogate(char16_t c)
+{
+    return c >= lowSurrogateFirst && c <= lowSurrogateLast;
+}
+
+/**
+ * Append the UTF-8-style encoding of `cp`.
+ *
+ * Unlike a UTF-8 encoder this accepts surrogate values, which is the one
+ * way WTF-8 differs on the encoding side.
+ */
+void encodeCodePoint(std::string & out, uint32_t cp)
+{
+    if (cp < 0x80) {
+        out += static_cast<char>(cp);
+    } else if (cp < 0x800) {
+        out += static_cast<char>(0xC0 | (cp >> 6));
+        out += static_cast<char>(0x80 | (cp & 0x3F));
+    } else if (cp < 0x10000) {
+        out += static_cast<char>(0xE0 | (cp >> 12));
+        out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+        out += static_cast<char>(0x80 | (cp & 0x3F));
+    } else {
+        out += static_cast<char>(0xF0 | (cp >> 18));
+        out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+        out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+        out += static_cast<char>(0x80 | (cp & 0x3F));
+    }
+}
+
+} // namespace
+
+std::string wtf8FromUtf16(std::u16string_view s)
+{
+    std::string out;
+    /* Most path characters are ASCII, so this is usually exact. */
+    out.reserve(s.size());
+
+    for (size_t i = 0; i < s.size(); ++i) {
+        char16_t c = s[i];
+        if (isHighSurrogate(c) && i + 1 < s.size() && isLowSurrogate(s[i + 1])) {
+            /* A valid pair denotes one supplementary code point, and is
+               encoded as that code point rather than as two surrogates.
+               This is what keeps WTF-8 a superset of UTF-8 for names that
+               happen to be well formed. */
+            uint32_t cp = 0x10000 + ((static_cast<uint32_t>(c) - highSurrogateFirst) << 10)
+                          + (static_cast<uint32_t>(s[i + 1]) - lowSurrogateFirst);
+            encodeCodePoint(out, cp);
+            ++i;
+        } else {
+            /* Everything else, unpaired surrogates included. Encoding one
+               is the entire reason this function exists: a strict UTF-8
+               encoder rejects it, and rejecting it means being unable to
+               name a file that exists. */
+            encodeCodePoint(out, c);
+        }
+    }
+
+    return out;
+}
+
+std::u16string utf16FromWtf8(std::string_view s)
+{
+    std::u16string out;
+    out.reserve(s.size());
+
+    size_t i = 0;
+    while (i < s.size()) {
+        uint8_t b = static_cast<uint8_t>(s[i]);
+        uint32_t cp;
+        size_t len;
+
+        /* The range the *second* byte is restricted to. Constraining it,
+           rather than range-checking the assembled code point afterwards,
+           is what makes an overlong encoding unrepresentable instead of
+           merely detected. That matters because accepting one would let a
+           caller smuggle a separator or a NUL past a check that inspected
+           the bytes. */
+        uint8_t secondLo = 0x80;
+        uint8_t secondHi = 0xBF;
+
+        if (b < 0x80) {
+            cp = b;
+            len = 1;
+        } else if (b >= 0xC2 && b <= 0xDF) {
+            /* 0xC0 and 0xC1 are excluded: they can only ever begin an
+               overlong two-byte form of an ASCII character. */
+            cp = b & 0x1F;
+            len = 2;
+        } else if (b >= 0xE0 && b <= 0xEF) {
+            cp = b & 0x0F;
+            len = 3;
+            if (b == 0xE0)
+                secondLo = 0xA0;
+            /* 0xED is deliberately left alone. Strict UTF-8 restricts it to
+               0x80-0x9F to exclude surrogates; WTF-8 encodes surrogates, so
+               the full range is legal here. This is the one place the
+               decoder is intentionally more permissive than UTF-8. */
+        } else if (b >= 0xF0 && b <= 0xF4) {
+            cp = b & 0x07;
+            len = 4;
+            if (b == 0xF0)
+                secondLo = 0x90;
+            if (b == 0xF4)
+                secondHi = 0x8F; /* else the result would exceed U+10FFFF */
+        } else {
+            /* A stray continuation byte (0x80-0xBF), an overlong lead
+               (0xC0, 0xC1), or a lead that cannot begin any valid sequence
+               (0xF5-0xFF). */
+            out += replacementChar;
+            ++i;
+            continue;
+        }
+
+        /* Validate the whole sequence before consuming any of it, so that a
+           malformed one costs a single byte and the bytes after it get
+           examined on their own terms rather than being swallowed. */
+        bool wellFormed = true;
+        for (size_t k = 1; k < len; ++k) {
+            if (i + k >= s.size()) {
+                wellFormed = false;
+                break;
+            }
+            uint8_t c = static_cast<uint8_t>(s[i + k]);
+            uint8_t lo = k == 1 ? secondLo : 0x80;
+            uint8_t hi = k == 1 ? secondHi : 0xBF;
+            if (c < lo || c > hi) {
+                wellFormed = false;
+                break;
+            }
+        }
+
+        if (!wellFormed) {
+            /* Exactly one byte, so progress is guaranteed and the decoder
+               cannot loop. */
+            out += replacementChar;
+            ++i;
+            continue;
+        }
+
+        for (size_t k = 1; k < len; ++k)
+            cp = (cp << 6) | (static_cast<uint8_t>(s[i + k]) & 0x3F);
+        i += len;
+
+        /* Unreachable given the byte ranges above; kept as an assertion of
+           the invariant rather than as live error handling. */
+        if (cp > maxCodePoint) {
+            out += replacementChar;
+            continue;
+        }
+
+        if (cp < 0x10000) {
+            /* Includes the surrogate range, which is how an unpaired
+               surrogate survives the round trip. */
+            out += static_cast<char16_t>(cp);
+        } else {
+            cp -= 0x10000;
+            out += static_cast<char16_t>(highSurrogateFirst + (cp >> 10));
+            out += static_cast<char16_t>(lowSurrogateFirst + (cp & 0x3FF));
+        }
+    }
+
+    return out;
+}
+
+} // namespace nix


### PR DESCRIPTION
## Motivation

`CanonPath`, the type the evaluator funnels every path through, cannot hold a Windows root.
`canon-path.cc:16` calls `canonPathInner<UnixPathTrait>`, whose `rootNameLen` returns 0
unconditionally, and `file-path-impl.hh:16` states the intent: "Nix's own 'logical' paths are always
Unix-style." A UNC path reaching the evaluator collapses into one relative component.

## Proposal

A variant over four roots (POSIX, drive, UNC, Win32-device) plus components held as WTF-8 bytes, with
the URI as serialization rather than in-memory representation. RFC 8089 supplies the mapping: E.3.1
for UNC, E.2 for drive letters, E.4 for backslashes; RFC 3986 supplies percent-encoding and segment
rules. Nix already cites RFC 8089 at `url.hh:82` and in a TODO at `url.cc:682`, and `boost::urls` is
already a dependency, so this is not a new standard but finishing something already written down.

Two gaps stated rather than hidden: section 4 puts non-UTF-8 explicitly out of scope, so
percent-encoded WTF-8 is a nix extension; and Appendix E is titled "Nonstandard Syntax Variations",
so it is informative rather than normative.

## Evidence and cost

32 round-trip tests pass over all root forms plus literal `%`, `%%`, `%41`, `a%2Fb`, space, `#`, `?`
and an unpaired surrogate. 303 constructor calls are mechanical; 128 `.abs()`/`.rel()` calls are
semantic and are the real cost.

## What blocks it

`url.cc:185` rejects any `file` URL with a non-empty host, so E.3.1 is unparseable today, and two
tests assert that rejection on purpose. Left untouched; it needs a maintainer's decision, and
`file://www.example.org` being a useful catch for a mistyped `https://` is the crux.

A cross-fork PR's base has to be a branch in NixOS/nix, so this cannot stack on #16451: the bottom
two commits here are #16451's.
