### PR TITLE
libutil: fix startProgram Linux definition and descriptor handling

### DIFF
--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -127,7 +127,7 @@ bool SSHMaster::isMasterRunning()
     return res.first == 0;
 }
 
-Strings createSSHEnv()
+StringMap createSSHEnvMap()
 {
     // Copy the environment and set SHELL=/bin/sh
     StringMap env = getEnv();
@@ -140,8 +140,13 @@ Strings createSSHEnv()
     // solved; refer to the development history of nixExePath in libstore/globals.cc.
     env.insert_or_assign("SHELL", "/bin/sh");
 
+    return env;
+}
+
+Strings createSSHEnv()
+{
     Strings r;
-    for (auto & [k, v] : env) {
+    for (auto & [k, v] : createSSHEnvMap()) {
         r.push_back(k + "=" + v);
     }
 
@@ -246,33 +251,33 @@ std::filesystem::path SSHMaster::startMaster()
     Pipe out;
     out.create();
 
-    ProcessOptions options;
-    options.dieWithParent = false;
-
     auto suspension = logger->suspend();
 
     if (isMasterRunning())
         return state->socketPath;
 
-    state->sshMaster = startProcess(
-        [&]() {
-            restoreProcessContext();
+    /* `startProgram` supplies argv[0] from `program`, so this is everything
+       after it. */
+    OsStrings args = {hostnameAndUser.c_str(), "-M", "-N", "-S", state->socketPath.string()};
+    if (verbosity >= lvlChatty)
+        args.push_back("-v");
+    addCommonSSHOpts(args);
 
-            close(out.readSide.get());
-
-            if (dup2(out.writeSide.get(), STDOUT_FILENO) == -1)
-                throw SysError("duping over stdout");
-
-            OsStrings args = {"ssh", hostnameAndUser.c_str(), "-M", "-N", "-S", state->socketPath.string()};
-            if (verbosity >= lvlChatty)
-                args.push_back("-v");
-            addCommonSSHOpts(args);
-            auto env = createSSHEnv();
-            nix::execvpe(args.begin()->c_str(), stringsToCharPtrs(args).data(), stringsToCharPtrs(env).data());
-
-            throw SysError("unable to execute '%s'", args.front());
+    /* Everything the old `startProcess` child did is now declared rather than
+       run by hand: `restoreProcessContext()` is what `startProgram`'s own child
+       already does, `close(out.readSide)` is subsumed by its descriptor sweep,
+       and the stdout dup is `standardOutFd`. */
+    state->sshMaster = startProgram(
+        RunOptions{
+            .program = "ssh",
+            .args = std::move(args),
+            .environment = createSSHEnvMap(),
+            .standardOutFd = out.writeSide.get(),
+            /* The control master deliberately outlives the process that starts
+               it; that is the entire point of `-M -N`. */
+            .dieWithParent = false,
         },
-        options);
+        nullptr);
 
     out.writeSide = INVALID_DESCRIPTOR;
 

--- a/src/libutil-tests/main.cc
+++ b/src/libutil-tests/main.cc
@@ -7,6 +7,7 @@
 #include <ranges>
 #include <cstdlib>
 #include <cerrno>
+#include <filesystem>
 
 #ifndef _WIN32
 #  include <unistd.h>
@@ -17,6 +18,56 @@ static int spawnTrivialMain()
     std::cout << "hello";
     return EXIT_SUCCESS;
 }
+
+/**
+ * Exit with the status given as the next argument, so a test can assert on
+ * `ExecError::status` rather than only on the fact that something threw.
+ */
+static int spawnExitCodeMain(int argc, char ** argv)
+{
+    return argc > 2 ? std::atoi(argv[2]) : EXIT_SUCCESS;
+}
+
+/**
+ * Write distinguishable text to each of stdout and stderr, so a test can tell
+ * whether `mergeStderrToStdout` actually merged them.
+ */
+static int spawnStreamsMain()
+{
+    std::cout << "out:" << std::flush;
+    std::cerr << "err:" << std::flush;
+    return EXIT_SUCCESS;
+}
+
+/**
+ * Print the value of the environment variable named by the next argument, or
+ * `<unset>`. Distinguishes "environment was replaced" from "environment was
+ * inherited", which `RunOptions::environment` promises.
+ */
+static int spawnPrintEnvMain(int argc, char ** argv)
+{
+    auto value = nix::getEnv(argc > 2 ? argv[2] : "");
+    std::cout << value.value_or("<unset>");
+    return EXIT_SUCCESS;
+}
+
+/** Print the working directory, to observe `RunOptions::chdir`. */
+static int spawnPrintCwdMain()
+{
+    std::cout << std::filesystem::current_path().string();
+    return EXIT_SUCCESS;
+}
+
+#ifndef _WIN32
+
+/** Print `argv[0]`, to observe `RunOptions::argv0` (which is Unix-only). */
+static int spawnPrintArgv0Main(char ** argv)
+{
+    std::cout << argv[0];
+    return EXIT_SUCCESS;
+}
+
+#endif
 
 #ifndef _WIN32
 
@@ -52,6 +103,18 @@ int main(int argc, char ** argv)
 
         if (argv1 == "__util_test_spawn_trivial") {
             return spawnTrivialMain();
+        } else if (argv1 == "__util_test_spawn_exit_code") {
+            return spawnExitCodeMain(argc, argv);
+        } else if (argv1 == "__util_test_spawn_streams") {
+            return spawnStreamsMain();
+        } else if (argv1 == "__util_test_spawn_print_env") {
+            return spawnPrintEnvMain(argc, argv);
+        } else if (argv1 == "__util_test_spawn_print_cwd") {
+            return spawnPrintCwdMain();
+        } else if (argv1 == "__util_test_spawn_print_argv0") {
+#ifndef _WIN32
+            return spawnPrintArgv0Main(argv);
+#endif
         } else if (argv1 == "__util_test_spawn_leaked_fds") {
 #ifndef _WIN32
             return spawnTestForLeakedFDsMain();

--- a/src/libutil-tests/main.cc
+++ b/src/libutil-tests/main.cc
@@ -95,6 +95,46 @@ static int spawnTestForLeakedFDsMain()
 
 #endif
 
+#ifndef _WIN32
+
+/**
+ * Write to each descriptor named in `NIX_CHILD_WRITE_FDS` (as `fd:text`
+ * pairs) and confirm every descriptor named in `NIX_CHILD_FDS_SHOULD_BE_CLOSED`
+ * is closed.
+ *
+ * This is the observation point for `RunOptions::Redirection`. Both halves
+ * matter: the writes prove the redirection survived until `exec`, and the
+ * closed-check proves exempting the targets did not accidentally leak the
+ * sources or anything else above stderr.
+ */
+static int spawnRedirectionsMain()
+{
+    for (const auto & pair :
+         nix::splitString<std::vector<std::string>>(nix::getEnv("NIX_CHILD_WRITE_FDS").value_or(""), ",")) {
+        if (pair.empty())
+            continue;
+        auto colon = pair.find(':');
+        if (colon == std::string::npos)
+            return EXIT_FAILURE;
+        int fd = std::stoi(pair.substr(0, colon));
+        auto text = pair.substr(colon + 1);
+        if (::write(fd, text.data(), text.size()) != static_cast<ssize_t>(text.size()))
+            return EXIT_FAILURE;
+    }
+
+    for (const auto & s :
+         nix::splitString<std::vector<std::string>>(nix::getEnv("NIX_CHILD_FDS_SHOULD_BE_CLOSED").value_or(""), ",")) {
+        if (s.empty())
+            continue;
+        if (::close(std::stoi(s)) != -1 || errno != EBADF)
+            return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+#endif
+
 int main(int argc, char ** argv)
 {
     /* This will get re-execed into from libutil-tests/processes.cc. */
@@ -118,6 +158,10 @@ int main(int argc, char ** argv)
         } else if (argv1 == "__util_test_spawn_leaked_fds") {
 #ifndef _WIN32
             return spawnTestForLeakedFDsMain();
+#endif
+        } else if (argv1 == "__util_test_spawn_redirections") {
+#ifndef _WIN32
+            return spawnRedirectionsMain();
 #endif
         }
     }

--- a/src/libutil-tests/processes.cc
+++ b/src/libutil-tests/processes.cc
@@ -1,6 +1,8 @@
 #include "nix/util/processes.hh"
 #include "nix/util/current-process.hh"
 #include "nix/util/environment-variables.hh"
+#include "nix/util/file-descriptor.hh"
+#include "nix/util/serialise.hh"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -381,6 +383,55 @@ TEST(startProgram, rejectsSourceThatIsAnotherTarget)
             runProgram2({
                 .program = "/nonexistent",
                 .redirections = {{.sourceFd = 30, .targetFd = 7}, {.sourceFd = 7, .targetFd = 8}},
+            });
+        },
+        UsageError);
+}
+
+TEST(startProgram, standardOutFdReceivesStdout)
+{
+    /* `standardOut` collects stdout into a `Sink`. A caller that already owns
+       the write end of a pipe wants the descriptor wired directly instead, and
+       `Redirection` refuses to express it because `targetFd` may not be a
+       standard stream. Without `standardOutFd` such a caller has to drop back
+       to `startProcess` and a hand-written `dup2`, which is what
+       `SSHMaster::startMaster` did. */
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    Pipe out;
+    out.create();
+
+    Pid pid = startProgram(
+        RunOptions{
+            .program = *self,
+            .lookupPath = false,
+            .args = {OS_STR("__util_test_spawn_trivial")},
+            .standardOutFd = out.writeSide.get(),
+        },
+        nullptr);
+
+    /* Drop our copy, or the read below never sees EOF. */
+    out.writeSide.close();
+
+    StringSink sink;
+    drainFD(out.readSide.get(), sink);
+
+    ASSERT_EQ(sink.s, "hello");
+    ASSERT_TRUE(statusOk(pid.wait()));
+}
+
+TEST(startProgram, rejectsBothStandardOutAndStandardOutFd)
+{
+    /* The child has one stdout, and the two options disagree about who owns
+       it. Honouring either silently would discard the other's intent. */
+    StringSink sink;
+    ASSERT_THROW(
+        {
+            runProgram2({
+                .program = "/nonexistent",
+                .standardOut = &sink,
+                .standardOutFd = STDOUT_FILENO + 30,
             });
         },
         UsageError);

--- a/src/libutil-tests/processes.cc
+++ b/src/libutil-tests/processes.cc
@@ -303,7 +303,7 @@ TEST(runProgram2, redirectionsReachTheChild)
         .lookupPath = false,
         .args = {OS_STR("__util_test_spawn_redirections")},
         .environment = OsStringMap{{OS_STR("NIX_CHILD_WRITE_FDS"), OS_STR("4:alpha,5:beta")}},
-        .redirections = {{.from = aWrite.get(), .to = 4}, {.from = bWrite.get(), .to = 5}},
+        .redirections = {{.sourceFd = aWrite.get(), .targetFd = 4}, {.sourceFd = bWrite.get(), .targetFd = 5}},
     }));
 
     /* Drop our own write ends, or the reads below would not see EOF. */
