### PR TITLE
tests/functional: Fix the sandbox probe on newer kernels

### DIFF
--- a/tests/functional/common/vars.sh
+++ b/tests/functional/common/vars.sh
@@ -75,7 +75,7 @@ export IMPURE_VAR2=bar
 # shellcheck disable=SC2034
 cacheDir=$TEST_ROOT/binary-cache
 
-if [[ $(uname) == Linux ]] && [[ -L /proc/self/ns/user ]] && unshare --user --mount-proc true; then
+if [[ $(uname) == Linux ]] && [[ -L /proc/self/ns/user ]] && unshare --user --pid --fork --mount-proc true; then
     _canUseSandbox=1
 fi
 


### PR DESCRIPTION
Mounting `proc` from a user namespace requires that the pid namespace be owned by that user namespace, so `unshare --user --mount-proc true` fails with `EPERM` (at least on Linux 6.18) even where sandboxing works fine, and every test that needs the sandbox was being skipped. Give the probe a pid namespace, as the sandbox itself has.

Assisted-by: Claude Code (Claude Fable 5.1)

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
