### PR TITLE
optimize: skip already hard-link'd paths using ....

### DIFF
--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -380,6 +380,16 @@ public:
      */
     void optimisePath(const std::filesystem::path & path, RepairFlag repair);
 
+    /**
+     * Check if a store path has been optimised using xattrs.
+     */
+    bool isPathOptimised(const std::filesystem::path & path) const;
+
+    /**
+     * Mark a store path as optimised using xattrs.
+     */
+    void markPathOptimised(const std::filesystem::path & path);
+
     bool verifyStore(bool checkContents, RepairFlag repair) override;
 
 protected:

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <future>
 #include <string>
+#include <atomic>
 #include <boost/unordered/unordered_flat_set.hpp>
 
 namespace nix {
@@ -508,6 +509,17 @@ private:
     std::pair<std::filesystem::path, AutoCloseFD> createTempDirInStore();
 
     typedef boost::unordered_flat_set<ino_t> InodeHash;
+
+    /**
+     * Cached result of whether xattrs are usable for optimisation
+     * tracking on this store (see isPathOptimised()/markPathOptimised()).
+     * Starts optimistic (false = "not known to be unsupported"); once a
+     * permanent failure (ENOTSUP/EOPNOTSUPP/EPERM/EACCES) is observed on
+     * any path, flips to true for the remaining lifetime of this
+     * LocalStore, so subsequent calls short-circuit without issuing a
+     * syscall that's known to fail again.
+     */
+    mutable std::atomic<bool> xattrsUnsupported{false};
 
     InodeHash loadInodeHash();
     Strings readDirectoryIgnoringInodes(const std::filesystem::path & path, const InodeHash & inodeHash);

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -163,34 +163,40 @@ void LocalStore::optimisePath_(
     /* Check if this is a known hash. */
     std::filesystem::path linkPath = std::filesystem::path{linksDir} / hash.to_string(HashFormat::Nix32, false);
 
+    /* Stat the link once, if it exists. */
+    auto stLink = maybeLstat(linkPath);
+
     /* Maybe delete the link, if it has been corrupted. */
-    if (pathExists(linkPath)) {
-        auto stLink = lstat(linkPath);
-        if (st.st_size != stLink.st_size || (repair && hash != ({
-                                                           hashPath(
-                                                               makeFSSourceAccessor(linkPath),
-                                                               FileSerialisationMethod::NixArchive,
-                                                               HashAlgorithm::SHA256)
-                                                               .hash;
-                                                       }))) {
+    if (stLink) {
+        if (st.st_size != stLink->st_size || (repair && hash != ({
+                                                            hashPath(
+                                                                makeFSSourceAccessor(linkPath),
+                                                                FileSerialisationMethod::NixArchive,
+                                                                HashAlgorithm::SHA256)
+                                                                .hash;
+                                                        }))) {
             // XXX: Consider overwriting linkPath with our valid version.
             warn("removing corrupted link %s", PathFmt(linkPath));
             warn(
                 "There may be more corrupted paths."
                 "\nYou should run `nix-store --verify --check-contents --repair` to fix them all");
             unlinkIfExists(linkPath);
+            stLink.reset();
         }
     }
 
-    if (!pathExists(linkPath)) {
+    if (!stLink) {
         /* Nope, create a hard link in the links directory. */
         try {
             std::filesystem::create_hard_link(path, linkPath);
             inodeHash.insert(st.st_ino);
+            stLink = st;  // After hardlinking, linkPath has same stat as path
         } catch (std::filesystem::filesystem_error & e) {
             if (e.code() == std::errc::file_exists) {
-                /* Fall through if another process created ‘linkPath’ before
+                /* Another process created ‘linkPath’ before
                    we did. */
+                stLink = lstat(linkPath);
+                inodeHash.insert(stLink->st_ino);
             }
 
             else if (e.code() == std::errc::no_space_on_device) {
@@ -210,9 +216,8 @@ void LocalStore::optimisePath_(
 
     /* Yes!  We've seen a file with the same contents.  Replace the
        current file with a hard link to that file. */
-    auto stLink = lstat(linkPath);
 
-    if (st.st_ino == stLink.st_ino) {
+    if (st.st_ino == stLink->st_ino) {
         debug("%1% is already linked to %2%", PathFmt(path), PathFmt(linkPath));
         return;
     }
@@ -235,7 +240,7 @@ void LocalStore::optimisePath_(
 
     try {
         std::filesystem::create_hard_link(linkPath, tempLink);
-        inodeHash.insert(st.st_ino);
+        inodeHash.insert(stLink->st_ino);
     } catch (std::filesystem::filesystem_error & e) {
         if (e.code() == std::errc::too_many_links) {
             /* Too many links to the same file (>= 32000 on most file

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -62,21 +62,29 @@ struct MakeReadOnly
 bool LocalStore::isPathOptimised(const std::filesystem::path & path) const
 {
 #if NIX_SUPPORT_ACL
+    if (xattrsUnsupported.load(std::memory_order_relaxed))
+        return false;
+
     char buf[32];
     ssize_t size = lgetxattr(path.c_str(), XATTR_OPTIMISED, buf, sizeof(buf));
 
     if (size < 0) {
         if (errno == ENOTSUP || errno == EOPNOTSUPP) {
-            // Filesystem doesn't support xattrs - feature disabled
-            static std::atomic<bool> warned{false};
-            if (!warned.exchange(true)) {
+            // Filesystem doesn't support xattrs - disable further attempts
+            // for the lifetime of this store, so we don't retry a syscall
+            // that's known to fail on every remaining path.
+            if (!xattrsUnsupported.exchange(true, std::memory_order_relaxed)) {
                 debug("filesystem at %s doesn't support extended attributes, optimization tracking disabled", path.string());
             }
             return false;
         }
-        // EPERM/EACCES means trusted.* but no CAP_SYS_ADMIN (non-root user)
-        // Return false so non-root users re-process (slower but correct)
+        // EPERM/EACCES means trusted.* but no CAP_SYS_ADMIN (non-root user).
+        // Our credentials won't change for the lifetime of this process,
+        // so this is just as permanent as ENOTSUP - cache it the same way.
         if (errno == EPERM || errno == EACCES) {
+            if (!xattrsUnsupported.exchange(true, std::memory_order_relaxed)) {
+                debug("no permission to read extended attributes at %s, optimization tracking disabled", path.string());
+            }
             return false;
         }
         // No xattr (ENODATA/ENOATTR) = not optimised
@@ -92,13 +100,21 @@ bool LocalStore::isPathOptimised(const std::filesystem::path & path) const
 void LocalStore::markPathOptimised(const std::filesystem::path & path)
 {
 #if NIX_SUPPORT_ACL
+    if (xattrsUnsupported.load(std::memory_order_relaxed))
+        return;
+
     std::string timestamp = std::to_string(time(nullptr));
 
     if (lsetxattr(path.c_str(), XATTR_OPTIMISED, timestamp.c_str(),
                   timestamp.size(), 0) < 0) {
-        if (errno != ENOTSUP && errno != EOPNOTSUPP && errno != EROFS &&
-            errno != EPERM && errno != EACCES) {
-            // Log unexpected errors, but ignore permission errors (non-root users)
+        if (errno == ENOTSUP || errno == EOPNOTSUPP || errno == EPERM || errno == EACCES) {
+            // Same permanent conditions as isPathOptimised() - stop retrying.
+            xattrsUnsupported.store(true, std::memory_order_relaxed);
+        } else if (errno != EROFS) {
+            // Log unexpected errors, but ignore read-only filesystem
+            // (also permanent, but not worth a dedicated flag - EROFS
+            // only matters for markPathOptimised, and failing silently
+            // there is already the correct behaviour).
             debug("failed to mark path optimised: %s", strerror(errno));
         }
         // Don't fail optimization if xattr fails
@@ -359,7 +375,9 @@ void LocalStore::optimiseStore(OptimiseStats & stats)
     auto paths = queryAllValidPaths();
 
     // Check if xattrs are usable by trying to list xattrs on linksDir.
-    // If not usable, we need to pre-load the inode hash as a fallback.
+    // If not usable, we need to pre-load the inode hash as a fallback,
+    // and can skip the per-path isPathOptimised()/markPathOptimised()
+    // syscalls entirely for the rest of this run.
     InodeHash inodeHash;
 #if NIX_SUPPORT_ACL
     // Try to list xattrs on linksDir to detect if they're usable
@@ -369,6 +387,7 @@ void LocalStore::optimiseStore(OptimiseStats & stats)
         // Load inode hash as fallback to avoid duplicate work
         debug("cannot use xattrs for optimization tracking (%s), loading inode hash", strerror(errno));
         inodeHash = loadInodeHash();
+        xattrsUnsupported.store(true, std::memory_order_relaxed);
     }
     // Otherwise: xattrs work (size >= 0)
     // Start with empty hash - xattr checks will skip already-optimised paths

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -16,9 +16,21 @@
 #include <unistd.h>
 #include <errno.h>
 
+#if NIX_SUPPORT_ACL
+#  include <sys/xattr.h>
+#endif
+
 #include "store-config-private.hh"
 
 namespace nix {
+
+#if NIX_SUPPORT_ACL
+// Use trusted.* namespace:
+// - Works on all file types (including symlinks)
+// - Requires CAP_SYS_ADMIN (nix-daemon has this)
+// - Non-root users can't read it, so they get no optimization (acceptable)
+static constexpr const char* XATTR_OPTIMISED = "trusted.nix.optimised";
+#endif
 
 static void makeWritable(const std::filesystem::path & path)
 {
@@ -46,6 +58,53 @@ struct MakeReadOnly
         }
     }
 };
+
+bool LocalStore::isPathOptimised(const std::filesystem::path & path) const
+{
+#if NIX_SUPPORT_ACL
+    char buf[32];
+    ssize_t size = lgetxattr(path.c_str(), XATTR_OPTIMISED, buf, sizeof(buf));
+
+    if (size < 0) {
+        if (errno == ENOTSUP || errno == EOPNOTSUPP) {
+            // Filesystem doesn't support xattrs - feature disabled
+            static std::atomic<bool> warned{false};
+            if (!warned.exchange(true)) {
+                debug("filesystem at %s doesn't support extended attributes, optimization tracking disabled", path.string());
+            }
+            return false;
+        }
+        // EPERM/EACCES means trusted.* but no CAP_SYS_ADMIN (non-root user)
+        // Return false so non-root users re-process (slower but correct)
+        if (errno == EPERM || errno == EACCES) {
+            return false;
+        }
+        // No xattr (ENODATA/ENOATTR) = not optimised
+        return false;
+    }
+
+    return true;  // xattr exists = already optimised
+#else
+    return false;  // Platform doesn't support xattrs: always re-optimize
+#endif
+}
+
+void LocalStore::markPathOptimised(const std::filesystem::path & path)
+{
+#if NIX_SUPPORT_ACL
+    std::string timestamp = std::to_string(time(nullptr));
+
+    if (lsetxattr(path.c_str(), XATTR_OPTIMISED, timestamp.c_str(),
+                  timestamp.size(), 0) < 0) {
+        if (errno != ENOTSUP && errno != EOPNOTSUPP && errno != EROFS &&
+            errno != EPERM && errno != EACCES) {
+            // Log unexpected errors, but ignore permission errors (non-root users)
+            debug("failed to mark path optimised: %s", strerror(errno));
+        }
+        // Don't fail optimization if xattr fails
+    }
+#endif
+}
 
 LocalStore::InodeHash LocalStore::loadInodeHash()
 {
@@ -238,8 +297,18 @@ void LocalStore::optimisePath_(
 
     std::filesystem::path tempLink = makeTempPath(config->realStoreDir.get(), ".tmp-link");
 
+    /* RAII cleanup for tempLink */
+    bool tempLinkCreated = false;
+    Finally cleanupTempLink([&]() {
+        if (tempLinkCreated) {
+            std::error_code ec;
+            std::filesystem::remove(tempLink, ec);
+        }
+    });
+
     try {
         std::filesystem::create_hard_link(linkPath, tempLink);
+        tempLinkCreated = true;
         inodeHash.insert(stLink->st_ino);
     } catch (std::filesystem::filesystem_error & e) {
         if (e.code() == std::errc::too_many_links) {
@@ -256,13 +325,8 @@ void LocalStore::optimisePath_(
     /* Atomically replace the old file with the new hard link. */
     try {
         std::filesystem::rename(tempLink, path);
+        tempLinkCreated = false; /* Successfully renamed, no cleanup needed */
     } catch (std::filesystem::filesystem_error & e) {
-        {
-            std::error_code ec;
-            remove(tempLink, ec); /* Clean up after ourselves. */
-            if (ec)
-                printError("unable to unlink %1%: %2%", PathFmt(tempLink), ec.message());
-        }
         if (e.code() == std::errc::too_many_links) {
             /* Some filesystems generate too many links on the rename,
                rather than on the original link.  (Probably it
@@ -293,22 +357,68 @@ void LocalStore::optimiseStore(OptimiseStats & stats)
     Activity act(*logger, actOptimiseStore);
 
     auto paths = queryAllValidPaths();
-    InodeHash inodeHash = loadInodeHash();
+
+    // Check if xattrs are usable by trying to list xattrs on linksDir.
+    // If not usable, we need to pre-load the inode hash as a fallback.
+    InodeHash inodeHash;
+#if NIX_SUPPORT_ACL
+    // Try to list xattrs on linksDir to detect if they're usable
+    ssize_t size = llistxattr(linksDir.string().c_str(), nullptr, 0);
+    if (size < 0) {
+        // Any failure means we can't rely on xattrs for optimization tracking
+        // Load inode hash as fallback to avoid duplicate work
+        debug("cannot use xattrs for optimization tracking (%s), loading inode hash", strerror(errno));
+        inodeHash = loadInodeHash();
+    }
+    // Otherwise: xattrs work (size >= 0)
+    // Start with empty hash - xattr checks will skip already-optimised paths
+#else
+    // Platform doesn't support xattrs at compile time
+    inodeHash = loadInodeHash();
+#endif
 
     act.progress(0, paths.size());
 
     uint64_t done = 0;
+    uint64_t skipped = 0;
 
     for (auto & i : paths) {
+        checkInterrupt();
+
+        auto fullPath = config->realStoreDir.get() / i.to_string();
+
+        // Check xattr FIRST - if optimised, skip expensive DB operations
+        if (isPathOptimised(fullPath)) {
+            debug("skipping already-optimised path '%s'", printStorePath(i));
+            skipped++;
+            done++;
+            act.progress(done, paths.size());
+            continue;
+        }
+
+        // Only do DB operations for paths that need optimization
         addTempRoot(i);
-        if (!isValidPath(i))
-            continue; /* path was GC'ed, probably */
+        if (!isValidPath(i)) {
+            /* path was GC'ed, probably */
+            done++;
+            act.progress(done, paths.size());
+            continue;
+        }
+
         {
             Activity act(*logger, lvlTalkative, actUnknown, fmt("optimising path '%s'", printStorePath(i)));
-            optimisePath_(&act, stats, config->realStoreDir.get() / i.to_string(), inodeHash, NoRepair);
+            optimisePath_(&act, stats, fullPath, inodeHash, NoRepair);
         }
+
+        // Mark path as optimised
+        markPathOptimised(fullPath);
+
         done++;
         act.progress(done, paths.size());
+    }
+
+    if (skipped > 0) {
+        printInfo("skipped %d already-optimised paths", skipped);
     }
 }
 


### PR DESCRIPTION
The idea here is to use xattrs to skip optimize for storePaths. Alternative is to use the DB, but this seems a bit more elegant.

- Is this approach worth pursuing?
- should we pursue an alternative?
- skip it?
- I've focused mostly on linux.... needs a review focused on other platforms/systems.

### Next steps
I'm trying to build toward an outcome. I've been using this follow-on set of PRs on a Hydra for a few months.

- incorporate sharding for the .links: https://github.com/tomberek/nix/tree/optimise/pr2-sharding
- use blake3 for hashing: WIP (https://github.com/NixOS/nix/commit/adb6a46446260fd4f2035fac95e18ec08b5b5e2d)
- allow concurrent optimize operations to take place using locking: https://github.com/tomberek/nix/tree/optimise/pr3-overflow-flock


(Lots of Claude iteration involved.)