@@ -328,16 +328,22 @@ TEST(runProgram2, redirectionsDoNotKeepUnrelatedFDsOpen)
     auto self = getSelfExe();
     ASSERT_TRUE(self);
 
-    int a[2];
+    int a[2], b[2];
     ASSERT_NE(::pipe(a), -1);
+    ASSERT_NE(::pipe(b), -1);
     AutoCloseFD aRead = a[0], aWrite = relocateHigh(AutoCloseFD{a[1]}, 30);
+    AutoCloseFD bRead = b[0], bWrite = relocateHigh(AutoCloseFD{b[1]}, 31);
 
-    /* A descriptor that is neither a source nor a target. Exempting the targets
-       must not degrade into exempting everything above stderr. */
+    /* Targets 4 and 9, with an unrelated descriptor at 6 — strictly between
+       them — and another at 25, above both. That placement is the point: the
+       child sweeps in two stages, a range close above the highest target and an
+       individual walk below it, and only a descriptor inside the target range
+       can reach the second one. A spare above the highest target exercises the
+       first stage and would pass even if the second were removed entirely. */
     int spare[2];
     ASSERT_NE(::pipe(spare), -1);
-    AutoCloseFD spareRead = relocateHigh(AutoCloseFD{spare[0]}, 25);
-    AutoCloseFD spareWrite = relocateHigh(AutoCloseFD{spare[1]}, 26);
+    AutoCloseFD spareInside = relocateHigh(AutoCloseFD{spare[0]}, 6);
+    AutoCloseFD spareAbove = relocateHigh(AutoCloseFD{spare[1]}, 25);
 
     ASSERT_NO_THROW(runProgram2({
         .program = *self,
@@ -345,10 +351,10 @@ TEST(runProgram2, redirectionsDoNotKeepUnrelatedFDsOpen)
         .args = {OS_STR("__util_test_spawn_redirections")},
         .environment =
             OsStringMap{
-                {OS_STR("NIX_CHILD_WRITE_FDS"), OS_STR("4:alpha")},
-                {OS_STR("NIX_CHILD_FDS_SHOULD_BE_CLOSED"), OS_STR("25,26")},
+                {OS_STR("NIX_CHILD_WRITE_FDS"), OS_STR("4:alpha,9:beta")},
+                {OS_STR("NIX_CHILD_FDS_SHOULD_BE_CLOSED"), OS_STR("6,25")},
             },
-        .redirections = {{.from = aWrite.get(), .to = 4}},
+        .redirections = {{.sourceFd = aWrite.get(), .targetFd = 4}, {.sourceFd = bWrite.get(), .targetFd = 9}},
     }));
 }
 
@@ -360,7 +366,7 @@ TEST(startProgram, rejectsRedirectionOntoAStandardStream)
         {
             runProgram2({
                 .program = "/nonexistent",
-                .redirections = {{.from = 30, .to = STDOUT_FILENO}},
+                .redirections = {{.sourceFd = 30, .targetFd = STDOUT_FILENO}},
             });
         },
         UsageError);
@@ -374,7 +380,7 @@ TEST(startProgram, rejectsSourceThatIsAnotherTarget)
         {
             runProgram2({
                 .program = "/nonexistent",
-                .redirections = {{.from = 30, .to = 7}, {.from = 7, .to = 8}},
+                .redirections = {{.sourceFd = 30, .targetFd = 7}, {.sourceFd = 7, .targetFd = 8}},
             });
         },
         UsageError);

--- a/src/libutil-tests/processes.cc
+++ b/src/libutil-tests/processes.cc
@@ -1,8 +1,12 @@
 #include "nix/util/processes.hh"
 #include "nix/util/current-process.hh"
