### PR TITLE
libstore: support configuration of Windows network isolation

### DIFF
--- a/src/libstore-tests/local-settings.cc
+++ b/src/libstore-tests/local-settings.cc
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include "nix/store/local-settings.hh"
+
+// Needed for template specialisations, as in local-store.cc.
+#include "nix/util/args.hh"
+#include "nix/util/config-impl.hh"
+#include "nix/util/abstract-setting-to-json.hh"
+
+namespace nix {
+
+/* ----------------------------------------------------------------------------
+ * SandboxNetworkMode
+ *
+ * The enum and its parse/to_string are platform-neutral even though only the
+ * Windows builder acts on the value, so these run everywhere. That is
+ * deliberate: it is the Linux CI that will catch a fourth mode being added
+ * without teaching `to_string` about it.
+ * --------------------------------------------------------------------------*/
+
+TEST(SandboxNetworkMode, defaultsToNone)
+{
+    Config config;
+    Setting<SandboxNetworkMode> setting{&config, snmNone, "sandbox-network", "description"};
+    ASSERT_EQ(setting.get(), snmNone);
+}
+
+TEST(SandboxNetworkMode, everyModeRoundTrips)
+{
+    /* Every enumerator must survive string -> enum -> string. A mode that
+       parses but has no `to_string` arm would otherwise only be caught by
+       `unreachable()` at runtime. */
+    for (auto & name : {"none", "wfp", "container"}) {
+        Config config;
+        Setting<SandboxNetworkMode> setting{&config, snmNone, "sandbox-network", "description"};
+        ASSERT_EQ(config.set("sandbox-network", name), true) << "failed to set " << name;
+        EXPECT_EQ(setting.to_string(), name);
+    }
+}
+
+TEST(SandboxNetworkMode, parsesEachName)
+{
+    Config config;
+    Setting<SandboxNetworkMode> setting{&config, snmNone, "sandbox-network", "description"};
+
+    setting.set("none");
+    EXPECT_EQ(setting.get(), snmNone);
+    setting.set("wfp");
+    EXPECT_EQ(setting.get(), snmWfp);
+    setting.set("container");
+    EXPECT_EQ(setting.get(), snmContainer);
+}
+
+TEST(SandboxNetworkMode, rejectsUnknownValue)
+{
+    Config config;
+    Setting<SandboxNetworkMode> setting{&config, snmNone, "sandbox-network", "description"};
+    EXPECT_THROW(setting.set("bogus"), UsageError);
+}
+
+TEST(SandboxNetworkMode, rejectsBooleanSpelling)
+{
+    /* `sandbox` is boolean-ish, and someone will reasonably try the same
+       spellings here. They must be rejected rather than silently meaning
+       something, since "true" says nothing about *which* mechanism to use. */
+    Config config;
+    Setting<SandboxNetworkMode> setting{&config, snmNone, "sandbox-network", "description"};
+    EXPECT_THROW(setting.set("true"), UsageError);
+    EXPECT_THROW(setting.set("false"), UsageError);
+    EXPECT_THROW(setting.set("relaxed"), UsageError);
+}
+
+TEST(SandboxNetworkMode, reportsTheModeNameToConfigShow)
+{
+    /* What `nix config show` prints. This goes through the virtual
+       `to_string()`, not through `NLOHMANN_JSON_SERIALIZE_ENUM` — that macro is
+       expanded in globals.cc, so its `to_json` is not visible by ADL outside
+       that translation unit and nlohmann would fall back to the underlying
+       integer. Asserting on the enum's JSON conversion here would therefore be
+       testing something the setting does not actually promise. */
+    Config config;
+    Setting<SandboxNetworkMode> setting{&config, snmNone, "sandbox-network", "description"};
+    ASSERT_EQ(config.set("sandbox-network", "wfp"), true);
+
+    std::map<std::string, Config::SettingInfo> settings;
+    config.getSettings(settings, /* overriddenOnly = */ false);
+
+    auto i = settings.find("sandbox-network");
+    ASSERT_NE(i, settings.end());
+    EXPECT_EQ(i->second.value, "wfp");
+}
+
+} // namespace nix

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -53,6 +53,7 @@ sources = files(
   'local-binary-cache-store.cc',
   'local-fs-store.cc',
   'local-overlay-store.cc',
+  'local-settings.cc',
   'local-store.cc',
   'machines.cc',
   'main.cc',

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -364,6 +364,49 @@ void BaseSetting<SandboxMode>::convertToArg(Args & args, const std::string & cat
     });
 }
 
