### PR TITLE
meson: Name the non-pkg-config dependency lists by visibility

### DIFF
--- a/nix-meson-build-support/common/asan-options/meson.build
+++ b/nix-meson-build-support/common/asan-options/meson.build
@@ -7,5 +7,5 @@ if cxx.get_id() == 'clang' and ('address' in get_option('b_sanitize') or 'undefi
 endif
 
 if 'address' in get_option('b_sanitize')
-  deps_other += declare_dependency(sources : 'asan-options.cc')
+  deps_private_no_pkgconfig += declare_dependency(sources : 'asan-options.cc')
 endif

--- a/nix-meson-build-support/common/assert-fail/meson.build
+++ b/nix-meson-build-support/common/assert-fail/meson.build
@@ -25,7 +25,7 @@ can_wrap_assert_fail = cxx.links(
 )
 
 if can_wrap_assert_fail
-  deps_other += declare_dependency(
+  deps_private_no_pkgconfig += declare_dependency(
     sources : 'wrap-assert-fail.cc',
     link_args : wrap_assert_fail_args,
   )

--- a/nix-meson-build-support/deps-lists/meson.build
+++ b/nix-meson-build-support/deps-lists/meson.build
@@ -31,6 +31,9 @@ deps_public = []
 deps_private_subproject = []
 deps_public_subproject = []
 
-# These are dependencencies without pkg-config files. Ideally they are
-# just private, but they may also be public (e.g. boost).
-deps_other = []
+# These are dependencies without pkg-config files (Boost, or ad-hoc
+# libraries from `find_library`). The private ones only link this library;
+# the public ones are also propagated to consumers within this build, but
+# cannot be expressed in the generated pkg-config file.
+deps_private_no_pkgconfig = []
+deps_public_no_pkgconfig = []

--- a/nix-meson-build-support/export/meson.build
+++ b/nix-meson-build-support/export/meson.build
@@ -39,6 +39,8 @@ elif plugin_c_api_enabled and not host_machine.system().startswith('windows')
   ) + ',--no-whole-archive'
 endif
 
+libraries_public = get_variable('libraries_public', [])
+
 import('pkgconfig').generate(
   this_library,
   filebase : meson.project_name(),
@@ -47,6 +49,7 @@ import('pkgconfig').generate(
   extra_cflags : extra_cflags,
   requires : requires_public,
   requires_private : requires_private,
+  libraries : libraries_public,
   libraries_private : libraries_private,
   variables : extra_pkg_config_variables,
 )
@@ -70,7 +73,7 @@ meson.override_dependency(
     include_directories : include_dirs,
     link_with : this_library,
     compile_args : [ '-std=c++23' ],
-    dependencies : deps_public_subproject + deps_public,
+    dependencies : deps_public_subproject + deps_public + deps_public_no_pkgconfig,
     variables : extra_pkg_config_variables,
   ),
 )
@@ -82,7 +85,7 @@ if installed_whole_archive_link_arg != ''
       include_directories : include_dirs,
       link_whole : [ this_static_library ],
       compile_args : [ '-std=c++23' ],
-      dependencies : deps_public_subproject + deps_public,
+      dependencies : deps_public_subproject + deps_public + deps_public_no_pkgconfig,
       variables : extra_pkg_config_variables,
     ),
   )

--- a/nix-meson-build-support/libatomic/meson.build
+++ b/nix-meson-build-support/libatomic/meson.build
@@ -4,5 +4,5 @@
 # We did not manage to test this reliably on all platforms, so we hardcode
 # it for now.
 if host_machine.cpu_family() in [ 'arm', 'ppc' ]
-  deps_other += cxx.find_library('atomic')
+  deps_private_no_pkgconfig += cxx.find_library('atomic')
 endif

--- a/nix-meson-build-support/subprojects/meson.build
+++ b/nix-meson-build-support/subprojects/meson.build
@@ -2,7 +2,7 @@ foreach maybe_subproject_dep : deps_private_maybe_subproject
   if maybe_subproject_dep.type_name() == 'internal'
     deps_private_subproject += maybe_subproject_dep
     # subproject sadly no good for pkg-config module
-    deps_other += maybe_subproject_dep
+    deps_private_no_pkgconfig += maybe_subproject_dep
   else
     deps_private += maybe_subproject_dep
   endif
@@ -12,7 +12,7 @@ foreach maybe_subproject_dep : deps_public_maybe_subproject
   if maybe_subproject_dep.type_name() == 'internal'
     deps_public_subproject += maybe_subproject_dep
     # subproject sadly no good for pkg-config module