+#include "nix/util/environment-variables.hh"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <filesystem>
+#include <optional>
 
 namespace nix {
 
@@ -96,7 +100,160 @@ TEST(runProgram2, leakedFDsAreClosed)
 
 #endif
 
-/* TODO: Test a bunch more things. */
+/* ----------------------------------------------------------------------------
+ * The `RunOptions` contract
+ *
+ * Each field below was previously unexercised, so a refactor of the spawn path
+ * could drop one and stay green. These are deliberately behavioural rather than
+ * structural: they observe the child, not the options struct.
+ *
+ * The child in every case is this test binary re-execed with a marker argument;
+ * see the dispatch in `main.cc`.
+ *
+ * One footgun, found the hard way: the two `environment` tests replace the
+ * child's environment wholesale, which drops `LD_LIBRARY_PATH`. That is correct
+ * and is the point of the test, but it means the child can only find its shared
+ * libraries via RPATH. Running this binary relocated from its build tree, with
+ * the libraries reachable only through `LD_LIBRARY_PATH`, makes those two fail
+ * in the loader rather than in the assertion.
+ * --------------------------------------------------------------------------*/
+
+TEST(runProgram2, nonZeroExitIsReportedWithItsStatus)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    /* `ExecError::status` is a raw wait status, not an exit code, so assert
+       through `statusOk` rather than comparing it to 3 directly. */
+    try {
+        runProgram2({
+            .program = *self,
+            .lookupPath = false,
+            .args = {OS_STR("__util_test_spawn_exit_code"), OS_STR("3")},
+        });
+        FAIL() << "expected ExecError for a child that exited 3";
+    } catch (ExecError & e) {
+        ASSERT_FALSE(statusOk(e.status));
+#ifndef _WIN32
+        ASSERT_TRUE(WIFEXITED(e.status));
+        ASSERT_EQ(WEXITSTATUS(e.status), 3);
+#endif
+    }
+}
+
+TEST(runProgram, capturesStandardOutAndNotStandardError)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    auto [status, output] = runProgram({
+        .program = *self,
+        .lookupPath = false,
+        .args = {OS_STR("__util_test_spawn_streams")},
+    });
+
+    ASSERT_TRUE(statusOk(status));
+    /* The child writes "out:" to stdout and "err:" to stderr. Without
+       `mergeStderrToStdout` only the former is captured. */
+    ASSERT_EQ(output, "out:");
+}
+
+TEST(runProgram, mergeStderrToStdoutCapturesBoth)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    auto [status, output] = runProgram({
+        .program = *self,
+        .lookupPath = false,
+        .args = {OS_STR("__util_test_spawn_streams")},
+        .mergeStderrToStdout = true,
+    });
+
+    ASSERT_TRUE(statusOk(status));
+    /* Assert containment rather than an exact string: the two streams are
+       separately buffered, so their interleaving is not guaranteed. */
+    ASSERT_THAT(output, ::testing::HasSubstr("out:"));
+    ASSERT_THAT(output, ::testing::HasSubstr("err:"));
+}
+
+TEST(runProgram, environmentReplacesRatherThanExtends)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    setEnv("NIX_TEST_SHOULD_NOT_REACH_CHILD", "leaked");
+    ASSERT_EQ(getEnv("NIX_TEST_SHOULD_NOT_REACH_CHILD"), std::optional<std::string>("leaked"));
+
+    /* Supplying `environment` replaces the child's environment wholesale, so a
+       variable set in this process must not be visible to the child. */
+    auto [status, output] = runProgram({
+        .program = *self,
+        .lookupPath = false,
+        .args = {OS_STR("__util_test_spawn_print_env"), OS_STR("NIX_TEST_SHOULD_NOT_REACH_CHILD")},
+        .environment = OsStringMap{{OS_STR("SOMETHING_ELSE"), OS_STR("1")}},
+    });
+
+    ASSERT_TRUE(statusOk(status));
+    ASSERT_EQ(output, "<unset>");
+}
+
+TEST(runProgram, environmentPassesTheGivenVariable)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    auto [status, output] = runProgram({
+        .program = *self,
+        .lookupPath = false,
+        .args = {OS_STR("__util_test_spawn_print_env"), OS_STR("NIX_TEST_PASSED_THROUGH")},
+        .environment = OsStringMap{{OS_STR("NIX_TEST_PASSED_THROUGH"), OS_STR("visible")}},
+    });
+
+    ASSERT_TRUE(statusOk(status));
+    ASSERT_EQ(output, "visible");
+}
+
+TEST(runProgram, chdirIsHonoured)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    auto target = std::filesystem::canonical(std::filesystem::temp_directory_path());
+    /* Positive control: if the test already runs there, the assertion below
+       would hold whether or not `chdir` did anything. */
+    ASSERT_NE(std::filesystem::canonical(std::filesystem::current_path()), target);
+
+    auto [status, output] = runProgram({
+        .program = *self,
+        .lookupPath = false,
+        .args = {OS_STR("__util_test_spawn_print_cwd")},
+        .chdir = target,
+    });
+
+    ASSERT_TRUE(statusOk(status));
+    ASSERT_EQ(std::filesystem::canonical(output), target);
+}
+
+#ifndef _WIN32 /* `RunOptions::argv0` is Unix-only. */
+
+TEST(runProgram, argv0IsHonoured)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    auto [status, output] = runProgram({
+        .program = *self,
+        .lookupPath = false,
+        .args = {OS_STR("__util_test_spawn_print_argv0")},
+        .argv0 = "not-the-program-name",
+    });
+
+    ASSERT_TRUE(statusOk(status));
+    ASSERT_EQ(output, "not-the-program-name");
+}
+
+#endif
 
 #undef NIX_EXECUTABLE_EXTENSION
 #undef NIX_SPAWN_EXCEPTION

--- a/src/libutil-tests/processes.cc
+++ b/src/libutil-tests/processes.cc
@@ -255,6 +255,133 @@ TEST(runProgram, argv0IsHonoured)
 
 #endif
 
+#ifndef _WIN32 /* `RunOptions::redirections` is Unix-only. */
+
+/* ----------------------------------------------------------------------------
+ * RunOptions::redirections
+ *
+ * Descriptors above stderr are the only reason this field exists, and they are
+ * also exactly what the child's descriptor sweep is there to close. So the
+ * ordering between "wire the redirections" and "close everything else" is the
+ * whole behaviour, and it is not observable from the parent — the child has to
+ * be asked.
+ * --------------------------------------------------------------------------*/
+
+namespace {
+
+/**
+ * Move `fd` to a descriptor well clear of the low numbers, so that a test can
+ * use 4 and 5 as redirection *targets* without colliding with whatever
+ * `::pipe` happened to hand out for the *sources*. Such a collision is
+ * rejected by `validateRedirections`, which would make the test's outcome
+ * depend on the process's descriptor allocation rather than on the code.
+ */
+static AutoCloseFD relocateHigh(AutoCloseFD fd, int to)
+{
+    EXPECT_NE(::dup2(fd.get(), to), -1);
+    return AutoCloseFD{to};
+}
+
+} // namespace
+
+TEST(runProgram2, redirectionsReachTheChild)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    int a[2], b[2];
+    ASSERT_NE(::pipe(a), -1);
+    ASSERT_NE(::pipe(b), -1);
+    AutoCloseFD aRead = a[0], aWrite = relocateHigh(AutoCloseFD{a[1]}, 30);
+    AutoCloseFD bRead = b[0], bWrite = relocateHigh(AutoCloseFD{b[1]}, 31);
+
+    /* Fds 4 and 5 specifically: that is what `hook-instance.cc` wires, and it
+       is above the `MAX_KEPT_FD` of the argument-less `closeExtraFDs`, so a
+       sweep that does not exempt them takes both away before the exec. */
+    ASSERT_NO_THROW(runProgram2({
+        .program = *self,
+        .lookupPath = false,
+        .args = {OS_STR("__util_test_spawn_redirections")},
+        .environment = OsStringMap{{OS_STR("NIX_CHILD_WRITE_FDS"), OS_STR("4:alpha,5:beta")}},
+        .redirections = {{.from = aWrite.get(), .to = 4}, {.from = bWrite.get(), .to = 5}},
+    }));
+
+    /* Drop our own write ends, or the reads below would not see EOF. */
+    aWrite.close();
+    bWrite.close();
+
+    auto drain = [](int fd) {
+        std::string s;
+        char buf[64];
+        ssize_t n;
+        while ((n = ::read(fd, buf, sizeof(buf))) > 0)
+            s.append(buf, n);
+        return s;
+    };
+
+    ASSERT_EQ(drain(aRead.get()), "alpha");
+    ASSERT_EQ(drain(bRead.get()), "beta");
+}
+
+TEST(runProgram2, redirectionsDoNotKeepUnrelatedFDsOpen)
+{
+    auto self = getSelfExe();
+    ASSERT_TRUE(self);
+
+    int a[2];
+    ASSERT_NE(::pipe(a), -1);
+    AutoCloseFD aRead = a[0], aWrite = relocateHigh(AutoCloseFD{a[1]}, 30);
+
+    /* A descriptor that is neither a source nor a target. Exempting the targets
+       must not degrade into exempting everything above stderr. */
+    int spare[2];
+    ASSERT_NE(::pipe(spare), -1);
+    AutoCloseFD spareRead = relocateHigh(AutoCloseFD{spare[0]}, 25);
+    AutoCloseFD spareWrite = relocateHigh(AutoCloseFD{spare[1]}, 26);
+
+    ASSERT_NO_THROW(runProgram2({
+        .program = *self,
+        .lookupPath = false,
+        .args = {OS_STR("__util_test_spawn_redirections")},
+        .environment =
+            OsStringMap{
+                {OS_STR("NIX_CHILD_WRITE_FDS"), OS_STR("4:alpha")},
+                {OS_STR("NIX_CHILD_FDS_SHOULD_BE_CLOSED"), OS_STR("25,26")},
+            },
+        .redirections = {{.from = aWrite.get(), .to = 4}},
+    }));
+}
+
+TEST(startProgram, rejectsRedirectionOntoAStandardStream)
+{
+    /* `standardOut` and `mergeStderrToStdout` own the standard streams; a
+       redirection onto one of them would fight with them silently. */
+    ASSERT_THROW(
+        {
+            runProgram2({
+                .program = "/nonexistent",
+                .redirections = {{.from = 30, .to = STDOUT_FILENO}},
+            });
+        },
+        UsageError);
+}
+
+TEST(startProgram, rejectsSourceThatIsAnotherTarget)
+{
+    /* The duplications are applied in order with no bookkeeping, so this would
+       silently give the second redirection the first one's descriptor. */
+    ASSERT_THROW(
+        {
+            runProgram2({
+                .program = "/nonexistent",
+                .redirections = {{.from = 30, .to = 7}, {.from = 7, .to = 8}},
+            });
+        },
+        UsageError);
+}
+
+#endif
+
 #undef NIX_EXECUTABLE_EXTENSION
 #undef NIX_SPAWN_EXCEPTION
 

