### PR TITLE
resolveDerivedPath: rebuild dynamic derivations lost to GC

### DIFF
--- a/src/libstore-tests/derived-path-resolve.cc
+++ b/src/libstore-tests/derived-path-resolve.cc
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+#include "nix/store/derivations.hh"
+#include "nix/store/dummy-store-impl.hh"
+#include "nix/store/realisation.hh"
+#include "nix/store/store-api.hh"
+#include "nix/store/tests/libstore.hh"
+
+namespace nix {
+
+class ResolveDerivedPathTest : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite()
+    {
+        initLibStore(false);
+    }
+
+protected:
+    EnableExperimentalFeature caFeature{"ca-derivations"};
+    EnableExperimentalFeature dynFeature{"dynamic-derivations"};
+
+    ref<DummyStore> store = [] {
+        auto cfg = make_ref<DummyStoreConfig>(StoreReference::Params{});
+        cfg->readOnly = false;
+        return cfg->openDummyStore();
+    }();
+
+    Derivation textDrv(std::string name)
+    {
+        return Derivation{
+            .outputs =
+                {{"out",
+                  DerivationOutput{DerivationOutput::CAFloating{
+                      .method = ContentAddressMethod::Raw::Text,
+                      .hashAlgo = HashAlgorithm::SHA256,
+                  }}}},
+            .platform = "x86_64-linux",
+            .builder = "/bin/sh",
+            .name = std::move(name),
+        };
+    }
+};
+
+// producer^out is realised but its path, the inner derivation, was garbage collected
+TEST_F(ResolveDerivedPathTest, nestedOutputOfCollectedDerivation)
+{
+    auto producer = store->writeDerivation(textDrv("inner.drv"));
+    StorePath inner{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-inner.drv"};
+
+    store->registerDrvOutput(Realisation{{.outPath = inner}, DrvOutput{producer, "out"}}, NoCheckSigs);
+    ASSERT_FALSE(store->isValidPath(inner));
+
+    auto req = SingleDerivedPath::Built{
+        .drvPath = make_ref<SingleDerivedPath>(SingleDerivedPath::Built{
+            .drvPath = makeConstantStorePathRef(producer),
+            .output = "out",
+        }),
+        .output = "out",
+    };
+
+    EXPECT_THROW(resolveDerivedPath(*store, req), MissingRealisation);
+}
+
+} // namespace nix

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -43,6 +43,7 @@ sources = files(
   'derivation/masked.cc',
   'derivation/resolution.cc',
   'derivation/write.cc',
+  'derived-path-resolve.cc',
   'derived-path.cc',
   'downstream-placeholder.cc',
   'dummy-store.cc',

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -404,6 +404,10 @@ StorePath resolveDerivedPath(Store & store, const SingleDerivedPath & req, Store
                 auto outPath = deepQueryPartialDerivationOutput(store, drvPath, bfd.output, evalStore_);
                 if (!outPath)
                     throw MissingRealisation(store, *bfd.drvPath, drvPath, bfd.output);
+                /* The realisation of a dynamic derivation can outlive the .drv file it names (garbage collection). */
+                if (outPath->isDerivation() && !store.isValidPath(*outPath)
+                    && !(evalStore_ && evalStore_->isValidPath(*outPath)))
+                    throw MissingRealisation(store, *bfd.drvPath, drvPath, bfd.output);
                 return *outPath;
             },
         },


### PR DESCRIPTION
The realisation of `x.drv.drv^out` names a .drv file. The garbage collector can delete that file while the realisation stays, and building `x.drv.drv^out^out` afterwards fails:

```
error: path '/nix/store/…-x.drv.drv' is not valid
```

instead of running the producer again. `resolveDerivedPath` now reports such a path as a missing realisation, which `DerivationTrampolineGoal` already handles by scheduling the producer.