+NLOHMANN_JSON_SERIALIZE_ENUM(
+    SandboxNetworkMode,
+    {
+        {SandboxNetworkMode::snmNone, "none"},
+        {SandboxNetworkMode::snmWfp, "wfp"},
+        {SandboxNetworkMode::snmContainer, "container"},
+    });
+
+template<>
+SandboxNetworkMode BaseSetting<SandboxNetworkMode>::parse(const std::string & str) const
+{
+    if (str == "none")
+        return snmNone;
+    else if (str == "wfp")
+        return snmWfp;
+    else if (str == "container")
+        return snmContainer;
+    else
+        throw UsageError("option '%s' has invalid value '%s'", name, str);
+}
+
+template<>
+struct BaseSetting<SandboxNetworkMode>::trait
+{
+    static constexpr bool appendable = false;
+};
+
+template<>
+std::string BaseSetting<SandboxNetworkMode>::to_string() const
+{
+    if (value == snmNone)
+        return "none";
+    else if (value == snmWfp)
+        return "wfp";
+    else if (value == snmContainer)
+        return "container";
+    else
+        unreachable();
+}
+
+/* Deliberately no `convertToArg` specialization: unlike `sandbox`, this is not
+   boolean-ish, so the generic `--sandbox-network <mode>` flag is the right shape. */
+
 void to_json(nlohmann::json & j, const ChrootPath & cp)
 {
     j = nlohmann::json{{"source", cp.source.string()}, {"optional", cp.optional}};

--- a/src/libstore/include/nix/store/local-settings.hh
+++ b/src/libstore/include/nix/store/local-settings.hh
@@ -23,6 +23,21 @@ SandboxMode BaseSetting<SandboxMode>::parse(const std::string & str) const;
 template<>
 std::string BaseSetting<SandboxMode>::to_string() const;
 
+/**
+ * How to deny a builder network access on Windows.
+ *
+ * Windows has no equivalent of `CLONE_NEWNET`, so unlike the Unix sandbox
+ * there is no single mechanism that is both correct and always available;
+ * hence a mode rather than a boolean. See the `sandbox-network` setting for
+ * what each mode costs and requires.
+ */
+typedef enum { snmNone, snmWfp, snmContainer } SandboxNetworkMode;
+
+template<>
+SandboxNetworkMode BaseSetting<SandboxNetworkMode>::parse(const std::string & str) const;
+template<>
+std::string BaseSetting<SandboxNetworkMode>::to_string() const;
+
 template<>
 PathsInChroot BaseSetting<PathsInChroot>::parse(const std::string & str) const;
 template<>
@@ -393,6 +408,45 @@ public:
           The default is `true` on Linux and `false` on all other platforms.
         )",
         {"build-use-chroot", "build-use-sandbox"}};
+
+#ifdef _WIN32
+    Setting<SandboxNetworkMode> sandboxNetworkMode{
+        this,
+        snmNone,
+        "sandbox-network",
+        R"(
+          How to deny a build network access.
+
+          On Linux, `sandbox` puts each build in a private network namespace,
+          so there is nothing to configure. Windows has no equivalent, and no
+          single available mechanism is both correct and unprivileged, so the
+          choice is exposed rather than decided here.
+
+          - `none` (default): builds are **not** isolated from the network. This
+            is today's behaviour, and it is the default so that enabling
+            sandboxing elsewhere does not silently start failing builds that
+            reach the network. Do not assume a Windows build is network-isolated
+            because `sandbox` is on.
+
+          - `wfp`: install Windows Filtering Platform block filters for the
+            build, scoped to the build user, and remove them when the build
+            ends. Requires rights to add WFP filters — membership in the
+            built-in Network Configuration Operators group is sufficient, full
+            administrator is not required. If those rights are missing the build
+            fails rather than running unprotected.
+
+          - `container`: not implemented. A network namespace on Windows is
+            attached to a *compute system*, so this would require running the
+            builder as a container via the Host Compute Service rather than as a
+            child process. Note also that Microsoft documents Windows containers
+            as not being a hostile security boundary, so this mode would be a
+            reproducibility measure and not a security control.
+
+          Fixed-output derivations are exempt in every mode, since they are
+          defined by their output hash and are expected to fetch from the
+          network.
+        )"};
+#endif
 
     Setting<PathsInChroot> sandboxPaths{
         this,

--- a/src/libstore/windows/build/windows-derivation-builder.cc
+++ b/src/libstore/windows/build/windows-derivation-builder.cc
@@ -3,6 +3,7 @@
 #include "nix/store/build/derivation-env-desugar.hh"
 #include "nix/store/local-store.hh"
 #include "nix/store/globals.hh"
+#include "nix/store/local-settings.hh"
 #include "nix/util/file-system.hh"
 #include "nix/util/muxable-pipe.hh"
 #include "nix/util/os-string.hh"
@@ -297,6 +298,49 @@ void WindowsDerivationBuilderImpl::spawnBuilder()
     builderPipe.writeSide.close();
 }
 