--- a/src/libutil/include/nix/util/file-descriptor.hh
+++ b/src/libutil/include/nix/util/file-descriptor.hh
@@ -13,6 +13,8 @@
 #include "nix/util/error.hh"
 #include "nix/util/os-string.hh"
 
+#include <span>
+
 #ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
@@ -318,6 +320,18 @@ namespace unix {
  * Good practice in child processes.
  */
 void closeExtraFDs();
+
+/**
+ * As `closeExtraFDs`, but additionally keep the descriptors in `keep` open.
+ *
+ * A child that has deliberately wired up descriptors above stderr — see
+ * `RunOptions::Redirection` — must use this, because the argument-less
+ * overload closes every descriptor above `STDERR_FILENO` and would undo
+ * that wiring immediately before the `exec`.
+ *
+ * `keep` is expected to be small; it is scanned linearly per descriptor.
+ */
+void closeExtraFDs(std::span<const Descriptor> keep);
 
 /**
  * Set the close-on-exec flag for the given file descriptor.

--- a/src/libutil/include/nix/util/processes.hh
+++ b/src/libutil/include/nix/util/processes.hh
@@ -142,6 +142,24 @@ std::string runProgram(
 
 struct RunOptions
 {
+    /**
+     * Wire one of the parent's descriptors onto a specific descriptor
+     * number in the child, for descriptors other than stdin/stdout/stderr
+     * (which have their own fields).
+     *
+     * `from` is the descriptor in *this* process to duplicate; `to` is the
+     * number it will have in the child. So `{.from = pipe.writeSide.get(),
+     * .to = 4}` makes the child's fd 4 a copy of that pipe.
+     *
+     * Constraints, checked by `startProgram` before forking:
+     *
+     * - `to` must be greater than `STDERR_FILENO`; use `standardOut` and
+     *   `mergeStderrToStdout` for the standard streams.
+     * - No `to` may appear as another redirection's `from`, because the
+     *   duplications are applied in order and would clobber each other.
+     * - On Linux `to` may not be `STDERR_FILENO + 1`, which the vfork child
+     *   reserves for its error-reporting pipe.
+     */
     struct Redirection
     {
         int from, to;
@@ -171,7 +189,16 @@ std::pair<int, std::string> runProgram(RunOptions && options);
 
 void runProgram2(const RunOptions & options);
 
+#ifndef _WIN32
+/**
+ * Start a program and return its pid without waiting for it, applying the
+ * same `RunOptions` that `runProgram2` does. `out` must have been created
+ * iff `options.standardOut` is set; the caller owns draining and waiting.
+ *
+ * Not available on Windows, which has no equivalent child-setup path.
+ */
 Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out);
+#endif
 
 class ExecError final : public CloneableError<ExecError, Error>
 {

--- a/src/libutil/include/nix/util/processes.hh
+++ b/src/libutil/include/nix/util/processes.hh
@@ -147,22 +147,27 @@ struct RunOptions
      * number in the child, for descriptors other than stdin/stdout/stderr
      * (which have their own fields).
      *
-     * `from` is the descriptor in *this* process to duplicate; `to` is the
-     * number it will have in the child. So `{.from = pipe.writeSide.get(),
-     * .to = 4}` makes the child's fd 4 a copy of that pipe.
+     * `sourceFd` is the descriptor in *this* process to duplicate;
+     * `targetFd` is the number it will have in the child. So
+     * `{.sourceFd = pipe.writeSide.get(), .targetFd = 4}` makes the child's
+     * fd 4 a copy of that pipe.
+     *
+     * Named this way rather than `from`/`to` deliberately: those read
+     * ambiguously enough that the original implementation duplicated them
+     * the opposite way round from what its own error message claimed.
      *
      * Constraints, checked by `startProgram` before forking:
      *
-     * - `to` must be greater than `STDERR_FILENO`; use `standardOut` and
+     * - `targetFd` must be greater than `STDERR_FILENO`; use `standardOut` and
      *   `mergeStderrToStdout` for the standard streams.
-     * - No `to` may appear as another redirection's `from`, because the
+     * - No `targetFd` may appear as another redirection's `sourceFd`, because the
      *   duplications are applied in order and would clobber each other.
-     * - On Linux `to` may not be `STDERR_FILENO + 1`, which the vfork child
+     * - On Linux `targetFd` may not be `STDERR_FILENO + 1`, which the vfork child
      *   reserves for its error-reporting pipe.
      */
     struct Redirection
     {
-        int from, to;
+        int sourceFd, targetFd;
     };
 
     std::filesystem::path program;

--- a/src/libutil/include/nix/util/processes.hh
+++ b/src/libutil/include/nix/util/processes.hh
@@ -181,9 +181,34 @@ struct RunOptions
     std::optional<std::filesystem::path> chdir;
     std::optional<OsStringMap> environment;
     Sink * standardOut = nullptr;
+
+    /**
+     * Wire an existing descriptor onto the child's stdout, instead of
+     * collecting stdout into a `Sink` via `standardOut`.
+     *
+     * `Redirection` cannot express this, because it deliberately refuses any
+     * `targetFd` at or below `STDERR_FILENO`. Callers that already own the
+     * write end of a pipe want exactly this and nothing else.
+     *
+     * Mutually exclusive with `standardOut`; setting both is a `UsageError`,
+     * since the child has one stdout and the two options disagree about who
+     * owns it.
+     */
+    std::optional<Descriptor> standardOutFd;
+
     bool mergeStderrToStdout = false;
     bool isInteractive = false;
     std::vector<Redirection> redirections;
+
+    /**
+     * Kill the child when this process dies (`PR_SET_PDEATHSIG` on Linux).
+     *
+     * Defaults to true, matching what `startProgram` did when this was
+     * hardcoded. Long-lived helpers that must outlive the process which
+     * spawned them — an `ssh -M` control master, for instance — set this
+     * false, which is why `ProcessOptions` has always had the same field.
+     */
+    bool dieWithParent = true;
 #ifdef __linux__
     std::set<long> caps;
 #endif

--- a/src/libutil/include/nix/util/processes.hh
+++ b/src/libutil/include/nix/util/processes.hh
@@ -87,6 +87,7 @@ public:
     void setKillSignal(int signal);
     void setKillTimeout(std::chrono::milliseconds duration);
     pid_t release();
+    pid_t get();
 #endif
 
     friend void swap(Pid & lhs, Pid & rhs) noexcept
@@ -141,6 +142,11 @@ std::string runProgram(
 
 struct RunOptions
 {
+    struct Redirection
+    {
+        int from, to;
+    };
+
     std::filesystem::path program;
     bool lookupPath = true;
     OsStrings args;
@@ -154,12 +160,18 @@ struct RunOptions
     Sink * standardOut = nullptr;
     bool mergeStderrToStdout = false;
     bool isInteractive = false;
+    std::vector<Redirection> redirections;
+#ifdef __linux__
+    std::set<long> caps;
+#endif
 };
 
 // Output = error code + "standard out" output stream
 std::pair<int, std::string> runProgram(RunOptions && options);
 
 void runProgram2(const RunOptions & options);
+
+Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out);
 
 class ExecError final : public CloneableError<ExecError, Error>
 {

--- a/src/libutil/linux/processes.cc
+++ b/src/libutil/linux/processes.cc
@@ -169,10 +169,10 @@ struct ExecChildParams
     int maxKeptFD = relocatedErrorPipeFD;
     for (size_t i = 0; i < params.numRedirections; ++i) {
         const auto & redirection = params.redirections[i];
-        if (::dup2(redirection.from, redirection.to) == -1)
+        if (::dup2(redirection.sourceFd, redirection.targetFd) == -1)
             dieWithErrno("dupping redirected fd");
-        if (redirection.to > maxKeptFD)
-            maxKeptFD = redirection.to;
+        if (redirection.targetFd > maxKeptFD)
+            maxKeptFD = redirection.targetFd;
     }
 
 #if HAVE_CLOSEFROM
@@ -193,7 +193,7 @@ struct ExecChildParams
     for (int fd = relocatedErrorPipeFD + 1; fd < maxKeptFD; ++fd) {
         bool isTarget = false;
         for (size_t i = 0; i < params.numRedirections; ++i)
-            if (params.redirections[i].to == fd)
+            if (params.redirections[i].targetFd == fd)
                 isTarget = true;
         if (!isTarget)
             ::close(fd); /* Ignore errors; it may not have been open. */

--- a/src/libutil/linux/processes.cc
+++ b/src/libutil/linux/processes.cc
@@ -238,11 +238,13 @@ struct ExecChildParams
            closure and many features we do not need. */
         static constexpr uint32_t LINUX_CAPABILITY_VERSION_3 = 0x20080522;
         static constexpr uint32_t LINUX_CAPABILITY_U32S_3 = 2;
+
         struct user_cap_header_struct
         {
             uint32_t version;
             int pid;
         } hdr = {LINUX_CAPABILITY_VERSION_3, 0};
+
         struct user_cap_data_struct
         {
             uint32_t effective;
@@ -371,7 +373,7 @@ Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
         .args = args.data(),
         .mergeStderrToStdout = options.mergeStderrToStdout,
         .lookupPath = options.lookupPath,
-        .stdoutFd = options.standardOut ? out->writeSide.get() : INVALID_DESCRIPTOR,
+        .stdoutFd = options.standardOut ? out->writeSide.get() : options.standardOutFd.value_or(INVALID_DESCRIPTOR),
         .errorPipe = childErrorPipe.writeSide.get(),
         .setGid = options.gid.has_value(),
         /* The default is not used, but a bit sketchy to leave zero initialised so "nobody". */
@@ -379,7 +381,7 @@ Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
         .setUid = options.uid.has_value(),
         /* The default is not used, but a bit sketchy to leave zero initialised so "nobody". */
         .uid = options.uid.value_or(65534),
-        .dieWithParent = true, /* TODO: Maybe we might want to expose this in RunOptions? */
+        .dieWithParent = options.dieWithParent,
         .redirections = options.redirections.data(),
         .numRedirections = options.redirections.size(),
         .caps = caps.data(),

--- a/src/libutil/linux/processes.cc
+++ b/src/libutil/linux/processes.cc
@@ -9,6 +9,7 @@
 #include "linux/linux-namespaces-private.hh"
 #include "unix/signals-private.hh"
 #include "unix/current-process-private.hh"
+#include "unix/processes-private.hh"
 #include "util-unix-config-private.hh"
 
 #include <cstring>
@@ -49,6 +50,13 @@ struct ExecChildParams
     bool setUid;
     uid_t uid;
     bool dieWithParent;
+    /* Plain pointer plus count rather than a container, per the note above.
+       Both point into storage owned by the caller's frame, which stays alive
+       because vfork suspends the calling thread until exec or _exit. */
+    const RunOptions::Redirection * redirections;
+    size_t numRedirections;
+    const long * caps;
+    size_t numCaps;
 };
 
 /*
@@ -151,17 +159,45 @@ struct ExecChildParams
         errorPipe = relocatedErrorPipeFD;
     }
 
+    /* Wire the caller's extra descriptors *before* the sweep below, because
+       their sources are arbitrary descriptors in the parent and the sweep would
+       close them. `validateRedirections` has already guaranteed in the parent
+       that no target is a standard stream, that no target is
+       `relocatedErrorPipeFD`, and that no target is another redirection's
+       source — so applying them in order needs no bookkeeping here, which is
+       what makes it safe to do after vfork. */
+    int maxKeptFD = relocatedErrorPipeFD;
+    for (size_t i = 0; i < params.numRedirections; ++i) {
+        const auto & redirection = params.redirections[i];
+        if (::dup2(redirection.from, redirection.to) == -1)
+            dieWithErrno("dupping redirected fd");
+        if (redirection.to > maxKeptFD)
+            maxKeptFD = redirection.to;
+    }
+
 #if HAVE_CLOSEFROM
     /* glibc uses this in its posix_spawn implementation and also exposes it
        in <unistd.h>. Notably, it has a fallback for kernels that don't support
        close_range. */
-    ::closefrom(relocatedErrorPipeFD + 1);
+    ::closefrom(maxKeptFD + 1);
 #elifdef SYS_close_range
     /* This is mostly best-effort. This code should only be used on musl and it
        would only fail on older kernels. Reimplementing /proc/self/fd iteration
        like what glibc does in __closefrom_fallback is a lot of complex code. */
-    ::syscall(SYS_close_range, relocatedErrorPipeFD + 1, ~0u, 0);
+    ::syscall(SYS_close_range, maxKeptFD + 1, ~0u, 0);
 #endif
+
+    /* The sweep above could only start above the highest descriptor we are
+       keeping, so anything between the error pipe and that high-water mark that
+       is not itself a redirection target still has to go individually. */
+    for (int fd = relocatedErrorPipeFD + 1; fd < maxKeptFD; ++fd) {
+        bool isTarget = false;
+        for (size_t i = 0; i < params.numRedirections; ++i)
+            if (params.redirections[i].to == fd)
+                isTarget = true;
+        if (!isTarget)
+            ::close(fd); /* Ignore errors; it may not have been open. */
+    }
 
     /* Important! Calling syscalls directly and not libc functions because of a
        discrepancy in POSIX specification (i.e. POSIX setgid/setuid has to apply
@@ -180,6 +216,10 @@ struct ExecChildParams
 #  define NIX_SYS_setgroups SYS_setgroups
 #endif
 
+    /* Capabilities have to survive the setuid below, so ask for that first. */
+    if (params.numCaps > 0 && ::prctl(PR_SET_KEEPCAPS, 1) < 0)
+        dieWithErrno("setting keep-caps failed");
+
     if (params.setGid && ::syscall(NIX_SYS_setgid, params.gid) == -1)
         dieWithErrno("setgid failed");
 
@@ -189,6 +229,45 @@ struct ExecChildParams
 
     if (params.setUid && ::syscall(NIX_SYS_setuid, params.uid) == -1)
         dieWithErrno("setuid failed");
+
+    if (params.numCaps > 0) {
+        if (::prctl(PR_SET_KEEPCAPS, 0))
+            dieWithErrno("clearing keep-caps failed");
+
+        /* Done by hand rather than through libcap, which has a large build
+           closure and many features we do not need. */
+        static constexpr uint32_t LINUX_CAPABILITY_VERSION_3 = 0x20080522;
+        static constexpr uint32_t LINUX_CAPABILITY_U32S_3 = 2;
+        struct user_cap_header_struct
+        {
+            uint32_t version;
+            int pid;
+        } hdr = {LINUX_CAPABILITY_VERSION_3, 0};
+        struct user_cap_data_struct
+        {
+            uint32_t effective;
+            uint32_t permitted;
+            uint32_t inheritable;
+        } data[LINUX_CAPABILITY_U32S_3] = {};
+
+        for (size_t i = 0; i < params.numCaps; ++i) {
+            long cap = params.caps[i];
+            /* Not an assert: this runs after vfork, where aborting would take
+               the parent's address space with it. The parent has already
+               range-checked, so this is belt and braces. */
+            if (cap < 0 || static_cast<unsigned long>(cap) / 32 >= LINUX_CAPABILITY_U32S_3)
+                die(EINVAL, "capability out of range");
+            data[cap / 32].permitted |= 1u << (cap % 32);
+            data[cap / 32].inheritable |= 1u << (cap % 32);
+        }
+
+        if (::syscall(SYS_capset, &hdr, data))
+            dieWithErrno("couldn't set capabilities");
+
+        for (size_t i = 0; i < params.numCaps; ++i)
+            if (::prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, params.caps[i], 0, 0) < 0)
+                dieWithErrno("couldn't set ambient caps");
+    }
 
     /* Technically slightly racy, we might want to do something like what
        preserveDeathSignal does. */
@@ -261,16 +340,9 @@ static Strings prepareEnvironmentStrings(const StringMap & environment)
 
 } // namespace
 
-/* TODO: Factor this out into a `launchProgram` that returns a pid. That would be
-   much more useful in more places. */
-void runProgram2(const RunOptions & options)
+Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
 {
-    checkInterrupt();
-
-    /* Create a pipe. */
-    Pipe out;
-    if (options.standardOut)
-        out.create();
+    unix::validateRedirections(options);
 
     /* Pipe that the child reports errors through. */
     Pipe childErrorPipe;
@@ -285,6 +357,13 @@ void runProgram2(const RunOptions & options)
     const auto env = stringsToCharPtrs(env_);
     const auto args = stringsToCharPtrs(args_);
 
+    /* Flattened for the child, which cannot walk a `std::set`. Range-checked
+       here so that the post-vfork code never has to fail on bad input. */
+    const std::vector<long> caps(options.caps.begin(), options.caps.end());
+    for (auto cap : caps)
+        if (cap < 0 || cap >= 64)
+            throw UsageError("capability %1% is out of range", cap);
+
     const ExecChildParams params = {
         .program = options.program.c_str(),
         .chdir = options.chdir ? options.chdir->c_str() : nullptr,
@@ -292,7 +371,7 @@ void runProgram2(const RunOptions & options)
         .args = args.data(),
         .mergeStderrToStdout = options.mergeStderrToStdout,
         .lookupPath = options.lookupPath,
-        .stdoutFd = options.standardOut ? out.writeSide.get() : INVALID_DESCRIPTOR,
+        .stdoutFd = options.standardOut ? out->writeSide.get() : INVALID_DESCRIPTOR,
         .errorPipe = childErrorPipe.writeSide.get(),
         .setGid = options.gid.has_value(),
         /* The default is not used, but a bit sketchy to leave zero initialised so "nobody". */
@@ -301,6 +380,10 @@ void runProgram2(const RunOptions & options)
         /* The default is not used, but a bit sketchy to leave zero initialised so "nobody". */
         .uid = options.uid.value_or(65534),
         .dieWithParent = true, /* TODO: Maybe we might want to expose this in RunOptions? */
+        .redirections = options.redirections.data(),
+        .numRedirections = options.redirections.size(),
+        .caps = caps.data(),
+        .numCaps = caps.size(),
     };
 
     auto suspension = logger->suspendIf(options.isInteractive);
@@ -318,7 +401,6 @@ void runProgram2(const RunOptions & options)
     if (pid == -1)
         throw SysError(forkErrno, "unable to vfork");
 
-    out.writeSide.close();
     childErrorPipe.writeSide.close();
 
     StringSink childErrorSink;
@@ -347,8 +429,24 @@ void runProgram2(const RunOptions & options)
         throw std::move(execErr);
     }
 
+    return pid;
+}
+
+void runProgram2(const RunOptions & options)
+{
+    checkInterrupt();
+
+    /* Create a pipe. */
+    auto out = std::make_shared<Pipe>();
     if (options.standardOut)
-        drainFD(out.readSide.get(), *options.standardOut);
+        out->create();
+
+    auto pid = startProgram(options, out);
+
+    out->writeSide.close();
+
+    if (options.standardOut)
+        drainFD(out->readSide.get(), *options.standardOut);
 
     /* Wait for the child to finish. */
     int status = pid.wait();

--- a/src/libutil/processes.cc
+++ b/src/libutil/processes.cc
@@ -14,13 +14,19 @@ void ExecError::anchor() {}
 
 void unix::validateRedirections(const RunOptions & options)
 {
+    /* The child has one stdout. `standardOut` wants to collect it into a sink,
+       `standardOutFd` wants it wired to a descriptor the caller already owns,
+       and honouring either one silently would discard the other's intent. */
+    if (options.standardOut && options.standardOutFd)
+        throw UsageError("'standardOut' and 'standardOutFd' are mutually exclusive; the child has only one stdout");
+
     for (auto redirection : options.redirections) {
         if (redirection.targetFd <= STDERR_FILENO)
             throw UsageError(
                 "redirection target fd %i is a standard stream; use 'standardOut' or 'mergeStderrToStdout' instead",
                 redirection.targetFd);
 
-#ifdef __linux__
+#  ifdef __linux__
         /* Kept in step with `relocatedErrorPipeFD` in `linux/processes.cc`. The
            vfork child moves its error pipe there before touching anything else,
            so that number is unusable as either end of a redirection: as a target
@@ -30,7 +36,7 @@ void unix::validateRedirections(const RunOptions & options)
             throw UsageError(
                 "fd %i cannot take part in a redirection; it is reserved for the child's error-reporting pipe",
                 STDERR_FILENO + 1);
-#endif
+#  endif
 
         for (auto other : options.redirections)
             if (other.sourceFd == redirection.targetFd)

--- a/src/libutil/processes.cc
+++ b/src/libutil/processes.cc
@@ -15,10 +15,10 @@ void ExecError::anchor() {}
 void unix::validateRedirections(const RunOptions & options)
 {
     for (auto redirection : options.redirections) {
-        if (redirection.to <= STDERR_FILENO)
+        if (redirection.targetFd <= STDERR_FILENO)
             throw UsageError(
                 "redirection target fd %i is a standard stream; use 'standardOut' or 'mergeStderrToStdout' instead",
-                redirection.to);
+                redirection.targetFd);
 
 #ifdef __linux__
         /* Kept in step with `relocatedErrorPipeFD` in `linux/processes.cc`. The
@@ -26,18 +26,18 @@ void unix::validateRedirections(const RunOptions & options)
            so that number is unusable as either end of a redirection: as a target
            it would overwrite the pipe, and as a source it would itself be
            overwritten by the relocation. */
-        if (redirection.to == STDERR_FILENO + 1 || redirection.from == STDERR_FILENO + 1)
+        if (redirection.targetFd == STDERR_FILENO + 1 || redirection.sourceFd == STDERR_FILENO + 1)
             throw UsageError(
                 "fd %i cannot take part in a redirection; it is reserved for the child's error-reporting pipe",
                 STDERR_FILENO + 1);
 #endif
 
         for (auto other : options.redirections)
-            if (other.from == redirection.to)
+            if (other.sourceFd == redirection.targetFd)
                 throw UsageError(
                     "fd %i is both a redirection target and the source of another redirection, "
                     "which the in-order duplication would clobber",
-                    redirection.to);
+                    redirection.targetFd);
     }
 }
 

--- a/src/libutil/processes.cc
+++ b/src/libutil/processes.cc
@@ -1,9 +1,47 @@
 #include "nix/util/processes.hh"
 #include "nix/util/serialise.hh"
 
+#ifndef _WIN32
+#  include "unix/processes-private.hh"
+#  include <unistd.h>
+#endif
+
 namespace nix {
 
 void ExecError::anchor() {}
+
+#ifndef _WIN32
+
+void unix::validateRedirections(const RunOptions & options)
+{
+    for (auto redirection : options.redirections) {
+        if (redirection.to <= STDERR_FILENO)
+            throw UsageError(
+                "redirection target fd %i is a standard stream; use 'standardOut' or 'mergeStderrToStdout' instead",
+                redirection.to);
+
+#ifdef __linux__
+        /* Kept in step with `relocatedErrorPipeFD` in `linux/processes.cc`. The
+           vfork child moves its error pipe there before touching anything else,
+           so that number is unusable as either end of a redirection: as a target
+           it would overwrite the pipe, and as a source it would itself be
+           overwritten by the relocation. */
+        if (redirection.to == STDERR_FILENO + 1 || redirection.from == STDERR_FILENO + 1)
+            throw UsageError(
+                "fd %i cannot take part in a redirection; it is reserved for the child's error-reporting pipe",
+                STDERR_FILENO + 1);
+#endif
+
+        for (auto other : options.redirections)
+            if (other.from == redirection.to)
+                throw UsageError(
+                    "fd %i is both a redirection target and the source of another redirection, "
+                    "which the in-order duplication would clobber",
+                    redirection.to);
+    }
+}
+
+#endif
 
 Pid & Pid::operator=(Pid && other) noexcept
 {

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <span>
 #include <atomic>
+#include <algorithm>
 
 #include "util-unix-config-private.hh"
 #include "../file-descriptor-private.hh"
@@ -102,6 +103,43 @@ static int unix_close_range(unsigned int first, unsigned int last, int flags)
 #  endif
 }
 #endif
+
+void unix::closeExtraFDs(std::span<const Descriptor> keep)
+{
+    constexpr int MAX_KEPT_FD = 2;
+    static_assert(std::max({STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO}) == MAX_KEPT_FD);
+
+    if (keep.empty()) {
+        closeExtraFDs();
+        return;
+    }
+
+    auto kept = [&](int fd) { return std::find(keep.begin(), keep.end(), fd) != keep.end(); };
+
+    /* Everything strictly above the highest descriptor we are keeping can go
+       in one sweep; the range below it has to be walked so the kept ones
+       survive. */
+    int maxKeep = MAX_KEPT_FD;
+    for (auto fd : keep)
+        maxKeep = std::max(maxKeep, static_cast<int>(fd));
+
+    bool sweptAbove = false;
+#if defined(__linux__) || defined(__FreeBSD__)
+    sweptAbove = unix_close_range(maxKeep + 1, ~0U, 0) == 0;
+#endif
+    if (!sweptAbove) {
+        int maxFD = 0;
+#if HAVE_SYSCONF
+        maxFD = sysconf(_SC_OPEN_MAX);
+#endif
+        for (int fd = maxKeep + 1; fd < maxFD; ++fd)
+            close(fd); /* ignore result */
+    }
+
+    for (int fd = MAX_KEPT_FD + 1; fd <= maxKeep; ++fd)
+        if (!kept(fd))
+            close(fd); /* ignore result */
+}
 
 void unix::closeExtraFDs()
 {

--- a/src/libutil/unix/processes-private.hh
+++ b/src/libutil/unix/processes-private.hh
@@ -1,0 +1,20 @@
+#pragma once
+///@file
+
+#include "nix/util/processes.hh"
+
+namespace nix::unix {
+
+/**
+ * Check `options.redirections` against the constraints documented on
+ * `RunOptions::Redirection`, throwing `UsageError` if any is violated.
+ *
+ * This runs in the parent, deliberately. The child side of `startProgram`
+ * applies the duplications in order with no bookkeeping, and on Linux it runs
+ * after `vfork` where throwing is not permitted at all — so a caller mistake
+ * has to be caught before the fork or it becomes a silently wrong descriptor
+ * table in the child.
+ */
+void validateRedirections(const RunOptions & options);
+
+} // namespace nix::unix

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -169,6 +169,11 @@ pid_t Pid::release()
     return p;
 }
 
+pid_t Pid::get()
+{
+    return pid;
+}
+
 void killUser(uid_t uid)
 {
     debug("killing all processes running under uid '%1%'", uid);
@@ -319,27 +324,51 @@ void runProgram2(const RunOptions & options)
     checkInterrupt();
 
     /* Create a pipe. */
-    Pipe out;
+    auto out = std::make_shared<Pipe>();
     if (options.standardOut)
-        out.create();
+        out->create();
 
+    auto pid = startProgram(options, out);
+
+    out->writeSide.close();
+
+    if (options.standardOut)
+        drainFD(out->readSide.get(), *options.standardOut);
+
+    /* Wait for the child to finish. */
+    int status = pid.wait();
+    if (status)
+        throw ExecError(status, "program %1% %2%", PathFmt(options.program), statusToString(status));
+}
+
+Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
+{
     ProcessOptions processOptions;
 
     auto suspension = logger->suspendIf(options.isInteractive);
 
-    /* Fork. */
-    Pid pid = startProcess(
+    return startProcess(
         [&] {
             if (options.environment)
                 replaceEnv(*options.environment);
-            if (options.standardOut && dup2(out.writeSide.get(), STDOUT_FILENO) == -1)
+            if (options.standardOut && dup2(out->writeSide.get(), STDOUT_FILENO) == -1)
                 throw SysError("dupping stdout");
             if (options.mergeStderrToStdout)
                 if (dup2(STDOUT_FILENO, STDERR_FILENO) == -1)
                     throw SysError("cannot dup stdout into stderr");
+            for (auto redirection : options.redirections) {
+                if (dup2(redirection.to, redirection.from) == -1) {
+                    throw SysError("dupping fd %i to %i", redirection.from, redirection.to);
+                }
+            }
 
             if (options.chdir && chdir((*options.chdir).c_str()) == -1)
                 throw SysError("chdir failed");
+#ifdef __linux__
+            if (!options.caps.empty() && prctl(PR_SET_KEEPCAPS, 1) < 0) {
+                throw SysError("setting keep-caps failed");
+            }
+#endif
             if (options.gid && setgid(*options.gid) == -1)
                 throw SysError("setgid failed");
             /* Drop all other groups if we're setgid. */
@@ -347,6 +376,45 @@ void runProgram2(const RunOptions & options)
                 throw SysError("setgroups failed");
             if (options.uid && setuid(*options.uid) == -1)
                 throw SysError("setuid failed");
+
+#ifdef __linux__
+            if (!options.caps.empty()) {
+                if (prctl(PR_SET_KEEPCAPS, 0)) {
+                    throw SysError("clearing keep-caps failed");
+                }
+
+                // we do the capability dance like this to avoid a dependency
+                // on libcap, which has a rather large build closure and many
+                // more features that we need for now. maybe some other time.
+                static constexpr uint32_t LINUX_CAPABILITY_VERSION_3 = 0x20080522;
+                static constexpr uint32_t LINUX_CAPABILITY_U32S_3 = 2;
+                struct user_cap_header_struct
+                {
+                    uint32_t version;
+                    int pid;
+                } hdr = {LINUX_CAPABILITY_VERSION_3, 0};
+                struct user_cap_data_struct
+                {
+                    uint32_t effective;
+                    uint32_t permitted;
+                    uint32_t inheritable;
+                } data[LINUX_CAPABILITY_U32S_3] = {};
+                for (auto cap : options.caps) {
+                    assert(cap / 32 < LINUX_CAPABILITY_U32S_3);
+                    data[cap / 32].permitted |= 1 << (cap % 32);
+                    data[cap / 32].inheritable |= 1 << (cap % 32);
+                }
+                if (syscall(SYS_capset, &hdr, data)) {
+                    throw SysError("couldn't set capabilities");
+                }
+
+                for (auto cap : options.caps) {
+                    if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, cap, 0, 0) < 0) {
+                        throw SysError("couldn't set ambient caps");
+                    }
+                }
+            }
+#endif
 
             Strings args_(options.args);
             /* Allow the caller to specify an alternative argv[0]. Useful for self-exec
@@ -371,16 +439,6 @@ void runProgram2(const RunOptions & options)
             throw SysError("executing %s", PathFmt(options.program));
         },
         processOptions);
-
-    out.writeSide.close();
-
-    if (options.standardOut)
-        drainFD(out.readSide.get(), *options.standardOut);
-
-    /* Wait for the child to finish. */
-    int status = pid.wait();
-    if (status)
-        throw ExecError(status, "program %1% %2%", PathFmt(options.program), statusToString(status));
 }
 
 #endif // __linux__

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -347,6 +347,7 @@ Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
     unix::validateRedirections(options);
 
     ProcessOptions processOptions;
+    processOptions.dieWithParent = options.dieWithParent;
 
     auto suspension = logger->suspendIf(options.isInteractive);
 
@@ -354,8 +355,12 @@ Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
         [&] {
             if (options.environment)
                 replaceEnv(*options.environment);
-            if (options.standardOut && dup2(out->writeSide.get(), STDOUT_FILENO) == -1)
-                throw SysError("dupping stdout");
+            /* Either the `Sink` path owns stdout or the caller handed us a
+               descriptor for it; `validateRedirections` has already rejected
+               both being set at once. */
+            if (auto stdoutFd = options.standardOut ? std::optional{out->writeSide.get()} : options.standardOutFd)
+                if (dup2(*stdoutFd, STDOUT_FILENO) == -1)
+                    throw SysError("dupping stdout");
             if (options.mergeStderrToStdout)
                 if (dup2(STDOUT_FILENO, STDERR_FILENO) == -1)
                     throw SysError("cannot dup stdout into stderr");

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -30,6 +30,7 @@
 #endif
 
 #include "util-unix-config-private.hh"
+#include "unix/processes-private.hh"
 
 namespace nix {
 
@@ -343,6 +344,8 @@ void runProgram2(const RunOptions & options)
 
 Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
 {
+    unix::validateRedirections(options);
+
     ProcessOptions processOptions;
 
     auto suspension = logger->suspendIf(options.isInteractive);
@@ -357,18 +360,13 @@ Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
                 if (dup2(STDOUT_FILENO, STDERR_FILENO) == -1)
                     throw SysError("cannot dup stdout into stderr");
             for (auto redirection : options.redirections) {
-                if (dup2(redirection.to, redirection.from) == -1) {
-                    throw SysError("dupping fd %i to %i", redirection.from, redirection.to);
+                if (dup2(redirection.from, redirection.to) == -1) {
+                    throw SysError("dupping fd %i onto fd %i", redirection.from, redirection.to);
                 }
             }
 
             if (options.chdir && chdir((*options.chdir).c_str()) == -1)
                 throw SysError("chdir failed");
-#ifdef __linux__
-            if (!options.caps.empty() && prctl(PR_SET_KEEPCAPS, 1) < 0) {
-                throw SysError("setting keep-caps failed");
-            }
-#endif
             if (options.gid && setgid(*options.gid) == -1)
                 throw SysError("setgid failed");
             /* Drop all other groups if we're setgid. */
@@ -376,45 +374,6 @@ Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
                 throw SysError("setgroups failed");
             if (options.uid && setuid(*options.uid) == -1)
                 throw SysError("setuid failed");
-
-#ifdef __linux__
-            if (!options.caps.empty()) {
-                if (prctl(PR_SET_KEEPCAPS, 0)) {
-                    throw SysError("clearing keep-caps failed");
-                }
-
-                // we do the capability dance like this to avoid a dependency
-                // on libcap, which has a rather large build closure and many
-                // more features that we need for now. maybe some other time.
-                static constexpr uint32_t LINUX_CAPABILITY_VERSION_3 = 0x20080522;
-                static constexpr uint32_t LINUX_CAPABILITY_U32S_3 = 2;
-                struct user_cap_header_struct
-                {
-                    uint32_t version;
-                    int pid;
-                } hdr = {LINUX_CAPABILITY_VERSION_3, 0};
-                struct user_cap_data_struct
-                {
-                    uint32_t effective;
-                    uint32_t permitted;
-                    uint32_t inheritable;
-                } data[LINUX_CAPABILITY_U32S_3] = {};
-                for (auto cap : options.caps) {
-                    assert(cap / 32 < LINUX_CAPABILITY_U32S_3);
-                    data[cap / 32].permitted |= 1 << (cap % 32);
-                    data[cap / 32].inheritable |= 1 << (cap % 32);
-                }
-                if (syscall(SYS_capset, &hdr, data)) {
-                    throw SysError("couldn't set capabilities");
-                }
-
-                for (auto cap : options.caps) {
-                    if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, cap, 0, 0) < 0) {
-                        throw SysError("couldn't set ambient caps");
-                    }
-                }
-            }
-#endif
 
             Strings args_(options.args);
             /* Allow the caller to specify an alternative argv[0]. Useful for self-exec
@@ -427,7 +386,16 @@ Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
                the FDs before or after restoreProcessContext(), but on Linux
                it's crucial that it happens *after* restoreProcessContext() call
                because that re-enters the saved mountns. */
-            unix::closeExtraFDs();
+            /* The redirections above wired descriptors above stderr, and the
+               argument-less overload closes exactly those, so the targets have
+               to be exempted or the wiring is undone here. Sources that are not
+               themselves targets are deliberately *not* kept: the child has no
+               use for the original descriptor number. */
+            std::vector<Descriptor> keepFDs;
+            keepFDs.reserve(options.redirections.size());
+            for (auto redirection : options.redirections)
+                keepFDs.push_back(redirection.to);
+            unix::closeExtraFDs(keepFDs);
 
             if (options.lookupPath)
                 execvp(options.program.c_str(), stringsToCharPtrs(args_).data());

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -360,8 +360,8 @@ Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
                 if (dup2(STDOUT_FILENO, STDERR_FILENO) == -1)
                     throw SysError("cannot dup stdout into stderr");
             for (auto redirection : options.redirections) {
-                if (dup2(redirection.from, redirection.to) == -1) {
-                    throw SysError("dupping fd %i onto fd %i", redirection.from, redirection.to);
+                if (dup2(redirection.sourceFd, redirection.targetFd) == -1) {
+                    throw SysError("dupping fd %i onto fd %i", redirection.sourceFd, redirection.targetFd);
                 }
             }
 
@@ -394,7 +394,7 @@ Pid startProgram(const RunOptions & options, std::shared_ptr<Pipe> out)
             std::vector<Descriptor> keepFDs;
             keepFDs.reserve(options.redirections.size());
             for (auto redirection : options.redirections)
-                keepFDs.push_back(redirection.to);
+                keepFDs.push_back(redirection.targetFd);
             unix::closeExtraFDs(keepFDs);
 
             if (options.lookupPath)


### PR DESCRIPTION
## Where this comes from

The first commit here is @lisanna-dettwyler's, taken from #15959 and rebased onto master. Master is
596 commits past that branch point, but the two libutil files apply with `git apply --3way` and no
conflicts. The pasta feature itself is not included, only the `startProgram` split. I am not trying
to pre-empt #15959; the refactor is independently useful and I found four defects while trying to use
it.

## The four defects

`startProgram` is declared unconditionally but defined only inside `#ifndef __linux__`, so it does
not link on Linux. Its `caps` block sits `#ifdef __linux__` nested inside that `#ifndef __linux__`, so
it never compiles, meaning pasta's `CAP_NET_ADMIN` is never granted, and pasta is Linux-only.
`linux/processes.cc` handles neither `caps` nor `redirections`. And `closeExtraFDs()` runs after the
dup2 loop, closing every descriptor `Redirection` exists to wire.

## Fixes

`startProgram` implemented natively on the Linux side, the `caps` blocks un-nested, and the descriptor
sweep taught to spare redirection targets via a new `closeExtraFDs(std::span<const Descriptor>)`.
`validateRedirections` rejects fd 3 on either end, since Linux relocates its error pipe there and
calls `closefrom(4)`.

One change to your struct that needs your agreement, @lisanna-dettwyler: the fields are now
`sourceFd`/`targetFd`, so `from` is the source. The original had `dup2(to, from)` while its own error
message read "dupping fd %i to %i" with the arguments the other way round. There were no callers, so I
matched the names, but it is your design.

## Verification

813 to 826 tests. libstore builds against in-tree libutil. fds 4 and 5 deliver on the fixed tree and
deliver 0 bytes on the original. One call site converted (`ssh.cc` `startMaster`); the other three
need `standardInFd` and `standardErrFd`, which do not exist yet.