-    deps_other += maybe_subproject_dep
+    deps_private_no_pkgconfig += maybe_subproject_dep
   else
     deps_public += maybe_subproject_dep
   endif

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -107,7 +107,7 @@ this_library = library(
   sources,
   config_priv_h,
   soversion : nix_soversion,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   link_args : linker_export_flags,
   prelink : true, # For C++ static initializers

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -53,7 +53,7 @@ build_both_libraries = get_option('plugin-c-api')
 
 library_kwargs = {
   'soversion' : nix_soversion,
-  'dependencies' : deps_public + deps_private + deps_other,
+  'dependencies' : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   'include_directories' : include_dirs,
   'link_args' : linker_export_flags,
   'install' : true,

--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -45,7 +45,7 @@ this_library = library(
   'nix-expr-test-support',
   sources,
   soversion : nix_soversion,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326
   #       is available. See also ../libutil/build.meson

--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -73,7 +73,7 @@ this_exe = executable(
   meson.project_name(),
   sources,
   config_priv_h,
-  dependencies : deps_private_subproject + deps_private + deps_other,
+  dependencies : deps_private_subproject + deps_private + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   # TODO: -lrapidcheck, see ../libutil-support/build.meson
   link_args : linker_export_flags + [ '-lrapidcheck' ],
@@ -107,7 +107,7 @@ if get_option('benchmarks')
     'nix-expr-benchmarks',
     benchmark_sources,
     config_priv_h,
-    dependencies : deps_private_subproject + deps_private + deps_other + [
+    dependencies : deps_private_subproject + deps_private + deps_private_no_pkgconfig + [
       gbenchmark,
     ],
     include_directories : include_dirs,

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -45,9 +45,8 @@ boost = dependency(
   ],
   include_type : 'system',
 )
-# boost is a public dependency, but not a pkg-config dependency unfortunately, so we
-# put in `deps_other`.
-deps_other += boost
+# boost is a public dependency, but not a pkg-config dependency unfortunately.
+deps_public_no_pkgconfig += boost
 
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
@@ -92,7 +91,7 @@ configdata_priv.set(
   toml11.version().version_compare('>= 4.0.0').to_int(),
 )
 
-deps_other += toml11
+deps_private_no_pkgconfig += toml11
 
 cpuid = dependency('libcpuid', 'cpuid', required : false)
 configdata_priv.set('HAVE_LIBCPUID', cpuid.found().to_int())
@@ -214,7 +213,7 @@ parser_library = static_library(
   lexer_tab,
   'lexer-helpers.cc',
   cpp_args : parser_library_cpp_args,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   # 1. Stdlib and regular assertions regress parser performance significantly, so build without
   # them for this one library when building in a release configuration.
@@ -235,7 +234,7 @@ this_library = library(
   parser_tab[1],
   lexer_tab[1],
   soversion : nix_soversion,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   link_args : linker_export_flags,
   link_whole : [ parser_library ],

--- a/src/libfetchers-c/meson.build
+++ b/src/libfetchers-c/meson.build
@@ -55,7 +55,7 @@ build_both_libraries = get_option('plugin-c-api')
 
 library_kwargs = {
   'soversion' : nix_soversion,
-  'dependencies' : deps_public + deps_private + deps_other,
+  'dependencies' : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   'include_directories' : include_dirs,
   'link_args' : linker_export_flags,
   'install' : true,

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -59,7 +59,7 @@ include_dirs = [ include_directories('.') ]
 this_exe = executable(
   meson.project_name(),
   sources,
-  dependencies : deps_private_subproject + deps_private + deps_other,
+  dependencies : deps_private_subproject + deps_private + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   # TODO: -lrapidcheck, see ../libutil-support/build.meson
   link_args : linker_export_flags + [ '-lrapidcheck' ],

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -63,7 +63,7 @@ this_library = library(
   'nixfetchers',
   sources,
   soversion : nix_soversion,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   link_args : linker_export_flags,
   prelink : true, # For C++ static initializers

--- a/src/libflake-c/meson.build
+++ b/src/libflake-c/meson.build
@@ -55,7 +55,7 @@ build_both_libraries = get_option('plugin-c-api')
 
 library_kwargs = {
   'soversion' : nix_soversion,
-  'dependencies' : deps_public + deps_private + deps_other,
+  'dependencies' : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   'include_directories' : include_dirs,
   'link_args' : linker_export_flags,
   'install' : true,

--- a/src/libflake-tests/meson.build
+++ b/src/libflake-tests/meson.build
@@ -47,7 +47,7 @@ include_dirs = [ include_directories('.') ]
 this_exe = executable(
   meson.project_name(),
   sources,
-  dependencies : deps_private_subproject + deps_private + deps_other,
+  dependencies : deps_private_subproject + deps_private + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   # TODO: -lrapidcheck, see ../libutil-support/build.meson
   link_args : linker_export_flags + [ '-lrapidcheck' ],

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -51,7 +51,7 @@ this_library = library(
   'nixflake',
   sources,
   soversion : nix_soversion,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   link_args : linker_export_flags,
   prelink : true, # For C++ static initializers

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -47,7 +47,7 @@ build_both_libraries = get_option('plugin-c-api')
 
 library_kwargs = {
   'soversion' : nix_soversion,
-  'dependencies' : deps_public + deps_private + deps_other,
+  'dependencies' : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   'include_directories' : include_dirs,
   'link_args' : linker_export_flags,
   'install' : true,

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -78,7 +78,7 @@ this_library = library(
   sources,
   config_priv_h,
   soversion : nix_soversion,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   link_args : linker_export_flags,
   prelink : true, # For C++ static initializers

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -50,7 +50,7 @@ build_both_libraries = get_option('plugin-c-api')
 
 library_kwargs = {
   'soversion' : nix_soversion,
-  'dependencies' : deps_public + deps_private + deps_other,
+  'dependencies' : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   'include_directories' : include_dirs,
   'link_args' : linker_export_flags,
   'install' : true,

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -51,7 +51,7 @@ this_library = library(
   'nix-store-test-support',
   sources,
   soversion : nix_soversion,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326
   #       is available. See also ../libutil/build.meson

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -30,7 +30,7 @@ subdir('nix-meson-build-support/windows-version')
 
 subdir('nix-meson-build-support/common')
 
-fuzz_dependencies = deps_private + deps_other
+fuzz_dependencies = deps_private + deps_private_no_pkgconfig
 
 sources = files(
   'build-result.cc',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -99,12 +99,12 @@ configdata_pub.set(
 
 if host_machine.system() == 'darwin'
   sandbox = cxx.find_library('sandbox')
-  deps_other += [ sandbox ]
+  deps_private_no_pkgconfig += [ sandbox ]
 endif
 
 if host_machine.system() == 'windows'
   wsock32 = cxx.find_library('wsock32')
-  deps_other += [ wsock32 ]
+  deps_private_no_pkgconfig += [ wsock32 ]
 endif
 
 subdir('nix-meson-build-support/libatomic')
@@ -119,9 +119,8 @@ boost = dependency(
   ],
   include_type : 'system',
 )
-# boost is a public dependency, but not a pkg-config dependency unfortunately, so we
-# put in `deps_other`.
-deps_other += boost
+# boost is a public dependency, but not a pkg-config dependency unfortunately.
+deps_public_no_pkgconfig += boost
 
 # This is quite new, but curl has a bunch of known issues with write pausing and decompression.
 # Please use libcurl >= 8.17. See https://github.com/curl/curl/issues/19334, https://github.com/curl/curl/issues/16280, https://github.com/curl/curl/issues/16955 if in doubt.
@@ -153,7 +152,7 @@ deps_private += seccomp
 if host_machine.system() == 'freebsd'
   # libjail is not in freebsd.libc, but there's no discovery mechanism
   libjail = declare_dependency(link_args : [ '-ljail' ])
-  deps_other += libjail
+  deps_private_no_pkgconfig += libjail
 endif
 
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
@@ -171,7 +170,7 @@ aws_crt_cpp = dependency(
 )
 
 if s3_aws_auth.enabled()
-  deps_other += aws_crt_cpp
+  deps_private_no_pkgconfig += aws_crt_cpp
 endif
 
 configdata_pub.set('NIX_WITH_AWS_AUTH', s3_aws_auth.enabled().to_int())
@@ -378,7 +377,7 @@ this_library = library(
   sources,
   config_priv_h,
   soversion : nix_soversion,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   link_args : linker_export_flags,
   prelink : true, # For C++ static initializers

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -54,7 +54,7 @@ build_both_libraries = get_option('plugin-c-api')
 
 library_kwargs = {
   'soversion' : nix_soversion,
-  'dependencies' : deps_public + deps_private + deps_other,
+  'dependencies' : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   'include_directories' : include_dirs,
   'link_args' : linker_export_flags,
   'install' : true,

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -42,7 +42,7 @@ this_library = library(
   'nix-util-test-support',
   sources,
   soversion : nix_soversion,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326
   #       is available. See also ../libutil/build.meson

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -26,15 +26,9 @@ subdir('nix-meson-build-support/subprojects')
 subdir('nix-meson-build-support/export-all-symbols')
 subdir('nix-meson-build-support/windows-version')
 
-if host_machine.system() == 'windows'
-  # Boost.ASIO needs this unconditionally.
-  socket = cxx.find_library('ws2_32')
-  deps_other += socket
-endif
-
 subdir('nix-meson-build-support/common')
 
-fuzz_dependencies = deps_private + deps_other
+fuzz_dependencies = deps_private + deps_private_no_pkgconfig
 
 sources = files(
   'alignment.cc',

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -63,15 +63,18 @@ configdata_pub.set(
 subdir('nix-meson-build-support/libatomic')
 
 if host_machine.system() == 'windows'
+  # Boost.Asio, included by the public `async.hh`, needs Winsock
+  # unconditionally, so consumers must link it too.
   socket = cxx.find_library('ws2_32')
+  deps_public_no_pkgconfig += socket
   # `NtCreateFile` and `RtlNtStatusToDosError`, used by the `*at`-style file
   # system functions in `windows/file-system-at.cc`, live here.
   nt = cxx.find_library('ntdll')
-  deps_other += [ socket, nt ]
+  deps_private_no_pkgconfig += nt
 elif host_machine.system() == 'sunos'
   socket = cxx.find_library('socket')
   network_service_library = cxx.find_library('nsl')
-  deps_other += [ socket, network_service_library ]
+  deps_private_no_pkgconfig += [ socket, network_service_library ]
 endif
 
 blake3 = dependency(
@@ -92,9 +95,8 @@ boost = dependency(
   include_type : 'system',
   version : '>=1.87.0',
 )
-# boost is a public dependency, but not a pkg-config dependency unfortunately, so we
-# put in `deps_other`.
-deps_other += boost
+# boost is a public dependency, but not a pkg-config dependency unfortunately.
+deps_public_no_pkgconfig += boost
 
 openssl = dependency(
   'libcrypto',
@@ -240,7 +242,7 @@ this_library = library(
   'nixutil',
   sources,
   soversion : nix_soversion,
-  dependencies : deps_public + deps_private + deps_other,
+  dependencies : deps_public + deps_private + deps_public_no_pkgconfig + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   link_args : linker_export_flags,
   prelink : true, # For C++ static initializers
@@ -250,11 +252,14 @@ this_library = library(
 
 install_headers(headers, subdir : 'nix/util', preserve_path : true)
 
+libraries_public = []
 libraries_private = []
 if host_machine.system() == 'windows'
-  # `libraries_private` cannot contain ad-hoc dependencies (from
-  # `find_library), so we need to do this manually
-  libraries_private += [ '-lws2_32', '-lntdll' ]
+  # The pkg-config `Libs` fields cannot contain ad-hoc dependencies (from
+  # `find_library`), so these are spelled out by hand. Winsock is public
+  # for the same reason as above: consumers of the headers need it too.
+  libraries_public += [ '-lws2_32' ]
+  libraries_private += [ '-lntdll' ]
 endif
 
 subdir('nix-meson-build-support/export')

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -199,7 +199,7 @@ include_dirs = [ include_directories('.') ]
 this_exe = executable(
   meson.project_name(),
   sources,
-  dependencies : deps_private_subproject + deps_private + deps_other + deps_plugin_c_apis,
+  dependencies : deps_private_subproject + deps_private + deps_private_no_pkgconfig + deps_plugin_c_apis,
   include_directories : include_dirs,
   link_args : linker_export_flags,
   export_dynamic : get_option('plugin-c-api'),

--- a/src/nswrapper/meson.build
+++ b/src/nswrapper/meson.build
@@ -34,7 +34,7 @@ include_dirs = [ include_directories('.') ]
 this_exe = executable(
   meson.project_name(),
   sources,
-  dependencies : deps_private_subproject + deps_private + deps_other,
+  dependencies : deps_private_subproject + deps_private + deps_private_no_pkgconfig,
   include_directories : include_dirs,
   link_args : linker_export_flags,
   install : true,

--- a/tests/functional/test-libstoreconsumer/meson.build
+++ b/tests/functional/test-libstoreconsumer/meson.build
@@ -1,12 +1,12 @@
 cxx = meson.get_compiler('cpp')
 
-deps_other = []
+deps_private_no_pkgconfig = []
 subdir('nix-meson-build-support/common/asan-options')
 
 libstoreconsumer_tester = executable(
   'test-libstoreconsumer',
   'main.cc',
-  dependencies : deps_other + [
+  dependencies : deps_private_no_pkgconfig + [
     dependency('nix-store'),
   ],
   build_by_default : false,


### PR DESCRIPTION
`deps_other` held dependencies that cannot be expressed in the generated pkg-config files (Boost, and ad-hoc libraries found with `find_library`), regardless of whether consumers of the library need them too. Rename it `deps_private_no_pkgconfig` and add a matching `deps_public_no_pkgconfig`, which the exported in-tree dependency carries to consumers within this build (the pkg-config files still cannot express it).

Boost moves to the public list, since its headers are included by public headers. So does `ws2_32` on Windows, since Boost.Asio, included by the public `async.hh`, needs Winsock in every consumer; that also lets `libutil-tests` drop its own lookup of it.

For consumers outside this build, the generated pkg-config file gets a public `Libs` entry for `ws2_32` as well (`libraries_public`, next to `libraries_private`), since those link against the installed library.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 