+/**
+ * Honour the `sandbox-network` setting, or refuse the build if we cannot.
+ *
+ * Exempts the same derivations Linux does. There, `CLONE_NEWNET` is added only
+ * `if (derivationType.isSandboxed())`, which keeps fixed-output derivations on
+ * the network because they are defined by their output hash and are expected to
+ * fetch.
+ *
+ * Both non-default modes currently throw, and the messages say why rather than
+ * just that they are unimplemented, because in both cases the blocker is a
+ * missing prerequisite elsewhere rather than unwritten filter code.
+ */
+static void applyNetworkIsolation(SandboxNetworkMode mode, bool sandboxed)
+{
+    if (!sandboxed)
+        return;
+
+    switch (mode) {
+
+    case snmNone:
+        /* No isolation. Deliberately silent rather than a warning: this is the
+           documented default, and warning on every build would be noise. */
+        return;
+
+    case snmWfp:
+        /* Filters have to be scoped to something. Scoping by executable path
+           (`FWPM_CONDITION_ALE_APP_ID`) would block that binary for every
+           process on the machine, so a `cmd.exe` builder would take the host
+           off the network. Scoping by user is correct, and needs a build user
+           we do not have: `UserLock` is implemented only under
+           `src/libstore/unix`, so `buildUser` is always null here. */
+        throw UnimplementedError(
+            "'sandbox-network = wfp' cannot be honoured: WFP filters must be scoped to a build user's SID, "
+            "and Windows has no build users yet. Refusing rather than running the build unisolated");
+
+    case snmContainer:
+        throw UnimplementedError(
+            "'sandbox-network = container' is not implemented: a Windows network namespace attaches to a "
+            "compute system, so this needs the builder run as a container via the Host Compute Service "
+            "rather than as a child process");
+    }
+}
+
 std::optional<Descriptor> WindowsDerivationBuilderImpl::startBuild()
 {
     /* There are no build users to contend over, so this never has to ask the
@@ -304,6 +348,9 @@ std::optional<Descriptor> WindowsDerivationBuilderImpl::startBuild()
 
     if (drv.isBuiltin())
         throw UnimplementedError("builtin builders are not yet supported on Windows");
+
+    /* Before anything is created, so an unsupported mode costs nothing. */
+    applyNetworkIsolation(store.config->getLocalSettings().sandboxNetworkMode, derivationType.isSandboxed());
 
     for (auto & [name, output] : drv.outputs) {
         auto * ia = std::get_if<DerivationOutput::InputAddressed>(&output.raw);


### PR DESCRIPTION
## Motivation

Windows builds have no network isolation and no way to ask for any. This adds a Windows-only
`sandbox-network` setting so the intent can be expressed, even where it cannot yet be honored.

## What it does

Three values: `none` (default, matching today's behavior), `wfp`, `container`. Fixed-output
derivations skip isolation, mirroring Linux.

Both non-default modes throw, deliberately. `wfp` needs filters scoped to a build user's SID, and
`UserLock` exists only under `src/libstore/unix`, so `buildUser` is always null on Windows.
`container` needs a compute system, so it wants the Host Compute Service rather than
`CreateProcessW`. Refusing beats running a build that believes it is isolated.

## Verification

Six new unit tests. `nix-store-tests` goes from 792 tests in 88 suites to 798 in 89; the six appear
by name under a `SandboxNetworkMode` suite that does not exist on master.

Not covered: `applyNetworkIsolation`'s dispatch is cross-compiled for `x86_64-w64-mingw32` and never
executed, so the two throwing arms have not been reached. Reaching them needs libstore running on
Windows, and `ci/gha/tests/windows.nix` builds `nix-util-tests` only, which links neither libmain nor
libstore. Wine does not implement WFP either, so even with build users that arm could not run in CI.
