### PR TITLE
libstore: Require canononical paths in the protocol and limit message size

### DIFF
--- a/src/libstore-tests/common-protocol.cc
+++ b/src/libstore-tests/common-protocol.cc
@@ -152,4 +152,65 @@ CHARACTERIZATION_TEST(
         },
     }))
 
+class CommonProtoStorePathTest : public ::testing::Test
+{
+    std::string storeDir = "/nix/store";
+
+protected:
+    StoreDirConfig store{storeDir};
+
+    std::string makeBasename(std::size_t nameLength) const
+    {
+        return std::string(StorePath::dummy.hashPart()) + "-" + std::string(nameLength, 'x');
+    }
+};
+
+TEST_F(CommonProtoStorePathTest, maximum_length)
+{
+    auto baseName = makeBasename(StorePath::MaxNameLen);
+    auto storePath = store.storeDir + "/" + baseName;
+    StringSource from{[&] {
+        StringSink sink;
+        writeString(storePath, sink);
+        return sink.s;
+    }()};
+    EXPECT_EQ(CommonProto::Serialise<StorePath>::read(store, {.from = from}), StorePath(baseName));
+}
+
+TEST_F(CommonProtoStorePathTest, too_long)
+{
+    std::string storePath = store.storeDir + "/" + std::string(StorePath::dummy.hashPart()) + "-"
+                            + std::string(StorePath::MaxNameLen + 1, 'x');
+    StringSource from{[&] {
+        StringSink sink;
+        writeString(storePath, sink);
+        return sink.s;
+    }()};
+    EXPECT_THROW(CommonProto::Serialise<StorePath>::read(store, {.from = from}), SerialisationError);
+}
+
+TEST_F(CommonProtoStorePathTest, wrong_store_dir)
+{
+    std::string storePath = "/gnu/store/" + makeBasename(StorePath::MaxNameLen);
+    StringSource from{[&] {
+        StringSink sink;
+        writeString(storePath, sink);
+        return sink.s;
+    }()};
+    EXPECT_THROW(CommonProto::Serialise<StorePath>::read(store, {.from = from}), BadStorePath);
+}
+
+TEST_F(CommonProtoStorePathTest, no_dot_dots)
+{
+    /* Everything immediately following the `/` is interpreted as a CanonPath, so `/` or `..`
+       has no special meaning. */
+    std::string storePath = store.storeDir + "/../" + makeBasename(8);
+    StringSource from{[&] {
+        StringSink sink;
+        writeString(storePath, sink);
+        return sink.s;
+    }()};
+    EXPECT_THROW(CommonProto::Serialise<StorePath>::read(store, {.from = from}), BadStorePath);
+}
+
 } // namespace nix

--- a/src/libstore-tests/fuzz/store-path.cc
+++ b/src/libstore-tests/fuzz/store-path.cc
@@ -21,12 +21,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
 
     auto parsedView = parsed->to_string();
 
-    /* Now actually check invariants. See nameRegexStr. MaxPathLen is actually
-       a misnomer - it's the maximum length of the store object name, not the
-       pathname. Pathname length includes the hash len + `-`.
+    /* Now actually check invariants. See nameRegexStr.
        Is the following checks a bit overkill? Maybe - but StorePath is also used
        everywhere so we better get it right. */
-    assert(parsedView.size() <= StorePath::MaxPathLen + StorePath::HashLen + 1);
+    assert(parsedView.size() <= StorePath::MaxBasenameLen);
 
     /* Name can't be empty, so strict comparison. */
     assert(parsedView.size() > StorePath::HashLen + 1);

--- a/src/libstore-tests/path.cc
+++ b/src/libstore-tests/path.cc
@@ -192,6 +192,15 @@ TEST_F(StorePathTest, mustBeDashAfterHashPart)
     EXPECT_NO_THROW(StorePath(hashPart + "-" + "name"));
 }
 
+TEST_F(StorePathTest, maximumLength)
+{
+    EXPECT_NO_THROW({
+        auto path = StorePath(StorePath::dummy.hashPart() + "-" + std::string(211, 'x'));
+        ASSERT_EQ(path.to_string().size(), StorePath::MaxBasenameLen);
+    });
+    EXPECT_THROW(StorePath(StorePath::dummy.hashPart() + "-" + std::string(212, 'x')), BadStorePath);
+}
+
 /* ----------------------------------------------------------------------------
  * JSON
  * --------------------------------------------------------------------------*/

--- a/src/libstore/common-protocol.cc
+++ b/src/libstore/common-protocol.cc
@@ -29,7 +29,7 @@ void CommonProto::Serialise<std::string>::write(
 
 StorePath CommonProto::Serialise<StorePath>::read(const StoreDirConfig & store, CommonProto::ReadConn conn)
 {
-    return store.parseStorePath(readString(conn.from));
+    return store.parseStorePathCanonical(readString(conn.from, store.maxCanonicalStorePathLen()));
 }
 
 void CommonProto::Serialise<StorePath>::write(
@@ -52,8 +52,8 @@ void CommonProto::Serialise<ContentAddress>::write(
 std::optional<StorePath>
 CommonProto::Serialise<std::optional<StorePath>>::read(const StoreDirConfig & store, CommonProto::ReadConn conn)
 {
-    auto s = readString(conn.from);
-    return s == "" ? std::optional<StorePath>{} : store.parseStorePath(s);
+    auto s = readString(conn.from, store.maxCanonicalStorePathLen());
+    return s == "" ? std::optional<StorePath>{} : store.parseStorePathCanonical(s);
 }
 
 void CommonProto::Serialise<std::optional<StorePath>>::write(

--- a/src/libstore/include/nix/store/path.hh
+++ b/src/libstore/include/nix/store/path.hh
@@ -40,7 +40,17 @@ public:
      */
     constexpr static size_t HashLen = 32; // i.e. 160 bits
 
-    constexpr static size_t MaxPathLen = 211;
+    /**
+     * @brief Maximum length of the name, i.e. everything after <hash part>-.
+     *
+     * It's chosen such that HashLen + MaxNameLen + 1 (dash) + len("/nix/store/") = 255
+     */
+    constexpr static size_t MaxNameLen = 211;
+
+    /**
+     * @brief Maximum length of the basename admitted by the constructor from a string.
+     */
+    constexpr static size_t MaxBasenameLen = HashLen + 1 + MaxNameLen;
 
     StorePath() = delete;
 
@@ -78,7 +88,7 @@ public:
         return std::string_view(baseName).substr(0, HashLen);
     }
 
-    static StorePath dummy;
+    static const StorePath dummy;
 
     static StorePath random(std::string_view name);
 };

--- a/src/libstore/include/nix/store/store-dir-config.hh
+++ b/src/libstore/include/nix/store/store-dir-config.hh
@@ -48,6 +48,12 @@ struct StoreDirConfig
 
     StringSet printStorePathSet(const StorePathSet & path) const;
 
+    std::size_t maxCanonicalStorePathLen() const noexcept
+    {
+        /* storeDir itself must be canonical + "/" + StorePath basename. */
+        return storeDir.size() + 1 + StorePath::MaxBasenameLen;
+    }
+
     /**
      * Display a set of paths in human-readable form (i.e., between quotes
      * and separated by commas).

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -13,8 +13,8 @@ void checkName(std::string_view name)
 {
     if (name.empty())
         throw BadStorePathName("name must not be empty");
-    if (name.size() > StorePath::MaxPathLen)
-        throw BadStorePathName("name '%s' must be no longer than %d characters", name, StorePath::MaxPathLen);
+    if (name.size() > StorePath::MaxNameLen)
+        throw BadStorePathName("name '%s' must be no longer than %d characters", name, StorePath::MaxNameLen);
     // See nameRegexStr for the definition
     if (name[0] == '.') {
         // check against "." and "..", followed by end or dash
@@ -76,7 +76,7 @@ void StorePath::requireDerivation() const
         throw FormatError("store path '%s' is not a valid derivation path", to_string());
 }
 
-StorePath StorePath::dummy("ffffffffffffffffffffffffffffffff-x");
+const StorePath StorePath::dummy("ffffffffffffffffffffffffffffffff-x");
 
 StorePath StorePath::random(std::string_view name)
 {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The fact that common protocol accepted paths that are not in canonical form
is certainly unintentional. The daemon should not be doing lexical canonicalisation
on behalf of the client. No legitimate nix client should have sent such messages
so this is not expected to be in any way noticeable.

In other news, we can now also limit allocation size in protocol parsers so that
obvious garbage is rejected fast and we don't have to go through `canonPath`, which
depends on std::filesystem::path and probably doesn't behave well with untrusted
inputs.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
